### PR TITLE
Refactor data type handling and fix convolution bias initialization

### DIFF
--- a/examples/qwen35_text_generation.py
+++ b/examples/qwen35_text_generation.py
@@ -564,7 +564,7 @@ def main():
         # ---------------------------------------------------------------
         prompt = args.prompt or "Describe this image in detail."
         print(f"Building 3-model VL pipeline for {args.model!r} ...")
-        pkg = build(args.model, dtype="f32", load_weights=True)
+        pkg = build(args.model, dtype="f16", load_weights=True)
         config = pkg.config
 
         if args.save_to:
@@ -620,7 +620,7 @@ def main():
             args.model,
             task="hybrid-text-generation",
             module_class=Qwen35CausalLMModel,
-            dtype="f32",
+            dtype="f16",
             load_weights=True,
         )
         config = pkg.config

--- a/examples/qwen35_text_generation.py
+++ b/examples/qwen35_text_generation.py
@@ -564,7 +564,7 @@ def main():
         # ---------------------------------------------------------------
         prompt = args.prompt or "Describe this image in detail."
         print(f"Building 3-model VL pipeline for {args.model!r} ...")
-        pkg = build(args.model, dtype="f16", load_weights=True)
+        pkg = build(args.model, dtype="f32", load_weights=True)
         config = pkg.config
 
         if args.save_to:

--- a/examples/qwen35_text_generation.py
+++ b/examples/qwen35_text_generation.py
@@ -552,6 +552,12 @@ def main():
         help="Save the ONNX model package to DIR and exit (no inference).",
     )
     parser.add_argument(
+        "--dtype",
+        default="f32",
+        choices=["f16", "f32"],
+        help="Precision type for the ONNX model (default: %(default)s).",
+    )
+    parser.add_argument(
         "--compare-hf",
         action="store_true",
         help="Also run with HuggingFace transformers and compare outputs.",
@@ -564,7 +570,7 @@ def main():
         # ---------------------------------------------------------------
         prompt = args.prompt or "Describe this image in detail."
         print(f"Building 3-model VL pipeline for {args.model!r} ...")
-        pkg = build(args.model, dtype="f32", load_weights=True)
+        pkg = build(args.model, dtype=args.dtype, load_weights=True)
         config = pkg.config
 
         if args.save_to:
@@ -620,7 +626,7 @@ def main():
             args.model,
             task="hybrid-text-generation",
             module_class=Qwen35CausalLMModel,
-            dtype="f16",
+            dtype=args.dtype,
             load_weights=True,
         )
         config = pkg.config

--- a/src/mobius/components/_gated_deltanet.py
+++ b/src/mobius/components/_gated_deltanet.py
@@ -74,9 +74,10 @@ class _DepthwiseConv1d(nn.Module):
             output: (B, D, T) — convolution output with SiLU.
             present_state: (B, D, K-1) — updated carry state.
         """
-        # Zero bias — model has no conv bias; the function requires it
+        # Zero bias — model has no conv bias; the function requires it.
+        # CastLike ensures the bias matches the weight dtype (e.g. f16).
         conv_bias = op.Expand(
-            op.Constant(value_float=0.0),
+            op.CastLike(op.Constant(value_float=0.0), self.weight),
             op.Constant(value_ints=[self._channels]),
         )
         return op.CausalConv1DWithState(
@@ -211,7 +212,10 @@ class GatedDeltaNet(nn.Module):
         # === L2 normalize Q and K ===
         query = _l2_normalize(op, query)
         key = _l2_normalize(op, key)
-        scale = op.Constant(value_float=1.0 / (self.head_k_dim**0.5))
+        scale = op.CastLike(
+            op.Constant(value_float=1.0 / (self.head_k_dim**0.5)),
+            query,
+        )
         query = op.Mul(query, scale)
 
         # === Compute gating parameters ===
@@ -272,6 +276,6 @@ def _l2_normalize(op: builder.OpBuilder, x, eps: float = 1e-6):
     """L2 normalize along the last dimension."""
     sq = op.Mul(x, x)
     sq_sum = op.ReduceSum(sq, [-1], keepdims=True)
-    eps_val = op.Constant(value_float=eps)
+    eps_val = op.CastLike(op.Constant(value_float=eps), x)
     inv_norm = op.Reciprocal(op.Sqrt(op.Add(sq_sum, eps_val)))
     return op.Mul(x, inv_norm)

--- a/src/mobius/functions/causal_conv.py
+++ b/src/mobius/functions/causal_conv.py
@@ -124,10 +124,13 @@ def causal_conv1d_with_state(
     # --- Build the ir.Function ---
     # Function signature declares attributes normally.
     # Inner Conv node references 'group' via ir.RefAttr.
+    # NOTE: Do not set ``overload`` here — the call sites
+    # (op.CausalConv1DWithState) do not set an overload on the
+    # node, so setting one on the function would prevent the
+    # serializer from matching nodes to this function definition.
     return ir.Function(
         domain=DOMAIN,
         name="CausalConv1DWithState",
-        overload=activation,
         graph=graph,
         attributes={
             "activation": ir.Attr(


### PR DESCRIPTION
This pull request primarily focuses on improving numerical stability and dtype consistency in the codebase, particularly for operations involving mixed-precision (such as `float16`). The changes ensure that constants used in computations match the data types of the operands, which helps prevent potential issues during inference or training. Additionally, there is a small fix to avoid setting function overloads that could interfere with serialization.

Improvements for dtype consistency and numerical stability:

* Updated all constant values in convolution and normalization operations to use `op.CastLike`, ensuring they match the dtype of associated tensors (e.g., `float16`). This affects the bias in convolution, scaling in attention, and epsilon in normalization.

Model and function configuration updates:

* Removed the explicit `overload` attribute from the `ir.Function` definition in `causal_conv1d_with_state` to prevent issues with node-function matching during serialization.