### PR TITLE
Extend GQA support to packedQKV GQA in rewrite rules

### DIFF
--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -88,8 +88,11 @@ def _apply_optimize(model: ir.Model, optimize: str | None) -> None:
 
     rule_map = {
         "bias_gelu": bias_gelu_rules,
-        "fused_matmul": fused_matmul_rules,
+        # group_query_attention (incl. QKV packing) must run before
+        # fused_matmul so that projections are still plain MatMul nodes
+        # when the packing pattern matches.
         "group_query_attention": group_query_attention_rules,
+        "fused_matmul": fused_matmul_rules,
         "packed_attention": packed_attention_rules,
         "skip_layer_norm": skip_layer_norm_rules,
         "skip_norm": skip_norm_rules,

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -86,14 +86,10 @@ def _apply_optimize(model: ir.Model, optimize: str | None) -> None:
         skip_norm_rules,
     )
 
-    # Insertion order determines application order for --optimize=all.
-    # group_query_attention runs before fused_matmul so that packed QKV
-    # can trace the original Transpose+MatMul pattern.  (The GQA rule
-    # also handles FusedMatMul, but running first is more efficient.)
     rule_map = {
         "bias_gelu": bias_gelu_rules,
-        "group_query_attention": group_query_attention_rules,
         "fused_matmul": fused_matmul_rules,
+        "group_query_attention": group_query_attention_rules,
         "packed_attention": packed_attention_rules,
         "skip_layer_norm": skip_layer_norm_rules,
         "skip_norm": skip_norm_rules,

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -86,10 +86,14 @@ def _apply_optimize(model: ir.Model, optimize: str | None) -> None:
         skip_norm_rules,
     )
 
+    # Insertion order determines application order for --optimize=all.
+    # group_query_attention runs before fused_matmul so that packed QKV
+    # can trace the original Transpose+MatMul pattern.  (The GQA rule
+    # also handles FusedMatMul, but running first is more efficient.)
     rule_map = {
         "bias_gelu": bias_gelu_rules,
-        "fused_matmul": fused_matmul_rules,
         "group_query_attention": group_query_attention_rules,
+        "fused_matmul": fused_matmul_rules,
         "packed_attention": packed_attention_rules,
         "skip_layer_norm": skip_layer_norm_rules,
         "skip_norm": skip_norm_rules,

--- a/src/mobius/rewrite_rules/_group_query_attention.py
+++ b/src/mobius/rewrite_rules/_group_query_attention.py
@@ -293,7 +293,11 @@ class PackQKVForGQA(RewriteRuleClassBase):
     data files for large models.
     """
 
-    _pack_counter: int = 0
+    _pack_counter: int
+
+    def __init__(self):
+        super().__init__()
+        self._pack_counter = 0
 
     # ------------------------------------------------------------------ pattern
 

--- a/src/mobius/rewrite_rules/_group_query_attention.py
+++ b/src/mobius/rewrite_rules/_group_query_attention.py
@@ -36,7 +36,6 @@ from onnxscript.rewriter._rewrite_rule import (
     RewriteRuleClassBase,
     RewriteRuleSet,
 )
-from onnxscript.rewriter.pattern import OrValue
 
 
 class RotaryAttentionToGQA(RewriteRuleClassBase):
@@ -226,26 +225,19 @@ class RotaryAttentionToGQA(RewriteRuleClassBase):
 
 
 def _get_weight_tensor(proj_node):
-    """Extract the constant weight tensor from a projection node.
+    """Extract the constant weight tensor from a MatMul projection node.
 
-    Handles three patterns:
+    Handles two patterns:
 
-    1. ``Transpose(weight, perm=[1,0]) -> MatMul(x, w_t)``
+    1. ``Transpose(weight, perm=[1,0]) → MatMul(x, w_t)``
+       — weight shape is ``(out_features, hidden_size)``, transposed=True
     2. ``MatMul(x, weight)``  (no transpose)
-    3. ``FusedMatMul(x, weight, transB=1)``  (post fused_matmul rewrite)
+       — weight shape is ``(hidden_size, out_features)``, transposed=False
 
     Returns:
         ``(numpy_array, is_transposed)`` on success, or ``(None, False)``
         if the weight cannot be extracted as a constant.
     """
-    if proj_node.op_type == "FusedMatMul":
-        trans_b = proj_node.attributes.get_int("transB", 0)
-        tensor = ir.convenience.get_const_tensor(proj_node.inputs[1])
-        if tensor is None:
-            return None, False
-        return tensor.numpy(), bool(trans_b)
-
-    # MatMul -- weight may be behind a Transpose
     weight_input = proj_node.inputs[1]
     producer = weight_input.producer()
     if producer is not None and producer.op_type == "Transpose":
@@ -267,29 +259,33 @@ class PackQKVForGQA(RewriteRuleClassBase):
 
     This rule runs **after** ``RotaryAttentionToGQA`` and looks for
     ``GroupQueryAttention`` nodes whose Q, K, V inputs each come from a
-    separate projection (``MatMul`` or ``FusedMatMul``) that shares
-    the same ``hidden_states`` input.
+    separate ``MatMul`` projection that shares the same ``hidden_states``
+    input.  The ``fused_matmul`` rewrite must run **after** this rule
+    so that projections are still plain ``MatMul`` nodes when this rule
+    matches.
 
     **Matched pattern:**
 
     .. code-block:: text
 
-        q = MatMul|FusedMatMul(hidden, W_q)
-        k = MatMul|FusedMatMul(hidden, W_k)
-        v = MatMul|FusedMatMul(hidden, W_v)
+        q = MatMul(hidden, W_q)
+        k = MatMul(hidden, W_k)
+        v = MatMul(hidden, W_v)
         out, pkey, pval = GroupQueryAttention(q, k, v, ...)
 
     **Replacement:**
 
     .. code-block:: text
 
-        W_qkv = concatenate([W_q, W_k, W_v])
-        packed = MatMul(hidden, W_qkv_t)
+        W_qkv = concatenate([W_q, W_k, W_v])  # normalized to (out, hidden)
+        packed = MatMul(hidden, Transpose(W_qkv))
         out, pkey, pval = GroupQueryAttention(packed, None, None, ...)
 
-    The packed weight is stored as a graph initializer (not a
-    ``Constant`` node attribute) so it can be serialised to external
-    data files for large models.
+    Each weight is independently normalized to ``(out_features,
+    hidden_size)`` before concatenation, so mixed transpose patterns
+    across Q/K/V are handled correctly.  The packed weight is stored as
+    a graph initializer (not a ``Constant`` node attribute) so it can
+    be serialised to external data files for large models.
     """
 
     _pack_counter: int
@@ -314,40 +310,9 @@ class PackQKVForGQA(RewriteRuleClassBase):
         cos_cache,
         sin_cache,
     ):
-        # Each projection may be MatMul or FusedMatMul (post fused_matmul)
-        q = OrValue(
-            [
-                op.MatMul(hidden, q_w),
-                op.FusedMatMul(
-                    hidden,
-                    q_w,
-                    _domain="com.microsoft",
-                    _allow_other_attributes=True,
-                ),
-            ]
-        )
-        k = OrValue(
-            [
-                op.MatMul(hidden, k_w),
-                op.FusedMatMul(
-                    hidden,
-                    k_w,
-                    _domain="com.microsoft",
-                    _allow_other_attributes=True,
-                ),
-            ]
-        )
-        v = OrValue(
-            [
-                op.MatMul(hidden, v_w),
-                op.FusedMatMul(
-                    hidden,
-                    v_w,
-                    _domain="com.microsoft",
-                    _allow_other_attributes=True,
-                ),
-            ]
-        )
+        q = op.MatMul(hidden, q_w)
+        k = op.MatMul(hidden, k_w)
+        v = op.MatMul(hidden, v_w)
 
         return op.GroupQueryAttention(
             q,
@@ -366,28 +331,17 @@ class PackQKVForGQA(RewriteRuleClassBase):
 
     # ------------------------------------------------------------------ check
 
-    def check(self, context, q_w, k_w, v_w, gqa_out, **_):
+    def check(self, context, gqa_out, **_):
         result = MatchResult()
 
         gqa_node = gqa_out.producer()
-        # Extract projection nodes from the GQA inputs
-        projs = []
         for i, name in enumerate(("q", "k", "v")):
             proj = gqa_node.inputs[i].producer()
             if proj is None:
                 return result.fail(f"{name} projection missing")
-            projs.append(proj)
-
-        # All weights must be extractable constants with consistent layout
-        is_transposed = None
-        for name, proj in zip(("q", "k", "v"), projs):
-            w_np, transposed = _get_weight_tensor(proj)
+            w_np, _ = _get_weight_tensor(proj)
             if w_np is None:
                 return result.fail(f"{name} weight not constant")
-            if is_transposed is None:
-                is_transposed = transposed
-            elif is_transposed != transposed:
-                return result.fail("Mixed transpose states")
 
         return result
 
@@ -397,9 +351,6 @@ class PackQKVForGQA(RewriteRuleClassBase):
         self,
         op,
         hidden,
-        q_w,
-        k_w,
-        v_w,
         past_key,
         past_value,
         seqlens_k,
@@ -414,22 +365,17 @@ class PackQKVForGQA(RewriteRuleClassBase):
         gqa_node = gqa_out.producer()
         graph = gqa_node.graph
 
-        q_proj = gqa_node.inputs[0].producer()
-
-        # Extract and concatenate weights
-        weights_np = []
-        is_transposed = None
+        # Extract weights, normalizing each to (out_features, hidden_size)
+        weights = []
         for i in range(3):
             proj = gqa_node.inputs[i].producer()
             w_np, transposed = _get_weight_tensor(proj)
-            if is_transposed is None:
-                is_transposed = transposed
-            weights_np.append(w_np)
+            if not transposed:
+                w_np = w_np.T
+            weights.append(w_np)
 
-        # Transposed: (out_features, hidden) -> concat axis=0
-        # Non-transposed: (hidden, out_features) -> concat axis=1
-        concat_axis = 0 if is_transposed else 1
-        w_qkv_np = np.concatenate(weights_np, axis=concat_axis)
+        # Concatenate along axis=0: all weights are (out, hidden)
+        w_qkv_np = np.concatenate(weights, axis=0)
 
         # Store packed weight as a graph initializer
         self._pack_counter += 1
@@ -440,20 +386,9 @@ class PackQKVForGQA(RewriteRuleClassBase):
         )
         graph.register_initializer(packed_w)
 
-        # Create the packed projection
-        if is_transposed:
-            if q_proj.op_type == "FusedMatMul":
-                packed_qkv = op.op(
-                    "FusedMatMul",
-                    inputs=[hidden, packed_w],
-                    domain="com.microsoft",
-                    attributes={"transB": 1},
-                )
-            else:
-                packed_w_t = op.Transpose(packed_w, perm=[1, 0])
-                packed_qkv = op.MatMul(hidden, packed_w_t)
-        else:
-            packed_qkv = op.MatMul(hidden, packed_w)
+        # Transpose + MatMul for the packed projection
+        packed_w_t = op.Transpose(packed_w, perm=[1, 0])
+        packed_qkv = op.MatMul(hidden, packed_w_t)
 
         # Forward all original GQA attributes
         attrs = {key: gqa_node.attributes[key].value for key in gqa_node.attributes}

--- a/src/mobius/rewrite_rules/_group_query_attention.py
+++ b/src/mobius/rewrite_rules/_group_query_attention.py
@@ -21,11 +21,42 @@ These rules are **not applied by default**.  Apply them post-export::
 
 from __future__ import annotations
 
+import numpy as np
+import onnx_ir as ir
 from onnxscript.rewriter._basics import MatchResult
 from onnxscript.rewriter._rewrite_rule import (
     RewriteRuleClassBase,
     RewriteRuleSet,
 )
+
+
+def _extract_weight(matmul_node):
+    """Extract the weight numpy array from a MatMul node.
+
+    Handles the ``Transpose(weight, perm=[1,0]) → MatMul`` pattern
+    commonly emitted by ``Linear`` layers.
+
+    Returns:
+        A tuple ``(numpy_array, is_transposed)`` where
+        ``is_transposed`` is ``True`` when the weight was preceded by a
+        ``Transpose``.  Returns ``(None, False)`` if the weight cannot
+        be extracted (e.g. not a constant initializer).
+    """
+    weight_input = matmul_node.inputs[1]
+    producer = weight_input.producer()
+
+    if producer is not None and producer.op_type == "Transpose":
+        perm = producer.attributes.get("perm", None)
+        if perm is not None and list(perm.value) == [1, 0]:
+            raw_weight = producer.inputs[0]
+            if raw_weight.const_value is None:
+                return None, False
+            return raw_weight.const_value.numpy(), True
+
+    # Direct weight (no Transpose)
+    if weight_input.const_value is None:
+        return None, False
+    return weight_input.const_value.numpy(), False
 
 
 class RotaryAttentionToGQA(RewriteRuleClassBase):
@@ -127,6 +158,63 @@ class RotaryAttentionToGQA(RewriteRuleClassBase):
 
         return result
 
+    # ------------------------------------------------------------ pack QKV
+
+    def _try_pack_qkv(self, op, q_pre, k_pre, v):
+        """Try to pack Q/K/V projections into a single MatMul.
+
+        Traces back from ``q_pre``, ``k_pre``, ``v`` to their producing
+        MatMul ops.  If all three share the same hidden_states input and
+        no QK norm is present, concatenates the weight matrices and
+        returns a single packed QKV output.
+
+        Returns:
+            The packed QKV ``ir.Value`` on success, or ``None`` when
+            packing is not possible (e.g. QK norm present, weights not
+            materialised, or different hidden_states inputs).
+        """
+        # 1. All three must come directly from MatMul (no QK norm)
+        q_matmul = q_pre.producer()
+        k_matmul = k_pre.producer()
+        v_matmul = v.producer()
+        for node in (q_matmul, k_matmul, v_matmul):
+            if node is None or node.op_type != "MatMul":
+                return None
+
+        # 2. All three MatMuls must share the same first input
+        if not (q_matmul.inputs[0] is k_matmul.inputs[0] is v_matmul.inputs[0]):
+            return None
+
+        hidden_states = q_matmul.inputs[0]
+
+        # 3. Extract weights, handling optional Transpose
+        weights_np = []
+        is_transposed = None
+        for matmul in (q_matmul, k_matmul, v_matmul):
+            w_value, transposed = _extract_weight(matmul)
+            if w_value is None:
+                return None
+            # All weights must follow the same pattern
+            if is_transposed is None:
+                is_transposed = transposed
+            elif is_transposed != transposed:
+                return None
+            weights_np.append(w_value)
+
+        # 4. Concatenate along the output dimension
+        # Transposed weights: shape (out_features, hidden_size) → axis=0
+        # Non-transposed weights: shape (hidden_size, out_features) → axis=1
+        concat_axis = 0 if is_transposed else 1
+        w_qkv_np = np.concatenate(weights_np, axis=concat_axis)
+
+        # 5. Create the packed MatMul
+        packed_weight = op.Constant(value=ir.Tensor(w_qkv_np))
+        if is_transposed:
+            # Emit Transpose + MatMul (same pattern as the original)
+            packed_weight_t = op.Transpose(packed_weight, perm=[1, 0])
+            return op.MatMul(hidden_states, packed_weight_t)
+        return op.MatMul(hidden_states, packed_weight)
+
     # ------------------------------------------------------------------ rewrite
 
     def rewrite(
@@ -181,10 +269,22 @@ class RotaryAttentionToGQA(RewriteRuleClassBase):
                 to=6,
             )
 
-        # Create GroupQueryAttention (3 outputs match Attention's 3)
-        outputs = op.op_multi_out(
-            "GroupQueryAttention",
-            inputs=[
+        # Try packed QKV path; fall back to separate Q/K/V
+        packed_qkv = self._try_pack_qkv(op, q_pre, k_pre, v)
+        if packed_qkv is not None:
+            gqa_inputs = [
+                packed_qkv,
+                None,
+                None,
+                past_key,
+                past_value,
+                self._seqlens_k,
+                self._total_seq_len,
+                self._cos_cache,
+                self._sin_cache,
+            ]
+        else:
+            gqa_inputs = [
                 q_pre,
                 k_pre,
                 v,
@@ -194,7 +294,12 @@ class RotaryAttentionToGQA(RewriteRuleClassBase):
                 self._total_seq_len,
                 self._cos_cache,
                 self._sin_cache,
-            ],
+            ]
+
+        # Create GroupQueryAttention (3 outputs match Attention's 3)
+        outputs = op.op_multi_out(
+            "GroupQueryAttention",
+            inputs=gqa_inputs,
             domain="com.microsoft",
             attributes={
                 "num_heads": q_num_heads,

--- a/src/mobius/rewrite_rules/_group_query_attention.py
+++ b/src/mobius/rewrite_rules/_group_query_attention.py
@@ -37,19 +37,30 @@ from onnxscript.rewriter._rewrite_rule import (
 )
 
 
-def _extract_weight(matmul_node):
-    """Extract the weight numpy array from a MatMul node.
+def _extract_weight(proj_node):
+    """Extract the weight numpy array from a projection node.
 
-    Handles the ``Transpose(weight, perm=[1,0]) → MatMul`` pattern
-    commonly emitted by ``Linear`` layers.
+    Handles three patterns emitted by ``Linear`` layers:
+
+    1. ``Transpose(weight, perm=[1,0]) → MatMul(x, w_t)``
+    2. ``MatMul(x, weight)``  (no transpose)
+    3. ``FusedMatMul(x, weight, transB=1)``  (after fused_matmul rewrite)
 
     Returns:
         A tuple ``(numpy_array, is_transposed)`` where
-        ``is_transposed`` is ``True`` when the weight was preceded by a
-        ``Transpose``.  Returns ``(None, False)`` if the weight cannot
-        be extracted (e.g. not a constant initializer).
+        ``is_transposed`` is ``True`` when the weight is stored in
+        ``(out_features, hidden_size)`` layout.  Returns
+        ``(None, False)`` if the weight cannot be extracted.
     """
-    weight_input = matmul_node.inputs[1]
+    if proj_node.op_type == "FusedMatMul":
+        trans_b = proj_node.attributes.get_int("transB", 0)
+        weight_input = proj_node.inputs[1]
+        if weight_input.const_value is None:
+            return None, False
+        return weight_input.const_value.numpy(), bool(trans_b)
+
+    # MatMul — weight may be behind a Transpose
+    weight_input = proj_node.inputs[1]
     producer = weight_input.producer()
 
     if producer is not None and producer.op_type == "Transpose":
@@ -182,34 +193,37 @@ class RotaryAttentionToGQA(RewriteRuleClassBase):
         """Try to pack Q/K/V projections into a single MatMul.
 
         Traces back from ``q_pre``, ``k_pre``, ``v`` to their producing
-        MatMul ops.  If all three share the same hidden_states input and
-        no QK norm is present, concatenates the weight matrices and
-        returns a single packed QKV output.
+        projection ops (``MatMul`` or ``FusedMatMul``).  If all three
+        share the same hidden_states input and no QK norm is present,
+        concatenates the weight matrices and returns a single packed QKV
+        output.
 
         Returns:
             The packed QKV ``ir.Value`` on success, or ``None`` when
             packing is not possible (e.g. QK norm present, weights not
             materialised, or different hidden_states inputs).
         """
-        # 1. All three must come directly from MatMul (no QK norm)
-        q_matmul = q_pre.producer()
-        k_matmul = k_pre.producer()
-        v_matmul = v.producer()
-        for node in (q_matmul, k_matmul, v_matmul):
-            if node is None or node.op_type != "MatMul":
+        proj_op_types = {"MatMul", "FusedMatMul"}
+
+        # 1. All three must come directly from a projection op (no QK norm)
+        q_proj = q_pre.producer()
+        k_proj = k_pre.producer()
+        v_proj = v.producer()
+        for node in (q_proj, k_proj, v_proj):
+            if node is None or node.op_type not in proj_op_types:
                 return None
 
-        # 2. All three MatMuls must share the same first input
-        if not (q_matmul.inputs[0] is k_matmul.inputs[0] is v_matmul.inputs[0]):
+        # 2. All three projections must share the same first input
+        if not (q_proj.inputs[0] is k_proj.inputs[0] is v_proj.inputs[0]):
             return None
 
-        hidden_states = q_matmul.inputs[0]
+        hidden_states = q_proj.inputs[0]
 
-        # 3. Extract weights, handling optional Transpose
+        # 3. Extract weights, handling Transpose and FusedMatMul
         weights_np = []
         is_transposed = None
-        for matmul in (q_matmul, k_matmul, v_matmul):
-            w_value, transposed = _extract_weight(matmul)
+        for proj in (q_proj, k_proj, v_proj):
+            w_value, transposed = _extract_weight(proj)
             if w_value is None:
                 return None
             # All weights must follow the same pattern
@@ -225,10 +239,18 @@ class RotaryAttentionToGQA(RewriteRuleClassBase):
         concat_axis = 0 if is_transposed else 1
         w_qkv_np = np.concatenate(weights_np, axis=concat_axis)
 
-        # 5. Create the packed MatMul
+        # 5. Create the packed projection
         packed_weight = op.Constant(value=ir.Tensor(w_qkv_np))
         if is_transposed:
-            # Emit Transpose + MatMul (same pattern as the original)
+            # Use FusedMatMul if source projections were FusedMatMul,
+            # otherwise emit Transpose + MatMul
+            if q_proj.op_type == "FusedMatMul":
+                return op.op(
+                    "FusedMatMul",
+                    inputs=[hidden_states, packed_weight],
+                    domain="com.microsoft",
+                    attributes={"transB": 1},
+                )
             packed_weight_t = op.Transpose(packed_weight, perm=[1, 0])
             return op.MatMul(hidden_states, packed_weight_t)
         return op.MatMul(hidden_states, packed_weight)

--- a/src/mobius/rewrite_rules/_group_query_attention.py
+++ b/src/mobius/rewrite_rules/_group_query_attention.py
@@ -10,6 +10,13 @@ embedding into the attention kernel and replaces the explicit attention
 bias with ``seqlens_k`` / ``total_sequence_length`` inputs computed
 from the ``attention_mask`` graph input.
 
+When the Q, K, and V projections are separate MatMuls that share the
+same hidden_states input (and no QK norm is applied), the rule also
+packs the three weight matrices into a single ``W_qkv`` and emits one
+packed MatMul.  The packed QKV tensor is passed in the ``query`` slot
+of ``GroupQueryAttention`` with ``key`` and ``value`` set to ``None``.
+Models with QK norm (e.g. Qwen3) fall back to separate Q/K/V inputs.
+
 These rules are **not applied by default**.  Apply them post-export::
 
     from mobius.rewrite_rules import group_query_attention_rules
@@ -76,12 +83,23 @@ class RotaryAttentionToGQA(RewriteRuleClassBase):
     attention with KV cache), and ``cos`` / ``sin`` are position-gathered
     from rotary cache tables via ``Gather``.
 
-    **Replacement:**
+    **Replacement (packed QKV, when Q/K/V share the same hidden_states
+    input and no QK norm is present):**
 
     .. code-block:: text
 
-        seqlens_k = Cast(ReduceSum(attention_mask, axis=1) - 1, INT32)
-        total_seq_len = Cast(Shape(attention_mask)[1], INT32)
+        W_qkv = concatenate([W_q, W_k, W_v])
+        packed_qkv = MatMul(hidden_states, W_qkv)
+        attn_out, present_key, present_value = GroupQueryAttention(
+            packed_qkv, None, None, past_key, past_value,
+            seqlens_k, total_seq_len, cos_cache, sin_cache,
+            num_heads=..., kv_num_heads=..., do_rotary=1,
+        )
+
+    **Replacement (separate Q/K/V, fallback for models with QK norm):**
+
+    .. code-block:: text
+
         attn_out, present_key, present_value = GroupQueryAttention(
             q_pre, k_pre, v, past_key, past_value,
             seqlens_k, total_seq_len, cos_cache, sin_cache,

--- a/src/mobius/rewrite_rules/_group_query_attention.py
+++ b/src/mobius/rewrite_rules/_group_query_attention.py
@@ -10,12 +10,13 @@ embedding into the attention kernel and replaces the explicit attention
 bias with ``seqlens_k`` / ``total_sequence_length`` inputs computed
 from the ``attention_mask`` graph input.
 
-When the Q, K, and V projections are separate MatMuls that share the
-same hidden_states input (and no QK norm is applied), the rule also
-packs the three weight matrices into a single ``W_qkv`` and emits one
-packed MatMul.  The packed QKV tensor is passed in the ``query`` slot
-of ``GroupQueryAttention`` with ``key`` and ``value`` set to ``None``.
-Models with QK norm (e.g. Qwen3) fall back to separate Q/K/V inputs.
+A second rule (``PackQKVForGQA``) runs after the GQA fusion and
+consolidates separate Q, K, V projection MatMuls into a single packed
+MatMul when they share the same hidden_states input.  The packed QKV
+tensor is passed in the ``query`` slot of ``GroupQueryAttention`` with
+``key`` and ``value`` set to ``None``.  Models with QK norm (e.g.
+Qwen3) are unaffected because the Q/K projections are followed by a
+normalization op, so the pattern does not match.
 
 These rules are **not applied by default**.  Apply them post-export::
 
@@ -37,46 +38,6 @@ from onnxscript.rewriter._rewrite_rule import (
 )
 
 
-def _extract_weight(proj_node):
-    """Extract the weight numpy array from a projection node.
-
-    Handles three patterns emitted by ``Linear`` layers:
-
-    1. ``Transpose(weight, perm=[1,0]) → MatMul(x, w_t)``
-    2. ``MatMul(x, weight)``  (no transpose)
-    3. ``FusedMatMul(x, weight, transB=1)``  (after fused_matmul rewrite)
-
-    Returns:
-        A tuple ``(numpy_array, is_transposed)`` where
-        ``is_transposed`` is ``True`` when the weight is stored in
-        ``(out_features, hidden_size)`` layout.  Returns
-        ``(None, False)`` if the weight cannot be extracted.
-    """
-    if proj_node.op_type == "FusedMatMul":
-        trans_b = proj_node.attributes.get_int("transB", 0)
-        weight_input = proj_node.inputs[1]
-        if weight_input.const_value is None:
-            return None, False
-        return weight_input.const_value.numpy(), bool(trans_b)
-
-    # MatMul — weight may be behind a Transpose
-    weight_input = proj_node.inputs[1]
-    producer = weight_input.producer()
-
-    if producer is not None and producer.op_type == "Transpose":
-        perm = producer.attributes.get("perm", None)
-        if perm is not None and list(perm.value) == [1, 0]:
-            raw_weight = producer.inputs[0]
-            if raw_weight.const_value is None:
-                return None, False
-            return raw_weight.const_value.numpy(), True
-
-    # Direct weight (no Transpose)
-    if weight_input.const_value is None:
-        return None, False
-    return weight_input.const_value.numpy(), False
-
-
 class RotaryAttentionToGQA(RewriteRuleClassBase):
     """Replace RotaryEmbedding + Attention with GroupQueryAttention.
 
@@ -94,23 +55,12 @@ class RotaryAttentionToGQA(RewriteRuleClassBase):
     attention with KV cache), and ``cos`` / ``sin`` are position-gathered
     from rotary cache tables via ``Gather``.
 
-    **Replacement (packed QKV, when Q/K/V share the same hidden_states
-    input and no QK norm is present):**
+    **Replacement:**
 
     .. code-block:: text
 
-        W_qkv = concatenate([W_q, W_k, W_v])
-        packed_qkv = MatMul(hidden_states, W_qkv)
-        attn_out, present_key, present_value = GroupQueryAttention(
-            packed_qkv, None, None, past_key, past_value,
-            seqlens_k, total_seq_len, cos_cache, sin_cache,
-            num_heads=..., kv_num_heads=..., do_rotary=1,
-        )
-
-    **Replacement (separate Q/K/V, fallback for models with QK norm):**
-
-    .. code-block:: text
-
+        seqlens_k = Cast(ReduceSum(attention_mask, axis=1) - 1, INT32)
+        total_seq_len = Cast(Shape(attention_mask)[1], INT32)
         attn_out, present_key, present_value = GroupQueryAttention(
             q_pre, k_pre, v, past_key, past_value,
             seqlens_k, total_seq_len, cos_cache, sin_cache,
@@ -187,74 +137,6 @@ class RotaryAttentionToGQA(RewriteRuleClassBase):
 
         return result
 
-    # ------------------------------------------------------------ pack QKV
-
-    def _try_pack_qkv(self, op, q_pre, k_pre, v):
-        """Try to pack Q/K/V projections into a single MatMul.
-
-        Traces back from ``q_pre``, ``k_pre``, ``v`` to their producing
-        projection ops (``MatMul`` or ``FusedMatMul``).  If all three
-        share the same hidden_states input and no QK norm is present,
-        concatenates the weight matrices and returns a single packed QKV
-        output.
-
-        Returns:
-            The packed QKV ``ir.Value`` on success, or ``None`` when
-            packing is not possible (e.g. QK norm present, weights not
-            materialised, or different hidden_states inputs).
-        """
-        proj_op_types = {"MatMul", "FusedMatMul"}
-
-        # 1. All three must come directly from a projection op (no QK norm)
-        q_proj = q_pre.producer()
-        k_proj = k_pre.producer()
-        v_proj = v.producer()
-        for node in (q_proj, k_proj, v_proj):
-            if node is None or node.op_type not in proj_op_types:
-                return None
-
-        # 2. All three projections must share the same first input
-        if not (q_proj.inputs[0] is k_proj.inputs[0] is v_proj.inputs[0]):
-            return None
-
-        hidden_states = q_proj.inputs[0]
-
-        # 3. Extract weights, handling Transpose and FusedMatMul
-        weights_np = []
-        is_transposed = None
-        for proj in (q_proj, k_proj, v_proj):
-            w_value, transposed = _extract_weight(proj)
-            if w_value is None:
-                return None
-            # All weights must follow the same pattern
-            if is_transposed is None:
-                is_transposed = transposed
-            elif is_transposed != transposed:
-                return None
-            weights_np.append(w_value)
-
-        # 4. Concatenate along the output dimension
-        # Transposed weights: shape (out_features, hidden_size) → axis=0
-        # Non-transposed weights: shape (hidden_size, out_features) → axis=1
-        concat_axis = 0 if is_transposed else 1
-        w_qkv_np = np.concatenate(weights_np, axis=concat_axis)
-
-        # 5. Create the packed projection
-        packed_weight = op.Constant(value=ir.Tensor(w_qkv_np))
-        if is_transposed:
-            # Use FusedMatMul if source projections were FusedMatMul,
-            # otherwise emit Transpose + MatMul
-            if q_proj.op_type == "FusedMatMul":
-                return op.op(
-                    "FusedMatMul",
-                    inputs=[hidden_states, packed_weight],
-                    domain="com.microsoft",
-                    attributes={"transB": 1},
-                )
-            packed_weight_t = op.Transpose(packed_weight, perm=[1, 0])
-            return op.MatMul(hidden_states, packed_weight_t)
-        return op.MatMul(hidden_states, packed_weight)
-
     # ------------------------------------------------------------------ rewrite
 
     def rewrite(
@@ -309,22 +191,10 @@ class RotaryAttentionToGQA(RewriteRuleClassBase):
                 to=6,
             )
 
-        # Try packed QKV path; fall back to separate Q/K/V
-        packed_qkv = self._try_pack_qkv(op, q_pre, k_pre, v)
-        if packed_qkv is not None:
-            gqa_inputs = [
-                packed_qkv,
-                None,
-                None,
-                past_key,
-                past_value,
-                self._seqlens_k,
-                self._total_seq_len,
-                self._cos_cache,
-                self._sin_cache,
-            ]
-        else:
-            gqa_inputs = [
+        # Create GroupQueryAttention (3 outputs match Attention's 3)
+        outputs = op.op_multi_out(
+            "GroupQueryAttention",
+            inputs=[
                 q_pre,
                 k_pre,
                 v,
@@ -334,12 +204,7 @@ class RotaryAttentionToGQA(RewriteRuleClassBase):
                 self._total_seq_len,
                 self._cos_cache,
                 self._sin_cache,
-            ]
-
-        # Create GroupQueryAttention (3 outputs match Attention's 3)
-        outputs = op.op_multi_out(
-            "GroupQueryAttention",
-            inputs=gqa_inputs,
+            ],
             domain="com.microsoft",
             attributes={
                 "num_heads": q_num_heads,
@@ -354,15 +219,250 @@ class RotaryAttentionToGQA(RewriteRuleClassBase):
         return outputs[0], outputs[1], outputs[2]
 
 
+# ====================================================================
+# PackQKVForGQA — consolidates 3 separate MatMuls into 1 packed MatMul
+# ====================================================================
+
+_PROJ_OP_TYPES = frozenset({"MatMul", "FusedMatMul"})
+
+
+def _get_weight_tensor(proj_node):
+    """Extract the constant weight tensor from a projection node.
+
+    Handles three patterns:
+
+    1. ``Transpose(weight, perm=[1,0]) -> MatMul(x, w_t)``
+    2. ``MatMul(x, weight)``  (no transpose)
+    3. ``FusedMatMul(x, weight, transB=1)``  (post fused_matmul rewrite)
+
+    Returns:
+        ``(numpy_array, is_transposed)`` on success, or ``(None, False)``
+        if the weight cannot be extracted as a constant.
+    """
+    if proj_node.op_type == "FusedMatMul":
+        trans_b = proj_node.attributes.get_int("transB", 0)
+        tensor = ir.convenience.get_const_tensor(proj_node.inputs[1])
+        if tensor is None:
+            return None, False
+        return tensor.numpy(), bool(trans_b)
+
+    # MatMul -- weight may be behind a Transpose
+    weight_input = proj_node.inputs[1]
+    producer = weight_input.producer()
+    if producer is not None and producer.op_type == "Transpose":
+        perm = producer.attributes.get("perm", None)
+        if perm is not None and list(perm.value) == [1, 0]:
+            tensor = ir.convenience.get_const_tensor(producer.inputs[0])
+            if tensor is None:
+                return None, False
+            return tensor.numpy(), True
+
+    tensor = ir.convenience.get_const_tensor(weight_input)
+    if tensor is None:
+        return None, False
+    return tensor.numpy(), False
+
+
+class PackQKVForGQA(RewriteRuleClassBase):
+    """Pack separate Q/K/V projections into a single MatMul for GQA.
+
+    This rule runs **after** ``RotaryAttentionToGQA`` and looks for
+    ``GroupQueryAttention`` nodes whose Q, K, V inputs each come from a
+    separate projection (``MatMul`` or ``FusedMatMul``) that shares
+    the same ``hidden_states`` input.
+
+    **Matched pattern:**
+
+    .. code-block:: text
+
+        q = MatMul(hidden, W_q_t)
+        k = MatMul(hidden, W_k_t)
+        v = MatMul(hidden, W_v_t)
+        out, pkey, pval = GroupQueryAttention(q, k, v, ...)
+
+    **Replacement:**
+
+    .. code-block:: text
+
+        W_qkv = concatenate([W_q, W_k, W_v])
+        packed = MatMul(hidden, W_qkv_t)
+        out, pkey, pval = GroupQueryAttention(packed, None, None, ...)
+
+    The packed weight is stored as a graph initializer (not a
+    ``Constant`` node attribute) so it can be serialised to external
+    data files for large models.
+    """
+
+    _pack_counter: int = 0
+
+    # ------------------------------------------------------------------ pattern
+
+    def pattern(
+        self,
+        op,
+        q,
+        k,
+        v,
+        past_key,
+        past_value,
+        seqlens_k,
+        total_seq_len,
+        cos_cache,
+        sin_cache,
+    ):
+        return op.GroupQueryAttention(
+            q,
+            k,
+            v,
+            past_key,
+            past_value,
+            seqlens_k,
+            total_seq_len,
+            cos_cache,
+            sin_cache,
+            _domain="com.microsoft",
+            _allow_other_attributes=True,
+            _outputs=["gqa_out", "present_key", "present_value"],
+        )
+
+    # ------------------------------------------------------------------ check
+
+    def check(self, context, q, k, v, gqa_out, **_):
+        result = MatchResult()
+
+        # Q, K, V must each come from a projection op
+        for name, val in [("q", q), ("k", k), ("v", v)]:
+            if val is None:
+                return result.fail(f"{name} is None")
+            prod = val.producer()
+            if prod is None or prod.op_type not in _PROJ_OP_TYPES:
+                return result.fail(f"{name} not from MatMul/FusedMatMul")
+
+        q_proj = q.producer()
+        k_proj = k.producer()
+        v_proj = v.producer()
+
+        # All three must share the same hidden_states input
+        if not (q_proj.inputs[0] is k_proj.inputs[0] is v_proj.inputs[0]):
+            return result.fail("Q/K/V don't share hidden_states")
+
+        # All weights must be extractable constants
+        for name, proj in [
+            ("q", q_proj),
+            ("k", k_proj),
+            ("v", v_proj),
+        ]:
+            w_np, _ = _get_weight_tensor(proj)
+            if w_np is None:
+                return result.fail(f"{name} weight not constant")
+
+        return result
+
+    # ------------------------------------------------------------------ rewrite
+
+    def rewrite(
+        self,
+        op,
+        q,
+        k,
+        v,
+        past_key,
+        past_value,
+        seqlens_k,
+        total_seq_len,
+        cos_cache,
+        sin_cache,
+        gqa_out,
+        present_key,
+        present_value,
+        **_,
+    ):
+        gqa_node = gqa_out.producer()
+        graph = gqa_node.graph
+
+        q_proj = q.producer()
+        k_proj = k.producer()
+        v_proj = v.producer()
+        hidden_states = q_proj.inputs[0]
+
+        # Extract and concatenate weights
+        weights_np = []
+        is_transposed = None
+        for proj in (q_proj, k_proj, v_proj):
+            w_np, transposed = _get_weight_tensor(proj)
+            if is_transposed is None:
+                is_transposed = transposed
+            weights_np.append(w_np)
+
+        # Transposed: (out_features, hidden) -> concat axis=0
+        # Non-transposed: (hidden, out_features) -> concat axis=1
+        concat_axis = 0 if is_transposed else 1
+        w_qkv_np = np.concatenate(weights_np, axis=concat_axis)
+
+        # Store packed weight as a graph initializer
+        self._pack_counter += 1
+        w_name = f"packed_qkv_weight_{self._pack_counter}"
+        packed_w = ir.Value(
+            name=w_name,
+            const_value=ir.Tensor(w_qkv_np, name=w_name),
+        )
+        graph.register_initializer(packed_w)
+
+        # Create the packed projection
+        if is_transposed:
+            if q_proj.op_type == "FusedMatMul":
+                packed_qkv = op.op(
+                    "FusedMatMul",
+                    inputs=[hidden_states, packed_w],
+                    domain="com.microsoft",
+                    attributes={"transB": 1},
+                )
+            else:
+                packed_w_t = op.Transpose(packed_w, perm=[1, 0])
+                packed_qkv = op.MatMul(hidden_states, packed_w_t)
+        else:
+            packed_qkv = op.MatMul(hidden_states, packed_w)
+
+        # Forward all original GQA attributes
+        attrs = {key: gqa_node.attributes[key].value for key in gqa_node.attributes}
+
+        outputs = op.op_multi_out(
+            "GroupQueryAttention",
+            inputs=[
+                packed_qkv,
+                None,
+                None,
+                past_key,
+                past_value,
+                seqlens_k,
+                total_seq_len,
+                cos_cache,
+                sin_cache,
+            ],
+            domain="com.microsoft",
+            attributes=attrs,
+            num_outputs=3,
+        )
+
+        return outputs[0], outputs[1], outputs[2]
+
+
 def group_query_attention_rules() -> RewriteRuleSet:
     """Return rules that fuse RotaryEmbedding + Attention into GQA.
 
-    These rules match the RotaryEmbedding -> Attention pattern common
-    in decoder layers and replace it with the Microsoft
-    ``GroupQueryAttention`` custom op with ``do_rotary=1``.
+    The rule set contains two rules applied in order:
+
+    1. ``RotaryAttentionToGQA`` -- fuses RotaryEmbedding + Attention into
+       ``GroupQueryAttention`` with separate Q, K, V inputs.
+    2. ``PackQKVForGQA`` -- consolidates the three separate Q/K/V
+       projection MatMuls into a single packed MatMul when possible.
 
     Returns:
-        :class:`RewriteRuleSet` containing the RotaryEmbedding+Attention
-        fusion rule.
+        :class:`RewriteRuleSet` containing both rules.
     """
-    return RewriteRuleSet([RotaryAttentionToGQA().rule()])
+    return RewriteRuleSet(
+        [
+            RotaryAttentionToGQA().rule(),
+            PackQKVForGQA().rule(),
+        ]
+    )

--- a/src/mobius/rewrite_rules/_group_query_attention.py
+++ b/src/mobius/rewrite_rules/_group_query_attention.py
@@ -346,15 +346,20 @@ class PackQKVForGQA(RewriteRuleClassBase):
         if not (q_proj.inputs[0] is k_proj.inputs[0] is v_proj.inputs[0]):
             return result.fail("Q/K/V don't share hidden_states")
 
-        # All weights must be extractable constants
+        # All weights must be extractable constants with consistent layout
+        is_transposed = None
         for name, proj in [
             ("q", q_proj),
             ("k", k_proj),
             ("v", v_proj),
         ]:
-            w_np, _ = _get_weight_tensor(proj)
+            w_np, transposed = _get_weight_tensor(proj)
             if w_np is None:
                 return result.fail(f"{name} weight not constant")
+            if is_transposed is None:
+                is_transposed = transposed
+            elif is_transposed != transposed:
+                return result.fail("Mixed transpose states")
 
         return result
 

--- a/src/mobius/rewrite_rules/_group_query_attention.py
+++ b/src/mobius/rewrite_rules/_group_query_attention.py
@@ -36,6 +36,7 @@ from onnxscript.rewriter._rewrite_rule import (
     RewriteRuleClassBase,
     RewriteRuleSet,
 )
+from onnxscript.rewriter.pattern import OrValue
 
 
 class RotaryAttentionToGQA(RewriteRuleClassBase):
@@ -223,8 +224,6 @@ class RotaryAttentionToGQA(RewriteRuleClassBase):
 # PackQKVForGQA — consolidates 3 separate MatMuls into 1 packed MatMul
 # ====================================================================
 
-_PROJ_OP_TYPES = frozenset({"MatMul", "FusedMatMul"})
-
 
 def _get_weight_tensor(proj_node):
     """Extract the constant weight tensor from a projection node.
@@ -275,9 +274,9 @@ class PackQKVForGQA(RewriteRuleClassBase):
 
     .. code-block:: text
 
-        q = MatMul(hidden, W_q_t)
-        k = MatMul(hidden, W_k_t)
-        v = MatMul(hidden, W_v_t)
+        q = MatMul|FusedMatMul(hidden, W_q)
+        k = MatMul|FusedMatMul(hidden, W_k)
+        v = MatMul|FusedMatMul(hidden, W_v)
         out, pkey, pval = GroupQueryAttention(q, k, v, ...)
 
     **Replacement:**
@@ -304,9 +303,10 @@ class PackQKVForGQA(RewriteRuleClassBase):
     def pattern(
         self,
         op,
-        q,
-        k,
-        v,
+        hidden,
+        q_w,
+        k_w,
+        v_w,
         past_key,
         past_value,
         seqlens_k,
@@ -314,6 +314,41 @@ class PackQKVForGQA(RewriteRuleClassBase):
         cos_cache,
         sin_cache,
     ):
+        # Each projection may be MatMul or FusedMatMul (post fused_matmul)
+        q = OrValue(
+            [
+                op.MatMul(hidden, q_w),
+                op.FusedMatMul(
+                    hidden,
+                    q_w,
+                    _domain="com.microsoft",
+                    _allow_other_attributes=True,
+                ),
+            ]
+        )
+        k = OrValue(
+            [
+                op.MatMul(hidden, k_w),
+                op.FusedMatMul(
+                    hidden,
+                    k_w,
+                    _domain="com.microsoft",
+                    _allow_other_attributes=True,
+                ),
+            ]
+        )
+        v = OrValue(
+            [
+                op.MatMul(hidden, v_w),
+                op.FusedMatMul(
+                    hidden,
+                    v_w,
+                    _domain="com.microsoft",
+                    _allow_other_attributes=True,
+                ),
+            ]
+        )
+
         return op.GroupQueryAttention(
             q,
             k,
@@ -331,32 +366,21 @@ class PackQKVForGQA(RewriteRuleClassBase):
 
     # ------------------------------------------------------------------ check
 
-    def check(self, context, q, k, v, gqa_out, **_):
+    def check(self, context, q_w, k_w, v_w, gqa_out, **_):
         result = MatchResult()
 
-        # Q, K, V must each come from a projection op
-        for name, val in [("q", q), ("k", k), ("v", v)]:
-            if val is None:
-                return result.fail(f"{name} is None")
-            prod = val.producer()
-            if prod is None or prod.op_type not in _PROJ_OP_TYPES:
-                return result.fail(f"{name} not from MatMul/FusedMatMul")
-
-        q_proj = q.producer()
-        k_proj = k.producer()
-        v_proj = v.producer()
-
-        # All three must share the same hidden_states input
-        if not (q_proj.inputs[0] is k_proj.inputs[0] is v_proj.inputs[0]):
-            return result.fail("Q/K/V don't share hidden_states")
+        gqa_node = gqa_out.producer()
+        # Extract projection nodes from the GQA inputs
+        projs = []
+        for i, name in enumerate(("q", "k", "v")):
+            proj = gqa_node.inputs[i].producer()
+            if proj is None:
+                return result.fail(f"{name} projection missing")
+            projs.append(proj)
 
         # All weights must be extractable constants with consistent layout
         is_transposed = None
-        for name, proj in [
-            ("q", q_proj),
-            ("k", k_proj),
-            ("v", v_proj),
-        ]:
+        for name, proj in zip(("q", "k", "v"), projs):
             w_np, transposed = _get_weight_tensor(proj)
             if w_np is None:
                 return result.fail(f"{name} weight not constant")
@@ -372,9 +396,10 @@ class PackQKVForGQA(RewriteRuleClassBase):
     def rewrite(
         self,
         op,
-        q,
-        k,
-        v,
+        hidden,
+        q_w,
+        k_w,
+        v_w,
         past_key,
         past_value,
         seqlens_k,
@@ -389,15 +414,13 @@ class PackQKVForGQA(RewriteRuleClassBase):
         gqa_node = gqa_out.producer()
         graph = gqa_node.graph
 
-        q_proj = q.producer()
-        k_proj = k.producer()
-        v_proj = v.producer()
-        hidden_states = q_proj.inputs[0]
+        q_proj = gqa_node.inputs[0].producer()
 
         # Extract and concatenate weights
         weights_np = []
         is_transposed = None
-        for proj in (q_proj, k_proj, v_proj):
+        for i in range(3):
+            proj = gqa_node.inputs[i].producer()
             w_np, transposed = _get_weight_tensor(proj)
             if is_transposed is None:
                 is_transposed = transposed
@@ -422,15 +445,15 @@ class PackQKVForGQA(RewriteRuleClassBase):
             if q_proj.op_type == "FusedMatMul":
                 packed_qkv = op.op(
                     "FusedMatMul",
-                    inputs=[hidden_states, packed_w],
+                    inputs=[hidden, packed_w],
                     domain="com.microsoft",
                     attributes={"transB": 1},
                 )
             else:
                 packed_w_t = op.Transpose(packed_w, perm=[1, 0])
-                packed_qkv = op.MatMul(hidden_states, packed_w_t)
+                packed_qkv = op.MatMul(hidden, packed_w_t)
         else:
-            packed_qkv = op.MatMul(hidden_states, packed_w)
+            packed_qkv = op.MatMul(hidden, packed_w)
 
         # Forward all original GQA attributes
         attrs = {key: gqa_node.attributes[key].value for key in gqa_node.attributes}

--- a/src/mobius/rewrite_rules/_group_query_attention_test.py
+++ b/src/mobius/rewrite_rules/_group_query_attention_test.py
@@ -173,7 +173,7 @@ class TestGroupQueryAttentionRules:
 
         matmul_after = count_ops(m)["MatMul"]
         num_layers = _LLAMA_CONFIG.num_hidden_layers
-        # 3 separate Q/K/V MatMuls → 1 packed MatMul per layer = -2 per layer
+        # 3 separate Q/K/V MatMuls -> 1 packed MatMul per layer = -2 per layer
         assert matmul_after == matmul_before - 2 * num_layers
 
     def test_packed_weight_shape_is_correct(self):
@@ -185,29 +185,23 @@ class TestGroupQueryAttentionRules:
 
         rewrite(m, pattern_rewrite_rules=group_query_attention_rules())
 
-        # Find a packed weight initializer by its shape
         q_dim = _LLAMA_CONFIG.num_attention_heads * _LLAMA_CONFIG.head_dim
         kv_dim = _LLAMA_CONFIG.num_key_value_heads * _LLAMA_CONFIG.head_dim
         hidden = _LLAMA_CONFIG.hidden_size
         expected_shape = (q_dim + 2 * kv_dim, hidden)
 
-        # Look through Constant nodes for the packed weight
+        # Packed weights are stored as graph initializers
         found = False
-        for node in m.graph:
-            if node.op_type != "Constant":
+        for init in m.graph.initializers.values():
+            if init.const_value is None:
                 continue
-            val = node.attributes.get("value", None)
-            if val is None:
-                continue
-            tensor = val.value
-            if tuple(tensor.shape) == expected_shape:
-                found = True
-                # Verify it's a valid float32 tensor
-                arr = tensor.numpy()
+            if tuple(init.const_value.shape) == expected_shape:
+                arr = init.const_value.numpy()
                 assert arr.dtype == np.float32
                 assert not np.any(np.isnan(arr))
+                found = True
                 break
-        assert found, f"No packed weight with shape {expected_shape} found"
+        assert found, f"No packed weight initializer with shape {expected_shape}"
 
     def test_falls_back_to_separate_qkv_with_qk_norm(self):
         """Qwen3 (QK norm) falls back; MatMul count unchanged."""
@@ -284,7 +278,7 @@ class TestGroupQueryAttentionRules:
         rewrite(m, pattern_rewrite_rules=group_query_attention_rules())
         counts = count_ops(m)
         assert counts["GroupQueryAttention"] == 2
-        # FusedMatMul count should decrease: 3 Q/K/V → 1 packed per layer
+        # FusedMatMul count should decrease: 3 Q/K/V -> 1 packed per layer
         fused_after = counts.get("FusedMatMul", 0)
         num_layers = _LLAMA_CONFIG.num_hidden_layers
         assert fused_after <= matmul_before - 2 * num_layers

--- a/src/mobius/rewrite_rules/_group_query_attention_test.py
+++ b/src/mobius/rewrite_rules/_group_query_attention_test.py
@@ -260,8 +260,8 @@ class TestGroupQueryAttentionRules:
         assert result["logits"].shape == (1, 3, 256)
         session.close()
 
-    def test_packed_qkv_after_fused_matmul_runs_with_ort(self):
-        """Packing works when fused_matmul runs first (--optimize=all)."""
+    def test_packed_gqa_then_fused_matmul_runs_with_ort(self):
+        """Packing runs before fused_matmul (mirrors --optimize=all order)."""
         from mobius.rewrite_rules import fused_matmul_rules
 
         model = registry.get("llama")(_LLAMA_CONFIG)
@@ -271,17 +271,17 @@ class TestGroupQueryAttentionRules:
 
         matmul_before = count_ops(m)["MatMul"]
 
-        # Apply fused_matmul first, then GQA (mirrors --optimize=all)
-        rewrite(m, pattern_rewrite_rules=fused_matmul_rules())
-        assert count_ops(m).get("FusedMatMul", 0) > 0
-
+        # GQA (with packing) runs first — sees plain MatMul nodes
         rewrite(m, pattern_rewrite_rules=group_query_attention_rules())
-        counts = count_ops(m)
-        assert counts["GroupQueryAttention"] == 2
-        # FusedMatMul count should decrease: 3 Q/K/V -> 1 packed per layer
-        fused_after = counts.get("FusedMatMul", 0)
+        counts_after_gqa = count_ops(m)
+        assert counts_after_gqa["GroupQueryAttention"] == 2
         num_layers = _LLAMA_CONFIG.num_hidden_layers
-        assert fused_after <= matmul_before - 2 * num_layers
+        assert counts_after_gqa["MatMul"] == matmul_before - 2 * num_layers
+
+        # Then fused_matmul converts remaining Transpose+MatMul
+        rewrite(m, pattern_rewrite_rules=fused_matmul_rules())
+        counts_final = count_ops(m)
+        assert counts_final.get("FusedMatMul", 0) > 0
 
         session = OnnxModelSession(m)
         feeds = make_prefill_feeds(session)

--- a/src/mobius/rewrite_rules/_group_query_attention_test.py
+++ b/src/mobius/rewrite_rules/_group_query_attention_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import numpy as np
 from onnxscript.rewriter import rewrite
 from onnxscript.rewriter._rewrite_rule import RewriteRuleSet
 
@@ -16,6 +17,41 @@ from mobius.rewrite_rules._testing_utils import (
     count_ops,
     fill_random_weights,
     make_prefill_feeds,
+)
+
+# Tiny llama config: no QK norm, weights are packable
+_LLAMA_CONFIG = ArchitectureConfig(
+    hidden_size=64,
+    intermediate_size=128,
+    num_attention_heads=4,
+    num_key_value_heads=2,
+    head_dim=16,
+    num_hidden_layers=2,
+    vocab_size=256,
+    max_position_embeddings=128,
+    hidden_act="silu",
+    rms_norm_eps=1e-6,
+    rope_type="default",
+    rope_theta=10000.0,
+    pad_token_id=0,
+)
+
+# Tiny qwen3 config: has QK norm, weights NOT packable
+_QWEN3_CONFIG = ArchitectureConfig(
+    hidden_size=64,
+    intermediate_size=128,
+    num_attention_heads=4,
+    num_key_value_heads=2,
+    head_dim=16,
+    num_hidden_layers=2,
+    vocab_size=256,
+    max_position_embeddings=128,
+    hidden_act="silu",
+    rms_norm_eps=1e-6,
+    rope_type="default",
+    rope_theta=10000.0,
+    pad_token_id=0,
+    attn_qk_norm=True,
 )
 
 
@@ -83,24 +119,8 @@ class TestGroupQueryAttentionRules:
 
     def test_rewritten_model_runs_with_ort(self):
         """GQA-rewritten model can be serialized and run with ORT."""
-        config = ArchitectureConfig(
-            hidden_size=64,
-            intermediate_size=128,
-            num_attention_heads=4,
-            num_key_value_heads=2,
-            head_dim=16,
-            num_hidden_layers=2,
-            vocab_size=256,
-            max_position_embeddings=128,
-            hidden_act="silu",
-            rms_norm_eps=1e-6,
-            rope_type="default",
-            rope_theta=10000.0,
-            pad_token_id=0,
-            attn_qk_norm=True,
-        )
-        model = registry.get("qwen3")(config)
-        pkg = build_from_module(model, config)
+        model = registry.get("qwen3")(_QWEN3_CONFIG)
+        pkg = build_from_module(model, _QWEN3_CONFIG)
         m = pkg["model"]
         fill_random_weights(m)
 
@@ -118,24 +138,116 @@ class TestGroupQueryAttentionRules:
         """Applying GQA + SkipNorm together produces a valid ORT model."""
         from mobius.rewrite_rules import skip_norm_rules
 
-        config = ArchitectureConfig(
-            hidden_size=64,
-            intermediate_size=128,
-            num_attention_heads=4,
-            num_key_value_heads=2,
-            head_dim=16,
-            num_hidden_layers=2,
-            vocab_size=256,
-            max_position_embeddings=128,
-            hidden_act="silu",
-            rms_norm_eps=1e-6,
-            rope_type="default",
-            rope_theta=10000.0,
-            pad_token_id=0,
-            attn_qk_norm=True,
-        )
-        model = registry.get("qwen3")(config)
-        pkg = build_from_module(model, config)
+        model = registry.get("qwen3")(_QWEN3_CONFIG)
+        pkg = build_from_module(model, _QWEN3_CONFIG)
+        m = pkg["model"]
+        fill_random_weights(m)
+
+        rewrite(m, pattern_rewrite_rules=group_query_attention_rules())
+        rewrite(m, pattern_rewrite_rules=skip_norm_rules())
+
+        counts = count_ops(m)
+        assert counts["GroupQueryAttention"] == 2
+        assert counts["SkipSimplifiedLayerNormalization"] > 0
+        assert counts.get("Attention", 0) == 0
+
+        session = OnnxModelSession(m)
+        feeds = make_prefill_feeds(session)
+        result = session.run(feeds)
+        assert "logits" in result
+        assert result["logits"].shape == (1, 3, 256)
+        session.close()
+
+    # ---- Packed QKV tests ----
+
+    def test_packed_qkv_reduces_matmul_count(self):
+        """Packing Q/K/V into one MatMul removes 2 MatMuls per layer."""
+        model = registry.get("llama")(_LLAMA_CONFIG)
+        pkg = build_from_module(model, _LLAMA_CONFIG)
+        m = pkg["model"]
+        fill_random_weights(m)
+
+        matmul_before = count_ops(m)["MatMul"]
+
+        rewrite(m, pattern_rewrite_rules=group_query_attention_rules())
+
+        matmul_after = count_ops(m)["MatMul"]
+        num_layers = _LLAMA_CONFIG.num_hidden_layers
+        # 3 separate Q/K/V MatMuls → 1 packed MatMul per layer = -2 per layer
+        assert matmul_after == matmul_before - 2 * num_layers
+
+    def test_packed_weight_shape_is_correct(self):
+        """Packed W_qkv has shape (q_dim + 2*kv_dim, hidden_size)."""
+        model = registry.get("llama")(_LLAMA_CONFIG)
+        pkg = build_from_module(model, _LLAMA_CONFIG)
+        m = pkg["model"]
+        fill_random_weights(m)
+
+        rewrite(m, pattern_rewrite_rules=group_query_attention_rules())
+
+        # Find a packed weight initializer by its shape
+        q_dim = _LLAMA_CONFIG.num_attention_heads * _LLAMA_CONFIG.head_dim
+        kv_dim = _LLAMA_CONFIG.num_key_value_heads * _LLAMA_CONFIG.head_dim
+        hidden = _LLAMA_CONFIG.hidden_size
+        expected_shape = (q_dim + 2 * kv_dim, hidden)
+
+        # Look through Constant nodes for the packed weight
+        found = False
+        for node in m.graph:
+            if node.op_type != "Constant":
+                continue
+            val = node.attributes.get("value", None)
+            if val is None:
+                continue
+            tensor = val.value
+            if tuple(tensor.shape) == expected_shape:
+                found = True
+                # Verify it's a valid float32 tensor
+                arr = tensor.numpy()
+                assert arr.dtype == np.float32
+                assert not np.any(np.isnan(arr))
+                break
+        assert found, f"No packed weight with shape {expected_shape} found"
+
+    def test_falls_back_to_separate_qkv_with_qk_norm(self):
+        """Qwen3 (QK norm) falls back; MatMul count unchanged."""
+        model = registry.get("qwen3")(_QWEN3_CONFIG)
+        pkg = build_from_module(model, _QWEN3_CONFIG)
+        m = pkg["model"]
+        fill_random_weights(m)
+
+        matmul_before = count_ops(m)["MatMul"]
+
+        rewrite(m, pattern_rewrite_rules=group_query_attention_rules())
+
+        # GQA should still be applied
+        assert count_ops(m)["GroupQueryAttention"] == 2
+        # But MatMul count should not decrease (no packing)
+        assert count_ops(m)["MatMul"] == matmul_before
+
+    def test_packed_model_runs_with_ort(self):
+        """Packed-QKV GQA model runs correctly with ORT."""
+        model = registry.get("llama")(_LLAMA_CONFIG)
+        pkg = build_from_module(model, _LLAMA_CONFIG)
+        m = pkg["model"]
+        fill_random_weights(m)
+
+        rewrite(m, pattern_rewrite_rules=group_query_attention_rules())
+        assert count_ops(m)["GroupQueryAttention"] == 2
+
+        session = OnnxModelSession(m)
+        feeds = make_prefill_feeds(session)
+        result = session.run(feeds)
+        assert "logits" in result
+        assert result["logits"].shape == (1, 3, 256)
+        session.close()
+
+    def test_combined_packed_gqa_and_skip_norm_runs_with_ort(self):
+        """Packed GQA + SkipNorm produces a valid ORT model."""
+        from mobius.rewrite_rules import skip_norm_rules
+
+        model = registry.get("llama")(_LLAMA_CONFIG)
+        pkg = build_from_module(model, _LLAMA_CONFIG)
         m = pkg["model"]
         fill_random_weights(m)
 

--- a/src/mobius/rewrite_rules/_group_query_attention_test.py
+++ b/src/mobius/rewrite_rules/_group_query_attention_test.py
@@ -265,3 +265,33 @@ class TestGroupQueryAttentionRules:
         assert "logits" in result
         assert result["logits"].shape == (1, 3, 256)
         session.close()
+
+    def test_packed_qkv_after_fused_matmul_runs_with_ort(self):
+        """Packing works when fused_matmul runs first (--optimize=all)."""
+        from mobius.rewrite_rules import fused_matmul_rules
+
+        model = registry.get("llama")(_LLAMA_CONFIG)
+        pkg = build_from_module(model, _LLAMA_CONFIG)
+        m = pkg["model"]
+        fill_random_weights(m)
+
+        matmul_before = count_ops(m)["MatMul"]
+
+        # Apply fused_matmul first, then GQA (mirrors --optimize=all)
+        rewrite(m, pattern_rewrite_rules=fused_matmul_rules())
+        assert count_ops(m).get("FusedMatMul", 0) > 0
+
+        rewrite(m, pattern_rewrite_rules=group_query_attention_rules())
+        counts = count_ops(m)
+        assert counts["GroupQueryAttention"] == 2
+        # FusedMatMul count should decrease: 3 Q/K/V → 1 packed per layer
+        fused_after = counts.get("FusedMatMul", 0)
+        num_layers = _LLAMA_CONFIG.num_hidden_layers
+        assert fused_after <= matmul_before - 2 * num_layers
+
+        session = OnnxModelSession(m)
+        feeds = make_prefill_feeds(session)
+        result = session.run(feeds)
+        assert "logits" in result
+        assert result["logits"].shape == (1, 3, 256)
+        session.close()


### PR DESCRIPTION
Fix #11

This pull request significantly enhances the GroupQueryAttention rewrite rule by introducing support for packing Q, K, and V projections into a single MatMul when possible, improving model efficiency. It also adds comprehensive tests to verify both the new packed QKV path and fallback behavior for models that cannot be packed (such as those with QK norm, e.g., Qwen3). The documentation and test infrastructure are updated to reflect these changes.

Key changes:

**GroupQueryAttention rewrite rule improvements:**

* Added logic to detect when Q, K, and V projections can be packed into a single MatMul by checking for shared input and absence of QK norm, then concatenating the weights and emitting a packed MatMul for GroupQueryAttention. The fallback path for models with QK norm remains unchanged. [[1]](diffhunk://#diff-05ea0a505b5dca0ba7c7a7a17ba02bc4c50a211a2af554617c600e17e463481cR13-R19) [[2]](diffhunk://#diff-05ea0a505b5dca0ba7c7a7a17ba02bc4c50a211a2af554617c600e17e463481cR179-R235) [[3]](diffhunk://#diff-05ea0a505b5dca0ba7c7a7a17ba02bc4c50a211a2af554617c600e17e463481cL184-R305) [[4]](diffhunk://#diff-05ea0a505b5dca0ba7c7a7a17ba02bc4c50a211a2af554617c600e17e463481cL197-R320)
* Updated documentation to describe the packed QKV optimization and fallback path, including code snippets for both scenarios. [[1]](diffhunk://#diff-05ea0a505b5dca0ba7c7a7a17ba02bc4c50a211a2af554617c600e17e463481cR13-R19) [[2]](diffhunk://#diff-05ea0a505b5dca0ba7c7a7a17ba02bc4c50a211a2af554617c600e17e463481cL48-L53)

**Helper and utility additions:**

* Introduced `_extract_weight` helper function to robustly extract and handle weight matrices from MatMul nodes, supporting both direct and transposed weights.

**Testing enhancements:**

* Added new test cases for the packed QKV path, including tests that verify MatMul reduction, correct packed weight shape, fallback behavior for QK norm models, and end-to-end execution with ONNX Runtime. [[1]](diffhunk://#diff-63c5e9ca11114f2bbd3649ba2e0af172f03e4c4cd3c357523380696ede6aeb66R22-R56) [[2]](diffhunk://#diff-63c5e9ca11114f2bbd3649ba2e0af172f03e4c4cd3c357523380696ede6aeb66L86-R123) [[3]](diffhunk://#diff-63c5e9ca11114f2bbd3649ba2e0af172f03e4c4cd3c357523380696ede6aeb66L121-R250)
* Refactored test configuration setup for clarity and reusability by introducing `_LLAMA_CONFIG` and `_QWEN3_CONFIG`.
* Updated existing tests to use the new configuration constants for consistency. [[1]](diffhunk://#diff-63c5e9ca11114f2bbd3649ba2e0af172f03e4c4cd3c357523380696ede6aeb66L86-R123) [[2]](diffhunk://#diff-63c5e9ca11114f2bbd3649ba2e0af172f03e4c4cd3c357523380696ede6aeb66L121-R250)