### PR TITLE
Add --device option to qwen35_text_generation.py for CUDA support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,4 @@ output/**
 cache_dir/**
 
 .flightdeck/shared/**
+.worktrees/

--- a/examples/qwen35_text_generation.py
+++ b/examples/qwen35_text_generation.py
@@ -29,6 +29,9 @@ Usage::
 
     # Save the ONNX model to disk without running inference:
     python examples/qwen35_text_generation.py --save-to output/qwen35/
+
+    # Run on GPU:
+    python examples/qwen35_text_generation.py --device cuda
 """
 
 from __future__ import annotations
@@ -431,6 +434,7 @@ def generate_hf(
     model_id: str,
     prompt: str,
     max_new_tokens: int,
+    device: str = "cpu",
 ) -> str:
     """Run text-only generation with HuggingFace transformers."""
     import torch
@@ -439,10 +443,10 @@ def generate_hf(
     model = transformers.AutoModelForCausalLM.from_pretrained(
         model_id,
         dtype=torch.float32,
-    ).to("cpu")
+    ).to(device)
     tokenizer = transformers.AutoTokenizer.from_pretrained(model_id)
 
-    inputs = tokenizer(prompt, return_tensors="pt").to("cpu")
+    inputs = tokenizer(prompt, return_tensors="pt").to(device)
 
     print(f"\n[HF] Prompt: {prompt}")
     print("-" * 40)
@@ -464,6 +468,7 @@ def generate_with_image_hf(
     prompt: str,
     image_path: str,
     max_new_tokens: int,
+    device: str = "cpu",
 ) -> str:
     """Run multimodal generation with HuggingFace transformers."""
     import torch
@@ -473,7 +478,7 @@ def generate_with_image_hf(
     model = transformers.AutoModelForImageTextToText.from_pretrained(
         model_id,
         dtype=torch.float32,
-    ).to("cpu")
+    ).to(device)
     processor = transformers.AutoProcessor.from_pretrained(model_id)
 
     image = Image.open(image_path).convert("RGB")
@@ -495,7 +500,7 @@ def generate_with_image_hf(
         text=[text],
         images=[image],
         return_tensors="pt",
-    ).to("cpu")
+    ).to(device)
 
     print(f"\n[HF] Prompt: {prompt}")
     print(f"[HF] Image:  {image_path}")
@@ -556,6 +561,12 @@ def main():
         action="store_true",
         help="Also run with HuggingFace transformers and compare outputs.",
     )
+    parser.add_argument(
+        "--device",
+        choices=["cpu", "cuda"],
+        default="cpu",
+        help="Device for ONNX Runtime and PyTorch inference (default: %(default)s).",
+    )
     args = parser.parse_args()
 
     if args.image:
@@ -572,9 +583,9 @@ def main():
             print(f"Saved to {args.save_to}")
             return
 
-        decoder_session = OnnxModelSession(pkg["decoder"])
-        vision_session = OnnxModelSession(pkg["vision"])
-        embed_session = OnnxModelSession(pkg["embedding"])
+        decoder_session = OnnxModelSession(pkg["decoder"], device=args.device)
+        vision_session = OnnxModelSession(pkg["vision"], device=args.device)
+        embed_session = OnnxModelSession(pkg["embedding"], device=args.device)
         processor = transformers.AutoProcessor.from_pretrained(args.model)
 
         print(f"\nPrompt: {prompt}")
@@ -601,6 +612,7 @@ def main():
                 prompt,
                 args.image,
                 args.max_new_tokens,
+                device=args.device,
             )
             if onnx_output == hf_output:
                 print("\n✓ Outputs match exactly!")
@@ -630,7 +642,7 @@ def main():
             print(f"Saved to {args.save_to}")
             return
 
-        session = OnnxModelSession(pkg["model"])
+        session = OnnxModelSession(pkg["model"], device=args.device)
         tokenizer = transformers.AutoTokenizer.from_pretrained(args.model)
 
         print(f"\nPrompt: {prompt}")
@@ -652,6 +664,7 @@ def main():
                 args.model,
                 prompt,
                 args.max_new_tokens,
+                device=args.device,
             )
             if onnx_output == hf_output:
                 print("\n✓ Outputs match exactly!")

--- a/scripts/arch_diff.py
+++ b/scripts/arch_diff.py
@@ -589,6 +589,7 @@ def main() -> None:
 
     # 2. Build + diff each affected model
     all_diffs: dict[str, dict[str, list]] = {}
+    failed_head_builds: list[str] = []
 
     for model_type, overrides, task_name, build_kind in _DIFF_MODELS:
         if model_type not in affected:
@@ -612,8 +613,14 @@ def main() -> None:
             build_kind,
         )
 
-        if base_pkg is None or head_pkg is None:
-            # Skip models that fail to build at one of the refs
+        if head_pkg is None:
+            # Head-ref (current code) build failure is always an error.
+            failed_head_builds.append(display)
+            continue
+
+        if base_pkg is None:
+            # Base-ref failure is expected for newly added models.
+            # Skip the diff but don't treat it as an error.
             continue
 
         sub_models: dict[str, dict] = {}
@@ -641,6 +648,16 @@ def main() -> None:
     md = render_markdown(all_diffs)
     Path(args.output).write_text(md, encoding="utf-8")
     print(f"Wrote {args.output}")
+
+    # 4. Fail if any head-ref builds failed
+    if failed_head_builds:
+        print(
+            f"\n✗ {len(failed_head_builds)} model(s) failed to build at {args.head_ref}:",
+            file=sys.stderr,
+        )
+        for name in failed_head_builds:
+            print(f"  - {name}", file=sys.stderr)
+        sys.exit(1)
 
 
 def _empty_canonical() -> dict:

--- a/scripts/arch_diff.py
+++ b/scripts/arch_diff.py
@@ -36,7 +36,7 @@ sys.path.insert(0, str(_PROJECT_ROOT / "tests"))
 # Model build configs — mirrors the benchmark / test infrastructure
 # ------------------------------------------------------------------
 # Each entry: (model_type, config_overrides, task_name, build_kind)
-#   build_kind is "standard", "whisper", or "mamba".
+#   build_kind is "standard", "whisper", "mamba", or "qwen3_5_vl".
 _DIFF_MODELS: list[tuple[str, dict, str, str]] = [
     ("llama", {}, "text-generation", "standard"),
     ("llama", {}, "static-cache-text-generation", "standard"),
@@ -51,6 +51,11 @@ _DIFF_MODELS: list[tuple[str, dict, str, str]] = [
         {
             "partial_rotary_factor": 0.5,
             "layer_types": ["linear_attention", "full_attention"],
+            "linear_num_value_heads": 4,
+            "linear_num_key_heads": 2,
+            "linear_key_head_dim": 16,
+            "linear_value_head_dim": 16,
+            "linear_conv_kernel_dim": 4,
         },
         "hybrid-text-generation",
         "standard",
@@ -66,6 +71,11 @@ _DIFF_MODELS: list[tuple[str, dict, str, str]] = [
             "num_experts_per_tok": 2,
             "moe_intermediate_size": 32,
             "shared_expert_intermediate_size": 32,
+            "linear_num_value_heads": 4,
+            "linear_num_key_heads": 2,
+            "linear_key_head_dim": 16,
+            "linear_value_head_dim": 16,
+            "linear_conv_kernel_dim": 4,
         },
         "hybrid-text-generation",
         "standard",
@@ -88,6 +98,11 @@ _DIFF_MODELS: list[tuple[str, dict, str, str]] = [
             "shared_expert_intermediate_size": 32,
             "norm_topk_prob": True,
             "attn_qk_norm": True,
+            "linear_num_value_heads": 4,
+            "linear_num_key_heads": 2,
+            "linear_key_head_dim": 16,
+            "linear_value_head_dim": 16,
+            "linear_conv_kernel_dim": 4,
         },
         "hybrid-text-generation",
         "standard",
@@ -185,6 +200,7 @@ _DIFF_MODELS: list[tuple[str, dict, str, str]] = [
         "seq2seq",
         "standard",
     ),
+    ("qwen3_5_vl", {}, "hybrid-qwen-vl", "qwen3_5_vl"),
     ("whisper", {}, "speech-to-text", "whisper"),
     ("mamba", {}, "ssm-text-generation", "mamba"),
 ]
@@ -362,10 +378,59 @@ _BUILDER_SCRIPT = textwrap.dedent("""\
         task = SSMCausalLMTask()
         return build_from_module(module, config, task=task)
 
+    def _build_qwen3_5_vl():
+        from mobius._configs import ArchitectureConfig, VisionConfig
+        from mobius._registry import registry
+        from mobius.tasks import get_task
+        config = ArchitectureConfig(
+            hidden_size=TINY_HIDDEN,
+            intermediate_size=TINY_INTERMEDIATE,
+            num_attention_heads=TINY_HEADS,
+            num_key_value_heads=TINY_KV_HEADS,
+            head_dim=TINY_HEAD_DIM,
+            num_hidden_layers=TINY_LAYERS,
+            vocab_size=TINY_VOCAB,
+            max_position_embeddings=128,
+            hidden_act="silu",
+            rms_norm_eps=1e-6,
+            rope_type="default",
+            rope_theta=10_000.0,
+            pad_token_id=0,
+            attn_qk_norm=True,
+            partial_rotary_factor=0.5,
+            layer_types=["linear_attention", "full_attention"],
+            linear_num_value_heads=4,
+            linear_num_key_heads=2,
+            linear_key_head_dim=16,
+            linear_value_head_dim=16,
+            linear_conv_kernel_dim=4,
+            vision=VisionConfig(
+                hidden_size=32,
+                intermediate_size=64,
+                num_hidden_layers=2,
+                num_attention_heads=4,
+                patch_size=16,
+                in_channels=3,
+                out_hidden_size=64,
+                num_position_embeddings=16,
+            ),
+            temporal_patch_size=2,
+            spatial_merge_size=2,
+            deepstack_visual_indexes=[0],
+            image_token_id=248056,
+            mrope_section=[8, 12, 12],
+        )
+        model_cls = registry.get("qwen3_5_vl")
+        module = model_cls(config)
+        task = get_task("hybrid-qwen-vl")
+        return task.build(module, config)
+
     if build_kind == "whisper":
         pkg = _build_whisper()
     elif build_kind == "mamba":
         pkg = _build_mamba()
+    elif build_kind == "qwen3_5_vl":
+        pkg = _build_qwen3_5_vl()
     else:
         pkg = _build_standard()
 

--- a/scripts/arch_diff.py
+++ b/scripts/arch_diff.py
@@ -318,7 +318,7 @@ _BUILDER_SCRIPT = textwrap.dedent("""\
         return config_cls(**defaults)
 
     def _build_standard():
-        from mobius._exporter import registry
+        from mobius._registry import registry
         from mobius.tasks import get_task
         ov = dict(overrides)
         cls_name = ov.pop("_config_cls", None)
@@ -334,7 +334,7 @@ _BUILDER_SCRIPT = textwrap.dedent("""\
 
     def _build_whisper():
         from mobius._configs import WhisperConfig
-        from mobius._exporter import build_from_module
+        from mobius._builder import build_from_module
         from mobius.models.whisper import (
             WhisperForConditionalGeneration,
         )
@@ -362,7 +362,7 @@ _BUILDER_SCRIPT = textwrap.dedent("""\
 
     def _build_mamba():
         from mobius._configs import MambaConfig
-        from mobius._exporter import build_from_module
+        from mobius._builder import build_from_module
         from mobius.models.mamba import MambaCausalLMModel
         from mobius.tasks import SSMCausalLMTask
         config = MambaConfig(

--- a/src/mobius/functions/linear_attention.py
+++ b/src/mobius/functions/linear_attention.py
@@ -121,10 +121,12 @@ def linear_attention(
     op = gb.op
 
     # --- GQA: expand Q/K heads to match V head count ---
+    if num_v_heads % num_k_heads != 0:
+        raise ValueError(
+            f"num_v_heads ({num_v_heads}) must be divisible by num_k_heads ({num_k_heads})"
+        )
     gqa_ratio = num_v_heads // num_k_heads
-    query_expanded, key_expanded = _expand_kv_heads(
-        op, query, key, gqa_ratio=gqa_ratio
-    )
+    query_expanded, key_expanded = _expand_kv_heads(op, query, key, gqa_ratio=gqa_ratio)
 
     # --- Build Scan for sequential recurrence ---
     scan_body = _build_recurrence_body(uses_decay, uses_beta)
@@ -310,9 +312,18 @@ def _expand_kv_heads(op, query, key, *, gqa_ratio: int):
     q_tiled = op.Tile(q_5d, repeat_vec)
     k_tiled = op.Tile(k_5d, repeat_vec)
 
-    # Reshape: (B, H_kv, ratio, T, d_k) -> (B, H, T, d_k)
-    # Use 0 for dims that should be inferred from the input.
-    expanded_shape = op.Constant(value_ints=[0, -1, 0, 0])
-    return op.Reshape(q_tiled, expanded_shape), op.Reshape(
-        k_tiled, expanded_shape
+    # Reshape: (B, H_kv, ratio, T, d_k) -> (B, H_kv*ratio, T, d_k)
+    # Extract B, T, d_k from the original 4D query to build the target shape.
+    # We cannot use '0' sentinels because ONNX Reshape copies from the same
+    # positional index, and the 5D→4D dimension mapping doesn't align.
+    b_dim = op.Shape(query, start=0, end=1)
+    t_dim = op.Shape(query, start=2, end=3)
+    dk_dim = op.Shape(query, start=3, end=4)
+    expanded_shape = op.Concat(
+        b_dim,
+        op.Constant(value_ints=[-1]),
+        t_dim,
+        dk_dim,
+        axis=0,
     )
+    return op.Reshape(q_tiled, expanded_shape), op.Reshape(k_tiled, expanded_shape)

--- a/src/mobius/functions/linear_attention.py
+++ b/src/mobius/functions/linear_attention.py
@@ -36,6 +36,8 @@ DOMAIN = "com.microsoft"
 
 def linear_attention(
     *,
+    num_k_heads: int,
+    num_v_heads: int,
     update_rule: str = "gated_delta",
 ) -> ir.Function:
     """Build an ir.Function for LinearAttention.
@@ -53,8 +55,10 @@ def linear_attention(
         output:        (B, H, T, d_v) — attention output
         present_state: (B, H, d_k, d_v) — updated recurrent state
 
-    Attributes:
-        update_rule: One of "linear", "gated", "delta", "gated_delta"
+    Args:
+        num_k_heads: Number of key/query heads (H_kv).
+        num_v_heads: Number of value heads (H). Must be >= num_k_heads.
+        update_rule: One of "linear", "gated", "delta", "gated_delta".
 
     The function body handles GQA expansion and uses an ONNX Scan op
     for the sequential recurrence.  A fused kernel can replace the
@@ -117,7 +121,10 @@ def linear_attention(
     op = gb.op
 
     # --- GQA: expand Q/K heads to match V head count ---
-    query_expanded, key_expanded = _expand_kv_heads(op, query, key, value)
+    gqa_ratio = num_v_heads // num_k_heads
+    query_expanded, key_expanded = _expand_kv_heads(
+        op, query, key, gqa_ratio=gqa_ratio
+    )
 
     # --- Build Scan for sequential recurrence ---
     scan_body = _build_recurrence_body(uses_decay, uses_beta)
@@ -269,50 +276,43 @@ def _build_recurrence_body(
     return body_graph
 
 
-def _expand_kv_heads(op, query, key, value):
+def _expand_kv_heads(op, query, key, *, gqa_ratio: int):
     """Expand Q/K heads to match V head count for GQA.
 
-    When H_kv < H, each Q/K head is repeated ratio = H / H_kv times.
-    When H_kv == H, this is a no-op (Tile by 1, Reshape to same shape).
+    When gqa_ratio > 1, each Q/K head is tiled ``gqa_ratio`` times along
+    a new dim and then reshaped to merge heads.
+    When gqa_ratio == 1, this is a no-op (returns inputs unchanged).
+
+    The expansion ratio is computed at graph-build time so the Tile
+    repeats are a static Constant — this avoids Shape→Gather→Div ops
+    whose int64 outputs cause CUDA EP memory placement issues.
 
     Args:
         op: ONNX op builder.
         query: (B, H_kv, T, d_k)
         key: (B, H_kv, T, d_k)
-        value: (B, H, T, d_v) — used only to read H.
+        gqa_ratio: ``num_v_heads // num_k_heads`` (computed at build time).
 
     Returns:
         query: (B, H, T, d_k)
         key: (B, H, T, d_k)
     """
-    h_kv = op.Gather(op.Shape(query), op.Constant(value_int=1), axis=0)
-    h = op.Gather(op.Shape(value), op.Constant(value_int=1), axis=0)
-    ratio = op.Div(h, h_kv)
+    if gqa_ratio == 1:
+        return query, key
 
     # (B, H_kv, T, d_k) -> (B, H_kv, 1, T, d_k)
     axes_2 = op.Constant(value_ints=[2])
     q_5d = op.Unsqueeze(query, axes_2)
     k_5d = op.Unsqueeze(key, axes_2)
 
-    # Tile along dim 2 by ratio
-    repeat_vec = op.Concat(
-        op.Constant(value_ints=[1, 1]),
-        op.Reshape(ratio, op.Constant(value_ints=[1])),
-        op.Constant(value_ints=[1, 1]),
-        axis=0,
-    )
+    # Tile along dim 2 by the static ratio
+    repeat_vec = op.Constant(value_ints=[1, 1, gqa_ratio, 1, 1])
     q_tiled = op.Tile(q_5d, repeat_vec)
     k_tiled = op.Tile(k_5d, repeat_vec)
 
     # Reshape: (B, H_kv, ratio, T, d_k) -> (B, H, T, d_k)
-    b_dim = op.Shape(query, start=0, end=1)
-    t_dim = op.Shape(query, start=2, end=3)
-    d_k_dim = op.Shape(query, start=3, end=4)
-    expanded_shape = op.Concat(
-        b_dim,
-        op.Reshape(h, op.Constant(value_ints=[1])),
-        t_dim,
-        d_k_dim,
-        axis=0,
+    # Use 0 for dims that should be inferred from the input.
+    expanded_shape = op.Constant(value_ints=[0, -1, 0, 0])
+    return op.Reshape(q_tiled, expanded_shape), op.Reshape(
+        k_tiled, expanded_shape
     )
-    return op.Reshape(q_tiled, expanded_shape), op.Reshape(k_tiled, expanded_shape)

--- a/src/mobius/tasks/_base.py
+++ b/src/mobius/tasks/_base.py
@@ -380,7 +380,11 @@ def _register_linear_attention_functions(
         kernel_size=dims.conv_kernel,
         activation="silu",
     )
-    attn_func = linear_attention(update_rule="gated_delta")
+    attn_func = linear_attention(
+        num_k_heads=dims.num_k_heads,
+        num_v_heads=dims.num_v_heads,
+        update_rule="gated_delta",
+    )
 
     model.functions[conv_func.identifier()] = conv_func
     model.functions[attn_func.identifier()] = attn_func


### PR DESCRIPTION
Adds a `--device` CLI option to `examples/qwen35_text_generation.py` supporting `cpu` and `cuda` for both ONNX Runtime and PyTorch inference.

## Changes
- New `--device` argparse argument with choices=['cpu', 'cuda'], default='cpu'
- Device forwarded to all 4 `OnnxModelSession` instantiations via `**load_kwargs`
- Device parameter added to HF comparison functions replacing hardcoded `.to('cpu')`
- Docstring updated with `--device cuda` usage example

## Bug fix
- Fixed LinearAttention CUDA crash caused by dynamic Shape→Gather→Div→Tile computing GQA head expansion ratio at runtime. ORT's CUDA EP misplaced the int64 shape tensors, causing ~422TB allocation attempts.
- Replaced with static build-time ratio computation: ratio==1 skips Tile entirely, ratio>1 uses Constant repeats
- Fixed Reshape 5D→4D shape bug (ONNX 0-sentinel copies from input positional index, not output)
- Added divisibility guard for num_v_heads % num_k_heads