### PR TITLE
Remove group attribute from CausalConv1DWithState

### DIFF
--- a/src/mobius/components/_gated_deltanet.py
+++ b/src/mobius/components/_gated_deltanet.py
@@ -45,9 +45,9 @@ class _DepthwiseConv1d(nn.Module):
     (``conv1d.weight``) automatically align with ONNX initializer names.
 
     The ``forward()`` method calls the ``CausalConv1DWithState``
-    function op from the ``pkg.mobius`` domain, passing the
-    ``group`` attribute so one function definition works for all channel
-    sizes.  Because the module is invoked via ``__call__``,
+    function op from the ``pkg.mobius`` domain.  The function derives
+    group=channels internally from the input shape, so the caller does
+    not need to supply it.  Because the module is invoked via ``__call__``,
     ``self.weight`` is automatically realized as a graph initializer
     with the correct qualified name.
     """
@@ -86,7 +86,6 @@ class _DepthwiseConv1d(nn.Module):
             conv_bias,
             conv_state,
             activation="silu",
-            group=self._channels,
             _domain="com.microsoft",
             _outputs=2,
         )

--- a/src/mobius/components/_gated_deltanet.py
+++ b/src/mobius/components/_gated_deltanet.py
@@ -45,9 +45,12 @@ class _DepthwiseConv1d(nn.Module):
     (``conv1d.weight``) automatically align with ONNX initializer names.
 
     The ``forward()`` method calls the ``CausalConv1DWithState``
-    function op from the ``pkg.mobius`` domain.  The function derives
-    group=channels internally from the input shape, so the caller does
-    not need to supply it.  Because the module is invoked via ``__call__``,
+    function op in the ``com.microsoft`` domain (registered as an
+    ``ir.Function`` by the task layer). The function is specialized
+    for depthwise convolution with ``group = channels`` baked in at
+    construction time from the ``channels`` argument, so the caller
+    does not supply ``group`` and it is not derived from the runtime
+    input shape. Because the module is invoked via ``__call__``,
     ``self.weight`` is automatically realized as a graph initializer
     with the correct qualified name.
     """

--- a/src/mobius/functions/causal_conv.py
+++ b/src/mobius/functions/causal_conv.py
@@ -26,22 +26,21 @@ DOMAIN = "com.microsoft"
 def causal_conv1d_with_state(
     *,
     kernel_size: int,
+    channels: int,
     activation: str = "silu",
 ) -> ir.Function:
     """Build an ir.Function for CausalConv1DWithState.
 
-    A single function definition works for all channel sizes because the
-    Conv ``group`` attribute is declared as a function-level attribute via
-    ``ref_attr_name`` and supplied by the caller at each call site.
+    The convolution is always depthwise (group = channels).  The group
+    count is derived from the ``channels`` build-time parameter so
+    callers never need to supply it as a function attribute.
 
     Args:
         kernel_size: Convolution kernel size (K).
+        channels: Number of input channels (D).  Used as the Conv
+            ``group`` attribute for depthwise convolution.
         activation: Fused activation — ``"silu"``, ``"swish"``, or
             ``"none"``.
-
-    Function attributes:
-        group: INT — number of groups for depthwise Conv (= channels D).
-            Passed by the caller and forwarded to the inner Conv node.
 
     Inputs:
         input:      (B, D, T)   — channels-first input
@@ -56,7 +55,7 @@ def causal_conv1d_with_state(
     The function body implements:
         1. Prepend conv_state to input along the time axis
         2. Slice out the new carry state (last K-1 positions)
-        3. Apply depthwise Conv1d (group from function attr, no padding)
+        3. Apply depthwise Conv1d (group = channels D, no padding)
         4. Add bias
         5. Apply activation (SiLU by default)
     """
@@ -94,13 +93,11 @@ def causal_conv1d_with_state(
     )
     present_state.name = "present_state"
 
-    # Step 3: Depthwise Conv1d (group forwarded from function attribute)
-    # ir.RefAttr makes the Conv node's ``group`` reference the
-    # function-level ``group`` attribute supplied by each caller.
+    # Step 3: Depthwise Conv1d (group = channels, always depthwise)
     conv_out = op.Conv(
         conv_input,
         weight_val,
-        group=ir.RefAttr("group", "group", ir.AttributeType.INT),
+        group=channels,
         pads=[0, 0],
     )
 
@@ -122,8 +119,6 @@ def causal_conv1d_with_state(
     graph.outputs.extend([output, present_state])
 
     # --- Build the ir.Function ---
-    # Function signature declares attributes normally.
-    # Inner Conv node references 'group' via ir.RefAttr.
     # NOTE: Do not set ``overload`` here — the call sites
     # (op.CausalConv1DWithState) do not set an overload on the
     # node, so setting one on the function would prevent the
@@ -137,11 +132,6 @@ def causal_conv1d_with_state(
                 "activation",
                 ir.AttributeType.STRING,
                 activation,
-            ),
-            "group": ir.Attr(
-                "group",
-                ir.AttributeType.INT,
-                0,
             ),
         },
     )

--- a/src/mobius/tasks/_base.py
+++ b/src/mobius/tasks/_base.py
@@ -378,6 +378,7 @@ def _register_linear_attention_functions(
 
     conv_func = causal_conv1d_with_state(
         kernel_size=dims.conv_kernel,
+        channels=dims.conv_dim,
         activation="silu",
     )
     attn_func = linear_attention(


### PR DESCRIPTION
Removes the `group` attribute from `CausalConv1DWithState` to align with the [ONNX spec proposal](https://github.com/onnx/onnx/issues/7689) which does not include it.

The `group` was always set to `channels` (depthwise convolution) across all models (Mamba, Mamba2, GatedDeltaNet, etc.). The weight shape `(D, 1, K)` already implies depthwise. The attribute existed only because the ir.Function decomposes into ONNX's standard `Conv` op which requires it.

## Changes
- Replaced `group` ir.RefAttr with a build-time `channels: int` parameter in `causal_conv.py`
- Updated call sites in `_gated_deltanet.py` and `_base.py`
- Updated docstrings

All tests pass, lint clean.