### PR TITLE
Add GPTQ-Int4 quantization support for Qwen3.5 models

### DIFF
--- a/src/mobius/_configs.py
+++ b/src/mobius/_configs.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import dataclasses
+import re
 
 import onnx_ir as ir
 import torch
@@ -549,12 +550,23 @@ class QuantizationConfig:
     configs (GPTQ, AWQ, etc.) so models can decide whether to use
     :class:`~mobius.components.QuantizedLinear` instead of
     :class:`~mobius.components.Linear`.
+
+    The ``exclude_patterns`` field stores regex patterns from the GPTQ
+    ``dynamic`` config (keys prefixed with ``-:``). These indicate
+    modules that should NOT be quantized. Models can check
+    ``is_excluded(module_name)`` at construction time to decide whether
+    a given layer should use quantized projections.
     """
 
     bits: int = 4
     group_size: int = 128
     quant_method: str = "none"
     sym: bool = True
+    exclude_patterns: tuple[str, ...] = ()
+
+    def is_excluded(self, module_name: str) -> bool:
+        """Return True if *module_name* matches any exclusion pattern."""
+        return any(re.search(p, module_name) for p in self.exclude_patterns)
 
     @classmethod
     def from_transformers(cls, hf_config) -> QuantizationConfig | None:
@@ -573,11 +585,26 @@ class QuantizationConfig:
         method = qc.get("quant_method", "none")
         if method == "none":
             return None
+
+        # Extract exclusion patterns from GPTQ dynamic config.
+        # Keys prefixed with "-:" are module-name regexes to exclude.
+        exclude_patterns: list[str] = []
+        dynamic = qc.get("dynamic", {})
+        if isinstance(dynamic, dict):
+            for key in dynamic:
+                if isinstance(key, str) and key.startswith("-:"):
+                    exclude_patterns.append(key[2:])
+        # Also check modules_to_not_convert (explicit module names)
+        for mod in qc.get("modules_to_not_convert") or []:
+            if isinstance(mod, str) and mod:
+                exclude_patterns.append(re.escape(mod))
+
         return cls(
             bits=qc.get("bits", 4),
             group_size=qc.get("group_size", 128),
             quant_method=method,
             sym=qc.get("sym", True),
+            exclude_patterns=tuple(exclude_patterns),
         )
 
 

--- a/src/mobius/_weight_utils.py
+++ b/src/mobius/_weight_utils.py
@@ -353,7 +353,10 @@ def preprocess_gptq_weights(
 
     for key, value in state_dict.items():
         if key.endswith(".g_idx"):
-            if not torch.equal(value, torch.arange(value.numel())):
+            # g_idx maps element i to its quantization group.  For
+            # non-desc_act models this is simply i // group_size.
+            trivial = torch.arange(value.numel(), dtype=value.dtype) // group_size
+            if not torch.equal(value, trivial):
                 logger.warning(
                     "Dropping %s — desc_act models with non-trivial "
                     "g_idx may produce incorrect results",

--- a/src/mobius/components/_attention.py
+++ b/src/mobius/components/_attention.py
@@ -292,6 +292,7 @@ class Qwen35Attention(nn.Module):
     def __init__(
         self,
         config: ArchitectureConfig,
+        linear_class: type | None = None,
     ):
         super().__init__()
         self.hidden_size = config.hidden_size
@@ -306,23 +307,24 @@ class Qwen35Attention(nn.Module):
         )
         self._rope_interleave = config.rope_interleave
 
+        lin_class = linear_class or Linear
         q_dim = self.num_attention_heads * self.head_dim
-        self.q_proj = Linear(
+        self.q_proj = lin_class(
             self.hidden_size,
             q_dim * 2,
             bias=config.attn_qkv_bias,
         )
-        self.k_proj = Linear(
+        self.k_proj = lin_class(
             self.hidden_size,
             self.num_key_value_heads * self.head_dim,
             bias=config.attn_qkv_bias,
         )
-        self.v_proj = Linear(
+        self.v_proj = lin_class(
             self.hidden_size,
             self.num_key_value_heads * self.head_dim,
             bias=config.attn_qkv_bias,
         )
-        self.o_proj = Linear(
+        self.o_proj = lin_class(
             q_dim,
             self.hidden_size,
             bias=config.attn_o_bias,

--- a/src/mobius/components/_gated_deltanet.py
+++ b/src/mobius/components/_gated_deltanet.py
@@ -105,7 +105,11 @@ class GatedDeltaNet(nn.Module):
     The recurrent state replaces the KV cache for these layers.
     """
 
-    def __init__(self, config: ArchitectureConfig):
+    def __init__(
+        self,
+        config: ArchitectureConfig,
+        linear_class: type | None = None,
+    ):
         super().__init__()
         self.hidden_size = config.hidden_size
         self.num_v_heads = config.linear_num_value_heads
@@ -117,17 +121,22 @@ class GatedDeltaNet(nn.Module):
         self.conv_kernel_size = config.linear_conv_kernel_dim
         self.conv_dim = self.key_dim * 2 + self.value_dim
 
+        # Use QuantizedLinear when provided, else standard Linear.
+        # in_proj_a and in_proj_b are always full-precision (too small
+        # to quantize and excluded by GPTQ configs).
+        lin_class = linear_class or Linear
+
         # QKV projection (fused: Q, K, V in one linear)
-        self.in_proj_qkv = Linear(
+        self.in_proj_qkv = lin_class(
             self.hidden_size,
             self.key_dim * 2 + self.value_dim,
             bias=False,
         )
         # Gating projection (z for silu gating in output norm)
-        self.in_proj_z = Linear(self.hidden_size, self.value_dim, bias=False)
-        # Beta projection (forget gate)
+        self.in_proj_z = lin_class(self.hidden_size, self.value_dim, bias=False)
+        # Beta projection (forget gate) — always full-precision
         self.in_proj_b = Linear(self.hidden_size, self.num_v_heads, bias=False)
-        # Alpha projection (decay control)
+        # Alpha projection (decay control) — always full-precision
         self.in_proj_a = Linear(self.hidden_size, self.num_v_heads, bias=False)
 
         # Causal depthwise Conv1D
@@ -141,7 +150,7 @@ class GatedDeltaNet(nn.Module):
         self.norm = PostGatedRMSNorm(self.head_v_dim, eps=config.rms_norm_eps)
 
         # Output projection
-        self.out_proj = Linear(self.value_dim, self.hidden_size, bias=False)
+        self.out_proj = lin_class(self.value_dim, self.hidden_size, bias=False)
 
     def forward(
         self,

--- a/src/mobius/models/qwen35.py
+++ b/src/mobius/models/qwen35.py
@@ -20,6 +20,7 @@ from mobius.components._common import (
 from mobius.components._gated_deltanet import GatedDeltaNet
 from mobius.components._mlp import MLP
 from mobius.components._moe import TopKGate
+from mobius.components._quantized_linear import make_quantized_linear_factory
 from mobius.components._rms_norm import OffsetRMSNorm
 from mobius.components._rotary_embedding import initialize_rope
 from mobius.models.base import CausalLMModel
@@ -46,9 +47,21 @@ class Qwen35DecoderLayer(nn.Module):
 
     Both variants use :class:`OffsetRMSNorm` (the *1 + weight* variant)
     for pre-attention and post-attention normalization.
+
+    Args:
+        config: Architecture configuration.
+        layer_idx: Index of this layer in the decoder stack.
+        linear_class: Factory for MLP projection layers (e.g.
+            ``QuantizedLinear`` for GPTQ).  Only applied to MLP, not
+            to attention or DeltaNet projections.
     """
 
-    def __init__(self, config: ArchitectureConfig, layer_idx: int):
+    def __init__(
+        self,
+        config: ArchitectureConfig,
+        layer_idx: int,
+        linear_class: type | None = None,
+    ):
         super().__init__()
         layer_types = config.layer_types or []
         self.layer_type: str = (
@@ -60,7 +73,7 @@ class Qwen35DecoderLayer(nn.Module):
         else:
             self.self_attn = Qwen35Attention(config)
 
-        self.mlp = MLP(config)
+        self.mlp = MLP(config, linear_class=linear_class)
         self.input_layernorm = OffsetRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = OffsetRMSNorm(
             config.hidden_size, eps=config.rms_norm_eps
@@ -112,16 +125,35 @@ class Qwen35TextModel(nn.Module):
     :class:`Qwen35DecoderLayer` instances that dispatch to either
     ``GatedDeltaNet`` or ``Qwen35Attention`` based on
     ``config.layer_types``.
+
+    When quantization is configured (e.g. GPTQ), only the MLP layers
+    use ``QuantizedLinear``.  Attention and DeltaNet projections remain
+    full-precision — matching the GPTQ config exclusion pattern
+    ``-:.*attn.*``.
     """
 
     def __init__(self, config: ArchitectureConfig):
         super().__init__()
         self._dtype = config.dtype
+
+        # Quantization: swap Linear for QuantizedLinear in MLP only.
+        linear_class = None
+        qc = getattr(config, "quantization", None)
+        if qc is not None and qc.quant_method != "none":
+            linear_class = make_quantized_linear_factory(
+                bits=qc.bits,
+                block_size=qc.group_size,
+                has_zero_point=not qc.sym,
+            )
+
         self.embed_tokens = Embedding(
             config.vocab_size, config.hidden_size, config.pad_token_id
         )
         self.layers = nn.ModuleList(
-            [Qwen35DecoderLayer(config, layer_idx=i) for i in range(config.num_hidden_layers)]
+            [
+                Qwen35DecoderLayer(config, layer_idx=i, linear_class=linear_class)
+                for i in range(config.num_hidden_layers)
+            ]
         )
         self.norm = OffsetRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.rotary_emb = initialize_rope(config)
@@ -229,9 +261,18 @@ class Qwen35MoEBlock(nn.Module):
         experts.N.{gate,up,down}_proj.weight
         shared_expert.{gate,up,down}_proj.weight
         shared_expert_gate.weight   → sigmoid gate for shared expert
+
+    Args:
+        config: Architecture configuration.
+        linear_class: Factory for MLP projection layers (e.g.
+            ``QuantizedLinear`` for GPTQ).
     """
 
-    def __init__(self, config: ArchitectureConfig):
+    def __init__(
+        self,
+        config: ArchitectureConfig,
+        linear_class: type | None = None,
+    ):
         super().__init__()
         assert config.num_local_experts is not None
         assert config.num_experts_per_tok is not None
@@ -243,13 +284,15 @@ class Qwen35MoEBlock(nn.Module):
         expert_config = dataclasses.replace(
             config, intermediate_size=config.moe_intermediate_size
         )
-        self.experts = nn.ModuleList([MLP(expert_config) for _ in range(num_experts)])
+        self.experts = nn.ModuleList(
+            [MLP(expert_config, linear_class=linear_class) for _ in range(num_experts)]
+        )
 
         shared_config = dataclasses.replace(
             config,
             intermediate_size=config.shared_expert_intermediate_size,
         )
-        self.shared_expert = MLP(shared_config)
+        self.shared_expert = MLP(shared_config, linear_class=linear_class)
         self.shared_expert_gate = Linear(config.hidden_size, 1, bias=False)
 
     def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
@@ -288,9 +331,14 @@ class Qwen35MoEDecoderLayer(Qwen35DecoderLayer):
     :class:`Qwen35MoEBlock`.
     """
 
-    def __init__(self, config: ArchitectureConfig, layer_idx: int):
-        super().__init__(config, layer_idx)
-        self.mlp = Qwen35MoEBlock(config)
+    def __init__(
+        self,
+        config: ArchitectureConfig,
+        layer_idx: int,
+        linear_class: type | None = None,
+    ):
+        super().__init__(config, layer_idx, linear_class=linear_class)
+        self.mlp = Qwen35MoEBlock(config, linear_class=linear_class)
 
 
 class Qwen35MoETextModel(nn.Module):
@@ -300,18 +348,33 @@ class Qwen35MoETextModel(nn.Module):
     :class:`Qwen35TextModel`, but each layer uses MoE FFN
     (:class:`Qwen35MoEBlock`) instead of dense MLP.
 
+    When quantization is configured (e.g. GPTQ), only the MLP layers
+    use ``QuantizedLinear``.  Attention and DeltaNet projections remain
+    full-precision.
+
     HuggingFace class: ``Qwen3_5MoeModel``
     """
 
     def __init__(self, config: ArchitectureConfig):
         super().__init__()
         self._dtype = config.dtype
+
+        # Quantization: swap Linear for QuantizedLinear in MLP only.
+        linear_class = None
+        qc = getattr(config, "quantization", None)
+        if qc is not None and qc.quant_method != "none":
+            linear_class = make_quantized_linear_factory(
+                bits=qc.bits,
+                block_size=qc.group_size,
+                has_zero_point=not qc.sym,
+            )
+
         self.embed_tokens = Embedding(
             config.vocab_size, config.hidden_size, config.pad_token_id
         )
         self.layers = nn.ModuleList(
             [
-                Qwen35MoEDecoderLayer(config, layer_idx=i)
+                Qwen35MoEDecoderLayer(config, layer_idx=i, linear_class=linear_class)
                 for i in range(config.num_hidden_layers)
             ]
         )

--- a/src/mobius/models/qwen35.py
+++ b/src/mobius/models/qwen35.py
@@ -11,6 +11,7 @@ from onnxscript import nn
 from onnxscript._internal import builder
 
 from mobius._configs import ArchitectureConfig
+from mobius._weight_utils import preprocess_gptq_weights
 from mobius.components._attention import Qwen35Attention
 from mobius.components._common import (
     Embedding,
@@ -553,6 +554,12 @@ class Qwen35VL3ModelCausalLMModel(nn.Module):
             elif stripped.startswith("language_model."):
                 suffix = stripped[len("language_model.") :]
                 renamed[f"decoder.model.{suffix}"] = value
+
+        # Transpose/reshape GPTQ quantized weights for MatMulNBits
+        qc = getattr(self.config, "quantization", None)
+        if qc is not None and qc.quant_method == "gptq":
+            renamed = preprocess_gptq_weights(renamed, bits=qc.bits, group_size=qc.group_size)
+
         return renamed
 
 

--- a/src/mobius/models/qwen35.py
+++ b/src/mobius/models/qwen35.py
@@ -52,11 +52,11 @@ class Qwen35DecoderLayer(nn.Module):
     Args:
         config: Architecture configuration.
         layer_idx: Index of this layer in the decoder stack.
-        linear_class: Factory for quantized projection layers (e.g.
-            ``QuantizedLinear`` for GPTQ).  Applied to MLP,
-            GatedDeltaNet projections (``in_proj_qkv``, ``in_proj_z``,
-            ``out_proj``), and Qwen35Attention projections (``q/k/v/o_proj``).
-            Not applied to DeltaNet's small ``in_proj_a``/``in_proj_b``.
+        linear_class: Factory for MLP projection layers (e.g.
+            ``QuantizedLinear`` for GPTQ).
+        attn_linear_class: Factory for attention/DeltaNet projection
+            layers.  Only set when the GPTQ config does not exclude
+            attention modules.  ``None`` means standard ``Linear``.
     """
 
     def __init__(
@@ -64,6 +64,7 @@ class Qwen35DecoderLayer(nn.Module):
         config: ArchitectureConfig,
         layer_idx: int,
         linear_class: type | None = None,
+        attn_linear_class: type | None = None,
     ):
         super().__init__()
         layer_types = config.layer_types or []
@@ -72,9 +73,9 @@ class Qwen35DecoderLayer(nn.Module):
         )
 
         if self.layer_type == "linear_attention":
-            self.linear_attn = GatedDeltaNet(config, linear_class=linear_class)
+            self.linear_attn = GatedDeltaNet(config, linear_class=attn_linear_class)
         else:
-            self.self_attn = Qwen35Attention(config, linear_class=linear_class)
+            self.self_attn = Qwen35Attention(config, linear_class=attn_linear_class)
 
         self.mlp = MLP(config, linear_class=linear_class)
         self.input_layernorm = OffsetRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
@@ -129,33 +130,48 @@ class Qwen35TextModel(nn.Module):
     ``GatedDeltaNet`` or ``Qwen35Attention`` based on
     ``config.layer_types``.
 
-    When quantization is configured (e.g. GPTQ), the MLP layers,
-    GatedDeltaNet projections (``in_proj_qkv``, ``in_proj_z``,
-    ``out_proj``), and Qwen35Attention projections (``q/k/v/o_proj``)
-    use ``QuantizedLinear``.  DeltaNet's small ``in_proj_a``/``in_proj_b``
-    remain full-precision.
+    When quantization is configured (e.g. GPTQ), MLP layers always use
+    ``QuantizedLinear``.  Attention/DeltaNet projections are only
+    quantized when the GPTQ config does not exclude them (checked via
+    ``QuantizationConfig.exclude_patterns``).  DeltaNet's small
+    ``in_proj_a``/``in_proj_b`` always remain full-precision.
     """
 
     def __init__(self, config: ArchitectureConfig):
         super().__init__()
         self._dtype = config.dtype
 
-        # Quantization: swap Linear for QuantizedLinear in MLP only.
-        linear_class = None
+        # Quantization: build QuantizedLinear factories.
+        # MLP is always quantized when GPTQ is active.
+        # Attention/DeltaNet projections are quantized only when not
+        # excluded by the GPTQ dynamic config (e.g. "-:.*attn.*").
+        mlp_linear_class = None
+        attn_linear_class = None
         qc = getattr(config, "quantization", None)
         if qc is not None and qc.quant_method != "none":
-            linear_class = make_quantized_linear_factory(
+            quantized_linear = make_quantized_linear_factory(
                 bits=qc.bits,
                 block_size=qc.group_size,
                 has_zero_point=not qc.sym,
             )
+            mlp_linear_class = quantized_linear
+            # Only quantize attention if not excluded by GPTQ config.
+            # The 27B official model excludes with "-:.*attn.*";
+            # community models may quantize everything.
+            if not qc.is_excluded("self_attn") and not qc.is_excluded("linear_attn"):
+                attn_linear_class = quantized_linear
 
         self.embed_tokens = Embedding(
             config.vocab_size, config.hidden_size, config.pad_token_id
         )
         self.layers = nn.ModuleList(
             [
-                Qwen35DecoderLayer(config, layer_idx=i, linear_class=linear_class)
+                Qwen35DecoderLayer(
+                    config,
+                    layer_idx=i,
+                    linear_class=mlp_linear_class,
+                    attn_linear_class=attn_linear_class,
+                )
                 for i in range(config.num_hidden_layers)
             ]
         )
@@ -340,8 +356,14 @@ class Qwen35MoEDecoderLayer(Qwen35DecoderLayer):
         config: ArchitectureConfig,
         layer_idx: int,
         linear_class: type | None = None,
+        attn_linear_class: type | None = None,
     ):
-        super().__init__(config, layer_idx, linear_class=linear_class)
+        super().__init__(
+            config,
+            layer_idx,
+            linear_class=linear_class,
+            attn_linear_class=attn_linear_class,
+        )
         self.mlp = Qwen35MoEBlock(config, linear_class=linear_class)
 
 
@@ -352,9 +374,9 @@ class Qwen35MoETextModel(nn.Module):
     :class:`Qwen35TextModel`, but each layer uses MoE FFN
     (:class:`Qwen35MoEBlock`) instead of dense MLP.
 
-    When quantization is configured (e.g. GPTQ), the MLP layers,
-    GatedDeltaNet projections, and Qwen35Attention projections use
-    ``QuantizedLinear``.
+    When quantization is configured (e.g. GPTQ), MLP layers always use
+    ``QuantizedLinear``.  Attention/DeltaNet projections are only
+    quantized when not excluded by the GPTQ config.
 
     HuggingFace class: ``Qwen3_5MoeModel``
     """
@@ -363,22 +385,31 @@ class Qwen35MoETextModel(nn.Module):
         super().__init__()
         self._dtype = config.dtype
 
-        # Quantization: swap Linear for QuantizedLinear in MLP only.
-        linear_class = None
+        # Quantization: build QuantizedLinear factories.
+        mlp_linear_class = None
+        attn_linear_class = None
         qc = getattr(config, "quantization", None)
         if qc is not None and qc.quant_method != "none":
-            linear_class = make_quantized_linear_factory(
+            quantized_linear = make_quantized_linear_factory(
                 bits=qc.bits,
                 block_size=qc.group_size,
                 has_zero_point=not qc.sym,
             )
+            mlp_linear_class = quantized_linear
+            if not qc.is_excluded("self_attn") and not qc.is_excluded("linear_attn"):
+                attn_linear_class = quantized_linear
 
         self.embed_tokens = Embedding(
             config.vocab_size, config.hidden_size, config.pad_token_id
         )
         self.layers = nn.ModuleList(
             [
-                Qwen35MoEDecoderLayer(config, layer_idx=i, linear_class=linear_class)
+                Qwen35MoEDecoderLayer(
+                    config,
+                    layer_idx=i,
+                    linear_class=mlp_linear_class,
+                    attn_linear_class=attn_linear_class,
+                )
                 for i in range(config.num_hidden_layers)
             ]
         )

--- a/src/mobius/models/qwen35.py
+++ b/src/mobius/models/qwen35.py
@@ -52,9 +52,11 @@ class Qwen35DecoderLayer(nn.Module):
     Args:
         config: Architecture configuration.
         layer_idx: Index of this layer in the decoder stack.
-        linear_class: Factory for MLP projection layers (e.g.
-            ``QuantizedLinear`` for GPTQ).  Only applied to MLP, not
-            to attention or DeltaNet projections.
+        linear_class: Factory for quantized projection layers (e.g.
+            ``QuantizedLinear`` for GPTQ).  Applied to MLP,
+            GatedDeltaNet projections (``in_proj_qkv``, ``in_proj_z``,
+            ``out_proj``), and Qwen35Attention projections (``q/k/v/o_proj``).
+            Not applied to DeltaNet's small ``in_proj_a``/``in_proj_b``.
     """
 
     def __init__(
@@ -70,9 +72,9 @@ class Qwen35DecoderLayer(nn.Module):
         )
 
         if self.layer_type == "linear_attention":
-            self.linear_attn = GatedDeltaNet(config)
+            self.linear_attn = GatedDeltaNet(config, linear_class=linear_class)
         else:
-            self.self_attn = Qwen35Attention(config)
+            self.self_attn = Qwen35Attention(config, linear_class=linear_class)
 
         self.mlp = MLP(config, linear_class=linear_class)
         self.input_layernorm = OffsetRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
@@ -127,10 +129,11 @@ class Qwen35TextModel(nn.Module):
     ``GatedDeltaNet`` or ``Qwen35Attention`` based on
     ``config.layer_types``.
 
-    When quantization is configured (e.g. GPTQ), only the MLP layers
-    use ``QuantizedLinear``.  Attention and DeltaNet projections remain
-    full-precision — matching the GPTQ config exclusion pattern
-    ``-:.*attn.*``.
+    When quantization is configured (e.g. GPTQ), the MLP layers,
+    GatedDeltaNet projections (``in_proj_qkv``, ``in_proj_z``,
+    ``out_proj``), and Qwen35Attention projections (``q/k/v/o_proj``)
+    use ``QuantizedLinear``.  DeltaNet's small ``in_proj_a``/``in_proj_b``
+    remain full-precision.
     """
 
     def __init__(self, config: ArchitectureConfig):
@@ -349,9 +352,9 @@ class Qwen35MoETextModel(nn.Module):
     :class:`Qwen35TextModel`, but each layer uses MoE FFN
     (:class:`Qwen35MoEBlock`) instead of dense MLP.
 
-    When quantization is configured (e.g. GPTQ), only the MLP layers
-    use ``QuantizedLinear``.  Attention and DeltaNet projections remain
-    full-precision.
+    When quantization is configured (e.g. GPTQ), the MLP layers,
+    GatedDeltaNet projections, and Qwen35Attention projections use
+    ``QuantizedLinear``.
 
     HuggingFace class: ``Qwen3_5MoeModel``
     """

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -613,12 +613,20 @@ class TestBuildGraphQuantized:
         pkg = task.build(module, config)
         model = pkg["model"]
 
-        # MLP projections (gate, up, down) are quantized;
-        # GatedDeltaNet and gated-attention projections use
-        # specialized components that bypass quantized linear.
+        # MLP projections (gate, up, down), GatedDeltaNet projections
+        # (in_proj_qkv, in_proj_z, out_proj), and Qwen35Attention
+        # projections (q, k, v, o) are all quantized.
         matmulnbits = [n for n in model.graph if n.op_type == "MatMulNBits"]
         num_mlp_projections_per_layer = 3  # gate, up, down
-        expected = 2 * num_mlp_projections_per_layer
+        num_deltanet_projections = 3  # in_proj_qkv, in_proj_z, out_proj
+        num_attention_projections = 4  # q, k, v, o
+        num_linear_attn_layers = sum(1 for t in config.layer_types if t == "linear_attention")
+        num_full_attn_layers = sum(1 for t in config.layer_types if t == "full_attention")
+        expected = (
+            config.num_hidden_layers * num_mlp_projections_per_layer
+            + num_linear_attn_layers * num_deltanet_projections
+            + num_full_attn_layers * num_attention_projections
+        )
         assert len(matmulnbits) == expected, (
             f"Expected {expected} MatMulNBits, got {len(matmulnbits)}"
         )

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -592,9 +592,10 @@ class TestBuildGraphQuantized:
         assert len(matmulnbits) == expected
 
     def test_qwen35_gptq_int4_builds(self):
-        """Qwen3.5 hybrid model builds with GPTQ-Int4 quantization."""
+        """Qwen3.5 hybrid model builds with GPTQ-Int4 (all layers quantized)."""
         from mobius._configs import QuantizationConfig
 
+        # No exclude_patterns → all projections quantized (community model)
         qc = QuantizationConfig(bits=4, group_size=32, quant_method="gptq", sym=True)
         config = _base_config(
             num_hidden_layers=2,
@@ -636,6 +637,42 @@ class TestBuildGraphQuantized:
         scales_names = [n for n in init_names if ".scales" in n]
         assert len(scales_names) == expected, (
             f"Expected {expected} scales initializers, got {len(scales_names)}"
+        )
+
+    def test_qwen35_gptq_int4_mlp_only(self):
+        """Qwen3.5 GPTQ with attn excluded (official 27B pattern)."""
+        from mobius._configs import QuantizationConfig
+
+        # Exclude attention: "-:.*attn.*" matches both self_attn and linear_attn
+        qc = QuantizationConfig(
+            bits=4,
+            group_size=32,
+            quant_method="gptq",
+            sym=True,
+            exclude_patterns=(r".*attn.*",),
+        )
+        config = _base_config(
+            num_hidden_layers=2,
+            partial_rotary_factor=0.5,
+            layer_types=["linear_attention", "full_attention"],
+            linear_num_value_heads=4,
+            linear_num_key_heads=2,
+            linear_key_head_dim=16,
+            linear_value_head_dim=16,
+            linear_conv_kernel_dim=4,
+            quantization=qc,
+        )
+        model_cls = registry.get("qwen3_5_text")
+        module = model_cls(config)
+        task = get_task("hybrid-text-generation")
+        pkg = task.build(module, config)
+        model = pkg["model"]
+
+        # Only MLP projections are quantized (attention is excluded)
+        matmulnbits = [n for n in model.graph if n.op_type == "MatMulNBits"]
+        expected = config.num_hidden_layers * 3  # gate, up, down per layer
+        assert len(matmulnbits) == expected, (
+            f"Expected {expected} MatMulNBits (MLP only), got {len(matmulnbits)}"
         )
 
 

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -591,6 +591,45 @@ class TestBuildGraphQuantized:
         expected = 1 * self.NUM_PROJECTIONS_PER_LAYER
         assert len(matmulnbits) == expected
 
+    def test_qwen35_gptq_int4_builds(self):
+        """Qwen3.5 hybrid model builds with GPTQ-Int4 quantization."""
+        from mobius._configs import QuantizationConfig
+
+        qc = QuantizationConfig(bits=4, group_size=32, quant_method="gptq", sym=True)
+        config = _base_config(
+            num_hidden_layers=2,
+            partial_rotary_factor=0.5,
+            layer_types=["linear_attention", "full_attention"],
+            linear_num_value_heads=4,
+            linear_num_key_heads=2,
+            linear_key_head_dim=16,
+            linear_value_head_dim=16,
+            linear_conv_kernel_dim=4,
+            quantization=qc,
+        )
+        model_cls = registry.get("qwen3_5_text")
+        module = model_cls(config)
+        task = get_task("hybrid-text-generation")
+        pkg = task.build(module, config)
+        model = pkg["model"]
+
+        # MLP projections (gate, up, down) are quantized;
+        # GatedDeltaNet and gated-attention projections use
+        # specialized components that bypass quantized linear.
+        matmulnbits = [n for n in model.graph if n.op_type == "MatMulNBits"]
+        num_mlp_projections_per_layer = 3  # gate, up, down
+        expected = 2 * num_mlp_projections_per_layer
+        assert len(matmulnbits) == expected, (
+            f"Expected {expected} MatMulNBits, got {len(matmulnbits)}"
+        )
+
+        # Verify scales initializers are present
+        init_names = list(model.graph.initializers)
+        scales_names = [n for n in init_names if ".scales" in n]
+        assert len(scales_names) == expected, (
+            f"Expected {expected} scales initializers, got {len(scales_names)}"
+        )
+
 
 class TestBuildGraphVisionLanguage:
     """Verify multimodal models build correctly."""


### PR DESCRIPTION
## GPTQ-Int4 Quantization Support for Qwen3.5

Adds GPTQ-Int4 quantization support for all Qwen3.5 model variants (text, MoE, VL).

### Key Changes

**Selective quantization via `exclude_patterns`**
- Added `exclude_patterns` field to `QuantizationConfig`, parsed from GPTQ `dynamic` config (`-:` prefixed regex patterns) and `modules_to_not_convert`
- Added `is_excluded(module_name)` method for models to check at construction time which layers should be quantized
- Official Qwen3.5-27B-GPTQ-Int4 excludes attention (`-:.*attn.*`) → MLP-only quantization
- Community models (e.g. Vishva007/Qwen3.5-0.8B-W4A16-AutoRound-GPTQ) quantize all layers including attention

**Per-component quantization control**
- `Qwen35TextModel` creates separate `mlp_linear_class` (always quantized) and `attn_linear_class` (conditional on `is_excluded()`)
- `Qwen35DecoderLayer` accepts both and routes `attn_linear_class` to `GatedDeltaNet` / `Qwen35Attention`, and `mlp_linear_class` to `MLP`
- Same pattern applied to `Qwen35MoEDecoderLayer` and `Qwen35MoETextModel`

**GatedDeltaNet and Qwen35Attention quantization support**
- Added optional `linear_class` parameter to `GatedDeltaNet.__init__()`
  - Quantizes `in_proj_qkv`, `in_proj_z`, `out_proj`
  - `in_proj_a` and `in_proj_b` always remain full-precision (too small to quantize)
- Added optional `linear_class` parameter to `Qwen35Attention.__init__()`
  - Quantizes `q_proj`, `k_proj`, `v_proj`, `o_proj`

**VL model GPTQ weight preprocessing**
- Fixed `Qwen35VL3ModelCausalLMModel.preprocess_weights()` to call `preprocess_gptq_weights()` for transposing/reshaping GPTQ scales, qweights, and qzeros from HuggingFace format to MatMulNBits format

**g_idx false-positive warning fix**
- Fixed trivial g_idx comparison in `preprocess_gptq_weights()` — was comparing against `torch.arange(K)` (identity) instead of `torch.arange(K) // group_size` (group assignments), causing spurious desc_act warnings on every GPTQ model

### Testing

- **Unit tests**: 1610 passed (added 2 GPTQ-specific tests: all-layers and MLP-only quantization patterns)
- **E2E build**: Verified with both `Qwen/Qwen3.5-27B-GPTQ-Int4` (MLP-only) and `Vishva007/Qwen3.5-0.8B-W4A16-AutoRound-GPTQ` (all-layers)
- **E2E inference**: 0.8B model produces coherent text on CPU
- **Lint**: Clean (`lintrunner f --output oneline --all-files`)

### Files Changed

- `src/mobius/_configs.py` — `QuantizationConfig.exclude_patterns` + `is_excluded()`
- `src/mobius/components/_gated_deltanet.py` — `linear_class` parameter
- `src/mobius/components/_attention.py` — `linear_class` parameter for `Qwen35Attention`
- `src/mobius/models/qwen35.py` — Selective quantization, VL preprocess_weights fix
- `src/mobius/_weight_utils.py` — g_idx false-positive fix
- `tests/build_graph_test.py` — GPTQ graph build tests
