### PR TITLE
Refactor data type handling and improve model precision in Qwen3.5

### DIFF
--- a/examples/qwen35_text_generation.py
+++ b/examples/qwen35_text_generation.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import argparse
 
+import ml_dtypes
 import numpy as np
 import transformers
 
@@ -52,7 +53,7 @@ MODEL_ID = "Qwen/Qwen3.5-0.8B"
 DEFAULT_PROMPT = "The capital of France is"
 MAX_NEW_TOKENS = 32
 
-DTYPE_MAP = {"f16": np.float16, "f32": np.float32}
+DTYPE_MAP = {"f16": np.float16, "f32": np.float32, "bf16": ml_dtypes.bfloat16}
 
 
 # ---------------------------------------------------------------------------
@@ -60,9 +61,7 @@ DTYPE_MAP = {"f16": np.float16, "f32": np.float32}
 # ---------------------------------------------------------------------------
 
 
-def init_hybrid_states(
-    config, dtype: np.dtype = np.float32
-) -> dict[str, np.ndarray]:
+def init_hybrid_states(config, dtype: np.dtype = np.float32) -> dict[str, np.ndarray]:
     """Initialize per-layer states for the hybrid architecture.
 
     Full-attention layers get empty KV caches (past_seq_len=0).
@@ -453,7 +452,7 @@ def generate_hf(
     # modeling code can find it.
     if hasattr(hf_config, "text_config"):
         hf_config = hf_config.text_config
-        
+
     model = transformers.AutoModelForCausalLM.from_pretrained(
         model_id,
         config=hf_config,

--- a/examples/qwen35_text_generation.py
+++ b/examples/qwen35_text_generation.py
@@ -574,7 +574,7 @@ def main():
     parser.add_argument(
         "--dtype",
         default="f32",
-        choices=["f16", "f32"],
+        choices=["f16", "bf16", "f32"],
         help="Precision type for the ONNX model (default: %(default)s).",
     )
     parser.add_argument(

--- a/examples/qwen35_text_generation.py
+++ b/examples/qwen35_text_generation.py
@@ -52,13 +52,17 @@ MODEL_ID = "Qwen/Qwen3.5-0.8B"
 DEFAULT_PROMPT = "The capital of France is"
 MAX_NEW_TOKENS = 32
 
+DTYPE_MAP = {"f16": np.float16, "f32": np.float32}
+
 
 # ---------------------------------------------------------------------------
 # Hybrid state initialization
 # ---------------------------------------------------------------------------
 
 
-def init_hybrid_states(config) -> dict[str, np.ndarray]:
+def init_hybrid_states(
+    config, dtype: np.dtype = np.float32
+) -> dict[str, np.ndarray]:
     """Initialize per-layer states for the hybrid architecture.
 
     Full-attention layers get empty KV caches (past_seq_len=0).
@@ -85,21 +89,21 @@ def init_hybrid_states(config) -> dict[str, np.ndarray]:
         if ltype == "linear_attention":
             # DeltaNet: fixed-size conv_state and recurrent_state
             states[f"past_key_values.{i}.conv_state"] = np.zeros(
-                (batch_size, conv_dim, conv_kernel - 1), dtype=np.float32
+                (batch_size, conv_dim, conv_kernel - 1), dtype=dtype
             )
             states[f"past_key_values.{i}.recurrent_state"] = np.zeros(
                 (batch_size, num_v_heads, head_k_dim, head_v_dim),
-                dtype=np.float32,
+                dtype=dtype,
             )
         else:
             # Full attention: empty KV cache (grows with each step)
             states[f"past_key_values.{i}.key"] = np.zeros(
                 (batch_size, config.num_key_value_heads, 0, config.head_dim),
-                dtype=np.float32,
+                dtype=dtype,
             )
             states[f"past_key_values.{i}.value"] = np.zeros(
                 (batch_size, config.num_key_value_heads, 0, config.head_dim),
-                dtype=np.float32,
+                dtype=dtype,
             )
 
     return states
@@ -140,6 +144,7 @@ def generate(
     prompt: str,
     config,
     *,
+    dtype: np.dtype = np.float32,
     max_new_tokens: int = MAX_NEW_TOKENS,
 ) -> str:
     """Greedy autoregressive generation with the hybrid architecture.
@@ -155,7 +160,7 @@ def generate(
     batch_size = 1
     prompt_len = input_ids.shape[1]
 
-    states = init_hybrid_states(config)
+    states = init_hybrid_states(config, dtype=dtype)
     past_seq_len = 0
     generated_ids: list[int] = []
 
@@ -283,6 +288,7 @@ def generate_with_image(
     image_path: str,
     config,
     *,
+    dtype: np.dtype = np.float32,
     max_new_tokens: int = MAX_NEW_TOKENS,
 ) -> str:
     """Greedy generation with the 3-model VL pipeline.
@@ -316,7 +322,7 @@ def generate_with_image(
     inputs = processor(text=[text], images=[image], return_tensors="pt")
 
     input_ids = inputs["input_ids"].numpy().astype(np.int64)
-    pixel_values = inputs["pixel_values"].numpy().astype(np.float32)
+    pixel_values = inputs["pixel_values"].numpy().astype(dtype)
     image_grid_thw = inputs["image_grid_thw"].numpy().astype(np.int64)
     batch_size = 1
 
@@ -350,7 +356,7 @@ def generate_with_image(
 
     # Step 4: Decoder prefill — process one token at a time
     # (DeltaNet layers only support seq_len=1)
-    states = init_hybrid_states(config)
+    states = init_hybrid_states(config, dtype=dtype)
     seq_len = inputs_embeds.shape[1]
     past_seq_len = 0
 
@@ -392,7 +398,7 @@ def generate_with_image(
         embed_out = embed_session.run(
             {
                 "input_ids": cur_input_ids,
-                "image_features": np.zeros((0, image_features.shape[-1]), dtype=np.float32),
+                "image_features": np.zeros((0, image_features.shape[-1]), dtype=dtype),
             }
         )
         cur_embeds = embed_out["inputs_embeds"]
@@ -440,8 +446,17 @@ def generate_hf(
     import torch
 
     print(f"[HF] Loading {model_id} ...")
+    hf_config = transformers.AutoConfig.from_pretrained(model_id)
+
+    # transformers ≥5.x uses a composite config for Qwen3.5 where
+    # vocab_size lives under text_config. Pass text_config so the
+    # modeling code can find it.
+    if hasattr(hf_config, "text_config"):
+        hf_config = hf_config.text_config
+        
     model = transformers.AutoModelForCausalLM.from_pretrained(
         model_id,
+        config=hf_config,
         dtype=torch.float32,
     ).to(device)
     tokenizer = transformers.AutoTokenizer.from_pretrained(model_id)
@@ -605,6 +620,7 @@ def main():
             prompt,
             args.image,
             config,
+            dtype=DTYPE_MAP[args.dtype],
             max_new_tokens=args.max_new_tokens,
         )
         print("-" * 40)
@@ -658,6 +674,7 @@ def main():
             tokenizer,
             prompt,
             config,
+            dtype=DTYPE_MAP[args.dtype],
             max_new_tokens=args.max_new_tokens,
         )
         print("-" * 40)

--- a/src/mobius/components/_gated_deltanet.py
+++ b/src/mobius/components/_gated_deltanet.py
@@ -234,34 +234,29 @@ class GatedDeltaNet(nn.Module):
         g = op.Mul(neg_a, softplus_val)  # (B, S, num_v_heads), float32
 
         # === LinearAttention ===
-        # The LinearAttention ir.Function declares all inputs as FLOAT.
-        # Cast activations to float32 before the call; cast outputs back.
-        # Transpose from (B, S, H, D) to (B, H, S, D)
+        # The LinearAttention function handles float32 casting internally.
+        # Transpose from (B, S, H, D) to (B, H, S, D).
         # Q/K keep native num_k_heads; V uses num_v_heads.
         # GQA expansion happens inside the function.
-        query_bhsd = op.Cast(op.Transpose(query, perm=[0, 2, 1, 3]), to=ir.DataType.FLOAT)
-        key_bhsd = op.Cast(op.Transpose(key, perm=[0, 2, 1, 3]), to=ir.DataType.FLOAT)
-        value_bhsd = op.Cast(op.Transpose(value, perm=[0, 2, 1, 3]), to=ir.DataType.FLOAT)
-        recurrent_state_f32 = op.Cast(recurrent_state, to=ir.DataType.FLOAT)
+        query_bhsd = op.Transpose(query, perm=[0, 2, 1, 3])
+        key_bhsd = op.Transpose(key, perm=[0, 2, 1, 3])
+        value_bhsd = op.Transpose(value, perm=[0, 2, 1, 3])
 
         # beta/decay: (B, S, H) -> (B, H, S)
-        beta_bhs = op.Cast(op.Transpose(beta, perm=[0, 2, 1]), to=ir.DataType.FLOAT)
-        g_bhs = op.Transpose(g, perm=[0, 2, 1])  # already float32
+        beta_bhs = op.Transpose(beta, perm=[0, 2, 1])
+        g_bhs = op.Transpose(g, perm=[0, 2, 1])  # float32 from decay computation
 
         output_4d, new_recurrent_state = op.LinearAttention(
             query_bhsd,  # (B, H_kv, S, d_k)
             key_bhsd,  # (B, H_kv, S, d_k)
             value_bhsd,  # (B, H, S, d_v)
-            recurrent_state_f32,  # (B, H, d_k, d_v)
-            g_bhs,  # (B, H, S) — decay in log-space
+            recurrent_state,  # (B, H, d_k, d_v)
+            g_bhs,  # (B, H, S) — decay in log-space, float32
             beta_bhs,  # (B, H, S) — update rate
             update_rule="gated_delta",
             _domain="com.microsoft",
             _outputs=2,
         )
-        # Cast outputs back to model precision (no-op for f32)
-        output_4d = op.CastLike(output_4d, hidden_states)
-        new_recurrent_state = op.CastLike(new_recurrent_state, hidden_states)
         # output_4d: (B, H, S, d_v) -> (B, S, H, d_v)
         output_per_head = op.Transpose(output_4d, perm=[0, 2, 1, 3])
 

--- a/src/mobius/components/_gated_deltanet.py
+++ b/src/mobius/components/_gated_deltanet.py
@@ -223,35 +223,45 @@ class GatedDeltaNet(nn.Module):
         # === Compute gating parameters ===
         # beta: (B, S, num_v_heads)
         beta = op.Sigmoid(b)
-        # decay: (B, S, num_v_heads)
-        a_plus_dt = op.Add(a, self.dt_bias)
-        softplus_val = op.Softplus(a_plus_dt)
-        neg_a = op.Neg(op.Exp(op.Cast(self.A_log, to=1)))
-        g = op.Mul(neg_a, softplus_val)
+        # Compute decay in float32 for numerical stability — mirrors HF:
+        #   g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
+        # Without .float(), exp() on fp16 A_log can produce -inf.
+        a_f32 = op.Cast(a, to=ir.DataType.FLOAT)
+        dt_bias_f32 = op.Cast(self.dt_bias, to=ir.DataType.FLOAT)
+        a_log_f32 = op.Cast(self.A_log, to=ir.DataType.FLOAT)
+        softplus_val = op.Softplus(op.Add(a_f32, dt_bias_f32))
+        neg_a = op.Neg(op.Exp(a_log_f32))
+        g = op.Mul(neg_a, softplus_val)  # (B, S, num_v_heads), float32
 
         # === LinearAttention ===
+        # The LinearAttention ir.Function declares all inputs as FLOAT.
+        # Cast activations to float32 before the call; cast outputs back.
         # Transpose from (B, S, H, D) to (B, H, S, D)
         # Q/K keep native num_k_heads; V uses num_v_heads.
         # GQA expansion happens inside the function.
-        query_bhsd = op.Transpose(query, perm=[0, 2, 1, 3])
-        key_bhsd = op.Transpose(key, perm=[0, 2, 1, 3])
-        value_bhsd = op.Transpose(value, perm=[0, 2, 1, 3])
+        query_bhsd = op.Cast(op.Transpose(query, perm=[0, 2, 1, 3]), to=ir.DataType.FLOAT)
+        key_bhsd = op.Cast(op.Transpose(key, perm=[0, 2, 1, 3]), to=ir.DataType.FLOAT)
+        value_bhsd = op.Cast(op.Transpose(value, perm=[0, 2, 1, 3]), to=ir.DataType.FLOAT)
+        recurrent_state_f32 = op.Cast(recurrent_state, to=ir.DataType.FLOAT)
 
         # beta/decay: (B, S, H) -> (B, H, S)
-        beta_bhs = op.Transpose(beta, perm=[0, 2, 1])
-        g_bhs = op.Transpose(g, perm=[0, 2, 1])
+        beta_bhs = op.Cast(op.Transpose(beta, perm=[0, 2, 1]), to=ir.DataType.FLOAT)
+        g_bhs = op.Transpose(g, perm=[0, 2, 1])  # already float32
 
         output_4d, new_recurrent_state = op.LinearAttention(
             query_bhsd,  # (B, H_kv, S, d_k)
             key_bhsd,  # (B, H_kv, S, d_k)
             value_bhsd,  # (B, H, S, d_v)
-            recurrent_state,  # (B, H, d_k, d_v)
+            recurrent_state_f32,  # (B, H, d_k, d_v)
             g_bhs,  # (B, H, S) — decay in log-space
             beta_bhs,  # (B, H, S) — update rate
             update_rule="gated_delta",
             _domain="com.microsoft",
             _outputs=2,
         )
+        # Cast outputs back to model precision (no-op for f32)
+        output_4d = op.CastLike(output_4d, hidden_states)
+        new_recurrent_state = op.CastLike(new_recurrent_state, hidden_states)
         # output_4d: (B, H, S, d_v) -> (B, S, H, d_v)
         output_per_head = op.Transpose(output_4d, perm=[0, 2, 1, 3])
 

--- a/src/mobius/components/_gated_deltanet.py
+++ b/src/mobius/components/_gated_deltanet.py
@@ -214,11 +214,6 @@ class GatedDeltaNet(nn.Module):
         # === L2 normalize Q and K ===
         query = _l2_normalize(op, query)
         key = _l2_normalize(op, key)
-        scale = op.CastLike(
-            op.Constant(value_float=1.0 / (self.head_k_dim**0.5)),
-            query,
-        )
-        query = op.Mul(query, scale)
 
         # === Compute gating parameters ===
         # beta: (B, S, num_v_heads)
@@ -254,6 +249,7 @@ class GatedDeltaNet(nn.Module):
             g_bhs,  # (B, H, S) — decay in log-space, float32
             beta_bhs,  # (B, H, S) — update rate
             update_rule="gated_delta",
+            scale=1.0 / (self.head_k_dim**0.5),
             _domain="com.microsoft",
             _outputs=2,
         )

--- a/src/mobius/functions/linear_attention.py
+++ b/src/mobius/functions/linear_attention.py
@@ -74,39 +74,22 @@ def linear_attention(
     uses_beta = update_rule in ("delta", "gated_delta")
 
     # --- Define function inputs ---
+    # query/key/value/past_state/beta accept any floating-point precision
+    # (float16/bfloat16/float32) — they form the implicit type parameter T.
+    # decay is ALWAYS float32: it is computed in float32 at the call site
+    # (HF pattern: -A_log.float().exp() * softplus(a.float() + dt_bias))
+    # to avoid exp/softplus overflow in lower precision. Declaring it as FLOAT
+    # here keeps it outside the type parameter T so ORT does not see a type
+    # conflict when the rest of the inputs are float16/bfloat16.
     # Q/K may have fewer heads (H_kv) than V/state (H) for GQA.
-    query = ir.Value(
-        name="query",
-        shape=ir.Shape(["B", "H_kv", "T", "d_k"]),
-        type=ir.TensorType(ir.DataType.FLOAT),
-    )
-    key = ir.Value(
-        name="key",
-        shape=ir.Shape(["B", "H_kv", "T", "d_k"]),
-        type=ir.TensorType(ir.DataType.FLOAT),
-    )
-    value = ir.Value(
-        name="value",
-        shape=ir.Shape(["B", "H", "T", "d_v"]),
-        type=ir.TensorType(ir.DataType.FLOAT),
-    )
-    past_state = ir.Value(
-        name="past_state",
-        shape=ir.Shape(["B", "H", "d_k", "d_v"]),
-        type=ir.TensorType(ir.DataType.FLOAT),
-    )
-    # decay/beta are 3D: (B, H, T) — no trailing singleton dim.
-    # The Scan body handles unsqueezing for broadcasting.
-    decay = ir.Value(
-        name="decay",
-        shape=ir.Shape(["B", "H", "T"]),
-        type=ir.TensorType(ir.DataType.FLOAT),
-    )
-    beta = ir.Value(
-        name="beta",
-        shape=ir.Shape(["B", "H", "T"]),
-        type=ir.TensorType(ir.DataType.FLOAT),
-    )
+    query = ir.Value(name="query")
+    key = ir.Value(name="key")
+    value = ir.Value(name="value")
+    past_state = ir.Value(name="past_state")
+    # decay: (B, H, T) — always float32; Scan body handles unsqueezing.
+    decay = ir.Value(name="decay", type=ir.TensorType(ir.DataType.FLOAT))
+    # beta: (B, H, T) — same precision as other activations (type T).
+    beta = ir.Value(name="beta")
     inputs = [query, key, value, past_state, decay, beta]
 
     # --- Build function body graph ---
@@ -128,19 +111,30 @@ def linear_attention(
     gqa_ratio = num_v_heads // num_k_heads
     query_expanded, key_expanded = _expand_kv_heads(op, query, key, gqa_ratio=gqa_ratio)
 
+    # --- Cast to float32 for Scan recurrence precision ---
+    # The recurrence requires float32 for numerical stability; inputs may be
+    # float16 or bfloat16.  decay is already FLOAT (declared above), so its
+    # Cast is always a no-op — kept for uniformity with the other inputs.
+    query_f32 = op.Cast(query_expanded, to=ir.DataType.FLOAT)
+    key_f32 = op.Cast(key_expanded, to=ir.DataType.FLOAT)
+    value_f32 = op.Cast(value, to=ir.DataType.FLOAT)
+    state_f32 = op.Cast(past_state, to=ir.DataType.FLOAT)
+    decay_f32 = op.Cast(decay, to=ir.DataType.FLOAT)  # no-op: decay is always FLOAT
+    beta_f32 = op.Cast(beta, to=ir.DataType.FLOAT)
+
     # --- Build Scan for sequential recurrence ---
     scan_body = _build_recurrence_body(uses_decay, uses_beta)
 
     # Transpose to T-first for Scan: (B, H, T, D) -> (T, B, H, D)
-    q_t = op.Transpose(query_expanded, perm=[2, 0, 1, 3])
-    k_t = op.Transpose(key_expanded, perm=[2, 0, 1, 3])
-    v_t = op.Transpose(value, perm=[2, 0, 1, 3])
+    q_t = op.Transpose(query_f32, perm=[2, 0, 1, 3])
+    k_t = op.Transpose(key_f32, perm=[2, 0, 1, 3])
+    v_t = op.Transpose(value_f32, perm=[2, 0, 1, 3])
     # decay/beta: (B, H, T) -> (T, B, H)
-    decay_t = op.Transpose(decay, perm=[2, 0, 1])
-    beta_t = op.Transpose(beta, perm=[2, 0, 1])
+    decay_t = op.Transpose(decay_f32, perm=[2, 0, 1])
+    beta_t = op.Transpose(beta_f32, perm=[2, 0, 1])
 
     present_state, output_t = op.Scan(
-        past_state,  # carry: (B, H, d_k, d_v)
+        state_f32,  # carry: (B, H, d_k, d_v)
         q_t,  # (T, B, H, d_k)
         k_t,  # (T, B, H, d_k)
         v_t,  # (T, B, H, d_v)
@@ -155,6 +149,10 @@ def linear_attention(
 
     # Transpose output back: (T, B, H, d_v) -> (B, H, T, d_v)
     output = op.Transpose(output_t, perm=[1, 2, 0, 3])
+
+    # Cast outputs back to the caller's input precision (no-op for float32)
+    output = op.CastLike(output, query)
+    present_state = op.CastLike(present_state, query)
 
     output.name = "output"
     present_state.name = "present_state"

--- a/src/mobius/functions/linear_attention.py
+++ b/src/mobius/functions/linear_attention.py
@@ -39,12 +39,12 @@ def linear_attention(
     num_k_heads: int,
     num_v_heads: int,
     update_rule: str = "gated_delta",
+    scale: float = 1.0,
 ) -> ir.Function:
     """Build an ir.Function for LinearAttention.
 
     Inputs:
-        query:      (B, H_kv, T, d_k) — query (may have fewer heads
-                    than value for GQA; pre-scaled by 1/sqrt(d_k))
+        query:      (B, H_kv, T, d_k) — query (L2-normalized, unscaled)
         key:        (B, H_kv, T, d_k) — key (L2-normalized)
         value:      (B, H, T, d_v) — value (H >= H_kv)
         past_state: (B, H, d_k, d_v) — recurrent state
@@ -59,10 +59,15 @@ def linear_attention(
         num_k_heads: Number of key/query heads (H_kv).
         num_v_heads: Number of value heads (H). Must be >= num_k_heads.
         update_rule: One of "linear", "gated", "delta", "gated_delta".
+        scale: Scalar multiplier applied to query before the recurrence.
+            Per the ONNX LinearAttention op spec, defaults to
+            ``1/sqrt(head_dim)`` in the op proposal.  Callers should
+            pass that value explicitly (or 1.0 if queries are
+            pre-scaled).
 
-    The function body handles GQA expansion and uses an ONNX Scan op
-    for the sequential recurrence.  A fused kernel can replace the
-    entire function for 10-50x speedup.
+    The function body handles GQA expansion, query scaling, and uses
+    an ONNX Scan op for the sequential recurrence.  A fused kernel
+    can replace the entire function for 10-50x speedup.
     """
     valid_rules = ("linear", "gated", "delta", "gated_delta")
     if update_rule not in valid_rules:
@@ -122,6 +127,11 @@ def linear_attention(
     decay_f32 = op.Cast(decay, to=ir.DataType.FLOAT)  # no-op: decay is always FLOAT
     beta_f32 = op.Cast(beta, to=ir.DataType.FLOAT)
 
+    # --- Apply query scale (matches op spec default of 1/sqrt(d_k)) ---
+    # Scale is applied after f32 cast for precision, and before the Scan
+    # recurrence.  A fused kernel reads the scale attribute directly.
+    query_f32 = op.Mul(query_f32, op.Constant(value_float=scale))
+
     # --- Build Scan for sequential recurrence ---
     scan_body = _build_recurrence_body(uses_decay, uses_beta)
 
@@ -165,11 +175,20 @@ def linear_attention(
         update_rule,
         ref_attr_name="update_rule",
     )
+    scale_attr = ir.Attr(
+        "scale",
+        ir.AttributeType.FLOAT,
+        scale,
+        ref_attr_name="scale",
+    )
     return ir.Function(
         domain=DOMAIN,
         name="LinearAttention",
         graph=graph,
-        attributes={"update_rule": update_rule_attr},
+        attributes={
+            "update_rule": update_rule_attr,
+            "scale": scale_attr,
+        },
     )
 
 

--- a/src/mobius/tasks/_base.py
+++ b/src/mobius/tasks/_base.py
@@ -385,6 +385,7 @@ def _register_linear_attention_functions(
         num_k_heads=dims.num_k_heads,
         num_v_heads=dims.num_v_heads,
         update_rule="gated_delta",
+        scale=1.0 / (dims.head_k_dim**0.5),
     )
 
     model.functions[conv_func.identifier()] = conv_func


### PR DESCRIPTION
This pull request improves precision handling and numerical stability for model inference and component computations, especially around ONNX export and attention mechanisms. It introduces support for configurable dtype (float16/float32) throughout the pipeline and ensures all mathematical operations and intermediate values are consistently cast to the appropriate precision, reducing the risk of numerical errors.

**Precision and dtype handling improvements:**

* Added a `--dtype` command-line argument to `examples/qwen35_text_generation.py`, allowing users to select between float16 (`f16`) and float32 (`f32`) precision for ONNX model export and inference. The selected dtype is now propagated to all relevant build and model instantiation functions.
* In `src/mobius/components/_gated_deltanet.py`, all bias, scaling, and normalization constants are now explicitly cast to match the precision of model weights or activations using `op.CastLike`, ensuring consistent dtype usage even when running in mixed precision.

**Numerical stability in attention computation:**

* The attention mechanism in `src/mobius/components/_gated_deltanet.py` now casts all relevant activations and parameters to float32 before performing operations prone to underflow/overflow (such as exponentiation and softplus), then casts results back to the model's working precision. This mirrors best practices in the reference Hugging Face implementation and prevents numerical instability, especially in float16 mode.

**ONNX function definition consistency:**

* The ONNX function for causal convolution (`src/mobius/functions/causal_conv.py`) no longer sets the `overload` attribute in its definition, ensuring compatibility with call sites and preventing issues during serialization.


**Notes for the Team**

To test that the changes work in FP16, use the following command. I was able to get the ONNX model producing identical results to HF. If there are questions let me know:

python examples/qwen35_text_generation.py --dtype f16  --model Qwen/Qwen3.5-0.8B --compare-hf