### PR TITLE
Add support for Nemotron models

### DIFF
--- a/.github/skills/adding-a-new-model/SKILL.md
+++ b/.github/skills/adding-a-new-model/SKILL.md
@@ -748,15 +748,15 @@ match HuggingFace, which explicitly upcasts with `.float()` /
 
 1. **Naive `CastLike` everywhere** — keeps everything in the model dtype
    (e.g. bf16), but `exp` overflows and the SSM state diverges.
-2. **Naive `Cast(to=1)` everywhere** — computes in fp32 but forgets to cast
+2. **Naive `Cast(to=ir.DataType.FLOAT)` everywhere** — computes in fp32 but forgets to cast
    back, producing type mismatches with downstream bf16 ops.
 
 **Correct pattern — upcast → compute → cast back:**
 ```python
 # 1. Upcast to fp32 for the sensitive region
-dt_f32 = op.Cast(dt, to=1)
+dt_f32 = op.Cast(dt, to=ir.DataType.FLOAT)
 dt_f32 = op.Softplus(dt_f32)
-a_neg = op.Neg(op.Exp(op.Cast(self.A_log, to=1)))
+a_neg = op.Neg(op.Exp(op.Cast(self.A_log, to=ir.DataType.FLOAT)))
 da = op.Exp(op.Mul(dt_4d, a_4d))  # all fp32 here
 ...
 # 2. Cast back to input dtype at the boundary
@@ -772,7 +772,7 @@ that the ONNX graph must replicate.
 
 | Region | HF evidence | ONNX pattern |
 |--------|-------------|-------------|
-| SSM recurrence (A, dt, exp, state) | `self.A_log.float()`, `hidden_states.float()`, `B.float()`, `C.float()` | `Cast(to=1)` all inputs, `CastLike` output |
+| SSM recurrence (A, dt, exp, state) | `self.A_log.float()`, `hidden_states.float()`, `B.float()`, `C.float()` | `Cast(to=ir.DataType.FLOAT)` all inputs, `CastLike` output |
 | GatedRMSNorm (SiLU + variance) | `hidden_states.to(torch.float32)`, `gate.to(torch.float32)` | Explicit fp32 for both, `CastLike` output |
 | RMSNorm variance | `hidden_states.to(torch.float32)` | ONNX `RMSNormalization` handles via `stash_type=1` (default) |
 
@@ -783,7 +783,7 @@ that the ONNX graph must replicate.
 
 **Use `CastLike` for** parameters/constants that should match the *current*
 compute dtype (which is fp32 inside an upcast region, or the model dtype
-outside).  Use `Cast(to=1)` to explicitly enter an fp32 region.
+outside).  Use `Cast(to=ir.DataType.FLOAT)` to explicitly enter an fp32 region.
 
 ## Reference implementations
 

--- a/.github/skills/adding-a-new-model/SKILL.md
+++ b/.github/skills/adding-a-new-model/SKILL.md
@@ -733,42 +733,57 @@ for i in range(num_groups - 1):
     codec_sum += cp_embed[i, codes[i + 1], :]
 ```
 
-### 16. Hardcoded `Cast(to=float32)` breaks bfloat16/float16 models
+### 16. Precision-sensitive ops need fp32 upcast
 
-**Symptom:** `ONNXRuntimeError: Type parameter (T) of Optype (Mul) bound to
-different types (tensor(float) and tensor(bfloat16))` when loading a model
-built with `--dtype bf16` or from a bfloat16 checkpoint.
+**Symptom:** Type mismatch errors (`tensor(float) vs tensor(bfloat16)`)
+when loading a model built with `--dtype bf16`, or numerical drift compared
+to HuggingFace when running in fp16/bf16.
 
-**Root cause:** Component code uses `op.Cast(self.param, to=1)` (hardcoded
-to float32) to cast learned parameters before arithmetic.  When the graph is
-built in bfloat16, intermediate tensors are bf16, but the Cast forces float32,
-producing a type mismatch in the downstream `Mul`/`Add`.
+**Root cause:** Operations like `exp`, `softplus`, `sigmoid` (in gated norms),
+and RMSNorm variance are numerically sensitive and must run in float32 to
+match HuggingFace, which explicitly upcasts with `.float()` /
+`.to(torch.float32)`.
 
-**Example (bad — from SSM components):**
+**Two distinct problems:**
+
+1. **Naive `CastLike` everywhere** — keeps everything in the model dtype
+   (e.g. bf16), but `exp` overflows and the SSM state diverges.
+2. **Naive `Cast(to=1)` everywhere** — computes in fp32 but forgets to cast
+   back, producing type mismatches with downstream bf16 ops.
+
+**Correct pattern — upcast → compute → cast back:**
 ```python
-# BAD — hardcoded float32 regardless of graph dtype
+# 1. Upcast to fp32 for the sensitive region
+dt_f32 = op.Cast(dt, to=1)
+dt_f32 = op.Softplus(dt_f32)
 a_neg = op.Neg(op.Exp(op.Cast(self.A_log, to=1)))
-dt = op.Add(dt_input, op.Cast(self.dt_bias, to=1))
+da = op.Exp(op.Mul(dt_4d, a_4d))  # all fp32 here
+...
+# 2. Cast back to input dtype at the boundary
+y = op.CastLike(y_f32, x)
+new_state = op.CastLike(new_state_f32, ssm_state)
 ```
 
-**Fix:** Use `op.CastLike(param, reference_tensor)` which adapts to whatever
-dtype the graph is using:
-```python
-# GOOD — matches the compute dtype (fp32, fp16, or bf16)
-a_neg = op.Neg(op.Exp(op.CastLike(self.A_log, dt)))
-dt = op.Add(dt_input, op.CastLike(self.dt_bias, dt_input))
-```
+**How to identify which ops need fp32:** Check the HuggingFace source for
+`.float()` or `.to(torch.float32)` calls.  Each one marks an fp32 region
+that the ONNX graph must replicate.
 
-**Rule of thumb:** Never use `op.Cast(to=<constant>)` on learned parameters
-or scalar constants that will be combined with activation tensors.  Always
-use `op.CastLike(value, reference)` where `reference` is a tensor already
-in the compute dtype.
+**Known fp32-required regions:**
 
-**Affected patterns:**
-- SSM parameters: `A_log`, `D`, `dt_bias` in `Mamba2Scan`/`SelectiveScan`
-- Gated attention: `A_log` in `GatedDeltaNet`
-- Timestep embeddings in diffusion models
-- Any `op.Constant(value_float=...)` multiplied with activation tensors
+| Region | HF evidence | ONNX pattern |
+|--------|-------------|-------------|
+| SSM recurrence (A, dt, exp, state) | `self.A_log.float()`, `hidden_states.float()`, `B.float()`, `C.float()` | `Cast(to=1)` all inputs, `CastLike` output |
+| GatedRMSNorm (SiLU + variance) | `hidden_states.to(torch.float32)`, `gate.to(torch.float32)` | Explicit fp32 for both, `CastLike` output |
+| RMSNorm variance | `hidden_states.to(torch.float32)` | ONNX `RMSNormalization` handles via `stash_type=1` (default) |
+
+**When fp32 upcast is NOT needed:**
+- Linear projections (`MatMul`) — runtime handles mixed precision
+- SiLU on conv output — HF keeps in model dtype
+- Standard attention — ONNX `Attention` op handles precision internally
+
+**Use `CastLike` for** parameters/constants that should match the *current*
+compute dtype (which is fp32 inside an upcast region, or the model dtype
+outside).  Use `Cast(to=1)` to explicitly enter an fp32 region.
 
 ## Reference implementations
 

--- a/.github/skills/adding-a-new-model/SKILL.md
+++ b/.github/skills/adding-a-new-model/SKILL.md
@@ -733,6 +733,43 @@ for i in range(num_groups - 1):
     codec_sum += cp_embed[i, codes[i + 1], :]
 ```
 
+### 16. Hardcoded `Cast(to=float32)` breaks bfloat16/float16 models
+
+**Symptom:** `ONNXRuntimeError: Type parameter (T) of Optype (Mul) bound to
+different types (tensor(float) and tensor(bfloat16))` when loading a model
+built with `--dtype bf16` or from a bfloat16 checkpoint.
+
+**Root cause:** Component code uses `op.Cast(self.param, to=1)` (hardcoded
+to float32) to cast learned parameters before arithmetic.  When the graph is
+built in bfloat16, intermediate tensors are bf16, but the Cast forces float32,
+producing a type mismatch in the downstream `Mul`/`Add`.
+
+**Example (bad — from SSM components):**
+```python
+# BAD — hardcoded float32 regardless of graph dtype
+a_neg = op.Neg(op.Exp(op.Cast(self.A_log, to=1)))
+dt = op.Add(dt_input, op.Cast(self.dt_bias, to=1))
+```
+
+**Fix:** Use `op.CastLike(param, reference_tensor)` which adapts to whatever
+dtype the graph is using:
+```python
+# GOOD — matches the compute dtype (fp32, fp16, or bf16)
+a_neg = op.Neg(op.Exp(op.CastLike(self.A_log, dt)))
+dt = op.Add(dt_input, op.CastLike(self.dt_bias, dt_input))
+```
+
+**Rule of thumb:** Never use `op.Cast(to=<constant>)` on learned parameters
+or scalar constants that will be combined with activation tensors.  Always
+use `op.CastLike(value, reference)` where `reference` is a tensor already
+in the compute dtype.
+
+**Affected patterns:**
+- SSM parameters: `A_log`, `D`, `dt_bias` in `Mamba2Scan`/`SelectiveScan`
+- Gated attention: `A_log` in `GatedDeltaNet`
+- Timestep embeddings in diffusion models
+- Any `op.Constant(value_float=...)` multiplied with activation tensors
+
 ## Reference implementations
 
 | Model | File | Key differences from base |

--- a/.github/skills/reusable-components/SKILL.md
+++ b/.github/skills/reusable-components/SKILL.md
@@ -370,7 +370,7 @@ Embedding(num_embeddings, embedding_dim, padding_idx=0)
 7. **Match HuggingFace's precision behaviour.** Components must work with any
    compute dtype (float32, float16, bfloat16).  For numerically sensitive ops
    (`exp`, `softplus`, RMSNorm variance), upcast to float32 with
-   `op.Cast(to=1)`, compute, then cast back with `op.CastLike(result, input)`.
+   `op.Cast(to=ir.DataType.FLOAT)`, compute, then cast back with `op.CastLike(result, input)`.
    For dtype-adaptive parameters, use `op.CastLike(param, reference)`.
    See "Precision-sensitive ops" below.
 
@@ -415,9 +415,9 @@ in float32 to match HuggingFace's behaviour.  The pattern is:
 
 ```python
 # Upcast inputs to fp32 for numerically sensitive exp/softplus
-dt_f32 = op.Cast(dt, to=1)
+dt_f32 = op.Cast(dt, to=ir.DataType.FLOAT)
 dt_f32 = op.Softplus(dt_f32)
-a_neg = op.Neg(op.Exp(op.Cast(self.A_log, to=1)))
+a_neg = op.Neg(op.Exp(op.Cast(self.A_log, to=ir.DataType.FLOAT)))
 ...
 # Cast output back to input dtype
 y = op.CastLike(y_f32, x)
@@ -445,7 +445,7 @@ y = op.CastLike(y_f32, x)
 **Rule of thumb:** Check the HuggingFace source for `.float()` or
 `.to(torch.float32)` calls.  Every such call indicates an fp32 upcast
 region that the ONNX component must replicate with explicit
-`op.Cast(to=1)` ... `op.CastLike(result, input)` bracketing.
+`op.Cast(to=ir.DataType.FLOAT)` ... `op.CastLike(result, input)` bracketing.
 
 ### Shape manipulation
 

--- a/.github/skills/reusable-components/SKILL.md
+++ b/.github/skills/reusable-components/SKILL.md
@@ -367,10 +367,12 @@ Embedding(num_embeddings, embedding_dim, padding_idx=0)
    computations (window reordering, RoPE, spatial merge), and document how
    the ONNX graph maps to the HuggingFace reference implementation.
 
-7. **Keep components dtype-agnostic.** Components must work with any compute
-   dtype (float32, float16, bfloat16).  Never hardcode a target dtype — use
-   `op.CastLike(value, reference)` to match the graph's dtype at runtime.
-   See "Dtype-agnostic casting" below.
+7. **Match HuggingFace's precision behaviour.** Components must work with any
+   compute dtype (float32, float16, bfloat16).  For numerically sensitive ops
+   (`exp`, `softplus`, RMSNorm variance), upcast to float32 with
+   `op.Cast(to=1)`, compute, then cast back with `op.CastLike(result, input)`.
+   For dtype-adaptive parameters, use `op.CastLike(param, reference)`.
+   See "Precision-sensitive ops" below.
 
 ## Common ONNX op patterns
 
@@ -392,32 +394,58 @@ eps = op.Constant(value_float=1e-6)
 
 ### Dtype-agnostic casting with `CastLike`
 
-When a learned parameter or float constant must match the compute dtype
-(fp32/fp16/bf16), use `op.CastLike` instead of `op.Cast(to=<constant>)`.
-The `--dtype` flag sets the graph dtype at build time, so components must
-adapt automatically.
+When a parameter or constant needs to match an activation tensor's dtype
+without knowing what it is at graph-build time, use `op.CastLike`:
 
 ```python
-# BAD — hardcoded to float32, breaks with bfloat16/float16 graphs
-a_neg = op.Neg(op.Exp(op.Cast(self.A_log, to=1)))
-
-# GOOD — adapts to whatever dtype dt already has
-a_neg = op.Neg(op.Exp(op.CastLike(self.A_log, dt)))
+# GOOD — adapts to whatever dtype hidden_states has
+scale = op.CastLike(op.Constant(value_float=1e-6), hidden_states)
 ```
-
-Common cases where `CastLike` is needed:
-
-| Pattern | Example |
-|---------|---------|
-| SSM parameters (`A_log`, `D`, `dt_bias`) | `op.CastLike(self.D, hidden_states)` |
-| Float constants in arithmetic | `op.CastLike(op.Constant(value_float=1e-6), x)` |
-| Norm scale for `LayerNormalization` | `scale = op.CastLike(scale, hidden_states)` |
 
 **When `op.Cast(to=...)` IS appropriate:** converting between fundamentally
 different types (e.g. int64 position_ids to float for arithmetic, or float
-timesteps to the model's compute type).  The key rule: never use a hardcoded
-Cast on values that will be combined (Mul/Add/etc.) with activation tensors
-whose dtype depends on the build configuration.
+timesteps to the model's compute type), and for the fp32 upcast pattern
+below.
+
+### Precision-sensitive ops: fp32 upcast pattern
+
+Some operations are numerically unstable in float16/bfloat16 and must run
+in float32 to match HuggingFace's behaviour.  The pattern is:
+**upcast → compute → cast back**.
+
+```python
+# Upcast inputs to fp32 for numerically sensitive exp/softplus
+dt_f32 = op.Cast(dt, to=1)
+dt_f32 = op.Softplus(dt_f32)
+a_neg = op.Neg(op.Exp(op.Cast(self.A_log, to=1)))
+...
+# Cast output back to input dtype
+y = op.CastLike(y_f32, x)
+```
+
+**Operations that need fp32 (based on HuggingFace source):**
+
+| Op | Why | HF pattern |
+|----|-----|-----------|
+| `Exp` on A_log/decay | Overflow/underflow in fp16 range | `self.A_log.float()` |
+| `Softplus` (dt) | Uses exp internally | `softplus(dt + dt_bias)` stays in fp32 context |
+| `Exp(dt * A)` (discretisation) | Exponential of product | `A.to(dtype=torch.float32)` |
+| SSM state update | Accumulates over many steps | `hidden_states.float()`, `B.float()`, `C.float()` |
+| RMSNorm variance | Small values squared then averaged | `hidden_states.to(torch.float32)` |
+| GatedRMSNorm (SiLU + norm) | Both gate and variance need fp32 | `gate.to(torch.float32)` |
+
+**When fp32 upcast is NOT needed:**
+
+- Linear projections (`MatMul`) — handled by the runtime
+- SiLU activation on conv output — stays in model dtype in HF
+- Standard attention — ONNX `Attention` op handles precision internally
+- `RMSNormalization` op — has `stash_type=1` (default) which auto-upcasts
+  the variance computation to fp32
+
+**Rule of thumb:** Check the HuggingFace source for `.float()` or
+`.to(torch.float32)` calls.  Every such call indicates an fp32 upcast
+region that the ONNX component must replicate with explicit
+`op.Cast(to=1)` ... `op.CastLike(result, input)` bracketing.
 
 ### Shape manipulation
 

--- a/.github/skills/reusable-components/SKILL.md
+++ b/.github/skills/reusable-components/SKILL.md
@@ -367,6 +367,11 @@ Embedding(num_embeddings, embedding_dim, padding_idx=0)
    computations (window reordering, RoPE, spatial merge), and document how
    the ONNX graph maps to the HuggingFace reference implementation.
 
+7. **Keep components dtype-agnostic.** Components must work with any compute
+   dtype (float32, float16, bfloat16).  Never hardcode a target dtype — use
+   `op.CastLike(value, reference)` to match the graph's dtype at runtime.
+   See "Dtype-agnostic casting" below.
+
 ## Common ONNX op patterns
 
 ### Scalar constants
@@ -384,6 +389,35 @@ one = op.Constant(value_int=1)
 # Float constants
 eps = op.Constant(value_float=1e-6)
 ```
+
+### Dtype-agnostic casting with `CastLike`
+
+When a learned parameter or float constant must match the compute dtype
+(fp32/fp16/bf16), use `op.CastLike` instead of `op.Cast(to=<constant>)`.
+The `--dtype` flag sets the graph dtype at build time, so components must
+adapt automatically.
+
+```python
+# BAD — hardcoded to float32, breaks with bfloat16/float16 graphs
+a_neg = op.Neg(op.Exp(op.Cast(self.A_log, to=1)))
+
+# GOOD — adapts to whatever dtype dt already has
+a_neg = op.Neg(op.Exp(op.CastLike(self.A_log, dt)))
+```
+
+Common cases where `CastLike` is needed:
+
+| Pattern | Example |
+|---------|---------|
+| SSM parameters (`A_log`, `D`, `dt_bias`) | `op.CastLike(self.D, hidden_states)` |
+| Float constants in arithmetic | `op.CastLike(op.Constant(value_float=1e-6), x)` |
+| Norm scale for `LayerNormalization` | `scale = op.CastLike(scale, hidden_states)` |
+
+**When `op.Cast(to=...)` IS appropriate:** converting between fundamentally
+different types (e.g. int64 position_ids to float for arithmetic, or float
+timesteps to the model's compute type).  The key rule: never use a hardcoded
+Cast on values that will be combined (Mul/Add/etc.) with activation tensors
+whose dtype depends on the build configuration.
 
 ### Shape manipulation
 

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -258,7 +258,7 @@ def _scan_l2_arch_tests(models: dict[str, ModelInfo]) -> None:
     if not arch_test.exists():
         return
 
-    content = arch_test.read_text()
+    content = arch_test.read_text(encoding="utf-8")
     for model_type, info in models.items():
         # L2 requires test_model_id in registry
         if info.test_model_id:
@@ -367,7 +367,7 @@ def _scan_integration_tests(models: dict[str, ModelInfo]) -> None:
     integration_files = list(tests_dir.glob("*integration*.py"))
 
     for test_file in integration_files:
-        content = test_file.read_text()
+        content = test_file.read_text(encoding="utf-8")
         for model_type in models:
             if f'"{model_type}"' in content or f"'{model_type}'" in content:
                 models[model_type].has_integration_test = True
@@ -400,7 +400,7 @@ def _scan_yaml_test_cases(models: dict[str, ModelInfo]) -> None:
 
     for yaml_file in sorted(cases_dir.rglob("*.yaml")):
         try:
-            data = yaml.safe_load(yaml_file.read_text())
+            data = yaml.safe_load(yaml_file.read_text(encoding="utf-8"))
         except Exception:
             continue
         if not isinstance(data, dict):
@@ -467,7 +467,7 @@ def _scan_l3_parity_status(models: dict[str, ModelInfo]) -> None:
         _ = importlib.util.module_from_spec(spec)
         # Don't actually run the test — just load the module-level dicts
         # by extracting them from the source text
-        content = parity_test.read_text()
+        content = parity_test.read_text(encoding="utf-8")
     except Exception:
         return
 

--- a/src/mobius/_builder.py
+++ b/src/mobius/_builder.py
@@ -310,8 +310,9 @@ def build(
         hf_config = transformers.AutoConfig.from_pretrained(
             model_id, trust_remote_code=trust_remote_code
         )
-    except (ValueError, OSError):
-        # AutoConfig failed — the model_type may not be in transformers.
+    except (ValueError, KeyError, OSError):
+        # AutoConfig failed — the model_type may not be in transformers,
+        # or the HF config class has a bug (e.g. NemotronH with '-' pattern).
         # Try loading config.json directly if the model is in our registry.
         hf_config = _try_load_config_json(model_id)
         if hf_config is None or hf_config.model_type not in registry:

--- a/src/mobius/_configs.py
+++ b/src/mobius/_configs.py
@@ -1686,6 +1686,77 @@ class BambaConfig(ArchitectureConfig):
 
 
 @dataclasses.dataclass
+class NemotronHConfig(ArchitectureConfig):
+    """Configuration for NemotronH hybrid Mamba2+Attention+MLP models.
+
+    Uses multi-head Mamba2/SSD layers interleaved with attention and
+    standalone MLP layers.  Each layer is a single-mixer block
+    (RMSNorm → mixer → residual).
+    """
+
+    mamba_n_heads: int = 128
+    mamba_d_head: int = 64
+    mamba_d_state: int = 128
+    mamba_n_groups: int = 8
+    mamba_d_conv: int = 4
+    mamba_expand: int = 2
+    mamba_conv_bias: bool = True
+    mamba_proj_bias: bool = False
+
+    @classmethod
+    def from_transformers(cls, config, parent_config=None) -> NemotronHConfig:
+        base = ArchitectureConfig.from_transformers(config, parent_config)
+
+        # Get layer types from layers_block_type or hybrid_override_pattern
+        layers_block_type = getattr(config, "layers_block_type", None)
+        if layers_block_type is None:
+            pattern = getattr(config, "hybrid_override_pattern", "")
+            # Map pattern chars: M=mamba2, *=full_attention, -=mlp
+            char_map = {"M": "mamba2", "*": "full_attention", "-": "mlp"}
+            layers_block_type = [char_map.get(c, "mamba2") for c in pattern]
+        else:
+            # Convert HF names to mobius names
+            type_map = {
+                "mamba": "mamba2",
+                "attention": "full_attention",
+                "moe": "mlp",
+            }
+            layers_block_type = [type_map.get(t, t) for t in layers_block_type]
+
+        # Override num_hidden_layers based on actual pattern length
+        n = len(layers_block_type) if layers_block_type else base.num_hidden_layers
+
+        mamba_expand = getattr(config, "expand", getattr(config, "mamba_expand", 2))
+        d_inner = config.hidden_size * mamba_expand
+
+        mamba_n_heads = getattr(config, "mamba_num_heads", 128)
+        mamba_d_head = getattr(config, "mamba_head_dim", "auto")
+        if mamba_d_head == "auto":
+            mamba_d_head = d_inner // mamba_n_heads
+
+        # Exclude fields we set explicitly to avoid duplicate keyword args
+        base_fields = {
+            k: v
+            for k, v in _shallow_fields(base).items()
+            if k not in ("layer_types", "num_hidden_layers", "hidden_act")
+        }
+        return cls(
+            **base_fields,
+            num_hidden_layers=n,
+            layer_types=layers_block_type,
+            hidden_act="relu2",
+            mamba_n_heads=mamba_n_heads,
+            mamba_d_head=mamba_d_head,
+            mamba_d_state=getattr(config, "ssm_state_size", 128),
+            mamba_n_groups=getattr(config, "n_groups", 8),
+            mamba_d_conv=getattr(config, "conv_kernel", 4),
+            mamba_expand=mamba_expand,
+            mamba_conv_bias=getattr(config, "use_conv_bias", True),
+            mamba_proj_bias=getattr(config, "mamba_proj_bias", False),
+        )
+
+
+@dataclasses.dataclass
 class WhisperConfig(BaseModelConfig):
     """Configuration for Whisper encoder-decoder models."""
 

--- a/src/mobius/_registry.py
+++ b/src/mobius/_registry.py
@@ -439,6 +439,11 @@ def _create_default_registry() -> ModelRegistry:
 
     reg.register("bamba", BambaCausalLMModel)
 
+    # --- Hybrid Mamba2+Attention+MLP (NemotronH) ---
+    from mobius.models.nemotron_h import NemotronHCausalLMModel
+
+    reg.register("nemotron_h", NemotronHCausalLMModel)
+
     # --- Multimodal ---
     for name in (
         "chameleon",

--- a/src/mobius/components/__init__.py
+++ b/src/mobius/components/__init__.py
@@ -33,6 +33,7 @@ __all__ = [
     "InputMixer",
     "LayerNorm",
     "LayerNormNoAffine",
+    "OffsetLayerNorm",
     "LayerScale",
     "Linear",
     "LoRALinear",
@@ -130,6 +131,7 @@ from mobius.components._common import (
     LayerNorm,
     LayerNormNoAffine,
     Linear,
+    OffsetLayerNorm,
     create_attention_bias,
     create_padding_mask,
 )

--- a/src/mobius/components/_common.py
+++ b/src/mobius/components/_common.py
@@ -69,6 +69,31 @@ class LayerNorm(nn.Module):
         )
 
 
+class OffsetLayerNorm(nn.Module):
+    """Layer Normalization with +1 offset on weight: output = LN(x, weight+1, bias).
+
+    Used by Nemotron where the HF checkpoint stores weights initialized
+    to zero, and the effective multiplier is (1 + weight).  Analogous to
+    ``OffsetRMSNorm`` but for full LayerNorm (with bias).
+    """
+
+    def __init__(self, hidden_size: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = nn.Parameter([hidden_size])
+        self.bias = nn.Parameter([hidden_size])
+        self.eps = eps
+
+    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+        effective_weight = op.Add(self.weight, 1.0)
+        return op.LayerNormalization(
+            hidden_states,
+            effective_weight,
+            self.bias,
+            epsilon=self.eps,
+            axis=-1,
+        )
+
+
 class LayerNormNoAffine(nn.Module):
     """Layer Normalization without learnable affine parameters.
 

--- a/src/mobius/components/_mamba_block.py
+++ b/src/mobius/components/_mamba_block.py
@@ -206,6 +206,7 @@ class Mamba2Block(nn.Module):
         conv_bias: bool = True,
         proj_bias: bool = False,
         eps: float = 1e-5,
+        norm_group_size: int | None = None,
     ):
         super().__init__()
         self.d_model = d_model
@@ -222,7 +223,7 @@ class Mamba2Block(nn.Module):
         self.in_proj = Linear(d_model, proj_size, bias=proj_bias)
         self.conv1d = _DepthwiseConv1d(self.conv_dim, conv_kernel, bias=conv_bias)
         self.ssm = Mamba2Scan(num_heads, d_head, d_state, n_groups)
-        self.norm = GatedRMSNorm(d_inner, eps=eps)
+        self.norm = GatedRMSNorm(d_inner, eps=eps, group_size=norm_group_size)
         self.out_proj = Linear(d_inner, d_model, bias=proj_bias)
 
     def forward(

--- a/src/mobius/components/_rms_norm.py
+++ b/src/mobius/components/_rms_norm.py
@@ -74,7 +74,6 @@ class GatedRMSNorm(nn.Module):
         # RMSNorm in fp32, then cast back to input dtype
         normed = op.RMSNormalization(
             gated,
-            op.Cast(self.weight, to=1),
             epsilon=self.variance_epsilon,
             axis=-1,
         )

--- a/src/mobius/components/_rms_norm.py
+++ b/src/mobius/components/_rms_norm.py
@@ -53,13 +53,24 @@ class GatedRMSNorm(nn.Module):
     The gate is applied first so it affects the normalization variance,
     matching HuggingFace's MambaRMSNormGated / BambaRMSNormGated.
 
-    Used in Mamba2 and Bamba layers.
+    When ``group_size`` is set, variance is computed per group
+    (matching HF's ``Zamba2RMSNormGated``). This is used by
+    NemotronH where group_size = d_inner // n_groups.
+
+    Used in Mamba2, Bamba, and NemotronH layers.
     """
 
-    def __init__(self, hidden_size: int, eps: float = 1e-6):
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-6,
+        group_size: int | None = None,
+    ):
         super().__init__()
+        self.hidden_size = hidden_size
         self.weight = nn.Parameter([hidden_size])
         self.variance_epsilon = eps
+        self.group_size = group_size
 
     def forward(self, op: builder.OpBuilder, hidden_states: ir.Value, gate: ir.Value):
         # Upcast to fp32 for SiLU gating + RMSNorm variance, matching HF
@@ -68,13 +79,38 @@ class GatedRMSNorm(nn.Module):
         g_f32 = op.Cast(gate, to=ir.DataType.FLOAT)
         gate_activated = op.Mul(g_f32, op.Sigmoid(g_f32))
         gated = op.Mul(h_f32, gate_activated)
-        # RMSNorm in fp32, then cast back to input dtype
-        normed = op.RMSNormalization(
-            gated,
-            self.weight,
-            epsilon=self.variance_epsilon,
-            axis=-1,
-        )
+
+        if self.group_size is not None and self.group_size < self.hidden_size:
+            # Grouped RMSNorm: reshape to (batch, n_groups, group_size),
+            # normalize within each group, then reshape back.
+            # Matches HF Zamba2RMSNormGated which does per-group variance.
+            n_groups = self.hidden_size // self.group_size
+            grouped = op.Reshape(
+                gated,
+                op.Constant(value_ints=[0, n_groups, self.group_size]),
+            )
+            weight_grouped = op.Reshape(
+                self.weight,
+                op.Constant(value_ints=[n_groups, self.group_size]),
+            )
+            normed = op.RMSNormalization(
+                grouped,
+                weight_grouped,
+                epsilon=self.variance_epsilon,
+                axis=-1,
+            )
+            normed = op.Reshape(
+                normed,
+                op.Constant(value_ints=[0, self.hidden_size]),
+            )
+        else:
+            # Standard RMSNorm over the full dimension
+            normed = op.RMSNormalization(
+                gated,
+                self.weight,
+                epsilon=self.variance_epsilon,
+                axis=-1,
+            )
         return op.CastLike(normed, hidden_states)
 
 

--- a/src/mobius/components/_rms_norm.py
+++ b/src/mobius/components/_rms_norm.py
@@ -71,6 +71,7 @@ class GatedRMSNorm(nn.Module):
         # RMSNorm in fp32, then cast back to input dtype
         normed = op.RMSNormalization(
             gated,
+            self.weight,
             epsilon=self.variance_epsilon,
             axis=-1,
         )

--- a/src/mobius/components/_rms_norm.py
+++ b/src/mobius/components/_rms_norm.py
@@ -8,6 +8,10 @@ import onnx_ir as ir
 from onnxscript import nn
 from onnxscript._internal import builder
 
+# ORT ≤1.24.4 CUDA kernel for RMSNormalization produces wrong results
+# when scale is 2D.  Set to True to emit decomposed ops as a workaround.
+_ORT_CUDA_GROUPED_RMSNORM_WORKAROUND = False
+
 
 class RMSNorm(nn.Module):
     """RMS Layer Normalization using the ONNX RMSNormalization op (opset 23)."""
@@ -89,20 +93,41 @@ class GatedRMSNorm(nn.Module):
                 gated,
                 op.Constant(value_ints=[0, n_groups, self.group_size]),
             )
-            weight_grouped = op.Reshape(
-                self.weight,
-                op.Constant(value_ints=[n_groups, self.group_size]),
-            )
-            normed = op.RMSNormalization(
-                grouped,
-                weight_grouped,
-                epsilon=self.variance_epsilon,
-                axis=-1,
-            )
-            normed = op.Reshape(
-                normed,
-                op.Constant(value_ints=[0, self.hidden_size]),
-            )
+            if _ORT_CUDA_GROUPED_RMSNORM_WORKAROUND:
+                # ORT ≤1.24.4 CUDA kernel for RMSNormalization produces
+                # wrong results when scale is 2D (e.g. [n_groups,
+                # group_size] on [batch, n_groups, group_size] input).
+                # Decompose into basic ops as a workaround. See
+                # repro: my/repro_rmsnorm_cuda_bug.py
+                variance = op.ReduceMean(
+                    op.Mul(grouped, grouped), axes=[-1], keepdims=True,
+                )
+                rnorm = op.Reciprocal(
+                    op.Sqrt(op.Add(variance, self.variance_epsilon)),
+                )
+                normed = op.Mul(grouped, rnorm)
+                normed = op.Reshape(
+                    normed,
+                    op.Constant(value_ints=[0, self.hidden_size]),
+                )
+                normed = op.Mul(
+                    normed, op.Cast(self.weight, to=ir.DataType.FLOAT),
+                )
+            else:
+                weight_grouped = op.Reshape(
+                    self.weight,
+                    op.Constant(value_ints=[n_groups, self.group_size]),
+                )
+                normed = op.RMSNormalization(
+                    grouped,
+                    weight_grouped,
+                    epsilon=self.variance_epsilon,
+                    axis=-1,
+                )
+                normed = op.Reshape(
+                    normed,
+                    op.Constant(value_ints=[0, self.hidden_size]),
+                )
         else:
             # Standard RMSNorm over the full dimension
             normed = op.RMSNormalization(

--- a/src/mobius/components/_rms_norm.py
+++ b/src/mobius/components/_rms_norm.py
@@ -113,7 +113,7 @@ class PostGatedRMSNorm(nn.Module):
         # Matches HF Qwen3_5RMSNormGated which does gate.to(float32).
         g_f32 = op.Cast(gate, to=1)
         gate_activated = op.Mul(g_f32, op.Sigmoid(g_f32))
-        result = op.Mul(op.Cast(normed, to=1), gate_activated)
+        result = op.Mul(op.Cast(normed, to=ir.DataType.FLOAT), gate_activated)
         return op.CastLike(result, hidden_states)
 
 

--- a/src/mobius/components/_rms_norm.py
+++ b/src/mobius/components/_rms_norm.py
@@ -95,7 +95,9 @@ class GatedRMSNorm(nn.Module):
                     op.Constant(value_ints=[0, n_groups, self.group_size]),
                 )
                 variance = op.ReduceMean(
-                    op.Mul(grouped, grouped), axes=[-1], keepdims=True,
+                    op.Mul(grouped, grouped),
+                    axes=[-1],
+                    keepdims=True,
                 )
                 rnorm = op.Reciprocal(
                     op.Sqrt(op.Add(variance, self.variance_epsilon)),
@@ -106,7 +108,8 @@ class GatedRMSNorm(nn.Module):
                     op.Constant(value_ints=[0, self.hidden_size]),
                 )
                 normed = op.Mul(
-                    normed, op.Cast(self.weight, to=ir.DataType.FLOAT),
+                    normed,
+                    op.Cast(self.weight, to=ir.DataType.FLOAT),
                 )
             else:
                 # Cast gated back to native dtype; RMSNormalization's

--- a/src/mobius/components/_rms_norm.py
+++ b/src/mobius/components/_rms_norm.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-
 import onnx_ir as ir
 from onnxscript import nn
 from onnxscript._internal import builder

--- a/src/mobius/components/_rms_norm.py
+++ b/src/mobius/components/_rms_norm.py
@@ -77,8 +77,7 @@ class GatedRMSNorm(nn.Module):
         self.group_size = group_size
 
     def forward(self, op: builder.OpBuilder, hidden_states: ir.Value, gate: ir.Value):
-        # Upcast to fp32 for SiLU gating + RMSNorm variance, matching HF
-        # which does hidden_states.to(float32) and gate.to(float32).
+        # SiLU gating in fp32 for precision, matching HF.
         h_f32 = op.Cast(hidden_states, to=ir.DataType.FLOAT)
         g_f32 = op.Cast(gate, to=ir.DataType.FLOAT)
         gate_activated = op.Mul(g_f32, op.Sigmoid(g_f32))
@@ -87,18 +86,15 @@ class GatedRMSNorm(nn.Module):
         if self.group_size is not None and self.group_size < self.hidden_size:
             # Grouped RMSNorm: reshape to (batch, n_groups, group_size),
             # normalize within each group, then reshape back.
-            # Matches HF Zamba2RMSNormGated which does per-group variance.
             n_groups = self.hidden_size // self.group_size
-            grouped = op.Reshape(
-                gated,
-                op.Constant(value_ints=[0, n_groups, self.group_size]),
-            )
             if _ORT_CUDA_GROUPED_RMSNORM_WORKAROUND:
                 # ORT ≤1.24.4 CUDA kernel for RMSNormalization produces
-                # wrong results when scale is 2D (e.g. [n_groups,
-                # group_size] on [batch, n_groups, group_size] input).
-                # Decompose into basic ops as a workaround. See
-                # repro: my/repro_rmsnorm_cuda_bug.py
+                # wrong results when scale is 2D. Decompose into basic
+                # ops as a workaround.
+                grouped = op.Reshape(
+                    gated,
+                    op.Constant(value_ints=[0, n_groups, self.group_size]),
+                )
                 variance = op.ReduceMean(
                     op.Mul(grouped, grouped), axes=[-1], keepdims=True,
                 )
@@ -114,6 +110,13 @@ class GatedRMSNorm(nn.Module):
                     normed, op.Cast(self.weight, to=ir.DataType.FLOAT),
                 )
             else:
+                # Cast gated back to native dtype; RMSNormalization's
+                # stash_type=1 handles internal fp32 for variance.
+                gated = op.CastLike(gated, hidden_states)
+                grouped = op.Reshape(
+                    gated,
+                    op.Constant(value_ints=[0, n_groups, self.group_size]),
+                )
                 weight_grouped = op.Reshape(
                     self.weight,
                     op.Constant(value_ints=[n_groups, self.group_size]),
@@ -129,7 +132,9 @@ class GatedRMSNorm(nn.Module):
                     op.Constant(value_ints=[0, self.hidden_size]),
                 )
         else:
-            # Standard RMSNorm over the full dimension
+            # Standard RMSNorm over the full dimension.
+            # Cast gated back to native dtype; stash_type=1 handles fp32.
+            gated = op.CastLike(gated, hidden_states)
             normed = op.RMSNormalization(
                 gated,
                 self.weight,

--- a/src/mobius/components/_rms_norm.py
+++ b/src/mobius/components/_rms_norm.py
@@ -65,16 +65,20 @@ class GatedRMSNorm(nn.Module):
         self.variance_epsilon = eps
 
     def forward(self, op: builder.OpBuilder, hidden_states: ir.Value, gate: ir.Value):
-        # Gate first: hidden * SiLU(gate)
-        gate_activated = op.Mul(gate, op.Sigmoid(gate))
-        gated = op.Mul(hidden_states, gate_activated)
-        # Then normalize the gated result
-        return op.RMSNormalization(
+        # Upcast to fp32 for SiLU gating + RMSNorm variance, matching HF
+        # which does hidden_states.to(float32) and gate.to(float32).
+        h_f32 = op.Cast(hidden_states, to=1)
+        g_f32 = op.Cast(gate, to=1)
+        gate_activated = op.Mul(g_f32, op.Sigmoid(g_f32))
+        gated = op.Mul(h_f32, gate_activated)
+        # RMSNorm in fp32, then cast back to input dtype
+        normed = op.RMSNormalization(
             gated,
-            self.weight,
+            op.Cast(self.weight, to=1),
             epsilon=self.variance_epsilon,
             axis=-1,
         )
+        return op.CastLike(normed, hidden_states)
 
 
 class PostGatedRMSNorm(nn.Module):
@@ -98,16 +102,20 @@ class PostGatedRMSNorm(nn.Module):
         self.variance_epsilon = eps
 
     def forward(self, op: builder.OpBuilder, hidden_states: ir.Value, gate: ir.Value):
-        # Normalize first
+        # RMSNorm uses stash_type=1 internally for fp32 variance.
         normed = op.RMSNormalization(
             hidden_states,
             self.weight,
             epsilon=self.variance_epsilon,
+            stash_type=1,
             axis=-1,
         )
-        # Then apply gate: normed * SiLU(gate)
-        gate_activated = op.Mul(gate, op.Sigmoid(gate))
-        return op.Mul(normed, gate_activated)
+        # Apply gate in fp32: normed * SiLU(gate), then cast back.
+        # Matches HF Qwen3_5RMSNormGated which does gate.to(float32).
+        g_f32 = op.Cast(gate, to=1)
+        gate_activated = op.Mul(g_f32, op.Sigmoid(g_f32))
+        result = op.Mul(op.Cast(normed, to=1), gate_activated)
+        return op.CastLike(result, hidden_states)
 
 
 def apply_rms_norm(op: builder.OpBuilder, x, weight, eps):

--- a/src/mobius/components/_rms_norm.py
+++ b/src/mobius/components/_rms_norm.py
@@ -3,13 +3,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 
+import onnx_ir as ir
 from onnxscript import nn
 from onnxscript._internal import builder
-
-if TYPE_CHECKING:
-    import onnx_ir as ir
 
 
 class RMSNorm(nn.Module):
@@ -67,8 +64,8 @@ class GatedRMSNorm(nn.Module):
     def forward(self, op: builder.OpBuilder, hidden_states: ir.Value, gate: ir.Value):
         # Upcast to fp32 for SiLU gating + RMSNorm variance, matching HF
         # which does hidden_states.to(float32) and gate.to(float32).
-        h_f32 = op.Cast(hidden_states, to=1)
-        g_f32 = op.Cast(gate, to=1)
+        h_f32 = op.Cast(hidden_states, to=ir.DataType.FLOAT)
+        g_f32 = op.Cast(gate, to=ir.DataType.FLOAT)
         gate_activated = op.Mul(g_f32, op.Sigmoid(g_f32))
         gated = op.Mul(h_f32, gate_activated)
         # RMSNorm in fp32, then cast back to input dtype
@@ -111,7 +108,7 @@ class PostGatedRMSNorm(nn.Module):
         )
         # Apply gate in fp32: normed * SiLU(gate), then cast back.
         # Matches HF Qwen3_5RMSNormGated which does gate.to(float32).
-        g_f32 = op.Cast(gate, to=1)
+        g_f32 = op.Cast(gate, to=ir.DataType.FLOAT)
         gate_activated = op.Mul(g_f32, op.Sigmoid(g_f32))
         result = op.Mul(op.Cast(normed, to=ir.DataType.FLOAT), gate_activated)
         return op.CastLike(result, hidden_states)

--- a/src/mobius/components/_ssm.py
+++ b/src/mobius/components/_ssm.py
@@ -18,6 +18,11 @@ Single-token decode recurrence:
 State carried across steps:
     ssm_state: (batch, d_inner, d_state)
 
+Precision: The SSM recurrence (softplus, exp, state update) is computed
+in float32 regardless of the model's compute dtype, matching HuggingFace
+which upcasts A_log, dt, hidden_states, B, C to float32 for these ops.
+The output and updated state are cast back to the input dtype.
+
 HuggingFace reference: ``MambaMixer`` (SSM portion).
 """
 
@@ -108,49 +113,50 @@ class SelectiveScan(nn.Module):
         # c_mat: (batch, 1, d_state)
 
         # --- Compute time step dt ---
-        # dt: (batch, 1, d_inner) via rank projection + softplus
-        dt = self.dt_proj(op, dt_raw)
+        # dt: (batch, 1, d_inner) via rank projection + softplus.
+        # Upcast to fp32 for softplus (uses exp internally) to match
+        # HuggingFace which computes the SSM recurrence in float32.
+        dt = op.Cast(self.dt_proj(op, dt_raw), to=1)
         dt = op.Softplus(dt)
 
         # --- Discretize state decay matrix A ---
-        # a_neg = -exp(A_log): (d_inner, d_state)
-        # CastLike ensures A_log matches the compute dtype (fp16/bf16/fp32).
-        a_neg = op.Neg(op.Exp(op.CastLike(self.A_log, dt)))
+        # a_neg = -exp(A_log) in fp32: (d_inner, d_state)
+        a_neg = op.Neg(op.Exp(op.Cast(self.A_log, to=1)))
 
         # Broadcast: dt (batch,1,d_inner,1) * A (1,1,d_inner,d_state)
         dt_4d = op.Unsqueeze(dt, [-1])  # (batch, 1, d_inner, 1)
         a_4d = op.Unsqueeze(a_neg, [0, 1])  # (1, 1, d_inner, d_state)
-        # da = exp(dt * A): (batch, 1, d_inner, d_state)
+        # da = exp(dt * A) in fp32: (batch, 1, d_inner, d_state)
         da = op.Exp(op.Mul(dt_4d, a_4d))
 
-        # --- Input contribution: dt * B * x ---
-        b_4d = op.Unsqueeze(b_mat, [2])  # (batch, 1, 1, d_state)
+        # --- Input contribution: dt * B * x (in fp32) ---
+        b_4d = op.Unsqueeze(op.Cast(b_mat, to=1), [2])
         dt_b = op.Mul(dt_4d, b_4d)  # (batch, 1, d_inner, d_state)
-        x_4d = op.Unsqueeze(x, [-1])  # (batch, 1, d_inner, 1)
+        x_4d = op.Unsqueeze(op.Cast(x, to=1), [-1])
         db_x = op.Mul(dt_b, x_4d)  # (batch, 1, d_inner, d_state)
 
         # --- Squeeze seq dim (single token) ---
         da_t = op.Squeeze(da, [1])  # (batch, d_inner, d_state)
         db_x_t = op.Squeeze(db_x, [1])  # (batch, d_inner, d_state)
 
-        # --- State update: h = dA * h_prev + dBx ---
-        new_ssm_state = op.Add(op.Mul(da_t, ssm_state), db_x_t)
+        # --- State update: h = dA * h_prev + dBx (in fp32) ---
+        new_ssm_state = op.Add(op.Mul(da_t, op.Cast(ssm_state, to=1)), db_x_t)
 
         # --- Readout: y = C · h ---
-        c_t = op.Squeeze(c_mat, [1])  # (batch, d_state)
+        c_t = op.Squeeze(op.Cast(c_mat, to=1), [1])  # (batch, d_state)
         c_3d = op.Unsqueeze(c_t, [1])  # (batch, 1, d_state)
         # h: (batch, d_inner, d_state), C: (batch, 1, d_state)
         # → element-wise mul then sum over d_state → (batch, d_inner)
         y = op.ReduceSum(op.Mul(new_ssm_state, c_3d), [-1], keepdims=False)
 
         # --- Skip connection: y += D * x ---
-        x_t = op.Squeeze(x, [1])  # (batch, d_inner)
-        y = op.Add(y, op.Mul(op.CastLike(self.D, x_t), x_t))
+        x_t = op.Squeeze(op.Cast(x, to=1), [1])  # (batch, d_inner)
+        y = op.Add(y, op.Mul(op.Cast(self.D, to=1), x_t))
 
-        # Restore seq dim: (batch, 1, d_inner)
-        y = op.Unsqueeze(y, [1])
+        # Restore seq dim and cast back to input dtype: (batch, 1, d_inner)
+        y = op.CastLike(op.Unsqueeze(y, [1]), x)
 
-        return y, new_ssm_state
+        return y, op.CastLike(new_ssm_state, ssm_state)
 
 
 class JambaSelectiveScan(SelectiveScan):
@@ -247,15 +253,15 @@ class Mamba2Scan(nn.Module):
             y: (batch, num_heads * d_head) -- output.
             new_ssm_state: (batch, num_heads, d_head, d_state).
         """
-        # dt = softplus(dt_input + dt_bias): (batch, num_heads)
-        # CastLike ensures parameters match the compute dtype (fp16/bf16/fp32).
-        dt = op.Add(dt_input, op.CastLike(self.dt_bias, dt_input))
-        dt = op.Softplus(dt)
+        # dt = softplus(dt_input + dt_bias) in fp32: (batch, num_heads)
+        # Upcast to fp32 for softplus/exp to match HuggingFace which
+        # computes the SSM recurrence in float32.
+        dt = op.Softplus(op.Add(op.Cast(dt_input, to=1), op.Cast(self.dt_bias, to=1)))
 
-        # A = -exp(A_log): (num_heads,)
-        a_neg = op.Neg(op.Exp(op.CastLike(self.A_log, dt)))
+        # A = -exp(A_log) in fp32: (num_heads,)
+        a_neg = op.Neg(op.Exp(op.Cast(self.A_log, to=1)))
 
-        # Broadcast for state update
+        # Broadcast for state update (all in fp32)
         dt_4d = op.Unsqueeze(dt, [2, 3])  # (batch, num_heads, 1, 1)
         a_2d = op.Unsqueeze(a_neg, [0])  # (1, num_heads)
         a_4d = op.Unsqueeze(a_2d, [2, 3])  # (1, num_heads, 1, 1)
@@ -263,27 +269,27 @@ class Mamba2Scan(nn.Module):
 
         # Reshape hidden: (batch, num_heads, d_head)
         hidden_shape = op.Constant(value_ints=[0, self.num_heads, self.d_head])
-        hidden_3d = op.Reshape(hidden_states, hidden_shape)
+        hidden_3d = op.Cast(op.Reshape(hidden_states, hidden_shape), to=1)
 
-        # Expand B from groups to heads
+        # Expand B from groups to heads (in fp32)
         b_shape = op.Constant(value_ints=[0, self.n_groups, 1, self.d_state])
-        b_4d = op.Reshape(b_mat, b_shape)
+        b_4d = op.Reshape(op.Cast(b_mat, to=1), b_shape)
         b_expand_shape = op.Constant(value_ints=[1, 1, self.heads_per_group, 1])
         b_expanded = op.Expand(b_4d, b_expand_shape)
         b_heads_shape = op.Constant(value_ints=[0, self.num_heads, self.d_state])
         b_heads = op.Reshape(b_expanded, b_heads_shape)
         b_ssm = op.Unsqueeze(b_heads, [2])
 
-        # dBx: dt * B * x
+        # dBx: dt * B * x (in fp32)
         dt_b = op.Mul(dt_4d, b_ssm)  # (batch, num_heads, 1, d_state)
         x_4d = op.Unsqueeze(hidden_3d, [3])
         db_x = op.Mul(dt_b, x_4d)  # (batch, num_heads, d_head, d_state)
 
-        # State update: h = dA * h_prev + dBx
-        new_ssm_state = op.Add(op.Mul(da, ssm_state), db_x)
+        # State update: h = dA * h_prev + dBx (in fp32)
+        new_ssm_state = op.Add(op.Mul(da, op.Cast(ssm_state, to=1)), db_x)
 
-        # Readout: y = C . h + D * x
-        c_4d = op.Reshape(c_mat, b_shape)
+        # Readout: y = C . h + D * x (in fp32)
+        c_4d = op.Reshape(op.Cast(c_mat, to=1), b_shape)
         c_expanded = op.Expand(c_4d, b_expand_shape)
         c_heads = op.Reshape(c_expanded, b_heads_shape)
         c_ssm = op.Unsqueeze(c_heads, [2])
@@ -293,14 +299,14 @@ class Mamba2Scan(nn.Module):
         )  # (batch, num_heads, d_head)
 
         # Skip: y += D * x
-        d_3d = op.Unsqueeze(op.CastLike(self.D, hidden_3d), [0, 2])
+        d_3d = op.Unsqueeze(op.Cast(self.D, to=1), [0, 2])
         y = op.Add(y, op.Mul(d_3d, hidden_3d))
 
-        # Flatten: (batch, num_heads * d_head)
+        # Flatten and cast back to input dtype: (batch, num_heads * d_head)
         flat_shape = op.Constant(value_ints=[0, self.num_heads * self.d_head])
-        y = op.Reshape(y, flat_shape)
+        y = op.CastLike(op.Reshape(y, flat_shape), hidden_states)
 
-        return y, new_ssm_state
+        return y, op.CastLike(new_ssm_state, ssm_state)
 
 
 class _RMSNorm(nn.Module):
@@ -312,9 +318,12 @@ class _RMSNorm(nn.Module):
         self._eps = eps
 
     def forward(self, op: builder.OpBuilder, x: ir.Value):
-        variance = op.ReduceMean(op.Mul(x, x), [-1], keepdims=True)
+        # Upcast to fp32 for variance computation (matching HF RMSNorm).
+        x_f32 = op.Cast(x, to=1)
+        variance = op.ReduceMean(op.Mul(x_f32, x_f32), [-1], keepdims=True)
         x_normed = op.Div(
-            x,
+            x_f32,
             op.Sqrt(op.Add(variance, op.Constant(value_float=self._eps))),
         )
-        return op.Mul(x_normed, op.CastLike(self.weight, x_normed))
+        result = op.Mul(x_normed, op.Cast(self.weight, to=1))
+        return op.CastLike(result, x)

--- a/src/mobius/components/_ssm.py
+++ b/src/mobius/components/_ssm.py
@@ -28,7 +28,6 @@ HuggingFace reference: ``MambaMixer`` (SSM portion).
 
 from __future__ import annotations
 
-
 import onnx_ir as ir
 from onnxscript import nn
 from onnxscript._internal import builder

--- a/src/mobius/components/_ssm.py
+++ b/src/mobius/components/_ssm.py
@@ -114,7 +114,8 @@ class SelectiveScan(nn.Module):
 
         # --- Discretize state decay matrix A ---
         # a_neg = -exp(A_log): (d_inner, d_state)
-        a_neg = op.Neg(op.Exp(op.Cast(self.A_log, to=1)))
+        # CastLike ensures A_log matches the compute dtype (fp16/bf16/fp32).
+        a_neg = op.Neg(op.Exp(op.CastLike(self.A_log, dt)))
 
         # Broadcast: dt (batch,1,d_inner,1) * A (1,1,d_inner,d_state)
         dt_4d = op.Unsqueeze(dt, [-1])  # (batch, 1, d_inner, 1)
@@ -144,7 +145,7 @@ class SelectiveScan(nn.Module):
 
         # --- Skip connection: y += D * x ---
         x_t = op.Squeeze(x, [1])  # (batch, d_inner)
-        y = op.Add(y, op.Mul(op.Cast(self.D, to=1), x_t))
+        y = op.Add(y, op.Mul(op.CastLike(self.D, x_t), x_t))
 
         # Restore seq dim: (batch, 1, d_inner)
         y = op.Unsqueeze(y, [1])
@@ -247,11 +248,12 @@ class Mamba2Scan(nn.Module):
             new_ssm_state: (batch, num_heads, d_head, d_state).
         """
         # dt = softplus(dt_input + dt_bias): (batch, num_heads)
-        dt = op.Add(dt_input, op.Cast(self.dt_bias, to=1))
+        # CastLike ensures parameters match the compute dtype (fp16/bf16/fp32).
+        dt = op.Add(dt_input, op.CastLike(self.dt_bias, dt_input))
         dt = op.Softplus(dt)
 
         # A = -exp(A_log): (num_heads,)
-        a_neg = op.Neg(op.Exp(op.Cast(self.A_log, to=1)))
+        a_neg = op.Neg(op.Exp(op.CastLike(self.A_log, dt)))
 
         # Broadcast for state update
         dt_4d = op.Unsqueeze(dt, [2, 3])  # (batch, num_heads, 1, 1)
@@ -291,7 +293,7 @@ class Mamba2Scan(nn.Module):
         )  # (batch, num_heads, d_head)
 
         # Skip: y += D * x
-        d_3d = op.Unsqueeze(op.Cast(self.D, to=1), [0, 2])
+        d_3d = op.Unsqueeze(op.CastLike(self.D, hidden_3d), [0, 2])
         y = op.Add(y, op.Mul(d_3d, hidden_3d))
 
         # Flatten: (batch, num_heads * d_head)
@@ -315,4 +317,4 @@ class _RMSNorm(nn.Module):
             x,
             op.Sqrt(op.Add(variance, op.Constant(value_float=self._eps))),
         )
-        return op.Mul(x_normed, op.Cast(self.weight, to=1))
+        return op.Mul(x_normed, op.CastLike(self.weight, x_normed))

--- a/src/mobius/components/_ssm.py
+++ b/src/mobius/components/_ssm.py
@@ -28,15 +28,12 @@ HuggingFace reference: ``MambaMixer`` (SSM portion).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 
+import onnx_ir as ir
 from onnxscript import nn
 from onnxscript._internal import builder
 
 from mobius.components._common import Linear
-
-if TYPE_CHECKING:
-    import onnx_ir as ir
 
 
 class SelectiveScan(nn.Module):
@@ -116,12 +113,12 @@ class SelectiveScan(nn.Module):
         # dt: (batch, 1, d_inner) via rank projection + softplus.
         # Upcast to fp32 for softplus (uses exp internally) to match
         # HuggingFace which computes the SSM recurrence in float32.
-        dt = op.Cast(self.dt_proj(op, dt_raw), to=1)
+        dt = op.Cast(self.dt_proj(op, dt_raw), to=ir.DataType.FLOAT)
         dt = op.Softplus(dt)
 
         # --- Discretize state decay matrix A ---
         # a_neg = -exp(A_log) in fp32: (d_inner, d_state)
-        a_neg = op.Neg(op.Exp(op.Cast(self.A_log, to=1)))
+        a_neg = op.Neg(op.Exp(op.Cast(self.A_log, to=ir.DataType.FLOAT)))
 
         # Broadcast: dt (batch,1,d_inner,1) * A (1,1,d_inner,d_state)
         dt_4d = op.Unsqueeze(dt, [-1])  # (batch, 1, d_inner, 1)
@@ -130,9 +127,9 @@ class SelectiveScan(nn.Module):
         da = op.Exp(op.Mul(dt_4d, a_4d))
 
         # --- Input contribution: dt * B * x (in fp32) ---
-        b_4d = op.Unsqueeze(op.Cast(b_mat, to=1), [2])
+        b_4d = op.Unsqueeze(op.Cast(b_mat, to=ir.DataType.FLOAT), [2])
         dt_b = op.Mul(dt_4d, b_4d)  # (batch, 1, d_inner, d_state)
-        x_4d = op.Unsqueeze(op.Cast(x, to=1), [-1])
+        x_4d = op.Unsqueeze(op.Cast(x, to=ir.DataType.FLOAT), [-1])
         db_x = op.Mul(dt_b, x_4d)  # (batch, 1, d_inner, d_state)
 
         # --- Squeeze seq dim (single token) ---
@@ -140,18 +137,18 @@ class SelectiveScan(nn.Module):
         db_x_t = op.Squeeze(db_x, [1])  # (batch, d_inner, d_state)
 
         # --- State update: h = dA * h_prev + dBx (in fp32) ---
-        new_ssm_state = op.Add(op.Mul(da_t, op.Cast(ssm_state, to=1)), db_x_t)
+        new_ssm_state = op.Add(op.Mul(da_t, op.Cast(ssm_state, to=ir.DataType.FLOAT)), db_x_t)
 
         # --- Readout: y = C · h ---
-        c_t = op.Squeeze(op.Cast(c_mat, to=1), [1])  # (batch, d_state)
+        c_t = op.Squeeze(op.Cast(c_mat, to=ir.DataType.FLOAT), [1])  # (batch, d_state)
         c_3d = op.Unsqueeze(c_t, [1])  # (batch, 1, d_state)
         # h: (batch, d_inner, d_state), C: (batch, 1, d_state)
         # → element-wise mul then sum over d_state → (batch, d_inner)
         y = op.ReduceSum(op.Mul(new_ssm_state, c_3d), [-1], keepdims=False)
 
         # --- Skip connection: y += D * x ---
-        x_t = op.Squeeze(op.Cast(x, to=1), [1])  # (batch, d_inner)
-        y = op.Add(y, op.Mul(op.Cast(self.D, to=1), x_t))
+        x_t = op.Squeeze(op.Cast(x, to=ir.DataType.FLOAT), [1])  # (batch, d_inner)
+        y = op.Add(y, op.Mul(op.Cast(self.D, to=ir.DataType.FLOAT), x_t))
 
         # Restore seq dim and cast back to input dtype: (batch, 1, d_inner)
         y = op.CastLike(op.Unsqueeze(y, [1]), x)
@@ -256,10 +253,10 @@ class Mamba2Scan(nn.Module):
         # dt = softplus(dt_input + dt_bias) in fp32: (batch, num_heads)
         # Upcast to fp32 for softplus/exp to match HuggingFace which
         # computes the SSM recurrence in float32.
-        dt = op.Softplus(op.Add(op.Cast(dt_input, to=1), op.Cast(self.dt_bias, to=1)))
+        dt = op.Softplus(op.Add(op.Cast(dt_input, to=ir.DataType.FLOAT), op.Cast(self.dt_bias, to=ir.DataType.FLOAT)))
 
         # A = -exp(A_log) in fp32: (num_heads,)
-        a_neg = op.Neg(op.Exp(op.Cast(self.A_log, to=1)))
+        a_neg = op.Neg(op.Exp(op.Cast(self.A_log, to=ir.DataType.FLOAT)))
 
         # Broadcast for state update (all in fp32)
         dt_4d = op.Unsqueeze(dt, [2, 3])  # (batch, num_heads, 1, 1)
@@ -269,11 +266,11 @@ class Mamba2Scan(nn.Module):
 
         # Reshape hidden: (batch, num_heads, d_head)
         hidden_shape = op.Constant(value_ints=[0, self.num_heads, self.d_head])
-        hidden_3d = op.Cast(op.Reshape(hidden_states, hidden_shape), to=1)
+        hidden_3d = op.Cast(op.Reshape(hidden_states, hidden_shape), to=ir.DataType.FLOAT)
 
         # Expand B from groups to heads (in fp32)
         b_shape = op.Constant(value_ints=[0, self.n_groups, 1, self.d_state])
-        b_4d = op.Reshape(op.Cast(b_mat, to=1), b_shape)
+        b_4d = op.Reshape(op.Cast(b_mat, to=ir.DataType.FLOAT), b_shape)
         b_expand_shape = op.Constant(value_ints=[1, 1, self.heads_per_group, 1])
         b_expanded = op.Expand(b_4d, b_expand_shape)
         b_heads_shape = op.Constant(value_ints=[0, self.num_heads, self.d_state])
@@ -286,10 +283,10 @@ class Mamba2Scan(nn.Module):
         db_x = op.Mul(dt_b, x_4d)  # (batch, num_heads, d_head, d_state)
 
         # State update: h = dA * h_prev + dBx (in fp32)
-        new_ssm_state = op.Add(op.Mul(da, op.Cast(ssm_state, to=1)), db_x)
+        new_ssm_state = op.Add(op.Mul(da, op.Cast(ssm_state, to=ir.DataType.FLOAT)), db_x)
 
         # Readout: y = C . h + D * x (in fp32)
-        c_4d = op.Reshape(op.Cast(c_mat, to=1), b_shape)
+        c_4d = op.Reshape(op.Cast(c_mat, to=ir.DataType.FLOAT), b_shape)
         c_expanded = op.Expand(c_4d, b_expand_shape)
         c_heads = op.Reshape(c_expanded, b_heads_shape)
         c_ssm = op.Unsqueeze(c_heads, [2])
@@ -299,7 +296,7 @@ class Mamba2Scan(nn.Module):
         )  # (batch, num_heads, d_head)
 
         # Skip: y += D * x
-        d_3d = op.Unsqueeze(op.Cast(self.D, to=1), [0, 2])
+        d_3d = op.Unsqueeze(op.Cast(self.D, to=ir.DataType.FLOAT), [0, 2])
         y = op.Add(y, op.Mul(d_3d, hidden_3d))
 
         # Flatten and cast back to input dtype: (batch, num_heads * d_head)
@@ -319,11 +316,11 @@ class _RMSNorm(nn.Module):
 
     def forward(self, op: builder.OpBuilder, x: ir.Value):
         # Upcast to fp32 for variance computation (matching HF RMSNorm).
-        x_f32 = op.Cast(x, to=1)
+        x_f32 = op.Cast(x, to=ir.DataType.FLOAT)
         variance = op.ReduceMean(op.Mul(x_f32, x_f32), [-1], keepdims=True)
         x_normed = op.Div(
             x_f32,
             op.Sqrt(op.Add(variance, op.Constant(value_float=self._eps))),
         )
-        result = op.Mul(x_normed, op.Cast(self.weight, to=1))
+        result = op.Mul(x_normed, op.Cast(self.weight, to=ir.DataType.FLOAT))
         return op.CastLike(result, x)

--- a/src/mobius/components/_ssm.py
+++ b/src/mobius/components/_ssm.py
@@ -252,7 +252,12 @@ class Mamba2Scan(nn.Module):
         # dt = softplus(dt_input + dt_bias) in fp32: (batch, num_heads)
         # Upcast to fp32 for softplus/exp to match HuggingFace which
         # computes the SSM recurrence in float32.
-        dt = op.Softplus(op.Add(op.Cast(dt_input, to=ir.DataType.FLOAT), op.Cast(self.dt_bias, to=ir.DataType.FLOAT)))
+        dt = op.Softplus(
+            op.Add(
+                op.Cast(dt_input, to=ir.DataType.FLOAT),
+                op.Cast(self.dt_bias, to=ir.DataType.FLOAT),
+            )
+        )
 
         # A = -exp(A_log) in fp32: (num_heads,)
         a_neg = op.Neg(op.Exp(op.Cast(self.A_log, to=ir.DataType.FLOAT)))

--- a/src/mobius/models/__init__.py
+++ b/src/mobius/models/__init__.py
@@ -36,6 +36,7 @@ __all__ = [
     "LLaVAModel",
     "MoECausalLMModel",
     "NemotronCausalLMModel",
+    "NemotronHCausalLMModel",
     "OLMo2CausalLMModel",
     "OLMoCausalLMModel",
     "OPTCausalLMModel",
@@ -122,6 +123,7 @@ from mobius.models.moe import (
     Phi3MoECausalLMModel,
 )
 from mobius.models.nemotron import NemotronCausalLMModel
+from mobius.models.nemotron_h import NemotronHCausalLMModel
 from mobius.models.olmo import OLMo2CausalLMModel, OLMoCausalLMModel
 from mobius.models.opt import OPTCausalLMModel
 from mobius.models.phi import (

--- a/src/mobius/models/nemotron.py
+++ b/src/mobius/models/nemotron.py
@@ -4,21 +4,29 @@
 from __future__ import annotations
 
 from mobius._configs import ArchitectureConfig
-from mobius.components import FCMLP, LayerNorm
+from mobius.components import FCMLP, OffsetLayerNorm
 from mobius.models.base import CausalLMModel
 
 
 class NemotronCausalLMModel(CausalLMModel):
-    """Nemotron model with non-simple LayerNorm and custom MLP order.
+    """Nemotron model with offset LayerNorm and non-gated MLP.
 
-    Nemotron uses full LayerNorm (not simplified RMS) with +1 offset,
-    and a simpler MLP path: up → activation → down (no gating).
+    Replicates HuggingFace's ``NemotronForCausalLM``.  Key differences
+    from the base ``CausalLMModel``:
+
+    - **NemotronLayerNorm1P**: Full LayerNorm (with bias) using a +1
+      weight offset — ``LayerNorm(x, weight + 1, bias, eps)``.
+    - **Non-gated MLP**: ``down_proj(act_fn(up_proj(x)))`` instead of
+      the GLU-style gated MLP.
+    - **relu2 activation**: Squared ReLU ``max(x, 0)²``.
+    - **partial_rotary_factor = 0.5**: Only half of head dimensions
+      receive RoPE positional encoding.
     """
 
     def __init__(self, config: ArchitectureConfig):
         super().__init__(config)
-        # Nemotron uses full LayerNorm (with bias), not RMSNorm
-        self.model.norm = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
+        # Replace RMSNorm with OffsetLayerNorm (LayerNorm with +1 weight offset)
+        self.model.norm = OffsetLayerNorm(config.hidden_size, eps=config.rms_norm_eps)
         for layer in self.model.layers:
             layer.mlp = FCMLP(
                 config.hidden_size,
@@ -26,7 +34,9 @@ class NemotronCausalLMModel(CausalLMModel):
                 activation=config.hidden_act,
                 bias=config.mlp_bias,
             )
-            layer.input_layernorm = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
-            layer.post_attention_layernorm = LayerNorm(
+            layer.input_layernorm = OffsetLayerNorm(
+                config.hidden_size, eps=config.rms_norm_eps
+            )
+            layer.post_attention_layernorm = OffsetLayerNorm(
                 config.hidden_size, eps=config.rms_norm_eps
             )

--- a/src/mobius/models/nemotron_h.py
+++ b/src/mobius/models/nemotron_h.py
@@ -38,13 +38,13 @@ from mobius._weight_utils import tie_word_embeddings
 from mobius.components import (
     Attention,
     Embedding,
+    FCMLP,
     Linear,
     Mamba2Block,
     RMSNorm,
     create_attention_bias,
     initialize_rope,
 )
-from mobius.models.nemotron import NemotronMLP
 
 if TYPE_CHECKING:
     import onnx_ir as ir
@@ -149,7 +149,7 @@ class NemotronHAttentionLayer(nn.Module):
 
 
 class NemotronHMLPLayer(nn.Module):
-    """NemotronH MLP layer: RMSNorm → NemotronMLP → residual.
+    """NemotronH MLP layer: RMSNorm → FCMLP → residual.
 
     Single-mixer block — stateless, no cache.
 
@@ -159,7 +159,12 @@ class NemotronHMLPLayer(nn.Module):
 
     def __init__(self, config: NemotronHConfig):
         super().__init__()
-        self.mlp = NemotronMLP(config)
+        self.mlp = FCMLP(
+            config.hidden_size,
+            config.intermediate_size,
+            activation=config.hidden_act,
+            bias=config.mlp_bias,
+        )
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
     def forward(

--- a/src/mobius/models/nemotron_h.py
+++ b/src/mobius/models/nemotron_h.py
@@ -1,0 +1,390 @@
+# Copyright (c) ONNX Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""NemotronH hybrid Mamba2 + Attention + MLP causal language model.
+
+NemotronH interleaves three layer types in a configurable pattern:
+- Mamba2/SSD layers for efficient recurrent processing
+- Transformer attention layers for global context
+- Dense MLP layers for feedforward computation
+
+Each layer is a single-mixer block: RMSNorm → mixer → residual.
+Unlike Jamba/Bamba where every layer has a mixer AND MLP, NemotronH
+treats MLP as a standalone layer type.
+
+Layer types are specified via ``layers_block_type`` in the HF config:
+``M`` = mamba, ``*`` = attention, ``-`` = mlp (dense feedforward).
+
+State per layer:
+    Mamba2: conv_state (batch, conv_dim, d_conv-1)
+            ssm_state (batch, num_heads, d_head, d_state)
+    Attention: standard KV cache (key + value)
+    MLP: stateless — no cache
+
+HuggingFace reference: ``NemotronHForCausalLM``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import torch
+from onnxscript import nn
+from onnxscript._internal import builder
+
+from mobius._configs import NemotronHConfig
+from mobius._weight_utils import tie_word_embeddings
+from mobius.components import (
+    Attention,
+    Embedding,
+    Linear,
+    Mamba2Block,
+    RMSNorm,
+    create_attention_bias,
+    initialize_rope,
+)
+from mobius.models.nemotron import NemotronMLP
+
+if TYPE_CHECKING:
+    import onnx_ir as ir
+
+# ---------------------------------------------------------------------------
+# Decoder layers
+# ---------------------------------------------------------------------------
+
+
+class NemotronHMambaLayer(nn.Module):
+    """NemotronH Mamba2 layer: RMSNorm → Mamba2Block → residual.
+
+    Single-mixer block — no MLP path.
+
+    Args:
+        config: NemotronH architecture config.
+    """
+
+    def __init__(self, config: NemotronHConfig):
+        super().__init__()
+        # d_inner = num_heads * head_dim (not hidden_size * expand)
+        d_inner = config.mamba_n_heads * config.mamba_d_head
+
+        self.mamba = Mamba2Block(
+            d_model=config.hidden_size,
+            d_inner=d_inner,
+            num_heads=config.mamba_n_heads,
+            d_head=config.mamba_d_head,
+            d_state=config.mamba_d_state,
+            n_groups=config.mamba_n_groups,
+            conv_kernel=config.mamba_d_conv,
+            conv_bias=config.mamba_conv_bias,
+            proj_bias=config.mamba_proj_bias,
+            eps=config.rms_norm_eps,
+        )
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        hidden_states: ir.Value,
+        attention_bias: ir.Value,
+        position_embeddings: tuple,
+        past_key_value: tuple | None,
+    ):
+        """Forward pass. Returns (hidden_states, (conv_state, ssm_state)).
+
+        attention_bias and position_embeddings are unused by Mamba layers
+        but accepted for uniform interface with attention layers.
+        """
+        del attention_bias, position_embeddings  # unused
+
+        # Pre-norm → Mamba2 → residual
+        residual = hidden_states
+        hidden_states = self.norm(op, hidden_states)
+
+        conv_state, ssm_state = past_key_value if past_key_value is not None else (None, None)
+        mamba_out, new_conv_state, new_ssm_state = self.mamba(
+            op, hidden_states, conv_state, ssm_state
+        )
+        hidden_states = op.Add(residual, mamba_out)
+
+        return hidden_states, (new_conv_state, new_ssm_state)
+
+
+class NemotronHAttentionLayer(nn.Module):
+    """NemotronH attention layer: RMSNorm → Attention → residual.
+
+    Single-mixer block — no MLP path.
+
+    Args:
+        config: NemotronH architecture config.
+    """
+
+    def __init__(self, config: NemotronHConfig):
+        super().__init__()
+        self.self_attn = Attention(config)
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        hidden_states: ir.Value,
+        attention_bias: ir.Value,
+        position_embeddings: tuple,
+        past_key_value: tuple | None,
+    ):
+        """Forward pass. Returns (hidden_states, (key, value))."""
+        residual = hidden_states
+        hidden_states = self.norm(op, hidden_states)
+
+        attn_output, present_kv = self.self_attn(
+            op,
+            hidden_states=hidden_states,
+            attention_bias=attention_bias,
+            position_embeddings=position_embeddings,
+            past_key_value=past_key_value,
+        )
+        hidden_states = op.Add(residual, attn_output)
+
+        return hidden_states, present_kv
+
+
+class NemotronHMLPLayer(nn.Module):
+    """NemotronH MLP layer: RMSNorm → NemotronMLP → residual.
+
+    Single-mixer block — stateless, no cache.
+
+    Args:
+        config: NemotronH architecture config.
+    """
+
+    def __init__(self, config: NemotronHConfig):
+        super().__init__()
+        self.mlp = NemotronMLP(config)
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        hidden_states: ir.Value,
+        attention_bias: ir.Value,
+        position_embeddings: tuple,
+        past_key_value: tuple | None,
+    ):
+        """Forward pass. Returns (hidden_states, (None, None)).
+
+        MLP layers are stateless — the None pair keeps the cache
+        list aligned with all layers.
+        """
+        del attention_bias, position_embeddings, past_key_value  # unused
+
+        # Pre-norm → MLP → residual
+        residual = hidden_states
+        hidden_states = self.norm(op, hidden_states)
+        hidden_states = self.mlp(op, hidden_states)
+        hidden_states = op.Add(residual, hidden_states)
+
+        return hidden_states, (None, None)
+
+
+# ---------------------------------------------------------------------------
+# Full model
+# ---------------------------------------------------------------------------
+
+
+class _NemotronHTextModel(nn.Module):
+    """NemotronH text backbone: embedding → N x (Mamba2|Attention|MLP) → norm.
+
+    Layer types are selected based on ``config.layer_types``:
+        ``"mamba2"`` → NemotronHMambaLayer
+        ``"full_attention"`` → NemotronHAttentionLayer
+        ``"mlp"`` → NemotronHMLPLayer
+    """
+
+    def __init__(self, config: NemotronHConfig):
+        super().__init__()
+        self._dtype = config.dtype
+        self.embed_tokens = Embedding(
+            config.vocab_size, config.hidden_size, config.pad_token_id
+        )
+
+        layer_types = config.layer_types or []
+        self.layers = nn.ModuleList([])
+        for i in range(config.num_hidden_layers):
+            ltype = layer_types[i] if i < len(layer_types) else "full_attention"
+            if ltype == "mamba2":
+                self.layers.append(NemotronHMambaLayer(config))
+            elif ltype == "mlp":
+                self.layers.append(NemotronHMLPLayer(config))
+            else:
+                self.layers.append(NemotronHAttentionLayer(config))
+
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = initialize_rope(config)
+
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        input_ids: ir.Value,
+        attention_mask: ir.Value,
+        position_ids: ir.Value,
+        past_key_values: list | None = None,
+    ):
+        hidden_states = self.embed_tokens(op, input_ids)
+        position_embeddings = self.rotary_emb(op, position_ids)
+
+        attention_bias = create_attention_bias(
+            op,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            dtype=self._dtype,
+        )
+
+        present_key_values = []
+        past_kvs = past_key_values or [None] * len(self.layers)
+        for layer, past_kv in zip(self.layers, past_kvs):
+            hidden_states, present_kv = layer(
+                op,
+                hidden_states=hidden_states,
+                attention_bias=attention_bias,
+                position_embeddings=position_embeddings,
+                past_key_value=past_kv,
+            )
+            present_key_values.append(present_kv)
+
+        hidden_states = self.norm(op, hidden_states)
+        return hidden_states, present_key_values
+
+
+class NemotronHCausalLMModel(nn.Module):
+    """NemotronH hybrid Mamba2+Attention+MLP causal language model.
+
+    Uses ``HybridCausalLMTask`` with mixed ``"mamba2"``,
+    ``"full_attention"``, and ``"mlp"`` layer types for the cache.
+
+    HuggingFace reference: ``NemotronHForCausalLM``.
+    """
+
+    default_task: str = "hybrid-text-generation"
+    category: str = "Hybrid SSM+Attention"
+    config_class: type = NemotronHConfig
+
+    def __init__(self, config: NemotronHConfig):
+        super().__init__()
+        self.config = config
+        self.model = _NemotronHTextModel(config)
+        self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        input_ids: ir.Value,
+        attention_mask: ir.Value,
+        position_ids: ir.Value,
+        past_key_values: list | None = None,
+    ):
+        hidden_states, present_key_values = self.model(
+            op,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+        )
+        logits = self.lm_head(op, hidden_states)
+        return logits, present_key_values
+
+    def preprocess_weights(
+        self, state_dict: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        """Map HuggingFace NemotronHForCausalLM weights to ONNX parameters.
+
+        Handles:
+        1. Weight tying (embed_tokens ↔ lm_head)
+        2. ``backbone.`` → ``model.`` prefix rename
+        3. ``backbone.embeddings.`` → ``model.embed_tokens.``
+        4. ``backbone.norm_f.`` → ``model.norm.``
+        5. Per-layer ``mixer.`` rename based on layer type:
+           - mamba: ``mixer.`` → ``mamba.`` (SSM params nested under ``mamba.ssm.``)
+           - attention: ``mixer.`` → ``self_attn.``
+           - mlp: ``mixer.`` → ``mlp.``
+        """
+        layer_types = self.config.layer_types or []
+
+        if self.config.tie_word_embeddings:
+            # Tie before renaming so both old-name keys exist
+            tie_word_embeddings(
+                state_dict,
+                embed_key="backbone.embeddings.weight",
+                head_key="lm_head.weight",
+            )
+
+        new_state_dict: dict[str, torch.Tensor] = {}
+        for key, value in state_dict.items():
+            new_key = _rename_nemotron_h_weight(key, layer_types)
+            new_state_dict[new_key] = value
+
+        return new_state_dict
+
+
+# Layer index regex: backbone.layers.<N>.<rest>
+_LAYER_RE = re.compile(r"^backbone\.layers\.(\d+)\.(.+)$")
+
+# Mamba SSM params that need to be nested under mamba.ssm
+_MAMBA_SSM_PARAMS = ("A_log", "D", "dt_bias")
+
+
+def _rename_nemotron_h_weight(key: str, layer_types: list[str]) -> str:
+    """Rename a single HF weight key to match ONNX module structure.
+
+    HF NemotronHForCausalLM weight naming:
+        backbone.embeddings.weight
+        backbone.norm_f.weight
+        backbone.layers.N.norm.weight
+        backbone.layers.N.mixer.{in_proj, conv1d, out_proj, norm, A_log, D, dt_bias}  (mamba)
+        backbone.layers.N.mixer.{q_proj, k_proj, v_proj, o_proj}.weight              (attention)
+        backbone.layers.N.mixer.{up_proj, down_proj}.weight                          (mlp)
+        lm_head.weight
+
+    ONNX parameter naming:
+        model.embed_tokens.weight
+        model.norm.weight
+        model.layers.N.norm.weight
+        model.layers.N.mamba.{in_proj, conv1d, out_proj, norm}   (mamba direct)
+        model.layers.N.mamba.ssm.{A_log, D, dt_bias}            (mamba SSM nested)
+        model.layers.N.self_attn.{q_proj, k_proj, v_proj, o_proj}.weight
+        model.layers.N.mlp.{up_proj, down_proj}.weight
+        lm_head.weight
+    """
+    # Global prefix renames
+    if key.startswith("backbone.embeddings."):
+        return key.replace("backbone.embeddings.", "model.embed_tokens.", 1)
+    if key.startswith("backbone.norm_f."):
+        return key.replace("backbone.norm_f.", "model.norm.", 1)
+
+    # Per-layer renames
+    m = _LAYER_RE.match(key)
+    if m:
+        layer_idx = int(m.group(1))
+        rest = m.group(2)
+        ltype = layer_types[layer_idx] if layer_idx < len(layer_types) else "full_attention"
+
+        if rest.startswith("mixer."):
+            mixer_rest = rest[len("mixer.") :]
+            if ltype == "mamba2":
+                # Check if this is an SSM param that needs nesting
+                param_name = mixer_rest.split(".")[0]
+                if param_name in _MAMBA_SSM_PARAMS:
+                    return f"model.layers.{layer_idx}.mamba.ssm.{mixer_rest}"
+                return f"model.layers.{layer_idx}.mamba.{mixer_rest}"
+            elif ltype == "full_attention":
+                return f"model.layers.{layer_idx}.self_attn.{mixer_rest}"
+            else:  # mlp
+                return f"model.layers.{layer_idx}.mlp.{mixer_rest}"
+
+        # norm.weight stays as norm.weight (already matching)
+        return f"model.layers.{layer_idx}.{rest}"
+
+    # Catch-all for backbone.X → model.X (shouldn't normally hit)
+    if key.startswith("backbone."):
+        return key.replace("backbone.", "model.", 1)
+
+    return key

--- a/src/mobius/models/nemotron_h.py
+++ b/src/mobius/models/nemotron_h.py
@@ -36,9 +36,9 @@ from onnxscript._internal import builder
 from mobius._configs import NemotronHConfig
 from mobius._weight_utils import tie_word_embeddings
 from mobius.components import (
+    FCMLP,
     Attention,
     Embedding,
-    FCMLP,
     Linear,
     Mamba2Block,
     RMSNorm,

--- a/src/mobius/models/nemotron_h.py
+++ b/src/mobius/models/nemotron_h.py
@@ -79,6 +79,9 @@ class NemotronHMambaLayer(nn.Module):
             conv_bias=config.mamba_conv_bias,
             proj_bias=config.mamba_proj_bias,
             eps=config.rms_norm_eps,
+            # NemotronH uses grouped RMSNorm: normalize within each
+            # group of heads_per_group * head_dim dimensions.
+            norm_group_size=d_inner // config.mamba_n_groups,
         )
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 

--- a/src/mobius/tasks/_base.py
+++ b/src/mobius/tasks/_base.py
@@ -19,6 +19,10 @@ from mobius._model_package import ModelPackage
 
 _FUNCTIONS_DOMAIN = "pkg.mobius"
 
+# Cache state pair: (key, value) or (conv_state, ssm_state) for stateful
+# layers.  MLP-only layers are stateless and use (None, None).
+StatePair = tuple[ir.Value, ir.Value] | tuple[None, None]
+
 
 class LinearAttentionDims(NamedTuple):
     """Dimension sizes for linear attention (DeltaNet) layers."""
@@ -201,21 +205,24 @@ def _make_hybrid_cache_inputs(
     past_seq_len: ir.SymbolicDim,
     *,
     prefix: str = "past_key_values",
-) -> tuple[list[ir.Value], list[tuple[ir.Value, ir.Value]]]:
+) -> tuple[list[ir.Value], list[StatePair]]:
     """Create cache inputs for hybrid models with mixed layer types.
 
     Supported layer types:
         ``"full_attention"`` — standard KV cache (key + value).
         ``"linear_attention"`` (DeltaNet) — conv_state + recurrent_state.
-        ``"mamba"`` — conv_state + ssm_state (Mamba SSM carry).
+        ``"mamba"`` / ``"mamba2"`` — conv_state + ssm_state.
+        ``"mlp"`` — stateless, produces ``(None, None)`` pair.
 
     Returns:
-        ``(flat_inputs, state_pairs)`` — same shape as
-        :func:`_make_kv_cache_inputs`.
+        ``(flat_inputs, state_pairs)`` — *flat_inputs* contains only
+        the ``ir.Value`` entries (no graph inputs for MLP layers);
+        *state_pairs* has one entry per layer, with ``(None, None)``
+        for stateless MLP layers.
     """
     layer_types = config.layer_types or []
     flat: list[ir.Value] = []
-    pairs: list[tuple[ir.Value, ir.Value]] = []
+    pairs: list[StatePair] = []
 
     # DeltaNet dimensions from config (computed once via shared helper)
     has_linear = "linear_attention" in layer_types
@@ -311,10 +318,10 @@ def _make_hybrid_cache_inputs(
 
 def _register_hybrid_cache_outputs(
     graph: ir.Graph,
-    present_key_values: list[tuple[ir.Value, ir.Value]],
+    present_key_values: list[StatePair],
     layer_types: list[str],
     *,
-    past_key_values: list[tuple[ir.Value, ir.Value]] | None = None,
+    past_key_values: list[StatePair] | None = None,
     prefix: str = "present",
 ) -> None:
     """Name and register hybrid cache outputs on the graph.

--- a/src/mobius/tasks/_base.py
+++ b/src/mobius/tasks/_base.py
@@ -235,7 +235,12 @@ def _make_hybrid_cache_inputs(
     mamba2_d_head = getattr(config, "mamba_d_head", 0)
     mamba2_d_state = getattr(config, "mamba_d_state", 0)
     mamba2_n_groups = getattr(config, "mamba_n_groups", 1)
-    mamba2_d_inner = config.hidden_size * mamba_expand
+    # Prefer n_heads * d_head (NemotronH); fall back to hidden * expand (Bamba)
+    mamba2_d_inner = (
+        mamba2_n_heads * mamba2_d_head
+        if mamba2_n_heads and mamba2_d_head
+        else config.hidden_size * mamba_expand
+    )
     mamba2_conv_dim = mamba2_d_inner + 2 * mamba2_n_groups * mamba2_d_state
 
     for i in range(config.num_hidden_layers):
@@ -254,6 +259,9 @@ def _make_hybrid_cache_inputs(
             )
             flat.extend([conv_state, rec_state])
             pairs.append((conv_state, rec_state))
+        elif ltype == "mlp":
+            # MLP-only layers are stateless — no cache inputs needed
+            pairs.append((None, None))
         elif ltype == "mamba":
             conv_state = ir.Value(
                 name=f"{prefix}.{i}.conv_state",
@@ -321,6 +329,8 @@ def _register_hybrid_cache_outputs(
     total_seq_len = ir.SymbolicDim("total_sequence_len")
     for i, (state_a, state_b) in enumerate(present_key_values):
         ltype = layer_types[i] if i < len(layer_types) else "full_attention"
+        if ltype == "mlp":
+            continue  # MLP layers produce no cache state
         if ltype == "linear_attention":
             state_a.name = f"{prefix}.{i}.conv_state"
             state_b.name = f"{prefix}.{i}.recurrent_state"

--- a/tests/_test_configs.py
+++ b/tests/_test_configs.py
@@ -23,6 +23,7 @@ from mobius._configs import (
     JambaConfig,
     Mamba2Config,
     MambaConfig,
+    NemotronHConfig,
     Sam2Config,
     SegformerConfig,
     YolosConfig,
@@ -726,6 +727,23 @@ CAUSAL_LM_CONFIGS: list[tuple[str, dict, bool]] = [
             "mamba_expand": 2,
         },
         False,
+    ),
+    # nemotron_h: hybrid Mamba2+Attention+MLP (requires NemotronHConfig)
+    (
+        "nemotron_h",
+        {
+            "hidden_act": "relu2",
+            "layer_types": ["mamba2", "mlp", "full_attention", "mlp"],
+            "_config_cls": NemotronHConfig,
+            "num_hidden_layers": 4,
+            "mamba_n_heads": TINY_KV_HEADS,
+            "mamba_d_head": TINY_HEAD_DIM,
+            "mamba_d_state": 16,
+            "mamba_n_groups": 1,
+            "mamba_d_conv": 4,
+            "mamba_expand": 2,
+        },
+        True,
     ),
     # gemma3n_text: all full attention (no sliding window)
     (

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -185,6 +185,8 @@ class TestBuildGraph:
         layer_types = config.layer_types or []
         for i in range(num_layers):
             ltype = layer_types[i] if i < len(layer_types) else "full_attention"
+            if ltype == "mlp":
+                continue  # MLP layers are stateless — no cache outputs
             if ltype in ("linear_attention",):
                 assert f"present.{i}.conv_state" in output_names, (
                     f"Missing present.{i}.conv_state"

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -2849,6 +2849,117 @@ class TestBuildBambaGraph:
 
 
 # ===========================================================================
+# Hybrid Mamba2+Attention+MLP (NemotronH) model tests
+# ===========================================================================
+
+
+class TestBuildNemotronHGraph:
+    """Verify NemotronH hybrid model weight renaming."""
+
+    def _nemotron_h_config(self):
+        from mobius._configs import NemotronHConfig
+
+        # 4 layers: mamba2, mlp, full_attention, mlp
+        return NemotronHConfig(
+            vocab_size=TINY_VOCAB,
+            hidden_size=TINY_HIDDEN,
+            intermediate_size=TINY_INTERMEDIATE,
+            num_hidden_layers=4,
+            num_attention_heads=TINY_HEADS,
+            num_key_value_heads=TINY_KV_HEADS,
+            rms_norm_eps=1e-5,
+            layer_types=["mamba2", "mlp", "full_attention", "mlp"],
+            mamba_n_heads=TINY_KV_HEADS,
+            mamba_d_head=TINY_HEAD_DIM,
+            mamba_d_state=16,
+            mamba_n_groups=1,
+            mamba_d_conv=4,
+            mamba_expand=2,
+            hidden_act="relu2",
+            head_dim=TINY_HEAD_DIM,
+        )
+
+    def test_nemotron_h_preprocess_weights(self):
+        """Verify preprocess_weights routes by layer type and nests SSM params."""
+        import torch
+
+        from mobius.models.nemotron_h import NemotronHCausalLMModel
+
+        config = self._nemotron_h_config()
+        module = NemotronHCausalLMModel(config)
+
+        # Simulate HF NemotronH weight names (backbone.* prefix,
+        # all layer mixers named "mixer.*" regardless of type)
+        state_dict = {
+            # Embeddings & final norm
+            "backbone.embeddings.weight": torch.zeros(1),
+            "backbone.norm_f.weight": torch.zeros(1),
+            "lm_head.weight": torch.zeros(1),
+            # Layer 0: mamba2 — SSM params + mixer params
+            "backbone.layers.0.norm.weight": torch.zeros(1),
+            "backbone.layers.0.mixer.A_log": torch.zeros(4),
+            "backbone.layers.0.mixer.D": torch.zeros(4),
+            "backbone.layers.0.mixer.dt_bias": torch.zeros(4),
+            "backbone.layers.0.mixer.in_proj.weight": torch.zeros(1),
+            "backbone.layers.0.mixer.conv1d.weight": torch.zeros(1),
+            "backbone.layers.0.mixer.out_proj.weight": torch.zeros(1),
+            "backbone.layers.0.mixer.norm.weight": torch.zeros(1),
+            # Layer 1: mlp
+            "backbone.layers.1.norm.weight": torch.zeros(1),
+            "backbone.layers.1.mixer.up_proj.weight": torch.zeros(1),
+            "backbone.layers.1.mixer.down_proj.weight": torch.zeros(1),
+            # Layer 2: full_attention
+            "backbone.layers.2.norm.weight": torch.zeros(1),
+            "backbone.layers.2.mixer.q_proj.weight": torch.zeros(1),
+            "backbone.layers.2.mixer.k_proj.weight": torch.zeros(1),
+            "backbone.layers.2.mixer.v_proj.weight": torch.zeros(1),
+            "backbone.layers.2.mixer.o_proj.weight": torch.zeros(1),
+            # Layer 3: mlp
+            "backbone.layers.3.norm.weight": torch.zeros(1),
+            "backbone.layers.3.mixer.up_proj.weight": torch.zeros(1),
+            "backbone.layers.3.mixer.down_proj.weight": torch.zeros(1),
+        }
+        result = module.preprocess_weights(state_dict)
+
+        # Global renames: backbone.embeddings -> model.embed_tokens,
+        # backbone.norm_f -> model.norm
+        assert "model.embed_tokens.weight" in result
+        assert "model.norm.weight" in result
+
+        # Layer 0 (mamba2): SSM params nested under mamba.ssm
+        assert "model.layers.0.mamba.ssm.A_log" in result
+        assert "model.layers.0.mamba.ssm.D" in result
+        assert "model.layers.0.mamba.ssm.dt_bias" in result
+        # Non-SSM mamba params stay under mamba.*
+        assert "model.layers.0.mamba.in_proj.weight" in result
+        assert "model.layers.0.mamba.conv1d.weight" in result
+        assert "model.layers.0.mamba.out_proj.weight" in result
+        assert "model.layers.0.mamba.norm.weight" in result
+
+        # Layer 1 (mlp): mixer -> mlp
+        assert "model.layers.1.mlp.up_proj.weight" in result
+        assert "model.layers.1.mlp.down_proj.weight" in result
+
+        # Layer 2 (full_attention): mixer -> self_attn
+        assert "model.layers.2.self_attn.q_proj.weight" in result
+        assert "model.layers.2.self_attn.k_proj.weight" in result
+        assert "model.layers.2.self_attn.v_proj.weight" in result
+        assert "model.layers.2.self_attn.o_proj.weight" in result
+
+        # Layer 3 (mlp): mixer -> mlp
+        assert "model.layers.3.mlp.up_proj.weight" in result
+        assert "model.layers.3.mlp.down_proj.weight" in result
+
+        # Per-layer norms keep their names
+        assert "model.layers.0.norm.weight" in result
+        assert "model.layers.2.norm.weight" in result
+
+        # No original backbone.* keys should remain
+        for key in result:
+            assert not key.startswith("backbone."), f"Unrenamed key: {key}"
+
+
+# ===========================================================================
 # Hybrid SSM+Attention (Jamba) model tests
 # ===========================================================================
 

--- a/tests/synthetic_parity_test.py
+++ b/tests/synthetic_parity_test.py
@@ -141,7 +141,6 @@ _XFAIL_REASONS: dict[str, str] = {
     "mpt": "HF MPT uses Wqkv naming, not query_key_value",
     # Architecture: LayerNorm with bias instead of RMSNorm
     "stablelm": "HF uses LayerNorm with bias (not RMSNorm)",
-    "nemotron": "Nemotron attention differs from base (needs investigation)",
     # Phi (original): HF uses dense, fc1/fc2, LayerNorm — not Llama-compatible
     "phi": "HF Phi uses dense/fc1/fc2 naming + LayerNorm",
     # Hybrid Mamba: weight naming and MoE routing differences


### PR DESCRIPTION
* Add support for Nemotron models
* Update skills for dtype handling

(Created by copilot. Reviewed it. Tested fp32 and fp16 models on CPU and CUDA EPs. CUDA requires a workaround for RMSNorm since the kernel doesn't seem to handle 2D scale tensor. Produces reasonably similar answers as the HF version, but not identical due to numeric differences.)
