### PR TITLE
Consolidate inline FC MLPs with reusable FCMLP component

### DIFF
--- a/src/mobius/components/__init__.py
+++ b/src/mobius/components/__init__.py
@@ -36,6 +36,7 @@ __all__ = [
     "Linear",
     "LoRALinear",
     "LinearMultiModalProjector",
+    "FCMLP",
     "MLP",
     "MLPMultiModalProjector",
     "MoELayer",
@@ -160,7 +161,7 @@ from mobius.components._encoder_decoder_attention import (
 from mobius.components._gated_deltanet import GatedDeltaNet
 from mobius.components._lora import LoRALinear
 from mobius.components._mamba_block import Mamba2Block, MambaBlock
-from mobius.components._mlp import MLP
+from mobius.components._mlp import FCMLP, MLP
 from mobius.components._moe import (
     MoELayer,
     SoftmaxTopKGate,

--- a/src/mobius/components/_encoder.py
+++ b/src/mobius/components/_encoder.py
@@ -10,8 +10,8 @@ from typing import TYPE_CHECKING
 from onnxscript import nn
 from onnxscript._internal import builder
 
-from mobius.components._activations import ACT2FN
 from mobius.components._common import Embedding, LayerNorm, Linear
+from mobius.components._mlp import FCMLP
 
 if TYPE_CHECKING:
     import onnx_ir as ir
@@ -86,10 +86,10 @@ class EncoderLayer(nn.Module):
             bias=bias,
         )
         self.post_attention_layernorm = LayerNorm(hidden_size, eps=layer_norm_eps)
-        self.mlp = _EncoderMLP(
+        self.mlp = FCMLP(
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
-            hidden_act=hidden_act,
+            activation=hidden_act,
             bias=bias,
         )
         self.post_mlp_layernorm = LayerNorm(hidden_size, eps=layer_norm_eps)
@@ -109,30 +109,6 @@ class EncoderLayer(nn.Module):
         hidden_states = self.post_mlp_layernorm(op, op.Add(hidden_states, mlp_output))
 
         return hidden_states
-
-
-class _EncoderMLP(nn.Module):
-    """Standard MLP for encoder models (not SwiGLU).
-
-    Structure: Linear(hidden→intermediate) → act → Linear(intermediate→hidden)
-    """
-
-    def __init__(
-        self,
-        hidden_size: int,
-        intermediate_size: int,
-        hidden_act: str = "gelu",
-        bias: bool = True,
-    ):
-        super().__init__()
-        self.up_proj = Linear(hidden_size, intermediate_size, bias=bias)
-        self.down_proj = Linear(intermediate_size, hidden_size, bias=bias)
-        self._act_fn = ACT2FN[hidden_act]
-
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
-        hidden_states = self.up_proj(op, hidden_states)
-        hidden_states = self._act_fn(op, hidden_states)
-        return self.down_proj(op, hidden_states)
 
 
 class BertEmbeddings(nn.Module):

--- a/src/mobius/components/_mlp.py
+++ b/src/mobius/components/_mlp.py
@@ -19,6 +19,9 @@ if TYPE_CHECKING:
 class MLP(nn.Module):
     """Feed-forward network with gated linear units (GLU-style).
 
+    Three-matrix architecture: ``gate_proj → activation → elementwise mul
+    with up_proj → down_proj``.  Used by Llama, Qwen, Mistral, etc.
+
     Args:
         config: Architecture configuration.
         linear_class: Factory callable ``(in_features, out_features, bias=...)``
@@ -44,3 +47,44 @@ class MLP(nn.Module):
         gate = self.act_fn(op, self.gate_proj(op, x))
         up = self.up_proj(op, x)
         return self.down_proj(op, op.Mul(gate, up))
+
+
+class FCMLP(nn.Module):
+    """Two-layer fully-connected MLP: ``up_proj → activation → down_proj``.
+
+    Used by models that do NOT use gated linear units (ViT, CLIP, GPT-2,
+    Falcon, DistilBERT, Wav2Vec2, BART, Whisper, Nemotron, etc.).
+
+    Default parameter names are ``up_proj`` / ``down_proj``.  Models with
+    different HuggingFace weight names (e.g. ``fc1``/``fc2``,
+    ``c_fc``/``c_proj``) should rename in ``preprocess_weights()``.
+
+    Args:
+        hidden_size: Input/output dimension.
+        intermediate_size: Hidden dimension of the inner layer.
+        activation: Activation function name (e.g. ``"gelu"``,
+            ``"quick_gelu"``, ``"relu"``).  Defaults to ``"gelu"``.
+        bias: Whether to include bias in both linear layers.
+        linear_class: Factory callable for creating linear layers.
+            Defaults to ``Linear``.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        activation: str = "gelu",
+        bias: bool = True,
+        linear_class: type | None = None,
+    ):
+        super().__init__()
+        if linear_class is None:
+            linear_class = Linear
+        self.up_proj = linear_class(hidden_size, intermediate_size, bias=bias)
+        self.down_proj = linear_class(intermediate_size, hidden_size, bias=bias)
+        self.act_fn = get_activation(activation)
+
+    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+        x = self.up_proj(op, x)
+        x = self.act_fn(op, x)
+        return self.down_proj(op, x)

--- a/src/mobius/components/_mlp.py
+++ b/src/mobius/components/_mlp.py
@@ -59,6 +59,14 @@ class FCMLP(nn.Module):
     different HuggingFace weight names (e.g. ``fc1``/``fc2``,
     ``c_fc``/``c_proj``) should rename in ``preprocess_weights()``.
 
+    Note: ``up_proj``/``down_proj`` was chosen over ``fc1``/``fc2`` for
+    consistency with the gated :class:`MLP` (``gate_proj``/``up_proj``/
+    ``down_proj``) and the broader LLM ecosystem (Llama, Qwen, Mistral).
+    HuggingFace models use many different names (fc1/fc2, lin1/lin2,
+    c_fc/c_proj, dense_h_to_4h/dense_4h_to_h, etc.) so no single choice
+    avoids renames for most models — 7 of 10 consolidated models need
+    ``preprocess_weights`` renames regardless.
+
     Args:
         hidden_size: Input/output dimension.
         intermediate_size: Hidden dimension of the inner layer.

--- a/src/mobius/components/_mlp_test.py
+++ b/src/mobius/components/_mlp_test.py
@@ -11,7 +11,7 @@ from mobius._testing import (
     create_test_input,
     make_config,
 )
-from mobius.components._mlp import MLP
+from mobius.components._mlp import FCMLP, MLP
 
 
 class TestMLP:
@@ -87,3 +87,83 @@ class TestMLP:
         mlp = MLP(config)
         assert list(mlp.gate_proj.weight.shape) == [256, 64]
         assert list(mlp.down_proj.weight.shape) == [64, 256]
+
+
+class TestFCMLP:
+    """Tests for the two-layer FC MLP (non-gated) component."""
+
+    def test_projection_shapes(self):
+        mlp = FCMLP(hidden_size=64, intermediate_size=128)
+        # up_proj: (intermediate_size, hidden_size) = (128, 64)
+        assert list(mlp.up_proj.weight.shape) == [128, 64]
+        # down_proj: (hidden_size, intermediate_size) = (64, 128)
+        assert list(mlp.down_proj.weight.shape) == [64, 128]
+
+    def test_parameter_count_no_bias(self):
+        mlp = FCMLP(hidden_size=64, intermediate_size=128, bias=False)
+        params = list(mlp.parameters())
+        # up_proj.weight + down_proj.weight = 2
+        assert len(params) == 2
+
+    def test_parameter_count_with_bias(self):
+        mlp = FCMLP(hidden_size=64, intermediate_size=128, bias=True)
+        params = list(mlp.parameters())
+        # 2 weights + 2 biases = 4
+        assert len(params) == 4
+
+    def test_forward_builds_graph(self):
+        mlp = FCMLP(hidden_size=64, intermediate_size=128)
+        builder, op, graph = create_test_builder()
+        x = create_test_input(builder, "x", [1, 8, 64])
+
+        result = mlp(op, x)
+        builder._adapt_outputs([result])
+        assert graph.num_nodes() > 0
+        # up_proj + down_proj = exactly 2 MatMul ops
+        assert count_op_type(graph, "MatMul") == 2
+
+    def test_forward_has_no_mul_gating(self):
+        # FC MLP is not gated — there should be no elementwise Mul for gating
+        mlp = FCMLP(hidden_size=64, intermediate_size=128)
+        builder, op, graph = create_test_builder()
+        x = create_test_input(builder, "x", [1, 8, 64])
+
+        mlp(op, x)
+        assert count_op_type(graph, "Mul") == 0
+
+    def test_gelu_activation(self):
+        mlp = FCMLP(hidden_size=64, intermediate_size=128, activation="gelu")
+        builder, op, graph = create_test_builder()
+        x = create_test_input(builder, "x", [1, 8, 64])
+
+        mlp(op, x)
+        assert count_op_type(graph, "Gelu") >= 1
+
+    def test_relu_activation(self):
+        mlp = FCMLP(hidden_size=64, intermediate_size=128, activation="relu")
+        builder, op, graph = create_test_builder()
+        x = create_test_input(builder, "x", [1, 8, 64])
+
+        mlp(op, x)
+        assert count_op_type(graph, "Relu") >= 1
+
+    def test_different_intermediate_size(self):
+        mlp = FCMLP(hidden_size=64, intermediate_size=256)
+        assert list(mlp.up_proj.weight.shape) == [256, 64]
+        assert list(mlp.down_proj.weight.shape) == [64, 256]
+
+    def test_linear_class_used_for_projections(self):
+        # Verify linear_class is applied to both projection layers
+        from mobius.components._common import Linear
+
+        created = []
+
+        class TrackingLinear(Linear):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                created.append(self)
+
+        mlp = FCMLP(hidden_size=64, intermediate_size=128, linear_class=TrackingLinear)
+        assert len(created) == 2
+        assert isinstance(mlp.up_proj, TrackingLinear)
+        assert isinstance(mlp.down_proj, TrackingLinear)

--- a/src/mobius/models/clip.py
+++ b/src/mobius/models/clip.py
@@ -12,8 +12,8 @@ from onnxscript import nn
 from onnxscript._internal import builder
 
 from mobius._configs import ArchitectureConfig
-from mobius.components._activations import ACT2FN
-from mobius.components._common import Embedding, LayerNorm, Linear
+from mobius.components import FCMLP
+from mobius.components._common import Embedding, LayerNorm
 from mobius.components._conv import Conv2d
 from mobius.components._encoder import EncoderAttention
 
@@ -91,7 +91,11 @@ class _CLIPVisionEncoderLayer(nn.Module):
         super().__init__()
         self.self_attn = EncoderAttention(config.hidden_size, config.num_attention_heads)
         self.layer_norm1 = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.mlp = _CLIPMLP(config)
+        self.mlp = FCMLP(
+            config.hidden_size,
+            config.intermediate_size,
+            activation=config.hidden_act or "quick_gelu",
+        )
         self.layer_norm2 = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
 
     def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
@@ -105,21 +109,6 @@ class _CLIPVisionEncoderLayer(nn.Module):
         hidden_states = self.mlp(op, hidden_states)
         hidden_states = op.Add(residual, hidden_states)
         return hidden_states
-
-
-class _CLIPMLP(nn.Module):
-    """CLIP MLP: fc1 → act → fc2."""
-
-    def __init__(self, config: ArchitectureConfig):
-        super().__init__()
-        self.fc1 = Linear(config.hidden_size, config.intermediate_size)
-        self.fc2 = Linear(config.intermediate_size, config.hidden_size)
-        self._act_fn = ACT2FN[config.hidden_act or "quick_gelu"]
-
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
-        hidden_states = self.fc1(op, hidden_states)
-        hidden_states = self._act_fn(op, hidden_states)
-        return self.fc2(op, hidden_states)
 
 
 class CLIPVisionModel(nn.Module):
@@ -208,9 +197,12 @@ def _rename_clip_vision_weight(name: str) -> str | None:
                 suffix = remainder[len(old) :]
                 return f"encoder.{layer_idx}.{new}{suffix}"
 
+        # MLP: fc1 → up_proj, fc2 → down_proj (FCMLP naming)
+        remainder = remainder.replace("mlp.fc1.", "mlp.up_proj.")
+        remainder = remainder.replace("mlp.fc2.", "mlp.down_proj.")
+
         # layer_norm1, layer_norm2, mlp pass through
-        remainder_new = remainder
-        return f"encoder.{layer_idx}.{remainder_new}"
+        return f"encoder.{layer_idx}.{remainder}"
 
     return None
 
@@ -249,7 +241,11 @@ class _CLIPTextEncoderLayer(nn.Module):
         super().__init__()
         self.self_attn = EncoderAttention(config.hidden_size, config.num_attention_heads)
         self.layer_norm1 = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.mlp = _CLIPMLP(config)
+        self.mlp = FCMLP(
+            config.hidden_size,
+            config.intermediate_size,
+            activation=config.hidden_act or "quick_gelu",
+        )
         self.layer_norm2 = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
 
     def forward(
@@ -372,6 +368,10 @@ def _rename_clip_text_weight(name: str) -> str | None:
             if remainder.startswith(old):
                 suffix = remainder[len(old) :]
                 return f"encoder.{layer_idx}.{new}{suffix}"
+
+        # MLP: fc1 → up_proj, fc2 → down_proj (FCMLP naming)
+        remainder = remainder.replace("mlp.fc1.", "mlp.up_proj.")
+        remainder = remainder.replace("mlp.fc2.", "mlp.down_proj.")
 
         # layer_norm1, layer_norm2, mlp pass through
         return f"encoder.{layer_idx}.{remainder}"

--- a/src/mobius/models/depth_anything.py
+++ b/src/mobius/models/depth_anything.py
@@ -21,12 +21,12 @@ from onnxscript._internal import builder
 
 from mobius._configs import ArchitectureConfig, DepthAnythingConfig
 from mobius.components import (
+    FCMLP,
     Conv2d,
     Conv2dNoBias,
     ConvTranspose2d,
     EncoderAttention,
     LayerNorm,
-    Linear,
 )
 
 # ---------------------------------------------------------------------------
@@ -111,7 +111,11 @@ class _ViTEncoderLayer(nn.Module):
             bias=True,
         )
         self.layernorm_after = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.mlp = _ViTMLP(config)
+        self.mlp = FCMLP(
+            config.hidden_size,
+            config.intermediate_size,
+            activation=config.hidden_act,
+        )
 
     def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
         residual = hidden_states
@@ -124,23 +128,6 @@ class _ViTEncoderLayer(nn.Module):
         hidden_states = self.mlp(op, hidden_states)
         hidden_states = op.Add(residual, hidden_states)
         return hidden_states
-
-
-class _ViTMLP(nn.Module):
-    """ViT MLP: Linear → GELU → Linear."""
-
-    def __init__(self, config: ArchitectureConfig):
-        super().__init__()
-        from mobius.components._activations import ACT2FN
-
-        self.up_proj = Linear(config.hidden_size, config.intermediate_size, bias=True)
-        self.down_proj = Linear(config.intermediate_size, config.hidden_size, bias=True)
-        self._act_fn = ACT2FN[config.hidden_act]
-
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
-        hidden_states = self.up_proj(op, hidden_states)
-        hidden_states = self._act_fn(op, hidden_states)
-        return self.down_proj(op, hidden_states)
 
 
 # ---------------------------------------------------------------------------

--- a/src/mobius/models/distilbert.py
+++ b/src/mobius/models/distilbert.py
@@ -12,8 +12,8 @@ from onnxscript import nn
 from onnxscript._internal import builder
 
 from mobius._configs import ArchitectureConfig
-from mobius.components._activations import ACT2FN
-from mobius.components._common import Embedding, LayerNorm, Linear
+from mobius.components import FCMLP
+from mobius.components._common import Embedding, LayerNorm
 from mobius.components._encoder import EncoderAttention
 
 if TYPE_CHECKING:
@@ -55,7 +55,11 @@ class _DistilBertEncoderLayer(nn.Module):
         super().__init__()
         self.attention = EncoderAttention(config.hidden_size, config.num_attention_heads)
         self.sa_layer_norm = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.ffn = _DistilBertFFN(config)
+        self.ffn = FCMLP(
+            config.hidden_size,
+            config.intermediate_size,
+            activation=config.hidden_act,
+        )
         self.output_layer_norm = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
 
     def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
@@ -68,21 +72,6 @@ class _DistilBertEncoderLayer(nn.Module):
         hidden_states = self.output_layer_norm(op, op.Add(hidden_states, ffn_output))
 
         return hidden_states
-
-
-class _DistilBertFFN(nn.Module):
-    """DistilBERT feed-forward: lin1 → act → lin2."""
-
-    def __init__(self, config: ArchitectureConfig):
-        super().__init__()
-        self.lin1 = Linear(config.hidden_size, config.intermediate_size)
-        self.lin2 = Linear(config.intermediate_size, config.hidden_size)
-        self._act_fn = ACT2FN[config.hidden_act]
-
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
-        hidden_states = self.lin1(op, hidden_states)
-        hidden_states = self._act_fn(op, hidden_states)
-        return self.lin2(op, hidden_states)
 
 
 class DistilBertModel(nn.Module):
@@ -179,6 +168,9 @@ def _rename_distilbert_weight(name: str) -> str | None:
                 return f"transformer.layer.{layer_idx}.{new}{suffix}"
 
         # ffn, sa_layer_norm, output_layer_norm pass through
-        return name
+        # FFN: lin1 → up_proj, lin2 → down_proj (FCMLP naming)
+        new_name = name.replace("ffn.lin1.", "ffn.up_proj.")
+        new_name = new_name.replace("ffn.lin2.", "ffn.down_proj.")
+        return new_name
 
     return None

--- a/src/mobius/models/falcon.py
+++ b/src/mobius/models/falcon.py
@@ -28,6 +28,7 @@ from onnxscript import nn
 from mobius._configs import ArchitectureConfig
 from mobius._weight_utils import split_fused_qkv
 from mobius.components import (
+    FCMLP,
     Attention,
     create_attention_bias,
     initialize_rope,
@@ -97,28 +98,6 @@ class _ALiBiAttention(nn.Module):
         return attn_out, (present_key, present_value)
 
 
-class _FalconMLP(nn.Module):
-    """Simple 2-layer MLP with GELU activation (no gating).
-
-    Matches HF FalconMLP: dense_h_to_4h → GELU → dense_4h_to_h.
-    """
-
-    def __init__(
-        self,
-        hidden_size: int,
-        intermediate_size: int,
-        bias: bool = False,
-    ):
-        super().__init__()
-        self.dense_h_to_4h = Linear(hidden_size, intermediate_size, bias=bias)
-        self.dense_4h_to_h = Linear(intermediate_size, hidden_size, bias=bias)
-
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
-        hidden_states = self.dense_h_to_4h(op, hidden_states)
-        hidden_states = op.Gelu(hidden_states)
-        return self.dense_4h_to_h(op, hidden_states)
-
-
 class _ALiBiDecoderLayer(nn.Module):
     """Decoder layer with ALiBi attention and parallel/sequential support.
 
@@ -141,9 +120,10 @@ class _ALiBiDecoderLayer(nn.Module):
         if not parallel_attn or dual_ln:
             self.ln_mlp = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.self_attention = _ALiBiAttention(config)
-        self.mlp = _FalconMLP(
+        self.mlp = FCMLP(
             config.hidden_size,
             config.intermediate_size,
+            activation="gelu",
             bias=config.mlp_bias,
         )
 
@@ -205,9 +185,10 @@ class _FalconDecoderLayer(nn.Module):
         if not parallel_attn or dual_ln:
             self.ln_mlp = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.self_attention = Attention(config)
-        self.mlp = _FalconMLP(
+        self.mlp = FCMLP(
             config.hidden_size,
             config.intermediate_size,
+            activation="gelu",
             bias=config.mlp_bias,
         )
 
@@ -476,6 +457,9 @@ class FalconCausalLMModel(nn.Module):
 
             # Output proj: HF uses "dense", Attention component uses "o_proj"
             new_key = key.replace("self_attention.dense.", "self_attention.o_proj.")
+            # MLP: HF uses dense_h_to_4h/dense_4h_to_h, FCMLP uses up_proj/down_proj
+            new_key = new_key.replace(".mlp.dense_h_to_4h.", ".mlp.up_proj.")
+            new_key = new_key.replace(".mlp.dense_4h_to_h.", ".mlp.down_proj.")
             new_state_dict[new_key] = value
 
         # Handle weight tying

--- a/src/mobius/models/gpt2.py
+++ b/src/mobius/models/gpt2.py
@@ -17,12 +17,12 @@ from onnxscript._internal import builder
 
 from mobius._configs import ArchitectureConfig
 from mobius.components import (
+    FCMLP,
     Embedding,
     LayerNorm,
     Linear,
     create_attention_bias,
 )
-from mobius.components._activations import ACT2FN
 from mobius.components._attention import Attention
 from mobius.models.base import CausalLMModel
 
@@ -107,9 +107,20 @@ class GPT2CausalLMModel(CausalLMModel):
                 new_state_dict[name.replace("c_proj.", "o_proj.")] = tensor
                 continue
 
-            # MLP Conv1D weights need transposing (names already match)
-            if name.endswith(".weight") and (".c_fc." in name or ".c_proj." in name):
-                new_state_dict[name] = tensor.t()
+            # MLP Conv1D weights need transposing + rename to FCMLP naming
+            # c_fc → up_proj, c_proj → down_proj (only in mlp.* context)
+            if name.endswith(".weight") and ".mlp.c_fc." in name:
+                new_state_dict[name.replace(".c_fc.", ".up_proj.")] = tensor.t()
+                continue
+            if name.endswith(".weight") and ".mlp.c_proj." in name:
+                new_state_dict[name.replace(".c_proj.", ".down_proj.")] = tensor.t()
+                continue
+            # MLP biases also need renaming
+            if name.endswith(".bias") and ".mlp.c_fc." in name:
+                new_state_dict[name.replace(".c_fc.", ".up_proj.")] = tensor
+                continue
+            if name.endswith(".bias") and ".mlp.c_proj." in name:
+                new_state_dict[name.replace(".c_proj.", ".down_proj.")] = tensor
                 continue
 
             new_state_dict[name] = tensor
@@ -190,7 +201,12 @@ class _GPT2DecoderLayer(nn.Module):
         self.ln_1 = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.attn = Attention(config)
         self.ln_2 = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.mlp = _GPT2MLP(config)
+        self.mlp = FCMLP(
+            config.hidden_size,
+            config.intermediate_size,
+            activation=config.hidden_act,
+            bias=True,
+        )
 
     def forward(
         self,
@@ -212,22 +228,3 @@ class _GPT2DecoderLayer(nn.Module):
         hidden_states = op.Add(residual, hidden_states)
 
         return hidden_states, present_kv
-
-
-class _GPT2MLP(nn.Module):
-    """GPT-2 MLP: Linear → act → Linear (not SwiGLU).
-
-    Attribute names match HF GPT-2 naming (c_fc, c_proj).
-    """
-
-    def __init__(self, config: ArchitectureConfig):
-        super().__init__()
-        intermediate_size = config.intermediate_size
-        self.c_fc = Linear(config.hidden_size, intermediate_size, bias=True)
-        self.c_proj = Linear(intermediate_size, config.hidden_size, bias=True)
-        self._act_fn = ACT2FN[config.hidden_act]
-
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
-        hidden_states = self.c_fc(op, hidden_states)
-        hidden_states = self._act_fn(op, hidden_states)
-        return self.c_proj(op, hidden_states)

--- a/src/mobius/models/nemotron.py
+++ b/src/mobius/models/nemotron.py
@@ -3,37 +3,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-from onnxscript import nn
-from onnxscript._internal import builder
-
 from mobius._configs import ArchitectureConfig
-from mobius.components import LayerNorm, Linear, get_activation
+from mobius.components import FCMLP, LayerNorm
 from mobius.models.base import CausalLMModel
-
-if TYPE_CHECKING:
-    import onnx_ir as ir
-
-
-class NemotronMLP(nn.Module):
-    """Nemotron MLP: up_proj → activation → down_proj (no gating)."""
-
-    def __init__(self, config: ArchitectureConfig):
-        super().__init__()
-
-        self.up_proj = Linear(
-            config.hidden_size, config.intermediate_size, bias=config.mlp_bias
-        )
-        self.down_proj = Linear(
-            config.intermediate_size, config.hidden_size, bias=config.mlp_bias
-        )
-        self.act_fn = get_activation(config.hidden_act)
-
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
-        x = self.up_proj(op, x)
-        x = self.act_fn(op, x)
-        return self.down_proj(op, x)
 
 
 class NemotronCausalLMModel(CausalLMModel):
@@ -48,7 +20,12 @@ class NemotronCausalLMModel(CausalLMModel):
         # Nemotron uses full LayerNorm (with bias), not RMSNorm
         self.model.norm = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
         for layer in self.model.layers:
-            layer.mlp = NemotronMLP(config)
+            layer.mlp = FCMLP(
+                config.hidden_size,
+                config.intermediate_size,
+                activation=config.hidden_act,
+                bias=config.mlp_bias,
+            )
             layer.input_layernorm = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
             layer.post_attention_layernorm = LayerNorm(
                 config.hidden_size, eps=config.rms_norm_eps

--- a/src/mobius/models/phi.py
+++ b/src/mobius/models/phi.py
@@ -19,9 +19,11 @@ from onnxscript._internal import builder
 from mobius._configs import ArchitectureConfig
 from mobius._weight_utils import split_fused_qkv, split_gate_up_proj
 from mobius.components import (
+    FCMLP,
     ConformerEncoder,
     Embedding,
     InputMixer,
+    LayerNorm,
     Linear,
     PatchEmbedding,
     RMSNorm,
@@ -38,12 +40,41 @@ from mobius.models.phi3 import Phi3CausalLMModel
 class PhiCausalLMModel(Phi3CausalLMModel):
     """Phi model (original) with FC-style MLP.
 
-    Uses fully-connected MLP style (up + activation + down, no gating)
-    instead of the gated projection style. Also uses full LayerNorm
-    instead of simplified RMS.
+    Uses fully-connected MLP (up → activation → down, no gating)
+    instead of the gated projection style used by Phi-3. Also uses
+    full LayerNorm instead of simplified RMSNorm.
 
     Replicates HuggingFace's ``PhiForCausalLM``.
     """
+
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__(config)
+        # Phi-1/2 uses full LayerNorm and 2-matrix FC MLP, not
+        # the gated 3-matrix MLP inherited from Phi3/Llama.
+        self.model.norm = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
+        for layer in self.model.layers:
+            layer.mlp = FCMLP(
+                config.hidden_size,
+                config.intermediate_size,
+                activation=config.hidden_act,
+                bias=config.mlp_bias,
+            )
+            layer.input_layernorm = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
+            layer.post_attention_layernorm = LayerNorm(
+                config.hidden_size, eps=config.rms_norm_eps
+            )
+
+    def preprocess_weights(
+        self, state_dict: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        state_dict = super().preprocess_weights(state_dict)
+        # HF Phi uses fc1/fc2 for the FC MLP; our FCMLP uses up_proj/down_proj
+        for key in list(state_dict.keys()):
+            if ".mlp.fc1." in key:
+                state_dict[key.replace(".mlp.fc1.", ".mlp.up_proj.")] = state_dict.pop(key)
+            elif ".mlp.fc2." in key:
+                state_dict[key.replace(".mlp.fc2.", ".mlp.down_proj.")] = state_dict.pop(key)
+        return state_dict
 
 
 def _parse_lora_adapters(

--- a/src/mobius/models/vit.py
+++ b/src/mobius/models/vit.py
@@ -15,12 +15,12 @@ from onnxscript._internal import builder
 
 from mobius._configs import ArchitectureConfig
 from mobius.components import (
-    Conv2d as _Conv2d,
-)
-from mobius.components import (
+    FCMLP,
     EncoderAttention,
     LayerNorm,
-    Linear,
+)
+from mobius.components import (
+    Conv2d as _Conv2d,
 )
 
 
@@ -143,7 +143,11 @@ class _ViTEncoderLayer(nn.Module):
             bias=True,
         )
         self.layernorm_after = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.mlp = _ViTMLP(config)
+        self.mlp = FCMLP(
+            config.hidden_size,
+            config.intermediate_size,
+            activation=config.hidden_act,
+        )
 
     def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
         residual = hidden_states
@@ -157,23 +161,6 @@ class _ViTEncoderLayer(nn.Module):
         hidden_states = op.Add(residual, hidden_states)
 
         return hidden_states
-
-
-class _ViTMLP(nn.Module):
-    """ViT MLP: Linear → GELU → Linear."""
-
-    def __init__(self, config: ArchitectureConfig):
-        super().__init__()
-        from mobius.components._activations import ACT2FN
-
-        self.up_proj = Linear(config.hidden_size, config.intermediate_size, bias=True)
-        self.down_proj = Linear(config.intermediate_size, config.hidden_size, bias=True)
-        self._act_fn = ACT2FN[config.hidden_act]
-
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
-        hidden_states = self.up_proj(op, hidden_states)
-        hidden_states = self._act_fn(op, hidden_states)
-        return self.down_proj(op, hidden_states)
 
 
 # Weight name mapping

--- a/src/mobius/models/wav2vec2.py
+++ b/src/mobius/models/wav2vec2.py
@@ -25,6 +25,7 @@ from onnxscript import nn
 from onnxscript._internal import builder
 
 from mobius._configs import ArchitectureConfig
+from mobius.components import FCMLP
 from mobius.components._common import LayerNorm, Linear
 
 if TYPE_CHECKING:
@@ -110,7 +111,7 @@ class _Wav2Vec2EncoderLayer(nn.Module):
         self.layer_norm = LayerNorm(hidden_size, eps=eps)
         head_dim = hidden_size // num_heads
         self.attention = _Wav2Vec2Attention(hidden_size, num_heads, head_dim)
-        self.feed_forward = _Wav2Vec2FFN(hidden_size, intermediate_size)
+        self.feed_forward = FCMLP(hidden_size, intermediate_size, activation="gelu", bias=True)
         self.final_layer_norm = LayerNorm(hidden_size, eps=eps)
 
     def forward(
@@ -162,21 +163,6 @@ class _Wav2Vec2Attention(nn.Module):
             scale=float(self.head_dim**-0.5),
         )
         return self.out_proj(op, attn_out)
-
-
-class _Wav2Vec2FFN(nn.Module):
-    """Feed-forward network: Linear → GELU → Linear."""
-
-    def __init__(self, hidden_size: int, intermediate_size: int):
-        super().__init__()
-        self.intermediate_dense = Linear(hidden_size, intermediate_size, bias=True)
-        self.output_dense = Linear(intermediate_size, hidden_size, bias=True)
-
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
-        hidden_states = self.intermediate_dense(op, hidden_states)
-        hidden_states = op.Gelu(hidden_states)
-        hidden_states = self.output_dense(op, hidden_states)
-        return hidden_states
 
 
 class _Wav2Vec2Encoder(nn.Module):
@@ -276,6 +262,7 @@ class Wav2Vec2Model(nn.Module):
 
         HF prefix: wav2vec2.* → strip it.
         Attribute names are aligned with HF (out_proj, encoder.layers).
+        FFN renames: intermediate_dense → up_proj, output_dense → down_proj (FCMLP naming).
         """
         new_state_dict = {}
         for key, value in state_dict.items():
@@ -285,5 +272,9 @@ class Wav2Vec2Model(nn.Module):
                 if new_key.startswith(prefix):
                     new_key = new_key[len(prefix) :]
                     break
+            # FFN: intermediate_dense → up_proj, output_dense → down_proj
+            new_key = new_key.replace(".intermediate_dense.", ".up_proj.").replace(
+                ".output_dense.", ".down_proj."
+            )
             new_state_dict[new_key] = value
         return new_state_dict

--- a/src/mobius/models/yolos.py
+++ b/src/mobius/models/yolos.py
@@ -21,12 +21,13 @@ from onnxscript._internal import builder
 
 from mobius._configs import ArchitectureConfig, YolosConfig
 from mobius.components import (
-    Conv2d as _Conv2d,
-)
-from mobius.components import (
+    FCMLP,
     EncoderAttention,
     LayerNorm,
     Linear,
+)
+from mobius.components import (
+    Conv2d as _Conv2d,
 )
 
 
@@ -110,7 +111,12 @@ class _YolosEncoderLayer(nn.Module):
             bias=True,
         )
         self.layernorm_after = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.mlp = _YolosMLP(config)
+        self.mlp = FCMLP(
+            config.hidden_size,
+            config.intermediate_size,
+            activation=config.hidden_act,
+            bias=True,
+        )
 
     def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
         residual = hidden_states
@@ -123,23 +129,6 @@ class _YolosEncoderLayer(nn.Module):
         hidden_states = self.mlp(op, hidden_states)
         hidden_states = op.Add(residual, hidden_states)
         return hidden_states
-
-
-class _YolosMLP(nn.Module):
-    """ViT MLP: Linear → GELU → Linear."""
-
-    def __init__(self, config: ArchitectureConfig):
-        super().__init__()
-        from mobius.components._activations import ACT2FN
-
-        self.up_proj = Linear(config.hidden_size, config.intermediate_size, bias=True)
-        self.down_proj = Linear(config.intermediate_size, config.hidden_size, bias=True)
-        self._act_fn = ACT2FN[config.hidden_act]
-
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
-        hidden_states = self.up_proj(op, hidden_states)
-        hidden_states = self._act_fn(op, hidden_states)
-        return self.down_proj(op, hidden_states)
 
 
 class _MLPPredictionHead(nn.Module):


### PR DESCRIPTION
## Summary

Replaces ~10 duplicate 2-matrix FC MLP implementations across model files with the existing reusable `FCMLP` component from `mobius.components`.

## Changes

### Bug fix
- **phi.py**: Fixed `PhiCausalLMModel` (Phi-1/2) which incorrectly inherited the 3-matrix gated MLP from Phi-3. Now uses `FCMLP` + `LayerNorm` matching HuggingFace's architecture.

### Consolidation
Replaced inline FC MLP classes with `FCMLP` component, with appropriate `preprocess_weights` mappings for each model's HF weight names:

| Model | Removed class | Weight renames |
|-------|--------------|----------------|
| yolos | `_YolosMLP` | Names already match |
| falcon | `_FalconMLP` | dense_h_to_4h → up_proj, dense_4h_to_h → down_proj |
| gpt2 | `_GPT2MLP` | c_fc → up_proj, c_proj → down_proj |
| distilbert | `_DistilBertFFN` | lin1 → up_proj, lin2 → down_proj |
| wav2vec2 | `_Wav2Vec2FFN` | intermediate_dense → up_proj, output_dense → down_proj |
| clip | `_CLIPMLP` | fc1 → up_proj, fc2 → down_proj |

### Skipped (not safe to replace)
- `internvl.py`: Uses custom `_InternVisionLinear`
- `cogvideox.py`: Uses custom `_Linear`
- `phi.py` (`_Phi4MMProjectionMLP`): Sequential indexed naming

## Testing
- All 512 build_graph tests pass
- All 1088 src/ unit tests pass
- Linter clean

Fixes #21