### PR TITLE
Display commit SHAs in CI outputs and add Qwen3.5 benchmarks

### DIFF
--- a/scripts/arch_diff.py
+++ b/scripts/arch_diff.py
@@ -222,6 +222,22 @@ def _display_key(model_type: str, task_name: str) -> str:
 # ------------------------------------------------------------------
 
 
+def _resolve_sha(ref: str) -> str:
+    """Return the short SHA for *ref*, or *ref* itself if resolution fails.
+
+    Falls back to the raw string on shallow clones, typos, or other git errors
+    so the rest of the script can continue rather than crashing.
+    """
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", ref],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except subprocess.CalledProcessError:
+        return ref
+
+
 def _changed_files(base_ref: str, head_ref: str) -> list[str]:
     """Return file paths changed between *base_ref* and *head_ref*."""
     result = subprocess.run(
@@ -572,6 +588,10 @@ def main() -> None:
         render_markdown,
     )
 
+    # Resolve refs to short SHAs for display in the markdown output
+    base_sha = _resolve_sha(args.base_ref)
+    head_sha = _resolve_sha(args.head_ref)
+
     # 1. Detect affected models
     if args.all:
         affected = {m[0] for m in _DIFF_MODELS}
@@ -581,7 +601,7 @@ def main() -> None:
         if not affected:
             print("No model source files changed — nothing to diff.")
             # Write a minimal report
-            md = render_markdown({})
+            md = render_markdown({}, base_ref=base_sha, head_ref=head_sha)
             Path(args.output).write_text(md, encoding="utf-8")
             return
 
@@ -645,7 +665,7 @@ def main() -> None:
         all_diffs[display] = sub_models
 
     # 3. Render and write
-    md = render_markdown(all_diffs)
+    md = render_markdown(all_diffs, base_ref=base_sha, head_ref=head_sha)
     Path(args.output).write_text(md, encoding="utf-8")
     print(f"Wrote {args.output}")
 

--- a/scripts/arch_diff.py
+++ b/scripts/arch_diff.py
@@ -31,6 +31,8 @@ _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_PROJECT_ROOT / "src"))
 sys.path.insert(0, str(_PROJECT_ROOT / "tests"))
 
+_GITHUB_REPO_URL = "https://github.com/onnxruntime/mobius"
+
 
 # ------------------------------------------------------------------
 # Model build configs — mirrors the benchmark / test infrastructure
@@ -601,7 +603,9 @@ def main() -> None:
         if not affected:
             print("No model source files changed — nothing to diff.")
             # Write a minimal report
-            md = render_markdown({}, base_ref=base_sha, head_ref=head_sha)
+            md = render_markdown(
+                {}, base_ref=base_sha, head_ref=head_sha, repo_url=_GITHUB_REPO_URL
+            )
             Path(args.output).write_text(md, encoding="utf-8")
             return
 
@@ -665,7 +669,9 @@ def main() -> None:
         all_diffs[display] = sub_models
 
     # 3. Render and write
-    md = render_markdown(all_diffs, base_ref=base_sha, head_ref=head_sha)
+    md = render_markdown(
+        all_diffs, base_ref=base_sha, head_ref=head_sha, repo_url=_GITHUB_REPO_URL
+    )
     Path(args.output).write_text(md, encoding="utf-8")
     print(f"Wrote {args.output}")
 

--- a/src/mobius/_graph_diff.py
+++ b/src/mobius/_graph_diff.py
@@ -338,6 +338,9 @@ def _op_diff_block(base_ops: list[str], head_ops: list[str]) -> str:
 
 def render_markdown(
     diffs: dict[str, dict[str, dict[str, Any]]],
+    *,
+    base_ref: str | None = None,
+    head_ref: str | None = None,
 ) -> str:
     """Render diffs for all affected models as GitHub-flavored Markdown.
 
@@ -347,6 +350,8 @@ def render_markdown(
             dict also carries ``"_base_ops"`` and ``"_head_ops"`` lists
             for rendering the diff block, and ``"_base_node_count"`` /
             ``"_head_node_count"`` ints for the summary.
+        base_ref: Short SHA or ref name for the base commit.
+        head_ref: Short SHA or ref name for the head commit.
 
     Returns:
         A Markdown string.
@@ -354,6 +359,9 @@ def render_markdown(
     lines: list[str] = []
     lines.append("<!-- arch-diff-bot -->")
     lines.append("## 🏗️ Architecture Diff\n")
+
+    if base_ref and head_ref:
+        lines.append(f"Comparing `{base_ref}` → `{head_ref}`\n")
 
     # ── summary table ────────────────────────────────────────────────
     lines.append("| Model | Sub-model | Changes | Status |")

--- a/src/mobius/_graph_diff.py
+++ b/src/mobius/_graph_diff.py
@@ -341,6 +341,7 @@ def render_markdown(
     *,
     base_ref: str | None = None,
     head_ref: str | None = None,
+    repo_url: str | None = None,
 ) -> str:
     """Render diffs for all affected models as GitHub-flavored Markdown.
 
@@ -352,6 +353,9 @@ def render_markdown(
             ``"_head_node_count"`` ints for the summary.
         base_ref: Short SHA or ref name for the base commit.
         head_ref: Short SHA or ref name for the head commit.
+        repo_url: GitHub repository URL (e.g. ``https://github.com/org/repo``).
+            When provided together with *base_ref* and *head_ref*, each SHA is
+            rendered as a clickable link to the commit page.
 
     Returns:
         A Markdown string.
@@ -361,7 +365,13 @@ def render_markdown(
     lines.append("## 🏗️ Architecture Diff\n")
 
     if base_ref and head_ref:
-        lines.append(f"Comparing `{base_ref}` → `{head_ref}`\n")
+
+        def _sha_link(sha: str) -> str:
+            if repo_url:
+                return f"[`{sha}`]({repo_url}/commit/{sha})"
+            return f"`{sha}`"
+
+        lines.append(f"Comparing {_sha_link(base_ref)} → {_sha_link(head_ref)}\n")
 
     # ── summary table ────────────────────────────────────────────────
     lines.append("| Model | Sub-model | Changes | Status |")

--- a/src/mobius/_graph_diff_test.py
+++ b/src/mobius/_graph_diff_test.py
@@ -508,9 +508,20 @@ class TestRenderMarkdown:
         assert "<details>" not in md
 
     def test_commit_shas_displayed(self) -> None:
-        """Passing base_ref and head_ref shows comparison line."""
+        """Passing base_ref and head_ref shows comparison line without links."""
         md = render_markdown({}, base_ref="abc1234", head_ref="def5678")
         assert "Comparing `abc1234` → `def5678`" in md
+
+    def test_commit_shas_as_links_when_repo_url_provided(self) -> None:
+        """Passing repo_url renders SHAs as clickable GitHub links."""
+        md = render_markdown(
+            {},
+            base_ref="abc1234",
+            head_ref="def5678",
+            repo_url="https://github.com/onnxruntime/mobius",
+        )
+        assert "[`abc1234`](https://github.com/onnxruntime/mobius/commit/abc1234)" in md
+        assert "[`def5678`](https://github.com/onnxruntime/mobius/commit/def5678)" in md
 
     def test_commit_shas_omitted_when_not_provided(self) -> None:
         """Without refs, no comparison line appears."""

--- a/src/mobius/_graph_diff_test.py
+++ b/src/mobius/_graph_diff_test.py
@@ -507,6 +507,16 @@ class TestRenderMarkdown:
         # No details sections
         assert "<details>" not in md
 
+    def test_commit_shas_displayed(self) -> None:
+        """Passing base_ref and head_ref shows comparison line."""
+        md = render_markdown({}, base_ref="abc1234", head_ref="def5678")
+        assert "Comparing `abc1234` → `def5678`" in md
+
+    def test_commit_shas_omitted_when_not_provided(self) -> None:
+        """Without refs, no comparison line appears."""
+        md = render_markdown({})
+        assert "Comparing" not in md
+
     def test_multiple_models(self) -> None:
         """Multiple model types are each rendered in the summary table."""
         diffs = {

--- a/tests/benchmark_build.py
+++ b/tests/benchmark_build.py
@@ -150,6 +150,41 @@ BENCHMARK_MODELS: list[_BenchEntry] = [
     ),
     _BenchEntry("whisper", {}, "speech-to-text", "custom"),
     _BenchEntry("mamba", {}, "ssm-text-generation", "custom"),
+    _BenchEntry(
+        "qwen3_5_text",
+        {
+            "partial_rotary_factor": 0.5,
+            "layer_types": ["linear_attention", "full_attention"],
+            "linear_num_value_heads": 4,
+            "linear_num_key_heads": 2,
+            "linear_key_head_dim": 16,
+            "linear_value_head_dim": 16,
+            "linear_conv_kernel_dim": 4,
+        },
+        "hybrid-text-generation",
+        "standard",
+    ),
+    _BenchEntry(
+        "qwen3_5_moe",
+        {
+            "hidden_act": "silu",
+            "layer_types": ["linear_attention", "full_attention"],
+            "partial_rotary_factor": 0.25,
+            "mrope_interleaved": True,
+            "num_local_experts": 4,
+            "num_experts_per_tok": 2,
+            "moe_intermediate_size": 32,
+            "shared_expert_intermediate_size": 32,
+            "linear_num_value_heads": 4,
+            "linear_num_key_heads": 2,
+            "linear_key_head_dim": 16,
+            "linear_value_head_dim": 16,
+            "linear_conv_kernel_dim": 4,
+        },
+        "hybrid-text-generation",
+        "standard",
+    ),
+    _BenchEntry("qwen3_5_vl", {}, "hybrid-qwen-vl", "custom"),
 ]
 
 
@@ -336,12 +371,72 @@ def _build_mamba() -> _BuildResult:
     )
 
 
+def _build_qwen3_5_vl() -> _BuildResult:
+    """Build Qwen3.5-VL using its VisionConfig and hybrid task."""
+    from mobius._configs import VisionConfig
+    from mobius._registry import registry
+    from mobius.tasks import get_task
+
+    config = _base_config(
+        attn_qk_norm=True,
+        partial_rotary_factor=0.5,
+        layer_types=["linear_attention", "full_attention"],
+        linear_num_value_heads=4,
+        linear_num_key_heads=2,
+        linear_key_head_dim=16,
+        linear_value_head_dim=16,
+        linear_conv_kernel_dim=4,
+        vision=VisionConfig(
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            patch_size=16,
+            in_channels=3,
+            out_hidden_size=64,
+            num_position_embeddings=16,
+        ),
+        temporal_patch_size=2,
+        spatial_merge_size=2,
+        deepstack_visual_indexes=[0],
+        image_token_id=248056,
+        mrope_section=[8, 12, 12],
+    )
+    model_cls = registry.get("qwen3_5_vl")
+    module = model_cls(config)
+    task = get_task("hybrid-qwen-vl")
+
+    tracemalloc.start()
+    t0 = time.perf_counter()
+    pkg = task.build(module, config)
+    elapsed = time.perf_counter() - t0
+    _current, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    total_nodes = 0
+    for model in pkg.values():
+        total_nodes += len(list(model.graph))
+
+    model_size = _measure_model_size(pkg)
+
+    return _BuildResult(
+        model_type="qwen3_5_vl",
+        elapsed_s=elapsed,
+        num_nodes=total_nodes,
+        num_models=len(pkg),
+        peak_memory_mb=peak / 1024 / 1024,
+        model_size_bytes=model_size,
+    )
+
+
 def _run_single(entry: _BenchEntry) -> _BuildResult:
     """Dispatch to the right build function."""
     if entry.model_type == "whisper":
         return _build_whisper()
     if entry.model_type == "mamba":
         return _build_mamba()
+    if entry.model_type == "qwen3_5_vl":
+        return _build_qwen3_5_vl()
     return _build_standard(entry)
 
 

--- a/tests/benchmark_compare.py
+++ b/tests/benchmark_compare.py
@@ -40,6 +40,9 @@ def compare(current_path: str, baseline_path: str) -> tuple[str, bool]:
     rows: list[tuple[str, str, str, str, str, str]] = []
     has_blocker = False
 
+    base_sha = baseline.get("_metadata", {}).get("commit", "unknown")
+    head_sha = current.get("_metadata", {}).get("commit", "unknown")
+
     for model, metrics in sorted(current["models"].items()):
         base = baseline.get("models", {}).get(model, {})
         for metric in THRESHOLDS:
@@ -70,6 +73,7 @@ def compare(current_path: str, baseline_path: str) -> tuple[str, bool]:
             )
 
     md = "## Performance Comparison\n\n"
+    md += f"Comparing `{base_sha}` → `{head_sha}`\n\n"
     md += "| Model | Metric | Baseline | Current | Delta | |\n"
     md += "|---|---|---:|---:|---:|---|\n"
     for model, metric, base_s, curr_s, delta_s, status in rows:

--- a/tests/benchmark_compare.py
+++ b/tests/benchmark_compare.py
@@ -29,6 +29,8 @@ THRESHOLDS: dict[str, tuple[float, float]] = {
     "num_nodes": (0.05, 0.10),
 }
 
+_GITHUB_REPO_URL = "https://github.com/onnxruntime/mobius"
+
 
 def compare(current_path: str, baseline_path: str) -> tuple[str, bool]:
     """Compare current vs baseline. Returns (markdown, has_blocker)."""
@@ -72,8 +74,11 @@ def compare(current_path: str, baseline_path: str) -> tuple[str, bool]:
                 )
             )
 
+    def _sha_link(sha: str) -> str:
+        return f"[`{sha}`]({_GITHUB_REPO_URL}/commit/{sha})"
+
     md = "## Performance Comparison\n\n"
-    md += f"Comparing `{base_sha}` → `{head_sha}`\n\n"
+    md += f"Comparing {_sha_link(base_sha)} → {_sha_link(head_sha)}\n\n"
     md += "| Model | Metric | Baseline | Current | Delta | |\n"
     md += "|---|---|---:|---:|---:|---|\n"
     for model, metric, base_s, curr_s, delta_s, status in rows:

--- a/tests/perf_baseline.json
+++ b/tests/perf_baseline.json
@@ -68,6 +68,21 @@
       "num_nodes": 109,
       "num_models": 1,
       "model_size_bytes": 368440
+    },
+    "qwen3_5_text (hybrid-text-generation)": {
+      "num_nodes": 148,
+      "num_models": 1,
+      "model_size_bytes": 468588
+    },
+    "qwen3_5_moe (hybrid-text-generation)": {
+      "num_nodes": 294,
+      "num_models": 1,
+      "model_size_bytes": 518252
+    },
+    "qwen3_5_vl (hybrid-qwen-vl)": {
+      "num_nodes": 428,
+      "num_models": 3,
+      "model_size_bytes": 1000924
     }
   }
 }


### PR DESCRIPTION
## Changes

### Architecture Diff
- Resolve `--base-ref` and `--head-ref` to short commit SHAs via `git rev-parse --short`
- Display compared SHAs in the markdown header (e.g., "Comparing `abc1234` → `def5678`")
- Graceful fallback to raw ref string if SHA resolution fails (shallow clones, invalid refs)

### Performance Comparison
- Add Qwen3.5 models to benchmarks (text, moe, vl) with custom VL builder
- Display commit SHAs in benchmark comparison markdown header
- Update perf_baseline.json with Qwen3.5 baseline values

### Testing
- Added tests for SHA display (present and absent cases)
- All existing tests pass
