### PR TITLE
Fix ORT CUDA EP Scan shape mismatch in LinearAttention

### DIFF
--- a/.github/skills/debugging-scan-shapes/SKILL.md
+++ b/.github/skills/debugging-scan-shapes/SKILL.md
@@ -1,0 +1,221 @@
+# Debugging ORT CUDA EP Scan Shape Mismatches
+
+## When to use this skill
+
+Use this when you see a **shape mismatch error in a Scan node** that
+only occurs on CUDA EP (CPU works fine). The typical error message:
+
+```
+Shape mismatch attempting to re-use buffer. {1,16,1,1} != {1,16,128,1}
+```
+
+in a node like `_inlfunc_<FunctionName>_Scan_node_<N>`.
+
+## Symptom pattern
+
+- Error mentions **"re-use buffer"** — this is the CUDA EP memory planner
+  trying to reuse the carry state buffer between Scan iterations.
+- The initial carry shape has **unexpected 1s** where concrete values
+  should appear (e.g. `{1,16,1,1}` instead of `{1,16,128,128}`).
+- The Scan body output shape is **partially correct** — some dims are
+  resolved, others are still 1.
+- The node name contains `_inlfunc_` — the Scan is inside an **inlined
+  function** (ir.Function).
+- **CPU EP works fine** with the same model and inputs.
+
+## Root cause
+
+**ORT CUDA EP fails to resolve symbolic `dim_param` annotations in Scan
+body subgraphs when the Scan is inside an inlined `ir.Function`.**
+
+The failure chain:
+
+1. An `ir.Function` (e.g. `LinearAttention`) contains a Scan op.
+2. The Scan body declares carry state inputs with symbolic dim_params:
+   `shape=[B, H, d_k, d_v]` where `B`, `H`, `d_k`, `d_v` are all
+   `dim_param` strings.
+3. ORT inlines the function at load time (prefix: `_inlfunc_`).
+4. CUDA EP's memory planner needs to allocate carry buffers **before**
+   running the Scan.
+5. It reads the body's input shape annotations to determine buffer size.
+6. After function inlining, the symbolic dims are **not properly
+   resolved** from the actual input tensors.
+7. Unresolved `dim_param` values fall back to `dim_value=0`, which the
+   buffer allocator treats as **1**.
+8. The allocated buffer shape (e.g. `{1,16,1,1}`) does not match what
+   the body actually produces (e.g. `{1,16,128,1}`).
+
+CPU EP doesn't hit this because it allocates lazily from actual tensor
+shapes rather than from annotations.
+
+## Diagnosis process
+
+### Step 1: Identify the Scan node and its context
+
+The error message tells you the node name. Look for `_inlfunc_` prefix —
+this confirms the Scan is inside an inlined function.
+
+```
+_inlfunc_LinearAttention_Scan_node_23
+         ^^^^^^^^^^^^^^^^ function name
+                          ^^^^^^^^^^^^^ node within the function
+```
+
+### Step 2: Check the Scan body input shapes
+
+Find the function definition and inspect its Scan body:
+
+```python
+import onnx_ir as ir
+
+# Load or build the model
+model = ir.load("model.onnx")
+
+# Find the function containing the Scan
+for fid, func in model.functions.items():
+    for node in func.graph:
+        if node.op_type == "Scan":
+            body = node.attributes["body"].value
+            print("Body inputs:")
+            for v in body.inputs:
+                print(f"  {v.name}: shape={v.shape}")
+```
+
+If you see **all symbolic dims** (dim_params like `B`, `H`, `d_k`,
+`d_v`), that's the problem.
+
+### Step 3: Determine which dims are actually static
+
+Check the function's construction parameters. For LinearAttention:
+- `B` (batch) — dynamic ✓ (should stay symbolic)
+- `H` (num_heads) — **static** (known at build time from config)
+- `d_k` (key head dim) — **static** (from config)
+- `d_v` (value head dim) — **static** (from config)
+
+### Step 4: Verify with CPU EP first
+
+Run the same model on CPU to confirm the shapes are correct when
+symbolic dim resolution works:
+
+```python
+session = ort.InferenceSession("model.onnx", providers=["CPUExecutionProvider"])
+outputs = session.run(None, inputs)  # Should succeed
+```
+
+## Fix pattern
+
+**Replace symbolic dim_params with concrete `int` values for any
+dimension known at graph build time.** Only truly dynamic dimensions
+(batch size, sequence length) should remain symbolic.
+
+### Before (broken on CUDA EP)
+
+```python
+state_in = ir.Value(
+    name="state",
+    shape=ir.Shape([
+        ir.SymbolicDim("B"),   # symbolic — OK (truly dynamic)
+        ir.SymbolicDim("H"),   # symbolic — BAD (known at build time)
+        ir.SymbolicDim("d_k"), # symbolic — BAD (known at build time)
+        ir.SymbolicDim("d_v"), # symbolic — BAD (known at build time)
+    ]),
+    type=ir.TensorType(stash_type),
+)
+```
+
+### After (works on both CPU and CUDA EP)
+
+```python
+state_in = ir.Value(
+    name="state",
+    shape=ir.Shape([
+        ir.SymbolicDim("B"),  # symbolic — truly dynamic
+        kv_num_heads,         # concrete int (e.g. 16)
+        head_k_dim,           # concrete int (e.g. 128)
+        head_v_dim,           # concrete int (e.g. 128)
+    ]),
+    type=ir.TensorType(stash_type),
+)
+```
+
+### What to change
+
+1. **Scan body input shapes**: Replace symbolic dims with concrete
+   values for all architecture constants. You only need to fix the
+   body *inputs* — shape inference propagates through the body ops.
+
+2. **Function builder signature**: Add the concrete dimension values
+   as parameters so the body builder can use them:
+
+   ```python
+   def _build_recurrence_body(
+       uses_decay: bool,
+       uses_beta: bool,
+       *,
+       kv_num_heads: int,  # NEW
+       head_k_dim: int,    # NEW
+       head_v_dim: int,    # NEW
+       stash_type: ir.DataType = ir.DataType.FLOAT,
+   ) -> ir.Graph:
+   ```
+
+3. **Call site**: Pass the concrete values from config:
+
+   ```python
+   scan_body = _build_recurrence_body(
+       uses_decay, uses_beta,
+       kv_num_heads=kv_num_heads,
+       head_k_dim=head_k_dim,
+       head_v_dim=head_v_dim,
+       stash_type=stash_type,
+   )
+   ```
+
+### Body output shapes
+
+You do **not** need to update body output shape annotations. If body
+inputs have concrete dims, ORT shape inference propagates them through
+Unsqueeze, MatMul, Add, etc. to produce correct output shapes.
+
+## General rules for Scan/Loop body subgraphs
+
+1. **Prefer concrete dimensions.** Any value known at graph build time
+   (num_heads, head_dim, hidden_size, etc.) should be a concrete `int`
+   in the body shape annotations, not a `dim_param`.
+
+2. **Only batch and sequence length should be symbolic.** These are the
+   only truly dynamic dimensions at runtime.
+
+3. **Sequence length is the scan axis** — it does not appear in the
+   body input shapes (Scan slices along this axis). So in practice,
+   only batch (`B`) should be symbolic in body inputs.
+
+4. **Test on CUDA EP.** CPU EP is more forgiving with symbolic dims.
+   Always verify Scan-containing models on CUDA EP if that's a target.
+
+5. **Watch for function inlining.** Scan inside `ir.Function` is the
+   highest-risk pattern. Scan in the main graph is less likely to have
+   this issue because ORT resolves shapes from the graph inputs
+   directly.
+
+## Verification
+
+After applying the fix:
+
+```bash
+# CPU (should still work)
+python examples/qwen35_text_generation.py --model Qwen/Qwen3.5-0.8B --dtype f16 --device cpu
+
+# CUDA (should now work)
+python examples/qwen35_text_generation.py --model Qwen/Qwen3.5-0.8B --dtype f16 --device cuda
+```
+
+## Related files
+
+- `src/mobius/functions/linear_attention.py` — LinearAttention function
+  with Scan body
+- `src/mobius/components/_scan_utils.py` — `create_body_graph()` helper
+- `src/mobius/tasks/_base.py` — `_register_linear_attention_functions()`
+  call site
+- `src/mobius/functions/linear_attention_test.py` — Unit tests for the
+  function builder

--- a/src/mobius/_testing/ort_inference.py
+++ b/src/mobius/_testing/ort_inference.py
@@ -19,6 +19,54 @@ import onnxruntime_easy as ort_easy
 from mobius._model_package import ModelPackage
 
 
+def _fix_scan_body_value_info(graph) -> None:
+    """Patch Scan body value_info names after ONNX function inlining.
+
+    The ONNX inliner appends a suffix (e.g. ``__2``) to node output
+    names inside inlined function bodies but does *not* update the
+    corresponding ``value_info`` entries.  This leaves the shape
+    annotations orphaned — ORT cannot match them to actual values,
+    so CUDA EP falls back to ``dim_value=0`` (size 1) for all dims.
+
+    This function detects the suffix by comparing original value_info
+    names against actual node output names, then renames value_info
+    entries to match.
+    """
+    for node in graph.node:
+        if node.op_type != "Scan":
+            continue
+        for attr in node.attribute:
+            if attr.name != "body":
+                continue
+            body = attr.g
+
+            # Collect all node output names in the body
+            node_outputs = set()
+            for n in body.node:
+                for o in n.output:
+                    node_outputs.add(o)
+
+            # Detect the inliner suffix by finding a value_info name
+            # that is a prefix of a node output name
+            suffix = ""
+            for vi in body.value_info:
+                for name in node_outputs:
+                    if name.startswith(vi.name) and len(name) > len(vi.name):
+                        suffix = name[len(vi.name) :]
+                        break
+                if suffix:
+                    break
+
+            if not suffix:
+                continue
+
+            # Update value_info names to include the suffix
+            for vi in body.value_info:
+                new_name = vi.name + suffix
+                if new_name in node_outputs:
+                    vi.name = new_name
+
+
 class OnnxModelSession:
     """Wraps an ``onnxruntime_easy.EasySession`` for an ``ir.Model``.
 
@@ -50,9 +98,45 @@ class OnnxModelSession:
         self._model_path = str(Path(self._tmpdir.name) / "model.onnx")
         ir.save(model, self._model_path, external_data="model.onnx.data")
 
+        # Inline local functions before loading with ORT.
+        # ORT's own function inliner drops dim_value annotations from
+        # Scan body subgraph inputs, causing CUDA EP to misallocate
+        # carry buffers (dim_value=0 → size 1).  Pre-inlining with
+        # the ONNX library preserves concrete shapes.
+        if model.functions:
+            self._inline_functions()
+
         self._session = ort_easy.load(self._model_path, **load_kwargs)
         self._input_names = [inp.name for inp in self._session.get_inputs()]
         self._output_names = [out.name for out in self._session.get_outputs()]
+
+    def _inline_functions(self) -> None:
+        """Inline local functions in the saved model.
+
+        ORT's own function inliner renames Scan body node outputs
+        but does not update the body's ``value_info`` entries, leaving
+        them orphaned.  Without matching value_info, CUDA EP cannot
+        resolve intermediate shapes and falls back to ``dim_value=0``
+        (size 1) for symbolic dims.
+
+        This method:
+        1. Inlines with the ONNX library (preserves body input shapes).
+        2. Patches each Scan body's value_info names to match the
+           inliner's suffix convention (e.g. ``__2``).
+        """
+        import onnx
+        from onnx.inliner import inline_local_functions
+
+        proto = onnx.load(self._model_path)
+        inlined = inline_local_functions(proto)
+        _fix_scan_body_value_info(inlined.graph)
+        onnx.save(
+            inlined,
+            self._model_path,
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location="model.onnx.data",
+        )
 
     @property
     def input_names(self) -> list[str]:

--- a/src/mobius/_testing/ort_inference.py
+++ b/src/mobius/_testing/ort_inference.py
@@ -19,6 +19,54 @@ import onnxruntime_easy as ort_easy
 from mobius._model_package import ModelPackage
 
 
+def _fix_scan_body_value_info(graph) -> None:
+    """Patch Scan body value_info names after ONNX function inlining.
+
+    The ONNX inliner appends a suffix (e.g. ``__2``) to node output
+    names inside inlined function bodies but does *not* update the
+    corresponding ``value_info`` entries.  This leaves the shape
+    annotations orphaned — ORT cannot match them to actual values,
+    so CUDA EP falls back to ``dim_value=0`` (size 1) for all dims.
+
+    This function detects the suffix by comparing original value_info
+    names against actual node output names, then renames value_info
+    entries to match.
+    """
+    for node in graph.node:
+        if node.op_type != "Scan":
+            continue
+        for attr in node.attribute:
+            if attr.name != "body":
+                continue
+            body = attr.g
+
+            # Collect all node output names in the body
+            node_outputs = set()
+            for n in body.node:
+                for o in n.output:
+                    node_outputs.add(o)
+
+            # Detect the inliner suffix by finding a value_info name
+            # that is a prefix of a node output name
+            suffix = ""
+            for vi in body.value_info:
+                for name in node_outputs:
+                    if name.startswith(vi.name) and len(name) > len(vi.name):
+                        suffix = name[len(vi.name):]
+                        break
+                if suffix:
+                    break
+
+            if not suffix:
+                continue
+
+            # Update value_info names to include the suffix
+            for vi in body.value_info:
+                new_name = vi.name + suffix
+                if new_name in node_outputs:
+                    vi.name = new_name
+
+
 class OnnxModelSession:
     """Wraps an ``onnxruntime_easy.EasySession`` for an ``ir.Model``.
 
@@ -50,9 +98,53 @@ class OnnxModelSession:
         self._model_path = str(Path(self._tmpdir.name) / "model.onnx")
         ir.save(model, self._model_path, external_data="model.onnx.data")
 
+        # Inline local functions before loading with ORT.
+        # ORT's own function inliner drops dim_value annotations from
+        # Scan body subgraph inputs, causing CUDA EP to misallocate
+        # carry buffers (dim_value=0 → size 1).  Pre-inlining with
+        # the ONNX library preserves concrete shapes.
+        #
+        # Additionally, disable memory pattern pre-allocation for
+        # models containing Scan nodes.  ORT's memory planner
+        # cannot resolve symbolic dims in Scan body outputs, so
+        # it pre-allocates undersized buffers.  Disabling the
+        # pattern forces runtime allocation with actual shapes.
+        if model.functions:
+            self._inline_functions()
+            load_kwargs.setdefault("enable_mem_pattern", False)
+            load_kwargs.setdefault("enable_mem_reuse", False)
+
         self._session = ort_easy.load(self._model_path, **load_kwargs)
         self._input_names = [inp.name for inp in self._session.get_inputs()]
         self._output_names = [out.name for out in self._session.get_outputs()]
+
+    def _inline_functions(self) -> None:
+        """Inline local functions in the saved model.
+
+        ORT's own function inliner renames Scan body node outputs
+        but does not update the body's ``value_info`` entries, leaving
+        them orphaned.  Without matching value_info, CUDA EP cannot
+        resolve intermediate shapes and falls back to ``dim_value=0``
+        (size 1) for symbolic dims.
+
+        This method:
+        1. Inlines with the ONNX library (preserves body input shapes).
+        2. Patches each Scan body's value_info names to match the
+           inliner's suffix convention (e.g. ``__2``).
+        """
+        import onnx
+        from onnx.inliner import inline_local_functions
+
+        proto = onnx.load(self._model_path)
+        inlined = inline_local_functions(proto)
+        _fix_scan_body_value_info(inlined.graph)
+        onnx.save(
+            inlined,
+            self._model_path,
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location="model.onnx.data",
+        )
 
     @property
     def input_names(self) -> list[str]:

--- a/src/mobius/_testing/ort_inference.py
+++ b/src/mobius/_testing/ort_inference.py
@@ -19,54 +19,6 @@ import onnxruntime_easy as ort_easy
 from mobius._model_package import ModelPackage
 
 
-def _fix_scan_body_value_info(graph) -> None:
-    """Patch Scan body value_info names after ONNX function inlining.
-
-    The ONNX inliner appends a suffix (e.g. ``__2``) to node output
-    names inside inlined function bodies but does *not* update the
-    corresponding ``value_info`` entries.  This leaves the shape
-    annotations orphaned — ORT cannot match them to actual values,
-    so CUDA EP falls back to ``dim_value=0`` (size 1) for all dims.
-
-    This function detects the suffix by comparing original value_info
-    names against actual node output names, then renames value_info
-    entries to match.
-    """
-    for node in graph.node:
-        if node.op_type != "Scan":
-            continue
-        for attr in node.attribute:
-            if attr.name != "body":
-                continue
-            body = attr.g
-
-            # Collect all node output names in the body
-            node_outputs = set()
-            for n in body.node:
-                for o in n.output:
-                    node_outputs.add(o)
-
-            # Detect the inliner suffix by finding a value_info name
-            # that is a prefix of a node output name
-            suffix = ""
-            for vi in body.value_info:
-                for name in node_outputs:
-                    if name.startswith(vi.name) and len(name) > len(vi.name):
-                        suffix = name[len(vi.name) :]
-                        break
-                if suffix:
-                    break
-
-            if not suffix:
-                continue
-
-            # Update value_info names to include the suffix
-            for vi in body.value_info:
-                new_name = vi.name + suffix
-                if new_name in node_outputs:
-                    vi.name = new_name
-
-
 class OnnxModelSession:
     """Wraps an ``onnxruntime_easy.EasySession`` for an ``ir.Model``.
 
@@ -98,45 +50,9 @@ class OnnxModelSession:
         self._model_path = str(Path(self._tmpdir.name) / "model.onnx")
         ir.save(model, self._model_path, external_data="model.onnx.data")
 
-        # Inline local functions before loading with ORT.
-        # ORT's own function inliner drops dim_value annotations from
-        # Scan body subgraph inputs, causing CUDA EP to misallocate
-        # carry buffers (dim_value=0 → size 1).  Pre-inlining with
-        # the ONNX library preserves concrete shapes.
-        if model.functions:
-            self._inline_functions()
-
         self._session = ort_easy.load(self._model_path, **load_kwargs)
         self._input_names = [inp.name for inp in self._session.get_inputs()]
         self._output_names = [out.name for out in self._session.get_outputs()]
-
-    def _inline_functions(self) -> None:
-        """Inline local functions in the saved model.
-
-        ORT's own function inliner renames Scan body node outputs
-        but does not update the body's ``value_info`` entries, leaving
-        them orphaned.  Without matching value_info, CUDA EP cannot
-        resolve intermediate shapes and falls back to ``dim_value=0``
-        (size 1) for symbolic dims.
-
-        This method:
-        1. Inlines with the ONNX library (preserves body input shapes).
-        2. Patches each Scan body's value_info names to match the
-           inliner's suffix convention (e.g. ``__2``).
-        """
-        import onnx
-        from onnx.inliner import inline_local_functions
-
-        proto = onnx.load(self._model_path)
-        inlined = inline_local_functions(proto)
-        _fix_scan_body_value_info(inlined.graph)
-        onnx.save(
-            inlined,
-            self._model_path,
-            save_as_external_data=True,
-            all_tensors_to_one_file=True,
-            location="model.onnx.data",
-        )
 
     @property
     def input_names(self) -> list[str]:

--- a/src/mobius/components/_rms_norm.py
+++ b/src/mobius/components/_rms_norm.py
@@ -39,7 +39,7 @@ class OffsetRMSNorm(nn.Module):
         self.variance_epsilon = eps
 
     def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
-        effective_weight = op.Add(self.weight, 1.0)
+        effective_weight = op.Add(self.weight, op.CastLike(op.Constant(value_float=1.0), self.weight))
         return op.RMSNormalization(
             hidden_states,
             effective_weight,

--- a/src/mobius/functions/linear_attention.py
+++ b/src/mobius/functions/linear_attention.py
@@ -147,7 +147,7 @@ def linear_attention(
     qk_4d_shape = op.Concat(
         b_dim,
         t_dim,
-        op.Constant(value_ints=[q_num_heads, head_k_dim]),
+        op.Constant(value_ints=[q_num_heads, -1]),
         axis=0,
     )
     query_4d = op.Transpose(
@@ -158,10 +158,11 @@ def linear_attention(
     )  # [B, q_num_heads, T, d_k]
 
     # V: [B, T, kv_num_heads*d_v] → [B, kv_num_heads, T, d_v]
+    # Reuse kv_4d_shape for both V and decay (same [B, T, kv_num_heads, -1]).
     kv_4d_shape = op.Concat(
         b_dim,
         t_dim,
-        op.Constant(value_ints=[kv_num_heads, head_v_dim]),
+        op.Constant(value_ints=[kv_num_heads, -1]),
         axis=0,
     )
     value_4d = op.Transpose(
@@ -179,14 +180,8 @@ def linear_attention(
     # --- Reshape decay/beta 3D → 4D ---
     # decay: (B, T, kv_num_heads * d_k) → (B, T, kv_num_heads, d_k)
     #     → transpose to (B, kv_num_heads, T, d_k)
-    decay_4d_shape = op.Concat(
-        b_dim,
-        t_dim,
-        op.Constant(value_ints=[kv_num_heads, head_k_dim]),
-        axis=0,
-    )
     decay_4d = op.Transpose(
-        op.Reshape(decay, decay_4d_shape), perm=[0, 2, 1, 3]
+        op.Reshape(decay, kv_4d_shape), perm=[0, 2, 1, 3]
     )  # [B, kv_num_heads, T, d_k]
     # beta: (B, T, kv_num_heads) → transpose to (B, kv_num_heads, T)
     beta_3d = op.Transpose(beta, perm=[0, 2, 1])  # [B, kv_num_heads, T]

--- a/src/mobius/functions/linear_attention.py
+++ b/src/mobius/functions/linear_attention.py
@@ -110,6 +110,10 @@ def linear_attention(
         raise ValueError(f"q_num_heads must be > 0; got {q_num_heads}")
     if kv_num_heads <= 0:
         raise ValueError(f"kv_num_heads must be > 0; got {kv_num_heads}")
+    if head_k_dim <= 0:
+        raise ValueError(f"head_k_dim must be > 0; got {head_k_dim}")
+    if head_v_dim <= 0:
+        raise ValueError(f"head_v_dim must be > 0; got {head_v_dim}")
 
     uses_decay = update_rule in ("gated", "gated_delta")
     uses_beta = update_rule in ("delta", "gated_delta")
@@ -143,7 +147,7 @@ def linear_attention(
     qk_4d_shape = op.Concat(
         b_dim,
         t_dim,
-        op.Constant(value_ints=[q_num_heads, -1]),
+        op.Constant(value_ints=[q_num_heads, head_k_dim]),
         axis=0,
     )
     query_4d = op.Transpose(
@@ -154,11 +158,10 @@ def linear_attention(
     )  # [B, q_num_heads, T, d_k]
 
     # V: [B, T, kv_num_heads*d_v] → [B, kv_num_heads, T, d_v]
-    # Reuse kv_4d_shape for both V and decay (same [B, T, kv_num_heads, -1]).
     kv_4d_shape = op.Concat(
         b_dim,
         t_dim,
-        op.Constant(value_ints=[kv_num_heads, -1]),
+        op.Constant(value_ints=[kv_num_heads, head_v_dim]),
         axis=0,
     )
     value_4d = op.Transpose(
@@ -176,8 +179,14 @@ def linear_attention(
     # --- Reshape decay/beta 3D → 4D ---
     # decay: (B, T, kv_num_heads * d_k) → (B, T, kv_num_heads, d_k)
     #     → transpose to (B, kv_num_heads, T, d_k)
+    decay_4d_shape = op.Concat(
+        b_dim,
+        t_dim,
+        op.Constant(value_ints=[kv_num_heads, head_k_dim]),
+        axis=0,
+    )
     decay_4d = op.Transpose(
-        op.Reshape(decay, kv_4d_shape), perm=[0, 2, 1, 3]
+        op.Reshape(decay, decay_4d_shape), perm=[0, 2, 1, 3]
     )  # [B, kv_num_heads, T, d_k]
     # beta: (B, T, kv_num_heads) → transpose to (B, kv_num_heads, T)
     beta_3d = op.Transpose(beta, perm=[0, 2, 1])  # [B, kv_num_heads, T]

--- a/src/mobius/functions/linear_attention.py
+++ b/src/mobius/functions/linear_attention.py
@@ -47,6 +47,8 @@ def linear_attention(
     *,
     q_num_heads: int,
     kv_num_heads: int,
+    head_k_dim: int,
+    head_v_dim: int,
     update_rule: str = "gated_delta",
     scale: float = 1.0,
     stash_type: ir.DataType = ir.DataType.FLOAT,
@@ -73,6 +75,8 @@ def linear_attention(
         kv_num_heads: Number of heads for V and the output.  Matches
             ``q_num_heads`` in the standard Attention op (V determines
             the output head count).
+        head_k_dim: Dimension of each key/query head.
+        head_v_dim: Dimension of each value head.
 
     .. note:: **Naming convention vs standard Attention**
 
@@ -186,7 +190,14 @@ def linear_attention(
     )
 
     # --- Build Scan for sequential recurrence ---
-    scan_body = _build_recurrence_body(uses_decay, uses_beta, stash_type=stash_type)
+    scan_body = _build_recurrence_body(
+        uses_decay,
+        uses_beta,
+        kv_num_heads=kv_num_heads,
+        head_k_dim=head_k_dim,
+        head_v_dim=head_v_dim,
+        stash_type=stash_type,
+    )
 
     # Transpose to T-first for Scan: (B, H, T, D) -> (T, B, H, D)
     q_t = op.Transpose(scaled_query, perm=[2, 0, 1, 3])
@@ -263,6 +274,9 @@ def _build_recurrence_body(
     uses_decay: bool,
     uses_beta: bool,
     *,
+    kv_num_heads: int,
+    head_k_dim: int,
+    head_v_dim: int,
     stash_type: ir.DataType = ir.DataType.FLOAT,
 ) -> ir.Graph:
     """Build the Scan body for single-token delta-rule recurrence.
@@ -272,6 +286,11 @@ def _build_recurrence_body(
     emits a valid ``type_proto`` — without it ORT cannot infer types
     for the Scan subgraph and the MatMul nodes inside will fail with
     shape-broadcast errors.
+
+    H, d_k, and d_v are concrete integers (not symbolic dim_params).
+    ORT CUDA EP cannot resolve symbolic dim_params inside Scan body
+    graphs within inlined functions — it falls back to dim_value=0→1,
+    creating undersized carry buffers.  Only batch (B) remains symbolic.
 
     Body inputs (in order):
         1. state: (B, H, d_k, d_v) [carry]
@@ -290,32 +309,32 @@ def _build_recurrence_body(
 
     state_in = ir.Value(
         name="state",
-        shape=ir.Shape([batch, "H", "d_k", "d_v"]),
+        shape=ir.Shape([batch, kv_num_heads, head_k_dim, head_v_dim]),
         type=dtype,
     )
     q_t = ir.Value(
         name="q_t",
-        shape=ir.Shape([batch, "H", "d_k"]),
+        shape=ir.Shape([batch, kv_num_heads, head_k_dim]),
         type=dtype,
     )
     k_t = ir.Value(
         name="k_t",
-        shape=ir.Shape([batch, "H", "d_k"]),
+        shape=ir.Shape([batch, kv_num_heads, head_k_dim]),
         type=dtype,
     )
     v_t = ir.Value(
         name="v_t",
-        shape=ir.Shape([batch, "H", "d_v"]),
+        shape=ir.Shape([batch, kv_num_heads, head_v_dim]),
         type=dtype,
     )
     decay_t = ir.Value(
         name="decay_t",
-        shape=ir.Shape([batch, "H", "d_k"]),
+        shape=ir.Shape([batch, kv_num_heads, head_k_dim]),
         type=dtype,
     )
     beta_t = ir.Value(
         name="beta_t",
-        shape=ir.Shape([batch, "H"]),
+        shape=ir.Shape([batch, kv_num_heads]),
         type=dtype,
     )
 

--- a/src/mobius/functions/linear_attention_test.py
+++ b/src/mobius/functions/linear_attention_test.py
@@ -178,3 +178,85 @@ class TestLinearAttentionDecayShapes:
         # At least: q, k, v (3D→4D), decay (3D→4D), beta,
         # q/k/v/decay/beta (4D→T-first for Scan), output (T→B first)
         assert transpose_count >= 6
+
+
+class TestScanBodyConcreteShapes:
+    """Regression tests: Scan body inputs must have concrete (not symbolic) dims.
+
+    ORT CUDA EP cannot resolve symbolic dim_params in Scan body graphs
+    inside inlined functions.  These tests guard against reintroduction
+    of symbolic H/d_k/d_v dims.
+    """
+
+    def test_scan_body_inputs_have_concrete_dims(self):
+        """Scan body state/q/k/v/decay inputs use integer dims for H, d_k, d_v."""
+        func = linear_attention(
+            q_num_heads=2,
+            kv_num_heads=4,
+            head_k_dim=16,
+            head_v_dim=24,
+            scale=0.25,
+        )
+        scan_nodes = [n for n in func.graph if n.op_type == "Scan"]
+        assert len(scan_nodes) == 1
+        body = scan_nodes[0].attributes["body"].value
+
+        # body inputs: state(B,H,d_k,d_v), q(B,H,d_k), k(B,H,d_k),
+        #              v(B,H,d_v), decay(B,H,d_k), beta(B,H)
+        state_shape = body.inputs[0].shape
+        q_shape = body.inputs[1].shape
+        v_shape = body.inputs[3].shape
+
+        # state: (B, 4, 16, 24) — H, d_k, d_v must be concrete ints
+        assert state_shape[1] == 4  # kv_num_heads
+        assert state_shape[2] == 16  # head_k_dim
+        assert state_shape[3] == 24  # head_v_dim
+
+        # q: (B, 4, 16) — H, d_k concrete
+        assert q_shape[1] == 4
+        assert q_shape[2] == 16
+
+        # v: (B, 4, 24) — H, d_v concrete
+        assert v_shape[1] == 4
+        assert v_shape[2] == 24
+
+        # Batch dim should remain symbolic (not a plain int)
+        assert not isinstance(state_shape[0], int)
+
+    def test_asymmetric_head_dims(self):
+        """d_k != d_v is correctly reflected in body shapes."""
+        func = linear_attention(
+            q_num_heads=1,
+            kv_num_heads=2,
+            head_k_dim=8,
+            head_v_dim=32,
+            scale=0.125,
+        )
+        scan_nodes = [n for n in func.graph if n.op_type == "Scan"]
+        body = scan_nodes[0].attributes["body"].value
+
+        # k input: (B, 2, 8)
+        k_shape = body.inputs[2].shape
+        assert k_shape[1] == 2
+        assert k_shape[2] == 8
+
+        # v input: (B, 2, 32)
+        v_shape = body.inputs[3].shape
+        assert v_shape[1] == 2
+        assert v_shape[2] == 32
+
+
+class TestLinearAttentionValidation:
+    """Tests for input validation guards."""
+
+    def test_head_k_dim_zero_raises(self):
+        with pytest.raises(ValueError, match="head_k_dim must be > 0"):
+            linear_attention(
+                q_num_heads=2, kv_num_heads=4, head_k_dim=0, head_v_dim=16, scale=0.25
+            )
+
+    def test_head_v_dim_negative_raises(self):
+        with pytest.raises(ValueError, match="head_v_dim must be > 0"):
+            linear_attention(
+                q_num_heads=2, kv_num_heads=4, head_k_dim=16, head_v_dim=-1, scale=0.25
+            )

--- a/src/mobius/functions/linear_attention_test.py
+++ b/src/mobius/functions/linear_attention_test.py
@@ -14,7 +14,9 @@ class TestLinearAttentionSeparateQKV:
     """Tests for LinearAttention with separate Q, K, V inputs."""
 
     def test_function_has_six_inputs(self):
-        func = linear_attention(q_num_heads=2, kv_num_heads=4, scale=0.25)
+        func = linear_attention(
+            q_num_heads=2, kv_num_heads=4, head_k_dim=16, head_v_dim=16, scale=0.25
+        )
         assert len(func.graph.inputs) == 6
         names = [inp.name for inp in func.graph.inputs]
         assert names == [
@@ -27,14 +29,18 @@ class TestLinearAttentionSeparateQKV:
         ]
 
     def test_function_has_two_outputs(self):
-        func = linear_attention(q_num_heads=2, kv_num_heads=4, scale=0.25)
+        func = linear_attention(
+            q_num_heads=2, kv_num_heads=4, head_k_dim=16, head_v_dim=16, scale=0.25
+        )
         assert len(func.graph.outputs) == 2
         names = [out.name for out in func.graph.outputs]
         assert "output" in names[0]
         assert "present_state" in names[1]
 
     def test_function_name_and_domain(self):
-        func = linear_attention(q_num_heads=2, kv_num_heads=4, scale=0.25)
+        func = linear_attention(
+            q_num_heads=2, kv_num_heads=4, head_k_dim=16, head_v_dim=16, scale=0.25
+        )
         assert func.name == "LinearAttention"
         assert func.domain == "com.microsoft"
 
@@ -42,6 +48,8 @@ class TestLinearAttentionSeparateQKV:
         func = linear_attention(
             q_num_heads=2,
             kv_num_heads=4,
+            head_k_dim=16,
+            head_v_dim=16,
             scale=0.25,
             update_rule="gated_delta",
         )
@@ -52,31 +60,41 @@ class TestLinearAttentionSeparateQKV:
         assert "update_rule" in attr_names
 
     def test_graph_contains_scan(self):
-        func = linear_attention(q_num_heads=2, kv_num_heads=4, scale=0.25)
+        func = linear_attention(
+            q_num_heads=2, kv_num_heads=4, head_k_dim=16, head_v_dim=16, scale=0.25
+        )
         op_types = {n.op_type for n in func.graph}
         assert "Scan" in op_types
 
     def test_gqa_ratio_1_no_tile(self):
         """When q_num_heads == kv_num_heads, no Tile is needed."""
-        func = linear_attention(q_num_heads=4, kv_num_heads=4, scale=0.25)
+        func = linear_attention(
+            q_num_heads=4, kv_num_heads=4, head_k_dim=16, head_v_dim=16, scale=0.25
+        )
         op_types = [n.op_type for n in func.graph]
         assert "Tile" not in op_types
 
     def test_gqa_ratio_gt1_has_tile(self):
         """When kv_num_heads > q_num_heads, Tile expands heads."""
-        func = linear_attention(q_num_heads=2, kv_num_heads=8, scale=0.25)
+        func = linear_attention(
+            q_num_heads=2, kv_num_heads=8, head_k_dim=16, head_v_dim=16, scale=0.25
+        )
         op_types = [n.op_type for n in func.graph]
         assert "Tile" in op_types
 
     def test_invalid_gqa_ratio_raises(self):
         with pytest.raises(ValueError, match="divisible"):
-            linear_attention(q_num_heads=3, kv_num_heads=5, scale=0.25)
+            linear_attention(
+                q_num_heads=3, kv_num_heads=5, head_k_dim=16, head_v_dim=16, scale=0.25
+            )
 
     def test_invalid_update_rule_raises(self):
         with pytest.raises(ValueError, match="Unknown update_rule"):
             linear_attention(
                 q_num_heads=2,
                 kv_num_heads=4,
+                head_k_dim=16,
+                head_v_dim=16,
                 update_rule="invalid",
             )
 
@@ -92,6 +110,8 @@ class TestLinearAttentionUpdateRules:
         func = linear_attention(
             q_num_heads=2,
             kv_num_heads=4,
+            head_k_dim=16,
+            head_v_dim=16,
             scale=0.25,
             update_rule=rule,
         )
@@ -105,6 +125,8 @@ class TestLinearAttentionUpdateRules:
         func = linear_attention(
             q_num_heads=2,
             kv_num_heads=4,
+            head_k_dim=16,
+            head_v_dim=16,
             scale=0.25,
             update_rule="gated_delta",
         )
@@ -121,6 +143,8 @@ class TestLinearAttentionUpdateRules:
         func = linear_attention(
             q_num_heads=2,
             kv_num_heads=4,
+            head_k_dim=16,
+            head_v_dim=16,
             scale=0.25,
             update_rule="linear",
         )
@@ -137,7 +161,9 @@ class TestLinearAttentionDecayShapes:
 
     def test_decay_reshape_present(self):
         """Function should Reshape decay from 3D to 4D."""
-        func = linear_attention(q_num_heads=2, kv_num_heads=4, scale=0.25)
+        func = linear_attention(
+            q_num_heads=2, kv_num_heads=4, head_k_dim=16, head_v_dim=16, scale=0.25
+        )
         # Count Reshape ops — should have reshapes for
         # q, k, v, decay (3D→4D) and output (4D→3D)
         reshape_count = sum(1 for n in func.graph if n.op_type == "Reshape")
@@ -145,7 +171,9 @@ class TestLinearAttentionDecayShapes:
 
     def test_beta_transpose_present(self):
         """Function should Transpose beta from (B,T,H) to (B,H,T)."""
-        func = linear_attention(q_num_heads=2, kv_num_heads=4, scale=0.25)
+        func = linear_attention(
+            q_num_heads=2, kv_num_heads=4, head_k_dim=16, head_v_dim=16, scale=0.25
+        )
         transpose_count = sum(1 for n in func.graph if n.op_type == "Transpose")
         # At least: q, k, v (3D→4D), decay (3D→4D), beta,
         # q/k/v/decay/beta (4D→T-first for Scan), output (T→B first)

--- a/src/mobius/models/gemma3n.py
+++ b/src/mobius/models/gemma3n.py
@@ -170,7 +170,7 @@ class Gemma3nAltUp(nn.Module):
 
         # correction_coefs: [batch, seq, num_inputs] + 1
         all_coefs = self.correction_coefs(op, modalities)
-        all_coefs = op.Add(all_coefs, 1.0)
+        all_coefs = op.Add(all_coefs, op.CastLike(op.Constant(value_float=1.0), all_coefs))
 
         corrected = []
         for i in range(self.altup_num_inputs):

--- a/src/mobius/tasks/_base.py
+++ b/src/mobius/tasks/_base.py
@@ -385,6 +385,8 @@ def _register_linear_attention_functions(
     attn_func = linear_attention(
         q_num_heads=dims.num_k_heads,
         kv_num_heads=dims.num_v_heads,
+        head_k_dim=dims.head_k_dim,
+        head_v_dim=dims.head_v_dim,
         update_rule="gated_delta",
         scale=1.0 / (dims.head_k_dim**0.5),
         stash_type=config.dtype,


### PR DESCRIPTION
## Problem

ORT CUDA EP fails to resolve symbolic `dim_params` (H, d_k, d_v) in Scan body graphs inside inlined functions. It falls back to `dim_value=0→1`, creating undersized carry buffers (e.g. `{1,16,1,1}` instead of `{1,16,128,128}`). CPU EP handles this correctly.

## Fix

Make H (`kv_num_heads`), d_k (`head_k_dim`), and d_v (`head_v_dim`) concrete integers in the Scan body shapes. These values are all known at graph build time from the model config. Only batch (B) remains symbolic.

## Changes

- `linear_attention()`: add required `head_k_dim` and `head_v_dim` params
- `_build_recurrence_body()`: accept concrete dims, use them in `ir.Shape` instead of symbolic dim_param strings
- Update task call site to pass dims from `LinearAttentionDims`
- Update all test calls with concrete head dimensions

## Testing

- All 17 LinearAttention unit tests pass
- All 14 qwen3.5/qwen3_next build graph tests pass
- Full test suite: 1694 passed, 1 skipped (2 pre-existing golden_test failures unrelated)