### PR TITLE
Auto-disable memory pattern for models with Scan ops

### DIFF
--- a/src/mobius/_flags.py
+++ b/src/mobius/_flags.py
@@ -79,6 +79,11 @@ class _Flags:
          - ``True``
          - Suppress "has no constant value" warnings from the initializer
            deduplication pass.
+       * - ``disable_mem_pattern_for_scan``
+         - ``MOBIUS_DISABLE_MEM_PATTERN_FOR_SCAN``
+         - ``True``
+         - Disable ORT memory-pattern pre-allocation for models with Scan
+           nodes.
     """
 
     suppress_dedup_warning: bool = dataclasses.field(
@@ -88,6 +93,17 @@ class _Flags:
 
     These warnings are expected noise when optimisation passes run before weights
     are loaded. Set ``MOBIUS_SUPPRESS_DEDUP_WARNING=0`` to see all warnings.
+    """
+
+    disable_mem_pattern_for_scan: bool = dataclasses.field(
+        default_factory=lambda: _env_bool("MOBIUS_DISABLE_MEM_PATTERN_FOR_SCAN", True)
+    )
+    """Disable ORT memory-pattern pre-allocation for models with Scan nodes.
+
+    ORT's memory planner cannot resolve symbolic dims in Scan body outputs,
+    so it pre-allocates undersized buffers.  Disabling the pattern forces
+    runtime allocation with actual shapes.  Set
+    ``MOBIUS_DISABLE_MEM_PATTERN_FOR_SCAN=0`` to restore default ORT behaviour.
     """
 
 

--- a/src/mobius/_testing/ort_inference.py
+++ b/src/mobius/_testing/ort_inference.py
@@ -16,7 +16,24 @@ import numpy as np
 import onnx_ir as ir
 import onnxruntime_easy as ort_easy
 
+from mobius import _flags
 from mobius._model_package import ModelPackage
+
+
+def _has_scan_nodes(model: ir.Model) -> bool:
+    """Return True if the model or any of its functions contain Scan ops.
+
+    Uses ``graph.all_nodes()`` which recurses into Loop/If/Scan
+    subgraph bodies so nested Scan nodes are not missed.
+    """
+    for node in model.graph.all_nodes():
+        if node.op_type == "Scan":
+            return True
+    for func in model.functions.values():
+        for node in func:
+            if node.op_type == "Scan":
+                return True
+    return False
 
 
 class OnnxModelSession:
@@ -46,6 +63,17 @@ class OnnxModelSession:
                     f"single ir.Model or index into the package."
                 )
             model = next(iter(model.values()))
+
+        # Disable memory-pattern pre-allocation for models with Scan
+        # nodes on CUDA.  ORT's memory planner cannot resolve symbolic
+        # dims in Scan body outputs, so it pre-allocates undersized
+        # buffers.  Disabling the pattern forces runtime allocation
+        # with actual shapes.
+        is_cuda = load_kwargs.get("device") == "cuda"
+        if is_cuda and _flags.flags.disable_mem_pattern_for_scan and _has_scan_nodes(model):
+            load_kwargs.setdefault("enable_mem_pattern", False)
+            load_kwargs.setdefault("enable_mem_reuse", False)
+
         self._tmpdir = tempfile.TemporaryDirectory()
         self._model_path = str(Path(self._tmpdir.name) / "model.onnx")
         ir.save(model, self._model_path, external_data="model.onnx.data")


### PR DESCRIPTION
## Problem

ORT's memory planner cannot resolve symbolic dims in Scan body outputs, so it pre-allocates undersized buffers. This causes shape mismatch errors on CUDA EP:

```
Shape mismatch attempting to re-use buffer. {1,16,1,1} != {1,16,128,1}
```

## Fix

Add `_has_scan_nodes()` helper that recursively detects Scan ops in the model graph and functions (using `graph.all_nodes()` to recurse into Loop/If subgraph bodies).

When Scan nodes are detected, automatically disable `enable_mem_pattern` and `enable_mem_reuse` in `OnnxModelSession`. This forces ORT to allocate buffers at runtime with actual shapes instead of pre-allocating based on unresolvable symbolic dims.

## Feature flag

Controlled via the `disable_mem_pattern_for_scan` feature flag (default: `True`).

- Env var: `MOBIUS_DISABLE_MEM_PATTERN_FOR_SCAN=0` to restore default ORT behaviour
- Programmatic: `flags.disable_mem_pattern_for_scan = False`

## Testing

- `python examples/qwen35_text_generation.py --model Qwen/Qwen3.5-0.8B --dtype f16 --device cuda` ✅
- `python examples/qwen35_text_generation.py --model Qwen/Qwen3.5-0.8B --dtype f16 --device cpu` ✅
- Unit tests: 1694 passed