### PR TITLE
Avoid locally generated symbolic dim names in LinearAttention

### DIFF
--- a/src/mobius/_flags.py
+++ b/src/mobius/_flags.py
@@ -79,11 +79,6 @@ class _Flags:
          - ``True``
          - Suppress "has no constant value" warnings from the initializer
            deduplication pass.
-       * - ``disable_mem_pattern_for_scan``
-         - ``MOBIUS_DISABLE_MEM_PATTERN_FOR_SCAN``
-         - ``True``
-         - Disable ORT memory-pattern pre-allocation for models with Scan
-           nodes.
     """
 
     suppress_dedup_warning: bool = dataclasses.field(
@@ -93,17 +88,6 @@ class _Flags:
 
     These warnings are expected noise when optimisation passes run before weights
     are loaded. Set ``MOBIUS_SUPPRESS_DEDUP_WARNING=0`` to see all warnings.
-    """
-
-    disable_mem_pattern_for_scan: bool = dataclasses.field(
-        default_factory=lambda: _env_bool("MOBIUS_DISABLE_MEM_PATTERN_FOR_SCAN", True)
-    )
-    """Disable ORT memory-pattern pre-allocation for models with Scan nodes.
-
-    ORT's memory planner cannot resolve symbolic dims in Scan body outputs,
-    so it pre-allocates undersized buffers.  Disabling the pattern forces
-    runtime allocation with actual shapes.  Set
-    ``MOBIUS_DISABLE_MEM_PATTERN_FOR_SCAN=0`` to restore default ORT behaviour.
     """
 
 

--- a/src/mobius/_testing/ort_inference.py
+++ b/src/mobius/_testing/ort_inference.py
@@ -16,24 +16,7 @@ import numpy as np
 import onnx_ir as ir
 import onnxruntime_easy as ort_easy
 
-from mobius import _flags
 from mobius._model_package import ModelPackage
-
-
-def _has_scan_nodes(model: ir.Model) -> bool:
-    """Return True if the model or any of its functions contain Scan ops.
-
-    Uses ``graph.all_nodes()`` which recurses into Loop/If/Scan
-    subgraph bodies so nested Scan nodes are not missed.
-    """
-    for node in model.graph.all_nodes():
-        if node.op_type == "Scan":
-            return True
-    for func in model.functions.values():
-        for node in func:
-            if node.op_type == "Scan":
-                return True
-    return False
 
 
 class OnnxModelSession:
@@ -63,16 +46,6 @@ class OnnxModelSession:
                     f"single ir.Model or index into the package."
                 )
             model = next(iter(model.values()))
-
-        # Disable memory-pattern pre-allocation for models with Scan
-        # nodes on CUDA.  ORT's memory planner cannot resolve symbolic
-        # dims in Scan body outputs, so it pre-allocates undersized
-        # buffers.  Disabling the pattern forces runtime allocation
-        # with actual shapes.
-        is_cuda = load_kwargs.get("device") == "cuda"
-        if is_cuda and _flags.flags.disable_mem_pattern_for_scan and _has_scan_nodes(model):
-            load_kwargs.setdefault("enable_mem_pattern", False)
-            load_kwargs.setdefault("enable_mem_reuse", False)
 
         self._tmpdir = tempfile.TemporaryDirectory()
         self._model_path = str(Path(self._tmpdir.name) / "model.onnx")

--- a/src/mobius/functions/linear_attention.py
+++ b/src/mobius/functions/linear_attention.py
@@ -274,11 +274,7 @@ def _build_recurrence_body(
 ) -> ir.Graph:
     """Build the Scan body for single-token delta-rule recurrence.
 
-    The body operates in ``stash_type`` precision.  Every body input
-    carries an explicit ``ir.TensorType`` so that the ONNX serializer
-    emits a valid ``type_proto`` — without it ORT cannot infer types
-    for the Scan subgraph and the MatMul nodes inside will fail with
-    shape-broadcast errors.
+    The body operates in ``stash_type`` precision.
 
     Body inputs (in order):
         1. state: (B, H, d_k, d_v) [carry]

--- a/src/mobius/functions/linear_attention.py
+++ b/src/mobius/functions/linear_attention.py
@@ -292,45 +292,23 @@ def _build_recurrence_body(
         1. new_state: (B, H, d_k, d_v) [carry]
         2. output_t: (B, H, d_v) [scan output]
     """
-    batch = ir.SymbolicDim("B")
     dtype = ir.TensorType(stash_type)
 
-    state_in = ir.Value(
-        name="state",
-        shape=ir.Shape([batch, "H", "d_k", "d_v"]),
-        type=dtype,
-    )
-    q_t = ir.Value(
-        name="q_t",
-        shape=ir.Shape([batch, "H", "d_k"]),
-        type=dtype,
-    )
-    k_t = ir.Value(
-        name="k_t",
-        shape=ir.Shape([batch, "H", "d_k"]),
-        type=dtype,
-    )
-    v_t = ir.Value(
-        name="v_t",
-        shape=ir.Shape([batch, "H", "d_v"]),
-        type=dtype,
-    )
+    # Only specify dtype, not shape. Shapes can be inferred from Scan op's
+    # inputs. Hard-coding locally chosen symbolic dim names is incorrect
+    # since ONNX has a global scope for symbolic dims.
+    state_in = ir.Value(name="state", type=dtype)
+    q_t = ir.Value(name="q_t", type=dtype)
+    k_t = ir.Value(name="k_t", type=dtype)
+    v_t = ir.Value(name="v_t", type=dtype)
     scan_in_vals = [q_t, k_t, v_t]
     decay_t: ir.Value | None = None
     beta_t: ir.Value | None = None
     if uses_decay:
-        decay_t = ir.Value(
-            name="decay_t",
-            shape=ir.Shape([batch, "H", "d_k"]),
-            type=dtype,
-        )
+        decay_t = ir.Value(name="decay_t", type=dtype)
         scan_in_vals.append(decay_t)
     if uses_beta:
-        beta_t = ir.Value(
-            name="beta_t",
-            shape=ir.Shape([batch, "H"]),
-            type=dtype,
-        )
+        beta_t = ir.Value(name="beta_t", type=dtype)
         scan_in_vals.append(beta_t)
 
     body_graph, body_builder = create_body_graph(

--- a/src/mobius/functions/linear_attention.py
+++ b/src/mobius/functions/linear_attention.py
@@ -292,7 +292,9 @@ def _build_recurrence_body(
 
     # Only specify dtype, not shape. Shapes can be inferred from Scan op's
     # inputs. Hard-coding locally chosen symbolic dim names is incorrect
-    # since ONNX has a global scope for symbolic dims.
+    # since ONNX has a global scope for symbolic dims. Even the dtype is
+    # optional in that it can be inferred, but specifying it is safe and
+    # can help as long as we know the exact type.
     state_in = ir.Value(name="state", type=dtype)
     q_t = ir.Value(name="q_t", type=dtype)
     k_t = ir.Value(name="k_t", type=dtype)


### PR DESCRIPTION
Avoid locally generated symbolic dim names in LinearAttention. If these names collide with same names used elsewhere in model, it can cause problems with ORT's memory-planner. ONNX has a global scope for the symbolic dims. (Filling these shapes are not necessary since type/shape inference is capable of doing it ... )