### PR TITLE
Fix dashboard link URL on docs site

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ ONNX model definitions for generative AI architectures using the [onnxscript](ht
 
 Build ONNX models directly from HuggingFace model IDs with automatic weight downloading, dtype casting, and multi-component export.
 
-📊 [Model Support Dashboard](https://onnxruntime.github.io/mobius/dashboard/index.html)
+<a href="dashboard/index.html">📊 Model Support Dashboard</a>
 
 ```{toctree}
 :maxdepth: 2

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ ONNX model definitions for generative AI architectures using the [onnxscript](ht
 
 Build ONNX models directly from HuggingFace model IDs with automatic weight downloading, dtype casting, and multi-component export.
 
-📊 [Model Support Dashboard](dashboard/index.html)
+📊 [Model Support Dashboard](https://onnxruntime.github.io/mobius/dashboard/index.html)
 
 ```{toctree}
 :maxdepth: 2


### PR DESCRIPTION
The model support dashboard link in `docs/index.md` was incorrectly using a relative path (`dashboard/index.html`), which Sphinx/MyST converts to a hash fragment (`#dashboard/index.html`) since the dashboard HTML is generated and placed in the output directory — not a Sphinx source document.

Changed to use the full absolute URL (`https://onnxruntime.github.io/mobius/dashboard/index.html`) so the link renders correctly.