### PR TITLE
Remove manual dtype/shape setting for graph outputs

### DIFF
--- a/src/mobius/tasks/_base.py
+++ b/src/mobius/tasks/_base.py
@@ -138,33 +138,16 @@ def _register_kv_cache_outputs(
     graph: ir.Graph,
     present_key_values: list[tuple[ir.Value, ir.Value]],
     *,
-    past_key_values: list[tuple[ir.Value, ir.Value]] | None = None,
     prefix: str = "present",
 ) -> None:
     """Name and register KV cache outputs on the graph.
 
-    When ``past_key_values`` is provided, output shapes are derived from
-    the corresponding past inputs (replacing the sequence-length dimension
-    with a ``total_sequence_len`` symbolic dim).
+    Output shapes and dtypes are inferred by the shape inference pass
+    that runs during model optimization.
     """
-    total_seq_len = ir.SymbolicDim("total_sequence_len")
     for i, (present_key, present_value) in enumerate(present_key_values):
         present_key.name = f"{prefix}.{i}.key"
         present_value.name = f"{prefix}.{i}.value"
-        if past_key_values is not None:
-            past_k, past_v = past_key_values[i]
-            if past_k.shape is not None and len(past_k.shape) >= 3:
-                present_key.shape = ir.Shape(
-                    [*past_k.shape[:-2], total_seq_len, past_k.shape[-1]]
-                )
-            if past_k.type is not None:
-                present_key.type = past_k.type
-            if past_v.shape is not None and len(past_v.shape) >= 3:
-                present_value.shape = ir.Shape(
-                    [*past_v.shape[:-2], total_seq_len, past_v.shape[-1]]
-                )
-            if past_v.type is not None:
-                present_value.type = past_v.type
         graph.outputs.append(present_key)
         graph.outputs.append(present_value)
 
@@ -333,7 +316,6 @@ def _register_hybrid_cache_outputs(
     present_key_values: list[tuple[ir.Value, ...]],
     layer_types: list[str],
     *,
-    past_key_values: list[tuple[ir.Value, ...]] | None = None,
     prefix: str = "present",
 ) -> None:
     """Name and register hybrid cache outputs on the graph.
@@ -343,10 +325,9 @@ def _register_hybrid_cache_outputs(
     ``.conv_state``/``.recurrent_state`` for linear attention layers,
     and ``.conv_state``/``.ssm_state`` for mamba/mamba2 layers.
 
-    When ``past_key_values`` is provided, output shapes are derived
-    from the corresponding past inputs.
+    Output shapes and dtypes are inferred by the shape inference pass
+    that runs during model optimization.
     """
-    total_seq_len = ir.SymbolicDim("total_sequence_len")
     for i, states in enumerate(present_key_values):
         ltype = layer_types[i] if i < len(layer_types) else "full_attention"
         if ltype == "mlp":
@@ -355,12 +336,6 @@ def _register_hybrid_cache_outputs(
             # Single recurrent state only (no conv_state for lightning)
             (state_a,) = states
             state_a.name = f"{prefix}.{i}.recurrent_state"
-            if past_key_values is not None:
-                (past_a,) = past_key_values[i]
-                if past_a.shape is not None:
-                    state_a.shape = past_a.shape
-                if past_a.type is not None:
-                    state_a.type = past_a.type
             graph.outputs.append(state_a)
         else:
             state_a, state_b = states
@@ -373,28 +348,6 @@ def _register_hybrid_cache_outputs(
             else:
                 state_a.name = f"{prefix}.{i}.key"
                 state_b.name = f"{prefix}.{i}.value"
-            if past_key_values is not None:
-                past_a, past_b = past_key_values[i]
-                if ltype == "full_attention":
-                    # KV cache: replace seq_len dim with total_seq_len
-                    if past_a.shape is not None and len(past_a.shape) >= 3:
-                        state_a.shape = ir.Shape(
-                            [*past_a.shape[:-2], total_seq_len, past_a.shape[-1]]
-                        )
-                    if past_b.shape is not None and len(past_b.shape) >= 3:
-                        state_b.shape = ir.Shape(
-                            [*past_b.shape[:-2], total_seq_len, past_b.shape[-1]]
-                        )
-                else:
-                    # Recurrent/conv states have fixed shape
-                    if past_a.shape is not None:
-                        state_a.shape = past_a.shape
-                    if past_b.shape is not None:
-                        state_b.shape = past_b.shape
-                if past_a.type is not None:
-                    state_a.type = past_a.type
-                if past_b.type is not None:
-                    state_b.type = past_b.type
             graph.outputs.append(state_a)
             graph.outputs.append(state_b)
 

--- a/src/mobius/tasks/_causal_lm.py
+++ b/src/mobius/tasks/_causal_lm.py
@@ -183,20 +183,14 @@ class CausalLMTask(ModelTask):
 
         # --- Output registration (static vs dynamic) ---
         if static:
-            kv_hidden = config.num_key_value_heads * config.head_dim
             _register_static_cache_outputs(
                 graph,
                 present_key_values,
-                config.dtype,
-                batch,
-                max_seq_len,
-                kv_hidden,
             )
         else:
             _register_kv_cache_outputs(
                 graph,
                 present_key_values,
-                past_key_values=past_key_values,
             )
 
         return ModelPackage({"model": _make_model(graph)}, config=config)
@@ -275,7 +269,6 @@ class HybridCausalLMTask(ModelTask):
             graph,
             present_key_values,
             config.layer_types or [],
-            past_key_values=past_key_values,
         )
 
         model = _make_model(graph)
@@ -348,19 +341,15 @@ def _make_static_cache_inputs(
 def _register_static_cache_outputs(
     graph: ir.Graph,
     present_key_values: list[tuple[ir.Value, ir.Value]],
-    dtype: ir.DataType,
-    batch: ir.SymbolicDim,
-    max_seq_len: int,
-    kv_hidden: int,
 ) -> None:
-    """Name and register static cache outputs on the graph."""
+    """Name and register static cache outputs on the graph.
+
+    Output shapes and dtypes are inferred by the shape inference pass
+    that runs during model optimization.
+    """
     for i, (updated_key, updated_value) in enumerate(present_key_values):
         updated_key.name = f"updated_key_cache.{i}"
         updated_value.name = f"updated_value_cache.{i}"
-        updated_key.shape = ir.Shape([batch, max_seq_len, kv_hidden])
-        updated_key.type = ir.TensorType(dtype)
-        updated_value.shape = ir.Shape([batch, max_seq_len, kv_hidden])
-        updated_value.type = ir.TensorType(dtype)
         graph.outputs.append(updated_key)
         graph.outputs.append(updated_value)
 

--- a/src/mobius/tasks/_multimodal.py
+++ b/src/mobius/tasks/_multimodal.py
@@ -107,6 +107,6 @@ class MultiModalTask(ModelTask):
 
         logits.name = "logits"
         graph.outputs.append(logits)
-        _register_kv_cache_outputs(graph, present_key_values, past_key_values=past_key_values)
+        _register_kv_cache_outputs(graph, present_key_values)
 
         return ModelPackage({"model": _make_model(graph)}, config=config)

--- a/src/mobius/tasks/_phi4mm_multimodal.py
+++ b/src/mobius/tasks/_phi4mm_multimodal.py
@@ -228,6 +228,5 @@ class Phi4MMMultiModalTask(ModelTask):
         _register_kv_cache_outputs(
             graph,
             present_key_values,
-            past_key_values=past_key_values,
         )
         return _make_model(graph)

--- a/src/mobius/tasks/_seq2seq.py
+++ b/src/mobius/tasks/_seq2seq.py
@@ -152,29 +152,14 @@ class Seq2SeqTask(ModelTask):
         logits.name = "logits"
         graph.outputs.append(logits)
 
-        total_seq_len = ir.SymbolicDim("total_sequence_len")
         for i, (k, v) in enumerate(present_self_kvs):
             k.name = f"present.{i}.self.key"
             v.name = f"present.{i}.self.value"
-            past_k, past_v = past_self_kvs[i]
-            if past_k.shape is not None and len(past_k.shape) >= 3:
-                k.shape = ir.Shape([*past_k.shape[:-2], total_seq_len, past_k.shape[-1]])
-                k.type = past_k.type
-            if past_v.shape is not None and len(past_v.shape) >= 3:
-                v.shape = ir.Shape([*past_v.shape[:-2], total_seq_len, past_v.shape[-1]])
-                v.type = past_v.type
             graph.outputs.extend([k, v])
 
         for i, (k, v) in enumerate(present_cross_kvs):
             k.name = f"present.{i}.cross.key"
             v.name = f"present.{i}.cross.value"
-            past_k, past_v = cross_past_kvs[i]
-            if past_k.shape is not None:
-                k.shape = past_k.shape
-                k.type = past_k.type
-            if past_v.shape is not None:
-                v.shape = past_v.shape
-                v.type = past_v.type
             graph.outputs.extend([k, v])
 
         return _make_model(graph)

--- a/src/mobius/tasks/_speech_language.py
+++ b/src/mobius/tasks/_speech_language.py
@@ -162,5 +162,5 @@ class SpeechLanguageTask(ModelTask):
 
         logits.name = "logits"
         graph.outputs.append(logits)
-        _register_kv_cache_outputs(graph, present_key_values, past_key_values=past_key_values)
+        _register_kv_cache_outputs(graph, present_key_values)
         return _make_model(graph)

--- a/src/mobius/tasks/_speech_to_text.py
+++ b/src/mobius/tasks/_speech_to_text.py
@@ -125,6 +125,6 @@ class SpeechToTextTask(ModelTask):
 
         logits.name = "logits"
         graph.outputs.append(logits)
-        _register_kv_cache_outputs(graph, present_key_values, past_key_values=past_key_values)
+        _register_kv_cache_outputs(graph, present_key_values)
 
         return _make_model(graph)

--- a/src/mobius/tasks/_tts.py
+++ b/src/mobius/tasks/_tts.py
@@ -113,7 +113,7 @@ class TTSTask(ModelTask):
         last_hidden_state.name = "last_hidden_state"
         graph.outputs.append(logits)
         graph.outputs.append(last_hidden_state)
-        _register_kv_cache_outputs(graph, present_key_values, past_key_values=past_key_values)
+        _register_kv_cache_outputs(graph, present_key_values)
         return _make_model(graph)
 
     def _build_code_predictor(
@@ -206,7 +206,7 @@ class TTSTask(ModelTask):
         # the initializer name used for weight loading.
         codec_embeddings.name = "codec_embeddings"
         graph.outputs.append(codec_embeddings)
-        _register_kv_cache_outputs(graph, present_key_values, past_key_values=past_key_values)
+        _register_kv_cache_outputs(graph, present_key_values)
         return _make_model(graph)
 
     def _build_embedding(

--- a/src/mobius/tasks/_vision_language.py
+++ b/src/mobius/tasks/_vision_language.py
@@ -112,6 +112,6 @@ class Qwen3VLVisionLanguageTask(ModelTask):
 
         logits.name = "logits"
         graph.outputs.append(logits)
-        _register_kv_cache_outputs(graph, present_key_values, past_key_values=past_key_values)
+        _register_kv_cache_outputs(graph, present_key_values)
 
         return ModelPackage({"model": _make_model(graph)}, config=config)

--- a/src/mobius/tasks/_vision_language_3model.py
+++ b/src/mobius/tasks/_vision_language_3model.py
@@ -107,7 +107,7 @@ class VisionLanguageTask(ModelTask):
 
         logits.name = "logits"
         graph.outputs.append(logits)
-        _register_kv_cache_outputs(graph, present_key_values, past_key_values=past_key_values)
+        _register_kv_cache_outputs(graph, present_key_values)
 
         return _make_model(graph)
 
@@ -238,7 +238,7 @@ class QwenVLTask(VisionLanguageTask):
 
         logits.name = "logits"
         graph.outputs.append(logits)
-        _register_kv_cache_outputs(graph, present_key_values, past_key_values=past_key_values)
+        _register_kv_cache_outputs(graph, present_key_values)
 
         return _make_model(graph)
 
@@ -347,7 +347,6 @@ class HybridQwenVLTask(QwenVLTask):
             graph,
             present_key_values,
             config.layer_types or [],
-            past_key_values=past_key_values,
         )
 
         model = _make_model(graph)
@@ -458,6 +457,6 @@ class MllamaVisionLanguageTask(VisionLanguageTask):
 
         logits.name = "logits"
         graph.outputs.append(logits)
-        _register_kv_cache_outputs(graph, present_key_values, past_key_values=past_key_values)
+        _register_kv_cache_outputs(graph, present_key_values)
 
         return _make_model(graph)

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -44,6 +44,7 @@ from onnx_ir.passes.common import CheckerPass
 
 from mobius._builder import (
     DTYPE_MAP,
+    SymbolicShapeInferencePass,
     build_from_module,
 )
 from mobius._config_resolver import _default_task_for_model
@@ -64,6 +65,7 @@ from mobius.tasks import (
 )
 
 _onnx_checker = CheckerPass()
+_shape_inference = SymbolicShapeInferencePass()
 
 # Models where the ONNX checker fails due to upstream onnx-ir issues
 # (e.g. value_info missing type field for custom ops).
@@ -98,6 +100,7 @@ def _run_onnx_checker(pkg: dict[str, ir.Model], model_type: str) -> None:
     """Run ONNX CheckerPass on all models in a package.
 
     Skips models in ``_CHECKER_SKIP_MODELS`` that have known upstream issues.
+    Runs shape inference first since the checker requires output shapes.
     """
     if model_type in _CHECKER_SKIP_MODELS:
         pytest.skip(
@@ -105,6 +108,7 @@ def _run_onnx_checker(pkg: dict[str, ir.Model], model_type: str) -> None:
             "upstream onnx-ir value_info missing type field for custom ops"
         )
     for model in pkg.values():
+        _shape_inference(model)
         _fill_dummy_weights(model)
         _onnx_checker(model)
 

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -113,6 +113,37 @@ def _run_onnx_checker(pkg: dict[str, ir.Model], model_type: str) -> None:
         _onnx_checker(model)
 
 
+def _assert_outputs_have_shapes_and_dtypes(
+    pkg: dict[str, ir.Model],
+    model_type: str,
+) -> None:
+    """Assert every graph output has a non-None shape and dtype.
+
+    Runs shape inference first (same as the real optimization pipeline)
+    to populate output metadata, then verifies all outputs have both
+    shape and type set.
+
+    Skips models in ``_CHECKER_SKIP_MODELS`` whose custom ops prevent
+    full shape propagation.
+    """
+    if model_type in _CHECKER_SKIP_MODELS:
+        pytest.skip(
+            f"Shape assertion skipped for {model_type}: "
+            "custom ops prevent full shape propagation"
+        )
+    for sub_name, model in pkg.items():
+        _shape_inference(model)
+        for output in model.graph.outputs:
+            assert output.shape is not None, (
+                f"{model_type}/{sub_name}: output '{output.name}' "
+                f"has no shape after shape inference"
+            )
+            assert output.type is not None, (
+                f"{model_type}/{sub_name}: output '{output.name}' "
+                f"has no dtype after shape inference"
+            )
+
+
 # Minimal configs for each architecture. These are hand-crafted small configs
 # that exercise each model class without needing to download from HuggingFace.
 
@@ -270,6 +301,15 @@ class TestBuildGraph:
         pkg = task.build(module, config)
         _run_onnx_checker(pkg, model_type)
 
+    def test_outputs_have_shapes_and_dtypes(self, model_type: str, config_overrides: dict):
+        """Verify shape inference populates all output shapes and dtypes."""
+        config = _base_config(**config_overrides)
+        model_cls = registry.get(model_type)
+        module = model_cls(config)
+        task = get_task(_default_task_for_model(model_type))
+        pkg = task.build(module, config)
+        _assert_outputs_have_shapes_and_dtypes(pkg, model_type)
+
 
 # === Encoder-only model configs (imported from _test_configs) ===
 _ENCODER_MODEL_CONFIGS: list[tuple[str, dict]] = [(mt, ov) for mt, ov, _ in ENCODER_CONFIGS]
@@ -334,6 +374,15 @@ class TestBuildEncoderGraph:
         pkg = task.build(module, config)
         _run_onnx_checker(pkg, model_type)
 
+    def test_outputs_have_shapes_and_dtypes(self, model_type: str, config_overrides: dict):
+        """Verify shape inference populates all output shapes and dtypes."""
+        config = _base_config(**config_overrides)
+        model_cls = registry.get(model_type)
+        module = model_cls(config)
+        task = get_task(_default_task_for_model(model_type))
+        pkg = task.build(module, config)
+        _assert_outputs_have_shapes_and_dtypes(pkg, model_type)
+
 
 # === Encoder-decoder model configs (imported from _test_configs) ===
 _SEQ2SEQ_MODEL_CONFIGS: list[tuple[str, dict]] = [(mt, ov) for mt, ov, _ in SEQ2SEQ_CONFIGS]
@@ -384,6 +433,15 @@ class TestBuildSeq2SeqGraph:
         pkg = task.build(module, config)
         _run_onnx_checker(pkg, model_type)
 
+    def test_outputs_have_shapes_and_dtypes(self, model_type: str, config_overrides: dict):
+        """Verify shape inference populates all output shapes and dtypes."""
+        config = _base_config(**config_overrides)
+        model_cls = registry.get(model_type)
+        module = model_cls(config)
+        task = get_task(_default_task_for_model(model_type))
+        pkg = task.build(module, config)
+        _assert_outputs_have_shapes_and_dtypes(pkg, model_type)
+
 
 # === Vision model configs (imported from _test_configs) ===
 _VISION_MODEL_CONFIGS: list[tuple[str, dict]] = [(mt, ov) for mt, ov, _ in VISION_CONFIGS]
@@ -419,6 +477,15 @@ class TestBuildVisionGraph:
         task = get_task(_default_task_for_model(model_type))
         pkg = task.build(module, config)
         _run_onnx_checker(pkg, model_type)
+
+    def test_outputs_have_shapes_and_dtypes(self, model_type: str, config_overrides: dict):
+        """Verify shape inference populates all output shapes and dtypes."""
+        config = _base_config(**config_overrides)
+        model_cls = registry.get(model_type)
+        module = model_cls(config)
+        task = get_task(_default_task_for_model(model_type))
+        pkg = task.build(module, config)
+        _assert_outputs_have_shapes_and_dtypes(pkg, model_type)
 
 
 # === Object detection model configs (imported from _test_configs) ===
@@ -458,6 +525,15 @@ class TestBuildDetectionGraph:
         task = get_task(_default_task_for_model(model_type))
         pkg = task.build(module, config)
         _run_onnx_checker(pkg, model_type)
+
+    def test_outputs_have_shapes_and_dtypes(self, model_type: str, config_overrides: dict):
+        """Verify shape inference populates all output shapes and dtypes."""
+        config = _base_config(**config_overrides)
+        model_cls = registry.get(model_type)
+        module = model_cls(config)
+        task = get_task(_default_task_for_model(model_type))
+        pkg = task.build(module, config)
+        _assert_outputs_have_shapes_and_dtypes(pkg, model_type)
 
 
 # === SSM (Mamba/Mamba2) configs ===
@@ -517,6 +593,15 @@ class TestBuildSSMGraph:
         task = get_task(_default_task_for_model(model_type))
         pkg = task.build(module, config)
         _run_onnx_checker(pkg, model_type)
+
+    def test_outputs_have_shapes_and_dtypes(self, model_type: str, config_overrides: dict):
+        """Verify shape inference populates all output shapes and dtypes."""
+        config = _base_config(**config_overrides)
+        model_cls = registry.get(model_type)
+        module = model_cls(config)
+        task = get_task(_default_task_for_model(model_type))
+        pkg = task.build(module, config)
+        _assert_outputs_have_shapes_and_dtypes(pkg, model_type)
 
 
 class TestBuildGraphLoRA:
@@ -3470,3 +3555,8 @@ class TestBuildStaticCacheGraph:
         op_types = {n.op_type for n in model.graph}
         assert "TensorScatter" in op_types
         assert "Attention" in op_types
+
+    def test_outputs_have_shapes_and_dtypes(self):
+        """Verify shape inference populates all output shapes and dtypes."""
+        model, _ = self._build_static_cache_model()
+        _assert_outputs_have_shapes_and_dtypes({"model": model}, "qwen2-static")


### PR DESCRIPTION
## Summary

The shape inference pass (`SymbolicShapeInferencePass`) already infers output dtype/shape automatically during model optimization. This removes redundant manual shape/type assignments from output registration functions in task files.

## Changes

### Task files (10 files, -71 lines net)

- **`_register_kv_cache_outputs()`** (`_base.py`): Removed `past_key_values` parameter and shape derivation logic. Now only names and registers outputs.
- **`_register_hybrid_cache_outputs()`** (`_base.py`): Removed `past_key_values` parameter and all shape/type copying for full_attention, linear_attention, mamba, and lightning_attention layer types.
- **`_register_static_cache_outputs()`** (`_causal_lm.py`): Removed `dtype`, `batch`, `max_seq_len`, `kv_hidden` parameters and explicit shape/type setting.
- **`_seq2seq.py`**: Removed inline shape/type assignments for self-attention and cross-attention KV cache outputs.
- Updated all callers in `_multimodal.py`, `_phi4mm_multimodal.py`, `_speech_language.py`, `_speech_to_text.py`, `_tts.py`, `_vision_language.py`, `_vision_language_3model.py`.

### Test infrastructure

- `tests/build_graph_test.py`: Run `SymbolicShapeInferencePass` before the ONNX checker in `_run_onnx_checker()` to match the real pipeline (checker requires output shapes).

## Test Results

1860 passed, 9 skipped, 0 failed. Lint clean.