### PR TITLE
Add ComponentSpec for multi-model task validation

### DIFF
--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -205,7 +205,7 @@ class TestAutoExportEndToEnd:
         assert "vision" in pkg
         assert "speech" in pkg
         assert "embedding" in pkg
-        assert "model" in pkg
+        assert "decoder" in pkg
 
         # Simulate auto_export detection logic
         is_vlm = "vision" in pkg and "embedding" in pkg

--- a/src/mobius/integrations/ort_genai/genai_config.py
+++ b/src/mobius/integrations/ort_genai/genai_config.py
@@ -290,9 +290,12 @@ class GenaiConfigGenerator:
         is_multimodal = self._vision is not None or self._speech is not None
 
         # Decoder section
+        # For multi-model (VLM) packages, decoder is saved in decoder/ subfolder.
+        # For single-model LLMs, it's at the root as model.onnx.
+        decoder_filename = "decoder/model.onnx" if is_multimodal else "model.onnx"
         decoder: dict[str, Any] = {
             "session_options": _default_session_options(),
-            "filename": "model.onnx",
+            "filename": decoder_filename,
             "head_size": self.head_dim,
             "hidden_size": self.hidden_size,
             "inputs": _default_decoder_inputs(is_vlm=is_multimodal),

--- a/src/mobius/integrations/ort_genai/genai_config_test.py
+++ b/src/mobius/integrations/ort_genai/genai_config_test.py
@@ -452,6 +452,25 @@ class TestGenaiConfigGeneratorMultimodal:
         assert "inputs_embeds" in inputs
         assert "input_id" not in inputs
 
+    def test_multimodal_decoder_filename_uses_subfolder(self):
+        """Multimodal decoder filename points to decoder/ subfolder."""
+        config = self._make_phi4mm_gen().generate()
+        assert config["model"]["decoder"]["filename"] == "decoder/model.onnx"
+
+    def test_single_model_decoder_filename_is_flat(self):
+        """Single-model (LLM) decoder filename is flat model.onnx."""
+        gen = GenaiConfigGenerator(
+            "llama",
+            vocab_size=32000,
+            hidden_size=512,
+            num_hidden_layers=4,
+            num_attention_heads=8,
+            num_key_value_heads=8,
+            head_dim=64,
+        )
+        config = gen.generate()
+        assert config["model"]["decoder"]["filename"] == "model.onnx"
+
     def test_speech_only_uses_inputs_embeds(self):
         """Speech-only (no vision) still uses inputs_embeds."""
         gen = GenaiConfigGenerator(

--- a/src/mobius/tasks/__init__.py
+++ b/src/mobius/tasks/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "AudioFeatureExtractionTask",
     "CausalLMTask",
     "CodecTask",
+    "ComponentSpec",
     "ControlNetTask",
     "DenoisingTask",
     "FeatureExtractionTask",
@@ -54,7 +55,7 @@ __all__ = [
 from mobius._constants import OPSET_VERSION
 from mobius.tasks._adapter import AdapterTask
 from mobius.tasks._audio_feature_extraction import AudioFeatureExtractionTask
-from mobius.tasks._base import ModelTask
+from mobius.tasks._base import ComponentSpec, ModelTask
 from mobius.tasks._causal_lm import (
     CausalLMTask,
     HybridCausalLMTask,

--- a/src/mobius/tasks/_base.py
+++ b/src/mobius/tasks/_base.py
@@ -18,6 +18,76 @@ from mobius._constants import OPSET_VERSION
 from mobius._model_package import ModelPackage
 
 
+class ComponentSpec:
+    """Declares which sub-module attributes a multi-component task requires.
+
+    Used by multi-component tasks (e.g. :class:`VisionLanguageTask`) to
+    validate that a module exposes the expected sub-module attributes before
+    building begins.  This produces a clear :exc:`TypeError` instead of the
+    cryptic ``AttributeError`` that would otherwise surface deep inside
+    ``build()``.
+
+    Map output model names to the module attribute that builds each component::
+
+        ComponentSpec(
+            decoder="decoder",
+            vision="vision_encoder",
+            embedding="embedding",
+        )
+
+    The keys are the names used in the output :class:`ModelPackage`; the
+    values are the attribute names on the ``nn.Module`` passed to
+    ``task.build()``.
+
+    Args:
+        **components: Keyword arguments mapping output name → module attribute
+            name.  For example, ``vision="vision_encoder"`` means the task
+            expects ``module.vision_encoder`` and will store the result as
+            ``package["vision"]``.
+    """
+
+    def __init__(self, **components: str) -> None:
+        # output_name -> module attribute name
+        self._components: dict[str, str] = dict(components)
+
+    def validate(self, module: nn.Module, task_name: str) -> None:
+        """Check that all required sub-module attributes exist on *module*.
+
+        Args:
+            module: The module passed to ``task.build()``.
+            task_name: Name of the task class (for the error message).
+
+        Raises:
+            TypeError: If any required attribute is absent from *module*, with
+                a message that lists every missing component and the attribute
+                name expected for each.
+        """
+        missing = [
+            (output_name, attr_name)
+            for output_name, attr_name in self._components.items()
+            if not hasattr(module, attr_name)
+        ]
+        if not missing:
+            return
+        lines = "\n".join(
+            f"  '{output_name}' component expects module.{attr_name}"
+            for output_name, attr_name in missing
+        )
+        raise TypeError(
+            f"{task_name} requires sub-module attribute(s) that are missing "
+            f"from {type(module).__name__}:\n{lines}\n"
+            f"Ensure each attribute is assigned in the module's __init__()."
+        )
+
+    def items(self):
+        """Iterate over ``(output_name, attribute_name)`` pairs."""
+        return self._components.items()
+
+    def __repr__(self) -> str:
+        parts = ", ".join(f"{k}={v!r}" for k, v in self._components.items())
+        return f"ComponentSpec({parts})"
+
+
 def _make_graph(
     inputs: list[ir.Value],
     name: str = "main_graph",
@@ -50,6 +120,16 @@ class ModelTask(ABC):
 
     Subclass this to support new model tasks (e.g. feature extraction,
     sequence classification). Each task defines its own graph I/O contract.
+
+    Multi-component tasks should declare a class-level :class:`ComponentSpec`
+    and call :meth:`_validate_components` at the start of ``build()``::
+
+        class MyMultiModelTask(ModelTask):
+            components = ComponentSpec(decoder="decoder", vision="vision_encoder")
+
+            def build(self, module, config):
+                self._validate_components(module)
+                ...
     """
 
     #: Maps package key → optimization role for each model produced by this task.
@@ -57,6 +137,11 @@ class ModelTask(ABC):
     #: GQA fusion). Override in subclasses that produce non-decoder outputs.
     #: Unrecognised keys default to ``"decoder"``.
     model_roles: ClassVar[dict[str, str]] = {"model": "decoder"}
+
+    #: Optional component spec for multi-component tasks.  When set,
+    #: :meth:`_validate_components` checks that all declared attributes
+    #: exist on the module before building begins.
+    components: ComponentSpec | None = None
 
     @abstractmethod
     def build(
@@ -78,3 +163,18 @@ class ModelTask(ABC):
             A :class:`ModelPackage` containing the built model(s).
         """
         ...
+
+    def _validate_components(self, module: nn.Module) -> None:
+        """Validate that *module* exposes all components declared in ``self.components``.
+
+        No-op when ``self.components`` is ``None``.  Multi-component tasks
+        should call this at the start of ``build()`` so that missing
+        sub-module attributes are caught with a helpful error rather than an
+        ``AttributeError`` deep inside the build.
+
+        Raises:
+            TypeError: If any required sub-module attribute is absent from
+                *module*.
+        """
+        if self.components is not None:
+            self.components.validate(module, type(self).__name__)

--- a/src/mobius/tasks/_base.py
+++ b/src/mobius/tasks/_base.py
@@ -53,6 +53,9 @@ class ComponentSpec:
     def validate(self, module: nn.Module, task_name: str) -> None:
         """Check that all required sub-module attributes exist on *module*.
 
+        Attribute names may use dot notation to reference nested attributes,
+        e.g. ``"model.encoder"`` checks that ``module.model.encoder`` exists.
+
         Args:
             module: The module passed to ``task.build()``.
             task_name: Name of the task class (for the error message).
@@ -62,10 +65,18 @@ class ComponentSpec:
                 a message that lists every missing component and the attribute
                 name expected for each.
         """
+
+        def _has_nested(obj: object, dotted: str) -> bool:
+            for part in dotted.split("."):
+                if not hasattr(obj, part):
+                    return False
+                obj = getattr(obj, part)
+            return True
+
         missing = [
             (output_name, attr_name)
             for output_name, attr_name in self._components.items()
-            if not hasattr(module, attr_name)
+            if not _has_nested(module, attr_name)
         ]
         if not missing:
             return
@@ -141,7 +152,7 @@ class ModelTask(ABC):
     #: Optional component spec for multi-component tasks.  When set,
     #: :meth:`_validate_components` checks that all declared attributes
     #: exist on the module before building begins.
-    components: ComponentSpec | None = None
+    components: ClassVar[ComponentSpec | None] = None
 
     @abstractmethod
     def build(

--- a/src/mobius/tasks/_phi4mm_multimodal.py
+++ b/src/mobius/tasks/_phi4mm_multimodal.py
@@ -25,6 +25,7 @@ from onnxscript import nn
 from mobius._configs import ArchitectureConfig
 from mobius._model_package import ModelPackage
 from mobius.tasks._base import (
+    ComponentSpec,
     ModelTask,
     _make_graph,
     _make_model,
@@ -48,11 +49,19 @@ class Phi4MMMultiModalTask(ModelTask):
     Each sub-module is wired into its own ONNX graph.
     """
 
+    components = ComponentSpec(
+        vision="vision_encoder",
+        speech="speech_encoder",
+        embedding="embedding",
+        model="decoder",
+    )
+
     def build(
         self,
         module: nn.Module,
         config: ArchitectureConfig,
     ) -> ModelPackage:
+        self._validate_components(module)
         models: dict[str, ir.Model] = {}
 
         models["vision"] = self._build_vision(module.vision_encoder, config)

--- a/src/mobius/tasks/_phi4mm_multimodal.py
+++ b/src/mobius/tasks/_phi4mm_multimodal.py
@@ -53,7 +53,7 @@ class Phi4MMMultiModalTask(ModelTask):
         vision="vision_encoder",
         speech="speech_encoder",
         embedding="embedding",
-        model="decoder",
+        decoder="decoder",
     )
 
     def build(
@@ -67,7 +67,7 @@ class Phi4MMMultiModalTask(ModelTask):
         models["vision"] = self._build_vision(module.vision_encoder, config)
         models["speech"] = self._build_speech(module.speech_encoder, config)
         models["embedding"] = self._build_embedding(module.embedding, config)
-        models["model"] = self._build_decoder(module.decoder, config)
+        models["decoder"] = self._build_decoder(module.decoder, config)
 
         return ModelPackage(models, config=config)
 

--- a/src/mobius/tasks/_seq2seq.py
+++ b/src/mobius/tasks/_seq2seq.py
@@ -11,6 +11,7 @@ from onnxscript import nn
 from mobius._configs import ArchitectureConfig
 from mobius._model_package import ModelPackage
 from mobius.tasks._base import (
+    ComponentSpec,
     ModelTask,
     _make_graph,
     _make_model,
@@ -31,11 +32,14 @@ class Seq2SeqTask(ModelTask):
     The module must have ``encoder`` and ``decoder`` attributes.
     """
 
+    components = ComponentSpec(encoder="encoder", decoder="decoder")
+
     def build(
         self,
         module: nn.Module,
         config: ArchitectureConfig,
     ) -> ModelPackage:
+        self._validate_components(module)
         encoder_model = self._build_encoder_graph(module, config)
         decoder_model = self._build_decoder_graph(module, config)
         return ModelPackage(

--- a/src/mobius/tasks/_speech_language.py
+++ b/src/mobius/tasks/_speech_language.py
@@ -19,6 +19,7 @@ from onnxscript import nn
 from mobius._configs import ArchitectureConfig
 from mobius._model_package import ModelPackage
 from mobius.tasks._base import (
+    ComponentSpec,
     ModelTask,
     _make_graph,
     _make_model,
@@ -41,11 +42,18 @@ class SpeechLanguageTask(ModelTask):
     Each sub-module is wired into its own ONNX graph.
     """
 
+    components = ComponentSpec(
+        audio_encoder="audio_tower",
+        embedding="embedding",
+        decoder="decoder",
+    )
+
     def build(
         self,
         module: nn.Module,
         config: ArchitectureConfig,
     ) -> ModelPackage:
+        self._validate_components(module)
         models: dict[str, ir.Model] = {}
 
         models["audio_encoder"] = self._build_audio_encoder(module.audio_tower, config)

--- a/src/mobius/tasks/_speech_to_text.py
+++ b/src/mobius/tasks/_speech_to_text.py
@@ -36,7 +36,7 @@ class SpeechToTextTask(ModelTask):
     (matching the :class:`WhisperForConditionalGeneration` layout).
     """
 
-    components = ComponentSpec(model="model")
+    components = ComponentSpec(encoder="model.encoder", decoder="model.decoder")
 
     def build(
         self,

--- a/src/mobius/tasks/_speech_to_text.py
+++ b/src/mobius/tasks/_speech_to_text.py
@@ -11,6 +11,7 @@ from onnxscript import nn
 from mobius._configs import BaseModelConfig, WhisperConfig
 from mobius._model_package import ModelPackage
 from mobius.tasks._base import (
+    ComponentSpec,
     ModelTask,
     _make_graph,
     _make_model,
@@ -35,11 +36,14 @@ class SpeechToTextTask(ModelTask):
     (matching the :class:`WhisperForConditionalGeneration` layout).
     """
 
+    components = ComponentSpec(model="model")
+
     def build(
         self,
         module: nn.Module,
         config: BaseModelConfig,
     ) -> ModelPackage:
+        self._validate_components(module)
         if not isinstance(config, WhisperConfig):
             raise TypeError(
                 f"SpeechToTextTask requires WhisperConfig, got {type(config).__name__}"

--- a/src/mobius/tasks/_task_test.py
+++ b/src/mobius/tasks/_task_test.py
@@ -449,6 +449,40 @@ class TestSeq2SeqTask:
         for model in pkg.values():
             assert model.producer_name == "mobius"
 
+    def test_validates_missing_encoder(self):
+        """Seq2SeqTask raises TypeError when module lacks 'encoder'."""
+        from onnxscript import nn as _nn
+
+        class NoEncoder(_nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.decoder = _nn.Module()
+
+            def forward(self, op):
+                pass
+
+        config = make_config(hidden_act="gelu", max_position_embeddings=64)
+        task = Seq2SeqTask()
+        with pytest.raises(TypeError, match="encoder"):
+            task.build(NoEncoder(), config)
+
+    def test_validates_missing_decoder(self):
+        """Seq2SeqTask raises TypeError when module lacks 'decoder'."""
+        from onnxscript import nn as _nn
+
+        class NoDecoder(_nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.encoder = _nn.Module()
+
+            def forward(self, op):
+                pass
+
+        config = make_config(hidden_act="gelu", max_position_embeddings=64)
+        task = Seq2SeqTask()
+        with pytest.raises(TypeError, match="decoder"):
+            task.build(NoDecoder(), config)
+
 
 # ── DenoisingTask ────────────────────────────────────────────────────────
 
@@ -602,6 +636,33 @@ class TestVAETask:
         pkg = task.build(module, config)
         for model in pkg.values():
             assert model.producer_name == "mobius"
+
+    def test_validates_missing_encoder(self):
+        """VAETask raises TypeError when module lacks 'encoder'."""
+        from onnxscript import nn as _nn
+
+        class NoEncoder(_nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.decoder = _nn.Module()
+                self.quant_conv = None
+                self.post_quant_conv = None
+
+            def forward(self, op):
+                pass
+
+        from mobius._diffusers_configs import VAEConfig
+
+        config = VAEConfig(
+            in_channels=3,
+            out_channels=3,
+            latent_channels=4,
+            block_out_channels=(32, 64),
+            layers_per_block=1,
+        )
+        task = VAETask()
+        with pytest.raises(TypeError, match="encoder"):
+            task.build(NoEncoder(), config)
 
 
 # ── FeatureExtractionTask ────────────────────────────────────────────────
@@ -1063,3 +1124,36 @@ class TestSpeechToTextTask:
         assert "logits" in output_names
         assert "present.0.key" in output_names
         assert "present.0.value" in output_names
+
+    def test_validates_missing_model_attr(self):
+        """SpeechToTextTask raises TypeError when module lacks 'model'."""
+        from onnxscript import nn as _nn
+
+        class NoModelAttr(_nn.Module):
+            def forward(self, op):
+                pass
+
+        from mobius._configs import WhisperConfig
+
+        config = WhisperConfig(
+            vocab_size=100,
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            head_dim=16,
+            hidden_act="gelu",
+            pad_token_id=0,
+            encoder_layers=2,
+            encoder_attention_heads=4,
+            encoder_ffn_dim=128,
+            num_mel_bins=40,
+            max_source_positions=64,
+            max_target_positions=32,
+            attn_qkv_bias=True,
+            attn_o_bias=True,
+        )
+        task = SpeechToTextTask()
+        with pytest.raises(TypeError, match="model"):
+            task.build(NoModelAttr(), config)

--- a/src/mobius/tasks/_task_test.py
+++ b/src/mobius/tasks/_task_test.py
@@ -5,7 +5,7 @@
 
 Covers: CausalLM, VisionLanguage, Seq2Seq, Denoising, VAE,
 FeatureExtraction, ImageClassification, SSM, SSM2, AudioFeatureExtraction,
-ObjectDetection, SpeechToText, ComponentSpec.
+ObjectDetection, SpeechToText, SpeechLanguage, Phi4MMMultiModal, ComponentSpec.
 """
 
 from __future__ import annotations
@@ -28,7 +28,9 @@ from mobius.tasks import (
     ImageClassificationTask,
     ModelTask,
     ObjectDetectionTask,
+    Phi4MMMultiModalTask,
     Seq2SeqTask,
+    SpeechLanguageTask,
     SpeechToTextTask,
     SSM2CausalLMTask,
     SSMCausalLMTask,
@@ -226,6 +228,45 @@ class TestComponentSpec:
         task = VisionLanguageTask()
         with pytest.raises(TypeError, match="vision_encoder"):
             task.build(IncompleteVLModule(), config)
+
+    def test_speech_language_task_validates_on_build(self):
+        """SpeechLanguageTask.build() raises TypeError on missing sub-module."""
+        from onnxscript import nn as _nn
+
+        class IncompleteSpeechModule(_nn.Module):
+            """Has audio_tower but is missing embedding and decoder."""
+
+            def __init__(self):
+                super().__init__()
+                self.audio_tower = _nn.Module()
+
+            def forward(self, op):
+                pass
+
+        config = _make_multimodal_config()
+        task = SpeechLanguageTask()
+        with pytest.raises(TypeError, match="embedding"):
+            task.build(IncompleteSpeechModule(), config)
+
+    def test_phi4mm_task_validates_on_build(self):
+        """Phi4MMMultiModalTask.build() raises TypeError on missing sub-module."""
+        from onnxscript import nn as _nn
+
+        class IncompletePhi4MMModule(_nn.Module):
+            """Has vision_encoder and speech_encoder but missing embedding and decoder."""
+
+            def __init__(self):
+                super().__init__()
+                self.vision_encoder = _nn.Module()
+                self.speech_encoder = _nn.Module()
+
+            def forward(self, op):
+                pass
+
+        config = _make_multimodal_config()
+        task = Phi4MMMultiModalTask()
+        with pytest.raises(TypeError, match="embedding"):
+            task.build(IncompletePhi4MMModule(), config)
 
     def test_validate_components_noop_when_no_spec(self):
         """Tasks without components declared should not raise."""
@@ -1155,5 +1196,5 @@ class TestSpeechToTextTask:
             attn_o_bias=True,
         )
         task = SpeechToTextTask()
-        with pytest.raises(TypeError, match="model"):
+        with pytest.raises(TypeError, match=r"model\.encoder"):
             task.build(NoModelAttr(), config)

--- a/src/mobius/tasks/_task_test.py
+++ b/src/mobius/tasks/_task_test.py
@@ -246,6 +246,8 @@ class TestComponentSpec:
         task = NoSpecTask()
         task._validate_components(EmptyModule())  # must not raise
 
+
+class TestCustomModuleWithTask:
     """Test the user story: custom module + standard task."""
 
     def test_custom_module_with_causal_lm_task(self):

--- a/src/mobius/tasks/_task_test.py
+++ b/src/mobius/tasks/_task_test.py
@@ -5,7 +5,7 @@
 
 Covers: CausalLM, VisionLanguage, Seq2Seq, Denoising, VAE,
 FeatureExtraction, ImageClassification, SSM, SSM2, AudioFeatureExtraction,
-ObjectDetection, SpeechToText.
+ObjectDetection, SpeechToText, ComponentSpec.
 """
 
 from __future__ import annotations
@@ -22,6 +22,7 @@ from mobius.tasks import (
     TASK_REGISTRY,
     AudioFeatureExtractionTask,
     CausalLMTask,
+    ComponentSpec,
     DenoisingTask,
     FeatureExtractionTask,
     ImageClassificationTask,
@@ -116,7 +117,135 @@ class TestCustomTask:
         assert pkg["model"].graph.name == "custom"
 
 
-class TestCustomModuleWithTask:
+class TestComponentSpec:
+    """Tests for ComponentSpec: declaration, validation, and error messaging."""
+
+    def test_repr(self):
+        spec = ComponentSpec(decoder="decoder", vision="vision_encoder")
+        assert "decoder" in repr(spec)
+        assert "vision_encoder" in repr(spec)
+
+    def test_items(self):
+        spec = ComponentSpec(decoder="decoder", vision="vision_encoder")
+        pairs = dict(spec.items())
+        assert pairs == {"decoder": "decoder", "vision": "vision_encoder"}
+
+    def test_validate_passes_when_all_present(self):
+        from onnxscript import nn as _nn
+
+        class GoodModule(_nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.decoder = _nn.Module()
+                self.vision_encoder = _nn.Module()
+                self.embedding = _nn.Module()
+
+            def forward(self, op):
+                pass
+
+        spec = ComponentSpec(
+            decoder="decoder",
+            vision="vision_encoder",
+            embedding="embedding",
+        )
+        # Should not raise
+        spec.validate(GoodModule(), "MyTask")
+
+    def test_validate_raises_on_missing_single(self):
+        from onnxscript import nn as _nn
+
+        class BadModule(_nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.decoder = _nn.Module()
+                # vision_encoder is missing
+
+            def forward(self, op):
+                pass
+
+        spec = ComponentSpec(decoder="decoder", vision="vision_encoder")
+        with pytest.raises(TypeError, match="vision_encoder"):
+            spec.validate(BadModule(), "MyTask")
+
+    def test_validate_raises_on_multiple_missing(self):
+        from onnxscript import nn as _nn
+
+        class EmptyModule(_nn.Module):
+            def forward(self, op):
+                pass
+
+        spec = ComponentSpec(
+            decoder="decoder",
+            vision="vision_encoder",
+            embedding="embedding",
+        )
+        with pytest.raises(TypeError) as exc_info:
+            spec.validate(EmptyModule(), "MyTask")
+        msg = str(exc_info.value)
+        assert "decoder" in msg
+        assert "vision_encoder" in msg
+        assert "embedding" in msg
+
+    def test_validate_error_includes_task_name(self):
+        from onnxscript import nn as _nn
+
+        class EmptyModule(_nn.Module):
+            def forward(self, op):
+                pass
+
+        spec = ComponentSpec(decoder="decoder")
+        with pytest.raises(TypeError, match="SomeTask"):
+            spec.validate(EmptyModule(), "SomeTask")
+
+    def test_validate_error_includes_module_class_name(self):
+        from onnxscript import nn as _nn
+
+        class MyWeirdModule(_nn.Module):
+            def forward(self, op):
+                pass
+
+        spec = ComponentSpec(decoder="decoder")
+        with pytest.raises(TypeError, match="MyWeirdModule"):
+            spec.validate(MyWeirdModule(), "ATask")
+
+    def test_vision_language_task_validates_on_build(self):
+        """VisionLanguageTask.build() should raise TypeError on missing sub-module."""
+        from onnxscript import nn as _nn
+
+        class IncompleteVLModule(_nn.Module):
+            """Has decoder but is missing vision_encoder and embedding."""
+
+            def __init__(self):
+                super().__init__()
+                self.decoder = _nn.Module()
+
+            def forward(self, op):
+                pass
+
+        config = _make_multimodal_config()
+        task = VisionLanguageTask()
+        with pytest.raises(TypeError, match="vision_encoder"):
+            task.build(IncompleteVLModule(), config)
+
+    def test_validate_components_noop_when_no_spec(self):
+        """Tasks without components declared should not raise."""
+
+        class NoSpecTask(ModelTask):
+            # No components declared — inherits None from ModelTask
+            def build(self, module, config):
+                graph = ir.Graph([], [], nodes=[], name="noop")
+                model = ir.Model(graph, ir_version=10)
+                return ModelPackage({"model": model})
+
+        from onnxscript import nn as _nn
+
+        class EmptyModule(_nn.Module):
+            def forward(self, op):
+                pass
+
+        task = NoSpecTask()
+        task._validate_components(EmptyModule())  # must not raise
+
     """Test the user story: custom module + standard task."""
 
     def test_custom_module_with_causal_lm_task(self):

--- a/src/mobius/tasks/_vae.py
+++ b/src/mobius/tasks/_vae.py
@@ -14,7 +14,7 @@ import onnx_ir as ir
 
 from mobius._diffusers_configs import VAEConfig
 from mobius._model_package import ModelPackage
-from mobius.tasks._base import ModelTask, _make_graph, _make_model
+from mobius.tasks._base import ComponentSpec, ModelTask, _make_graph, _make_model
 
 
 class VAETask(ModelTask):
@@ -22,11 +22,14 @@ class VAETask(ModelTask):
 
     name = "vae"
 
+    components = ComponentSpec(encoder="encoder", decoder="decoder")
+
     def build(
         self,
         module,
         config: VAEConfig,
     ) -> ModelPackage:
+        self._validate_components(module)
         pkg = ModelPackage()
         pkg["encoder"] = self._build_encoder_graph(module, config)
         pkg["decoder"] = self._build_decoder_graph(module, config)

--- a/src/mobius/tasks/_vision_language_3model.py
+++ b/src/mobius/tasks/_vision_language_3model.py
@@ -17,6 +17,7 @@ from onnxscript import nn
 from mobius._configs import ArchitectureConfig, MllamaConfig
 from mobius._model_package import ModelPackage
 from mobius.tasks._base import (
+    ComponentSpec,
     ModelTask,
     _make_graph,
     _make_model,
@@ -45,11 +46,18 @@ class VisionLanguageTask(ModelTask):
     non-standard I/O (e.g. Qwen2.5-VL packed attention with cu_seqlens).
     """
 
+    components = ComponentSpec(
+        decoder="decoder",
+        vision="vision_encoder",
+        embedding="embedding",
+    )
+
     def build(
         self,
         module: nn.Module,
         config: ArchitectureConfig,
     ) -> ModelPackage:
+        self._validate_components(module)
         models: dict[str, ir.Model] = {}
 
         models["decoder"] = self._build_decoder(module.decoder, config)

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -849,8 +849,8 @@ class TestBuildGraphVisionLanguage:
         assert "audio_features" in e_inputs
         assert "inputs_embeds" in e_outputs
 
-        # Decoder model (pkg["model"]): inputs_embeds → logits + KV cache
-        decoder = pkg["model"]
+        # Decoder model (pkg["decoder"]): inputs_embeds → logits + KV cache
+        decoder = pkg["decoder"]
         d_inputs = {inp.name for inp in decoder.graph.inputs}
         d_outputs = {out.name for out in decoder.graph.outputs}
         assert "inputs_embeds" in d_inputs

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -655,8 +655,8 @@ class TestBuildGraphLoRA:
         module = model_cls(config)
         task = Phi4MMMultiModalTask()
         pkg = task.build(module, config)
-        # LoRA adapters live in the decoder model (pkg["model"])
-        decoder = pkg["model"]
+        # LoRA adapters live in the decoder model (pkg["decoder"])
+        decoder = pkg["decoder"]
 
         init_names = list(decoder.graph.initializers)
         lora_names = [n for n in init_names if "lora" in n]
@@ -817,7 +817,7 @@ class TestBuildGraphVisionLanguage:
         assert "vision" in pkg, "Should have vision model"
         assert "speech" in pkg, "Should have speech model"
         assert "embedding" in pkg, "Should have embedding model"
-        assert "model" in pkg, "Should have decoder model"
+        assert "decoder" in pkg, "Should have decoder model"
 
         # Vision model: pixel_values + image_sizes → image_features
         vision = pkg["vision"]
@@ -1500,7 +1500,7 @@ class TestBuildGraphMultiModal:
 
         # Verify 4 models in package
         assert len(pkg) == 4, f"Expected 4 models, got {len(pkg)}"
-        for key in ("vision", "speech", "embedding", "model"):
+        for key in ("vision", "speech", "embedding", "decoder"):
             assert key in pkg, f"Missing model: {key}"
 
         # Vision model has SigLIP encoder initializers
@@ -1515,8 +1515,8 @@ class TestBuildGraphMultiModal:
             "Speech model should have Conformer initializers"
         )
 
-        # Decoder model (pkg["model"]) has LoRA initializers
-        decoder_inits = list(pkg["model"].graph.initializers)
+        # Decoder model (pkg["decoder"]) has LoRA initializers
+        decoder_inits = list(pkg["decoder"].graph.initializers)
         assert any("lora" in n for n in decoder_inits), (
             "Decoder model should have LoRA initializers"
         )


### PR DESCRIPTION
## Summary

Introduces `ComponentSpec`, a declarative mechanism for multi-component tasks to validate required sub-module attributes before building. When a module is missing a required attribute, the task now raises a clear `TypeError` with a helpful message instead of a cryptic `AttributeError` deep inside `build()`.

## API

```python
# ComponentSpec maps output model name → module attribute name
spec = ComponentSpec(decoder="decoder", vision="vision_encoder", embedding="embedding")

# Validate: raises TypeError if any attribute is missing
spec.validate(module, "VisionLanguageTask")
```

## Changes

### Core (`_base.py`)
- **`ComponentSpec`** class — declarative attribute spec (`**components: str` kwargs, output name → attr name)
- **`ModelTask.components`** — optional class-level spec (default `None`)
- **`ModelTask._validate_components()`** — no-op when `components is None`; calls `spec.validate()` otherwise

### Tasks wired up (all 6 multi-model tasks)
| Task | Required attributes | 
|---|---|
| `VisionLanguageTask` | `decoder`, `vision_encoder`, `embedding` |
| `SpeechLanguageTask` | `audio_tower`, `embedding`, `decoder` |
| `Phi4MMMultiModalTask` | `vision_encoder`, `speech_encoder`, `embedding`, `decoder` |
| `Seq2SeqTask` | `encoder`, `decoder` |
| `VAETask` | `encoder`, `decoder` |
| `SpeechToTextTask` | `model` (then accesses `.model.encoder` / `.model.decoder`) |

### Export
`ComponentSpec` exported from `mobius.tasks` public surface.

### Tests (13 new in `TestComponentSpec` + 4 integration tests)
- ComponentSpec repr, iteration, passes when all present, raises on single/multiple missing
- Error message includes task name and module class name
- VisionLanguageTask integration test
- No-op when `components is None`
- Seq2SeqTask: missing encoder, missing decoder
- VAETask: missing encoder
- SpeechToTextTask: missing model