### PR TITLE
Fix ReduceSumSquare: axes as input per ONNX spec

### DIFF
--- a/src/mobius/components/_gated_deltanet.py
+++ b/src/mobius/components/_gated_deltanet.py
@@ -212,13 +212,13 @@ class GatedDeltaNet(nn.Module):
         # TODO: Use op.LpNormalization directly once ORT >=1.25 supports it.
         q_4d = op.Reshape(query, qk_4d_shape)  # (B, T, num_k_heads, head_k_dim)
         q_l2 = op.Sqrt(
-            op.ReduceSumSquare(q_4d, axes=[-1], keepdims=1)
+            op.ReduceSumSquare(q_4d, [-1], keepdims=1)
         )  # (B, T, num_k_heads, 1) — L2 norm per head
         query = op.Reshape(op.Div(q_4d, q_l2), qk_3d_shape)  # (B, T, key_dim)
 
         k_4d = op.Reshape(key, qk_4d_shape)  # (B, T, num_k_heads, head_k_dim)
         k_l2 = op.Sqrt(
-            op.ReduceSumSquare(k_4d, axes=[-1], keepdims=1)
+            op.ReduceSumSquare(k_4d, [-1], keepdims=1)
         )  # (B, T, num_k_heads, 1) — L2 norm per head
         key = op.Reshape(op.Div(k_4d, k_l2), qk_3d_shape)  # (B, T, key_dim)
 

--- a/src/mobius/models/qwen3_tts_tokenizer.py
+++ b/src/mobius/models/qwen3_tts_tokenizer.py
@@ -593,9 +593,9 @@ class _EncoderVQ(nn.Module):
         embedding = self.codebook(op)
 
         # Find nearest: ||x - e||² = ||x||² - 2*x·e^T + ||e||²
-        x_sq = op.ReduceSumSquare(x_t, axes=[-1], keepdims=1)  # (B,T,1)
+        x_sq = op.ReduceSumSquare(x_t, [-1], keepdims=1)  # (B,T,1)
         e_sq = op.ReduceSumSquare(
-            op.Unsqueeze(embedding, [0]), axes=[-1], keepdims=0
+            op.Unsqueeze(embedding, [0]), [-1], keepdims=0
         )  # (1, codebook_size)
         dot = op.MatMul(x_t, op.Transpose(embedding, perm=[1, 0]))
         distances = op.Add(op.Sub(x_sq, op.Mul(dot, op.Constant(value_float=2.0))), e_sq)


### PR DESCRIPTION
Per ONNX opset 18+, `ReduceSumSquare` takes `axes` as an optional **input tensor**, not an attribute.

## Problem

The current code passes `axes=[-1]` as a keyword argument, which onnxscript interprets as an **attribute**. This produces an invalid ONNX graph per the spec.

## Fix

Change `axes=[-1]` (attribute) → `[-1]` (positional input tensor), matching the pattern used by `ReduceSum` and `ReduceMean` throughout the codebase.

## Files changed

| File | Sites | Context |
|------|-------|---------|
| `src/mobius/components/_gated_deltanet.py` | 2 | L2 normalization of Q and K in GatedDeltaNet attention |
| `src/mobius/models/qwen3_tts_tokenizer.py` | 2 | Nearest-neighbor codebook lookup (distance computation) |

## Testing

2219 passed, 29 skipped. Lint clean.