### PR TITLE
Add VibeVoice ASR model (microsoft/VibeVoice-ASR-HF)

### DIFF
--- a/src/mobius/_configs.py
+++ b/src/mobius/_configs.py
@@ -1923,3 +1923,84 @@ class WhisperConfig(BaseModelConfig):
             options["dtype"] = resolved
 
         return cls(**options)
+
+
+@dataclasses.dataclass
+class AudioTokenizerEncoderConfig:
+    """Configuration for a single VibeVoice causal 1D CNN audio encoder.
+
+    Used for both the acoustic and semantic tokenizer encoders in VibeVoice ASR.
+    Each encoder takes raw waveform ``(batch, 1, num_samples)`` and produces
+    latents ``(batch, num_frames, hidden_size)`` via:
+    - Stem: CausalConv1d + ConvNeXt blocks
+    - 6 encoder layers, each with a strided CausalConv1d + ConvNeXt blocks
+    - Head: CausalConv1d → hidden_size output channels
+    """
+
+    channels: int = 1
+    num_filters: int = 32
+    hidden_size: int = 64
+    depths: list = dataclasses.field(default_factory=lambda: [3, 3, 3, 3, 3, 3, 8])
+    downsampling_ratios: list = dataclasses.field(default_factory=lambda: [2, 2, 4, 5, 5, 8])
+    kernel_size: int = 7
+    ffn_expansion: int = 4
+    rms_norm_eps: float = 1e-5
+    layer_scale_init_value: float = 1e-6
+
+    @classmethod
+    def from_hf(cls, hf_enc_config) -> AudioTokenizerEncoderConfig:
+        """Build from a HuggingFace acoustic/semantic tokenizer encoder config."""
+        return cls(
+            channels=getattr(hf_enc_config, "channels", 1),
+            num_filters=getattr(hf_enc_config, "num_filters", 32),
+            hidden_size=getattr(hf_enc_config, "hidden_size", 64),
+            depths=list(getattr(hf_enc_config, "depths", [3, 3, 3, 3, 3, 3, 8])),
+            downsampling_ratios=list(
+                getattr(hf_enc_config, "downsampling_ratios", [2, 2, 4, 5, 5, 8])
+            ),
+            kernel_size=getattr(hf_enc_config, "kernel_size", 7),
+            ffn_expansion=getattr(hf_enc_config, "ffn_expansion", 4),
+            rms_norm_eps=getattr(hf_enc_config, "rms_norm_eps", 1e-5),
+            layer_scale_init_value=getattr(hf_enc_config, "layer_scale_init_value", 1e-6),
+        )
+
+
+@dataclasses.dataclass
+class VibeVoiceAsrConfig(ArchitectureConfig):
+    """Configuration for VibeVoice ASR (microsoft/VibeVoice-ASR-HF).
+
+    Combines two causal 1D CNN audio encoders (acoustic + semantic) with a
+    Qwen2 language model backbone and an MLP projector:
+
+    - ``acoustic_encoder``: causal CNN tokenizer, outputs dim 64
+    - ``semantic_encoder``: causal CNN tokenizer, outputs dim 128
+    - ``multi_modal_projector``: 2-path MLP, outputs sum → hidden_size
+    - text decoder: standard Qwen2 (28 layers, hidden_size=3584)
+
+    HuggingFace class: ``VibeVoiceAsrForConditionalGeneration``
+    """
+
+    acoustic_encoder: AudioTokenizerEncoderConfig = dataclasses.field(
+        default_factory=AudioTokenizerEncoderConfig
+    )
+    semantic_encoder: AudioTokenizerEncoderConfig = dataclasses.field(
+        default_factory=lambda: AudioTokenizerEncoderConfig(hidden_size=128)
+    )
+    audio_token_id: int = 151648
+
+    @classmethod
+    def from_transformers(cls, config, parent_config=None) -> VibeVoiceAsrConfig:
+        """Extract VibeVoiceAsrConfig from a HuggingFace VibeVoiceAsrConfig."""
+        text_cfg = config.text_config
+        base = ArchitectureConfig.from_transformers(text_cfg, parent_config=None)
+        base_fields = _shallow_fields(base)
+        return cls(
+            **base_fields,
+            acoustic_encoder=AudioTokenizerEncoderConfig.from_hf(
+                config.acoustic_tokenizer_encoder_config
+            ),
+            semantic_encoder=AudioTokenizerEncoderConfig.from_hf(
+                config.semantic_tokenizer_encoder_config
+            ),
+            audio_token_id=getattr(config, "audio_token_id", 151648),
+        )

--- a/src/mobius/_registry.py
+++ b/src/mobius/_registry.py
@@ -24,6 +24,7 @@ from onnxscript import nn
 
 from mobius._configs import (
     BaseModelConfig,
+    VibeVoiceAsrConfig,
     WhisperConfig,
 )
 from mobius.models import (
@@ -114,6 +115,7 @@ from mobius.models.segformer import SegformerForSemanticSegmentation
 from mobius.models.starcoder2 import StarCoder2CausalLMModel
 from mobius.models.t5 import T5ForConditionalGeneration
 from mobius.models.trocr import TrOCRForConditionalGeneration
+from mobius.models.vibevoice_asr import VibeVoiceAsrModel
 from mobius.models.vit import ViTModel
 from mobius.models.wav2vec2 import Wav2Vec2Model
 from mobius.models.xlm import XLMCausalLMModel
@@ -538,6 +540,13 @@ def _create_default_registry() -> ModelRegistry:
         "qwen3_forced_aligner", Qwen3ASRForConditionalGeneration, task="speech-language"
     )
 
+    reg.register(
+        "vibevoice_asr",
+        VibeVoiceAsrModel,
+        task="vibevoice-asr",
+        config_class=VibeVoiceAsrConfig,
+    )
+
     reg.register("qwen3_tts", Qwen3TTSForConditionalGeneration)
 
     reg.register("qwen3_tts_tokenizer_12hz", Qwen3TTSTokenizerV2Model, task="codec")
@@ -847,6 +856,7 @@ _TEST_MODEL_IDS: dict[str, str] = {
     # --- Speech ---
     "whisper": "openai/whisper-tiny",
     "qwen3_asr": "Qwen/Qwen3-ASR-2B-Instruct",
+    "vibevoice_asr": "microsoft/VibeVoice-ASR-HF",
     "speecht5": "microsoft/speecht5_asr",
     "sew": "asapp/sew-tiny-100k",
     "sew-d": "asapp/sew-d-tiny-100k",

--- a/src/mobius/models/__init__.py
+++ b/src/mobius/models/__init__.py
@@ -114,6 +114,7 @@ __all__ = [
     "T5ForConditionalGeneration",
     "UNet2DConditionModel",
     "ViTModel",
+    "VibeVoiceAsrModel",
     "VideoAutoencoderModel",
     "Wav2Vec2Model",
     "WhisperForConditionalGeneration",
@@ -234,6 +235,7 @@ from mobius.models.starcoder2 import StarCoder2CausalLMModel
 from mobius.models.t5 import T5ForConditionalGeneration
 from mobius.models.unet import UNet2DConditionModel
 from mobius.models.vae import AutoencoderKLModel
+from mobius.models.vibevoice_asr import VibeVoiceAsrModel
 from mobius.models.video_vae import VideoAutoencoderModel
 from mobius.models.vit import ViTModel
 from mobius.models.wav2vec2 import Wav2Vec2Model

--- a/src/mobius/models/vibevoice_asr.py
+++ b/src/mobius/models/vibevoice_asr.py
@@ -425,6 +425,16 @@ class VibeVoiceAsrAudioTower(nn.Module):
 
     def __init__(self, config: VibeVoiceAsrConfig):
         super().__init__()
+        # Both encoders must downsample at the same rate so their frame counts align.
+        # The projector sums acoustic + semantic features element-wise.
+        acoustic_ratios = config.acoustic_encoder.downsampling_ratios
+        semantic_ratios = config.semantic_encoder.downsampling_ratios
+        if acoustic_ratios != semantic_ratios:
+            raise ValueError(
+                f"acoustic_encoder.downsampling_ratios {acoustic_ratios} must match "
+                f"semantic_encoder.downsampling_ratios {semantic_ratios} so frame "
+                f"counts align for element-wise summation in the projector."
+            )
         self.acoustic_tokenizer_encoder = AudioTokenizerEncoder(config.acoustic_encoder)
         self.semantic_tokenizer_encoder = AudioTokenizerEncoder(config.semantic_encoder)
         self.multi_modal_projector = VibeVoiceAsrMultiModalProjector(config)

--- a/src/mobius/models/vibevoice_asr.py
+++ b/src/mobius/models/vibevoice_asr.py
@@ -25,12 +25,11 @@ from __future__ import annotations
 import numpy as np
 import onnx_ir as ir
 from onnxscript import nn
-
 from onnxscript._internal import builder
 
 from mobius._configs import AudioTokenizerEncoderConfig, VibeVoiceAsrConfig
 from mobius.components import Embedding, Linear, RMSNorm
-from mobius.components._common import create_attention_bias
+from mobius.components._common import create_padding_mask
 from mobius.components._decoder import DecoderLayer
 from mobius.components._rotary_embedding import initialize_rope
 
@@ -106,8 +105,11 @@ class _FeedForward(nn.Module):
         self.linear2 = Linear(ffn_hidden, hidden_size, bias=True)
 
     def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
-        """Args:
+        """Apply linear1 → GELU → linear2.
+
+        Args:
             x: (batch, seq_len, hidden_size)
+
         Returns:
             (batch, seq_len, hidden_size)
         """
@@ -130,7 +132,7 @@ class _ConvNeXt1DBlock(nn.Module):
     Matches HF ``VibeVoiceAcousticTokenizerConvNext1dLayer``.
 
     Weight names:
-      norm.weight, mixer.conv.weight, mixer.bias,
+      norm.weight, mixer.conv.weight, mixer.conv.bias,
       gamma, ffn_norm.weight, ffn.linear1.weight, ffn.linear1.bias,
       ffn.linear2.weight, ffn.linear2.bias, ffn_gamma
     """
@@ -214,7 +216,7 @@ class _AudioEncoderStem(nn.Module):
 
     Matches HF ``VibeVoiceAcousticTokenizerEncoderStem``.
     Weight names:
-      conv.conv.weight, conv.bias
+      conv.conv.weight, conv.conv.bias
       stage.0.{norm,mixer,gamma,ffn_norm,ffn,ffn_gamma}
     """
 
@@ -235,8 +237,11 @@ class _AudioEncoderStem(nn.Module):
         )
 
     def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
-        """Args:
+        """Apply stem conv then ConvNeXt blocks.
+
+        Args:
             x: (batch, channels=1, num_samples)
+
         Returns:
             (batch, num_filters, num_samples)
         """
@@ -253,7 +258,7 @@ class _AudioEncoderLayer(nn.Module):
 
     Matches HF ``VibeVoiceAcousticTokenizerEncoderLayer``.
     Weight names:
-      conv.conv.weight, conv.bias
+      conv.conv.weight, conv.conv.bias
       stage.0.{…}, stage.1.{…}, …
     """
 
@@ -282,8 +287,11 @@ class _AudioEncoderLayer(nn.Module):
         )
 
     def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
-        """Args:
+        """Apply strided downsampling conv then ConvNeXt blocks.
+
+        Args:
             x: (batch, in_channels, seq_len)
+
         Returns:
             (batch, out_channels, seq_len // stride)
         """
@@ -306,11 +314,11 @@ class AudioTokenizerEncoder(nn.Module):
     Matches HF ``VibeVoiceAcousticTokenizerEncoderModel``.
 
     Weight names:
-      stem.conv.conv.weight, stem.conv.bias
+      stem.conv.conv.weight, stem.conv.conv.bias
       stem.stage.{0..N-1}.*
-      conv_layers.{0..5}.conv.conv.weight, conv_layers.{0..5}.conv.bias
+      conv_layers.{0..5}.conv.conv.weight, conv_layers.{0..5}.conv.conv.bias
       conv_layers.{0..5}.stage.{0..M-1}.*
-      head.conv.weight, head.bias
+      head.conv.weight, head.conv.bias
     """
 
     def __init__(self, enc_config: AudioTokenizerEncoderConfig):
@@ -428,7 +436,7 @@ class VibeVoiceAsrAudioTower(nn.Module):
             input_values: (batch, 1, num_samples) raw audio at 24 kHz
 
         Returns:
-            (num_audio_tokens, lm_hidden) — flattened batch×time
+            (num_audio_tokens, lm_hidden) — flattened batch*time
         """
         # Each encoder: (B, 1, T) → (B, num_frames, hidden_size)
         acoustic_latents = self.acoustic_tokenizer_encoder(op, input_values)
@@ -437,7 +445,7 @@ class VibeVoiceAsrAudioTower(nn.Module):
         # Project to LM dimension: (B, num_frames, lm_hidden)
         features = self.multi_modal_projector(op, acoustic_latents, semantic_latents)
 
-        # Flatten batch × time → (N_audio_tokens, lm_hidden) for embedding injection
+        # Flatten batch * time → (N_audio_tokens, lm_hidden) for embedding injection
         batch_time = op.Shape(features, start=0, end=2)
         feat_dim = op.Shape(features, start=2, end=3)
         # keepdims=1: result shape (1,) so Concat with feat_dim works on axis=0
@@ -526,8 +534,6 @@ class VibeVoiceAsrDecoderModel(nn.Module):
 
     def __init__(self, config: VibeVoiceAsrConfig):
         super().__init__()
-        self._dtype = config.dtype
-
         self.layers = nn.ModuleList(
             [DecoderLayer(config) for _ in range(config.num_hidden_layers)]
         )
@@ -556,11 +562,12 @@ class VibeVoiceAsrDecoderModel(nn.Module):
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(op, position_ids)
 
-        attention_bias = create_attention_bias(
+        # Causal masking is handled by is_causal=1 on the Attention op;
+        # create_padding_mask provides only the padding mask for Flash Attention eligibility.
+        padding_mask = create_padding_mask(
             op,
             input_ids=inputs_embeds,
             attention_mask=attention_mask,
-            dtype=self._dtype,
         )
 
         present_key_values = []
@@ -569,7 +576,7 @@ class VibeVoiceAsrDecoderModel(nn.Module):
             hidden_states, present_kv = layer(
                 op,
                 hidden_states=hidden_states,
-                attention_bias=attention_bias,
+                attention_bias=padding_mask,
                 position_embeddings=position_embeddings,
                 past_key_value=past_kv,
             )
@@ -627,9 +634,7 @@ class VibeVoiceAsrModel(nn.Module):
             past_key_values=past_key_values,
         )
 
-    def preprocess_weights(
-        self, state_dict: dict[str, object]
-    ) -> dict[str, object]:
+    def preprocess_weights(self, state_dict: dict[str, object]) -> dict[str, object]:
         """Map HuggingFace weight names to ONNX module structure.
 
         HF layout:
@@ -645,24 +650,26 @@ class VibeVoiceAsrModel(nn.Module):
         cleaned: dict[str, object] = {}
         for key, value in state_dict.items():
             # Audio tower sub-modules
-            if key.startswith((
-                "acoustic_tokenizer_encoder.",
-                "semantic_tokenizer_encoder.",
-                "multi_modal_projector.",
-            )):
+            if key.startswith(
+                (
+                    "acoustic_tokenizer_encoder.",
+                    "semantic_tokenizer_encoder.",
+                    "multi_modal_projector.",
+                )
+            ):
                 cleaned[f"audio_tower.{key}"] = value
                 continue
 
             # Language model → decoder / embedding split
             if key.startswith("language_model."):
-                rest = key[len("language_model."):]
+                rest = key[len("language_model.") :]
 
                 if rest.startswith("lm_head."):
                     cleaned[f"decoder.{rest}"] = value
                     continue
 
                 if rest.startswith("model."):
-                    inner = rest[len("model."):]
+                    inner = rest[len("model.") :]
                     if inner.startswith("embed_tokens."):
                         cleaned[f"embedding.{inner}"] = value
                     elif inner.startswith(("layers.", "norm.", "rotary_emb.")):

--- a/src/mobius/models/vibevoice_asr.py
+++ b/src/mobius/models/vibevoice_asr.py
@@ -1,0 +1,685 @@
+# Copyright (c) ONNX Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""VibeVoice ASR model implementation.
+
+Architecture: microsoft/VibeVoice-ASR-HF
+
+A speech recognition model combining two causal 1D CNN audio encoders
+(acoustic + semantic tokenizers) with a Qwen2 language model backbone:
+
+1. ``acoustic_tokenizer_encoder``: causal ConvNeXt CNN → latents (B, T, 64)
+2. ``semantic_tokenizer_encoder``: causal ConvNeXt CNN → latents (B, T, 128)
+3. ``multi_modal_projector``: 2-path MLP, outputs summed → (N_tokens, hidden)
+4. ``language_model``: Qwen2 decoder (hidden_size=3584, 28 layers)
+
+The three sub-models produced are:
+
+- ``audio_tower``: raw waveform (B, 1, T) → audio features (N_tokens, lm_hidden)
+- ``embedding``: input_ids + audio_features → inputs_embeds
+- ``decoder``: inputs_embeds → logits + KV cache
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import onnx_ir as ir
+from onnxscript import nn
+
+from onnxscript._internal import builder
+
+from mobius._configs import AudioTokenizerEncoderConfig, VibeVoiceAsrConfig
+from mobius.components import Embedding, Linear, RMSNorm
+from mobius.components._common import create_attention_bias
+from mobius.components._decoder import DecoderLayer
+from mobius.components._rotary_embedding import initialize_rope
+
+
+class _CausalConv1d(nn.Module):
+    """Causal 1D convolution with left-only padding.
+
+    Pads ``left_pad = (kernel_size - 1) * dilation - (stride - 1)`` samples
+    on the left so the output is causal (no look-ahead).
+
+    Matches HF ``VibeVoiceAcousticTokenizerCausalConv1d``.
+
+    Weight names: ``conv.weight``, ``conv.bias``
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int = 1,
+        dilation: int = 1,
+        groups: int = 1,
+    ):
+        super().__init__()
+        # Left causal padding: eliminates look-ahead
+        self._left_pad = (kernel_size - 1) * dilation - (stride - 1)
+        self._stride = stride
+        self._dilation = dilation
+        self._groups = groups
+        self._kernel_size = kernel_size
+        # Weight: (out_channels, in_channels // groups, kernel_size)
+        self.conv = nn.Parameter([out_channels, in_channels // groups, kernel_size])
+        self.bias = nn.Parameter([out_channels])
+
+    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+        """Apply causal padding then Conv1d.
+
+        Args:
+            x: (batch, channels, seq_len)
+
+        Returns:
+            (batch, out_channels, out_seq_len)
+        """
+        if self._left_pad > 0:
+            # ONNX Pad pads format for 3D input (N,C,L): [N_beg,C_beg,L_beg, N_end,C_end,L_end]
+            pads = op.Constant(value_ints=[0, 0, self._left_pad, 0, 0, 0])
+            x = op.Pad(x, pads)
+
+        # Conv1d: kernel_shape=[k], strides=[s], dilations=[d], group=g
+        return op.Conv(
+            x,
+            self.conv,
+            self.bias,
+            kernel_shape=[self._kernel_size],
+            strides=[self._stride],
+            dilations=[self._dilation],
+            group=self._groups,
+            pads=[0, 0],
+        )
+
+
+class _FeedForward(nn.Module):
+    """2-layer FFN: linear1 → GELU → linear2.
+
+    Matches HF ``VibeVoiceAcousticTokenizerFeedForward``.
+    Weight names: linear1.weight, linear1.bias, linear2.weight, linear2.bias
+    """
+
+    def __init__(self, hidden_size: int, ffn_hidden: int):
+        super().__init__()
+        self.linear1 = Linear(hidden_size, ffn_hidden, bias=True)
+        self.linear2 = Linear(ffn_hidden, hidden_size, bias=True)
+
+    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+        """Args:
+            x: (batch, seq_len, hidden_size)
+        Returns:
+            (batch, seq_len, hidden_size)
+        """
+        x = self.linear1(op, x)
+        x = op.Gelu(x)
+        return self.linear2(op, x)
+
+
+class _ConvNeXt1DBlock(nn.Module):
+    """ConvNeXt-style 1D block with depthwise mixer and FFN.
+
+    Structure (inputs in (batch, channels, seq_len) format):
+      mixer:
+        x → transpose → RMSNorm → transpose → depthwise_CausalConv1d
+          → scale by gamma (channel-wise) → residual_add
+      ffn:
+        x → transpose → RMSNorm → linear1 → GELU → linear2 → transpose
+          → scale by ffn_gamma (channel-wise) → residual_add
+
+    Matches HF ``VibeVoiceAcousticTokenizerConvNext1dLayer``.
+
+    Weight names:
+      norm.weight, mixer.conv.weight, mixer.bias,
+      gamma, ffn_norm.weight, ffn.linear1.weight, ffn.linear1.bias,
+      ffn.linear2.weight, ffn.linear2.bias, ffn_gamma
+    """
+
+    def __init__(self, enc_config: AudioTokenizerEncoderConfig, hidden_size: int):
+        super().__init__()
+        self._hidden_size = hidden_size
+
+        self.norm = RMSNorm(hidden_size, eps=enc_config.rms_norm_eps)
+        self.ffn_norm = RMSNorm(hidden_size, eps=enc_config.rms_norm_eps)
+
+        # Depthwise causal conv: groups=hidden_size (one filter per channel)
+        self.mixer = _CausalConv1d(
+            in_channels=hidden_size,
+            out_channels=hidden_size,
+            kernel_size=enc_config.kernel_size,
+            groups=hidden_size,
+        )
+
+        # Layer scale parameters: trainable scalar per channel, initialized to layer_scale_init_value
+        self.gamma = nn.Parameter(
+            [hidden_size],
+            data=ir.Tensor(
+                np.full((hidden_size,), enc_config.layer_scale_init_value, dtype=np.float32)
+            ),
+        )
+        self.ffn_gamma = nn.Parameter(
+            [hidden_size],
+            data=ir.Tensor(
+                np.full((hidden_size,), enc_config.layer_scale_init_value, dtype=np.float32)
+            ),
+        )
+
+        # FFN: linear1 → GELU → linear2
+        ffn_hidden = enc_config.ffn_expansion * hidden_size
+        self.ffn = _FeedForward(hidden_size, ffn_hidden)
+
+    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+        """Forward pass for one ConvNeXt block.
+
+        Args:
+            x: (batch, channels, seq_len)
+
+        Returns:
+            (batch, channels, seq_len) — same shape
+        """
+        residual = x
+
+        # --- Mixer branch ---
+        # Transpose: (B, C, L) → (B, L, C) for RMSNorm (normalizes last dim)
+        xt = op.Transpose(x, perm=[0, 2, 1])
+        xt = self.norm(op, xt)  # (B, L, C)
+        # Transpose back: (B, L, C) → (B, C, L)
+        xt = op.Transpose(xt, perm=[0, 2, 1])
+        xt = self.mixer(op, xt)  # depthwise CausalConv1d: (B, C, L)
+
+        # Channel-wise scaling: gamma shape (C,) → (1, C, 1) for broadcasting
+        gamma = op.Reshape(self.gamma, op.Constant(value_ints=[1, self._hidden_size, 1]))
+        xt = op.Mul(xt, gamma)
+        x = op.Add(residual, xt)
+
+        # --- FFN branch ---
+        residual = x
+        # Transpose: (B, C, L) → (B, L, C) for FFN (operates on last dim)
+        xf = op.Transpose(x, perm=[0, 2, 1])
+        xf = self.ffn_norm(op, xf)  # (B, L, C)
+        xf = self.ffn(op, xf)  # (B, L, C) → (B, L, C)
+        # Transpose back: (B, L, C) → (B, C, L)
+        xf = op.Transpose(xf, perm=[0, 2, 1])
+
+        # Channel-wise scaling by ffn_gamma
+        ffn_gamma = op.Reshape(
+            self.ffn_gamma, op.Constant(value_ints=[1, self._hidden_size, 1])
+        )
+        xf = op.Mul(xf, ffn_gamma)
+        return op.Add(residual, xf)
+
+
+class _AudioEncoderStem(nn.Module):
+    """Encoder stem: CausalConv1d(channels→num_filters) + N ConvNeXt blocks.
+
+    Matches HF ``VibeVoiceAcousticTokenizerEncoderStem``.
+    Weight names:
+      conv.conv.weight, conv.bias
+      stage.0.{norm,mixer,gamma,ffn_norm,ffn,ffn_gamma}
+    """
+
+    def __init__(self, enc_config: AudioTokenizerEncoderConfig):
+        super().__init__()
+        # Stem conv: input channels → num_filters, no stride, kernel=kernel_size
+        self.conv = _CausalConv1d(
+            in_channels=enc_config.channels,
+            out_channels=enc_config.num_filters,
+            kernel_size=enc_config.kernel_size,
+        )
+        # ConvNeXt blocks in stem, all at num_filters channels
+        self.stage = nn.ModuleList(
+            [
+                _ConvNeXt1DBlock(enc_config, enc_config.num_filters)
+                for _ in range(enc_config.depths[0])
+            ]
+        )
+
+    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+        """Args:
+            x: (batch, channels=1, num_samples)
+        Returns:
+            (batch, num_filters, num_samples)
+        """
+        x = self.conv(op, x)  # (B, num_filters, L)
+        for block in self.stage:
+            x = block(op, x)
+        return x
+
+
+class _AudioEncoderLayer(nn.Module):
+    """One encoder stage: strided CausalConv1d (downsampling) + N ConvNeXt blocks.
+
+    stage_idx is 0-based; output channels = num_filters * 2^(stage_idx+1).
+
+    Matches HF ``VibeVoiceAcousticTokenizerEncoderLayer``.
+    Weight names:
+      conv.conv.weight, conv.bias
+      stage.0.{…}, stage.1.{…}, …
+    """
+
+    def __init__(self, enc_config: AudioTokenizerEncoderConfig, stage_idx: int):
+        super().__init__()
+        stride = enc_config.downsampling_ratios[stage_idx]
+        # Input channels: num_filters * 2^stage_idx (output of previous stage)
+        # Output channels: num_filters * 2^(stage_idx+1)
+        in_ch = enc_config.num_filters * (2**stage_idx)
+        out_ch = enc_config.num_filters * (2 ** (stage_idx + 1))
+
+        # Strided conv for downsampling: kernel = stride * 2 (per HF source)
+        self.conv = _CausalConv1d(
+            in_channels=in_ch,
+            out_channels=out_ch,
+            kernel_size=stride * 2,
+            stride=stride,
+        )
+        # ConvNeXt blocks at output channel count
+        # depths[stage_idx+1]: first depth entry is for stem
+        self.stage = nn.ModuleList(
+            [
+                _ConvNeXt1DBlock(enc_config, out_ch)
+                for _ in range(enc_config.depths[stage_idx + 1])
+            ]
+        )
+
+    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+        """Args:
+            x: (batch, in_channels, seq_len)
+        Returns:
+            (batch, out_channels, seq_len // stride)
+        """
+        x = self.conv(op, x)  # Downsampling strided CausalConv1d
+        for block in self.stage:
+            x = block(op, x)
+        return x
+
+
+class AudioTokenizerEncoder(nn.Module):
+    """Full audio tokenizer encoder: raw waveform → latent frame embeddings.
+
+    Architecture:
+      stem → 6 encoder layers (strided) → head CausalConv1d → permute
+
+    Input:  ``(batch, 1, num_samples)`` raw audio at 24 kHz
+    Output: ``(batch, num_frames, hidden_size)``
+            where num_frames = num_samples // hop_length
+
+    Matches HF ``VibeVoiceAcousticTokenizerEncoderModel``.
+
+    Weight names:
+      stem.conv.conv.weight, stem.conv.bias
+      stem.stage.{0..N-1}.*
+      conv_layers.{0..5}.conv.conv.weight, conv_layers.{0..5}.conv.bias
+      conv_layers.{0..5}.stage.{0..M-1}.*
+      head.conv.weight, head.bias
+    """
+
+    def __init__(self, enc_config: AudioTokenizerEncoderConfig):
+        super().__init__()
+        n_stages = len(enc_config.downsampling_ratios)
+
+        self.stem = _AudioEncoderStem(enc_config)
+        self.conv_layers = nn.ModuleList(
+            [_AudioEncoderLayer(enc_config, i) for i in range(n_stages)]
+        )
+        # Head: final channels → hidden_size, kernel_size=config.kernel_size
+        final_channels = enc_config.num_filters * (2**n_stages)
+        self.head = _CausalConv1d(
+            in_channels=final_channels,
+            out_channels=enc_config.hidden_size,
+            kernel_size=enc_config.kernel_size,
+        )
+
+    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+        """Encode raw waveform to latent frames.
+
+        Args:
+            x: (batch, 1, num_samples)
+
+        Returns:
+            (batch, num_frames, hidden_size)
+        """
+        x = self.stem(op, x)  # (B, num_filters, T)
+        for layer in self.conv_layers:
+            x = layer(op, x)  # Progressive downsampling
+        x = self.head(op, x)  # (B, hidden_size, T//hop_total)
+        # Permute: (B, C, T) → (B, T, C) to match LM convention
+        return op.Transpose(x, perm=[0, 2, 1])  # (B, num_frames, hidden_size)
+
+
+class VibeVoiceAsrMultiModalProjector(nn.Module):
+    """Two-path MLP projector: acoustic + semantic → single LM-dimension tensor.
+
+    Each path: linear_1 → RMSNorm → linear_2
+    Output: acoustic_out + semantic_out
+
+    Matches HF ``VibeVoiceAsrMultiModalProjector``.
+
+    Weight names:
+      acoustic_linear_1.{weight,bias}, acoustic_norm.weight,
+      acoustic_linear_2.{weight,bias},
+      semantic_linear_1.{weight,bias}, semantic_norm.weight,
+      semantic_linear_2.{weight,bias}
+    """
+
+    def __init__(self, config: VibeVoiceAsrConfig):
+        super().__init__()
+        lm_hidden = config.hidden_size
+        acoustic_dim = config.acoustic_encoder.hidden_size
+        semantic_dim = config.semantic_encoder.hidden_size
+
+        self.acoustic_linear_1 = Linear(acoustic_dim, lm_hidden, bias=True)
+        self.acoustic_norm = RMSNorm(lm_hidden, eps=1e-6)
+        self.acoustic_linear_2 = Linear(lm_hidden, lm_hidden, bias=True)
+
+        self.semantic_linear_1 = Linear(semantic_dim, lm_hidden, bias=True)
+        self.semantic_norm = RMSNorm(lm_hidden, eps=1e-6)
+        self.semantic_linear_2 = Linear(lm_hidden, lm_hidden, bias=True)
+
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        acoustic_latents: ir.Value,
+        semantic_latents: ir.Value,
+    ) -> ir.Value:
+        """Project audio latents to LM hidden dimension.
+
+        Args:
+            acoustic_latents: (batch, num_frames, acoustic_hidden)
+            semantic_latents: (batch, num_frames, semantic_hidden)
+
+        Returns:
+            (batch, num_frames, lm_hidden) — sum of both paths
+        """
+        # Acoustic path: linear_1 → norm → linear_2
+        a = self.acoustic_linear_1(op, acoustic_latents)
+        a = self.acoustic_norm(op, a)
+        a = self.acoustic_linear_2(op, a)
+
+        # Semantic path: linear_1 → norm → linear_2
+        s = self.semantic_linear_1(op, semantic_latents)
+        s = self.semantic_norm(op, s)
+        s = self.semantic_linear_2(op, s)
+
+        return op.Add(a, s)
+
+
+class VibeVoiceAsrAudioTower(nn.Module):
+    """Combined audio encoding: two CNN encoders + projector.
+
+    Takes raw waveform input and produces projected audio features
+    suitable for the language model.
+
+    Sub-modules (named to match HF weight key prefixes):
+      - ``acoustic_tokenizer_encoder``: causal CNN (hidden_size=64)
+      - ``semantic_tokenizer_encoder``: causal CNN (hidden_size=128)
+      - ``multi_modal_projector``: 2-path MLP → summed output
+    """
+
+    def __init__(self, config: VibeVoiceAsrConfig):
+        super().__init__()
+        self.acoustic_tokenizer_encoder = AudioTokenizerEncoder(config.acoustic_encoder)
+        self.semantic_tokenizer_encoder = AudioTokenizerEncoder(config.semantic_encoder)
+        self.multi_modal_projector = VibeVoiceAsrMultiModalProjector(config)
+
+    def forward(self, op: builder.OpBuilder, input_values: ir.Value) -> ir.Value:
+        """Encode audio waveform to projected features.
+
+        Args:
+            input_values: (batch, 1, num_samples) raw audio at 24 kHz
+
+        Returns:
+            (num_audio_tokens, lm_hidden) — flattened batch×time
+        """
+        # Each encoder: (B, 1, T) → (B, num_frames, hidden_size)
+        acoustic_latents = self.acoustic_tokenizer_encoder(op, input_values)
+        semantic_latents = self.semantic_tokenizer_encoder(op, input_values)
+
+        # Project to LM dimension: (B, num_frames, lm_hidden)
+        features = self.multi_modal_projector(op, acoustic_latents, semantic_latents)
+
+        # Flatten batch × time → (N_audio_tokens, lm_hidden) for embedding injection
+        batch_time = op.Shape(features, start=0, end=2)
+        feat_dim = op.Shape(features, start=2, end=3)
+        # keepdims=1: result shape (1,) so Concat with feat_dim works on axis=0
+        n_tokens = op.ReduceProd(batch_time, keepdims=1)
+        flat_shape = op.Concat(n_tokens, feat_dim, axis=0)
+        return op.Reshape(features, flat_shape)
+
+
+class VibeVoiceAsrEmbeddingModel(nn.Module):
+    """Text embedding with audio feature injection.
+
+    Replaces audio token placeholders in the text embedding sequence
+    with the corresponding projected audio features using a CumSum-based
+    gather (same pattern as Qwen3ASREmbeddingModel).
+
+    Weight names:
+      embed_tokens.weight
+    """
+
+    def __init__(self, config: VibeVoiceAsrConfig):
+        super().__init__()
+        self._audio_token_id = config.audio_token_id
+        self.embed_tokens = Embedding(config.vocab_size, config.hidden_size)
+
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        input_ids: ir.Value,
+        audio_features: ir.Value,
+    ) -> ir.Value:
+        """Embed input_ids and scatter in audio features at audio token positions.
+
+        Args:
+            input_ids: (batch, seq_len) INT64
+            audio_features: (num_audio_tokens, lm_hidden) float
+
+        Returns:
+            (batch, seq_len, lm_hidden) inputs_embeds
+        """
+        # Text embeddings: (batch, seq_len, hidden_size)
+        inputs_embeds = self.embed_tokens(op, input_ids)
+
+        # Boolean mask where input_ids == audio_token_id
+        audio_token = op.Constant(value_int=self._audio_token_id)
+        is_audio = op.Equal(input_ids, audio_token)  # (batch, seq_len) bool
+        # Expand to (batch, seq_len, 1) for broadcasting with embeddings
+        is_audio_3d = op.Unsqueeze(is_audio, [-1])
+
+        # Prepend a zero row to audio_features so index 0 → "no audio"
+        feature_dim = op.Shape(audio_features, start=1, end=2)
+        zero_row_shape = op.Concat(op.Constant(value_ints=[1]), feature_dim, axis=0)
+        zero_row = op.ConstantOfShape(
+            zero_row_shape,
+            value=ir.tensor(np.zeros(1, dtype=np.float32)),
+        )
+        # padded_features: (num_audio_tokens + 1, lm_hidden)
+        padded_features = op.Concat(zero_row, audio_features, axis=0)
+
+        # CumSum gives 1-based indices into padded_features at audio positions;
+        # non-audio positions are masked back to 0 (the zero padding row)
+        is_audio_int = op.Cast(is_audio, to=ir.DataType.INT64)
+        flat_mask = op.Reshape(is_audio_int, op.Constant(value_ints=[-1]))
+        flat_indices = op.CumSum(flat_mask, op.Constant(value_int=0))
+        flat_indices = op.Mul(flat_indices, flat_mask)
+        # Reshape back to (batch, seq_len)
+        indices = op.Reshape(flat_indices, op.Shape(input_ids))
+
+        # Gather audio features at computed indices: (batch, seq_len, lm_hidden)
+        gathered = op.Gather(padded_features, indices, axis=0)
+
+        # Replace audio token positions with projected audio features
+        return op.Where(is_audio_3d, gathered, inputs_embeds)
+
+
+class VibeVoiceAsrDecoderModel(nn.Module):
+    """Qwen2 text decoder for VibeVoice ASR.
+
+    Standard decoder with 2D position_ids (not MRoPE 3D).
+    Takes inputs_embeds (fused text+audio) instead of input_ids.
+
+    Weight names (after preprocess_weights strips language_model.model./lm_head. prefixes):
+      layers.N.{self_attn, mlp, input_layernorm, post_attention_layernorm}.*
+      norm.weight
+      lm_head.weight
+    """
+
+    def __init__(self, config: VibeVoiceAsrConfig):
+        super().__init__()
+        self._dtype = config.dtype
+
+        self.layers = nn.ModuleList(
+            [DecoderLayer(config) for _ in range(config.num_hidden_layers)]
+        )
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = initialize_rope(config)
+        self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        inputs_embeds: ir.Value,
+        attention_mask: ir.Value,
+        position_ids: ir.Value,
+        past_key_values: list | None = None,
+    ) -> tuple[ir.Value, list]:
+        """Decode embeddings to logits with KV cache.
+
+        Args:
+            inputs_embeds: (batch, seq_len, hidden_size)
+            attention_mask: (batch, past_seq_len + seq_len) INT64
+            position_ids: (batch, seq_len) INT64 — standard 2D, not MRoPE
+
+        Returns:
+            (logits, present_key_values)
+        """
+        hidden_states = inputs_embeds
+        position_embeddings = self.rotary_emb(op, position_ids)
+
+        attention_bias = create_attention_bias(
+            op,
+            input_ids=inputs_embeds,
+            attention_mask=attention_mask,
+            dtype=self._dtype,
+        )
+
+        present_key_values = []
+        past_kvs = past_key_values or [None] * len(self.layers)
+        for layer, past_kv in zip(self.layers, past_kvs):
+            hidden_states, present_kv = layer(
+                op,
+                hidden_states=hidden_states,
+                attention_bias=attention_bias,
+                position_embeddings=position_embeddings,
+                past_key_value=past_kv,
+            )
+            present_key_values.append(present_kv)
+
+        hidden_states = self.norm(op, hidden_states)
+        logits = self.lm_head(op, hidden_states)
+        return logits, present_key_values
+
+
+class VibeVoiceAsrModel(nn.Module):
+    """VibeVoice ASR composite model for speech recognition.
+
+    Contains three sub-models for the three-model ONNX split:
+
+    - ``audio_tower``: two causal CNN encoders + projector
+      (raw waveform → audio features)
+    - ``embedding``: text embedding + audio feature injection
+    - ``decoder``: Qwen2 text decoder with KV cache
+
+    HuggingFace class: ``VibeVoiceAsrForConditionalGeneration``
+    (microsoft/VibeVoice-ASR-HF)
+    """
+
+    default_task: str = "vibevoice-asr"
+    category: str = "Speech-to-Text"
+    config_class: type = VibeVoiceAsrConfig
+
+    def __init__(self, config: VibeVoiceAsrConfig):
+        super().__init__()
+        self.config = config
+
+        self.audio_tower = VibeVoiceAsrAudioTower(config)
+        self.embedding = VibeVoiceAsrEmbeddingModel(config)
+        self.decoder = VibeVoiceAsrDecoderModel(config)
+
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        input_ids: ir.Value,
+        attention_mask: ir.Value,
+        position_ids: ir.Value,
+        past_key_values: list | None = None,
+    ):
+        """Text-only forward: embeds input_ids and decodes (no audio injection).
+
+        Audio injection happens via the separate embedding ONNX model.
+        """
+        inputs_embeds = self.embedding.embed_tokens(op, input_ids)
+        return self.decoder(
+            op,
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+        )
+
+    def preprocess_weights(
+        self, state_dict: dict[str, object]
+    ) -> dict[str, object]:
+        """Map HuggingFace weight names to ONNX module structure.
+
+        HF layout:
+          acoustic_tokenizer_encoder.*   → audio_tower.acoustic_tokenizer_encoder.*
+          semantic_tokenizer_encoder.*   → audio_tower.semantic_tokenizer_encoder.*
+          multi_modal_projector.*        → audio_tower.multi_modal_projector.*
+          language_model.model.embed_tokens.* → embedding.embed_tokens.*
+          language_model.model.layers.*  → decoder.layers.*
+          language_model.model.norm.*    → decoder.norm.*
+          language_model.model.rotary_emb.* → decoder.rotary_emb.*
+          language_model.lm_head.*       → decoder.lm_head.*
+        """
+        cleaned: dict[str, object] = {}
+        for key, value in state_dict.items():
+            # Audio tower sub-modules
+            if key.startswith((
+                "acoustic_tokenizer_encoder.",
+                "semantic_tokenizer_encoder.",
+                "multi_modal_projector.",
+            )):
+                cleaned[f"audio_tower.{key}"] = value
+                continue
+
+            # Language model → decoder / embedding split
+            if key.startswith("language_model."):
+                rest = key[len("language_model."):]
+
+                if rest.startswith("lm_head."):
+                    cleaned[f"decoder.{rest}"] = value
+                    continue
+
+                if rest.startswith("model."):
+                    inner = rest[len("model."):]
+                    if inner.startswith("embed_tokens."):
+                        cleaned[f"embedding.{inner}"] = value
+                    elif inner.startswith(("layers.", "norm.", "rotary_emb.")):
+                        cleaned[f"decoder.{inner}"] = value
+                    else:
+                        cleaned[key] = value
+                    continue
+
+            cleaned[key] = value
+
+        # Weight tying: embed_tokens ↔ lm_head
+        if self.config.tie_word_embeddings:
+            embed_key = "embedding.embed_tokens.weight"
+            lm_key = "decoder.lm_head.weight"
+            if embed_key in cleaned and lm_key not in cleaned:
+                cleaned[lm_key] = cleaned[embed_key]
+            elif lm_key in cleaned and embed_key not in cleaned:
+                cleaned[embed_key] = cleaned[lm_key]
+
+        return cleaned

--- a/src/mobius/tasks/__init__.py
+++ b/src/mobius/tasks/__init__.py
@@ -46,6 +46,7 @@ __all__ = [
     "TASK_REGISTRY",
     "TTSTask",
     "VAETask",
+    "VibeVoiceAsrTask",
     "VideoDenoisingTask",
     "VisionLanguageTask",
     "get_task",
@@ -74,6 +75,7 @@ from mobius.tasks._speech_to_text import SpeechToTextTask
 from mobius.tasks._ssm_causal_lm import SSM2CausalLMTask, SSMCausalLMTask
 from mobius.tasks._tts import TTSTask
 from mobius.tasks._vae import VAETask
+from mobius.tasks._vibevoice_asr import VibeVoiceAsrTask
 from mobius.tasks._video_denoising import VideoDenoisingTask
 from mobius.tasks._vision_language import Qwen3VLVisionLanguageTask
 from mobius.tasks._vision_language_3model import (
@@ -113,6 +115,7 @@ TASK_REGISTRY: dict[str, type[ModelTask]] = {
     "ssm-text-generation": SSMCausalLMTask,
     "ssm2-text-generation": SSM2CausalLMTask,
     "tts": TTSTask,
+    "vibevoice-asr": VibeVoiceAsrTask,
     "video-denoising": VideoDenoisingTask,
 }
 

--- a/src/mobius/tasks/_base.py
+++ b/src/mobius/tasks/_base.py
@@ -139,15 +139,24 @@ def _register_kv_cache_outputs(
     present_key_values: list[tuple[ir.Value, ir.Value]],
     *,
     prefix: str = "present",
+    past_key_values: list[tuple[ir.Value, ir.Value]] | None = None,
 ) -> None:
     """Name and register KV cache outputs on the graph.
 
-    Output shapes and dtypes are inferred by the shape inference pass
-    that runs during model optimization.
+    When ``past_key_values`` is provided, the dtype from each past KV input
+    is propagated to the corresponding present KV output so callers do not
+    need to rely entirely on shape inference for output type information.
     """
     for i, (present_key, present_value) in enumerate(present_key_values):
         present_key.name = f"{prefix}.{i}.key"
         present_value.name = f"{prefix}.{i}.value"
+
+        if past_key_values is not None:
+            past_key, past_value = past_key_values[i]
+            if past_key.type is not None:
+                present_key.type = past_key.type
+            if past_value.type is not None:
+                present_value.type = past_value.type
 
         graph.outputs.append(present_key)
         graph.outputs.append(present_value)

--- a/src/mobius/tasks/_vibevoice_asr.py
+++ b/src/mobius/tasks/_vibevoice_asr.py
@@ -155,5 +155,5 @@ class VibeVoiceAsrTask(ModelTask):
 
         logits.name = "logits"
         graph.outputs.append(logits)
-        _register_kv_cache_outputs(graph, present_key_values)
+        _register_kv_cache_outputs(graph, present_key_values, past_key_values=past_key_values)
         return _make_model(graph)

--- a/src/mobius/tasks/_vibevoice_asr.py
+++ b/src/mobius/tasks/_vibevoice_asr.py
@@ -1,0 +1,159 @@
+# Copyright (c) ONNX Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""VibeVoice ASR 3-model split task.
+
+Produces three ONNX models:
+1. **audio_encoder**: raw waveform (batch, 1, num_samples) → audio_features
+2. **embedding**: input_ids + audio_features → inputs_embeds
+3. **decoder**: inputs_embeds + position_ids + KV cache → logits + KV cache
+
+The key differences from the generic SpeechLanguageTask:
+- Audio input is raw waveform (B, 1, T), NOT a mel spectrogram
+- Decoder uses standard 2D position_ids, NOT MRoPE 3D
+"""
+
+from __future__ import annotations
+
+import onnx_ir as ir
+from onnxscript import nn
+
+from mobius._configs import ArchitectureConfig
+from mobius._model_package import ModelPackage
+from mobius.tasks._base import (
+    ModelTask,
+    _make_graph,
+    _make_kv_cache_inputs,
+    _make_model,
+    _register_kv_cache_outputs,
+)
+
+
+class VibeVoiceAsrTask(ModelTask):
+    """3-model split for VibeVoice ASR.
+
+    The module must provide three sub-modules as attributes:
+
+    - ``audio_tower``: audio encoder taking ``input_values`` (raw waveform)
+    - ``embedding``: embedding model fusing text + audio features
+    - ``decoder``: text decoder taking ``inputs_embeds`` with KV cache
+
+    Each sub-module is wired into its own ONNX graph.
+    """
+
+    def build(
+        self,
+        module: nn.Module,
+        config: ArchitectureConfig,
+    ) -> ModelPackage:
+        models: dict[str, ir.Model] = {}
+
+        models["audio_encoder"] = self._build_audio_encoder(module.audio_tower, config)
+        models["embedding"] = self._build_embedding(module.embedding, config)
+        models["decoder"] = self._build_decoder(module.decoder, config)
+
+        return ModelPackage(models, config=config)
+
+    def _build_audio_encoder(
+        self,
+        audio_tower: nn.Module,
+        config: ArchitectureConfig,
+    ) -> ir.Model:
+        """Build audio encoder: raw waveform (B, 1, T) → audio features (N, hidden)."""
+        batch = ir.SymbolicDim("batch")
+        num_samples = ir.SymbolicDim("num_samples")
+
+        # Raw waveform input: (batch, 1, num_samples)
+        input_values = ir.Value(
+            name="input_values",
+            shape=ir.Shape([batch, 1, num_samples]),
+            type=ir.TensorType(config.dtype),
+        )
+
+        graph, builder = _make_graph([input_values], name="audio_encoder")
+        audio_features = audio_tower(builder.op, input_values)
+
+        audio_features.name = "audio_features"
+        graph.outputs.append(audio_features)
+        return _make_model(graph)
+
+    def _build_embedding(
+        self,
+        embedding: nn.Module,
+        config: ArchitectureConfig,
+    ) -> ir.Model:
+        """Build embedding: input_ids + audio_features → inputs_embeds."""
+        batch = ir.SymbolicDim("batch")
+        seq_len = ir.SymbolicDim("sequence_len")
+        num_audio_tokens = ir.SymbolicDim("num_audio_tokens")
+
+        input_ids = ir.Value(
+            name="input_ids",
+            shape=ir.Shape([batch, seq_len]),
+            type=ir.TensorType(ir.DataType.INT64),
+        )
+        audio_features = ir.Value(
+            name="audio_features",
+            shape=ir.Shape([num_audio_tokens, config.hidden_size]),
+            type=ir.TensorType(config.dtype),
+        )
+
+        graph, builder = _make_graph([input_ids, audio_features], name="embedding")
+        inputs_embeds = embedding(builder.op, input_ids, audio_features)
+
+        inputs_embeds.name = "inputs_embeds"
+        graph.outputs.append(inputs_embeds)
+        return _make_model(graph)
+
+    def _build_decoder(
+        self,
+        decoder: nn.Module,
+        config: ArchitectureConfig,
+    ) -> ir.Model:
+        """Build decoder with standard 2D position_ids (not MRoPE 3D)."""
+        batch = ir.SymbolicDim("batch")
+        seq_len = ir.SymbolicDim("sequence_len")
+        past_seq_len = ir.SymbolicDim("past_sequence_len")
+
+        inputs_embeds = ir.Value(
+            name="inputs_embeds",
+            shape=ir.Shape([batch, seq_len, config.hidden_size]),
+            type=ir.TensorType(config.dtype),
+        )
+        attention_mask = ir.Value(
+            name="attention_mask",
+            shape=ir.Shape([batch, "past_seq_len + seq_len"]),
+            type=ir.TensorType(ir.DataType.INT64),
+        )
+        # Standard 2D position_ids (batch, seq_len) — not MRoPE's (3, batch, seq_len)
+        position_ids = ir.Value(
+            name="position_ids",
+            shape=ir.Shape([batch, seq_len]),
+            type=ir.TensorType(ir.DataType.INT64),
+        )
+
+        graph_inputs = [inputs_embeds, attention_mask, position_ids]
+
+        kv_inputs, past_key_values = _make_kv_cache_inputs(
+            config.num_hidden_layers,
+            config.num_key_value_heads,
+            config.head_dim,
+            config.dtype,
+            batch,
+            past_seq_len,
+        )
+        graph_inputs.extend(kv_inputs)
+
+        graph, builder = _make_graph(graph_inputs, name="decoder")
+        logits, present_key_values = decoder(
+            builder.op,
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+        )
+
+        logits.name = "logits"
+        graph.outputs.append(logits)
+        _register_kv_cache_outputs(graph, present_key_values)
+        return _make_model(graph)

--- a/testdata/cases/schema.json
+++ b/testdata/cases/schema.json
@@ -48,7 +48,8 @@
         "seq2seq",
         "speech-language",
         "speech-to-text",
-        "text-generation"
+        "text-generation",
+        "vibevoice-asr"
       ],
       "description": "Task type string matching the mobius registry."
     },

--- a/testdata/cases/speech/vibevoice-asr.yaml
+++ b/testdata/cases/speech/vibevoice-asr.yaml
@@ -1,0 +1,17 @@
+model_id: "microsoft/VibeVoice-ASR-HF"
+revision: "f22241c2062b3b25272bf117397e03d73381037a"
+task_type: "vibevoice-asr"
+dtype: "float32"
+
+inputs:
+  audio:
+    - "652-129742-0006.flac"
+
+generation:
+  max_new_tokens: 50
+  do_sample: false
+
+level: "L4+L5"
+
+skip_reason: "Requires raw waveform audio preprocessing not yet supported in test harness."
+notes: "VibeVoice ASR speech recognition. 3-model split: audio_encoder + embedding + decoder. Raw waveform input (not mel spectrogram)."

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -53,9 +53,11 @@ from mobius._config_resolver import _default_task_for_model
 from mobius._configs import (
     ArchitectureConfig,
     AudioConfig,
+    AudioTokenizerEncoderConfig,
     CodePredictorConfig,
     SpeakerEncoderConfig,
     TTSConfig,
+    VibeVoiceAsrConfig,
     VisionConfig,
 )
 from mobius._registry import registry
@@ -1787,6 +1789,181 @@ class TestBuildGraphQwen3ASR:
         assert logits.shape[1] == seq_len
 
 
+class TestBuildVibeVoiceAsrGraph:
+    """Verify VibeVoice ASR 3-model split with VibeVoiceAsrTask."""
+
+    def _vv_config(self) -> VibeVoiceAsrConfig:
+        """Tiny config: hidden_size=64, 2 layers, reduced audio encoders."""
+        return VibeVoiceAsrConfig(
+            hidden_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            intermediate_size=128,
+            vocab_size=256,
+            max_position_embeddings=128,
+            head_dim=32,
+            hidden_act="silu",
+            acoustic_encoder=AudioTokenizerEncoderConfig(
+                hidden_size=64,
+                num_filters=4,
+                depths=[1, 1, 1, 1, 1, 1, 1],
+                downsampling_ratios=[2, 2, 2, 2, 2, 2],
+            ),
+            semantic_encoder=AudioTokenizerEncoderConfig(
+                hidden_size=128,
+                num_filters=4,
+                depths=[1, 1, 1, 1, 1, 1, 1],
+                downsampling_ratios=[2, 2, 2, 2, 2, 2],
+            ),
+            audio_token_id=100,
+        )
+
+    def test_package_builds_3_models(self):
+        """Build VibeVoice ASR and verify 3-model package."""
+        from mobius.models.vibevoice_asr import VibeVoiceAsrModel
+        from mobius.tasks import VibeVoiceAsrTask
+
+        config = self._vv_config()
+        module = VibeVoiceAsrModel(config)
+        pkg = build_from_module(module, config, task=VibeVoiceAsrTask())
+
+        assert "audio_encoder" in pkg
+        assert "embedding" in pkg
+        assert "decoder" in pkg
+
+    def test_audio_tower_io(self):
+        """Verify audio tower inputs/outputs."""
+        from mobius.models.vibevoice_asr import VibeVoiceAsrModel
+        from mobius.tasks import VibeVoiceAsrTask
+
+        config = self._vv_config()
+        module = VibeVoiceAsrModel(config)
+        pkg = build_from_module(module, config, task=VibeVoiceAsrTask())
+        audio_tower = pkg["audio_encoder"]
+
+        input_names = {inp.name for inp in audio_tower.graph.inputs}
+        assert "input_values" in input_names
+
+        output_names = {out.name for out in audio_tower.graph.outputs}
+        assert "audio_features" in output_names
+
+    def test_embedding_io(self):
+        """Verify embedding model inputs/outputs."""
+        from mobius.models.vibevoice_asr import VibeVoiceAsrModel
+        from mobius.tasks import VibeVoiceAsrTask
+
+        config = self._vv_config()
+        module = VibeVoiceAsrModel(config)
+        pkg = build_from_module(module, config, task=VibeVoiceAsrTask())
+        embedding = pkg["embedding"]
+
+        input_names = {inp.name for inp in embedding.graph.inputs}
+        assert "input_ids" in input_names
+        assert "audio_features" in input_names
+
+        output_names = {out.name for out in embedding.graph.outputs}
+        assert "inputs_embeds" in output_names
+
+    def test_decoder_io(self):
+        """Verify decoder has standard 2D position_ids and KV cache."""
+        from mobius.models.vibevoice_asr import VibeVoiceAsrModel
+        from mobius.tasks import VibeVoiceAsrTask
+
+        config = self._vv_config()
+        module = VibeVoiceAsrModel(config)
+        pkg = build_from_module(module, config, task=VibeVoiceAsrTask())
+        decoder = pkg["decoder"]
+
+        input_names = {inp.name for inp in decoder.graph.inputs}
+        assert "inputs_embeds" in input_names
+        assert "attention_mask" in input_names
+        assert "position_ids" in input_names
+
+        output_names = {out.name for out in decoder.graph.outputs}
+        assert "logits" in output_names
+        assert "present.0.key" in output_names
+        assert "present.0.value" in output_names
+
+    def test_registry_lookup(self):
+        """Verify vibevoice_asr is registered with vibevoice-asr task."""
+        from mobius.models.vibevoice_asr import VibeVoiceAsrModel
+
+        assert registry.get("vibevoice_asr") is VibeVoiceAsrModel
+        assert _default_task_for_model("vibevoice_asr") == "vibevoice-asr"
+
+    def test_3model_pipeline_runs_with_ort(self):
+        """Run audio_tower → embedding → decoder with ORT."""
+        import numpy as np
+
+        from mobius._testing.ort_inference import OnnxModelSession
+        from mobius.models.vibevoice_asr import VibeVoiceAsrModel
+        from mobius.rewrite_rules._testing_utils import fill_random_weights
+        from mobius.tasks import VibeVoiceAsrTask
+
+        config = self._vv_config()
+        module = VibeVoiceAsrModel(config)
+        pkg = build_from_module(module, config, task=VibeVoiceAsrTask())
+
+        for model in pkg.values():
+            fill_random_weights(model)
+
+        # Step 1: Audio tower — raw waveform (batch=1, channels=1, samples=1024)
+        audio_sess = OnnxModelSession(pkg["audio_encoder"])
+        waveform = np.random.randn(1, 1, 1024).astype(np.float32)
+        audio_out = audio_sess.run({"input_values": waveform})
+        audio_features = audio_out["audio_features"]  # (num_tokens, hidden_size)
+        num_audio_tokens = audio_features.shape[0]
+        audio_sess.close()
+
+        # Step 2: Embedding — text + audio tokens
+        audio_token_id = config.audio_token_id
+        prefix = [1, 2, 3]
+        suffix = [4, 5]
+        input_ids = np.array(
+            [prefix + [audio_token_id] * num_audio_tokens + suffix],
+            dtype=np.int64,
+        )
+
+        embed_sess = OnnxModelSession(pkg["embedding"])
+        embed_out = embed_sess.run({"input_ids": input_ids, "audio_features": audio_features})
+        inputs_embeds = embed_out["inputs_embeds"]
+        embed_sess.close()
+
+        seq_len = inputs_embeds.shape[1]
+        assert seq_len == input_ids.shape[1]
+        assert inputs_embeds.shape[2] == config.hidden_size
+
+        # Step 3: Decoder — 2D position_ids (not MRoPE)
+        decoder_sess = OnnxModelSession(pkg["decoder"])
+        past_kv = {}
+        for i in range(config.num_hidden_layers):
+            past_kv[f"past_key_values.{i}.key"] = np.zeros(
+                (1, config.num_key_value_heads, 0, config.head_dim),
+                dtype=np.float32,
+            )
+            past_kv[f"past_key_values.{i}.value"] = np.zeros(
+                (1, config.num_key_value_heads, 0, config.head_dim),
+                dtype=np.float32,
+            )
+
+        position_ids = np.arange(seq_len, dtype=np.int64).reshape(1, -1)
+
+        dec_out = decoder_sess.run(
+            {
+                "inputs_embeds": inputs_embeds,
+                "attention_mask": np.ones((1, seq_len), dtype=np.int64),
+                "position_ids": position_ids,
+                **past_kv,
+            }
+        )
+        decoder_sess.close()
+
+        logits = dec_out["logits"]
+        assert logits.shape[0] == 1
+        assert logits.shape[1] == seq_len
+
+
 class TestBuildGraphQwen3TTS:
     """Verify Qwen3-TTS 4-model split with TTSTask."""
 
@@ -3338,6 +3515,7 @@ _SPECIALIZED_TEST_MODEL_TYPES: set[str] = {
     "qwen3_forced_aligner",
     "qwen3_tts",
     "qwen3_tts_tokenizer_12hz",
+    "vibevoice_asr",
     "whisper",
     # SSM dedicated tests
     "falcon_mamba",

--- a/tests/model_coverage_test.py
+++ b/tests/model_coverage_test.py
@@ -245,6 +245,7 @@ _COVERAGE_SKIP: dict[str, str] = {
     "sam2": "Vision model — no test_model_id yet",
     "smolvlm": "VL model — no test_model_id yet",
     "solar_open": "No test_model_id — no suitable public checkpoint",
+    "vibevoice_asr": "ASR model — tested via TestBuildVibeVoiceAsrGraph",
     "video_llava": "VL model — no test_model_id yet",
     "vipllava": "VL model — no test_model_id yet",
     "vit_hybrid": "Vision model — no test_model_id yet",


### PR DESCRIPTION
## Summary
Adds the VibeVoice ASR speech recognition model.

### Architecture
- Dual CNN audio encoders (CausalConv1d + ConvNeXt blocks)
- MLP projector to align audio features with text embedding space
- Qwen2 text decoder backbone
- 3-model split: audio_encoder, embedding, decoder

### Implementation
- AudioTokenizerEncoderConfig + VibeVoiceAsrConfig
- Full model in vibevoice_asr.py
- VibeVoiceAsrTask (custom 3-model task)
- Registry integration

### Testing
6 new tests in TestBuildVibeVoiceAsrGraph, all pass. Full suite: 2588 passed.