### PR TITLE
Add NVIDIA models (Nemotron VL, Nemotron Flash, AudioFlamingo3)

### DIFF
--- a/examples/audioflamingo3.py
+++ b/examples/audioflamingo3.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python
+# Copyright (c) ONNX Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""AudioFlamingo-3 audio understanding with ONNX models.
+
+AudioFlamingo-3 combines a Whisper-Large audio encoder with a Qwen2-7B language
+decoder.  Three ONNX models are built by mobius and chained for inference:
+
+    audio → mel spectrogram → audio_encoder → embedding → decoder → text
+
+Prerequisites::
+
+    pip install mobius-ai[transformers] librosa
+
+Usage::
+
+    # Answer a question about an audio file
+    python examples/audioflamingo3.py --audio speech.wav
+
+    # Custom prompt
+    python examples/audioflamingo3.py --audio meeting.wav --prompt "Summarise the meeting."
+
+    # Use a different model size or variant
+    python examples/audioflamingo3.py --model nvidia/audio-flamingo-3-hf --audio clip.wav
+
+    # Save ONNX models without running inference
+    python examples/audioflamingo3.py --audio dummy.wav --save-to output/audioflamingo3/
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+import transformers
+
+from mobius import build
+from mobius._testing.ort_inference import OnnxModelSession
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+MODEL_ID = "nvidia/audio-flamingo-3-hf"
+SAMPLE_RATE = 16000
+
+# Whisper-Large audio encoder parameters
+N_MELS = 128
+N_FFT = 400
+HOP_LENGTH = 160
+MAX_AUDIO_FRAMES = 3000  # Receptive field: 30s at 16 kHz with hop_length=160
+
+# Audio encoder output length (2x Conv1d downsampling of MAX_AUDIO_FRAMES)
+NUM_AUDIO_TOKENS = 1500
+
+# Qwen2 tokenizer special token IDs
+AUDIO_TOKEN_ID = 151669  # <|audio_pad|>  — audio feature placeholder
+IM_START = 151644  # <|im_start|>
+IM_END = 151645  # <|im_end|>
+EOS_IDS = {151643, 151645}  # <|endoftext|>, <|im_end|>
+
+# Text segment token IDs used in the Qwen2 chat template
+_SYSTEM_ID = 8948  # "system"
+_USER_ID = 872  # "user"
+_ASSISTANT_ID = 77091  # "assistant"
+_NEWLINE_ID = 198  # "\n"
+
+DEFAULT_PROMPT = "Please describe what you hear in this audio."
+MAX_NEW_TOKENS = 128
+
+
+# ---------------------------------------------------------------------------
+# Mel spectrogram
+# ---------------------------------------------------------------------------
+
+
+def compute_mel_spectrogram(audio: np.ndarray) -> np.ndarray:
+    """Compute Whisper-style log-mel spectrogram.
+
+    Pads or truncates ``audio`` to exactly ``MAX_AUDIO_FRAMES`` time frames
+    using :class:`~transformers.WhisperFeatureExtractor`.
+
+    Args:
+        audio: 1-D float32 array of raw audio samples at ``SAMPLE_RATE`` Hz.
+
+    Returns:
+        Float32 array of shape ``(1, N_MELS, MAX_AUDIO_FRAMES)`` — ready to
+        pass into the ``audio_encoder`` ONNX model as ``input_features``.
+    """
+    from transformers import WhisperFeatureExtractor
+
+    fe = WhisperFeatureExtractor(
+        feature_size=N_MELS,
+        n_fft=N_FFT,
+        hop_length=HOP_LENGTH,
+        sampling_rate=SAMPLE_RATE,
+    )
+    out = fe(
+        audio,
+        sampling_rate=SAMPLE_RATE,
+        return_tensors="np",
+        padding=True,
+    )
+    return out["input_features"].astype(np.float32)  # (1, N_MELS, MAX_AUDIO_FRAMES)
+
+
+# ---------------------------------------------------------------------------
+# Prompt construction
+# ---------------------------------------------------------------------------
+
+
+def build_prompt_ids(tokenizer, prompt: str) -> np.ndarray:
+    """Construct Qwen2 chat-format input_ids with audio token placeholders.
+
+    The audio section is represented by ``NUM_AUDIO_TOKENS`` consecutive
+    ``AUDIO_TOKEN_ID`` placeholders.  The embedding model replaces these with
+    the actual audio features at inference time.
+
+    Format::
+
+        <|im_start|>system
+        You are a helpful audio AI assistant.<|im_end|>
+        <|im_start|>user
+        <NUM_AUDIO_TOKENS x AUDIO_TOKEN_ID><prompt text><|im_end|>
+        <|im_start|>assistant
+
+    Args:
+        tokenizer: HuggingFace tokenizer loaded from the model.
+        prompt: User's text question about the audio.
+
+    Returns:
+        Int64 array of shape ``(1, seq_len)``.
+    """
+    system_text_ids = tokenizer.encode(
+        "You are a helpful audio AI assistant.", add_special_tokens=False
+    )
+    prompt_ids = tokenizer.encode(prompt, add_special_tokens=False)
+    audio_placeholders = [AUDIO_TOKEN_ID] * NUM_AUDIO_TOKENS
+
+    ids = [
+        IM_START,
+        _SYSTEM_ID,
+        _NEWLINE_ID,
+        *system_text_ids,
+        IM_END,
+        _NEWLINE_ID,
+        IM_START,
+        _USER_ID,
+        _NEWLINE_ID,
+        *audio_placeholders,
+        *prompt_ids,
+        IM_END,
+        _NEWLINE_ID,
+        IM_START,
+        _ASSISTANT_ID,
+        _NEWLINE_ID,
+    ]
+    return np.array([ids], dtype=np.int64)
+
+
+# ---------------------------------------------------------------------------
+# Inference
+# ---------------------------------------------------------------------------
+
+
+def transcribe(
+    sessions: dict[str, OnnxModelSession],
+    tokenizer,
+    audio: np.ndarray,
+    config,
+    *,
+    prompt: str = DEFAULT_PROMPT,
+    max_new_tokens: int = MAX_NEW_TOKENS,
+) -> str:
+    """Run the full AudioFlamingo-3 ONNX inference pipeline.
+
+    Chains the three ONNX models produced by mobius:
+
+    1. ``audio_encoder`` — mel (1, 128, 3000) → audio_features (1, 1500, hidden)
+    2. ``embedding`` — input_ids + audio_features → inputs_embeds
+    3. ``decoder`` — inputs_embeds + KV cache → logits (autoregressive loop)
+
+    Args:
+        sessions: ``{model_name: OnnxModelSession}`` for the three models.
+        tokenizer: HuggingFace Qwen2 tokenizer.
+        audio: Raw 1-D float32 audio at 16 kHz.
+        config: :class:`~mobius.ArchitectureConfig` from the built package.
+        prompt: Text question about the audio content.
+        max_new_tokens: Maximum number of tokens to generate.
+
+    Returns:
+        Decoded text response.
+    """
+    batch_size = 1
+
+    # --- Step 1: mel spectrogram (1, 128, 3000) --------------------------------
+    mel = compute_mel_spectrogram(audio)
+
+    # --- Step 2: audio encoder → audio_features (1, 1500, hidden) -------------
+    encoder_out = sessions["audio_encoder"].run({"input_features": mel})
+    audio_features = encoder_out["audio_features"]  # (1, 1500, hidden)
+    # Embedding model expects 2D input: (num_audio_tokens, hidden)
+    audio_features_2d = audio_features[0]  # (1500, hidden)
+
+    # --- Step 3: prompt input_ids with audio placeholders ----------------------
+    input_ids = build_prompt_ids(tokenizer, prompt)  # (1, seq_len)
+
+    # --- Step 4: embedding model — fuse text + audio embeddings ----------------
+    embed_out = sessions["embedding"].run(
+        {"input_ids": input_ids, "audio_features": audio_features_2d}
+    )
+    inputs_embeds = embed_out["inputs_embeds"]  # (1, seq_len, hidden)
+
+    # --- Step 5: autoregressive decoding with the text decoder -----------------
+    num_layers = config.num_hidden_layers
+    num_kv_heads = config.num_key_value_heads
+    head_dim = config.head_dim
+
+    # Initialise empty KV cache
+    past_kv: dict[str, np.ndarray] = {}
+    for i in range(num_layers):
+        past_kv[f"past_key_values.{i}.key"] = np.zeros(
+            (batch_size, num_kv_heads, 0, head_dim), dtype=np.float32
+        )
+        past_kv[f"past_key_values.{i}.value"] = np.zeros(
+            (batch_size, num_kv_heads, 0, head_dim), dtype=np.float32
+        )
+
+    # Prefill: standard 1D position_ids (Qwen2 uses 1D RoPE, not MRoPE)
+    prefill_len = inputs_embeds.shape[1]
+    position_ids = np.arange(prefill_len, dtype=np.int64)[np.newaxis, :]  # (1, seq_len)
+
+    out = sessions["decoder"].run(
+        {
+            "inputs_embeds": inputs_embeds,
+            "attention_mask": np.ones((batch_size, prefill_len), dtype=np.int64),
+            "position_ids": position_ids,
+            **past_kv,
+        }
+    )
+
+    # First generated token
+    next_token = int(np.argmax(out["logits"][:, -1, :]))
+    generated_ids = [next_token]
+    print(tokenizer.decode([next_token], skip_special_tokens=True), end="", flush=True)
+
+    for i in range(num_layers):
+        past_kv[f"past_key_values.{i}.key"] = out[f"present.{i}.key"]
+        past_kv[f"past_key_values.{i}.value"] = out[f"present.{i}.value"]
+
+    past_seq_len = prefill_len
+
+    # Decode loop: single-token steps (no audio features in subsequent steps)
+    for _ in range(max_new_tokens - 1):
+        if next_token in EOS_IDS:
+            break
+
+        cur_ids = np.array([[next_token]], dtype=np.int64)
+        # Pass empty audio_features — no audio tokens in decode steps
+        dummy_audio = np.zeros((0, audio_features_2d.shape[-1]), dtype=np.float32)
+        embed_out = sessions["embedding"].run(
+            {"input_ids": cur_ids, "audio_features": dummy_audio}
+        )
+        cur_embeds = embed_out["inputs_embeds"]
+
+        total_seq_len = past_seq_len + 1
+        pos = np.array([[past_seq_len]], dtype=np.int64)  # (1, 1)
+
+        out = sessions["decoder"].run(
+            {
+                "inputs_embeds": cur_embeds,
+                "attention_mask": np.ones((batch_size, total_seq_len), dtype=np.int64),
+                "position_ids": pos,
+                **past_kv,
+            }
+        )
+
+        next_token = int(np.argmax(out["logits"][:, -1, :]))
+        generated_ids.append(next_token)
+        print(tokenizer.decode([next_token], skip_special_tokens=True), end="", flush=True)
+
+        for i in range(num_layers):
+            past_kv[f"past_key_values.{i}.key"] = out[f"present.{i}.key"]
+            past_kv[f"past_key_values.{i}.value"] = out[f"present.{i}.value"]
+
+        past_seq_len = total_seq_len
+
+    print()
+    return tokenizer.decode(generated_ids, skip_special_tokens=True)
+
+
+def load_audio_file(path: str) -> np.ndarray:
+    """Load and resample an audio file to 16 kHz mono float32."""
+    import librosa
+
+    audio, _ = librosa.load(path, sr=SAMPLE_RATE, mono=True)
+    return audio.astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="AudioFlamingo-3 audio understanding with ONNX models.",
+    )
+    parser.add_argument(
+        "--model",
+        default=MODEL_ID,
+        help="HuggingFace model ID (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--audio",
+        required=True,
+        metavar="FILE",
+        help="Audio file to process (WAV, FLAC, MP3, …).",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=DEFAULT_PROMPT,
+        help="Text question about the audio (default: %(default)r).",
+    )
+    parser.add_argument(
+        "--max-new-tokens",
+        type=int,
+        default=MAX_NEW_TOKENS,
+        help="Maximum tokens to generate (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--save-to",
+        metavar="DIR",
+        default=None,
+        help="Save ONNX models to DIR and exit without running inference.",
+    )
+    args = parser.parse_args()
+
+    print(f"Building ONNX models from {args.model!r} ...")
+    pkg = build(args.model, dtype="f32", load_weights=not args.save_to)
+    config = pkg.config
+
+    if args.save_to:
+        pkg.save(args.save_to, check_weights=False)
+        print(f"Saved to {args.save_to}")
+        return
+
+    print("Creating inference sessions ...")
+    sessions = {name: OnnxModelSession(model) for name, model in pkg.items()}
+
+    tokenizer = transformers.AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
+
+    print(f"Loading audio: {args.audio}")
+    audio = load_audio_file(args.audio)
+    duration = len(audio) / SAMPLE_RATE
+    print(f"Duration: {duration:.1f}s — prompt: {args.prompt!r}\n")
+    print("Response: ", end="", flush=True)
+
+    result = transcribe(
+        sessions,
+        tokenizer,
+        audio,
+        config,
+        prompt=args.prompt,
+        max_new_tokens=args.max_new_tokens,
+    )
+    print(f"\n📝 Result: {result}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mobius/_configs.py
+++ b/src/mobius/_configs.py
@@ -108,6 +108,9 @@ class VisionConfig:
     mrope_section: list[int] | None = None
     # Phi4MM image embedding
     image_crop_size: int | None = None
+    # RADIO vision encoder (Nemotron VL)
+    num_summary_tokens: int = 0
+    projector_hidden_size: int | None = None
     # LoRA config
     lora: dict | None = None
 
@@ -1923,3 +1926,196 @@ class WhisperConfig(BaseModelConfig):
             options["dtype"] = resolved
 
         return cls(**options)
+
+
+@dataclasses.dataclass
+class NemotronFlashConfig(ArchitectureConfig):
+    """Configuration for NemotronFlash hybrid GLA+Mamba2+Attention+FFN models.
+
+    NemotronFlash interleaves four layer types:
+    - GLA (Gated Linear Attention / DeltaNet) for linear-recurrence layers
+    - Mamba2/SSD layers for efficient recurrent processing
+    - Standard GQA attention layers for global context
+    - Dense FFN-only layers for feedforward computation
+
+    Memory tokens (``num_memory_tokens``) are learnable vectors prepended to
+    the input embeddings at every forward step.
+
+    Layer types in HF config (``layer_types`` field):
+        ``"deltanet"`` → mobius ``"deltanet"`` (treated as full_attention KV cache)
+        ``"m2"`` → mobius ``"mamba2"``
+        ``"a"`` → mobius ``"full_attention"``
+        ``"f"`` → mobius ``"mlp"``
+    """
+
+    num_memory_tokens: int = 0
+
+    # Mamba2/SSD params
+    mamba_n_heads: int = 0
+    mamba_d_head: int = 64
+    mamba_d_state: int = 128
+    mamba_n_groups: int = 1
+    mamba_d_conv: int = 4
+    mamba_expand: int = 2
+    mamba_conv_bias: bool = True
+    mamba_proj_bias: bool = False
+
+    @classmethod
+    def from_transformers(cls, config, parent_config=None) -> NemotronFlashConfig:
+        base = ArchitectureConfig.from_transformers(config, parent_config)
+
+        # Compute intermediate_size from ffn_expand_ratio using SwiGLU formula
+        ffn_expand = getattr(config, "ffn_expand_ratio", 3)
+        hidden = base.hidden_size
+        intermediate = hidden * ffn_expand * 2 // 3
+
+        # Map HF layer types to mobius canonical types
+        type_map = {"f": "mlp", "m2": "mamba2", "a": "full_attention", "deltanet": "deltanet"}
+        layer_types_hf = getattr(config, "layer_types", []) or []
+        layer_types = [type_map.get(t, "full_attention") for t in layer_types_hf]
+
+        # Mamba2 head count: total inner dim / head_dim
+        mamba_expand = getattr(config, "mamba_expand", 2)
+        d_inner = hidden * mamba_expand
+        mamba2_headdim = getattr(config, "mamba2_headdim", 64)
+        mamba_n_heads = d_inner // mamba2_headdim
+
+        # Exclude fields we override to avoid duplicate keyword args
+        base_fields = {
+            k: v
+            for k, v in _shallow_fields(base).items()
+            if k not in ("layer_types", "num_hidden_layers", "intermediate_size")
+        }
+        return cls(
+            **base_fields,
+            intermediate_size=intermediate,
+            layer_types=layer_types,
+            num_hidden_layers=len(layer_types),
+            num_memory_tokens=getattr(config, "num_memory_tokens", 0),
+            mamba_n_heads=mamba_n_heads,
+            mamba_d_head=mamba2_headdim,
+            mamba_d_state=getattr(config, "mamba_d_state", 128),
+            mamba_n_groups=getattr(config, "mamba_n_groups", 1),
+            mamba_d_conv=getattr(config, "mamba_d_conv", 4),
+            mamba_expand=mamba_expand,
+            mamba_conv_bias=getattr(config, "mamba_conv_bias", True),
+            mamba_proj_bias=getattr(config, "mamba_proj_bias", False),
+        )
+
+
+@dataclasses.dataclass
+class LlamaNemotronNanoVLConfig(ArchitectureConfig):
+    """Configuration for Llama_Nemotron_Nano_VL (RADIO + Llama 3.1 VL model).
+
+    Extracts text parameters from ``llm_config`` and builds a
+    :class:`VisionConfig` from the top-level RADIO ViT-H/16 fields.
+
+    RADIO ViT-H/16 parameters (hardcoded for this architecture):
+    - hidden_size: from ``vit_hidden_size`` (default 1280)
+    - num_hidden_layers: 32 (ViT-H depth)
+    - num_attention_heads: 16 (ViT-H heads)
+    - intermediate_size: 4 * vit_hidden_size
+    """
+
+    @classmethod
+    def from_transformers(cls, config, parent_config=None) -> LlamaNemotronNanoVLConfig:
+        # Text params come from llm_config (not the standard top-level fields)
+        llm_config = getattr(config, "llm_config", config)
+        base = ArchitectureConfig.from_transformers(llm_config)
+
+        # RADIO ViT-H/16 vision parameters from top-level config fields
+        vit_hidden = getattr(config, "vit_hidden_size", 1280)
+        image_size = getattr(config, "force_image_size", 512)
+        patch_size = getattr(config, "patch_size", 16)
+
+        # Compute RADIO num_summary_tokens = num_cls_tokens + num_registers.
+        # num_cls_tokens = number of unique teachers (when cls_token_per_teacher=True).
+        # num_registers rounds up to the nearest register_multiple.
+        vc_args = getattr(config, "vision_config", None)
+        vc_args = getattr(vc_args, "args", None) or {}
+        teachers = vc_args.get("teachers", [])
+        cls_per_teacher = vc_args.get("cls_token_per_teacher", False)
+        num_cls = (
+            len({t.get("name", t) if isinstance(t, dict) else t for t in teachers})
+            if cls_per_teacher
+            else 1
+        )
+        reg_multiple = vc_args.get("register_multiple", None)
+        num_registers = (reg_multiple - (num_cls % reg_multiple)) if reg_multiple else 0
+        num_summary_tokens = num_cls + num_registers  # 8 for C-RADIOv2-H (4 CLS + 4 registers)
+
+        vision = VisionConfig(
+            hidden_size=vit_hidden,
+            num_hidden_layers=32,  # ViT-H depth
+            num_attention_heads=16,  # ViT-H heads
+            intermediate_size=vit_hidden * 4,  # MLP ratio 4x
+            image_size=image_size,
+            patch_size=patch_size,
+            image_token_id=128256,  # <image> token in Llama tokenizer
+            num_summary_tokens=num_summary_tokens,
+            projector_hidden_size=getattr(config, "projector_hidden_size", None),
+        )
+
+        base_fields = {
+            k: v
+            for k, v in _shallow_fields(base).items()
+            if k not in ("vision", "image_token_id")
+        }
+        return cls(**base_fields, vision=vision, image_token_id=128256)
+
+
+@dataclasses.dataclass
+class NemotronHNanoVLConfig(NemotronHConfig):
+    """Configuration for NemotronH_Nano_VL_V2 (RADIO + NemotronH VL model).
+
+    Extends :class:`NemotronHConfig` to inherit all NemotronH hybrid fields
+    (Mamba2 heads, layer_types, etc.) and adds RADIO vision encoder config.
+    Same RADIO vision encoder as ``LlamaNemotronNanoVLConfig`` but text decoder
+    is NemotronH hybrid (Mamba2 + Attention + MLP).
+    """
+
+    @classmethod
+    def from_transformers(cls, config, parent_config=None) -> NemotronHNanoVLConfig:
+        # Text params come from llm_config (NemotronH hybrid model)
+        llm_config = getattr(config, "llm_config", config)
+        base = NemotronHConfig.from_transformers(llm_config)
+
+        # RADIO ViT-H/16 vision parameters (same as LlamaNemotronNanoVLConfig)
+        vit_hidden = getattr(config, "vit_hidden_size", 1280)
+        image_size = getattr(config, "force_image_size", 512)
+        patch_size = getattr(config, "patch_size", 16)
+
+        # Compute RADIO num_summary_tokens (same logic as LlamaNemotronNanoVLConfig)
+        vc_args = getattr(config, "vision_config", None)
+        vc_args = getattr(vc_args, "args", None) or {}
+        teachers = vc_args.get("teachers", [])
+        cls_per_teacher = vc_args.get("cls_token_per_teacher", False)
+        num_cls = (
+            len({t.get("name", t) if isinstance(t, dict) else t for t in teachers})
+            if cls_per_teacher
+            else 1
+        )
+        reg_multiple = vc_args.get("register_multiple", None)
+        num_registers = (reg_multiple - (num_cls % reg_multiple)) if reg_multiple else 0
+        num_summary_tokens = num_cls + num_registers  # 8 for C-RADIOv2-H
+
+        vision = VisionConfig(
+            hidden_size=vit_hidden,
+            num_hidden_layers=32,  # ViT-H depth
+            num_attention_heads=16,  # ViT-H heads
+            intermediate_size=vit_hidden * 4,  # MLP ratio 4x
+            image_size=image_size,
+            patch_size=patch_size,
+            image_token_id=None,  # image token is handled via image_flags in VL pipeline
+            num_summary_tokens=num_summary_tokens,
+            projector_hidden_size=getattr(config, "projector_hidden_size", None),
+        )
+
+        base_fields = {
+            k: v
+            for k, v in _shallow_fields(base).items()
+            if k not in ("vision", "image_token_id")
+        }
+        return cls(**base_fields, vision=vision, image_token_id=128256)
+
+

--- a/src/mobius/_registry.py
+++ b/src/mobius/_registry.py
@@ -471,6 +471,11 @@ def _create_default_registry() -> ModelRegistry:
 
     reg.register("nemotron_h", NemotronHCausalLMModel)
 
+    # --- Hybrid GLA+Mamba2+Attention+FFN (NemotronFlash) ---
+    from mobius.models.nemotron_flash import NemotronFlashCausalLMModel
+
+    reg.register("nemotron_flash", NemotronFlashCausalLMModel)
+
     # --- Multimodal ---
     for name in (
         "chameleon",
@@ -524,6 +529,36 @@ def _create_default_registry() -> ModelRegistry:
     reg.register("qwen3_5", Qwen35VL3ModelCausalLMModel, task="hybrid-qwen-vl")
     reg.register("qwen3_5_vl", Qwen35VL3ModelCausalLMModel, task="hybrid-qwen-vl")
     reg.register("qwen3_5_vl_text", Qwen35VLTextModel)
+
+    # --- NVIDIA VL ---
+    from mobius._configs import LlamaNemotronNanoVLConfig
+    from mobius.models.llama_nemotron_nano_vl import LlamaNemotronNanoVLModel
+
+    reg.register(
+        "Llama_Nemotron_Nano_VL",
+        LlamaNemotronNanoVLModel,
+        task="vision-language",
+        config_class=LlamaNemotronNanoVLConfig,
+    )
+
+    from mobius._configs import NemotronHNanoVLConfig
+    from mobius.models.nemotronh_nano_vl import NemotronHNanoVLModel
+
+    reg.register(
+        "NemotronH_Nano_VL_V2",
+        NemotronHNanoVLModel,
+        task="hybrid-vision-language",
+        config_class=NemotronHNanoVLConfig,
+    )
+
+    # --- NVIDIA Audio ---
+    from mobius.models.audioflamingo3 import (
+        AudioFlamingo3ForConditionalGeneration,
+    )
+
+    reg.register(
+        "audioflamingo3", AudioFlamingo3ForConditionalGeneration, task="audio-language"
+    )
 
     # --- Speech ---
     reg.register(
@@ -820,6 +855,8 @@ _TEST_MODEL_IDS: dict[str, str] = {
     # --- Hybrid SSM+Attention ---
     "jamba": "ai21labs/Jamba-v0.1",
     "bamba": "ibm-fms/Bamba-9B",
+    "nemotron_h": "nvidia/Nemotron-H-47B-Base-8K",
+    "nemotron_flash": "nvidia/nemotron-flash-1b",
 
     # --- Multimodal ---
     "qwen2_vl": "Qwen/Qwen2-VL-2B-Instruct",
@@ -843,6 +880,8 @@ _TEST_MODEL_IDS: dict[str, str] = {
     "instructblip": "Salesforce/instructblip-flan-t5-xl",
     "llava_onevision": "llava-hf/llava-onevision-qwen2-0.5b-ov-hf",
     "molmo": "allenai/MolmoE-1B-0924",
+    "Llama_Nemotron_Nano_VL": "nvidia/Llama-Nemotron-Nano-VL-8B-v1",
+    "NemotronH_Nano_VL_V2": "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16",
 
     # --- Speech ---
     "whisper": "openai/whisper-tiny",
@@ -858,6 +897,7 @@ _TEST_MODEL_IDS: dict[str, str] = {
     "musicgen": "facebook/musicgen-small",
     "seamless_m4t": "facebook/hf-seamless-m4t-medium",
     "seamless_m4t_v2": "facebook/seamless-m4t-v2-large",
+    "audioflamingo3": "nvidia/audio-flamingo-3-hf",
 
     # --- Encoder-only ---
     "bert": "google-bert/bert-base-uncased",
@@ -1064,6 +1104,12 @@ _FAMILY_OVERRIDES: dict[str, str] = {
     "clip_vision_model": "clip",
     "siglip_vision_model": "clip",
     "siglip2_vision_model": "clip",
+    "nemotron": "nemotron",
+    "nemotron_h": "nemotron",
+    "nemotron_flash": "nemotron",
+    "Llama_Nemotron_Nano_VL": "nemotron",
+    "NemotronH_Nano_VL_V2": "nemotron",
+    "audioflamingo3": "audioflamingo",
 }
 
 # -- Variant labels for code-path identification --

--- a/src/mobius/models/__init__.py
+++ b/src/mobius/models/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "ArceeCausalLMModel",
     "AutoencoderKLModel",
     "AutoencoderKLQwenImageModel",
+    "AudioFlamingo3ForConditionalGeneration",
     "BambaCausalLMModel",
     "BartForConditionalGeneration",
     "BertModel",
@@ -56,6 +57,7 @@ __all__ = [
     "JambaCausalLMModel",
     "JetMoeCausalLMModel",
     "Llama4CausalLMModel",
+    "LlamaNemotronNanoVLModel",
     "LLaVAModel",
     "LayerNormCausalLMModel",
     "LongcatFlashCausalLMModel",
@@ -66,7 +68,9 @@ __all__ = [
     "MoECausalLMModel",
     "NanoChatCausalLMModel",
     "NemotronCausalLMModel",
+    "NemotronFlashCausalLMModel",
     "NemotronHCausalLMModel",
+    "NemotronHNanoVLModel",
     "OLMo2CausalLMModel",
     "OLMoCausalLMModel",
     "OPTCausalLMModel",
@@ -123,6 +127,7 @@ __all__ = [
 from mobius.models.adapters import IPAdapterModel, T2IAdapterModel
 from mobius.models.apertus import ApertusCausalLMModel
 from mobius.models.arcee import ArceeCausalLMModel
+from mobius.models.audioflamingo3 import AudioFlamingo3ForConditionalGeneration
 from mobius.models.bamba import BambaCausalLMModel
 from mobius.models.bart import BartForConditionalGeneration
 from mobius.models.base import CausalLMModel, LayerNormCausalLMModel
@@ -162,6 +167,7 @@ from mobius.models.internvl import InternVL2Model
 from mobius.models.jamba import JambaCausalLMModel
 from mobius.models.jetmoe import JetMoeCausalLMModel
 from mobius.models.llama4 import Llama4CausalLMModel
+from mobius.models.llama_nemotron_nano_vl import LlamaNemotronNanoVLModel
 from mobius.models.llava import LLaVAModel
 from mobius.models.longcat_flash import LongcatFlashCausalLMModel
 from mobius.models.mamba import Mamba2CausalLMModel, MambaCausalLMModel
@@ -177,6 +183,8 @@ from mobius.models.moe import (
 from mobius.models.nanochat import NanoChatCausalLMModel
 from mobius.models.nemotron import NemotronCausalLMModel
 from mobius.models.nemotron_h import NemotronHCausalLMModel
+from mobius.models.nemotron_flash import NemotronFlashCausalLMModel
+from mobius.models.nemotronh_nano_vl import NemotronHNanoVLModel
 from mobius.models.olmo import OLMo2CausalLMModel, OLMoCausalLMModel
 from mobius.models.opt import OPTCausalLMModel
 from mobius.models.persimmon import PersimmonCausalLMModel

--- a/src/mobius/models/audioflamingo3.py
+++ b/src/mobius/models/audioflamingo3.py
@@ -1,0 +1,411 @@
+# Copyright (c) ONNX Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""AudioFlamingo-3: Whisper audio encoder + Qwen2 language decoder.
+
+Architecture:
+  - Audio encoder: Whisper-Large encoder (Conv1d x2 → sinusoidal PE → 32
+    encoder layers → LayerNorm) + 2-layer MLP projector (1280 → 3584)
+  - Text decoder: Qwen2-7B (28 layers, GQA 28h/4kv, RMSNorm, standard 1D RoPE)
+  - Fusion: Audio features replace ``audio_token_id`` positions in text embeddings
+
+Three ONNX models are exported via :class:`~mobius.tasks.AudioLanguageTask`:
+
+1. ``audio_encoder`` — mel (batch, 128, 3000) → audio_features (batch, 1500, 3584)
+2. ``embedding``     — input_ids + audio_features → inputs_embeds
+3. ``decoder``       — inputs_embeds + position_ids → logits + KV cache
+
+Reference: https://huggingface.co/nvidia/audio-flamingo-3-hf
+HuggingFace class: AudioFlamingo3ForConditionalGeneration
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import onnx_ir as ir
+import torch
+from onnxscript import nn
+from onnxscript._internal import builder
+
+from mobius._configs import ArchitectureConfig
+from mobius.components._common import (
+    Embedding,
+    LayerNorm,
+    Linear,
+    create_attention_bias,
+)
+from mobius.components._decoder import DecoderLayer
+from mobius.components._rms_norm import RMSNorm
+from mobius.components._rotary_embedding import initialize_rope
+from mobius.components._whisper import Conv1d, WhisperEncoderLayer
+
+
+def _sinusoidal_positional_embedding(max_positions: int, d_model: int) -> np.ndarray:
+    """Whisper-style sinusoidal positional embeddings.
+
+    Returns ``[max_positions, d_model]`` float32 array matching
+    ``WhisperPositionalEmbedding`` in HuggingFace transformers.
+    """
+    position = np.arange(max_positions, dtype=np.float32)[:, np.newaxis]
+    half_dim = d_model // 2
+    div_term = np.exp(np.arange(half_dim, dtype=np.float32) * -(math.log(10000.0) / half_dim))
+    pe = np.zeros((max_positions, d_model), dtype=np.float32)
+    pe[:, :half_dim] = np.sin(position * div_term)
+    pe[:, half_dim:] = np.cos(position * div_term)
+    return pe
+
+
+class _AudioFlamingo3Projector(nn.Module):
+    """2-layer MLP projector for AudioFlamingo-3.
+
+    Maps Whisper encoder output to text hidden size:
+        Linear(d_model → text_hidden, bias=True) + GELU + Linear(text_hidden → text_hidden, bias=True)
+
+    HF weight names: ``multi_modal_projector.linear_1.*``, ``multi_modal_projector.linear_2.*``
+    (remapped to ``projector.linear_1.*``, ``projector.linear_2.*`` by ``preprocess_weights``).
+    """
+
+    def __init__(self, d_model: int, output_dim: int):
+        super().__init__()
+        self.linear_1 = Linear(d_model, output_dim, bias=True)
+        self.linear_2 = Linear(output_dim, output_dim, bias=True)
+
+    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+        # (batch, seq_len, d_model) → (batch, seq_len, output_dim)
+        x = self.linear_1(op, x)
+        x = op.Gelu(x)
+        x = self.linear_2(op, x)
+        return x
+
+
+class AudioFlamingo3Encoder(nn.Module):
+    """AudioFlamingo-3 audio encoder: mel spectrogram → projected features.
+
+    Architecture mirrors Whisper-Large (identical dims) followed by a
+    2-layer MLP projector that maps audio hidden states to text hidden size.
+
+    Inputs:
+        input_features: ``(batch, num_mel_bins, audio_seq_len)`` mel spectrogram
+
+    Output:
+        audio_features: ``(batch, audio_seq_len // 2, text_hidden_size)``
+    """
+
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+        audio = config.audio
+        assert audio is not None, "AudioConfig required for AudioFlamingo3Encoder"
+
+        d_model = audio.d_model or 1280
+        num_mel_bins = audio.num_mel_bins or 128
+        encoder_layers = audio.encoder_layers or 32
+        encoder_heads = audio.encoder_attention_heads or 20
+        encoder_ffn = audio.encoder_ffn_dim or 5120
+        max_source_positions = audio.max_source_positions or 1500
+
+        # eps=1e-5 matches Whisper's LayerNorm epsilon
+        eps = 1e-5
+
+        # Conv1d downsampling (stride=2 on second conv halves the sequence)
+        self.conv1 = Conv1d(num_mel_bins, d_model, kernel_size=3, padding=1)
+        self.conv2 = Conv1d(d_model, d_model, kernel_size=3, stride=2, padding=1)
+
+        # Frozen sinusoidal positional embeddings (not learned, stored as a constant)
+        pe_data = _sinusoidal_positional_embedding(max_source_positions, d_model)
+        self.embed_positions = nn.Parameter(
+            [max_source_positions, d_model],
+            name="embed_positions.weight",
+            data=ir.tensor(pe_data),
+        )
+
+        # 32 bidirectional encoder layers (Whisper-Large dims)
+        self.layers = nn.ModuleList(
+            [
+                WhisperEncoderLayer(d_model, encoder_heads, encoder_ffn, eps=eps)
+                for _ in range(encoder_layers)
+            ]
+        )
+        self.layer_norm = LayerNorm(d_model, eps=eps)
+
+        # 2-layer MLP projector: audio hidden → text hidden
+        self.projector = _AudioFlamingo3Projector(d_model, config.hidden_size)
+
+    def forward(self, op: builder.OpBuilder, input_features: ir.Value) -> ir.Value:
+        # input_features: (batch, num_mel_bins, audio_seq_len)
+
+        # Conv1d pair + GELU: (batch, d_model, audio_seq_len // 2)
+        hidden_states = op.Gelu(self.conv1(op, input_features))
+        hidden_states = op.Gelu(self.conv2(op, hidden_states))
+
+        # Transpose: (batch, audio_seq_len // 2, d_model)
+        hidden_states = op.Transpose(hidden_states, perm=[0, 2, 1])
+
+        # Slice positional embeddings to actual sequence length
+        # (PE is max_source_positions long; audio may be shorter in practice)
+        seq_len = op.Shape(hidden_states, start=1, end=2)
+        pe_slice = op.Slice(
+            self.embed_positions,
+            op.Constant(value_ints=[0]),
+            seq_len,
+            op.Constant(value_ints=[0]),
+        )
+        hidden_states = op.Add(hidden_states, pe_slice)
+
+        # 32 bidirectional encoder layers
+        for layer in self.layers:
+            hidden_states = layer(op, hidden_states)
+
+        # Final LayerNorm: (batch, audio_seq_len // 2, d_model)
+        hidden_states = self.layer_norm(op, hidden_states)
+
+        # 2-layer MLP projector: (batch, audio_seq_len // 2, text_hidden)
+        hidden_states = self.projector(op, hidden_states)
+
+        return hidden_states
+
+
+class AudioFlamingo3EmbeddingModel(nn.Module):
+    """AudioFlamingo-3 embedding model: fuses text and audio embeddings.
+
+    Replaces ``audio_token_id`` positions in the text embedding with
+    audio features from the audio encoder (using Gather + CumSum + Where).
+
+    Inputs:
+        input_ids:      ``(batch, seq_len)`` token IDs
+        audio_features: ``(batch, audio_tokens, text_hidden_size)`` projected features
+
+    Output:
+        inputs_embeds: ``(batch, seq_len, hidden_size)``
+    """
+
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+        self.embed_tokens = Embedding(
+            config.vocab_size, config.hidden_size, config.pad_token_id
+        )
+        self._audio_token_id = config.audio.audio_token_id if config.audio else 151669
+
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        input_ids: ir.Value,
+        audio_features: ir.Value,
+    ) -> ir.Value:
+        """Fuse text embeddings with audio features.
+
+        Audio features are inserted at positions where ``input_ids == audio_token_id``.
+        Uses cumulative sum on the audio mask to index into the flattened
+        ``audio_features`` tensor.
+
+        ``audio_features`` is expected to be 2D: ``(total_audio_tokens, hidden_size)``.
+        """
+        # Text embeddings: (batch, seq_len, hidden_size)
+        inputs_embeds = self.embed_tokens(op, input_ids)
+
+        # audio_features: (total_audio_tokens, hidden_size)
+        # Get feature dim for zero-padding row construction
+        feature_dim = op.Shape(audio_features, start=1, end=2)  # hidden_size
+
+        # Create mask: True where input_ids == audio_token_id
+        audio_token = op.Constant(value_int=self._audio_token_id)
+        is_audio = op.Equal(input_ids, audio_token)  # (batch, seq_len)
+        is_audio_3d = op.Unsqueeze(is_audio, [-1])  # (batch, seq_len, 1)
+
+        # Prepend a zero row so gather index 0 maps to zero padding
+        zero_row = op.ConstantOfShape(
+            op.Concat(op.Constant(value_ints=[1]), feature_dim, axis=0),
+            value=ir.tensor(np.zeros(1, dtype=np.float32)),
+        )
+        # padded: (total_audio_tokens + 1, hidden_size)
+        padded_features = op.Concat(zero_row, audio_features, axis=0)
+
+        # CumSum of the flattened boolean mask gives 1-based indices
+        # (0 = zero-padding row for non-audio positions)
+        is_audio_int = op.Cast(is_audio, to=7)  # INT64
+        flat_mask = op.Reshape(is_audio_int, op.Constant(value_ints=[-1]))
+        flat_indices = op.CumSum(flat_mask, op.Constant(value_int=0))
+        # Zero out non-audio positions so they gather from the padding row
+        flat_indices = op.Mul(flat_indices, flat_mask)
+        indices = op.Reshape(flat_indices, op.Shape(input_ids))  # (batch, seq_len)
+
+        # Gather audio features at computed indices
+        gathered = op.Gather(padded_features, indices, axis=0)
+
+        # Where: replace audio positions with gathered features
+        inputs_embeds = op.Where(is_audio_3d, gathered, inputs_embeds)
+        return inputs_embeds
+
+
+class AudioFlamingo3DecoderModel(nn.Module):
+    """AudioFlamingo-3 text decoder: inputs_embeds → logits + KV cache.
+
+    Standard Qwen2-7B decoder with GQA (28h/4kv), RMSNorm, and
+    standard 1D RoPE. Takes ``inputs_embeds`` (fused text+audio).
+
+    Inputs:
+        inputs_embeds:   ``(batch, seq_len, hidden_size)``
+        attention_mask:  ``(batch, past_seq_len + seq_len)``
+        position_ids:    ``(batch, seq_len)`` standard 1D RoPE
+        past_key_values: list of ``(key, value)`` tensors per layer
+
+    Outputs:
+        logits:           ``(batch, seq_len, vocab_size)``
+        present_key_values: list of updated ``(key, value)`` tensors
+    """
+
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+        self._dtype = config.dtype
+        self.layers = nn.ModuleList(
+            [DecoderLayer(config) for _ in range(config.num_hidden_layers)]
+        )
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = initialize_rope(config)
+        self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        inputs_embeds: ir.Value,
+        attention_mask: ir.Value,
+        position_ids: ir.Value,
+        past_key_values: list | None = None,
+    ) -> tuple[ir.Value, list]:
+        hidden_states = inputs_embeds
+        # position_ids: (batch, seq_len) → standard 1D RoPE embeddings
+        position_embeddings = self.rotary_emb(op, position_ids)
+
+        attention_bias = create_attention_bias(
+            op,
+            input_ids=inputs_embeds,
+            attention_mask=attention_mask,
+            dtype=self._dtype,
+        )
+
+        present_key_values = []
+        past_kvs = past_key_values or [None] * len(self.layers)
+        for layer, past_kv in zip(self.layers, past_kvs):
+            hidden_states, present_kv = layer(
+                op,
+                hidden_states=hidden_states,
+                attention_bias=attention_bias,
+                position_embeddings=position_embeddings,
+                past_key_value=past_kv,
+            )
+            present_key_values.append(present_kv)
+
+        # Post-norm and LM head: (batch, seq_len, vocab_size)
+        hidden_states = self.norm(op, hidden_states)
+        logits = self.lm_head(op, hidden_states)
+        return logits, present_key_values
+
+
+class AudioFlamingo3ForConditionalGeneration(nn.Module):
+    """AudioFlamingo-3 composite model for audio understanding.
+
+    Exports three ONNX models via :class:`~mobius.tasks.AudioLanguageTask`:
+
+    - ``audio_encoder``: Whisper-Large encoder + 2-layer MLP projector
+    - ``embedding``: text embedding + audio token fusion
+    - ``decoder``: Qwen2-7B decoder with KV cache
+
+    HF weight layout:
+        ``audio_tower.*``              → ``audio_tower.*`` (encoder, direct match)
+        ``multi_modal_projector.*``    → ``audio_tower.projector.*``
+        ``language_model.model.embed_tokens.*`` → ``embedding.embed_tokens.*``
+        ``language_model.model.layers.*`` → ``decoder.layers.*``
+        ``language_model.model.norm.*``   → ``decoder.norm.*``
+        ``language_model.lm_head.*``      → ``decoder.lm_head.*``
+
+    Reference: https://huggingface.co/nvidia/audio-flamingo-3-hf
+    HuggingFace class: AudioFlamingo3ForConditionalGeneration
+    """
+
+    default_task: str = "audio-language"
+    category: str = "Audio"
+
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+        self.config = config
+        self.audio_tower = AudioFlamingo3Encoder(config)
+        self.embedding = AudioFlamingo3EmbeddingModel(config)
+        self.decoder = AudioFlamingo3DecoderModel(config)
+
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        input_ids: ir.Value,
+        attention_mask: ir.Value,
+        position_ids: ir.Value,
+        past_key_values: list | None = None,
+    ) -> tuple[ir.Value, list]:
+        """Text-generation forward (audio features fused externally)."""
+        inputs_embeds = self.embedding.embed_tokens(op, input_ids)
+        return self.decoder(
+            op,
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+        )
+
+    def preprocess_weights(
+        self, state_dict: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        """Map HuggingFace weight names to ONNX module structure.
+
+        Remapping rules:
+        - ``audio_tower.*``                           → ``audio_tower.*``  (direct, encoder matches)
+        - ``multi_modal_projector.linear_1.*``        → ``audio_tower.projector.linear_1.*``
+        - ``multi_modal_projector.linear_2.*``        → ``audio_tower.projector.linear_2.*``
+        - ``language_model.model.embed_tokens.*``     → ``embedding.embed_tokens.*``
+        - ``language_model.model.{layers,norm,rotary_emb}.*`` → ``decoder.{layers,norm,rotary_emb}.*``
+        - ``language_model.lm_head.*``                → ``decoder.lm_head.*``
+        """
+        cleaned: dict[str, torch.Tensor] = {}
+
+        for key, value in state_dict.items():
+            # audio_tower.* → audio_tower.*  (direct, weight names align)
+            if key.startswith("audio_tower."):
+                cleaned[key] = value
+                continue
+
+            # multi_modal_projector.* → audio_tower.projector.*
+            if key.startswith("multi_modal_projector."):
+                inner = key[len("multi_modal_projector.") :]
+                cleaned[f"audio_tower.projector.{inner}"] = value
+                continue
+
+            # language_model.lm_head.* → decoder.lm_head.*
+            if key.startswith("language_model.lm_head."):
+                inner = key[len("language_model.lm_head.") :]
+                cleaned[f"decoder.lm_head.{inner}"] = value
+                continue
+
+            # language_model.model.* → route to embedding or decoder
+            if key.startswith("language_model.model."):
+                inner = key[len("language_model.model.") :]
+
+                if inner.startswith("embed_tokens."):
+                    cleaned[f"embedding.{inner}"] = value
+                    continue
+
+                if inner.startswith(("layers.", "norm.", "rotary_emb.")):
+                    cleaned[f"decoder.{inner}"] = value
+                    continue
+
+            # Pass through any other keys unchanged
+            cleaned[key] = value
+
+        # Weight tying: lm_head shares embed_tokens weights in Qwen2
+        embed_key = "embedding.embed_tokens.weight"
+        lm_key = "decoder.lm_head.weight"
+        if self.config.tie_word_embeddings:
+            if embed_key in cleaned and lm_key not in cleaned:
+                cleaned[lm_key] = cleaned[embed_key]
+            elif lm_key in cleaned and embed_key not in cleaned:
+                cleaned[embed_key] = cleaned[lm_key]
+
+        return cleaned

--- a/src/mobius/models/audioflamingo3.py
+++ b/src/mobius/models/audioflamingo3.py
@@ -90,7 +90,8 @@ class AudioFlamingo3Encoder(nn.Module):
         input_features: ``(batch, num_mel_bins, audio_seq_len)`` mel spectrogram
 
     Output:
-        audio_features: ``(batch, audio_seq_len // 2, text_hidden_size)``
+        audio_features: ``(batch * audio_seq_len // 2, text_hidden_size)``
+        Flattened to 2D to match SpeechLanguageTask embedding contract.
     """
 
     def __init__(self, config: ArchitectureConfig):
@@ -163,6 +164,13 @@ class AudioFlamingo3Encoder(nn.Module):
         # 2-layer MLP projector: (batch, audio_seq_len // 2, text_hidden)
         hidden_states = self.projector(op, hidden_states)
 
+        # Flatten to 2D (batch * audio_seq_len // 2, text_hidden) to match
+        # SpeechLanguageTask._build_embedding which expects (num_audio_tokens, hidden)
+        hidden_dim = op.Shape(hidden_states, start=2, end=3)
+        hidden_states = op.Reshape(
+            hidden_states, op.Concat(op.Constant(value_ints=[-1]), hidden_dim, axis=0)
+        )
+
         return hidden_states
 
 
@@ -174,7 +182,7 @@ class AudioFlamingo3EmbeddingModel(nn.Module):
 
     Inputs:
         input_ids:      ``(batch, seq_len)`` token IDs
-        audio_features: ``(batch, audio_tokens, text_hidden_size)`` projected features
+        audio_features: ``(num_audio_tokens, text_hidden_size)`` projected features (2D)
 
     Output:
         inputs_embeds: ``(batch, seq_len, hidden_size)``
@@ -185,6 +193,7 @@ class AudioFlamingo3EmbeddingModel(nn.Module):
         self.embed_tokens = Embedding(
             config.vocab_size, config.hidden_size, config.pad_token_id
         )
+        # 151669 is the default audio_token_id in Qwen2's tokenizer for AudioFlamingo3
         self._audio_token_id = config.audio.audio_token_id if config.audio else 151669
 
     def forward(

--- a/src/mobius/models/llama_nemotron_nano_vl.py
+++ b/src/mobius/models/llama_nemotron_nano_vl.py
@@ -1,0 +1,443 @@
+# Copyright (c) ONNX Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Llama_Nemotron_Nano_VL multimodal model — RADIO vision + Llama 3.1 text decoder.
+
+Splits the Llama_Nemotron_Nano_VL architecture into three ONNX models for
+onnxruntime-genai:
+
+- **decoder**: Llama 3.1 text decoder taking ``inputs_embeds``
+- **vision**: RADIO ViT-H/16 encoder + pixel shuffle + MLP projector
+- **embedding**: token embedding + image feature fusion
+
+Architecture differences from InternVL2:
+- RADIO ViT-H/16 vision encoder with CPE-style conditional positional encoding
+- CPE = ViTPatchGenerator: learned pos_embed stored at max resolution (2048×2048),
+  window-selected to actual input resolution at inference (512×512 → 32×32 grid)
+- pos_embed added to patch tokens BEFORE prepending CLS + register tokens
+- Patch embedding uses Conv2d without bias (``Conv2dNoBias``)
+- 8 special summary tokens total (4 CLS per teacher + 4 registers) stripped after ViT
+- No final LayerNorm (RADIO sets ``model.norm = nn.Identity()``)
+- Llama 3.1 text decoder (GQA) instead of InternLM/Qwen2
+
+HuggingFace reference: ``nvidia/Llama-3.1-Nemotron-Nano-VL-8B-V1``
+(model_type ``Llama_Nemotron_Nano_VL``).
+
+HuggingFace weight names:
+- ``vision_model.radio_model.model.patch_generator.{embedder.weight, cls_token.token, pos_embed}``
+- ``vision_model.radio_model.model.blocks.N.*``
+- ``vision_model.radio_model.input_conditioner.*`` (skipped — normalization stats)
+- ``mlp1.{0,1,3}.*``
+- ``language_model.model.* / language_model.lm_head.*``
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from onnxscript import nn
+from onnxscript._internal import builder
+
+from mobius._configs import ArchitectureConfig
+from mobius.components import (
+    Conv2dNoBias,
+    Linear,
+)
+from mobius.components._vision import VisionLayerNorm
+from mobius.models.internvl import (
+    _GELUPlaceholder,
+    _InternVisionAttention,
+    _InternVisionMLP,
+    _InternVL2DecoderModel,
+    _InternVL2EmbeddingModel,
+)
+
+if TYPE_CHECKING:
+    import onnx_ir as ir
+
+
+# ---------------------------------------------------------------------------
+# RADIO vision encoder components
+# ---------------------------------------------------------------------------
+
+
+class _RADIOBlock(nn.Module):
+    """RADIO transformer block: pre-norm attention + pre-norm FFN.
+
+    Unlike InternViT, RADIO omits layer scale parameters (``ls1``, ``ls2``).
+    Attention and MLP sub-modules reuse InternViT implementations since the
+    QKV-fused attention and fc1→GELU→fc2 MLP are identical.
+
+    HF reference: ViT block in ``vision_model.radio_model.model.blocks.N``.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        num_heads: int,
+        norm_eps: float = 1e-6,
+    ):
+        super().__init__()
+        self.attn = _InternVisionAttention(hidden_size, num_heads)
+        self.mlp = _InternVisionMLP(hidden_size, intermediate_size)
+        self.norm1 = VisionLayerNorm(hidden_size, eps=norm_eps)
+        self.norm2 = VisionLayerNorm(hidden_size, eps=norm_eps)
+
+    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+        # Pre-norm attention with residual (no layer scale)
+        residual = hidden_states
+        hidden_states = self.norm1(op, hidden_states)
+        hidden_states = self.attn(op, hidden_states)
+        hidden_states = op.Add(residual, hidden_states)
+
+        # Pre-norm FFN with residual (no layer scale)
+        residual = hidden_states
+        hidden_states = self.norm2(op, hidden_states)
+        hidden_states = self.mlp(op, hidden_states)
+        hidden_states = op.Add(residual, hidden_states)
+        return hidden_states
+
+
+class _RADIOVisionModel(nn.Module):
+    """RADIO ViT-H/16 vision encoder with CPE-style variable-resolution position encoding.
+
+    Uses RADIO's ``ViTPatchGenerator`` architecture:
+    1. Patch embedding (Conv2d, no bias)
+    2. Add position embeddings to patch tokens only (BEFORE prepending CLS)
+    3. Prepend CLS + register tokens (``num_summary_tokens`` total)
+    4. 32 transformer blocks (pre-norm, no layer scale)
+    5. No final LayerNorm (RADIO sets ``model.norm = nn.Identity()``)
+
+    RADIO's position embedding table (``pos_embed``) is stored at max-resolution
+    ``(cpe_max_size // patch_size)²``.  For the fixed 512×512 inference resolution
+    used here, a ``(32×32)`` window is sliced from the ``(128×128)`` table during
+    weight loading in ``preprocess_weights``.
+
+    Parameter shapes:
+    - ``patch_embed.weight``: ``[hidden, 3, patch, patch]``
+    - ``cls_token``: ``[num_summary_tokens, hidden]`` (CLS + register tokens, no batch dim)
+    - ``pos_embed``: ``[1, num_patches, hidden]`` (patches only, no CLS position)
+
+    HF reference: ``vision_model.radio_model.model`` in ``Llama_Nemotron_Nano_VL``.
+    """
+
+    def __init__(
+        self,
+        image_size: int,
+        patch_size: int,
+        hidden_size: int,
+        num_layers: int,
+        intermediate_size: int,
+        num_heads: int,
+        num_summary_tokens: int = 8,
+        norm_eps: float = 1e-6,
+    ):
+        super().__init__()
+        self.num_patches = (image_size // patch_size) ** 2
+        self.num_summary_tokens = num_summary_tokens
+        # RADIO patch embedding has no bias term
+        self.patch_embed = Conv2dNoBias(
+            3, hidden_size, kernel_size=patch_size, stride=patch_size
+        )
+        # CLS + register tokens — shape [num_summary_tokens, hidden_size] (no batch dim)
+        # HF: cls_token.token  shape [num_cls + num_registers, hidden]
+        self.cls_token = nn.Parameter([num_summary_tokens, hidden_size])
+        # Position embedding table for patch positions only (no CLS in pos table)
+        # At runtime (fixed 512×512 input), shape [1, num_patches, hidden_size]
+        # preprocess_weights windows this from the large [1, max_patches, hidden] table
+        self.pos_embed = nn.Parameter([1, self.num_patches, hidden_size])
+        self.blocks = nn.ModuleList(
+            [
+                _RADIOBlock(hidden_size, intermediate_size, num_heads, norm_eps)
+                for _ in range(num_layers)
+            ]
+        )
+
+    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+        # pixel_values: [batch, 3, image_size, image_size]
+        patch_embeds = self.patch_embed(op, pixel_values)
+        # patch_embeds: [batch, hidden_size, grid_h, grid_w]
+
+        # Flatten spatial dims: [batch, hidden_size, num_patches]
+        batch_size = op.Shape(patch_embeds, start=0, end=1)
+        hidden_dim = op.Shape(patch_embeds, start=1, end=2)
+        flat_shape = op.Concat(batch_size, hidden_dim, op.Constant(value_ints=[-1]), axis=0)
+        patch_embeds = op.Reshape(patch_embeds, flat_shape)
+        # Transpose to [batch, num_patches, hidden_size]
+        patch_embeds = op.Transpose(patch_embeds, perm=[0, 2, 1])
+
+        # Add position embeddings to patch tokens ONLY (RADIO style — before CLS prepend)
+        # pos_embed: [1, num_patches, hidden_size] → broadcast over batch
+        patch_embeds = op.Add(patch_embeds, self.pos_embed)
+
+        # Expand and prepend CLS + register tokens: [num_summary_tokens, hidden] → [batch, N, hidden]
+        cls = op.Expand(
+            op.Unsqueeze(self.cls_token, [0]),  # [1, num_summary_tokens, hidden]
+            op.Concat(
+                batch_size,
+                op.Constant(value_ints=[self.num_summary_tokens]),
+                hidden_dim,
+                axis=0,
+            ),
+        )
+        # [batch, num_summary_tokens + num_patches, hidden_size]
+        embeddings = op.Concat(cls, patch_embeds, axis=1)
+
+        # Pass through transformer blocks (no final LayerNorm — RADIO uses nn.Identity)
+        for block in self.blocks:
+            embeddings = block(op, embeddings)
+        return embeddings
+
+
+# ---------------------------------------------------------------------------
+# Vision encoder with pixel shuffle + MLP projector
+# ---------------------------------------------------------------------------
+
+
+class _LlamaNemotronNanoVLVisionEncoderModel(nn.Module):
+    """RADIO vision encoder + pixel shuffle + mlp1 projector.
+
+    Pipeline: pixel_values → RADIO ViT → strip CLS → pixel_shuffle(0.5)
+    → mlp1(LayerNorm → Linear → GELU → Linear) → image_features.
+
+    The pixel shuffle halves spatial dimensions and quadruples channels:
+    ``(N, H*W, C) → (N, H/2 * W/2, C*4)``
+
+    HF reference: ``Llama_Nemotron_Nano_VL.extract_feature`` +
+    ``Llama_Nemotron_Nano_VL.pixel_shuffle``.
+    """
+
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+        vc = config.vision
+        assert vc is not None, "VisionConfig is required"
+        self._downsample_ratio = 0.5
+        vit_hidden = vc.hidden_size
+        llm_hidden = config.hidden_size
+        # After pixel shuffle: vit_hidden * (1 / ratio)^2 = vit_hidden * 4
+        proj_input_dim = vit_hidden * int((1 / self._downsample_ratio) ** 2)
+        # Number of special tokens (CLS + registers) prepended by RADIO's ViTPatchGenerator
+        self._num_summary_tokens = vc.num_summary_tokens  # 8 for C-RADIOv2-H
+
+        self.vision_model = _RADIOVisionModel(
+            image_size=vc.image_size,
+            patch_size=vc.patch_size,
+            hidden_size=vit_hidden,
+            num_layers=vc.num_hidden_layers,
+            intermediate_size=vc.intermediate_size,
+            num_heads=vc.num_attention_heads,
+            num_summary_tokens=self._num_summary_tokens,
+            norm_eps=vc.norm_eps,
+        )
+        # mlp1: Sequential(LayerNorm, Linear, GELU, Linear)
+        # Indices: 0=LayerNorm, 1=Linear, 2=GELU (no params), 3=Linear
+        self.mlp1 = nn.Sequential(
+            VisionLayerNorm(proj_input_dim),
+            Linear(proj_input_dim, llm_hidden, bias=True),
+            _GELUPlaceholder(),
+            Linear(llm_hidden, llm_hidden, bias=True),
+        )
+
+    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+        # Run RADIO ViT encoder
+        vit_embeds = self.vision_model(op, pixel_values)
+        # vit_embeds: [batch, num_summary_tokens + num_patches, hidden_size]
+
+        # Strip all special tokens (CLS + registers) — RADIO uses num_summary_tokens=8
+        # for C-RADIOv2-H (4 CLS per teacher + 4 registers).
+        # Result: [batch, num_patches, hidden_size] (spatial patch features only)
+        vit_embeds = op.Slice(
+            vit_embeds,
+            op.Constant(value_ints=[self._num_summary_tokens]),  # start
+            op.Constant(value_ints=[2147483647]),  # end=INT_MAX
+            op.Constant(value_ints=[1]),  # axes=[1] (sequence dim)
+        )
+
+        # Pixel shuffle: (batch, num_patches, C) → (batch, num_patches/4, C*4)
+        vit_embeds = self._pixel_shuffle(op, vit_embeds)
+
+        # MLP projector: LayerNorm → Linear → GELU → Linear
+        image_features = self.mlp1(op, vit_embeds)
+        return image_features
+
+    def _pixel_shuffle(self, op, x):
+        """Pixel shuffle downsampling (ps_version='v2').
+
+        Reshapes (N, H*W, C) → spatial grid → interleave by scale factor
+        → flatten back to (N, H'*W', C').
+
+        With downsample_ratio=0.5:
+          (N, H*W, C) → (N, H, W, C) → (N, W, H/2, C*2)
+          → (N, H/2, W, C*2) → (N, H/2, W/2, C*4)
+          → (N, W/2, H/2, C*4) → (N, H/2*W/2, C*4)
+
+        HF reference: ``Llama_Nemotron_Nano_VL.pixel_shuffle``.
+        """
+        scale = self._downsample_ratio  # 0.5
+        batch = op.Shape(x, start=0, end=1)
+        seq_len = op.Shape(x, start=1, end=2)
+        channels = op.Shape(x, start=2, end=3)
+
+        # Compute H = W = sqrt(num_patches). Tiles are always square.
+        h = op.Cast(op.Sqrt(op.Cast(seq_len, to=1)), to=7)  # float sqrt → int64
+        w = h
+
+        # Reshape to (N, H, W, C) spatial grid
+        x = op.Reshape(x, op.Concat(batch, h, w, channels, axis=0))
+
+        # Step 1: view(N, W, H*scale, C/scale)
+        h_scaled = op.Cast(op.Mul(op.Cast(h, to=1), op.Constant(value_float=scale)), to=7)
+        c_over_scale = op.Cast(
+            op.Div(op.Cast(channels, to=1), op.Constant(value_float=scale)), to=7
+        )
+        x = op.Reshape(x, op.Concat(batch, w, h_scaled, c_over_scale, axis=0))
+
+        # Step 2: permute(0, 2, 1, 3) → (N, H*scale, W, C/scale)
+        x = op.Transpose(x, perm=[0, 2, 1, 3])
+
+        # Step 3: view(N, H*scale, W*scale, C/(scale^2))
+        w_scaled = op.Cast(op.Mul(op.Cast(w, to=1), op.Constant(value_float=scale)), to=7)
+        c_over_scale2 = op.Cast(
+            op.Div(op.Cast(channels, to=1), op.Constant(value_float=scale * scale)), to=7
+        )
+        x = op.Reshape(x, op.Concat(batch, h_scaled, w_scaled, c_over_scale2, axis=0))
+
+        # Step 4 (ps_version='v2'): permute(0, 2, 1, 3)
+        x = op.Transpose(x, perm=[0, 2, 1, 3])
+
+        # Flatten spatial dims → (N, H'*W', C*4)
+        x = op.Reshape(
+            x, op.Concat(batch, op.Constant(value_ints=[-1]), c_over_scale2, axis=0)
+        )
+        return x
+
+    def preprocess_weights(
+        self, state_dict: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        return {
+            key: value
+            for key, value in state_dict.items()
+            if key.startswith(("vision_model.", "mlp1."))
+        }
+
+
+# ---------------------------------------------------------------------------
+# Three-model split
+# ---------------------------------------------------------------------------
+
+
+class LlamaNemotronNanoVLModel(nn.Module):
+    """Llama_Nemotron_Nano_VL vision-language model (3-model split).
+
+    Builds three separate ONNX models:
+    - decoder: Llama 3.1 text decoder taking inputs_embeds
+    - vision: RADIO ViT-H/16 + pixel shuffle + MLP projector
+    - embedding: token embedding + image feature fusion
+
+    HF reference: ``nvidia/Llama-Nemotron-Nano-VL-8B-v1``
+    (model_type ``Llama_Nemotron_Nano_VL``).
+    """
+
+    default_task: str = "vision-language"
+    category: str = "Multimodal"
+
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+        self.config = config
+        self.decoder = _InternVL2DecoderModel(config)
+        self.vision_encoder = _LlamaNemotronNanoVLVisionEncoderModel(config)
+        self.embedding = _InternVL2EmbeddingModel(config)
+
+    def forward(self, op: builder.OpBuilder, **kwargs):
+        raise NotImplementedError(
+            "LlamaNemotronNanoVLModel uses VisionLanguageTask which calls "
+            "each sub-module (decoder, vision_encoder, embedding) separately."
+        )
+
+    def preprocess_weights(
+        self, state_dict: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        """Route HF weights to the correct ONNX sub-model initializer names.
+
+        HF prefixes → ONNX prefixes:
+        - ``vision_model.radio_model.model.patch_generator.embedder.weight``
+            → ``vision_encoder.vision_model.patch_embed.weight``
+        - ``vision_model.radio_model.model.patch_generator.cls_token.token``
+            → ``vision_encoder.vision_model.cls_token``
+            (shape [num_summary_tokens, hidden] — CLS + registers, no batch dim)
+        - ``vision_model.radio_model.model.patch_generator.pos_embed``
+            → ``vision_encoder.vision_model.pos_embed``  (window-selected from max resolution)
+            The stored pos_embed is [1, (cpe_max_size/patch)², hidden].
+            For fixed 512×512 inference we window-select the top-left 32×32 tile:
+            reshape [1, 128, 128, hidden] → take [:, :32, :32, :] → [1, 1024, hidden].
+        - ``vision_model.radio_model.model.blocks.N.*``
+            → ``vision_encoder.vision_model.blocks.N.*``
+        - ``vision_model.radio_model.input_conditioner.*`` → SKIP (image normalization stats)
+        - ``mlp1.*`` → ``vision_encoder.mlp1.*``
+        - ``language_model.model.*`` → ``decoder.model.*``
+        - ``language_model.lm_head.*`` → ``decoder.lm_head.*``
+        - ``language_model.model.embed_tokens.*``
+            → ``embedding.embed_tokens.*`` (dual copy)
+        """
+        renamed: dict[str, torch.Tensor] = {}
+
+        vc = self.config.vision
+        assert vc is not None
+        # Window-select parameters: pos_embed is stored at max resolution (128×128 grid)
+        # but we use a fixed 32×32 grid for 512×512 images.
+        image_size = vc.image_size
+        patch_size = vc.patch_size
+        h_in = w_in = image_size // patch_size  # 32 for 512px
+
+        pg = "vision_model.radio_model.model.patch_generator."
+        blocks_prefix = "vision_model.radio_model.model.blocks."
+        ic = "vision_model.radio_model.input_conditioner."
+
+        for key, value in state_dict.items():
+            if key.startswith(ic):
+                # Skip image normalization stats — not used for ONNX inference
+                continue
+            elif key == pg + "embedder.weight":
+                renamed["vision_encoder.vision_model.patch_embed.weight"] = value
+            elif key == pg + "cls_token.token":
+                # shape [num_summary_tokens, hidden] — no batch dim (ClsToken.token)
+                renamed["vision_encoder.vision_model.cls_token"] = value
+            elif key == pg + "pos_embed":
+                # Window-select from max-resolution table → target inference resolution.
+                # HF stores [1, (cpe_max/patch)², hidden]; we slice [1, h_in*w_in, hidden].
+                # The table is a 2-D grid; top-left (h_in × w_in) window matches the
+                # upper-left patch positions at the target resolution.
+                n, max_patches, c = value.shape
+                h_max = w_max = int(max_patches**0.5)
+                if h_max == h_in:
+                    # Already the right size (e.g. model trained at exactly image_size)
+                    renamed["vision_encoder.vision_model.pos_embed"] = value
+                else:
+                    # Reshape to 2-D grid, take top-left window, flatten
+                    grid = value.reshape(n, h_max, w_max, c)
+                    sliced = grid[:, :h_in, :w_in, :].reshape(n, h_in * w_in, c)
+                    renamed["vision_encoder.vision_model.pos_embed"] = sliced.contiguous()
+            elif key.startswith(blocks_prefix):
+                # blocks.N.* → vision_encoder.vision_model.blocks.N.*
+                suffix = key[len("vision_model.radio_model.model.") :]
+                renamed[f"vision_encoder.vision_model.{suffix}"] = value
+            elif key.startswith("mlp1."):
+                renamed[f"vision_encoder.{key}"] = value
+            elif key.startswith("language_model."):
+                suffix = key[len("language_model.") :]
+                renamed[f"decoder.{suffix}"] = value
+                # Embedding model also needs embed_tokens
+                if suffix.startswith("model.embed_tokens."):
+                    embed_suffix = suffix[len("model.") :]
+                    renamed[f"embedding.{embed_suffix}"] = value
+
+        # Weight tying: copy embed_tokens → lm_head when lm_head is absent
+        if self.config.tie_word_embeddings:
+            embed_key = "embedding.embed_tokens.weight"
+            head_key = "decoder.lm_head.weight"
+            if head_key not in renamed and embed_key in renamed:
+                renamed[head_key] = renamed[embed_key]
+
+        return renamed

--- a/src/mobius/models/llama_nemotron_nano_vl.py
+++ b/src/mobius/models/llama_nemotron_nano_vl.py
@@ -281,6 +281,7 @@ class _LlamaNemotronNanoVLVisionEncoderModel(nn.Module):
         channels = op.Shape(x, start=2, end=3)
 
         # Compute H = W = sqrt(num_patches). Tiles are always square.
+        # to=1 is ONNX TensorProto.FLOAT, to=7 is TensorProto.INT64
         h = op.Cast(op.Sqrt(op.Cast(seq_len, to=1)), to=7)  # float sqrt → int64
         w = h
 

--- a/src/mobius/models/nemotron_flash.py
+++ b/src/mobius/models/nemotron_flash.py
@@ -66,7 +66,8 @@ class NemotronFlashGLALayer(nn.Module):
 
     Weight prefix: ``gla.`` (q_proj, k_proj, v_proj, o_proj).
     For graph construction, uses standard GQA Attention as a placeholder.
-    The actual GLA recurrence will be implemented for parity later.
+    TODO(#92): Replace placeholder GQA with actual GLA linear recurrence
+    for numerical parity with HuggingFace.
 
     Layer type: ``"deltanet"`` — treated as full KV cache in the task.
 

--- a/src/mobius/models/nemotron_flash.py
+++ b/src/mobius/models/nemotron_flash.py
@@ -1,0 +1,494 @@
+# Copyright (c) ONNX Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""NemotronFlash hybrid GLA+Mamba2+Attention+FFN causal language model.
+
+NemotronFlash interleaves four layer types in a configurable pattern:
+- GLA (Gated Linear Attention / DeltaNet) layers for efficient linear recurrence
+- Mamba2/SSD layers for efficient recurrent processing
+- Standard GQA attention layers for global context
+- Dense FFN-only layers for feedforward computation
+
+Each layer is a single-mixer block: norm → mixer → residual.
+
+Additionally, NemotronFlash prepends ``num_memory_tokens`` learnable memory
+tokens to every forward call, extending the effective sequence length.  These
+tokens are sliced off after the transformer layers so only the original token
+hidden states are returned.
+
+Layer types (HF → mobius canonical):
+    ``"deltanet"`` → ``"deltanet"``  (treated as full KV-cache in task)
+    ``"m2"`` → ``"mamba2"``
+    ``"a"`` → ``"full_attention"``
+    ``"f"`` → ``"mlp"``
+
+Weight naming differences from NemotronH:
+    - Pre-norm is ``input_layernorm`` (not ``norm``)
+    - Final norm is ``final_layernorm`` (not ``norm``)
+    - GLA layers use ``gla.*`` weight prefix (not ``self_attn.*``)
+    - FFN layers use ``ffn.*`` prefix and ``pre_ffn_layernorm`` (not ``norm``)
+    - Memory tokens: ``model.memory_tokens`` parameter
+
+HuggingFace reference: ``NemotronFlashForCausalLM``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from onnxscript import nn
+from onnxscript._internal import builder
+
+from mobius._configs import NemotronFlashConfig
+from mobius._weight_utils import tie_word_embeddings
+from mobius.components import (
+    Attention,
+    Embedding,
+    Linear,
+    MLP,
+    Mamba2Block,
+    RMSNorm,
+    create_attention_bias,
+    initialize_rope,
+)
+
+if TYPE_CHECKING:
+    import onnx_ir as ir
+
+# ---------------------------------------------------------------------------
+# Decoder layers
+# ---------------------------------------------------------------------------
+
+
+class NemotronFlashGLALayer(nn.Module):
+    """GLA (Gated Linear Attention / DeltaNet) layer.
+
+    Weight prefix: ``gla.`` (q_proj, k_proj, v_proj, o_proj).
+    For graph construction, uses standard GQA Attention as a placeholder.
+    The actual GLA recurrence will be implemented for parity later.
+
+    Layer type: ``"deltanet"`` — treated as full KV cache in the task.
+
+    Args:
+        config: NemotronFlash architecture config.
+    """
+
+    def __init__(self, config: NemotronFlashConfig):
+        super().__init__()
+        # 'gla' attribute → weight paths: gla.q_proj.weight, gla.k_proj.weight, etc.
+        self.gla = Attention(config)
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        hidden_states: ir.Value,
+        attention_bias: ir.Value,
+        position_embeddings: tuple,
+        past_key_value: tuple | None,
+    ):
+        """Forward pass. Returns (hidden_states, (key, value)).
+
+        Uses GQA attention as a placeholder for the GLA computation.
+        """
+        residual = hidden_states
+        hidden_states = self.input_layernorm(op, hidden_states)
+
+        attn_output, present_kv = self.gla(
+            op,
+            hidden_states=hidden_states,
+            attention_bias=attention_bias,
+            position_embeddings=position_embeddings,
+            past_key_value=past_key_value,
+        )
+        hidden_states = op.Add(residual, attn_output)
+
+        return hidden_states, present_kv
+
+
+class NemotronFlashFFNLayer(nn.Module):
+    """FFN-only layer (HF type ``"f"``).
+
+    Weight prefix: ``ffn.`` (gate_proj, up_proj, down_proj).
+    Pre-norm attribute: ``pre_ffn_layernorm``.
+    Stateless — returns ``(None, None)`` as cache.
+
+    Args:
+        config: NemotronFlash architecture config.
+    """
+
+    def __init__(self, config: NemotronFlashConfig):
+        super().__init__()
+        # 'mlp' attribute → weight paths: mlp.gate_proj.weight, etc.
+        # HF uses 'ffn.*' prefix; preprocess_weights renames ffn.* → mlp.*
+        self.mlp = MLP(config)
+        # 'pre_ffn_layernorm' matches HF weight name directly
+        self.pre_ffn_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        hidden_states: ir.Value,
+        attention_bias: ir.Value,
+        position_embeddings: tuple,
+        past_key_value: tuple | None,
+    ):
+        """Forward pass. Returns (hidden_states, (None, None)).
+
+        FFN layers are stateless — the None pair keeps the cache list aligned.
+        """
+        del attention_bias, position_embeddings, past_key_value  # unused
+
+        residual = hidden_states
+        hidden_states = self.pre_ffn_layernorm(op, hidden_states)
+        hidden_states = self.mlp(op, hidden_states)
+        hidden_states = op.Add(residual, hidden_states)
+
+        return hidden_states, (None, None)
+
+
+class NemotronFlashMambaLayer(nn.Module):
+    """Mamba2 layer (HF type ``"m2"``).
+
+    Pre-norm attribute: ``input_layernorm`` (unlike NemotronH which uses ``norm``).
+    Returns ``(conv_state, ssm_state)`` matching the mamba2 cache type.
+
+    Args:
+        config: NemotronFlash architecture config.
+    """
+
+    def __init__(self, config: NemotronFlashConfig):
+        super().__init__()
+        # d_inner = num_heads * head_dim
+        d_inner = config.mamba_n_heads * config.mamba_d_head
+
+        self.mamba = Mamba2Block(
+            d_model=config.hidden_size,
+            d_inner=d_inner,
+            num_heads=config.mamba_n_heads,
+            d_head=config.mamba_d_head,
+            d_state=config.mamba_d_state,
+            n_groups=config.mamba_n_groups,
+            conv_kernel=config.mamba_d_conv,
+            conv_bias=config.mamba_conv_bias,
+            proj_bias=config.mamba_proj_bias,
+            eps=config.rms_norm_eps,
+            # NemotronFlash uses grouped RMSNorm: normalize within each group
+            norm_group_size=d_inner // config.mamba_n_groups,
+        )
+        # 'input_layernorm' matches HF weight name (NemotronH uses 'norm')
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        hidden_states: ir.Value,
+        attention_bias: ir.Value,
+        position_embeddings: tuple,
+        past_key_value: tuple | None,
+    ):
+        """Forward pass. Returns (hidden_states, (conv_state, ssm_state)).
+
+        attention_bias and position_embeddings are unused by Mamba layers
+        but accepted for a uniform interface with attention layers.
+        """
+        del attention_bias, position_embeddings  # unused
+
+        residual = hidden_states
+        hidden_states = self.input_layernorm(op, hidden_states)
+
+        conv_state, ssm_state = past_key_value if past_key_value is not None else (None, None)
+        mamba_out, new_conv_state, new_ssm_state = self.mamba(
+            op, hidden_states, conv_state, ssm_state
+        )
+        hidden_states = op.Add(residual, mamba_out)
+
+        return hidden_states, (new_conv_state, new_ssm_state)
+
+
+class NemotronFlashAttentionLayer(nn.Module):
+    """Standard GQA attention layer (HF type ``"a"``).
+
+    Pre-norm attribute: ``input_layernorm`` (unlike NemotronH which uses ``norm``).
+
+    Args:
+        config: NemotronFlash architecture config.
+    """
+
+    def __init__(self, config: NemotronFlashConfig):
+        super().__init__()
+        self.self_attn = Attention(config)
+        # 'input_layernorm' matches HF weight name (NemotronH uses 'norm')
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        hidden_states: ir.Value,
+        attention_bias: ir.Value,
+        position_embeddings: tuple,
+        past_key_value: tuple | None,
+    ):
+        """Forward pass. Returns (hidden_states, (key, value))."""
+        residual = hidden_states
+        hidden_states = self.input_layernorm(op, hidden_states)
+
+        attn_output, present_kv = self.self_attn(
+            op,
+            hidden_states=hidden_states,
+            attention_bias=attention_bias,
+            position_embeddings=position_embeddings,
+            past_key_value=past_key_value,
+        )
+        hidden_states = op.Add(residual, attn_output)
+
+        return hidden_states, present_kv
+
+
+# ---------------------------------------------------------------------------
+# Full model
+# ---------------------------------------------------------------------------
+
+
+class _NemotronFlashTextModel(nn.Module):
+    """NemotronFlash text backbone with memory tokens.
+
+    Prepends ``num_memory_tokens`` learnable memory tokens to the input
+    embeddings, runs ``N x (GLA | Mamba2 | Attention | FFN)`` layers,
+    then slices the memory tokens off before the final norm.
+
+    Layer types are selected based on ``config.layer_types``:
+        ``"deltanet"`` → NemotronFlashGLALayer
+        ``"mamba2"`` → NemotronFlashMambaLayer
+        ``"mlp"`` → NemotronFlashFFNLayer
+        ``"full_attention"`` → NemotronFlashAttentionLayer
+    """
+
+    def __init__(self, config: NemotronFlashConfig):
+        super().__init__()
+        self._config = config
+        self._dtype = config.dtype
+
+        self.embed_tokens = Embedding(
+            config.vocab_size, config.hidden_size, config.pad_token_id
+        )
+
+        # Learnable memory tokens prepended to input embeddings every forward call
+        if config.num_memory_tokens > 0:
+            self.memory_tokens = nn.Parameter(
+                [config.num_memory_tokens, config.hidden_size]
+            )
+
+        layer_types = config.layer_types or []
+        self.layers = nn.ModuleList([])
+        for i in range(config.num_hidden_layers):
+            ltype = layer_types[i] if i < len(layer_types) else "full_attention"
+            if ltype == "deltanet":
+                self.layers.append(NemotronFlashGLALayer(config))
+            elif ltype == "mamba2":
+                self.layers.append(NemotronFlashMambaLayer(config))
+            elif ltype == "mlp":
+                self.layers.append(NemotronFlashFFNLayer(config))
+            else:  # "full_attention"
+                self.layers.append(NemotronFlashAttentionLayer(config))
+
+        # 'final_layernorm' matches HF weight name (NemotronH uses 'norm')
+        self.final_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = initialize_rope(config)
+
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        input_ids: ir.Value,
+        attention_mask: ir.Value,
+        position_ids: ir.Value,
+        past_key_values: list | None = None,
+    ):
+        hidden_states = self.embed_tokens(op, input_ids)  # (batch, seq, H)
+
+        num_mem = self._config.num_memory_tokens
+        if num_mem > 0:
+            hidden_states, position_ids, attention_mask = self._prepend_memory_tokens(
+                op, hidden_states, position_ids, attention_mask, input_ids
+            )
+            # Use extended input to drive attention bias shape
+            attention_input = self._make_extended_input_ids(op, input_ids)
+        else:
+            attention_input = input_ids
+
+        position_embeddings = self.rotary_emb(op, position_ids)
+        attention_bias = create_attention_bias(
+            op,
+            input_ids=attention_input,
+            attention_mask=attention_mask,
+            dtype=self._dtype,
+        )
+
+        present_key_values = []
+        past_kvs = past_key_values or [None] * len(self.layers)
+        for layer, past_kv in zip(self.layers, past_kvs):
+            hidden_states, present_kv = layer(
+                op,
+                hidden_states=hidden_states,
+                attention_bias=attention_bias,
+                position_embeddings=position_embeddings,
+                past_key_value=past_kv,
+            )
+            present_key_values.append(present_kv)
+
+        if num_mem > 0:
+            # Slice off the leading memory token outputs; keep only the original seq
+            # Slice(data, starts, ends, axes): axis=1, start=num_mem, end=max_int
+            hidden_states = op.Slice(
+                hidden_states,
+                op.Constant(value_ints=[num_mem]),  # starts
+                op.Constant(value_ints=[2147483647]),  # ends (INT_MAX)
+                op.Constant(value_ints=[1]),  # axes = [1]
+            )
+
+        hidden_states = self.final_layernorm(op, hidden_states)
+        return hidden_states, present_key_values
+
+    def _prepend_memory_tokens(
+        self,
+        op: builder.OpBuilder,
+        hidden_states: ir.Value,
+        position_ids: ir.Value,
+        attention_mask: ir.Value,
+        input_ids: ir.Value,
+    ) -> tuple[ir.Value, ir.Value, ir.Value]:
+        """Prepend memory tokens to hidden_states, and extend position_ids / attention_mask.
+
+        Returns:
+            (extended_hidden_states, extended_position_ids, extended_attention_mask)
+        """
+        num_mem = self._config.num_memory_tokens
+        batch_size = op.Shape(hidden_states, start=0, end=1)  # 1D tensor [B]
+        num_mem_tensor = op.Constant(value_ints=[num_mem])  # 1D tensor [num_mem]
+
+        # --- Expand memory tokens: (num_mem, H) → (batch, num_mem, H) ---
+        mem = op.Unsqueeze(self.memory_tokens, [0])  # (1, num_mem, H)
+        expand_shape = op.Concat(
+            batch_size,
+            op.Constant(value_ints=[num_mem, self._config.hidden_size]),
+            axis=0,
+        )  # 1D tensor [B, num_mem, H]
+        mem = op.Expand(mem, expand_shape)  # (batch, num_mem, H)
+        hidden_states = op.Concat(mem, hidden_states, axis=1)  # (batch, num_mem+seq, H)
+
+        # --- Extend position IDs: prepend [0, 1, ..., num_mem-1] ---
+        mem_pos = op.Unsqueeze(
+            op.Range(
+                op.Constant(value_int=0),
+                op.Constant(value_int=num_mem),
+                op.Constant(value_int=1),
+            ),
+            [0],
+        )  # (1, num_mem) - int64
+        mem_pos = op.Expand(
+            mem_pos, op.Concat(batch_size, num_mem_tensor, axis=0)
+        )  # (batch, num_mem)
+        mem_pos = op.CastLike(mem_pos, position_ids)
+        position_ids = op.Concat(mem_pos, position_ids, axis=1)  # (batch, num_mem+seq)
+
+        # --- Extend attention mask: prepend ones for memory token positions ---
+        mem_mask = op.Expand(
+            op.Constant(value_ints=[1]),  # scalar-like 1D [1]
+            op.Concat(batch_size, num_mem_tensor, axis=0),  # [B, num_mem]
+        )  # (batch, num_mem)
+        mem_mask = op.CastLike(mem_mask, attention_mask)
+        attention_mask = op.Concat(mem_mask, attention_mask, axis=1)
+
+        return hidden_states, position_ids, attention_mask
+
+    def _make_extended_input_ids(
+        self, op: builder.OpBuilder, input_ids: ir.Value
+    ) -> ir.Value:
+        """Create a fake input_ids of shape (batch, num_mem+seq) for attention bias shape.
+
+        The values don't matter; only the shape is used by create_attention_bias.
+        """
+        num_mem = self._config.num_memory_tokens
+        batch_size = op.Shape(input_ids, start=0, end=1)  # [B]
+        seq_len = op.Shape(input_ids, start=1, end=2)  # [S]
+        extended_seq = op.Add(seq_len, op.Constant(value_ints=[num_mem]))  # [num_mem+S]
+        # Expand shape-[1] zero tensor to (batch, num_mem+seq)
+        return op.Expand(
+            op.Constant(value_ints=[0]),
+            op.Concat(batch_size, extended_seq, axis=0),
+        )
+
+
+class NemotronFlashCausalLMModel(nn.Module):
+    """NemotronFlash hybrid GLA+Mamba2+Attention+FFN causal language model.
+
+    Interleaves four layer types:
+    - GLA (Gated Linear Attention / DeltaNet) — linear recurrence with KV cache
+    - Mamba2/SSD — efficient recurrent SSM layers
+    - Standard GQA attention — global context attention layers
+    - Dense FFN — stateless feedforward layers
+
+    Prepends ``num_memory_tokens`` learnable memory tokens to every forward call.
+
+    Uses ``HybridCausalLMTask`` with mixed layer types for cache management.
+
+    HuggingFace reference: ``NemotronFlashForCausalLM`` (trust_remote_code).
+    """
+
+    default_task: str = "hybrid-text-generation"
+    category: str = "Hybrid SSM+Attention"
+    config_class: type = NemotronFlashConfig
+
+    def __init__(self, config: NemotronFlashConfig):
+        super().__init__()
+        self.config = config
+        self.model = _NemotronFlashTextModel(config)
+        self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        input_ids: ir.Value,
+        attention_mask: ir.Value,
+        position_ids: ir.Value,
+        past_key_values: list | None = None,
+    ):
+        hidden_states, present_key_values = self.model(
+            op,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+        )
+        logits = self.lm_head(op, hidden_states)
+        return logits, present_key_values
+
+    def preprocess_weights(
+        self, state_dict: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        """Map HuggingFace NemotronFlashForCausalLM weights to ONNX parameters.
+
+        HF weight names already match the ONNX module hierarchy because
+        attribute names were chosen to align with HF naming:
+          - model.embed_tokens.weight  ✓
+          - model.memory_tokens        ✓
+          - model.layers.N.gla.*       ✓ (deltanet layers)
+          - model.layers.N.self_attn.* ✓ (attention layers)
+          - model.layers.N.mamba.*     ✓ (mamba2 layers)
+          - model.layers.N.ffn.*       → model.layers.N.mlp.* (rename: HF uses 'ffn', ONNX uses 'mlp')
+          - model.layers.N.input_layernorm.weight  ✓
+          - model.layers.N.pre_ffn_layernorm.weight ✓
+          - model.final_layernorm.weight  ✓
+          - lm_head.weight             ✓
+
+        Handles:
+        - ``model.layers.N.ffn.*`` → ``model.layers.N.mlp.*``: ONNX uses the standard
+          ``mlp`` attribute name for FFN-only layers; HF uses ``ffn.*`` prefix.
+        - Weight tying (embed_tokens ↔ lm_head).
+        """
+        # Rename HF 'ffn.*' to ONNX 'mlp.*' for FFN-only layers
+        state_dict = {key.replace(".ffn.", ".mlp."): value for key, value in state_dict.items()}
+        if self.config.tie_word_embeddings:
+            tie_word_embeddings(state_dict)
+        return state_dict

--- a/src/mobius/models/nemotron_h.py
+++ b/src/mobius/models/nemotron_h.py
@@ -236,13 +236,21 @@ class _NemotronHTextModel(nn.Module):
         attention_mask: ir.Value,
         position_ids: ir.Value,
         past_key_values: list | None = None,
+        inputs_embeds: ir.Value | None = None,
     ):
-        hidden_states = self.embed_tokens(op, input_ids)
+        if inputs_embeds is not None:
+            # VL path: fused image+text embeddings provided externally; skip embed_tokens
+            hidden_states = inputs_embeds
+            seq_shape_source = inputs_embeds  # [B, S, H] — dim 1 is sequence length
+        else:
+            hidden_states = self.embed_tokens(op, input_ids)
+            seq_shape_source = input_ids  # [B, S] — dim 1 is sequence length
+
         position_embeddings = self.rotary_emb(op, position_ids)
 
         attention_bias = create_attention_bias(
             op,
-            input_ids=input_ids,
+            input_ids=seq_shape_source,
             attention_mask=attention_mask,
             dtype=self._dtype,
         )

--- a/src/mobius/models/nemotronh_nano_vl.py
+++ b/src/mobius/models/nemotronh_nano_vl.py
@@ -86,15 +86,6 @@ class _NemotronHVLDecoderModel(nn.Module):
         logits = self.lm_head(op, hidden_states)
         return logits, present_key_values
 
-    def preprocess_weights(
-        self, state_dict: dict[str, torch.Tensor]
-    ) -> dict[str, torch.Tensor]:
-        return {
-            key: value
-            for key, value in state_dict.items()
-            if key.startswith(("model.", "lm_head."))
-        }
-
 
 # ---------------------------------------------------------------------------
 # Three-model split

--- a/src/mobius/models/nemotronh_nano_vl.py
+++ b/src/mobius/models/nemotronh_nano_vl.py
@@ -1,0 +1,201 @@
+# Copyright (c) ONNX Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""NemotronH_Nano_VL_V2 multimodal model — RADIO vision + NemotronH text decoder.
+
+Splits the NemotronH_Nano_VL_V2 architecture into three ONNX models for
+onnxruntime-genai:
+
+- **decoder**: NemotronH hybrid (Mamba2 + Attention + MLP) text decoder taking
+  ``inputs_embeds``
+- **vision**: RADIO ViT-H/16 encoder + pixel shuffle + MLP projector
+- **embedding**: token embedding + image feature fusion
+
+Architecture notes:
+- Identical RADIO vision encoder to ``Llama_Nemotron_Nano_VL`` (RADIO ViT-H/16 CPE)
+- NemotronH text decoder (hybrid Mamba2 + Attention + MLP layers)
+- Larger MLP projector: 5120 → 20480 (projector_hidden_size) → 5120 (llm_hidden)
+- ``ps_version='v2'`` pixel shuffle
+
+HuggingFace reference: ``nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16``
+(model_type ``NemotronH_Nano_VL_V2``).
+
+HuggingFace weight names:
+- ``vision_model.radio_model.model.patch_generator.*``
+- ``vision_model.radio_model.model.blocks.N.*``
+- ``vision_model.radio_model.input_conditioner.*`` (skipped)
+- ``mlp1.{0,1,3}.*``
+- ``language_model.backbone.*`` / ``language_model.lm_head.*``
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from onnxscript import nn
+from onnxscript._internal import builder
+
+from mobius._configs import ArchitectureConfig
+from mobius.components import Linear
+from mobius.components._vision import VisionLayerNorm
+from mobius.models.internvl import _GELUPlaceholder, _InternVL2EmbeddingModel
+from mobius.models.llama_nemotron_nano_vl import _LlamaNemotronNanoVLVisionEncoderModel
+from mobius.models.nemotron_h import _NemotronHTextModel, _rename_nemotron_h_weight
+
+if TYPE_CHECKING:
+    import onnx_ir as ir
+
+
+# ---------------------------------------------------------------------------
+# NemotronH text decoder for VL — takes inputs_embeds
+# ---------------------------------------------------------------------------
+
+
+class _NemotronHVLDecoderModel(nn.Module):
+    """NemotronH text decoder for VL use — takes ``inputs_embeds`` instead of ``input_ids``.
+
+    Wraps ``_NemotronHTextModel`` and exposes the VL-compatible interface (same
+    as ``_InternVL2DecoderModel``) so the ``VisionLanguageTask`` can drive it.
+
+    HF weight prefix: ``language_model.backbone.*`` / ``language_model.lm_head.*``.
+    """
+
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+        self.config = config
+        self.model = _NemotronHTextModel(config)
+        self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        inputs_embeds: ir.Value,
+        attention_mask: ir.Value,
+        position_ids: ir.Value,
+        past_key_values: list | None = None,
+    ):
+        hidden_states, present_key_values = self.model(
+            op,
+            input_ids=None,  # type: ignore[arg-type]
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+        )
+        logits = self.lm_head(op, hidden_states)
+        return logits, present_key_values
+
+    def preprocess_weights(
+        self, state_dict: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        return {
+            key: value
+            for key, value in state_dict.items()
+            if key.startswith(("model.", "lm_head."))
+        }
+
+
+# ---------------------------------------------------------------------------
+# Three-model split
+# ---------------------------------------------------------------------------
+
+
+class NemotronHNanoVLModel(nn.Module):
+    """NemotronH_Nano_VL_V2 vision-language model (3-model split).
+
+    Builds three separate ONNX models:
+    - decoder: NemotronH hybrid text decoder taking inputs_embeds
+    - vision: RADIO ViT-H/16 + pixel shuffle + MLP projector
+    - embedding: token embedding + image feature fusion
+
+    HF reference: ``nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16``
+    (model_type ``NemotronH_Nano_VL_V2``).
+    """
+
+    default_task: str = "hybrid-vision-language"
+    category: str = "Multimodal"
+
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+        self.config = config
+        self.decoder = _NemotronHVLDecoderModel(config)
+        self.vision_encoder = _LlamaNemotronNanoVLVisionEncoderModel(config)
+        self.embedding = _InternVL2EmbeddingModel(config)
+
+    def forward(self, op: builder.OpBuilder, **kwargs):
+        raise NotImplementedError(
+            "NemotronHNanoVLModel uses HybridVisionLanguageTask which calls "
+            "each sub-module (decoder, vision_encoder, embedding) separately."
+        )
+
+    def preprocess_weights(
+        self, state_dict: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        """Route HF weights to the correct ONNX sub-model initializer names.
+
+        HF prefixes → ONNX prefixes:
+        - ``vision_model.radio_model.model.patch_generator.*``
+            → ``vision_encoder.vision_model.*`` (window-select pos_embed)
+        - ``vision_model.radio_model.model.blocks.N.*``
+            → ``vision_encoder.vision_model.blocks.N.*``
+        - ``vision_model.radio_model.input_conditioner.*`` → SKIP
+        - ``mlp1.*`` → ``vision_encoder.mlp1.*``
+        - ``language_model.*`` → apply NemotronH weight renaming → ``decoder.*``
+        - ``language_model.backbone.embeddings.weight``
+            → ``embedding.embed_tokens.weight`` (dual copy)
+        """
+        renamed: dict[str, torch.Tensor] = {}
+
+        vc = self.config.vision
+        assert vc is not None
+        image_size = vc.image_size
+        patch_size = vc.patch_size
+        h_in = w_in = image_size // patch_size
+
+        pg = "vision_model.radio_model.model.patch_generator."
+        blocks_prefix = "vision_model.radio_model.model.blocks."
+        ic = "vision_model.radio_model.input_conditioner."
+
+        layer_types = self.config.layer_types or []
+
+        for key, value in state_dict.items():
+            if key.startswith(ic):
+                continue  # skip image normalization stats
+            elif key == pg + "embedder.weight":
+                renamed["vision_encoder.vision_model.patch_embed.weight"] = value
+            elif key == pg + "cls_token.token":
+                renamed["vision_encoder.vision_model.cls_token"] = value
+            elif key == pg + "pos_embed":
+                # Window-select from max-resolution table to inference resolution
+                n, max_patches, c = value.shape
+                h_max = w_max = int(max_patches**0.5)
+                if h_max == h_in:
+                    renamed["vision_encoder.vision_model.pos_embed"] = value
+                else:
+                    grid = value.reshape(n, h_max, w_max, c)
+                    sliced = grid[:, :h_in, :w_in, :].reshape(n, h_in * w_in, c)
+                    renamed["vision_encoder.vision_model.pos_embed"] = sliced.contiguous()
+            elif key.startswith(blocks_prefix):
+                suffix = key[len("vision_model.radio_model.model."):]
+                renamed[f"vision_encoder.vision_model.{suffix}"] = value
+            elif key.startswith("mlp1."):
+                renamed[f"vision_encoder.{key}"] = value
+            elif key.startswith("language_model."):
+                # Strip "language_model." prefix, then apply NemotronH weight renaming
+                raw = key[len("language_model."):]
+                # NemotronH renaming: backbone.* → model.*, etc.
+                onnx_key = _rename_nemotron_h_weight(raw, layer_types)
+                renamed[f"decoder.{onnx_key}"] = value
+                # Embedding model also needs embed_tokens
+                if raw == "backbone.embeddings.weight":
+                    renamed["embedding.embed_tokens.weight"] = value
+
+        # Weight tying: copy embed_tokens → lm_head when tie_word_embeddings=True
+        if self.config.tie_word_embeddings:
+            embed_key = "embedding.embed_tokens.weight"
+            head_key = "decoder.lm_head.weight"
+            if head_key not in renamed and embed_key in renamed:
+                renamed[head_key] = renamed[embed_key]
+
+        return renamed

--- a/src/mobius/tasks/__init__.py
+++ b/src/mobius/tasks/__init__.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 __all__ = [
     "AdapterTask",
     "AudioFeatureExtractionTask",
+    "AudioLanguageTask",
     "CausalLMTask",
     "CodecTask",
     "ControlNetTask",
@@ -28,6 +29,7 @@ __all__ = [
     "FeatureExtractionTask",
     "HybridCausalLMTask",
     "HybridQwenVLTask",
+    "HybridVisionLanguageTask",
     "ImageClassificationTask",
     "ModelTask",
     "MllamaVisionLanguageTask",
@@ -54,6 +56,7 @@ __all__ = [
 from mobius._constants import OPSET_VERSION
 from mobius.tasks._adapter import AdapterTask
 from mobius.tasks._audio_feature_extraction import AudioFeatureExtractionTask
+from mobius.tasks._audio_language import AudioLanguageTask
 from mobius.tasks._base import ModelTask
 from mobius.tasks._causal_lm import (
     CausalLMTask,
@@ -78,6 +81,7 @@ from mobius.tasks._video_denoising import VideoDenoisingTask
 from mobius.tasks._vision_language import Qwen3VLVisionLanguageTask
 from mobius.tasks._vision_language_3model import (
     HybridQwenVLTask,
+    HybridVisionLanguageTask,
     MllamaVisionLanguageTask,
     QwenVLTask,
     VisionLanguageTask,
@@ -90,6 +94,7 @@ from mobius.tasks._vision_language_3model import (
 TASK_REGISTRY: dict[str, type[ModelTask]] = {
     "adapter": AdapterTask,
     "audio-feature-extraction": AudioFeatureExtractionTask,
+    "audio-language": AudioLanguageTask,
     "codec": CodecTask,
     "controlnet": ControlNetTask,
     "denoising": DenoisingTask,
@@ -105,6 +110,7 @@ TASK_REGISTRY: dict[str, type[ModelTask]] = {
     "mllama-vision-language": MllamaVisionLanguageTask,
     "qwen-vl": QwenVLTask,
     "hybrid-qwen-vl": HybridQwenVLTask,
+    "hybrid-vision-language": HybridVisionLanguageTask,
     "qwen3-vl-vision-language": Qwen3VLVisionLanguageTask,
     "multimodal": MultiModalTask,
     "phi4mm-multimodal": Phi4MMMultiModalTask,

--- a/src/mobius/tasks/_audio_language.py
+++ b/src/mobius/tasks/_audio_language.py
@@ -1,0 +1,94 @@
+# Copyright (c) ONNX Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Audio-language 3-model split task for audio understanding models.
+
+Same structure as SpeechLanguageTask but uses 1D position_ids for
+decoders with standard RoPE (not MRoPE), such as Qwen2.
+"""
+
+from __future__ import annotations
+
+import onnx_ir as ir
+from onnxscript import nn
+
+from mobius._configs import ArchitectureConfig
+from mobius.tasks._base import (
+    _make_graph,
+    _make_kv_cache_inputs,
+    _make_model,
+    _register_kv_cache_outputs,
+)
+from mobius.tasks._speech_language import SpeechLanguageTask
+
+
+class AudioLanguageTask(SpeechLanguageTask):
+    """3-model split for audio-language models with standard 1D RoPE.
+
+    Identical to :class:`SpeechLanguageTask` except the decoder uses
+    standard 1D ``position_ids`` with shape ``[batch, seq_len]`` instead
+    of MRoPE 3D ``[3, batch, seq_len]``.
+
+    The module must expose three sub-module attributes:
+
+    - ``audio_tower``: audio encoder (mel → audio features)
+    - ``embedding``: embedding model (input_ids + audio_features → inputs_embeds)
+    - ``decoder``: text decoder with standard 1D RoPE and KV cache
+
+    Use this task for models whose text decoder is a standard 1D-RoPE
+    transformer (e.g. Qwen2), in contrast to MRoPE-based decoders like
+    Qwen3-ASR.
+    """
+
+    def _build_decoder(
+        self,
+        decoder: nn.Module,
+        config: ArchitectureConfig,
+    ) -> ir.Model:
+        """Build decoder with standard 1D position_ids [batch, seq_len]."""
+        batch = ir.SymbolicDim("batch")
+        seq_len = ir.SymbolicDim("sequence_len")
+        past_seq_len = ir.SymbolicDim("past_sequence_len")
+
+        inputs_embeds = ir.Value(
+            name="inputs_embeds",
+            shape=ir.Shape([batch, seq_len, config.hidden_size]),
+            type=ir.TensorType(config.dtype),
+        )
+        attention_mask = ir.Value(
+            name="attention_mask",
+            shape=ir.Shape([batch, "past_seq_len + seq_len"]),
+            type=ir.TensorType(ir.DataType.INT64),
+        )
+        # Standard 1D position_ids — shape [batch, seq_len]
+        position_ids = ir.Value(
+            name="position_ids",
+            shape=ir.Shape([batch, seq_len]),
+            type=ir.TensorType(ir.DataType.INT64),
+        )
+
+        graph_inputs = [inputs_embeds, attention_mask, position_ids]
+
+        kv_inputs, past_key_values = _make_kv_cache_inputs(
+            config.num_hidden_layers,
+            config.num_key_value_heads,
+            config.head_dim,
+            config.dtype,
+            batch,
+            past_seq_len,
+        )
+        graph_inputs.extend(kv_inputs)
+
+        graph, builder = _make_graph(graph_inputs, name="decoder")
+        logits, present_key_values = decoder(
+            builder.op,
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+        )
+
+        logits.name = "logits"
+        graph.outputs.append(logits)
+        _register_kv_cache_outputs(graph, present_key_values)
+        return _make_model(graph)

--- a/src/mobius/tasks/_audio_language.py
+++ b/src/mobius/tasks/_audio_language.py
@@ -90,5 +90,5 @@ class AudioLanguageTask(SpeechLanguageTask):
 
         logits.name = "logits"
         graph.outputs.append(logits)
-        _register_kv_cache_outputs(graph, present_key_values)
+        _register_kv_cache_outputs(graph, present_key_values=present_key_values)
         return _make_model(graph)

--- a/src/mobius/tasks/_base.py
+++ b/src/mobius/tasks/_base.py
@@ -20,8 +20,9 @@ from mobius._model_package import ModelPackage
 _FUNCTIONS_DOMAIN = "pkg.mobius"
 
 # Cache state pair: (key, value) or (conv_state, ssm_state) for stateful
-# layers.  MLP-only layers are stateless and use (None, None).
-StatePair = tuple[ir.Value, ir.Value] | tuple[None, None]
+# layers.  Single-state layers (conv/lightning) use a 1-tuple.
+# MLP-only layers are stateless and use (None, None).
+StatePair = tuple[ir.Value, ir.Value] | tuple[ir.Value] | tuple[None, None]
 
 
 class LinearAttentionDims(NamedTuple):
@@ -194,6 +195,7 @@ def _make_hybrid_cache_inputs(
 
     Supported layer types:
         ``"full_attention"`` — standard KV cache (key + value).
+        ``"conv"`` — ShortConv conv_state only.
         ``"linear_attention"`` (DeltaNet) — conv_state + recurrent_state.
         ``"mamba"`` / ``"mamba2"`` — conv_state + ssm_state.
         ``"mlp"`` — stateless, produces ``(None, None)`` pair.
@@ -262,6 +264,17 @@ def _make_hybrid_cache_inputs(
             )
             flat.extend([conv_state, rec_state])
             pairs.append((conv_state, rec_state))
+        elif ltype == "conv":
+            # ShortConv layers: conv_state only (no SSM state)
+            # State: (batch, hidden_size, short_conv_kernel - 1)
+            short_conv_kernel = getattr(config, "short_conv_kernel", 3)
+            conv_state = ir.Value(
+                name=f"{prefix}.{i}.conv_state",
+                shape=ir.Shape([batch, config.hidden_size, short_conv_kernel - 1]),
+                type=ir.TensorType(dtype),
+            )
+            flat.append(conv_state)
+            pairs.append((conv_state,))  # 1-tuple: conv has no second state
         elif ltype == "mlp":
             # MLP-only layers are stateless — no cache inputs needed
             pairs.append((None, None))
@@ -337,6 +350,11 @@ def _register_hybrid_cache_outputs(
             # Single recurrent state only (no conv_state for lightning)
             (state_a,) = states
             state_a.name = f"{prefix}.{i}.recurrent_state"
+            graph.outputs.append(state_a)
+        elif ltype == "conv":
+            # ShortConv: single conv_state only
+            (state_a,) = states
+            state_a.name = f"{prefix}.{i}.conv_state"
             graph.outputs.append(state_a)
         else:
             state_a, state_b = states

--- a/src/mobius/tasks/_vision_language_3model.py
+++ b/src/mobius/tasks/_vision_language_3model.py
@@ -354,6 +354,73 @@ class HybridQwenVLTask(QwenVLTask):
         return model
 
 
+class HybridVisionLanguageTask(VisionLanguageTask):
+    """3-model VL split with hybrid KV + SSM cache for the text decoder.
+
+    Used by models like NemotronH_Nano_VL_V2 that pair a RADIO vision encoder
+    with a hybrid text decoder (Mamba2 + Attention + MLP layers).  Vision and
+    embedding models use the standard :class:`VisionLanguageTask` implementations;
+    only the decoder uses hybrid cache inputs/outputs.
+    """
+
+    def _build_decoder(
+        self,
+        decoder: nn.Module,
+        config: ArchitectureConfig,
+    ) -> ir.Model:
+        """Build hybrid text decoder: inputs_embeds → logits + hybrid cache."""
+        batch = ir.SymbolicDim("batch")
+        seq_len = ir.SymbolicDim("sequence_len")
+        past_seq_len = ir.SymbolicDim("past_sequence_len")
+
+        inputs_embeds = ir.Value(
+            name="inputs_embeds",
+            shape=ir.Shape([batch, seq_len, config.hidden_size]),
+            type=ir.TensorType(config.dtype),
+        )
+        attention_mask = ir.Value(
+            name="attention_mask",
+            shape=ir.Shape([batch, "past_seq_len + seq_len"]),
+            type=ir.TensorType(ir.DataType.INT64),
+        )
+        position_ids = ir.Value(
+            name="position_ids",
+            shape=ir.Shape([batch, seq_len]),
+            type=ir.TensorType(ir.DataType.INT64),
+        )
+
+        graph_inputs = [inputs_embeds, attention_mask, position_ids]
+
+        cache_inputs, past_key_values = _make_hybrid_cache_inputs(
+            config,
+            config.dtype,
+            batch,
+            past_seq_len,
+        )
+        graph_inputs.extend(cache_inputs)
+
+        graph, graph_builder = _make_graph(graph_inputs, name="decoder")
+        op = graph_builder.op
+
+        logits, present_key_values = decoder(
+            op,
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+        )
+
+        logits.name = "logits"
+        graph.outputs.append(logits)
+        _register_hybrid_cache_outputs(
+            graph,
+            present_key_values,
+            config.layer_types or [],
+        )
+
+        return _make_model(graph)
+
+
 class MllamaVisionLanguageTask(VisionLanguageTask):
     """Mllama VL task with cross-attention KV caching.
 

--- a/src/mobius/tasks/_vision_language_3model.py
+++ b/src/mobius/tasks/_vision_language_3model.py
@@ -107,7 +107,7 @@ class VisionLanguageTask(ModelTask):
 
         logits.name = "logits"
         graph.outputs.append(logits)
-        _register_kv_cache_outputs(graph, present_key_values)
+        _register_kv_cache_outputs(graph, present_key_values=present_key_values)
 
         return _make_model(graph)
 
@@ -238,7 +238,7 @@ class QwenVLTask(VisionLanguageTask):
 
         logits.name = "logits"
         graph.outputs.append(logits)
-        _register_kv_cache_outputs(graph, present_key_values)
+        _register_kv_cache_outputs(graph, present_key_values=present_key_values)
 
         return _make_model(graph)
 
@@ -524,6 +524,6 @@ class MllamaVisionLanguageTask(VisionLanguageTask):
 
         logits.name = "logits"
         graph.outputs.append(logits)
-        _register_kv_cache_outputs(graph, present_key_values)
+        _register_kv_cache_outputs(graph, present_key_values=present_key_values)
 
         return _make_model(graph)

--- a/testdata/cases/audio/audioflamingo3-hf.yaml
+++ b/testdata/cases/audio/audioflamingo3-hf.yaml
@@ -1,0 +1,20 @@
+model_id: "nvidia/audio-flamingo-3-hf"
+revision: "5c47d2de83c3163162586561f3ddba75b4a1194e"
+task_type: "audio-language"
+dtype: "float32"
+
+inputs:
+  prompts:
+    - "Transcribe the following audio."
+  audio:
+    - "test_audio.wav"
+
+level: "L4+L5"
+
+generation:
+  max_new_tokens: 30
+  do_sample: false
+
+trust_remote_code: true
+skip_reason: "AudioFlamingo3 — requires audio preprocessing pipeline not yet integrated; model uses custom AudioLanguageTask."
+notes: "AudioFlamingo3. Whisper audio encoder + projector + Qwen2-7B text decoder. 3-model audio-language split."

--- a/testdata/cases/causal-lm/nemotron-flash-1b.yaml
+++ b/testdata/cases/causal-lm/nemotron-flash-1b.yaml
@@ -1,0 +1,18 @@
+model_id: "nvidia/nemotron-flash-1b"
+revision: "da87f707f678b5936e67fdcfe598f76ebcc5fdbc"
+task_type: "text-generation"
+dtype: "float32"
+
+inputs:
+  prompts:
+    - "Here is my poem:"
+
+level: "L4+L5"
+
+generation:
+  max_new_tokens: 20
+  do_sample: false
+
+trust_remote_code: true
+skip_reason: "nemotron_flash 1B — trust_remote_code required; GLA layer uses placeholder attention (parity pass deferred)."
+notes: "NemotronFlash 1B. Hybrid GLA+Mamba2+Attention+FFN with 256 learnable memory tokens."

--- a/testdata/cases/schema.json
+++ b/testdata/cases/schema.json
@@ -35,6 +35,7 @@
       "type": "string",
       "enum": [
         "audio-feature-extraction",
+        "audio-language",
         "audio-to-audio",
         "codec",
         "depth-estimation",

--- a/testdata/cases/vision-language/llama-nemotron-nano-vl-8b.yaml
+++ b/testdata/cases/vision-language/llama-nemotron-nano-vl-8b.yaml
@@ -1,0 +1,20 @@
+model_id: "nvidia/Llama-Nemotron-Nano-VL-8B-v1"
+revision: "437f4e28b989cc2d9a16b6767cc930cdf48797ff"
+task_type: "image-text-to-text"
+dtype: "float32"
+
+inputs:
+  prompts:
+    - "Describe this image in detail."
+  images:
+    - "pipeline-cat-chonk.jpeg"
+
+level: "L4+L5"
+
+generation:
+  max_new_tokens: 30
+  do_sample: false
+
+trust_remote_code: true
+skip_reason: "8B model too large for CI. Custom RADIO vision encoder requires trust_remote_code."
+notes: "Llama_Nemotron_Nano_VL 8B. RADIO ViT-H/16 vision encoder + Llama 3.1 8B text decoder. InternVL2-style 3-model split."

--- a/testdata/cases/vision-language/nemotronh-nano-vl-12b.yaml
+++ b/testdata/cases/vision-language/nemotronh-nano-vl-12b.yaml
@@ -1,0 +1,20 @@
+model_id: "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16"
+revision: "5d250e2e111dc5e1434131bdf3d590c27a878ade"
+task_type: "image-text-to-text"
+dtype: "float32"
+
+inputs:
+  prompts:
+    - "Describe this image in detail."
+  images:
+    - "pipeline-cat-chonk.jpeg"
+
+level: "L4+L5"
+
+generation:
+  max_new_tokens: 30
+  do_sample: false
+
+trust_remote_code: true
+skip_reason: "12B NemotronH hybrid model too large for CI. Requires trust_remote_code for RADIO vision encoder."
+notes: "NemotronH_Nano_VL_V2 12B. RADIO ViT-H/16 vision encoder + NemotronH-12B hybrid Mamba2/attention decoder. projector_hidden_size=20480."

--- a/tests/_test_configs.py
+++ b/tests/_test_configs.py
@@ -34,7 +34,9 @@ from mobius._configs import (
     MambaConfig,
     MllamaConfig,
     NanoChatConfig,
+    NemotronFlashConfig,
     NemotronHConfig,
+    NemotronHNanoVLConfig,
     Sam2Config,
     SegformerConfig,
     VisionConfig,
@@ -1113,6 +1115,24 @@ CAUSAL_LM_CONFIGS: list[tuple[str, dict, bool]] = [
         {"partial_rotary_factor": 0.25},
         False,
     ),
+    # nemotron_flash: hybrid GLA+Mamba2+Attention+FFN (requires NemotronFlashConfig)
+    (
+        "nemotron_flash",
+        {
+            "_config_cls": NemotronFlashConfig,
+            "hidden_act": "silu",
+            "num_hidden_layers": 4,
+            "layer_types": ["deltanet", "mlp", "mamba2", "full_attention"],
+            "num_memory_tokens": 2,
+            "mamba_n_heads": TINY_KV_HEADS,
+            "mamba_d_head": TINY_HEAD_DIM,
+            "mamba_d_state": 8,
+            "mamba_n_groups": 1,
+            "mamba_d_conv": 4,
+            "mamba_expand": 2,
+        },
+        True,
+    ),
 ]
 
 
@@ -1975,12 +1995,55 @@ VL_CONFIGS: list[tuple[str, dict, bool]] = [
         },
         True,
     ),
+    # --- NVIDIA RADIO+Llama VL ---
+    (
+        "Llama_Nemotron_Nano_VL",
+        {
+            "vision": VisionConfig(
+                hidden_size=32,
+                intermediate_size=64,
+                num_hidden_layers=1,
+                num_attention_heads=2,
+                image_size=28,
+                patch_size=14,
+                norm_eps=1e-6,
+                # RADIO uses 8 special tokens (4 CLS + 4 registers); use 2 for tiny test
+                num_summary_tokens=2,
+            ),
+            "image_token_id": 128256,
+        },
+        True,
+    ),
+    # --- NVIDIA RADIO+NemotronH VL ---
+    (
+        "NemotronH_Nano_VL_V2",
+        {
+            "_config_cls": NemotronHNanoVLConfig,
+            "hidden_act": "relu2",
+            "layer_types": ["mamba2", "mlp", "full_attention", "mlp"],
+            "num_hidden_layers": 4,
+            "mamba_n_heads": TINY_KV_HEADS,
+            "mamba_d_head": TINY_HEAD_DIM,
+            "mamba_d_state": 16,
+            "mamba_n_groups": 1,
+            "mamba_d_conv": 4,
+            "mamba_expand": 2,
+            "vision": VisionConfig(
+                hidden_size=32,
+                intermediate_size=64,
+                num_hidden_layers=1,
+                num_attention_heads=2,
+                image_size=28,
+                patch_size=14,
+                norm_eps=1e-6,
+                num_summary_tokens=2,
+                projector_hidden_size=64,
+            ),
+            "image_token_id": 128256,
+        },
+        True,
+    ),
 ]
-
-
-# ---------------------------------------------------------------------------
-# Speech / TTS / Codec configs
-# ---------------------------------------------------------------------------
 SPEECH_CONFIGS: list[tuple[str, dict, bool]] = [
     # --- Whisper (speech-to-text, encoder-decoder) ---
     (
@@ -2078,6 +2141,27 @@ SPEECH_CONFIGS: list[tuple[str, dict, bool]] = [
                 max_position_embeddings=128,
                 num_quantizers=8,
                 num_semantic_quantizers=1,
+            ),
+        },
+        True,
+    ),
+    # --- AudioFlamingo-3 (audio-language: Whisper encoder + Qwen2 decoder) ---
+    (
+        "audioflamingo3",
+        {
+            # Qwen2 decoder settings (attn_qkv_bias=True is set automatically
+            # for model_type="qwen2", but the test config uses model_type="audioflamingo3"
+            # so we set it explicitly here)
+            "attn_qkv_bias": True,
+            "audio": AudioConfig(
+                d_model=64,
+                encoder_layers=2,
+                encoder_attention_heads=4,
+                encoder_ffn_dim=128,
+                num_mel_bins=128,
+                max_source_positions=100,
+                audio_token_id=200,
+                projection_hidden_size=64,
             ),
         },
         True,

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -270,6 +270,11 @@ class TestBuildGraph:
                 assert f"present.{i}.ssm_state" in output_names, (
                     f"Missing present.{i}.ssm_state"
                 )
+            elif ltype == "conv":
+                # ShortConv: single conv_state only
+                assert f"present.{i}.conv_state" in output_names, (
+                    f"Missing present.{i}.conv_state"
+                )
             else:
                 assert f"present.{i}.key" in output_names, f"Missing present.{i}.key"
                 assert f"present.{i}.value" in output_names, f"Missing present.{i}.value"
@@ -1787,6 +1792,158 @@ class TestBuildGraphQwen3ASR:
         assert logits.shape[1] == seq_len
 
 
+class TestBuildGraphAudioFlamingo3:
+    """Verify AudioFlamingo-3 3-model split with AudioLanguageTask."""
+
+    def _af3_config(self):
+        return _base_config(
+            attn_qkv_bias=True,
+            hidden_act="silu",
+            audio=AudioConfig(
+                d_model=64,
+                encoder_layers=2,
+                encoder_attention_heads=4,
+                encoder_ffn_dim=128,
+                num_mel_bins=128,
+                max_source_positions=100,
+                audio_token_id=200,
+                projection_hidden_size=TINY_HIDDEN,
+            ),
+        )
+
+    def test_package_builds_3_models(self):
+        """Build AudioFlamingo-3 and verify 3-model package."""
+        from mobius.models.audioflamingo3 import AudioFlamingo3ForConditionalGeneration
+        from mobius.tasks import AudioLanguageTask
+
+        config = self._af3_config()
+        module = AudioFlamingo3ForConditionalGeneration(config)
+        pkg = build_from_module(module, config, task=AudioLanguageTask())
+
+        assert "audio_encoder" in pkg
+        assert "embedding" in pkg
+        assert "decoder" in pkg
+
+    def test_decoder_uses_1d_position_ids(self):
+        """Verify decoder uses standard 1D position_ids (not MRoPE 3D)."""
+        from mobius.models.audioflamingo3 import AudioFlamingo3ForConditionalGeneration
+        from mobius.tasks import AudioLanguageTask
+
+        config = self._af3_config()
+        module = AudioFlamingo3ForConditionalGeneration(config)
+        pkg = build_from_module(module, config, task=AudioLanguageTask())
+        decoder = pkg["decoder"]
+
+        # position_ids should have shape [batch, seq_len] — 2D rank, not 3D MRoPE
+        pid_input = next(inp for inp in decoder.graph.inputs if inp.name == "position_ids")
+        assert pid_input.shape is not None
+        assert len(pid_input.shape) == 2, (
+            f"Expected 2D position_ids, got shape {pid_input.shape}"
+        )
+
+    def test_audio_encoder_io(self):
+        """Verify audio encoder inputs/outputs."""
+        from mobius.models.audioflamingo3 import AudioFlamingo3ForConditionalGeneration
+        from mobius.tasks import AudioLanguageTask
+
+        config = self._af3_config()
+        module = AudioFlamingo3ForConditionalGeneration(config)
+        pkg = build_from_module(module, config, task=AudioLanguageTask())
+        encoder = pkg["audio_encoder"]
+
+        input_names = {inp.name for inp in encoder.graph.inputs}
+        assert "input_features" in input_names
+
+        output_names = {out.name for out in encoder.graph.outputs}
+        assert "audio_features" in output_names
+
+    def test_registry_lookup(self):
+        """Verify audioflamingo3 is registered with audio-language task."""
+        from mobius.models.audioflamingo3 import AudioFlamingo3ForConditionalGeneration
+
+        assert registry.get("audioflamingo3") is AudioFlamingo3ForConditionalGeneration
+        assert _default_task_for_model("audioflamingo3") == "audio-language"
+
+    def test_pipeline_runs_with_ort(self):
+        """Run audio_encoder → embedding → decoder with ORT.
+
+        Verifies that:
+        1. Audio encoder produces audio_features of correct shape
+        2. Embedding fuses text tokens with audio features
+        3. Decoder accepts 1D position_ids and returns logits
+        """
+        import numpy as np
+
+        from mobius._testing.ort_inference import OnnxModelSession
+        from mobius.models.audioflamingo3 import AudioFlamingo3ForConditionalGeneration
+        from mobius.rewrite_rules._testing_utils import fill_random_weights
+        from mobius.tasks import AudioLanguageTask
+
+        config = self._af3_config()
+        module = AudioFlamingo3ForConditionalGeneration(config)
+        pkg = build_from_module(module, config, task=AudioLanguageTask())
+
+        for model in pkg.values():
+            fill_random_weights(model)
+
+        # Step 1: Audio encoder — (1, n_mels, 50) mel → (1, 25, hidden)
+        enc_sess = OnnxModelSession(pkg["audio_encoder"])
+        mel = np.random.randn(1, config.audio.num_mel_bins, 50).astype(np.float32)
+        enc_out = enc_sess.run({"input_features": mel})
+        audio_features = enc_out["audio_features"]
+        num_audio_tokens = audio_features.shape[1]
+        # Flatten batch dim: (1, tokens, hidden) → (tokens, hidden)
+        audio_features_2d = audio_features.reshape(-1, audio_features.shape[-1])
+        enc_sess.close()
+
+        # Step 2: Embedding — text tokens with audio placeholders
+        audio_token_id = config.audio.audio_token_id
+        prefix_ids = [1, 2, 3]
+        suffix_ids = [4, 5]
+        input_ids = np.array(
+            [prefix_ids + [audio_token_id] * num_audio_tokens + suffix_ids],
+            dtype=np.int64,
+        )
+
+        embed_sess = OnnxModelSession(pkg["embedding"])
+        embed_out = embed_sess.run(
+            {"input_ids": input_ids, "audio_features": audio_features_2d}
+        )
+        inputs_embeds = embed_out["inputs_embeds"]
+        embed_sess.close()
+
+        assert inputs_embeds.shape[1] == input_ids.shape[1]
+        assert inputs_embeds.shape[2] == config.hidden_size
+
+        # Step 3: Decoder — standard 1D position_ids [batch, seq_len]
+        seq_len = inputs_embeds.shape[1]
+        decoder_sess = OnnxModelSession(pkg["decoder"])
+        past_kv = {}
+        for i in range(config.num_hidden_layers):
+            past_kv[f"past_key_values.{i}.key"] = np.zeros(
+                (1, config.num_key_value_heads, 0, config.head_dim), dtype=np.float32
+            )
+            past_kv[f"past_key_values.{i}.value"] = np.zeros(
+                (1, config.num_key_value_heads, 0, config.head_dim), dtype=np.float32
+            )
+
+        # 1D position_ids: (1, seq_len) — not 3D MRoPE
+        position_ids = np.arange(seq_len, dtype=np.int64).reshape(1, -1)
+
+        dec_out = decoder_sess.run(
+            {
+                "inputs_embeds": inputs_embeds,
+                "attention_mask": np.ones((1, seq_len), dtype=np.int64),
+                "position_ids": position_ids,
+                **past_kv,
+            }
+        )
+        decoder_sess.close()
+
+        logits = dec_out["logits"]
+        assert logits.shape == (1, seq_len, config.vocab_size)
+
+
 class TestBuildGraphQwen3TTS:
     """Verify Qwen3-TTS 4-model split with TTSTask."""
 
@@ -3137,6 +3294,153 @@ class TestBuildNemotronHGraph:
 
 
 # ===========================================================================
+# Hybrid GLA+Mamba2+Attention+FFN (NemotronFlash) model tests
+# ===========================================================================
+
+
+class TestBuildNemotronFlashGraph:
+    """Verify NemotronFlash hybrid model builds correctly and has correct structure."""
+
+    def _nemotron_flash_config(self):
+        from mobius._configs import NemotronFlashConfig
+
+        # 4 layers: deltanet, mlp, mamba2, full_attention
+        return NemotronFlashConfig(
+            vocab_size=TINY_VOCAB,
+            hidden_size=TINY_HIDDEN,
+            intermediate_size=TINY_INTERMEDIATE,
+            num_hidden_layers=4,
+            num_attention_heads=TINY_HEADS,
+            num_key_value_heads=TINY_KV_HEADS,
+            head_dim=TINY_HEAD_DIM,
+            rms_norm_eps=1e-5,
+            layer_types=["deltanet", "mlp", "mamba2", "full_attention"],
+            num_memory_tokens=2,
+            mamba_n_heads=TINY_KV_HEADS,
+            mamba_d_head=TINY_HEAD_DIM,
+            mamba_d_state=8,
+            mamba_n_groups=1,
+            mamba_d_conv=4,
+            mamba_expand=2,
+            hidden_act="silu",
+        )
+
+    def test_nemotron_flash_builds(self):
+        """Build NemotronFlash model and verify the graph constructs without error."""
+        from mobius._builder import build_from_module
+        from mobius.models.nemotron_flash import NemotronFlashCausalLMModel
+
+        config = self._nemotron_flash_config()
+        module = NemotronFlashCausalLMModel(config)
+        pkg = build_from_module(module, config, task="hybrid-text-generation")
+        assert "model" in pkg
+        model = pkg["model"]
+        assert model is not None
+
+    def test_nemotron_flash_layer_dispatch(self):
+        """Verify layers are dispatched to the correct classes by type."""
+        from mobius.models.nemotron_flash import (
+            NemotronFlashAttentionLayer,
+            NemotronFlashFFNLayer,
+            NemotronFlashGLALayer,
+            NemotronFlashMambaLayer,
+        )
+
+        config = self._nemotron_flash_config()
+        from mobius.models.nemotron_flash import NemotronFlashCausalLMModel
+
+        module = NemotronFlashCausalLMModel(config)
+        layers = list(module.model.layers)
+        assert len(layers) == 4
+        assert isinstance(layers[0], NemotronFlashGLALayer), (
+            f"Layer 0 should be GLA, got {type(layers[0])}"
+        )
+        assert isinstance(layers[1], NemotronFlashFFNLayer), (
+            f"Layer 1 should be FFN, got {type(layers[1])}"
+        )
+        assert isinstance(layers[2], NemotronFlashMambaLayer), (
+            f"Layer 2 should be Mamba, got {type(layers[2])}"
+        )
+        assert isinstance(layers[3], NemotronFlashAttentionLayer), (
+            f"Layer 3 should be Attention, got {type(layers[3])}"
+        )
+
+    def test_nemotron_flash_weight_names(self):
+        """Verify weight names match HuggingFace nemotron-flash naming convention."""
+        from mobius._builder import build_from_module
+        from mobius.models.nemotron_flash import NemotronFlashCausalLMModel
+
+        config = self._nemotron_flash_config()
+        module = NemotronFlashCausalLMModel(config)
+        pkg = build_from_module(module, config, task="hybrid-text-generation")
+        model = pkg["model"]
+        initializer_names = set(model.graph.initializers.keys())
+
+        # Memory tokens parameter
+        assert "model.memory_tokens" in initializer_names
+
+        # Final norm (not 'norm' like NemotronH)
+        assert "model.final_layernorm.weight" in initializer_names
+        assert "model.norm.weight" not in initializer_names
+
+        # Layer 0 (deltanet/GLA): uses 'gla.*' prefix, 'input_layernorm'
+        assert "model.layers.0.gla.q_proj.weight" in initializer_names
+        assert "model.layers.0.gla.k_proj.weight" in initializer_names
+        assert "model.layers.0.gla.v_proj.weight" in initializer_names
+        assert "model.layers.0.gla.o_proj.weight" in initializer_names
+        assert "model.layers.0.input_layernorm.weight" in initializer_names
+
+        # Layer 1 (mlp/FFN): uses 'mlp.*' prefix (ONNX), 'pre_ffn_layernorm'
+        assert "model.layers.1.mlp.gate_proj.weight" in initializer_names
+        assert "model.layers.1.mlp.up_proj.weight" in initializer_names
+        assert "model.layers.1.mlp.down_proj.weight" in initializer_names
+        assert "model.layers.1.pre_ffn_layernorm.weight" in initializer_names
+
+        # Layer 2 (mamba2): uses 'mamba.*' prefix, 'input_layernorm'
+        assert "model.layers.2.mamba.in_proj.weight" in initializer_names
+        assert "model.layers.2.mamba.out_proj.weight" in initializer_names
+        assert "model.layers.2.input_layernorm.weight" in initializer_names
+
+        # Layer 3 (full_attention): uses 'self_attn.*' prefix, 'input_layernorm'
+        assert "model.layers.3.self_attn.q_proj.weight" in initializer_names
+        assert "model.layers.3.self_attn.k_proj.weight" in initializer_names
+        assert "model.layers.3.self_attn.v_proj.weight" in initializer_names
+        assert "model.layers.3.self_attn.o_proj.weight" in initializer_names
+        assert "model.layers.3.input_layernorm.weight" in initializer_names
+
+    def test_nemotron_flash_preprocess_weights(self):
+        """Verify preprocess_weights handles ffn→mlp rename and weight tying."""
+        import torch
+
+        from mobius.models.nemotron_flash import NemotronFlashCausalLMModel
+
+        config = self._nemotron_flash_config()
+        config.tie_word_embeddings = True
+        module = NemotronFlashCausalLMModel(config)
+
+        # Real HF checkpoint with tie_word_embeddings=True only stores embed_tokens.weight
+        state_dict = {
+            "model.embed_tokens.weight": torch.ones(TINY_VOCAB, TINY_HIDDEN),
+            # FFN layer uses 'ffn.*' naming in HF
+            "model.layers.1.ffn.gate_proj.weight": torch.zeros(TINY_INTERMEDIATE, TINY_HIDDEN),
+            "model.layers.1.ffn.up_proj.weight": torch.zeros(TINY_INTERMEDIATE, TINY_HIDDEN),
+            "model.layers.1.ffn.down_proj.weight": torch.zeros(TINY_HIDDEN, TINY_INTERMEDIATE),
+        }
+        result = module.preprocess_weights(state_dict)
+
+        # Weight tying: lm_head.weight should be copied from embed_tokens.weight
+        assert "lm_head.weight" in result
+        assert torch.allclose(result["lm_head.weight"], result["model.embed_tokens.weight"])
+
+        # ffn.* should be renamed to mlp.*
+        assert "model.layers.1.mlp.gate_proj.weight" in result
+        assert "model.layers.1.mlp.up_proj.weight" in result
+        assert "model.layers.1.mlp.down_proj.weight" in result
+        # Original ffn.* keys should not remain
+        assert "model.layers.1.ffn.gate_proj.weight" not in result
+
+
+# ===========================================================================
 # Hybrid SSM+Attention (Jamba) model tests
 # ===========================================================================
 
@@ -3700,3 +4004,5 @@ class TestBuildSpeechGraph:
         task = get_task(_default_task_for_model(model_type))
         pkg = task.build(module, config)
         _assert_outputs_have_shapes_and_dtypes(pkg, model_type)
+
+

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -1886,14 +1886,13 @@ class TestBuildGraphAudioFlamingo3:
         for model in pkg.values():
             fill_random_weights(model)
 
-        # Step 1: Audio encoder — (1, n_mels, 50) mel → (1, 25, hidden)
+        # Step 1: Audio encoder — (1, n_mels, 50) mel → (25, hidden) flattened 2D
         enc_sess = OnnxModelSession(pkg["audio_encoder"])
         mel = np.random.randn(1, config.audio.num_mel_bins, 50).astype(np.float32)
         enc_out = enc_sess.run({"input_features": mel})
         audio_features = enc_out["audio_features"]
-        num_audio_tokens = audio_features.shape[1]
-        # Flatten batch dim: (1, tokens, hidden) → (tokens, hidden)
-        audio_features_2d = audio_features.reshape(-1, audio_features.shape[-1])
+        # Encoder already returns 2D (num_audio_tokens, hidden_size)
+        num_audio_tokens = audio_features.shape[0]
         enc_sess.close()
 
         # Step 2: Embedding — text tokens with audio placeholders
@@ -1907,7 +1906,7 @@ class TestBuildGraphAudioFlamingo3:
 
         embed_sess = OnnxModelSession(pkg["embedding"])
         embed_out = embed_sess.run(
-            {"input_ids": input_ids, "audio_features": audio_features_2d}
+            {"input_ids": input_ids, "audio_features": audio_features}
         )
         inputs_embeds = embed_out["inputs_embeds"]
         embed_sess.close()


### PR DESCRIPTION
## Summary
Adds NVIDIA model architectures with full test coverage.

### Models
- **NemotronFlash** — Hybrid GLA+Mamba2+Attention+FFN with learnable memory tokens
- **Llama_Nemotron_Nano_VL** — InternVL-style VL: RADIO ViT-H/16 vision + Llama 3.1 decoder
- **NemotronH_Nano_VL_V2** — RADIO ViT-H/16 vision + NemotronH hybrid (Mamba2+Attention) decoder
- **AudioFlamingo3** — Whisper encoder + Qwen2 audio-language decoder (3-model split)
- **vaultgemma** — Registered as gemma3-compatible architecture

### Tasks
- `AudioLanguageTask` — 3-model audio-language split (audio_encoder + embedding + decoder)
- `HybridVisionLanguageTask` — VL split with hybrid KV+SSM cache for the text decoder

### Infrastructure
- `VisionConfig` extended with `num_summary_tokens`, `projector_hidden_size` (RADIO)
- `NemotronFlashConfig`, `LlamaNemotronNanoVLConfig`, `NemotronHNanoVLConfig`
- `conv` layer type support in `_make_hybrid_cache_inputs`
- `audio-language` added to YAML schema

### Testing
- 2248 build_graph + unit tests pass
- 371 model_coverage tests pass
- YAML test cases with SHA-pinned revisions for all 4 models

### Scope cleanup
Branch cleaned from original fork that contained LFM2/Moshi code (now on separate `justinchu/liquidai-models` branch).