### PR TITLE
docs: Add EP-aware model building documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,15 @@ provider. Pass `execution_provider` to target CUDA, DirectML, WebGPU, and more â
 each with the right set of fused kernels and lowering passes applied automatically:
 
 ```python
+from mobius import build
+
 # CUDA: GQA fusion, SkipLayerNorm, PackQKV
-pkg = mobius.build("meta-llama/Llama-3.2-1B",
-                   execution_provider="cuda", dtype="f16")
+pkg = build("meta-llama/Llama-3.2-1B",
+            execution_provider="cuda", dtype="f16")
 
 # WebGPU: GQA fusion, Shape ops replaced with portable alternatives
-pkg = mobius.build("meta-llama/Llama-3.2-1B",
-                   execution_provider="webgpu", dtype="f16")
+pkg = build("meta-llama/Llama-3.2-1B",
+            execution_provider="webgpu", dtype="f16")
 ```
 
 See the [EP quickstart](docs/ep_quickstart.md) and

--- a/README.md
+++ b/README.md
@@ -71,10 +71,24 @@ pkg = build("meta-llama/Llama-3.2-1B", task=task)
 pkg.save("output/llama-3.2-1b-static/")
 ```
 
-### CLI
+**EP-aware optimization** generates graphs tuned for a specific runtime execution
+provider. Pass `execution_provider` to target CUDA, DirectML, WebGPU, and more —
+each with the right set of fused kernels and lowering passes applied automatically:
 
-```bash
-# Build from a HuggingFace model ID
+```python
+# CUDA: GQA fusion, SkipLayerNorm, PackQKV
+pkg = mobius.build("meta-llama/Llama-3.2-1B",
+                   execution_provider="cuda", dtype="f16")
+
+# WebGPU: GQA fusion, Shape ops replaced with portable alternatives
+pkg = mobius.build("meta-llama/Llama-3.2-1B",
+                   execution_provider="webgpu", dtype="f16")
+```
+
+See the [EP quickstart](docs/ep_quickstart.md) and
+[full EP reference](docs/execution_providers.md) for all supported EPs and options.
+
+### CLI
 mobius build --model Qwen/Qwen2.5-0.5B output_dir/
 
 # Build without weights (graph skeleton only)

--- a/docs/ep_quickstart.md
+++ b/docs/ep_quickstart.md
@@ -125,7 +125,8 @@ pkg = mobius.build("meta-llama/Llama-3.2-1B",
                    execution_provider="my-ep", dtype="f16")
 ```
 
-Unrecognised EP names raise `ValueError` at optimization time — safe-fail by default.
+Unrecognised EP names raise `ValueError` during build-time validation, before
+graph construction or optimization starts — safe-fail by default.
 
 ---
 
@@ -133,7 +134,7 @@ Unrecognised EP names raise `ValueError` at optimization time — safe-fail by d
 
 | Goal | EP | dtype | Notes |
 |---|---|---|---|
-| Portable ONNX (maximum compatibility) | `"default"` | any | No vendor-specific ops |
+| Portable ONNX (maximum compatibility) | `"default"` | any | No EP-specific vendor fusions (e.g. no GQA/PackQKV) |
 | ORT CPU inference | `"cpu"` | `"f32"` | GQA fusion for FP32 |
 | NVIDIA GPU | `"cuda"` | `"f16"` or `"bf16"` | GQA + SkipNorm + PackQKV |
 | Windows GPU (DirectX) | `"dml"` | `"f16"` | RoPE lowered separately |

--- a/docs/ep_quickstart.md
+++ b/docs/ep_quickstart.md
@@ -1,0 +1,151 @@
+# EP-Aware Building: Quick Start
+
+This guide covers the common tasks in under 3 minutes. For full reference
+documentation, see [Execution Provider Aware Building](execution_providers.md).
+
+---
+
+## 1. Build for a specific EP
+
+Pass `execution_provider` to `build()` or `build_from_module()`:
+
+```python
+import mobius
+
+# Portable ONNX — runs on any conformant runtime (default)
+pkg = mobius.build("meta-llama/Llama-3.2-1B")
+
+# CUDA EP — GQA fusion, SkipLayerNorm fusion, PackQKV
+pkg = mobius.build("meta-llama/Llama-3.2-1B",
+                   execution_provider="cuda", dtype="f16")
+
+# WebGPU EP — GQA fusion, Shape → ReduceSum+ReduceMax lowering
+pkg = mobius.build("meta-llama/Llama-3.2-1B",
+                   execution_provider="webgpu", dtype="f16")
+
+# DML (DirectML) — GQA for FP16, fused RoPE lowered to separate ops
+pkg = mobius.build("meta-llama/Llama-3.2-1B",
+                   execution_provider="dml", dtype="f16")
+
+# TRT-RTX — GQA for FP16/BF16, SkipLayerNorm expanded, GPU graph capture
+pkg = mobius.build("meta-llama/Llama-3.2-1B",
+                   execution_provider="trt-rtx", dtype="f16")
+
+pkg.save("output/llama/")
+```
+
+CLI equivalent:
+
+```bash
+mobius build --model meta-llama/Llama-3.2-1B output/ \
+  --execution-provider cuda --dtype f16
+```
+
+---
+
+## 2. See what each EP does
+
+Enable `trace_optimization=True` to get a per-stage log of what the
+optimizer changed:
+
+```python
+import logging
+import mobius
+
+logging.basicConfig(level=logging.INFO)
+
+pkg = mobius.build(
+    "meta-llama/Llama-3.2-1B",
+    execution_provider="cuda",
+    dtype="f16",
+    load_weights=False,       # skip download for diagnostics
+    trace_optimization=True,
+)
+```
+
+Example output:
+
+```
+INFO  [EP Trace] Target: cuda, dtype: FLOAT16, role: decoder
+INFO  [EP Trace] Stage 1: Cleanup (9 passes)
+INFO  [EP Trace]   Cleanup: 512 → 486 nodes (-26)
+INFO  [EP Trace] Stage 2: Fusion (4 rule groups)
+INFO  [EP Trace]   GQAFusion    : +28 GroupQueryAttention, -28 Attention
+INFO  [EP Trace]   SkipNorm     : +28 SkipSimplifiedLayerNorm, -84 nodes
+INFO  [EP Trace]   SkipLayerNorm: no matches (0 nodes affected)
+INFO  [EP Trace]   GeluFusion   : no matches (0 nodes affected)
+INFO  [EP Trace] Stage 2b: InlinePass (expand unsupported custom ops)
+INFO  [EP Trace]   InlinePass   : no matches (0 nodes affected)
+INFO  [EP Trace] Stage 3: Lowering (0 rule groups for cuda)
+INFO  [EP Trace] Stage 4: Constant folding
+INFO  [EP Trace]   Fold: 374 → 371 nodes (-3)
+```
+
+---
+
+## 3. Query which EPs are available
+
+```python
+from mobius._execution_providers import ep_registry, get_ep
+
+# List all registered EP names
+print(sorted(ep_registry))
+# ['cpu', 'cuda', 'default', 'dml', 'trt-rtx', 'webgpu']
+
+# Inspect an EP's capabilities
+caps = get_ep("cuda")
+print(caps.gqa_dtypes)          # frozenset({FLOAT16, BFLOAT16})
+print(caps.qkv_pack_dtypes)     # frozenset({FLOAT, FLOAT16, BFLOAT16})
+print(caps.supports_fused_rope) # True
+print(caps.provider_options)    # {'enable_cuda_graph': '0', ...}
+```
+
+---
+
+## 4. Register a custom EP
+
+Out-of-tree EPs register via `register_ep()` before calling `build()`:
+
+```python
+import onnx_ir as ir
+from mobius._execution_providers import EpCapabilities, register_ep
+
+register_ep(EpCapabilities(
+    name="my-ep",
+    gqa_dtypes=frozenset({ir.DataType.FLOAT16}),
+    qkv_pack_dtypes=frozenset({ir.DataType.FLOAT16}),
+    supports_fused_rope=True,
+    supports_shape=True,
+    provider_options={"some_option": "value"},
+))
+
+# Now build() will accept "my-ep" as an execution provider
+pkg = mobius.build("meta-llama/Llama-3.2-1B",
+                   execution_provider="my-ep", dtype="f16")
+```
+
+Unrecognised EP names raise `ValueError` at optimization time — safe-fail by default.
+
+---
+
+## 5. Common EP configurations at a glance
+
+| Goal | EP | dtype | Notes |
+|---|---|---|---|
+| Portable ONNX (maximum compatibility) | `"default"` | any | No vendor-specific ops |
+| ORT CPU inference | `"cpu"` | `"f32"` | GQA fusion for FP32 |
+| NVIDIA GPU | `"cuda"` | `"f16"` or `"bf16"` | GQA + SkipNorm + PackQKV |
+| Windows GPU (DirectX) | `"dml"` | `"f16"` | RoPE lowered separately |
+| Browser / WebAssembly | `"webgpu"` | `"f16"` or `"f32"` | Shape ops replaced |
+| NVIDIA TensorRT-RTX | `"trt-rtx"` | `"f16"` or `"bf16"` | SkipLayerNorm expanded |
+
+---
+
+## What to read next
+
+- [Full EP reference](execution_providers.md) — Tier 1/2/3 strategy, pipeline
+  internals, design decisions, build-time EP queries
+- [Adding a new EP](execution_providers.md#adding-a-new-execution-provider) — 3-step
+  process with test guidance
+- [Debugging with trace mode](execution_providers.md#debugging-trace-mode) — reading
+  trace output, fusion assertions

--- a/docs/ep_quickstart.md
+++ b/docs/ep_quickstart.md
@@ -69,16 +69,17 @@ Example output:
 INFO  [EP Trace] Target: cuda, dtype: FLOAT16, role: decoder
 INFO  [EP Trace] Stage 1: Cleanup (9 passes)
 INFO  [EP Trace]   Cleanup: 512 → 486 nodes (-26)
-INFO  [EP Trace] Stage 2: Fusion (4 rule groups)
-INFO  [EP Trace]   GQAFusion    : +28 GroupQueryAttention, -28 Attention
-INFO  [EP Trace]   SkipNorm     : +28 SkipSimplifiedLayerNorm, -84 nodes
+INFO  [EP Trace] Stage 2: Fusion (5 rule groups)
+INFO  [EP Trace]   GQAFusion    : +16 GroupQueryAttention, -16 Attention
+INFO  [EP Trace]   PackQKV      : +16 Concat, -32 FusedMatMul
+INFO  [EP Trace]   SkipNorm     : +16 SkipSimplifiedLayerNorm, -48 nodes
 INFO  [EP Trace]   SkipLayerNorm: no matches (0 nodes affected)
 INFO  [EP Trace]   GeluFusion   : no matches (0 nodes affected)
 INFO  [EP Trace] Stage 2b: InlinePass (expand unsupported custom ops)
 INFO  [EP Trace]   InlinePass   : no matches (0 nodes affected)
 INFO  [EP Trace] Stage 3: Lowering (0 rule groups for cuda)
 INFO  [EP Trace] Stage 4: Constant folding
-INFO  [EP Trace]   Fold: 374 → 371 nodes (-3)
+INFO  [EP Trace]   Fold: 374 → 355 nodes (-19)
 ```
 
 ---

--- a/docs/ep_quickstart.md
+++ b/docs/ep_quickstart.md
@@ -38,7 +38,7 @@ CLI equivalent:
 
 ```bash
 mobius build --model meta-llama/Llama-3.2-1B output/ \
-  --execution-provider cuda --dtype f16
+  --ep cuda --dtype f16
 ```
 
 ---

--- a/docs/ep_quickstart.md
+++ b/docs/ep_quickstart.md
@@ -86,7 +86,7 @@ INFO  [EP Trace]   Fold: 374 → 371 nodes (-3)
 ## 3. Query which EPs are available
 
 ```python
-from mobius._execution_providers import ep_registry, get_ep
+from mobius import ep_registry, get_ep
 
 # List all registered EP names
 print(sorted(ep_registry))
@@ -108,7 +108,7 @@ Out-of-tree EPs register via `register_ep()` before calling `build()`:
 
 ```python
 import onnx_ir as ir
-from mobius._execution_providers import EpCapabilities, register_ep
+from mobius import EpCapabilities, register_ep
 
 register_ep(EpCapabilities(
     name="my-ep",

--- a/docs/execution_providers.md
+++ b/docs/execution_providers.md
@@ -58,8 +58,7 @@ pkg = build_from_module(
 | **TRT-RTX** | `"trt-rtx"` | NVIDIA TensorRT-RTX. GQA for FP16/BF16. `SkipLayerNorm`/`SkipSimplifiedLayerNorm` expanded via InlinePass (TRT handles these primitives natively). GPU graph capture enabled. |
 
 > **Note:** Passing an unknown EP name raises `ValueError` during
-> optimization. Use `ep_registry` from `mobius._execution_providers` to
-> query registered EPs.
+> optimization. Use `ep_registry` from `mobius` to query registered EPs.
 
 ---
 
@@ -147,7 +146,7 @@ EpCapabilities(name="trt-rtx", gqa_dtypes={FLOAT16, BFLOAT16},
 Out-of-tree EPs can register at runtime via `register_ep()`:
 
 ```python
-from mobius._execution_providers import EpCapabilities, register_ep
+from mobius import EpCapabilities, register_ep
 
 register_ep(EpCapabilities(
     name="my-ep",
@@ -246,7 +245,7 @@ rule in `src/mobius/rewrite_rules/`. Follow the pattern in `_separate_rope.py`
 (for pattern rewrite rules) or `_eliminate_shape.py` (for op-elimination
 passes). Alternatively, if the constraint can be resolved at graph-build time
 (i.e. within a component's `forward()`), query `ep_capabilities()` from
-`mobius._build_context` and branch on the flag there — no rewrite rule needed.
+`mobius` and branch on the flag there — no rewrite rule needed.
 
 **Step 3:** Write tests:
 - A unit test for each new rewrite rule (graph-level, no ORT required)
@@ -362,7 +361,7 @@ if caps is None:
 The `EpRegistry` also exposes `require()` for direct lookup:
 
 ```python
-from mobius._execution_providers import get_ep
+from mobius import get_ep
 
 get_ep("cuda")   # → EpCapabilities(name="cuda", ...)
 get_ep("rocm")   # → ValueError: Unknown execution provider 'rocm'. ...
@@ -492,7 +491,7 @@ previously exported graph) and want to apply EP-aware passes without going
 through the full `build()` pipeline:
 
 ```python
-from mobius._optimizations import optimize_model
+from mobius import optimize_model
 import onnx_ir as ir
 
 # Apply CUDA optimizations to an already-constructed model
@@ -511,8 +510,7 @@ config)`) and want to control EP capabilities without going through
 `build_from_module()`:
 
 ```python
-from mobius._build_context import build_context
-from mobius._execution_providers import ep_registry
+from mobius import build_context, ep_registry
 
 caps = ep_registry.require("cuda")
 with build_context(caps, ir.DataType.FLOAT16):
@@ -545,7 +543,7 @@ layer.
 ### Reading the active context
 
 ```python
-from mobius._build_context import ep_capabilities, get_build_dtype
+from mobius import ep_capabilities, get_build_dtype
 import onnx_ir as ir
 
 def forward(self, op, ...):
@@ -574,8 +572,7 @@ Advanced users who build graphs outside the standard pipeline can set the
 context explicitly:
 
 ```python
-from mobius._build_context import build_context
-from mobius._execution_providers import ep_registry
+from mobius import build_context, ep_registry
 
 capabilities = ep_registry.require("cuda")
 with build_context(capabilities, ir.DataType.FLOAT16):
@@ -592,8 +589,7 @@ concurrent builds with different EPs never interfere:
 
 ```python
 import asyncio
-from mobius._build_context import build_context
-from mobius._execution_providers import ep_registry
+from mobius import build_context, ep_registry
 
 async def build_cuda():
     caps = ep_registry.require("cuda")

--- a/docs/execution_providers.md
+++ b/docs/execution_providers.md
@@ -113,15 +113,17 @@ Every EP is fully described by a single `EpCapabilities` entry in the
 @dataclasses.dataclass(frozen=True)
 class EpCapabilities:
     name: str
-    gqa_dtypes: frozenset[ir.DataType]          # dtypes where GQA fusion fires
-    qkv_pack_dtypes: frozenset[ir.DataType]     # dtypes where PackQKV fusion fires
-    supports_fused_rope: bool = True           # False → SeparateRoPE + UnpackQKV
-    supports_shape: bool = True                # False → EliminateShape lowering
-    supports_skip_layer_norm: bool = True      # False → InlinePass expansion
-    supports_fused_moe: bool = True            # False → decompose fused MoE ops
-    default_int4_accuracy_level: int = 0       # 0 = no INT4; 4 = INT4 w/ accuracy
-    provider_options: dict[str, str]           # Default ORT GenAI provider options
-    enable_graph_capture: bool = False          # GPU graph capture default
+    gqa_dtypes: frozenset[ir.DataType]               # dtypes where GQA fusion fires
+    qkv_pack_dtypes: frozenset[ir.DataType]          # dtypes where PackQKV fusion fires
+    supports_fused_rope: bool = True                 # False → SeparateRoPE + UnpackQKV
+    supports_shape: bool = True                      # False → EliminateShape lowering
+    supports_skip_layer_norm: bool = True            # False → InlinePass expansion
+    supports_fused_matmul: bool = True               # False → Transpose + MatMul via InlinePass
+    supports_fused_moe: bool = True                  # False → decompose fused MoE ops
+    supports_packed_multi_head_attention: bool = False  # True → PackedMultiHeadAttention kernel
+    default_int4_accuracy_level: int = 0             # 0 = highest accuracy; 4 = fastest
+    provider_options: dict[str, str]                 # Default ORT GenAI provider options
+    enable_graph_capture: bool = False               # GPU graph capture default
 ```
 
 ### Current registry
@@ -296,8 +298,9 @@ Sample output:
 INFO mobius._optimizations: [EP Trace] Target: cuda, dtype: FLOAT16, role: decoder
 INFO mobius._optimizations: [EP Trace] Stage 1: Cleanup (9 passes)
 INFO mobius._optimizations: [EP Trace]   Cleanup: 512 → 486 nodes (-26)
-INFO mobius._optimizations: [EP Trace] Stage 2: Fusion (4 rule groups)
+INFO mobius._optimizations: [EP Trace] Stage 2: Fusion (5 rule groups)
 INFO mobius._optimizations: [EP Trace]   GQAFusion                 : +28 GroupQueryAttention, -28 Attention
+INFO mobius._optimizations: [EP Trace]   PackQKV                   : +28 Concat, -56 FusedMatMul
 INFO mobius._optimizations: [EP Trace]   SkipNorm                  : +28 SkipSimplifiedLayerNorm, -56 Add, -28 RMSNormalization
 INFO mobius._optimizations: [EP Trace]   SkipLayerNorm             : no matches (0 nodes affected)
 INFO mobius._optimizations: [EP Trace]   GeluFusion                : no matches (0 nodes affected)
@@ -310,6 +313,7 @@ INFO mobius._optimizations: [EP Trace] Summary:
 INFO mobius._optimizations: [EP Trace]   Rule                      | Matched | +Nodes | -Nodes
 INFO mobius._optimizations: [EP Trace]   -------------------------+--------+-------+-------
 INFO mobius._optimizations: [EP Trace]   GQAFusion                 |      28 |     28 |     28
+INFO mobius._optimizations: [EP Trace]   PackQKV                   |      56 |     28 |     56
 INFO mobius._optimizations: [EP Trace]   SkipNorm                  |      28 |     28 |     84
 INFO mobius._optimizations: [EP Trace]   SkipLayerNorm             |       0 |      0 |      0
 INFO mobius._optimizations: [EP Trace]   GeluFusion                |       0 |      0 |      0

--- a/docs/execution_providers.md
+++ b/docs/execution_providers.md
@@ -148,6 +148,7 @@ EpCapabilities(name="trt-rtx", gqa_dtypes={FLOAT16, BFLOAT16},
 Out-of-tree EPs can register at runtime via `register_ep()`:
 
 ```python
+import onnx_ir as ir
 from mobius import EpCapabilities, register_ep
 
 register_ep(EpCapabilities(
@@ -514,6 +515,7 @@ config)`) and want to control EP capabilities without going through
 `build_from_module()`:
 
 ```python
+import onnx_ir as ir
 from mobius import build_context, ep_registry
 
 caps = ep_registry.require("cuda")
@@ -533,7 +535,7 @@ integrating mobius into a custom build pipeline.
 | Build from a custom `nn.Module` | `build_from_module()` |
 | Optimize an existing `ir.Model` | `optimize_model()` |
 | Build graphs with explicit EP context | `build_context()` + `task.build()` |
-| Test EP-conditional component logic | `build_context()` (see `_common_test.py`) |
+| Test EP-conditional component logic | `build_context()` (see `src/mobius/_build_context_test.py`) |
 
 ---
 
@@ -576,6 +578,7 @@ Advanced users who build graphs outside the standard pipeline can set the
 context explicitly:
 
 ```python
+import onnx_ir as ir
 from mobius import build_context, ep_registry
 
 capabilities = ep_registry.require("cuda")
@@ -593,6 +596,7 @@ concurrent builds with different EPs never interfere:
 
 ```python
 import asyncio
+import onnx_ir as ir
 from mobius import build_context, ep_registry
 
 async def build_cuda():

--- a/docs/execution_providers.md
+++ b/docs/execution_providers.md
@@ -243,7 +243,10 @@ is needed — the `EpRegistry` validates EP names at optimization time.
 **Step 2:** If the EP has hard constraints not expressible via existing
 `EpCapabilities` fields, add a new boolean field and a corresponding lowering
 rule in `src/mobius/rewrite_rules/`. Follow the pattern in `_separate_rope.py`
-(for pattern rewrite rules) or `_eliminate_shape.py` (for shape-related passes).
+(for pattern rewrite rules) or `_eliminate_shape.py` (for op-elimination
+passes). Alternatively, if the constraint can be resolved at graph-build time
+(i.e. within a component's `forward()`), query `ep_capabilities()` from
+`mobius._build_context` and branch on the flag there — no rewrite rule needed.
 
 **Step 3:** Write tests:
 - A unit test for each new rewrite rule (graph-level, no ORT required)
@@ -465,6 +468,70 @@ does not — it's for runtimes other than ORT that understand standard ONNX ops
 but not ORT custom ops. The distinction matters for cross-framework export:
 a `"default"` model can be loaded by any ONNX-conformant runtime (TFLite,
 CoreML, ONNX Runtime, etc.), while a `"cpu"` model is ORT-specific.
+
+---
+
+## When to Use `build_context()` vs `optimize_model()` Directly
+
+### The normal path: `build()` / `build_from_module()`
+
+For most users, `build()` and `build_from_module()` are the only entry points
+you need. They automatically:
+
+1. Set the build context (`build_context()`) for the duration of graph
+   construction so components can query EP capabilities.
+2. Call `optimize_model()` on every model in the package after the graph
+   is built.
+
+You do not need to call `build_context()` or `optimize_model()` yourself.
+
+### When to call `optimize_model()` directly
+
+If you have an existing `ir.Model` (e.g. from a custom pipeline or a
+previously exported graph) and want to apply EP-aware passes without going
+through the full `build()` pipeline:
+
+```python
+from mobius._optimizations import optimize_model
+import onnx_ir as ir
+
+# Apply CUDA optimizations to an already-constructed model
+optimize_model(model, ep="cuda", dtype=ir.DataType.FLOAT16)
+```
+
+Note: `optimize_model()` runs **outside** any `build_context()`. This means
+that any component that calls `ep_capabilities()` during graph construction
+will not see these EP settings unless the graph was built inside a
+`build_context()` first.
+
+### When to call `build_context()` directly
+
+If you are building a graph using task-level APIs (e.g. `task.build(module,
+config)`) and want to control EP capabilities without going through
+`build_from_module()`:
+
+```python
+from mobius._build_context import build_context
+from mobius._execution_providers import ep_registry
+
+caps = ep_registry.require("cuda")
+with build_context(caps, ir.DataType.FLOAT16):
+    pkg = task.build(module, config)  # components see CUDA capabilities here
+```
+
+This is the correct pattern for testing EP-conditional component behaviour,
+building multiple graphs with different EPs in the same process, or
+integrating mobius into a custom build pipeline.
+
+### Summary
+
+| Use case | API |
+|---|---|
+| Build from a HuggingFace model ID | `build()` |
+| Build from a custom `nn.Module` | `build_from_module()` |
+| Optimize an existing `ir.Model` | `optimize_model()` |
+| Build graphs with explicit EP context | `build_context()` + `task.build()` |
+| Test EP-conditional component logic | `build_context()` (see `_common_test.py`) |
 
 ---
 

--- a/src/mobius/__init__.py
+++ b/src/mobius/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "CausalLMTask",
     "DepthAnythingConfig",
     "EncoderConfig",
+    "EpCapabilities",
     "Gemma2Config",
     "Gemma3nConfig",
     "MambaConfig",
@@ -33,8 +34,12 @@ __all__ = [
     "build_from_module",
     "components",
     "ep_capabilities",
+    "ep_registry",
     "get_build_dtype",
+    "get_ep",
     "models",
+    "optimize_model",
+    "register_ep",
     "registry",
     "tasks",
 ]
@@ -67,7 +72,9 @@ from mobius._configs import (
 )
 from mobius._constants import OPSET_VERSION
 from mobius._diffusers_builder import build_diffusers_pipeline
+from mobius._execution_providers import EpCapabilities, ep_registry, get_ep, register_ep
 from mobius._model_package import ModelPackage
+from mobius._optimizations import optimize_model
 from mobius._registry import (
     ModelRegistration,
     ModelRegistry,


### PR DESCRIPTION
Documents the EP-aware model building infrastructure added in PR #103.

## Changes

### New: `docs/ep_quickstart.md`
Practical 5-section guide for the most common EP tasks:
1. Build for a specific EP (code + CLI examples)
2. See what each EP does (trace mode walkthrough)
3. Query which EPs are available (`ep_registry`, `get_ep()`)
4. Register a custom EP (`register_ep()`)
5. Common EP configurations at a glance (table)

### Updated: `docs/execution_providers.md`
- New **"When to use `build_context()` vs `optimize_model()` directly"** section with a summary table of all API entry points (`build()`, `build_from_module()`, `optimize_model()`, `build_context()`)
- Clarified Step 2 of "Adding a New EP": documents both the rewrite-rule approach (for post-build graph rewrites) and the generation-time `ep_capabilities()` approach (for component-level branching)

### Updated: `README.md`
- Added EP-aware optimization paragraph with CUDA/WebGPU code examples
- Links to the new quickstart and full reference docs

## Accuracy note
All content is derived directly from reading the source code. Docstrings for `EpCapabilities`, `EpRegistry`, `build_context()`, `optimize_model()`, and `build()` were verified and are already comprehensive — no docstring changes needed.