### PR TITLE
refactor: replace inline language_model. prefix loops with vlm_decoder_weights() [SUPERSEDED]

### DIFF
--- a/src/mobius/models/gemma3_text.py
+++ b/src/mobius/models/gemma3_text.py
@@ -12,6 +12,7 @@ from onnxscript import nn
 from onnxscript._internal import builder
 
 from mobius._configs import ArchitectureConfig
+from mobius._weight_utils import vlm_decoder_weights
 from mobius.components import (
     MLP,
     Attention,
@@ -187,10 +188,4 @@ class Gemma3CausalLMModel(CausalLMModel):
         self, state_dict: dict[str, torch.Tensor]
     ) -> dict[str, torch.Tensor]:
         """Preprocess weights, handling language_model prefix from multimodal."""
-        for key in list(state_dict.keys()):
-            if "language_model." in key:
-                new_key = key.replace("language_model.", "")
-                state_dict[new_key] = state_dict.pop(key)
-            elif "vision_tower" in key or "multi_modal_projector" in key:
-                state_dict.pop(key)
-        return super().preprocess_weights(state_dict)
+        return super().preprocess_weights(vlm_decoder_weights(state_dict))

--- a/src/mobius/models/gemma3n.py
+++ b/src/mobius/models/gemma3n.py
@@ -27,6 +27,7 @@ from onnxscript import nn
 from onnxscript._internal import builder
 
 from mobius._configs import Gemma3nConfig
+from mobius._weight_utils import vlm_decoder_weights
 from mobius.components import (
     MLP,
     Attention,
@@ -599,14 +600,7 @@ class Gemma3nCausalLMModel(CausalLMModel):
         self, state_dict: dict[str, torch.Tensor]
     ) -> dict[str, torch.Tensor]:
         """Preprocess weights, handling language_model prefix from multimodal."""
-        for key in list(state_dict.keys()):
-            if "language_model." in key:
-                new_key = key.replace("language_model.", "")
-                state_dict[new_key] = state_dict.pop(key)
-            elif "vision_tower" in key or "multi_modal_projector" in key:
-                state_dict.pop(key)
-            elif "audio_tower" in key:
-                state_dict.pop(key)
+        state_dict = vlm_decoder_weights(state_dict)
 
         # AltUp submodules (correction_coefs, prediction_coefs, modality_router,
         # router_norm, correct_output_scale) are called via plain methods rather than

--- a/src/mobius/models/qwen_vl.py
+++ b/src/mobius/models/qwen_vl.py
@@ -10,6 +10,7 @@ from onnxscript import nn
 from onnxscript._internal import builder
 
 from mobius._configs import ArchitectureConfig
+from mobius._weight_utils import vlm_decoder_weights
 from mobius.components import (
     InputMixer,
     Qwen3VLVisionModel,
@@ -38,13 +39,7 @@ class _QwenVLTextMixin:
     def preprocess_weights(
         self, state_dict: dict[str, torch.Tensor]
     ) -> dict[str, torch.Tensor]:
-        for key in list(state_dict.keys()):
-            if "language_model." in key:
-                new_key = key.replace("language_model.", "")
-                state_dict[new_key] = state_dict.pop(key)
-            elif "visual." in key:
-                state_dict.pop(key)
-        return super().preprocess_weights(state_dict)
+        return super().preprocess_weights(vlm_decoder_weights(state_dict))
 
 
 class Qwen25VLTextModel(_QwenVLTextMixin, CausalLMModel):


### PR DESCRIPTION
**⚠️ This PR is superseded and should be closed.** The same change was made on PR #116 (justinchu/refactor-weight-utils) and subsequently **reverted** after Copilot review identified a critical correctness bug.

## What this PR actually contains

Replaces inline `language_model.` prefix-stripping loops with `vlm_decoder_weights()` in 3 files:
- `src/mobius/models/gemma3_text.py`
- `src/mobius/models/gemma3n.py`
- `src/mobius/models/qwen_vl.py`

3 files changed, 6 insertions(+), 22 deletions(-)

## Why this is broken

`vlm_decoder_weights()` is a **filter** — it returns only keys that start with `language_model.`, producing an empty dict for standalone text model checkpoints (e.g. `google/gemma-3-1b-pt`, `google/gemma-3n-E2B-pt`) which have no such prefix. The original inline loops were **conditional renames** — they renamed matching keys but passed all non-matching keys through unchanged.

This was caught by Copilot review on PR #116 and reverted in commit `91819b8`. This branch (`justinchu/refactor-vl-vision`) contains the pre-revert broken version and should be closed.