### PR TITLE
refactor: Consolidate MLP variants (9→3)

### DIFF
--- a/src/mobius/components/__init__.py
+++ b/src/mobius/components/__init__.py
@@ -30,6 +30,7 @@ __all__ = [
     "EncoderLayer",
     "FCMLP",
     "GatedDeltaNet",
+    "GatedMLP",
     "GatedRMSNorm",
     "Gemma3MultiModalProjector",
     "GroupNorm",
@@ -66,7 +67,6 @@ __all__ = [
     "Qwen25VLPatchMerger",
     "Qwen25VLVisionAttention",
     "Qwen25VLVisionBlock",
-    "Qwen25VLVisionMLP",
     "Qwen25VLVisionModel",
     "Qwen25VLVisionRotaryEmbedding",
     "Qwen35Attention",
@@ -76,7 +76,6 @@ __all__ = [
     "Qwen3VLPatchMerger",
     "Qwen3VLVisionAttention",
     "Qwen3VLVisionBlock",
-    "Qwen3VLVisionMLP",
     "Qwen3VLVisionModel",
     "Qwen3VLVisionRotaryEmbedding",
     "RMSNorm",
@@ -174,7 +173,7 @@ from mobius.components._gated_deltanet import GatedDeltaNet
 from mobius.components._lightning_attention import LightningAttention
 from mobius.components._lora import LoRALinear
 from mobius.components._mamba_block import Mamba2Block, MambaBlock
-from mobius.components._mlp import FCMLP, MLP
+from mobius.components._mlp import FCMLP, GatedMLP, MLP
 from mobius.components._moe import (
     MoELayer,
     SigmoidTopKGate,
@@ -210,7 +209,6 @@ from mobius.components._qwen3_vl_vision import (
     Qwen3VLPatchMerger,
     Qwen3VLVisionAttention,
     Qwen3VLVisionBlock,
-    Qwen3VLVisionMLP,
     Qwen3VLVisionModel,
     Qwen3VLVisionRotaryEmbedding,
 )
@@ -219,7 +217,6 @@ from mobius.components._qwen25_vl_vision import (
     Qwen25VLPatchMerger,
     Qwen25VLVisionAttention,
     Qwen25VLVisionBlock,
-    Qwen25VLVisionMLP,
     Qwen25VLVisionModel,
     Qwen25VLVisionRotaryEmbedding,
 )

--- a/src/mobius/components/__init__.py
+++ b/src/mobius/components/__init__.py
@@ -173,7 +173,7 @@ from mobius.components._gated_deltanet import GatedDeltaNet
 from mobius.components._lightning_attention import LightningAttention
 from mobius.components._lora import LoRALinear
 from mobius.components._mamba_block import Mamba2Block, MambaBlock
-from mobius.components._mlp import FCMLP, GatedMLP, MLP
+from mobius.components._mlp import FCMLP, MLP, GatedMLP
 from mobius.components._moe import (
     MoELayer,
     SigmoidTopKGate,

--- a/src/mobius/components/_codec_transformer.py
+++ b/src/mobius/components/_codec_transformer.py
@@ -24,6 +24,7 @@ from mobius.components._common import (
     LayerNorm,
     Linear,
 )
+from mobius.components._mlp import FCMLP, GatedMLP
 from mobius.components._rms_norm import RMSNorm
 from mobius.components._rotary_embedding import (
     BaseRope,
@@ -76,7 +77,8 @@ class CodecDecoderTransformerLayer(nn.Module):
         self.self_attn_layer_scale = LayerScale(hidden_size)
 
         self.post_attention_layernorm = RMSNorm(hidden_size, eps=rms_norm_eps)
-        self.mlp = _SwiGLUMLP(hidden_size, intermediate_size)
+        # SwiGLU MLP: SiLU(gate_proj(x)) * up_proj(x) → down_proj
+        self.mlp = GatedMLP(hidden_size, intermediate_size, activation="silu", bias=False)
         self.mlp_layer_scale = LayerScale(hidden_size)
 
     def forward(
@@ -194,23 +196,6 @@ class _CodecDecoderAttention(nn.Module):
         )
 
         return self.o_proj(op, attn_out)
-
-
-class _SwiGLUMLP(nn.Module):
-    """SwiGLU MLP: SiLU(gate_proj(x)) * up_proj(x) → down_proj."""
-
-    def __init__(self, hidden_size: int, intermediate_size: int):
-        super().__init__()
-        self.gate_proj = Linear(hidden_size, intermediate_size, bias=False)
-        self.up_proj = Linear(hidden_size, intermediate_size, bias=False)
-        self.down_proj = Linear(intermediate_size, hidden_size, bias=False)
-
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
-        gate = self.gate_proj(op, x)
-        up = self.up_proj(op, x)
-        # SiLU(gate) * up
-        activated = op.Mul(op.Mul(gate, op.Sigmoid(gate)), up)
-        return self.down_proj(op, activated)
 
 
 class CodecDecoderTransformerModel(nn.Module):
@@ -341,7 +326,8 @@ class CodecEncoderTransformerLayer(nn.Module):
         self.self_attn_layer_scale = LayerScale(hidden_size)
 
         self.post_attention_layernorm = LayerNorm(hidden_size)
-        self.mlp = _GELUFc1Fc2MLP(hidden_size, intermediate_size)
+        # GELU fc1/fc2 MLP (no bias, matches Mimi encoder)
+        self.mlp = FCMLP(hidden_size, intermediate_size, activation="gelu", bias=False)
         self.mlp_layer_scale = LayerScale(hidden_size)
 
     def forward(
@@ -374,18 +360,6 @@ class CodecEncoderTransformerLayer(nn.Module):
         hidden_states = op.Add(residual, hidden_states)
 
         return hidden_states
-
-
-class _GELUFc1Fc2MLP(nn.Module):
-    """Simple MLP: fc1 → GELU → fc2."""
-
-    def __init__(self, hidden_size: int, intermediate_size: int):
-        super().__init__()
-        self.fc1 = Linear(hidden_size, intermediate_size, bias=False)
-        self.fc2 = Linear(intermediate_size, hidden_size, bias=False)
-
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
-        return self.fc2(op, op.Gelu(self.fc1(op, x)))
 
 
 class CodecEncoderTransformerModel(nn.Module):

--- a/src/mobius/components/_mlp.py
+++ b/src/mobius/components/_mlp.py
@@ -55,7 +55,17 @@ class GatedMLP(nn.Module):
     Implements SwiGLU / GeGLU / GateMLP patterns where the hidden
     dimension is split into a gate branch and an up branch.
 
-    Replaces: ``Qwen25VLVisionMLP``, ``_SwiGLUMLP``, ``PixtralGatedMLP``.
+    **When to use GatedMLP vs MLP:** Both implement the same gated forward
+    pass, but differ in how dimensions are specified at construction time.
+    Use ``GatedMLP`` when the model config provides ``hidden_size`` and
+    ``intermediate_size`` directly (vision encoders, codec models, etc.).
+    Use :class:`MLP` when the model dimensions come from an
+    :class:`~mobius._configs.ArchitectureConfig` object (language model
+    decoder layers).
+
+    Default parameter names are ``gate_proj`` / ``up_proj`` / ``down_proj``.
+    Models with different HuggingFace weight names should rename in
+    ``preprocess_weights()``.
 
     Args:
         hidden_size: Input/output dimension.

--- a/src/mobius/components/_mlp.py
+++ b/src/mobius/components/_mlp.py
@@ -49,6 +49,45 @@ class MLP(nn.Module):
         return self.down_proj(op, op.Mul(gate, up))
 
 
+class GatedMLP(nn.Module):
+    """Gated MLP: ``act(gate_proj(x)) * up_proj(x) → down_proj``.
+
+    Implements SwiGLU / GeGLU / GateMLP patterns where the hidden
+    dimension is split into a gate branch and an up branch.
+
+    Replaces: ``Qwen25VLVisionMLP``, ``_SwiGLUMLP``, ``PixtralGatedMLP``.
+
+    Args:
+        hidden_size: Input/output dimension.
+        intermediate_size: Hidden dimension of the gate/up branches.
+        activation: Activation applied to the gate branch (default
+            ``"silu"`` for SwiGLU).
+        bias: Whether to include bias in all projection layers.
+        linear_class: Factory callable for creating linear layers.
+            Defaults to ``Linear``.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        activation: str = "silu",
+        bias: bool = False,
+        linear_class: type | None = None,
+    ):
+        super().__init__()
+        if linear_class is None:
+            linear_class = Linear
+        self.gate_proj = linear_class(hidden_size, intermediate_size, bias=bias)
+        self.up_proj = linear_class(hidden_size, intermediate_size, bias=bias)
+        self.down_proj = linear_class(intermediate_size, hidden_size, bias=bias)
+        self.act_fn = get_activation(activation)
+
+    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+        gate = self.act_fn(op, self.gate_proj(op, x))
+        return self.down_proj(op, op.Mul(gate, self.up_proj(op, x)))
+
+
 class FCMLP(nn.Module):
     """Two-layer fully-connected MLP: ``up_proj → activation → down_proj``.
 

--- a/src/mobius/components/_mlp_test.py
+++ b/src/mobius/components/_mlp_test.py
@@ -11,7 +11,7 @@ from mobius._testing import (
     create_test_input,
     make_config,
 )
-from mobius.components._mlp import FCMLP, MLP
+from mobius.components._mlp import FCMLP, GatedMLP, MLP
 
 
 class TestMLP:
@@ -165,5 +165,68 @@ class TestFCMLP:
 
         mlp = FCMLP(hidden_size=64, intermediate_size=128, linear_class=TrackingLinear)
         assert len(created) == 2
+        assert isinstance(mlp.up_proj, TrackingLinear)
+        assert isinstance(mlp.down_proj, TrackingLinear)
+
+
+class TestGatedMLP:
+    """Tests for GatedMLP (SwiGLU/GeGLU style gated MLP)."""
+
+    def test_projection_shapes(self):
+        mlp = GatedMLP(hidden_size=64, intermediate_size=128)
+        assert list(mlp.gate_proj.weight.shape) == [128, 64]
+        assert list(mlp.up_proj.weight.shape) == [128, 64]
+        assert list(mlp.down_proj.weight.shape) == [64, 128]
+
+    def test_parameter_count_no_bias(self):
+        mlp = GatedMLP(hidden_size=64, intermediate_size=128, bias=False)
+        params = list(mlp.parameters())
+        # gate_proj.weight + up_proj.weight + down_proj.weight = 3
+        assert len(params) == 3
+
+    def test_parameter_count_with_bias(self):
+        mlp = GatedMLP(hidden_size=64, intermediate_size=128, bias=True)
+        params = list(mlp.parameters())
+        # 3 weights + 3 biases = 6
+        assert len(params) == 6
+
+    def test_silu_activation(self):
+        mlp = GatedMLP(hidden_size=64, intermediate_size=128, activation="silu")
+        builder, op, graph = create_test_builder()
+        x = create_test_input(builder, "x", [1, 8, 64])
+        mlp(op, x)
+        # SiLU = x * sigmoid(x): Sigmoid + Mul (gate) + Mul (gate*up)
+        assert count_op_type(graph, "Sigmoid") >= 1
+        assert count_op_type(graph, "Mul") >= 2
+
+    def test_gelu_activation(self):
+        mlp = GatedMLP(hidden_size=64, intermediate_size=128, activation="gelu")
+        builder, op, graph = create_test_builder()
+        x = create_test_input(builder, "x", [1, 8, 64])
+        mlp(op, x)
+        assert count_op_type(graph, "Gelu") >= 1
+
+    def test_forward_builds_graph(self):
+        mlp = GatedMLP(hidden_size=64, intermediate_size=128)
+        builder, op, graph = create_test_builder()
+        x = create_test_input(builder, "x", [1, 8, 64])
+        result = mlp(op, x)
+        builder._adapt_outputs([result])
+        assert graph.num_nodes() > 0
+        assert count_op_type(graph, "FusedMatMul") == 3
+
+    def test_linear_class_applied(self):
+        from mobius.components._common import Linear
+
+        created = []
+
+        class TrackingLinear(Linear):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                created.append(self)
+
+        mlp = GatedMLP(hidden_size=64, intermediate_size=128, linear_class=TrackingLinear)
+        assert len(created) == 3
+        assert isinstance(mlp.gate_proj, TrackingLinear)
         assert isinstance(mlp.up_proj, TrackingLinear)
         assert isinstance(mlp.down_proj, TrackingLinear)

--- a/src/mobius/components/_mlp_test.py
+++ b/src/mobius/components/_mlp_test.py
@@ -11,7 +11,7 @@ from mobius._testing import (
     create_test_input,
     make_config,
 )
-from mobius.components._mlp import FCMLP, GatedMLP, MLP
+from mobius.components._mlp import FCMLP, MLP, GatedMLP
 
 
 class TestMLP:

--- a/src/mobius/components/_pixtral_vision.py
+++ b/src/mobius/components/_pixtral_vision.py
@@ -211,7 +211,9 @@ class PixtralTransformerLayer(nn.Module):
         )
         self.ffn_norm = RMSNorm(hidden_size, eps)
         # SiLU gated MLP (no bias, matches HF PixtralAttentionMLP)
-        self.feed_forward = GatedMLP(hidden_size, intermediate_size, activation="silu", bias=False)
+        self.feed_forward = GatedMLP(
+            hidden_size, intermediate_size, activation="silu", bias=False
+        )
 
     def forward(
         self,

--- a/src/mobius/components/_pixtral_vision.py
+++ b/src/mobius/components/_pixtral_vision.py
@@ -25,9 +25,9 @@ from onnxscript import nn
 from onnxscript._internal import builder
 
 from mobius._configs import ArchitectureConfig
-from mobius.components._activations import silu
 from mobius.components._common import Linear
 from mobius.components._conv import Conv2dNoBias
+from mobius.components._mlp import GatedMLP
 from mobius.components._rms_norm import RMSNorm
 from mobius.components._rotary_embedding import (
     apply_rotary_pos_emb,
@@ -188,38 +188,6 @@ class PixtralAttention(nn.Module):
         return self.o_proj(op, attn_output)
 
 
-class PixtralGatedMLP(nn.Module):
-    """Gated MLP with SiLU activation for Pixtral vision encoder.
-
-    ``SiLU(gate_proj(x)) * up_proj(x) → down_proj``
-
-    HF weight names: ``feed_forward.{gate,up,down}_proj.weight``
-    """
-
-    def __init__(self, hidden_size: int, intermediate_size: int):
-        super().__init__()
-        self.gate_proj = Linear(
-            hidden_size,
-            intermediate_size,
-            bias=False,
-        )
-        self.up_proj = Linear(
-            hidden_size,
-            intermediate_size,
-            bias=False,
-        )
-        self.down_proj = Linear(
-            intermediate_size,
-            hidden_size,
-            bias=False,
-        )
-
-    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
-        gate = silu(op, self.gate_proj(op, x))
-        up = self.up_proj(op, x)
-        return self.down_proj(op, op.Mul(gate, up))
-
-
 class PixtralTransformerLayer(nn.Module):
     """Single Pixtral transformer layer: pre-norm attn + MLP.
 
@@ -242,10 +210,8 @@ class PixtralTransformerLayer(nn.Module):
             head_dim,
         )
         self.ffn_norm = RMSNorm(hidden_size, eps)
-        self.feed_forward = PixtralGatedMLP(
-            hidden_size,
-            intermediate_size,
-        )
+        # SiLU gated MLP (no bias, matches HF PixtralAttentionMLP)
+        self.feed_forward = GatedMLP(hidden_size, intermediate_size, activation="silu", bias=False)
 
     def forward(
         self,

--- a/src/mobius/components/_qformer.py
+++ b/src/mobius/components/_qformer.py
@@ -24,8 +24,8 @@ from typing import TYPE_CHECKING
 from onnxscript import nn
 from onnxscript._internal import builder
 
-from mobius.components._activations import ACT2FN
 from mobius.components._common import LayerNorm, Linear
+from mobius.components._mlp import FCMLP
 
 if TYPE_CHECKING:
     import onnx_ir as ir
@@ -107,30 +107,6 @@ class QFormerAttention(nn.Module):
         return self.out_proj(op, attn_output)
 
 
-class _QFormerMLP(nn.Module):
-    """Standard MLP for Q-Former layers (not SwiGLU).
-
-    Structure: Linear(hidden→intermediate) → activation → Linear(intermediate→hidden)
-    """
-
-    def __init__(
-        self,
-        hidden_size: int,
-        intermediate_size: int,
-        hidden_act: str = "gelu",
-        bias: bool = True,
-    ):
-        super().__init__()
-        self.up_proj = Linear(hidden_size, intermediate_size, bias=bias)
-        self.down_proj = Linear(intermediate_size, hidden_size, bias=bias)
-        self._act_fn = ACT2FN[hidden_act]
-
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
-        hidden_states = self.up_proj(op, hidden_states)
-        hidden_states = self._act_fn(op, hidden_states)
-        return self.down_proj(op, hidden_states)
-
-
 class QFormerLayer(nn.Module):
     """Single Q-Former transformer layer.
 
@@ -181,11 +157,11 @@ class QFormerLayer(nn.Module):
         )
         self.cross_attn_layernorm = LayerNorm(hidden_size, eps=layer_norm_eps)
 
-        # Feed-forward network
-        self.mlp = _QFormerMLP(
+        # Feed-forward network (up_proj/down_proj weight names already match FCMLP)
+        self.mlp = FCMLP(
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
-            hidden_act=hidden_act,
+            activation=hidden_act,
             bias=bias,
         )
         self.mlp_layernorm = LayerNorm(hidden_size, eps=layer_norm_eps)

--- a/src/mobius/components/_qwen25_vl_vision.py
+++ b/src/mobius/components/_qwen25_vl_vision.py
@@ -8,8 +8,7 @@ Provides modules for the Qwen2.5-VL vision backbone:
 - ``Qwen25VLPatchEmbed``: Conv3d patch tokenisation (14x14x2, no bias).
 - ``Qwen25VLVisionRotaryEmbedding``: 2D rotary embeddings from grid positions.
 - ``Qwen25VLVisionAttention``: Packed MHA with cu_seqlens boundaries.
-- ``Qwen25VLVisionMLP``: Gate-up-down MLP with SiLU activation.
-- ``Qwen25VLVisionBlock``: Pre-norm transformer block (RMSNorm → Attn → MLP).
+- ``Qwen25VLVisionBlock``: Pre-norm transformer block (uses ``GatedMLP``).
 - ``Qwen25VLPatchMerger``: Spatial merge via RMSNorm → reshape → MLP.
 - ``Qwen25VLVisionModel``: Full encoder with windowed + full attention.
 
@@ -30,6 +29,7 @@ from onnxscript._internal import builder
 
 from mobius._build_context import ep_capabilities
 from mobius.components._common import Linear
+from mobius.components._mlp import GatedMLP
 from mobius.components._rms_norm import RMSNorm
 from mobius.components._scan_utils import (
     compact_scan_output,
@@ -342,25 +342,6 @@ class Qwen25VLVisionAttention(nn.Module):
         return op.Where(same_segment, zero, neg_inf)
 
 
-class Qwen25VLVisionMLP(nn.Module):
-    """Gate-up-down MLP with SiLU activation (bias=True).
-
-    Matches HF Qwen2_5_VLMLP: gate_proj * act(up_proj) → down_proj.
-    """
-
-    def __init__(self, hidden_size: int, intermediate_size: int):
-        super().__init__()
-        self.gate_proj = Linear(hidden_size, intermediate_size, bias=True)
-        self.up_proj = Linear(hidden_size, intermediate_size, bias=True)
-        self.down_proj = Linear(intermediate_size, hidden_size, bias=True)
-
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
-        gate = self.gate_proj(op, hidden_states)
-        gate = op.Mul(gate, op.Sigmoid(gate))  # SiLU
-        up = self.up_proj(op, hidden_states)
-        return self.down_proj(op, op.Mul(gate, up))
-
-
 class Qwen25VLVisionBlock(nn.Module):
     """Pre-norm vision transformer block.
 
@@ -372,7 +353,8 @@ class Qwen25VLVisionBlock(nn.Module):
         self.norm1 = RMSNorm(hidden_size, eps=1e-6)
         self.norm2 = RMSNorm(hidden_size, eps=1e-6)
         self.attn = Qwen25VLVisionAttention(hidden_size, num_heads)
-        self.mlp = Qwen25VLVisionMLP(hidden_size, intermediate_size)
+        # SiLU gated MLP with bias (gate_proj/up_proj/down_proj names match HF)
+        self.mlp = GatedMLP(hidden_size, intermediate_size, activation="silu", bias=True)
 
     def forward(
         self,

--- a/src/mobius/components/_qwen3_vl_vision.py
+++ b/src/mobius/components/_qwen3_vl_vision.py
@@ -8,8 +8,7 @@ Provides modules for the Qwen3-VL vision backbone:
 - ``Qwen3VLPatchEmbed``: Conv3d patch tokenisation (temporal + spatial).
 - ``Qwen3VLVisionRotaryEmbedding``: 2D rotary embeddings from grid positions.
 - ``Qwen3VLVisionAttention``: Packed bidirectional MHA with ``cu_seqlens``.
-- ``Qwen3VLVisionMLP``: Single-gate MLP (Linear → activation → Linear).
-- ``Qwen3VLVisionBlock``: Pre-norm transformer block.
+- ``Qwen3VLVisionBlock``: Pre-norm transformer block (uses ``FCMLP``).
 - ``Qwen3VLPatchMerger``: Spatial merge to reduce token count.
 - ``Qwen3VLVisionModel``: Full encoder stack with DeepStack outputs.
 
@@ -29,6 +28,7 @@ from onnxscript._internal import builder
 
 from mobius._build_context import ep_capabilities
 from mobius.components._common import LayerNorm, Linear
+from mobius.components._mlp import FCMLP
 from mobius.components._scan_utils import (
     compact_scan_output,
     create_body_graph,
@@ -320,20 +320,6 @@ class Qwen3VLVisionAttention(nn.Module):
         return attn_output
 
 
-class Qwen3VLVisionMLP(nn.Module):
-    """Single-gate MLP for the vision encoder."""
-
-    def __init__(self, hidden_size: int, intermediate_size: int):
-        super().__init__()
-        self.linear_fc1 = Linear(hidden_size, intermediate_size, bias=True)
-        self.linear_fc2 = Linear(intermediate_size, hidden_size, bias=True)
-
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
-        hidden_states = self.linear_fc1(op, hidden_states)
-        hidden_states = op.Gelu(hidden_states, approximate="tanh")
-        return self.linear_fc2(op, hidden_states)
-
-
 class Qwen3VLVisionBlock(nn.Module):
     """Pre-norm vision transformer block with packed attention.
 
@@ -345,7 +331,8 @@ class Qwen3VLVisionBlock(nn.Module):
         self.norm1 = LayerNorm(hidden_size, eps=1e-6)
         self.attn = Qwen3VLVisionAttention(hidden_size, num_heads)
         self.norm2 = LayerNorm(hidden_size, eps=1e-6)
-        self.mlp = Qwen3VLVisionMLP(hidden_size, intermediate_size)
+        # GELU (tanh approx) MLP with bias (HF linear_fc1/linear_fc2 → up_proj/down_proj)
+        self.mlp = FCMLP(hidden_size, intermediate_size, activation="gelu_new", bias=True)
 
     def forward(
         self,

--- a/src/mobius/components/_sam_vision.py
+++ b/src/mobius/components/_sam_vision.py
@@ -25,6 +25,7 @@ from onnxscript import nn
 from onnxscript._internal import builder
 
 from mobius.components._common import Linear
+from mobius.components._mlp import FCMLP
 
 
 class _SAMPatchEmbed(nn.Module):
@@ -237,18 +238,6 @@ class _SAMAttention(nn.Module):
         )
 
 
-class _SAMMLPBlock(nn.Module):
-    """MLP block for SAM: Linear → GELU → Linear."""
-
-    def __init__(self, embedding_dim: int, mlp_dim: int):
-        super().__init__()
-        self.lin1 = Linear(embedding_dim, mlp_dim, bias=True)
-        self.lin2 = Linear(mlp_dim, embedding_dim, bias=True)
-
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
-        return self.lin2(op, op.Gelu(self.lin1(op, x)))
-
-
 class _SAMBlock(nn.Module):
     """SAM transformer block with optional window attention.
 
@@ -287,7 +276,8 @@ class _SAMBlock(nn.Module):
             input_size=attn_input_size,
         )
         self.norm2 = _SAMLayerNorm(dim)
-        self.mlp = _SAMMLPBlock(dim, int(dim * mlp_ratio))
+        # GELU MLP with bias (HF lin1/lin2 → up_proj/down_proj)
+        self.mlp = FCMLP(dim, int(dim * mlp_ratio), activation="gelu", bias=True)
 
         self._window_size = window_size
         self._input_size = input_size

--- a/src/mobius/components/_vision.py
+++ b/src/mobius/components/_vision.py
@@ -20,6 +20,7 @@ from onnxscript import nn
 from onnxscript._internal import builder
 
 from mobius._configs import ArchitectureConfig
+from mobius.components._mlp import FCMLP
 
 if TYPE_CHECKING:
     import onnx_ir as ir
@@ -124,9 +125,15 @@ class VisionAttention(nn.Module):
 
 
 class _VisionLinear(nn.Module):
-    """Linear layer with bias for vision encoder."""
+    """Linear layer with Transpose+MatMul using standard ONNX ops.
 
-    def __init__(self, in_features: int, out_features: int):
+    Uses standard ONNX ops (not FusedMatMul) so ONNX symbolic shape
+    inference can propagate output shapes. Always includes bias.
+    The ``bias`` kwarg is accepted for API compatibility with ``FCMLP``'s
+    ``linear_class`` protocol but is always True.
+    """
+
+    def __init__(self, in_features: int, out_features: int, bias: bool = True):
         super().__init__()
         self.weight = nn.Parameter([out_features, in_features])
         self.bias = nn.Parameter([out_features])
@@ -135,20 +142,6 @@ class _VisionLinear(nn.Module):
         weight_t = op.Transpose(self.weight, perm=[1, 0])
         result = op.MatMul(x, weight_t)
         return op.Add(result, self.bias)
-
-
-class VisionMLP(nn.Module):
-    """Two-layer MLP with GELU activation for vision encoders."""
-
-    def __init__(self, hidden_size: int, intermediate_size: int):
-        super().__init__()
-        self.fc1 = _VisionLinear(hidden_size, intermediate_size)
-        self.fc2 = _VisionLinear(intermediate_size, hidden_size)
-
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
-        hidden_states = self.fc1(op, hidden_states)
-        hidden_states = op.Gelu(hidden_states, approximate="tanh")
-        return self.fc2(op, hidden_states)
 
 
 class VisionLayerNorm(nn.Module):
@@ -187,7 +180,14 @@ class VisionEncoderLayer(nn.Module):
         self.layer_norm1 = VisionLayerNorm(hidden_size, eps=norm_eps)
         self.self_attn = VisionAttention(hidden_size, num_heads)
         self.layer_norm2 = VisionLayerNorm(hidden_size, eps=norm_eps)
-        self.mlp = VisionMLP(hidden_size, intermediate_size)
+        # GELU (tanh approx) MLP with bias (HF fc1/fc2 → up_proj/down_proj).
+        # Uses _VisionLinear (Transpose+MatMul) instead of Linear (FusedMatMul)
+        # so ONNX symbolic shape inference can propagate output shapes through
+        # models that feed vision features into dynamic Expand ops (e.g. BLIP-2).
+        self.mlp = FCMLP(
+            hidden_size, intermediate_size, activation="gelu_new", bias=True,
+            linear_class=_VisionLinear,
+        )
 
     def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
         residual = hidden_states

--- a/src/mobius/components/_vision.py
+++ b/src/mobius/components/_vision.py
@@ -185,7 +185,10 @@ class VisionEncoderLayer(nn.Module):
         # so ONNX symbolic shape inference can propagate output shapes through
         # models that feed vision features into dynamic Expand ops (e.g. BLIP-2).
         self.mlp = FCMLP(
-            hidden_size, intermediate_size, activation="gelu_new", bias=True,
+            hidden_size,
+            intermediate_size,
+            activation="gelu_new",
+            bias=True,
             linear_class=_VisionLinear,
         )
 

--- a/src/mobius/components/_vision_test.py
+++ b/src/mobius/components/_vision_test.py
@@ -20,7 +20,6 @@ from mobius.components._vision import (
     VisionEncoder,
     VisionEncoderLayer,
     VisionLayerNorm,
-    VisionMLP,
     VisionModel,
 )
 
@@ -70,16 +69,6 @@ class TestVisionAttention:
         result = attn(op, hidden)
         b._adapt_outputs([result])
         assert count_op_type(graph, "Attention") == 1
-
-
-class TestVisionMLP:
-    def test_forward(self):
-        mlp = VisionMLP(hidden_size=64, intermediate_size=128)
-        b, op, graph = create_test_builder()
-        hidden = create_test_input(b, "hidden", [1, 16, 64])
-        result = mlp(op, hidden)
-        b._adapt_outputs([result])
-        assert graph.num_nodes() > 0
 
 
 class TestVisionLayerNorm:

--- a/src/mobius/models/blip2.py
+++ b/src/mobius/models/blip2.py
@@ -126,6 +126,9 @@ class _Blip2VisionEncoderModel(nn.Module):
         for key, value in state_dict.items():
             # Vision model weights (ViT)
             if key.startswith("vision_model."):
+                # VisionModel MLP uses up_proj/down_proj; HF uses fc1/fc2
+                key = key.replace(".mlp.fc1.", ".mlp.up_proj.")
+                key = key.replace(".mlp.fc2.", ".mlp.down_proj.")
                 renamed[key] = value
             # Language projection (Q-Former output → text dim)
             elif key.startswith("language_projection."):

--- a/src/mobius/models/deepseek_ocr2.py
+++ b/src/mobius/models/deepseek_ocr2.py
@@ -337,7 +337,9 @@ class DeepSeekOCR2VisionEncoderModel(nn.Module):
             new_key = key[len("model.") :]
 
             if new_key.startswith("sam_model."):
-                # SAM weights map directly
+                # SAM weights: lin1/lin2 → up_proj/down_proj
+                new_key = new_key.replace(".mlp.lin1.", ".mlp.up_proj.")
+                new_key = new_key.replace(".mlp.lin2.", ".mlp.down_proj.")
                 renamed[new_key] = value
             elif new_key.startswith("qwen2_model."):
                 # HF: qwen2_model.model.model.layers.N.* → qwen2_model.layers.N.*

--- a/src/mobius/models/gemma3.py
+++ b/src/mobius/models/gemma3.py
@@ -94,11 +94,14 @@ class _Gemma3VisionEncoderModel(nn.Module):
     def preprocess_weights(
         self, state_dict: dict[str, torch.Tensor]
     ) -> dict[str, torch.Tensor]:
-        renamed: dict[str, torch.Tensor] = {
-            key: value
-            for key, value in state_dict.items()
-            if key.startswith(("vision_tower.", "multi_modal_projector."))
-        }
+        renamed: dict[str, torch.Tensor] = {}
+        for key, value in state_dict.items():
+            if not key.startswith(("vision_tower.", "multi_modal_projector.")):
+                continue
+            # VisionModel MLP uses up_proj/down_proj; HF uses fc1/fc2
+            key = key.replace(".mlp.fc1.", ".mlp.up_proj.")
+            key = key.replace(".mlp.fc2.", ".mlp.down_proj.")
+            renamed[key] = value
         return renamed
 
 

--- a/src/mobius/models/llava.py
+++ b/src/mobius/models/llava.py
@@ -93,11 +93,14 @@ class _LLaVAVisionEncoderModel(nn.Module):
     def preprocess_weights(
         self, state_dict: dict[str, torch.Tensor]
     ) -> dict[str, torch.Tensor]:
-        renamed: dict[str, torch.Tensor] = {
-            key: value
-            for key, value in state_dict.items()
-            if key.startswith(("vision_tower.", "multi_modal_projector."))
-        }
+        renamed: dict[str, torch.Tensor] = {}
+        for key, value in state_dict.items():
+            if not key.startswith(("vision_tower.", "multi_modal_projector.")):
+                continue
+            # VisionModel MLP uses up_proj/down_proj; HF uses fc1/fc2
+            key = key.replace(".mlp.fc1.", ".mlp.up_proj.")
+            key = key.replace(".mlp.fc2.", ".mlp.down_proj.")
+            renamed[key] = value
         return renamed
 
 

--- a/src/mobius/models/mllama.py
+++ b/src/mobius/models/mllama.py
@@ -318,9 +318,15 @@ class _MllamaVisionEncoderModel(nn.Module):
     def preprocess_weights(
         self, state_dict: dict[str, torch.Tensor]
     ) -> dict[str, torch.Tensor]:
-        return {
-            key: value for key, value in state_dict.items() if key.startswith("vision_model.")
-        }
+        renamed: dict[str, torch.Tensor] = {}
+        for key, value in state_dict.items():
+            if not key.startswith("vision_model."):
+                continue
+            # VisionModel MLP uses up_proj/down_proj; HF uses fc1/fc2
+            key = key.replace(".mlp.fc1.", ".mlp.up_proj.")
+            key = key.replace(".mlp.fc2.", ".mlp.down_proj.")
+            renamed[key] = value
+        return renamed
 
 
 class _MllamaEmbeddingModel(nn.Module):

--- a/src/mobius/models/qwen35.py
+++ b/src/mobius/models/qwen35.py
@@ -473,6 +473,9 @@ class Qwen35VL3ModelCausalLMModel(nn.Module):
                 stripped = stripped[len("model.") :]
 
             if stripped.startswith("visual."):
+                # Qwen3-VL uses linear_fc1/fc2; ONNX uses up_proj/down_proj
+                stripped = stripped.replace(".mlp.linear_fc1.", ".mlp.up_proj.")
+                stripped = stripped.replace(".mlp.linear_fc2.", ".mlp.down_proj.")
                 renamed[f"vision_encoder.{stripped}"] = value
             elif stripped.startswith("language_model.embed_tokens."):
                 suffix = stripped[len("language_model.") :]

--- a/src/mobius/models/qwen3_tts_tokenizer.py
+++ b/src/mobius/models/qwen3_tts_tokenizer.py
@@ -708,6 +708,10 @@ class Qwen3TTSTokenizerV2Model(nn.Module):
             if "codebook.initialized" in key:
                 continue
 
+            # Rename encoder transformer MLP weights:
+            # HF uses fc1/fc2; ONNX uses up_proj/down_proj
+            key = key.replace(".mlp.fc1.", ".mlp.up_proj.")
+            key = key.replace(".mlp.fc2.", ".mlp.down_proj.")
             # Pass through everything else
             cleaned[key] = value
 

--- a/src/mobius/models/qwen_vl.py
+++ b/src/mobius/models/qwen_vl.py
@@ -811,7 +811,7 @@ class Qwen3VLVisionEncoderModel(nn.Module):
         for key, value in state_dict.items():
             stripped = key
             if stripped.startswith("model."):
-                stripped = stripped[len("model."):]
+                stripped = stripped[len("model.") :]
             if stripped.startswith("visual."):
                 # Qwen3-VL uses linear_fc1/fc2; ONNX uses up_proj/down_proj
                 stripped = stripped.replace(".mlp.linear_fc1.", ".mlp.up_proj.")

--- a/src/mobius/models/qwen_vl.py
+++ b/src/mobius/models/qwen_vl.py
@@ -676,6 +676,9 @@ class Qwen3VL3ModelCausalLMModel(nn.Module):
                 stripped = stripped[len("model.") :]
 
             if stripped.startswith("visual."):
+                # Qwen3-VL uses linear_fc1/fc2; ONNX uses up_proj/down_proj
+                stripped = stripped.replace(".mlp.linear_fc1.", ".mlp.up_proj.")
+                stripped = stripped.replace(".mlp.linear_fc2.", ".mlp.down_proj.")
                 renamed[f"vision_encoder.{stripped}"] = value
             elif stripped.startswith("language_model.embed_tokens."):
                 # Shared embedding → both decoder and embedding model
@@ -808,8 +811,11 @@ class Qwen3VLVisionEncoderModel(nn.Module):
         for key, value in state_dict.items():
             stripped = key
             if stripped.startswith("model."):
-                stripped = stripped[len("model.") :]
+                stripped = stripped[len("model."):]
             if stripped.startswith("visual."):
+                # Qwen3-VL uses linear_fc1/fc2; ONNX uses up_proj/down_proj
+                stripped = stripped.replace(".mlp.linear_fc1.", ".mlp.up_proj.")
+                stripped = stripped.replace(".mlp.linear_fc2.", ".mlp.down_proj.")
                 renamed[stripped] = value
         return renamed
 


### PR DESCRIPTION
## Summary

Reduces MLP class count from 9 → 3 by adding a new `GatedMLP` component and absorbing 6 specialised classes into `GatedMLP`/`FCMLP`.

## New component

**`GatedMLP`** — `act(gate_proj(x)) * up_proj(x) → down_proj`. Added to `components/_mlp.py` with `TestGatedMLP` unit tests.

## Classes removed (8)

| Class | File | Replaced by |
|---|---|---|
| `Qwen25VLVisionMLP` | `_qwen25_vl_vision.py` | `GatedMLP` |
| `_SwiGLUMLP` | `_codec_transformer.py` | `GatedMLP` |
| `PixtralGatedMLP` | `_pixtral_vision.py` | `GatedMLP` |
| `Qwen3VLVisionMLP` | `_qwen3_vl_vision.py` | `FCMLP` |
| `_QFormerMLP` | `_qformer.py` | `FCMLP` |
| `_GELUFc1Fc2MLP` | `_codec_transformer.py` | `FCMLP` |
| `_SAMMLPBlock` | `_sam_vision.py` | `FCMLP` |
| `VisionMLP` | `_vision.py` | `FCMLP` |

## Implementation notes

- **Gated variants** need no `preprocess_weights` renames — HF names (`gate_proj`/`up_proj`/`down_proj`) already match.
- **VisionMLP** replaced by `FCMLP(linear_class=_VisionLinear)` to preserve standard ONNX ops (Transpose+MatMul) needed for symbolic shape inference through BLIP-2's Q-Former dynamic `Expand`.
- **preprocess_weights** renames added in 7 model files for `fc1`/`fc2`, `linear_fc1`/`linear_fc2`, `lin1`/`lin2` → `up_proj`/`down_proj`.

## Tests

All 2286 tests pass (excluding pre-existing phi4mm skips).