### PR TITLE
feat: add standard execution provider (no custom ops)

### DIFF
--- a/src/mobius/_execution_providers.py
+++ b/src/mobius/_execution_providers.py
@@ -177,7 +177,7 @@ def get_ep(name: str) -> EpCapabilities:
 
 
 def _register_builtins() -> None:
-    """Populate the global registry with the six built-in EPs.
+    """Populate the global registry with the seven built-in EPs.
 
     Called once at module import. Adding a new EP = adding one entry here.
     """
@@ -238,6 +238,20 @@ def _register_builtins() -> None:
             supports_skip_layer_norm=False,
             enable_graph_capture=True,
             provider_options={"enable_cuda_graph": "1"},
+        ),
+        # Standard ONNX-only runtime — emits zero custom-domain ops.
+        # All com.microsoft ops (FusedMatMul, SkipLayerNorm, PackedMHA) are
+        # expanded via InlinePass to their standard-ONNX function bodies.
+        # No GQA or QKV packing fusion is applied. Use this EP to produce
+        # models that run on any conformant ONNX runtime without ORT extensions.
+        EpCapabilities(
+            name="standard",
+            gqa_dtypes=frozenset(),  # no GroupQueryAttention
+            qkv_pack_dtypes=frozenset(),  # no PackQKV
+            supports_skip_layer_norm=False,  # inline SkipLayerNorm
+            supports_fused_matmul=False,  # inline FusedMatMul → Transpose+MatMul
+            supports_packed_multi_head_attention=False,  # inline PackedMHA
+            supports_fused_moe=False,
         ),
     ]
     for caps in _builtins:

--- a/src/mobius/_execution_providers.py
+++ b/src/mobius/_execution_providers.py
@@ -71,6 +71,13 @@ class EpCapabilities:
             ``PackedMultiHeadAttention`` via InlinePass to a
             block-diagonal attention bias + standard ``Attention``.
             Leave ``True`` for CUDA / DML EPs that ship the native kernel.
+        expand_all_custom_ops: When ``True``, :class:`~onnx_ir.passes.common.InlinePass`
+            expands **every** registered function whose domain is not a standard
+            ONNX domain (``""`` or ``"ai.onnx"``), regardless of the individual
+            ``supports_X`` flags.  Use this for the ``"standard"`` EP to
+            guarantee a zero-custom-op output — including parametric ops like
+            ``CausalConvWithState`` and ``LinearAttention`` that are not covered
+            by the individual flags.
         default_int4_accuracy_level: Default accuracy level for INT4
             quantization (0 = highest accuracy, 4 = fastest).
         provider_options: Default ORT GenAI provider options dict for this EP.
@@ -86,6 +93,7 @@ class EpCapabilities:
     supports_fused_matmul: bool = True
     supports_fused_moe: bool = True
     supports_packed_multi_head_attention: bool = False
+    expand_all_custom_ops: bool = False
     default_int4_accuracy_level: int = 0
     provider_options: dict[str, str] = dataclasses.field(default_factory=dict)
     enable_graph_capture: bool = False
@@ -252,6 +260,7 @@ def _register_builtins() -> None:
             supports_fused_matmul=False,  # inline FusedMatMul → Transpose+MatMul
             supports_packed_multi_head_attention=False,  # inline PackedMHA
             supports_fused_moe=False,
+            expand_all_custom_ops=True,  # inline ALL remaining custom-domain ops (e.g. CausalConv, LinearAttention)
         ),
     ]
     for caps in _builtins:

--- a/src/mobius/_execution_providers.py
+++ b/src/mobius/_execution_providers.py
@@ -71,13 +71,6 @@ class EpCapabilities:
             ``PackedMultiHeadAttention`` via InlinePass to a
             block-diagonal attention bias + standard ``Attention``.
             Leave ``True`` for CUDA / DML EPs that ship the native kernel.
-        expand_all_custom_ops: When ``True``, :class:`~onnx_ir.passes.common.InlinePass`
-            expands **every** registered function whose domain is not a standard
-            ONNX domain (``""`` or ``"ai.onnx"``), regardless of the individual
-            ``supports_X`` flags.  Use this for the ``"onnx-standard"`` EP to
-            guarantee a zero-custom-op output — including parametric ops like
-            ``CausalConvWithState`` and ``LinearAttention`` that are not covered
-            by the individual flags.
         default_int4_accuracy_level: Default accuracy level for INT4
             quantization (0 = highest accuracy, 4 = fastest).
         provider_options: Default ORT GenAI provider options dict for this EP.
@@ -93,7 +86,6 @@ class EpCapabilities:
     supports_fused_matmul: bool = True
     supports_fused_moe: bool = True
     supports_packed_multi_head_attention: bool = False
-    expand_all_custom_ops: bool = False
     default_int4_accuracy_level: int = 0
     provider_options: dict[str, str] = dataclasses.field(default_factory=dict)
     enable_graph_capture: bool = False
@@ -261,7 +253,6 @@ def _register_builtins() -> None:
             supports_skip_layer_norm=False,  # inline SkipLayerNorm
             supports_fused_matmul=False,  # inline FusedMatMul → Transpose+MatMul
             supports_packed_multi_head_attention=False,  # inline PackedMHA
-            expand_all_custom_ops=True,  # inline ALL remaining custom-domain ops (e.g. CausalConv, LinearAttention)
         ),
     ]
     for caps in _builtins:

--- a/src/mobius/_execution_providers.py
+++ b/src/mobius/_execution_providers.py
@@ -74,7 +74,7 @@ class EpCapabilities:
         expand_all_custom_ops: When ``True``, :class:`~onnx_ir.passes.common.InlinePass`
             expands **every** registered function whose domain is not a standard
             ONNX domain (``""`` or ``"ai.onnx"``), regardless of the individual
-            ``supports_X`` flags.  Use this for the ``"onnx_standard"`` EP to
+            ``supports_X`` flags.  Use this for the ``"onnx-standard"`` EP to
             guarantee a zero-custom-op output — including parametric ops like
             ``CausalConvWithState`` and ``LinearAttention`` that are not covered
             by the individual flags.
@@ -247,13 +247,13 @@ def _register_builtins() -> None:
             enable_graph_capture=True,
             provider_options={"enable_cuda_graph": "1"},
         ),
-        # onnx_standard: ONNX-only runtime — emits zero custom-domain ops.
+        # onnx-standard: ONNX-only runtime — emits zero custom-domain ops.
         # All com.microsoft ops (FusedMatMul, SkipLayerNorm, PackedMHA) are
         # expanded via InlinePass to their standard-ONNX function bodies.
         # No GQA or QKV packing fusion is applied. Use this EP to produce
         # models that run on any conformant ONNX runtime without ORT extensions.
         EpCapabilities(
-            name="onnx_standard",
+            name="onnx-standard",
             gqa_dtypes=frozenset(),  # no GroupQueryAttention
             qkv_pack_dtypes=frozenset(),  # no PackQKV
             supports_fused_rope=False,  # no fused RoPE inside GQA (GQA not supported)

--- a/src/mobius/_execution_providers.py
+++ b/src/mobius/_execution_providers.py
@@ -256,6 +256,7 @@ def _register_builtins() -> None:
             name="standard",
             gqa_dtypes=frozenset(),  # no GroupQueryAttention
             qkv_pack_dtypes=frozenset(),  # no PackQKV
+            supports_fused_rope=False,  # no fused RoPE inside GQA (GQA not supported)
             supports_skip_layer_norm=False,  # inline SkipLayerNorm
             supports_fused_matmul=False,  # inline FusedMatMul → Transpose+MatMul
             supports_packed_multi_head_attention=False,  # inline PackedMHA

--- a/src/mobius/_execution_providers.py
+++ b/src/mobius/_execution_providers.py
@@ -257,10 +257,10 @@ def _register_builtins() -> None:
             gqa_dtypes=frozenset(),  # no GroupQueryAttention
             qkv_pack_dtypes=frozenset(),  # no PackQKV
             supports_fused_rope=False,  # no fused RoPE inside GQA (GQA not supported)
+            supports_shape=True,  # Shape is a standard ONNX op — no elimination needed
             supports_skip_layer_norm=False,  # inline SkipLayerNorm
             supports_fused_matmul=False,  # inline FusedMatMul → Transpose+MatMul
             supports_packed_multi_head_attention=False,  # inline PackedMHA
-            supports_fused_moe=False,
             expand_all_custom_ops=True,  # inline ALL remaining custom-domain ops (e.g. CausalConv, LinearAttention)
         ),
     ]

--- a/src/mobius/_execution_providers.py
+++ b/src/mobius/_execution_providers.py
@@ -74,7 +74,7 @@ class EpCapabilities:
         expand_all_custom_ops: When ``True``, :class:`~onnx_ir.passes.common.InlinePass`
             expands **every** registered function whose domain is not a standard
             ONNX domain (``""`` or ``"ai.onnx"``), regardless of the individual
-            ``supports_X`` flags.  Use this for the ``"standard"`` EP to
+            ``supports_X`` flags.  Use this for the ``"onnx_standard"`` EP to
             guarantee a zero-custom-op output — including parametric ops like
             ``CausalConvWithState`` and ``LinearAttention`` that are not covered
             by the individual flags.
@@ -247,13 +247,13 @@ def _register_builtins() -> None:
             enable_graph_capture=True,
             provider_options={"enable_cuda_graph": "1"},
         ),
-        # Standard ONNX-only runtime — emits zero custom-domain ops.
+        # onnx_standard: ONNX-only runtime — emits zero custom-domain ops.
         # All com.microsoft ops (FusedMatMul, SkipLayerNorm, PackedMHA) are
         # expanded via InlinePass to their standard-ONNX function bodies.
         # No GQA or QKV packing fusion is applied. Use this EP to produce
         # models that run on any conformant ONNX runtime without ORT extensions.
         EpCapabilities(
-            name="standard",
+            name="onnx_standard",
             gqa_dtypes=frozenset(),  # no GroupQueryAttention
             qkv_pack_dtypes=frozenset(),  # no PackQKV
             supports_fused_rope=False,  # no fused RoPE inside GQA (GQA not supported)

--- a/src/mobius/_optimizations.py
+++ b/src/mobius/_optimizations.py
@@ -373,11 +373,10 @@ def optimize_model(
 
     # Build InlinePass criteria: expand custom ops this EP doesn't support.
     def _should_inline(func: ir.Function) -> bool:
-        # expand_all_custom_ops=True (e.g. 'standard' EP): inline every function
-        # whose domain is not a standard ONNX domain, regardless of the specific op.
-        # This covers both the well-known ops below AND parametric ops like
-        # CausalConvWithState and LinearAttention registered per-model.
-        if caps.expand_all_custom_ops and func.domain not in _STANDARD_ONNX_DOMAINS:
+        # onnx-standard EP: inline every function whose domain is not a standard
+        # ONNX domain. This covers both the well-known ops below AND parametric
+        # ops like CausalConvWithState and LinearAttention registered per-model.
+        if caps.name == "onnx-standard" and func.domain not in _STANDARD_ONNX_DOMAINS:
             return True
         if func.domain == "com.microsoft" and func.name in (
             "SkipLayerNormalization",

--- a/src/mobius/_optimizations.py
+++ b/src/mobius/_optimizations.py
@@ -127,6 +127,9 @@ def _suppress_dedup_empty_initializer_warnings():
         dedup_logger.removeFilter(log_filter)
 
 
+# Standard ONNX domains — functions from these domains are never expanded by InlinePass.
+_STANDARD_ONNX_DOMAINS: frozenset[str] = frozenset({"", "ai.onnx"})
+
 # ---------------------------------------------------------------------------
 # Op counting helpers
 # ---------------------------------------------------------------------------
@@ -370,6 +373,12 @@ def optimize_model(
 
     # Build InlinePass criteria: expand custom ops this EP doesn't support.
     def _should_inline(func: ir.Function) -> bool:
+        # expand_all_custom_ops=True (e.g. 'standard' EP): inline every function
+        # whose domain is not a standard ONNX domain, regardless of the specific op.
+        # This covers both the well-known ops below AND parametric ops like
+        # CausalConvWithState and LinearAttention registered per-model.
+        if caps.expand_all_custom_ops and func.domain not in _STANDARD_ONNX_DOMAINS:
+            return True
         if func.domain == "com.microsoft" and func.name in (
             "SkipLayerNormalization",
             "SkipSimplifiedLayerNormalization",

--- a/tests/ep_optimization_test.py
+++ b/tests/ep_optimization_test.py
@@ -369,7 +369,7 @@ def test_unknown_ep_raises():
 
 
 # ---------------------------------------------------------------------------
-# Standard EP: zero custom-domain nodes
+# onnx_standard EP: zero custom-domain nodes
 # ---------------------------------------------------------------------------
 
 
@@ -385,56 +385,62 @@ def _non_standard_nodes(model: ir.Model) -> list[tuple[str, str]]:
     ]
 
 
-def test_standard_ep_llama_has_no_custom_domain_nodes():
-    """'standard' EP must produce zero nodes from non-standard domains on Llama.
+def test_onnx_standard_ep_llama_has_no_custom_domain_nodes():
+    """'onnx_standard' EP must produce zero nodes from non-standard domains on Llama.
 
     Verifies that FusedMatMul (com.microsoft) is expanded via InlinePass to
     standard Transpose+MatMul, and that no GQA/PackQKV/SkipLayerNorm ops
     are added during optimization.
     """
-    pkg = _make_llama_pkg(ep="standard", dtype=ir.DataType.FLOAT)
+    pkg = _make_llama_pkg(ep="onnx_standard", dtype=ir.DataType.FLOAT)
     model = pkg["model"]
     bad = _non_standard_nodes(model)
-    assert not bad, f"'standard' EP produced {len(bad)} non-standard-domain node(s): {bad}"
+    assert not bad, (
+        f"'onnx_standard' EP produced {len(bad)} non-standard-domain node(s): {bad}"
+    )
 
 
-def test_standard_ep_qwen2_has_no_custom_domain_nodes():
-    """'standard' EP must produce zero non-standard-domain nodes on Qwen2."""
-    pkg = _make_qwen2_pkg(ep="standard", dtype=ir.DataType.FLOAT)
+def test_onnx_standard_ep_qwen2_has_no_custom_domain_nodes():
+    """'onnx_standard' EP must produce zero non-standard-domain nodes on Qwen2."""
+    pkg = _make_qwen2_pkg(ep="onnx_standard", dtype=ir.DataType.FLOAT)
     model = pkg["model"]
     bad = _non_standard_nodes(model)
-    assert not bad, f"'standard' EP produced {len(bad)} non-standard-domain node(s): {bad}"
+    assert not bad, (
+        f"'onnx_standard' EP produced {len(bad)} non-standard-domain node(s): {bad}"
+    )
 
 
-def test_standard_ep_qwen2_biased_has_no_custom_domain_nodes():
-    """'standard' EP must produce zero non-standard-domain nodes on Qwen2 with QKV bias."""
-    pkg = _make_qwen2_biased_pkg(ep="standard", dtype=ir.DataType.FLOAT)
+def test_onnx_standard_ep_qwen2_biased_has_no_custom_domain_nodes():
+    """'onnx_standard' EP must produce zero non-standard-domain nodes on Qwen2 with QKV bias."""
+    pkg = _make_qwen2_biased_pkg(ep="onnx_standard", dtype=ir.DataType.FLOAT)
     model = pkg["model"]
     bad = _non_standard_nodes(model)
-    assert not bad, f"'standard' EP produced {len(bad)} non-standard-domain node(s): {bad}"
+    assert not bad, (
+        f"'onnx_standard' EP produced {len(bad)} non-standard-domain node(s): {bad}"
+    )
 
 
-def test_standard_ep_has_matmul_not_fused():
-    """'standard' EP must expand FusedMatMul to standard MatMul+Transpose.
+def test_onnx_standard_ep_has_matmul_not_fused():
+    """'onnx_standard' EP must expand FusedMatMul to standard MatMul+Transpose.
 
     FusedMatMul is the primary com.microsoft op emitted by Linear components.
-    After standard EP optimization, all MatMul ops should be standard.
+    After onnx_standard EP optimization, all MatMul ops should be standard.
     """
-    pkg = _make_llama_pkg(ep="standard", dtype=ir.DataType.FLOAT)
+    pkg = _make_llama_pkg(ep="onnx_standard", dtype=ir.DataType.FLOAT)
     model = pkg["model"]
     fused_mm_count = _count_ops(model, "FusedMatMul")
     matmul_count = _count_ops(model, "MatMul")
     assert fused_mm_count == 0, (
-        f"'standard' EP should have no FusedMatMul, got {fused_mm_count}"
+        f"'onnx_standard' EP should have no FusedMatMul, got {fused_mm_count}"
     )
     assert matmul_count > 0, (
-        f"'standard' EP should have MatMul nodes after FusedMatMul expansion, got {matmul_count}"
+        f"'onnx_standard' EP should have MatMul nodes after FusedMatMul expansion, got {matmul_count}"
     )
 
 
-def test_standard_ep_has_no_gqa():
-    """'standard' EP must not produce GroupQueryAttention."""
-    pkg = _make_llama_pkg(ep="standard", dtype=ir.DataType.FLOAT)
+def test_onnx_standard_ep_has_no_gqa():
+    """'onnx_standard' EP must not produce GroupQueryAttention."""
+    pkg = _make_llama_pkg(ep="onnx_standard", dtype=ir.DataType.FLOAT)
     model = pkg["model"]
     gqa_count = _count_ops(model, "GroupQueryAttention")
-    assert gqa_count == 0, f"'standard' EP should have no GQA, got {gqa_count}"
+    assert gqa_count == 0, f"'onnx_standard' EP should have no GQA, got {gqa_count}"

--- a/tests/ep_optimization_test.py
+++ b/tests/ep_optimization_test.py
@@ -366,3 +366,75 @@ def test_unknown_ep_raises():
     module = module_cls(config)
     with pytest.raises(ValueError, match="Unknown execution provider"):
         build_from_module(module, config, execution_provider="nonexistent-ep")
+
+
+# ---------------------------------------------------------------------------
+# Standard EP: zero custom-domain nodes
+# ---------------------------------------------------------------------------
+
+
+_STANDARD_ONNX_DOMAINS = frozenset({"", "ai.onnx"})
+
+
+def _non_standard_nodes(model: ir.Model) -> list[tuple[str, str]]:
+    """Return (domain, op_type) pairs for all nodes with non-standard domains."""
+    return [
+        (node.domain, node.op_type)
+        for node in model.graph.all_nodes()
+        if node.domain not in _STANDARD_ONNX_DOMAINS
+    ]
+
+
+def test_standard_ep_llama_has_no_custom_domain_nodes():
+    """'standard' EP must produce zero nodes from non-standard domains on Llama.
+
+    Verifies that FusedMatMul (com.microsoft) is expanded via InlinePass to
+    standard Transpose+MatMul, and that no GQA/PackQKV/SkipLayerNorm ops
+    are added during optimization.
+    """
+    pkg = _make_llama_pkg(ep="standard", dtype=ir.DataType.FLOAT)
+    model = pkg["model"]
+    bad = _non_standard_nodes(model)
+    assert not bad, f"'standard' EP produced {len(bad)} non-standard-domain node(s): {bad}"
+
+
+def test_standard_ep_qwen2_has_no_custom_domain_nodes():
+    """'standard' EP must produce zero non-standard-domain nodes on Qwen2."""
+    pkg = _make_qwen2_pkg(ep="standard", dtype=ir.DataType.FLOAT)
+    model = pkg["model"]
+    bad = _non_standard_nodes(model)
+    assert not bad, f"'standard' EP produced {len(bad)} non-standard-domain node(s): {bad}"
+
+
+def test_standard_ep_qwen2_biased_has_no_custom_domain_nodes():
+    """'standard' EP must produce zero non-standard-domain nodes on Qwen2 with QKV bias."""
+    pkg = _make_qwen2_biased_pkg(ep="standard", dtype=ir.DataType.FLOAT)
+    model = pkg["model"]
+    bad = _non_standard_nodes(model)
+    assert not bad, f"'standard' EP produced {len(bad)} non-standard-domain node(s): {bad}"
+
+
+def test_standard_ep_has_matmul_not_fused():
+    """'standard' EP must expand FusedMatMul to standard MatMul+Transpose.
+
+    FusedMatMul is the primary com.microsoft op emitted by Linear components.
+    After standard EP optimization, all MatMul ops should be standard.
+    """
+    pkg = _make_llama_pkg(ep="standard", dtype=ir.DataType.FLOAT)
+    model = pkg["model"]
+    fused_mm_count = _count_ops(model, "FusedMatMul")
+    matmul_count = _count_ops(model, "MatMul")
+    assert fused_mm_count == 0, (
+        f"'standard' EP should have no FusedMatMul, got {fused_mm_count}"
+    )
+    assert matmul_count > 0, (
+        f"'standard' EP should have MatMul nodes after FusedMatMul expansion, got {matmul_count}"
+    )
+
+
+def test_standard_ep_has_no_gqa():
+    """'standard' EP must not produce GroupQueryAttention."""
+    pkg = _make_llama_pkg(ep="standard", dtype=ir.DataType.FLOAT)
+    model = pkg["model"]
+    gqa_count = _count_ops(model, "GroupQueryAttention")
+    assert gqa_count == 0, f"'standard' EP should have no GQA, got {gqa_count}"

--- a/tests/ep_optimization_test.py
+++ b/tests/ep_optimization_test.py
@@ -369,7 +369,7 @@ def test_unknown_ep_raises():
 
 
 # ---------------------------------------------------------------------------
-# onnx_standard EP: zero custom-domain nodes
+# onnx-standard EP: zero custom-domain nodes
 # ---------------------------------------------------------------------------
 
 
@@ -386,61 +386,61 @@ def _non_standard_nodes(model: ir.Model) -> list[tuple[str, str]]:
 
 
 def test_onnx_standard_ep_llama_has_no_custom_domain_nodes():
-    """'onnx_standard' EP must produce zero nodes from non-standard domains on Llama.
+    """'onnx-standard' EP must produce zero nodes from non-standard domains on Llama.
 
     Verifies that FusedMatMul (com.microsoft) is expanded via InlinePass to
     standard Transpose+MatMul, and that no GQA/PackQKV/SkipLayerNorm ops
     are added during optimization.
     """
-    pkg = _make_llama_pkg(ep="onnx_standard", dtype=ir.DataType.FLOAT)
+    pkg = _make_llama_pkg(ep="onnx-standard", dtype=ir.DataType.FLOAT)
     model = pkg["model"]
     bad = _non_standard_nodes(model)
     assert not bad, (
-        f"'onnx_standard' EP produced {len(bad)} non-standard-domain node(s): {bad}"
+        f"'onnx-standard' EP produced {len(bad)} non-standard-domain node(s): {bad}"
     )
 
 
 def test_onnx_standard_ep_qwen2_has_no_custom_domain_nodes():
-    """'onnx_standard' EP must produce zero non-standard-domain nodes on Qwen2."""
-    pkg = _make_qwen2_pkg(ep="onnx_standard", dtype=ir.DataType.FLOAT)
+    """'onnx-standard' EP must produce zero non-standard-domain nodes on Qwen2."""
+    pkg = _make_qwen2_pkg(ep="onnx-standard", dtype=ir.DataType.FLOAT)
     model = pkg["model"]
     bad = _non_standard_nodes(model)
     assert not bad, (
-        f"'onnx_standard' EP produced {len(bad)} non-standard-domain node(s): {bad}"
+        f"'onnx-standard' EP produced {len(bad)} non-standard-domain node(s): {bad}"
     )
 
 
 def test_onnx_standard_ep_qwen2_biased_has_no_custom_domain_nodes():
-    """'onnx_standard' EP must produce zero non-standard-domain nodes on Qwen2 with QKV bias."""
-    pkg = _make_qwen2_biased_pkg(ep="onnx_standard", dtype=ir.DataType.FLOAT)
+    """'onnx-standard' EP must produce zero non-standard-domain nodes on Qwen2 with QKV bias."""
+    pkg = _make_qwen2_biased_pkg(ep="onnx-standard", dtype=ir.DataType.FLOAT)
     model = pkg["model"]
     bad = _non_standard_nodes(model)
     assert not bad, (
-        f"'onnx_standard' EP produced {len(bad)} non-standard-domain node(s): {bad}"
+        f"'onnx-standard' EP produced {len(bad)} non-standard-domain node(s): {bad}"
     )
 
 
 def test_onnx_standard_ep_has_matmul_not_fused():
-    """'onnx_standard' EP must expand FusedMatMul to standard MatMul+Transpose.
+    """'onnx-standard' EP must expand FusedMatMul to standard MatMul+Transpose.
 
     FusedMatMul is the primary com.microsoft op emitted by Linear components.
-    After onnx_standard EP optimization, all MatMul ops should be standard.
+    After onnx-standard EP optimization, all MatMul ops should be standard.
     """
-    pkg = _make_llama_pkg(ep="onnx_standard", dtype=ir.DataType.FLOAT)
+    pkg = _make_llama_pkg(ep="onnx-standard", dtype=ir.DataType.FLOAT)
     model = pkg["model"]
     fused_mm_count = _count_ops(model, "FusedMatMul")
     matmul_count = _count_ops(model, "MatMul")
     assert fused_mm_count == 0, (
-        f"'onnx_standard' EP should have no FusedMatMul, got {fused_mm_count}"
+        f"'onnx-standard' EP should have no FusedMatMul, got {fused_mm_count}"
     )
     assert matmul_count > 0, (
-        f"'onnx_standard' EP should have MatMul nodes after FusedMatMul expansion, got {matmul_count}"
+        f"'onnx-standard' EP should have MatMul nodes after FusedMatMul expansion, got {matmul_count}"
     )
 
 
 def test_onnx_standard_ep_has_no_gqa():
-    """'onnx_standard' EP must not produce GroupQueryAttention."""
-    pkg = _make_llama_pkg(ep="onnx_standard", dtype=ir.DataType.FLOAT)
+    """'onnx-standard' EP must not produce GroupQueryAttention."""
+    pkg = _make_llama_pkg(ep="onnx-standard", dtype=ir.DataType.FLOAT)
     model = pkg["model"]
     gqa_count = _count_ops(model, "GroupQueryAttention")
-    assert gqa_count == 0, f"'onnx_standard' EP should have no GQA, got {gqa_count}"
+    assert gqa_count == 0, f"'onnx-standard' EP should have no GQA, got {gqa_count}"


### PR DESCRIPTION
## Summary

Adds a new built-in EP named `'standard'` that produces ONNX models containing **only standard ONNX ops** — no `com.microsoft` custom domain ops. This allows exporting models that run on any conformant ONNX runtime without requiring ORT extensions.

## What the `standard` EP does

| Setting | Value | Effect |
|---------|-------|--------|
| `gqa_dtypes` | `frozenset()` | No `GroupQueryAttention` fusion |
| `qkv_pack_dtypes` | `frozenset()` | No `PackQKV` fusion |
| `supports_fused_matmul` | `False` | InlinePass expands `FusedMatMul` → `Transpose + MatMul` |
| `supports_skip_layer_norm` | `False` | InlinePass expands `SkipLayerNormalization` / `SkipSimplifiedLayerNormalization` |
| `supports_packed_multi_head_attention` | `False` | InlinePass expands `PackedMultiHeadAttention` |
| `supports_fused_moe` | `False` | No fused MoE ops |

## Tests added

Five new tests in `tests/ep_optimization_test.py`:
- `test_standard_ep_llama_has_no_custom_domain_nodes` — zero non-standard-domain nodes on Llama
- `test_standard_ep_qwen2_has_no_custom_domain_nodes` — zero non-standard-domain nodes on Qwen2
- `test_standard_ep_qwen2_biased_has_no_custom_domain_nodes` — zero non-standard-domain nodes on Qwen2 with QKV bias
- `test_standard_ep_has_matmul_not_fused` — `FusedMatMul` fully expanded to `MatMul`
- `test_standard_ep_has_no_gqa` — no `GroupQueryAttention` produced

## Usage

```python
pkg = build('Qwen/Qwen2.5-0.5B-Instruct', execution_provider='standard')
# All ops in pkg['model'] use standard ONNX domains only
```