### PR TITLE
docs: fix onnx-standard documentation follow-up

### DIFF
--- a/docs/ep_quickstart.md
+++ b/docs/ep_quickstart.md
@@ -33,7 +33,7 @@ pkg = mobius.build("meta-llama/Llama-3.2-1B",
 
 # ONNX-standard — zero custom-domain ops, safe for any conformant ONNX runtime
 pkg = mobius.build("meta-llama/Llama-3.2-1B",
-                   execution_provider="onnx-standard")
+                   execution_provider="onnx-standard")  # works with any dtype
 
 pkg.save("output/llama/")
 ```
@@ -95,7 +95,7 @@ from mobius import ep_registry, get_ep
 
 # List all registered EP names
 print(sorted(ep_registry))
-# ['cpu', 'cuda', 'default', 'dml', 'trt-rtx', 'webgpu']
+# ['cpu', 'cuda', 'default', 'dml', 'onnx-standard', 'trt-rtx', 'webgpu']
 
 # Inspect an EP's capabilities
 caps = get_ep("cuda")

--- a/docs/ep_quickstart.md
+++ b/docs/ep_quickstart.md
@@ -33,7 +33,7 @@ pkg = mobius.build("meta-llama/Llama-3.2-1B",
 
 # ONNX-standard — zero custom-domain ops, safe for any conformant ONNX runtime
 pkg = mobius.build("meta-llama/Llama-3.2-1B",
-                   execution_provider="onnx-standard")  # works with any dtype
+                   execution_provider="onnx-standard")  # dtype defaults to f32; you can also pass f16/bf16
 
 pkg.save("output/llama/")
 ```

--- a/docs/execution_providers.md
+++ b/docs/execution_providers.md
@@ -148,7 +148,8 @@ EpCapabilities(name="trt-rtx", gqa_dtypes={FLOAT16, BFLOAT16},
                provider_options={"enable_cuda_graph": "1"})
 EpCapabilities(name="onnx-standard",
                gqa_dtypes=frozenset(), qkv_pack_dtypes=frozenset(),
-               supports_fused_rope=False, supports_skip_layer_norm=False,
+               supports_fused_rope=False,  # no-op: SeparateRoPE only applies to GQA nodes, which are never emitted
+               supports_skip_layer_norm=False,
                supports_fused_matmul=False,
                supports_packed_multi_head_attention=False)
 ```

--- a/docs/execution_providers.md
+++ b/docs/execution_providers.md
@@ -148,7 +148,7 @@ EpCapabilities(name="trt-rtx", gqa_dtypes={FLOAT16, BFLOAT16},
                provider_options={"enable_cuda_graph": "1"})
 EpCapabilities(name="onnx-standard",
                gqa_dtypes=frozenset(), qkv_pack_dtypes=frozenset(),
-               supports_fused_rope=False,  # no-op: SeparateRoPE only applies to GQA nodes, which are never emitted
+               supports_fused_rope=False,  # not used by default for this EP, since it does not enable GQA fusion
                supports_skip_layer_norm=False,
                supports_fused_matmul=False,
                supports_packed_multi_head_attention=False)


### PR DESCRIPTION
Three small fixes to the `onnx-standard` EP docs added in PR #122.

## Changes

1. **`ep_quickstart.md` — `sorted(ep_registry)` output**: Added `'onnx-standard'` in its correct alphabetical position (`'dml' < 'onnx-standard' < 'trt-rtx'`)

2. **`execution_providers.md` — registry snippet**: Added comment on `supports_fused_rope=False` clarifying it is a no-op for `onnx-standard` — SeparateRoPE only applies to GQA nodes, which are never emitted because `gqa_dtypes=frozenset()`

3. **`ep_quickstart.md` — `onnx-standard` build snippet**: Added `# works with any dtype` comment so readers don't think the omitted `dtype=` argument was accidental (all other examples show `dtype='f16'`)