### PR TITLE
docs: index all docs/ pages in Sphinx navigation

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -14,3 +14,16 @@ Public API documentation for `mobius`.
 - [`ModelPackage`](model_package.md) — Collection of named ONNX models
 - [`BaseModelConfig`](base_model_config.md) — Base configuration class
 - [`ModelRegistry`](model_registry.md) — Architecture registry
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+build
+build_from_module
+build_from_gguf
+apply_weights
+model_package
+base_model_config
+model_registry
+```

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,4 +1,4 @@
-# Design Document — mobius
+# System Architecture
 
 ## Overview
 

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -1,0 +1,17 @@
+# Design Documents
+
+Detailed design notes and proposals for `mobius` subsystems.
+
+```{toctree}
+:maxdepth: 1
+
+config-redesign
+gguf-support-proposal
+golden-infra-design
+multi-tier-testing-strategy
+perf-benchmarking
+phi4mm-architecture
+phi4mm-four-model-split
+phi4mm-ort-genai-integration
+test-infrastructure-map
+```

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -5,6 +5,7 @@ Detailed design notes and proposals for `mobius` subsystems.
 ```{toctree}
 :maxdepth: 1
 
+../design
 config-redesign
 gguf-support-proposal
 golden-infra-design

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,8 +21,8 @@ models/index
 :maxdepth: 2
 :caption: Execution Providers
 
-execution_providers
 ep_quickstart
+execution_providers
 ```
 
 ```{toctree}
@@ -31,15 +31,20 @@ ep_quickstart
 
 api/index
 feature-flags
-ai-model-support-strategy
 ```
 
 ```{toctree}
 :maxdepth: 2
 :caption: Design
 
-design
 design/index
+```
+
+```{toctree}
+:maxdepth: 2
+:caption: Contributing
+
+ai-model-support-strategy
 ```
 
 ```{toctree}

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,13 +8,43 @@ Build ONNX models directly from HuggingFace model IDs with automatic weight down
 
 ```{toctree}
 :maxdepth: 2
-:caption: Contents
+:caption: User Guide
 
 getting-started
 cli
+module-architecture
+model-catalog
 models/index
-design
-test-architecture
-ai-model-support-strategy
+```
+
+```{toctree}
+:maxdepth: 2
+:caption: Execution Providers
+
+execution_providers
+ep_quickstart
+```
+
+```{toctree}
+:maxdepth: 2
+:caption: Reference
+
+api/index
 feature-flags
+ai-model-support-strategy
+```
+
+```{toctree}
+:maxdepth: 2
+:caption: Design
+
+design
+design/index
+```
+
+```{toctree}
+:maxdepth: 2
+:caption: Research
+
+research/testing-strategy-analysis
 ```


### PR DESCRIPTION
## Problem

Many `docs/` files were orphaned — not reachable from the Sphinx site navigation. The old `index.md` had a single toctree with only 6 entries, and one of those (`test-architecture`) pointed to a deleted file.

## Changes

### `docs/index.md`
- Replaced single toctree with 5 captioned toctrees: **User Guide**, **Execution Providers**, **Reference**, **Design**, **Research**
- Removed broken `test-architecture` reference (file deleted in an earlier commit; content lives in `design/multi-tier-testing-strategy.md`)
- Added all previously orphaned top-level pages

### `docs/design/index.md` *(new)*
- Toctree listing all 9 files in `docs/design/`

### `docs/api/index.md`
- Added hidden toctree so Sphinx registers all 7 API reference pages

## Previously missing from site nav (now included)

| File | Description |
|------|-------------|
| `docs/module-architecture.md` | Module architecture overview |
| `docs/model-catalog.md` | Model catalog |
| `docs/execution_providers.md` | EP reference |
| `docs/ep_quickstart.md` | EP quickstart |
| `docs/api/*.md` | 7 API reference pages |
| `docs/design/*.md` | 9 design documents |
| `docs/research/testing-strategy-analysis.md` | Research note |

## Validation

Ran `sphinx-build docs /tmp/test -b dummy` — no "not in toctree" warnings. All pages discovered. Pre-existing cross-ref warnings in `ep_quickstart.md` and `design/test-infrastructure-map.md` are unchanged.