### PR TITLE
feat: Add export_for_ort_genai() API and --runtime ort-genai CLI flag

### DIFF
--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -211,7 +211,7 @@ def _cmd_build(args: argparse.Namespace) -> None:
 def _save_package(
     pkg, output_dir: str, args, optimize: str | None, component_filter: str | None
 ) -> None:
-    """Save a ModelPackage to disk, applying optimizations."""
+    """Save a ModelPackage to disk, applying optimizations and runtime configs."""
     components = (lambda name: name == component_filter) if component_filter else None
     for name, model in pkg.items():
         if components is not None and not components(name):
@@ -234,6 +234,19 @@ def _save_package(
         else:
             path = os.path.join(output_dir, "model.onnx")
         print(f"Saved {name} to {path}")
+
+    runtime = getattr(args, "runtime", None)
+    if runtime == "ort-genai":
+        from mobius.integrations.ort_genai import export_for_ort_genai
+
+        hf_model_id = getattr(args, "model", None)
+        ep = getattr(args, "execution_provider", "cpu")
+        # Normalize EP: "default" means no EP-specific options → use "cpu"
+        if ep == "default":
+            ep = "cpu"
+        artifacts = export_for_ort_genai(pkg, output_dir, hf_model_id=hf_model_id, ep=ep)
+        for name, path in artifacts.items():
+            print(f"  {name}: {path}")
 
 
 def _cmd_list(args: argparse.Namespace) -> None:
@@ -489,6 +502,18 @@ def main(argv: list[str] | None = None) -> None:
             "(default: 'default' → portable ONNX, no vendor fusions). "
             "Use 'mobius list eps' to see available EPs. "
             "Examples: default, cpu, cuda, dml, webgpu, trt-rtx."
+        ),
+    )
+    build_parser.add_argument(
+        "--runtime",
+        default=None,
+        choices=["ort-genai"],
+        metavar="RUNTIME",
+        help=(
+            "Generate runtime-specific config files after building. "
+            "Currently supports: 'ort-genai' (writes genai_config.json and "
+            "copies tokenizer files). Requires --model (not --config) for "
+            "tokenizer file download."
         ),
     )
     build_parser.set_defaults(func=_cmd_build)

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -237,11 +237,11 @@ def _save_package(
 
     runtime = getattr(args, "runtime", None)
     if runtime == "ort-genai":
-        from mobius.integrations.ort_genai import export_for_ort_genai
+        from mobius.integrations.ort_genai import write_ort_genai_config
 
         hf_model_id = getattr(args, "model", None)
         ep = getattr(args, "execution_provider", "cpu")
-        artifacts = export_for_ort_genai(pkg, output_dir, hf_model_id=hf_model_id, ep=ep)
+        artifacts = write_ort_genai_config(pkg, output_dir, hf_model_id=hf_model_id, ep=ep)
         for name, path in artifacts.items():
             print(f"  {name}: {path}")
 

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -241,9 +241,6 @@ def _save_package(
 
         hf_model_id = getattr(args, "model", None)
         ep = getattr(args, "execution_provider", "cpu")
-        # Normalize EP: "default" means no EP-specific options → use "cpu"
-        if ep == "default":
-            ep = "cpu"
         artifacts = export_for_ort_genai(pkg, output_dir, hf_model_id=hf_model_id, ep=ep)
         for name, path in artifacts.items():
             print(f"  {name}: {path}")

--- a/src/mobius/integrations/ort_genai/__init__.py
+++ b/src/mobius/integrations/ort_genai/__init__.py
@@ -7,6 +7,7 @@ All onnxruntime-genai specific code lives here. The core model/task/component
 layers remain runtime-agnostic.
 """
 
+from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
 from mobius.integrations.ort_genai.ep_config import (
     make_genai_decoder_config,
     make_kv_cache_dim_name,
@@ -19,6 +20,7 @@ from mobius.integrations.ort_genai.genai_config import (
 
 __all__ = [
     "GenaiConfigGenerator",
+    "export_for_ort_genai",
     "make_genai_decoder_config",
     "make_kv_cache_dim_name",
     "make_provider_options",

--- a/src/mobius/integrations/ort_genai/__init__.py
+++ b/src/mobius/integrations/ort_genai/__init__.py
@@ -7,7 +7,7 @@ All onnxruntime-genai specific code lives here. The core model/task/component
 layers remain runtime-agnostic.
 """
 
-from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
+from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
 from mobius.integrations.ort_genai.ep_config import (
     make_genai_decoder_config,
     make_kv_cache_dim_name,
@@ -20,7 +20,7 @@ from mobius.integrations.ort_genai.genai_config import (
 
 __all__ = [
     "GenaiConfigGenerator",
-    "export_for_ort_genai",
+    "write_ort_genai_config",
     "make_genai_decoder_config",
     "make_kv_cache_dim_name",
     "make_provider_options",

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -5,14 +5,14 @@
 
 Two entry points:
 
-- :func:`export_for_ort_genai` — programmatic API. Takes an already-built
+- :func:`write_ort_genai_config` — programmatic API. Takes an already-built
   :class:`~mobius._model_package.ModelPackage` (with weights) and writes the
   ORT-GenAI config artifacts (``genai_config.json``, tokenizer files,
   ``processor_config.json``) alongside the ONNX models.
 
 - :func:`auto_export` — end-to-end convenience function. Builds the model
   from a HuggingFace ID, saves the ONNX files, then calls
-  :func:`export_for_ort_genai` to write the config artifacts.
+  :func:`write_ort_genai_config` to write the config artifacts.
 
 Both functions produce a directory that ``onnxruntime-genai`` can load
 directly.
@@ -21,11 +21,11 @@ Example::
 
     # Programmatic API — build first, then export configs
     from mobius import build
-    from mobius.integrations.ort_genai import export_for_ort_genai
+    from mobius.integrations.ort_genai import write_ort_genai_config
 
     pkg = build("Qwen/Qwen3-0.6B", load_weights=True)
     pkg.save("/output/qwen3")
-    export_for_ort_genai(pkg, "/output/qwen3", hf_model_id="Qwen/Qwen3-0.6B")
+    write_ort_genai_config(pkg, "/output/qwen3", hf_model_id="Qwen/Qwen3-0.6B")
 
     # End-to-end convenience
     from mobius.integrations.ort_genai.auto_export import auto_export
@@ -174,7 +174,7 @@ def _write_genai_config(
     return generator.write(output_dir)
 
 
-def export_for_ort_genai(
+def write_ort_genai_config(
     pkg: ModelPackage,
     directory: str,
     *,
@@ -220,7 +220,7 @@ def export_for_ort_genai(
     config = getattr(pkg, "config", None)
     if config is None:
         raise ValueError(
-            "export_for_ort_genai requires ModelPackage.config to be set. "
+            "write_ort_genai_config requires ModelPackage.config to be set. "
             "This is set automatically when building with mobius.build(). "
             "Diffusion models (which have no config) are not supported."
         )
@@ -324,7 +324,7 @@ def auto_export(
     1. Builds the ONNX graph(s) via :func:`~mobius._builder.build`
     2. Downloads and applies HuggingFace weights
     3. Saves ONNX model(s) with external data
-    4. Calls :func:`export_for_ort_genai` to write ``genai_config.json``,
+    4. Calls :func:`write_ort_genai_config` to write ``genai_config.json``,
        tokenizer files, and ``processor_config.json``
 
     Args:
@@ -379,7 +379,7 @@ def auto_export(
     )
 
     # Write ORT-GenAI config artifacts (genai_config.json, tokenizer, processor)
-    result = export_for_ort_genai(
+    result = write_ort_genai_config(
         pkg,
         output_dir,
         hf_model_id=model_id,

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -3,16 +3,32 @@
 
 """Auto-export pipeline for onnxruntime-genai.
 
-Chains: build() → apply weights → generate genai_config.json → save ONNX
-models → copy tokenizer files. Produces a directory that onnxruntime-genai
-can load directly.
+Two entry points:
 
-This module imports from the core library at call time (not module load)
-to keep the integration layer lightweight.
+- :func:`export_for_ort_genai` — programmatic API. Takes an already-built
+  :class:`~mobius._model_package.ModelPackage` (with weights) and writes the
+  ORT-GenAI config artifacts (``genai_config.json``, tokenizer files,
+  ``processor_config.json``) alongside the ONNX models.
+
+- :func:`auto_export` — end-to-end convenience function. Builds the model
+  from a HuggingFace ID, saves the ONNX files, then calls
+  :func:`export_for_ort_genai` to write the config artifacts.
+
+Both functions produce a directory that ``onnxruntime-genai`` can load
+directly.
 
 Example::
 
-    from mobius.integrations.ort_genai import auto_export
+    # Programmatic API — build first, then export configs
+    from mobius import build
+    from mobius.integrations.ort_genai import export_for_ort_genai
+
+    pkg = build("Qwen/Qwen3-0.6B", load_weights=True)
+    pkg.save("/output/qwen3")
+    export_for_ort_genai(pkg, "/output/qwen3", hf_model_id="Qwen/Qwen3-0.6B")
+
+    # End-to-end convenience
+    from mobius.integrations.ort_genai.auto_export import auto_export
 
     auto_export("Qwen/Qwen3-0.6B", "/output/qwen3")
 """
@@ -23,7 +39,10 @@ import json
 import logging
 import os
 import shutil
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from mobius._model_package import ModelPackage
 
 logger = logging.getLogger(__name__)
 
@@ -102,105 +121,41 @@ def _write_processor_config(
     return path
 
 
-def auto_export(
-    model_id: str,
+def _write_genai_config(
+    config: Any,
     output_dir: str,
     *,
-    dtype: str | None = None,
-    task: str | None = None,
-    external_data: str = "onnx",
-    trust_remote_code: bool = False,
-    context_length: int = 4096,
-    progress_bar: bool = True,
-) -> dict[str, str]:
-    """Build and export a model for onnxruntime-genai.
+    ort_model_type: str,
+    ep: str,
+    context_length: int,
+    bos_token_id: int | None,
+    eos_token_id: int | list[int] | None,
+    pad_token_id: int | None,
+    is_vlm: bool,
+    has_speech: bool,
+) -> str:
+    """Generate and write genai_config.json.
 
-    This is the main entry point for producing ORT-GenAI-ready model
-    directories. It:
-
-    1. Builds the ONNX graph(s) via :func:`build`
-    2. Downloads and applies HuggingFace weights
-    3. Generates ``genai_config.json``
-    4. Saves ONNX model(s) with external data
-    5. Copies tokenizer files from HuggingFace Hub
-
-    Args:
-        model_id: HuggingFace model repository ID.
-        output_dir: Directory to write all output files.
-        dtype: Override model dtype (``"f32"``, ``"f16"``, ``"bf16"``).
-        task: Override model task (auto-detected if ``None``).
-        external_data: External data format (``"onnx"`` or
-            ``"safetensors"``).
-        trust_remote_code: Trust remote code for HuggingFace config.
-        context_length: Maximum context length for genai_config.json.
-        progress_bar: Show progress bar during save.
-
-    Returns:
-        Dict mapping output artifact names to file paths, e.g.::
-
-            {
-                "genai_config": "/output/genai_config.json",
-                "model": "/output/model.onnx",
-                "tokenizer": "/output/tokenizer.json",
-            }
+    Returns the path to the written file.
     """
-    import transformers
+    from mobius.integrations.ort_genai.genai_config import GenaiConfigGenerator
 
-    from mobius._builder import build
-    from mobius.integrations.ort_genai.genai_config import (
-        GenaiConfigGenerator,
-    )
-
-    os.makedirs(output_dir, exist_ok=True)
-
-    # 1. Load HF config for metadata (model_type, token IDs)
-    hf_config = transformers.AutoConfig.from_pretrained(
-        model_id, trust_remote_code=trust_remote_code
-    )
-    model_type = hf_config.model_type
-    ort_model_type = _resolve_ort_genai_model_type(model_type)
-
-    # 2. Build ONNX graph(s) with weights
-    logger.info("Building ONNX model for %s", model_id)
-    pkg = build(
-        model_id,
-        task=task,
-        dtype=dtype,
-        load_weights=True,
-        trust_remote_code=trust_remote_code,
-    )
-    config = getattr(pkg, "config", None)
-    if config is None:
-        raise ValueError(
-            f"Model package for '{model_id}' has no config attribute. "
-            "auto_export requires a config to generate genai_config.json. "
-            "Diffusion models are not yet supported."
-        )
-
-    # 3. Detect multimodal capabilities from the model package
-    is_vlm = "vision" in pkg and "embedding" in pkg
-    has_speech = "speech" in pkg
-
-    # Auto-detect phi4mm: HF model_type may be "phi" but model has speech
-    if ort_model_type == "phi" and has_speech:
-        ort_model_type = "phi4mm"
-
-    # 4. Generate genai_config.json
-    logger.info("Generating genai_config.json")
     generator = GenaiConfigGenerator.from_config(
         config,
         ort_model_type,
         context_length=context_length,
-        bos_token_id=getattr(hf_config, "bos_token_id", None),
-        eos_token_id=getattr(hf_config, "eos_token_id", None),
-        pad_token_id=getattr(hf_config, "pad_token_id", None),
+        ep=ep,
+        bos_token_id=bos_token_id,
+        eos_token_id=eos_token_id,
+        pad_token_id=pad_token_id,
     )
+
     if is_vlm:
         image_token_id = getattr(config, "image_token_id", None)
         if image_token_id is not None:
-            # Phi4MM uses different vision inputs than Qwen2.5-VL
             vision_kwargs: dict[str, Any] = {}
             if has_speech:
+                # Phi4MM uses different vision inputs than Qwen2.5-VL
                 vision_kwargs["spatial_merge_size"] = None
                 vision_kwargs["config_filename"] = "vision_processor.json"
                 vision_kwargs["input_names"] = {
@@ -216,9 +171,189 @@ def auto_export(
         )
         generator.with_speech(audio_token_id=audio_token_id)
 
-    genai_path = generator.write(output_dir)
+    return generator.write(output_dir)
 
-    # 5. Save ONNX models
+
+def export_for_ort_genai(
+    pkg: ModelPackage,
+    directory: str,
+    *,
+    hf_model_id: str | None = None,
+    ep: str = "cpu",
+    context_length: int = 4096,
+) -> dict[str, str]:
+    """Generate ORT-GenAI config artifacts for an already-built ModelPackage.
+
+    Writes ``genai_config.json``, optionally copies tokenizer files from
+    HuggingFace Hub, and writes ``processor_config.json`` for VLM models.
+    Does NOT build or save ONNX models — call :meth:`~mobius._model_package.ModelPackage.save`
+    separately before or after this function.
+
+    Args:
+        pkg: Already-built :class:`~mobius._model_package.ModelPackage` with
+            weights applied and ``config`` set.
+        directory: Output directory (created if needed).
+        hf_model_id: HuggingFace model ID. When provided, used to fetch token
+            IDs (``bos``/``eos``/``pad``) and download tokenizer files.
+            When ``None``, token IDs default to ``None`` and tokenizer files
+            are not copied.
+        ep: Execution provider for ``session_options`` in
+            ``genai_config.json`` (e.g. ``"cpu"``, ``"cuda"``, ``"dml"``,
+            ``"trt-rtx"``). Defaults to ``"cpu"``.
+        context_length: Minimum context length written to
+            ``genai_config.json``. Overridden upward by
+            ``max_position_embeddings`` from ``pkg.config``.
+
+    Returns:
+        Dict mapping artifact name to file path, e.g.::
+
+            {
+                "genai_config": "/output/genai_config.json",
+                "tokenizer.json": "/output/tokenizer.json",
+                "processor_config": "/output/processor_config.json",
+            }
+
+    Raises:
+        ValueError: If ``pkg.config`` is ``None`` (required for config
+            generation).
+    """
+    config = getattr(pkg, "config", None)
+    if config is None:
+        raise ValueError(
+            "export_for_ort_genai requires ModelPackage.config to be set. "
+            "This is set automatically when building with mobius.build(). "
+            "Diffusion models (which have no config) are not supported."
+        )
+
+    os.makedirs(directory, exist_ok=True)
+
+    # Resolve token IDs and ORT model type from HF config (if provided)
+    bos_token_id: int | None = None
+    eos_token_id: int | list[int] | None = None
+    pad_token_id: int | None = None
+    ort_model_type: str
+
+    if hf_model_id is not None:
+        import transformers
+
+        hf_config = transformers.AutoConfig.from_pretrained(hf_model_id)
+        model_type = hf_config.model_type
+        ort_model_type = _resolve_ort_genai_model_type(model_type)
+        bos_token_id = getattr(hf_config, "bos_token_id", None)
+        eos_token_id = getattr(hf_config, "eos_token_id", None)
+        pad_token_id = getattr(hf_config, "pad_token_id", None)
+    else:
+        # Fall back to model_type from the mobius ArchitectureConfig
+        raw_type = getattr(config, "model_type", "unknown")
+        ort_model_type = _resolve_ort_genai_model_type(raw_type)
+
+    # Detect multimodal capabilities from the package keys
+    is_vlm = "vision" in pkg and "embedding" in pkg
+    has_speech = "speech" in pkg
+
+    # Auto-detect phi4mm: HF model_type may be "phi" but model has speech
+    if ort_model_type == "phi" and has_speech:
+        ort_model_type = "phi4mm"
+
+    logger.info("Generating genai_config.json for %s (ep=%s)", ort_model_type, ep)
+    genai_path = _write_genai_config(
+        config,
+        directory,
+        ort_model_type=ort_model_type,
+        ep=ep,
+        context_length=context_length,
+        bos_token_id=bos_token_id,
+        eos_token_id=eos_token_id,
+        pad_token_id=pad_token_id,
+        is_vlm=is_vlm,
+        has_speech=has_speech,
+    )
+
+    result: dict[str, str] = {"genai_config": genai_path}
+
+    # Copy tokenizer files when a HF model ID is available
+    if hf_model_id is not None:
+        logger.info("Copying tokenizer files from %s", hf_model_id)
+        tokenizer_files = _copy_tokenizer_files(hf_model_id, directory)
+        for tf in tokenizer_files:
+            result[tf] = os.path.join(directory, tf)
+
+    # Write processor_config.json for VLMs
+    processor_path = _write_processor_config(config, directory)
+    if processor_path:
+        result["processor_config"] = processor_path
+
+    logger.info("ORT-GenAI artifacts written: %d files", len(result))
+    return result
+
+
+def auto_export(
+    model_id: str,
+    output_dir: str,
+    *,
+    dtype: str | None = None,
+    task: str | None = None,
+    external_data: str = "onnx",
+    trust_remote_code: bool = False,
+    context_length: int = 4096,
+    ep: str = "cpu",
+    progress_bar: bool = True,
+) -> dict[str, str]:
+    """Build and export a model for onnxruntime-genai.
+
+    This is the end-to-end convenience function for producing ORT-GenAI-ready
+    model directories. It:
+
+    1. Builds the ONNX graph(s) via :func:`~mobius._builder.build`
+    2. Downloads and applies HuggingFace weights
+    3. Saves ONNX model(s) with external data
+    4. Calls :func:`export_for_ort_genai` to write ``genai_config.json``,
+       tokenizer files, and ``processor_config.json``
+
+    Args:
+        model_id: HuggingFace model repository ID.
+        output_dir: Directory to write all output files.
+        dtype: Override model dtype (``"f32"``, ``"f16"``, ``"bf16"``).
+        task: Override model task (auto-detected if ``None``).
+        external_data: External data format (``"onnx"`` or
+            ``"safetensors"``).
+        trust_remote_code: Trust remote code for HuggingFace config.
+        context_length: Minimum context length for genai_config.json.
+        ep: Execution provider for ``session_options`` in
+            ``genai_config.json``. Defaults to ``"cpu"``.
+        progress_bar: Show progress bar during save.
+
+    Returns:
+        Dict mapping output artifact names to file paths, e.g.::
+
+            {
+                "genai_config": "/output/genai_config.json",
+                "model": "/output/model.onnx",
+                "tokenizer.json": "/output/tokenizer.json",
+            }
+    """
+    from mobius._builder import build
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Build ONNX graph(s) with weights
+    logger.info("Building ONNX model for %s", model_id)
+    pkg = build(
+        model_id,
+        task=task,
+        dtype=dtype,
+        load_weights=True,
+        trust_remote_code=trust_remote_code,
+    )
+
+    if getattr(pkg, "config", None) is None:
+        raise ValueError(
+            f"Model package for '{model_id}' has no config attribute. "
+            "auto_export requires a config to generate genai_config.json. "
+            "Diffusion models are not yet supported."
+        )
+
+    # Save ONNX models
     logger.info("Saving ONNX models to %s", output_dir)
     pkg.save(
         output_dir,
@@ -226,24 +361,37 @@ def auto_export(
         progress_bar=progress_bar,
     )
 
-    # 6. Copy tokenizer files
-    logger.info("Copying tokenizer files")
-    tokenizer_files = _copy_tokenizer_files(model_id, output_dir)
+    # Write ORT-GenAI config artifacts (genai_config.json, tokenizer, processor)
+    result = export_for_ort_genai(
+        pkg,
+        output_dir,
+        hf_model_id=model_id,
+        ep=ep,
+        context_length=context_length,
+    )
 
-    # 7. Write processor_config.json for VLMs
-    processor_path = _write_processor_config(config, output_dir)
-
-    # Build result manifest
-    result: dict[str, str] = {"genai_config": genai_path}
+    # Add ONNX model paths to manifest
     if len(pkg) == 1:
         result["model"] = os.path.join(output_dir, "model.onnx")
     else:
         for name in pkg:
             result[name] = os.path.join(output_dir, name, "model.onnx")
-    for tf in tokenizer_files:
-        result[tf] = os.path.join(output_dir, tf)
-    if processor_path:
-        result["processor_config"] = processor_path
 
     logger.info("Export complete: %d artifacts", len(result))
     return result
+
+
+# ORT-GenAI model type overrides for model types whose ORT-GenAI name
+# differs from the HuggingFace model_type.
+_ORT_GENAI_MODEL_TYPE: dict[str, str] = {
+    "llama": "llama",
+    "qwen2": "qwen2",
+    "qwen3": "qwen2",
+    "phi3": "phi3",
+    "phi": "phi",
+    "phi4mm": "phi4mm",
+    "phi4_multimodal": "phi4mm",
+    "gemma": "gemma",
+    "gemma2": "gemma",
+    "mistral": "mistral",
+}

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -227,6 +227,11 @@ def export_for_ort_genai(
 
     os.makedirs(directory, exist_ok=True)
 
+    # Normalize EP: 'default' and 'onnx-standard' are portable-ONNX modes
+    # that carry no EP-specific session options → treat as CPU.
+    if ep in ("default", "onnx-standard"):
+        ep = "cpu"
+
     # Resolve token IDs and ORT model type from HF config (if provided)
     bos_token_id: int | None = None
     eos_token_id: int | list[int] | None = None
@@ -243,15 +248,27 @@ def export_for_ort_genai(
         eos_token_id = getattr(hf_config, "eos_token_id", None)
         pad_token_id = getattr(hf_config, "pad_token_id", None)
     else:
-        # Fall back to model_type from the mobius ArchitectureConfig
+        # Fall back to model_type from the mobius ArchitectureConfig.
+        # This path is taken when hf_model_id is not provided, so HF config
+        # is unavailable. The ArchitectureConfig.model_type may be absent on
+        # older configs, producing 'unknown' — ORT-GenAI may reject it.
         raw_type = getattr(config, "model_type", "unknown")
         ort_model_type = _resolve_ort_genai_model_type(raw_type)
+        if ort_model_type == "unknown":
+            logger.warning(
+                "Could not determine ORT-GenAI model type: pkg.config has no "
+                "'model_type' attribute. Pass hf_model_id to resolve it from "
+                "the HuggingFace config, or the generated genai_config.json "
+                "may not load correctly."
+            )
 
     # Detect multimodal capabilities from the package keys
     is_vlm = "vision" in pkg and "embedding" in pkg
     has_speech = "speech" in pkg
 
-    # Auto-detect phi4mm: HF model_type may be "phi" but model has speech
+    # Phi4MM quirk: HF reports model_type='phi' but the model package
+    # includes a 'speech' component that distinguishes it from plain Phi.
+    # Override to 'phi4mm' so ORT-GenAI loads the correct pipeline.
     if ort_model_type == "phi" and has_speech:
         ort_model_type = "phi4mm"
 
@@ -378,20 +395,3 @@ def auto_export(
             result[name] = os.path.join(output_dir, name, "model.onnx")
 
     logger.info("Export complete: %d artifacts", len(result))
-    return result
-
-
-# ORT-GenAI model type overrides for model types whose ORT-GenAI name
-# differs from the HuggingFace model_type.
-_ORT_GENAI_MODEL_TYPE: dict[str, str] = {
-    "llama": "llama",
-    "qwen2": "qwen2",
-    "qwen3": "qwen2",
-    "phi3": "phi3",
-    "phi": "phi",
-    "phi4mm": "phi4mm",
-    "phi4_multimodal": "phi4mm",
-    "gemma": "gemma",
-    "gemma2": "gemma",
-    "mistral": "mistral",
-}

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -78,7 +78,7 @@ class TestCopyTokenizerFiles:
 
 
 class TestExportForOrtGenai:
-    """Unit tests for export_for_ort_genai()."""
+    """Unit tests for write_ort_genai_config()."""
 
     @staticmethod
     def _make_pkg():
@@ -103,10 +103,10 @@ class TestExportForOrtGenai:
 
     def test_genai_config_json_is_written(self, tmp_path):
         """genai_config.json is always written to the output directory."""
-        from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
+        from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
 
         pkg = self._make_pkg()
-        result = export_for_ort_genai(pkg, str(tmp_path))
+        result = write_ort_genai_config(pkg, str(tmp_path))
 
         assert "genai_config" in result
         assert os.path.isfile(result["genai_config"])
@@ -120,7 +120,7 @@ class TestExportForOrtGenai:
         import dataclasses
 
         from mobius._model_package import ModelPackage
-        from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
+        from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
 
         @dataclasses.dataclass
         class FakeVision:
@@ -146,7 +146,7 @@ class TestExportForOrtGenai:
             },
             config=FakeConfig(),
         )
-        result = export_for_ort_genai(pkg, str(tmp_path))
+        result = write_ort_genai_config(pkg, str(tmp_path))
 
         assert "processor_config" in result
         assert os.path.isfile(result["processor_config"])
@@ -156,28 +156,28 @@ class TestExportForOrtGenai:
 
     def test_processor_config_not_written_without_vision(self, tmp_path):
         """processor_config.json is NOT written when pkg.config has no vision attr."""
-        from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
+        from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
 
         pkg = self._make_pkg()
-        result = export_for_ort_genai(pkg, str(tmp_path))
+        result = write_ort_genai_config(pkg, str(tmp_path))
 
         assert "processor_config" not in result
         assert not os.path.exists(os.path.join(str(tmp_path), "processor_config.json"))
 
     def test_tokenizer_not_copied_without_model_id(self, tmp_path):
         """No tokenizer files copied when hf_model_id=None."""
-        from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
+        from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
 
         pkg = self._make_pkg()
         with mock.patch(
             "mobius.integrations.ort_genai.auto_export._copy_tokenizer_files"
         ) as mock_copy:
-            export_for_ort_genai(pkg, str(tmp_path), hf_model_id=None)
+            write_ort_genai_config(pkg, str(tmp_path), hf_model_id=None)
         mock_copy.assert_not_called()
 
     def test_tokenizer_copied_when_model_id_provided(self, tmp_path):
         """Tokenizer files are copied when hf_model_id is provided."""
-        from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
+        from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
 
         pkg = self._make_pkg()
         with (
@@ -190,17 +190,17 @@ class TestExportForOrtGenai:
             mock_hf.return_value = mock.MagicMock(
                 model_type="qwen2", bos_token_id=1, eos_token_id=2, pad_token_id=0
             )
-            result = export_for_ort_genai(pkg, str(tmp_path), hf_model_id="fake/model")
+            result = write_ort_genai_config(pkg, str(tmp_path), hf_model_id="fake/model")
 
         mock_copy.assert_called_once_with("fake/model", str(tmp_path))
         assert "tokenizer.json" in result
 
     def test_ep_default_normalizes_to_cpu(self, tmp_path):
         """ep='default' is normalized to cpu (provider_options=[])."""
-        from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
+        from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
 
         pkg = self._make_pkg()
-        result = export_for_ort_genai(pkg, str(tmp_path), ep="default")
+        result = write_ort_genai_config(pkg, str(tmp_path), ep="default")
 
         with open(result["genai_config"]) as f:
             data = json.load(f)
@@ -208,10 +208,10 @@ class TestExportForOrtGenai:
 
     def test_ep_onnx_standard_normalizes_to_cpu(self, tmp_path):
         """ep='onnx-standard' is normalized to cpu (provider_options=[])."""
-        from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
+        from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
 
         pkg = self._make_pkg()
-        result = export_for_ort_genai(pkg, str(tmp_path), ep="onnx-standard")
+        result = write_ort_genai_config(pkg, str(tmp_path), ep="onnx-standard")
 
         with open(result["genai_config"]) as f:
             data = json.load(f)
@@ -219,10 +219,10 @@ class TestExportForOrtGenai:
 
     def test_ep_cuda_passes_through(self, tmp_path):
         """ep='cuda' passes through to session_options with CUDA provider."""
-        from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
+        from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
 
         pkg = self._make_pkg()
-        result = export_for_ort_genai(pkg, str(tmp_path), ep="cuda")
+        result = write_ort_genai_config(pkg, str(tmp_path), ep="cuda")
 
         with open(result["genai_config"]) as f:
             data = json.load(f)
@@ -233,24 +233,24 @@ class TestExportForOrtGenai:
     def test_raises_when_pkg_config_is_none(self, tmp_path):
         """ValueError is raised when pkg.config is None."""
         from mobius._model_package import ModelPackage
-        from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
+        from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
 
         pkg = ModelPackage({"model": mock.MagicMock()}, config=None)
         with pytest.raises(ValueError, match="config"):
-            export_for_ort_genai(pkg, str(tmp_path))
+            write_ort_genai_config(pkg, str(tmp_path))
 
     def test_does_not_require_onnxruntime_genai(self, tmp_path):
-        """export_for_ort_genai works without onnxruntime-genai installed."""
+        """write_ort_genai_config works without onnxruntime-genai installed."""
         import sys
 
-        from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
+        from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
 
         pkg = self._make_pkg()
         # Remove onnxruntime_genai from sys.modules if present, then restore
         saved = sys.modules.pop("onnxruntime_genai", None)
         try:
             # Should not raise ImportError — ort-genai runtime is not needed
-            result = export_for_ort_genai(pkg, str(tmp_path))
+            result = write_ort_genai_config(pkg, str(tmp_path))
             assert "genai_config" in result
         finally:
             if saved is not None:

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -77,6 +77,186 @@ class TestCopyTokenizerFiles:
         assert (dst / "tokenizer.json").exists()
 
 
+class TestExportForOrtGenai:
+    """Unit tests for export_for_ort_genai()."""
+
+    @staticmethod
+    def _make_pkg():
+        """Build a minimal LLM-only ModelPackage with a fake config."""
+        import dataclasses
+
+        from mobius._model_package import ModelPackage
+
+        @dataclasses.dataclass
+        class FakeConfig:
+            model_type: str = "qwen2"
+            vocab_size: int = 256
+            hidden_size: int = 64
+            num_hidden_layers: int = 2
+            num_attention_heads: int = 4
+            num_key_value_heads: int = 2
+            head_dim: int = 16
+            max_position_embeddings: int = 128
+
+        pkg = ModelPackage({"model": mock.MagicMock()}, config=FakeConfig())
+        return pkg
+
+    def test_genai_config_json_is_written(self, tmp_path):
+        """genai_config.json is always written to the output directory."""
+        from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
+
+        pkg = self._make_pkg()
+        result = export_for_ort_genai(pkg, str(tmp_path))
+
+        assert "genai_config" in result
+        assert os.path.isfile(result["genai_config"])
+        with open(result["genai_config"]) as f:
+            data = json.load(f)
+        assert "model" in data
+        assert data["model"]["type"] == "qwen2"
+
+    def test_processor_config_written_with_vision(self, tmp_path):
+        """processor_config.json is written when pkg.config.vision is set."""
+        import dataclasses
+
+        from mobius._model_package import ModelPackage
+        from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
+
+        @dataclasses.dataclass
+        class FakeVision:
+            image_size: int = 448
+            patch_size: int = 14
+
+        @dataclasses.dataclass
+        class FakeConfig:
+            model_type: str = "qwen2"
+            vocab_size: int = 256
+            hidden_size: int = 64
+            num_hidden_layers: int = 2
+            num_attention_heads: int = 4
+            num_key_value_heads: int = 2
+            head_dim: int = 16
+            vision: FakeVision = dataclasses.field(default_factory=FakeVision)
+
+        pkg = ModelPackage(
+            {
+                "model": mock.MagicMock(),
+                "vision": mock.MagicMock(),
+                "embedding": mock.MagicMock(),
+            },
+            config=FakeConfig(),
+        )
+        result = export_for_ort_genai(pkg, str(tmp_path))
+
+        assert "processor_config" in result
+        assert os.path.isfile(result["processor_config"])
+        with open(result["processor_config"]) as f:
+            data = json.load(f)
+        assert data["image_size"] == 448
+
+    def test_processor_config_not_written_without_vision(self, tmp_path):
+        """processor_config.json is NOT written when pkg.config has no vision attr."""
+        from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
+
+        pkg = self._make_pkg()
+        result = export_for_ort_genai(pkg, str(tmp_path))
+
+        assert "processor_config" not in result
+        assert not os.path.exists(os.path.join(str(tmp_path), "processor_config.json"))
+
+    def test_tokenizer_not_copied_without_model_id(self, tmp_path):
+        """No tokenizer files copied when hf_model_id=None."""
+        from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
+
+        pkg = self._make_pkg()
+        with mock.patch(
+            "mobius.integrations.ort_genai.auto_export._copy_tokenizer_files"
+        ) as mock_copy:
+            export_for_ort_genai(pkg, str(tmp_path), hf_model_id=None)
+        mock_copy.assert_not_called()
+
+    def test_tokenizer_copied_when_model_id_provided(self, tmp_path):
+        """Tokenizer files are copied when hf_model_id is provided."""
+        from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
+
+        pkg = self._make_pkg()
+        with (
+            mock.patch(
+                "mobius.integrations.ort_genai.auto_export._copy_tokenizer_files",
+                return_value=["tokenizer.json"],
+            ) as mock_copy,
+            mock.patch("transformers.AutoConfig.from_pretrained") as mock_hf,
+        ):
+            mock_hf.return_value = mock.MagicMock(
+                model_type="qwen2", bos_token_id=1, eos_token_id=2, pad_token_id=0
+            )
+            result = export_for_ort_genai(pkg, str(tmp_path), hf_model_id="fake/model")
+
+        mock_copy.assert_called_once_with("fake/model", str(tmp_path))
+        assert "tokenizer.json" in result
+
+    def test_ep_default_normalizes_to_cpu(self, tmp_path):
+        """ep='default' is normalized to cpu (provider_options=[])."""
+        from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
+
+        pkg = self._make_pkg()
+        result = export_for_ort_genai(pkg, str(tmp_path), ep="default")
+
+        with open(result["genai_config"]) as f:
+            data = json.load(f)
+        assert data["model"]["decoder"]["session_options"]["provider_options"] == []
+
+    def test_ep_onnx_standard_normalizes_to_cpu(self, tmp_path):
+        """ep='onnx-standard' is normalized to cpu (provider_options=[])."""
+        from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
+
+        pkg = self._make_pkg()
+        result = export_for_ort_genai(pkg, str(tmp_path), ep="onnx-standard")
+
+        with open(result["genai_config"]) as f:
+            data = json.load(f)
+        assert data["model"]["decoder"]["session_options"]["provider_options"] == []
+
+    def test_ep_cuda_passes_through(self, tmp_path):
+        """ep='cuda' passes through to session_options with CUDA provider."""
+        from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
+
+        pkg = self._make_pkg()
+        result = export_for_ort_genai(pkg, str(tmp_path), ep="cuda")
+
+        with open(result["genai_config"]) as f:
+            data = json.load(f)
+        provider_opts = data["model"]["decoder"]["session_options"]["provider_options"]
+        assert len(provider_opts) == 1
+        assert "CUDAExecutionProvider" in provider_opts[0]
+
+    def test_raises_when_pkg_config_is_none(self, tmp_path):
+        """ValueError is raised when pkg.config is None."""
+        from mobius._model_package import ModelPackage
+        from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
+
+        pkg = ModelPackage({"model": mock.MagicMock()}, config=None)
+        with pytest.raises(ValueError, match="config"):
+            export_for_ort_genai(pkg, str(tmp_path))
+
+    def test_does_not_require_onnxruntime_genai(self, tmp_path):
+        """export_for_ort_genai works without onnxruntime-genai installed."""
+        import sys
+
+        from mobius.integrations.ort_genai.auto_export import export_for_ort_genai
+
+        pkg = self._make_pkg()
+        # Remove onnxruntime_genai from sys.modules if present, then restore
+        saved = sys.modules.pop("onnxruntime_genai", None)
+        try:
+            # Should not raise ImportError — ort-genai runtime is not needed
+            result = export_for_ort_genai(pkg, str(tmp_path))
+            assert "genai_config" in result
+        finally:
+            if saved is not None:
+                sys.modules["onnxruntime_genai"] = saved
+
+
 @pytest.mark.integration
 class TestAutoExportEndToEnd:
     """Integration test: auto_export with a tiny model (no real download)."""

--- a/src/mobius/integrations/ort_genai/genai_config.py
+++ b/src/mobius/integrations/ort_genai/genai_config.py
@@ -69,6 +69,21 @@ def _default_session_options() -> dict[str, Any]:
     }
 
 
+def _make_session_options(ep: str) -> dict[str, Any]:
+    """Return session options with EP-specific provider_options.
+
+    Args:
+        ep: Execution provider name (e.g. ``"cpu"``, ``"cuda"``,
+            ``"dml"``, ``"trt-rtx"``).
+    """
+    from mobius.integrations.ort_genai.ep_config import make_provider_options
+
+    return {
+        "log_id": "onnxruntime-genai",
+        "provider_options": make_provider_options(ep),
+    }
+
+
 class GenaiConfigGenerator:
     """Generates genai_config.json dicts for onnxruntime-genai.
 
@@ -85,6 +100,8 @@ class GenaiConfigGenerator:
         num_key_value_heads: Number of KV heads (for GQA).
         head_dim: Size per attention head.
         context_length: Maximum context length. Defaults to 4096.
+        ep: Execution provider for ``session_options`` (e.g. ``"cpu"``,
+            ``"cuda"``, ``"dml"``, ``"trt-rtx"``). Defaults to ``"cpu"``.
         bos_token_id: Beginning-of-sequence token ID.
         eos_token_id: End-of-sequence token ID(s).
         pad_token_id: Padding token ID.
@@ -101,6 +118,7 @@ class GenaiConfigGenerator:
         num_key_value_heads: int,
         head_dim: int,
         context_length: int = 4096,
+        ep: str = "cpu",
         bos_token_id: int | None = None,
         eos_token_id: int | list[int] | None = None,
         pad_token_id: int | None = None,
@@ -113,6 +131,7 @@ class GenaiConfigGenerator:
         self.num_key_value_heads = num_key_value_heads
         self.head_dim = head_dim
         self.context_length = context_length
+        self.ep = ep
         self.bos_token_id = bos_token_id
         self.eos_token_id = eos_token_id
         self.pad_token_id = pad_token_id
@@ -132,6 +151,7 @@ class GenaiConfigGenerator:
         model_type: str,
         *,
         context_length: int = 4096,
+        ep: str = "cpu",
         bos_token_id: int | None = None,
         eos_token_id: int | list[int] | None = None,
         pad_token_id: int | None = None,
@@ -162,6 +182,7 @@ class GenaiConfigGenerator:
             num_key_value_heads=config.num_key_value_heads,
             head_dim=config.head_dim,
             context_length=context_length,
+            ep=ep,
             bos_token_id=bos_token_id,
             eos_token_id=eos_token_id,
             pad_token_id=pad,
@@ -215,7 +236,7 @@ class GenaiConfigGenerator:
             "config_filename": config_filename,
             "inputs": input_names,
             "outputs": output_names,
-            "session_options": _default_session_options(),
+            "session_options": _make_session_options(self.ep),
         }
         if spatial_merge_size is not None:
             self._vision["spatial_merge_size"] = spatial_merge_size
@@ -229,7 +250,7 @@ class GenaiConfigGenerator:
             "outputs": {
                 "inputs_embeds": "inputs_embeds",
             },
-            "session_options": _default_session_options(),
+            "session_options": _make_session_options(self.ep),
         }
         self._vlm_token_ids["image_token_id"] = image_token_id
         if vision_start_token_id is not None:
@@ -277,7 +298,7 @@ class GenaiConfigGenerator:
             "config_filename": config_filename,
             "inputs": input_names,
             "outputs": output_names,
-            "session_options": _default_session_options(),
+            "session_options": _make_session_options(self.ep),
         }
 
         if audio_token_id is not None:
@@ -291,7 +312,7 @@ class GenaiConfigGenerator:
 
         # Decoder section
         decoder: dict[str, Any] = {
-            "session_options": _default_session_options(),
+            "session_options": _make_session_options(self.ep),
             "filename": "model.onnx",
             "head_size": self.head_dim,
             "hidden_size": self.hidden_size,

--- a/src/mobius/integrations/ort_genai/genai_config.py
+++ b/src/mobius/integrations/ort_genai/genai_config.py
@@ -61,14 +61,6 @@ def _default_search_params() -> dict[str, Any]:
     }
 
 
-def _default_session_options() -> dict[str, Any]:
-    """Return default ORT session options."""
-    return {
-        "log_id": "onnxruntime-genai",
-        "provider_options": [],
-    }
-
-
 def _make_session_options(ep: str) -> dict[str, Any]:
     """Return session options with EP-specific provider_options.
 
@@ -99,7 +91,10 @@ class GenaiConfigGenerator:
         num_attention_heads: Number of query attention heads.
         num_key_value_heads: Number of KV heads (for GQA).
         head_dim: Size per attention head.
-        context_length: Maximum context length. Defaults to 4096.
+        context_length: Minimum context length written to
+            ``genai_config.json``. Overridden upward by
+            ``max_position_embeddings`` from the model config when that
+            value is larger. Defaults to 4096.
         ep: Execution provider for ``session_options`` (e.g. ``"cpu"``,
             ``"cuda"``, ``"dml"``, ``"trt-rtx"``). Defaults to ``"cpu"``.
         bos_token_id: Beginning-of-sequence token ID.

--- a/src/mobius/integrations/ort_genai/genai_config_test.py
+++ b/src/mobius/integrations/ort_genai/genai_config_test.py
@@ -480,3 +480,85 @@ class TestGenaiConfigGeneratorMultimodal:
         )
         result = gen.with_vision(image_token_id=200010).with_speech()
         assert result is gen
+
+
+class TestMakeSessionOptions:
+    """Tests for the _make_session_options() helper."""
+
+    def test_cpu_has_empty_provider_options(self):
+        """CPU EP produces empty provider_options (no special session config)."""
+        from mobius.integrations.ort_genai.genai_config import _make_session_options
+
+        opts = _make_session_options("cpu")
+        assert opts["log_id"] == "onnxruntime-genai"
+        assert opts["provider_options"] == []
+
+    def test_cuda_has_cuda_provider_options(self):
+        """CUDA EP produces a provider_options entry for CUDAExecutionProvider."""
+        from mobius.integrations.ort_genai.genai_config import _make_session_options
+
+        opts = _make_session_options("cuda")
+        assert opts["log_id"] == "onnxruntime-genai"
+        assert len(opts["provider_options"]) == 1
+        assert "CUDAExecutionProvider" in opts["provider_options"][0]
+
+    def test_dml_has_dml_provider_options(self):
+        """DML EP produces a provider_options entry for DmlExecutionProvider."""
+        from mobius.integrations.ort_genai.genai_config import _make_session_options
+
+        opts = _make_session_options("dml")
+        assert opts["log_id"] == "onnxruntime-genai"
+        assert len(opts["provider_options"]) == 1
+        assert "DmlExecutionProvider" in opts["provider_options"][0]
+
+
+class TestGenaiConfigGeneratorEp:
+    """Tests for EP threading through all session_options blocks."""
+
+    def _gen(self, ep: str) -> GenaiConfigGenerator:
+        return GenaiConfigGenerator(
+            "llama",
+            vocab_size=32000,
+            hidden_size=4096,
+            num_hidden_layers=32,
+            num_attention_heads=32,
+            num_key_value_heads=8,
+            head_dim=128,
+            ep=ep,
+        )
+
+    def test_cpu_ep_decoder_has_empty_provider_options(self):
+        """CPU EP: decoder session_options.provider_options is empty."""
+        config = self._gen("cpu").generate()
+        assert config["model"]["decoder"]["session_options"]["provider_options"] == []
+
+    def test_cuda_ep_decoder_has_cuda_provider_options(self):
+        """CUDA EP: decoder session_options.provider_options has CUDA entry."""
+        config = self._gen("cuda").generate()
+        opts = config["model"]["decoder"]["session_options"]["provider_options"]
+        assert len(opts) == 1
+        assert "CUDAExecutionProvider" in opts[0]
+
+    def test_cuda_ep_all_blocks_have_cuda_session_options(self):
+        """CUDA EP applied to all 4 session blocks (decoder, vision, embedding, speech)."""
+        gen = GenaiConfigGenerator(
+            "phi4mm",
+            vocab_size=200064,
+            hidden_size=3072,
+            num_hidden_layers=32,
+            num_attention_heads=24,
+            num_key_value_heads=8,
+            head_dim=128,
+            ep="cuda",
+        ).with_vision(image_token_id=200010).with_speech()
+        config = gen.generate()
+
+        for block in ("decoder", "vision", "embedding", "speech"):
+            if block not in config["model"]:
+                continue
+            session_opts = config["model"][block]["session_options"]
+            provider_options = session_opts["provider_options"]
+            assert len(provider_options) == 1, f"{block} missing CUDA provider options"
+            assert "CUDAExecutionProvider" in provider_options[0], (
+                f"{block} has wrong EP in provider_options"
+            )

--- a/src/mobius/integrations/ort_genai/genai_config_test.py
+++ b/src/mobius/integrations/ort_genai/genai_config_test.py
@@ -541,16 +541,20 @@ class TestGenaiConfigGeneratorEp:
 
     def test_cuda_ep_all_blocks_have_cuda_session_options(self):
         """CUDA EP applied to all 4 session blocks (decoder, vision, embedding, speech)."""
-        gen = GenaiConfigGenerator(
-            "phi4mm",
-            vocab_size=200064,
-            hidden_size=3072,
-            num_hidden_layers=32,
-            num_attention_heads=24,
-            num_key_value_heads=8,
-            head_dim=128,
-            ep="cuda",
-        ).with_vision(image_token_id=200010).with_speech()
+        gen = (
+            GenaiConfigGenerator(
+                "phi4mm",
+                vocab_size=200064,
+                hidden_size=3072,
+                num_hidden_layers=32,
+                num_attention_heads=24,
+                num_key_value_heads=8,
+                head_dim=128,
+                ep="cuda",
+            )
+            .with_vision(image_token_id=200010)
+            .with_speech()
+        )
         config = gen.generate()
 
         for block in ("decoder", "vision", "embedding", "speech"):

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -180,22 +180,24 @@ class TestCLIBuildRuntime:
 
     def test_runtime_ort_genai_calls_write_ort_genai_config(self):
         """--runtime ort-genai calls write_ort_genai_config() after building."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch(
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            mock.patch(
                 "mobius.integrations.ort_genai.write_ort_genai_config",
                 return_value={},
-            ) as mock_export:
-                main(
-                    [
-                        "build",
-                        "--model",
-                        "Qwen/Qwen2.5-0.5B",
-                        tmpdir,
-                        "--no-weights",
-                        "--runtime",
-                        "ort-genai",
-                    ]
-                )
+            ) as mock_export,
+        ):
+            main(
+                [
+                    "build",
+                    "--model",
+                    "Qwen/Qwen2.5-0.5B",
+                    tmpdir,
+                    "--no-weights",
+                    "--runtime",
+                    "ort-genai",
+                ]
+            )
 
         mock_export.assert_called_once()
         call_kwargs = mock_export.call_args
@@ -203,26 +205,25 @@ class TestCLIBuildRuntime:
 
     def test_no_runtime_does_not_call_write_ort_genai_config(self):
         """Omitting --runtime does NOT call write_ort_genai_config()."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch(
-                "mobius.integrations.ort_genai.write_ort_genai_config"
-            ) as mock_export:
-                main(["build", "--model", "Qwen/Qwen2.5-0.5B", tmpdir, "--no-weights"])
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            mock.patch("mobius.integrations.ort_genai.write_ort_genai_config") as mock_export,
+        ):
+            main(["build", "--model", "Qwen/Qwen2.5-0.5B", tmpdir, "--no-weights"])
 
         mock_export.assert_not_called()
 
     def test_invalid_runtime_value_errors(self):
         """An unrecognised --runtime value causes argparse to exit with an error."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with pytest.raises(SystemExit):
-                main(
-                    [
-                        "build",
-                        "--model",
-                        "Qwen/Qwen2.5-0.5B",
-                        tmpdir,
-                        "--no-weights",
-                        "--runtime",
-                        "tensorrt",  # not a supported value
-                    ]
-                )
+        with tempfile.TemporaryDirectory() as tmpdir, pytest.raises(SystemExit):
+            main(
+                [
+                    "build",
+                    "--model",
+                    "Qwen/Qwen2.5-0.5B",
+                    tmpdir,
+                    "--no-weights",
+                    "--runtime",
+                    "tensorrt",  # not a supported value
+                ]
+            )

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -178,11 +178,11 @@ class TestCLIInfo:
 class TestCLIBuildRuntime:
     """Test the ``--runtime`` flag on the ``build`` subcommand."""
 
-    def test_runtime_ort_genai_calls_export_for_ort_genai(self):
-        """--runtime ort-genai calls export_for_ort_genai() after building."""
+    def test_runtime_ort_genai_calls_write_ort_genai_config(self):
+        """--runtime ort-genai calls write_ort_genai_config() after building."""
         with tempfile.TemporaryDirectory() as tmpdir:
             with mock.patch(
-                "mobius.integrations.ort_genai.export_for_ort_genai",
+                "mobius.integrations.ort_genai.write_ort_genai_config",
                 return_value={},
             ) as mock_export:
                 main(
@@ -201,11 +201,11 @@ class TestCLIBuildRuntime:
         call_kwargs = mock_export.call_args
         assert call_kwargs.kwargs.get("hf_model_id") == "Qwen/Qwen2.5-0.5B"
 
-    def test_no_runtime_does_not_call_export_for_ort_genai(self):
-        """Omitting --runtime does NOT call export_for_ort_genai()."""
+    def test_no_runtime_does_not_call_write_ort_genai_config(self):
+        """Omitting --runtime does NOT call write_ort_genai_config()."""
         with tempfile.TemporaryDirectory() as tmpdir:
             with mock.patch(
-                "mobius.integrations.ort_genai.export_for_ort_genai"
+                "mobius.integrations.ort_genai.write_ort_genai_config"
             ) as mock_export:
                 main(["build", "--model", "Qwen/Qwen2.5-0.5B", tmpdir, "--no-weights"])
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+from unittest import mock
 
 import onnx
 import pytest
@@ -172,3 +173,56 @@ class TestCLIInfo:
         out = capsys.readouterr().out
         assert "qwen2" in out
         assert "Supported" in out
+
+
+class TestCLIBuildRuntime:
+    """Test the ``--runtime`` flag on the ``build`` subcommand."""
+
+    def test_runtime_ort_genai_calls_export_for_ort_genai(self):
+        """--runtime ort-genai calls export_for_ort_genai() after building."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch(
+                "mobius.integrations.ort_genai.export_for_ort_genai",
+                return_value={},
+            ) as mock_export:
+                main(
+                    [
+                        "build",
+                        "--model",
+                        "Qwen/Qwen2.5-0.5B",
+                        tmpdir,
+                        "--no-weights",
+                        "--runtime",
+                        "ort-genai",
+                    ]
+                )
+
+        mock_export.assert_called_once()
+        call_kwargs = mock_export.call_args
+        assert call_kwargs.kwargs.get("hf_model_id") == "Qwen/Qwen2.5-0.5B"
+
+    def test_no_runtime_does_not_call_export_for_ort_genai(self):
+        """Omitting --runtime does NOT call export_for_ort_genai()."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch(
+                "mobius.integrations.ort_genai.export_for_ort_genai"
+            ) as mock_export:
+                main(["build", "--model", "Qwen/Qwen2.5-0.5B", tmpdir, "--no-weights"])
+
+        mock_export.assert_not_called()
+
+    def test_invalid_runtime_value_errors(self):
+        """An unrecognised --runtime value causes argparse to exit with an error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pytest.raises(SystemExit):
+                main(
+                    [
+                        "build",
+                        "--model",
+                        "Qwen/Qwen2.5-0.5B",
+                        tmpdir,
+                        "--no-weights",
+                        "--runtime",
+                        "tensorrt",  # not a supported value
+                    ]
+                )


### PR DESCRIPTION
## Summary

Adds a programmatic API and CLI flag for generating [onnxruntime-genai](https://github.com/microsoft/onnxruntime-genai) config artifacts from a built `ModelPackage`.

## Changes

### `write_ort_genai_config()` — programmatic API

New function in `src/mobius/integrations/ort_genai/auto_export.py`, exported from `mobius.integrations.ort_genai`.

```python
from mobius.integrations.ort_genai import write_ort_genai_config

pkg = build("Qwen/Qwen3-0.6B")
pkg.save("/output/qwen3")
write_ort_genai_config(pkg, "output/qwen3", hf_model_id="Qwen/Qwen3-0.6B")
```

**What it writes:**
- `genai_config.json` — always written; includes model type, context length, search params, and EP-specific `session_options`
- `processor_config.json` — written only for VLMs (when `pkg.config.vision` exists)
- Tokenizer files (`tokenizer.json`, `tokenizer_config.json`, etc.) — copied from HuggingFace Hub only when `hf_model_id` is provided

**What it does NOT do:** write ONNX model files. Call `pkg.save()` separately before or after.

**Parameters:**
- `pkg` — already-built `ModelPackage` with `config` set (required)
- `directory` — output directory (created if needed)
- `hf_model_id` — optional HF model ID for token IDs and tokenizer files
- `ep` — execution provider (`"cpu"`, `"cuda"`, `"dml"`, `"trt-rtx"`); defaults to `"cpu"`
- `context_length` — minimum context length floor; overridden upward by `max_position_embeddings`

**EP normalization:** `"default"` and `"onnx-standard"` (mobius-internal portable-ONNX EP names) are normalized to `"cpu"` before generating session options.

### `--runtime ort-genai` CLI flag

```bash
mobius build --model Qwen/Qwen3-0.6B output/qwen3 --runtime ort-genai
```

Calls `write_ort_genai_config()` after `pkg.save()` in the build pipeline. Passes `--model` as `hf_model_id` and `--ep` as the execution provider. Accepts `"ort-genai"` as the only valid value (leaves room for future runtimes).

### `GenaiConfigGenerator.ep` parameter

`GenaiConfigGenerator` and its `from_config()` factory now accept an `ep` parameter. The EP is threaded through all four `session_options` blocks: `decoder`, `vision`, `embedding`, and `speech`.

Replaced dead `_default_session_options()` with `_make_session_options(ep)`.

### `auto_export()` refactor

The existing `auto_export()` function now delegates to `write_ort_genai_config()` internally instead of duplicating config-generation logic.

### Phi4MM heuristic

When HF reports `model_type="phi"` but the package includes a `"speech"` key, the ORT model type is overridden to `"phi4mm"` so ORT-GenAI loads the correct pipeline.

### Unknown model type warning

When `hf_model_id` is not provided and `pkg.config` has no `model_type` attribute, a `logger.warning` is emitted explaining the limitation.

## Tests

19 new unit tests across three files:

- **`auto_export_test.py` — `TestExportForOrtGenai`**: `genai_config.json` always written; `processor_config.json` conditional on vision config; tokenizer copy gating (with/without `hf_model_id`); EP normalization (`default`/`onnx-standard` → `cpu`, `cuda` passthrough); `ValueError` on missing config; no `onnxruntime-genai` import required
- **`genai_config_test.py` — `TestMakeSessionOptions`**: cpu/cuda/dml EP produce correct `provider_options` shapes
- **`genai_config_test.py` — `TestGenaiConfigGeneratorEp`**: CUDA EP threads through all 4 session blocks
- **`cli_test.py` — `TestCLIBuildRuntime`**: `--runtime ort-genai` calls `write_ort_genai_config()` with correct `hf_model_id`; omitting `--runtime` skips it; invalid value → argparse error

All tests use `unittest.mock` — no real HuggingFace downloads or ORT-GenAI installation required.
