### PR TITLE
chore: update license headers to Microsoft MIT

### DIFF
--- a/.github/skills/adding-a-new-model/SKILL.md
+++ b/.github/skills/adding-a-new-model/SKILL.md
@@ -46,8 +46,8 @@ If the logits match HuggingFace, you only need the registry entry.
 Create `src/mobius/models/<model_name>.py`.  The minimal template:
 
 ```python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 
@@ -304,7 +304,7 @@ new model is a significant addition.
 
 ## Checklist
 
-- [ ] Model file in `src/mobius/models/` with Apache-2.0 copyright header
+- [ ] Model file in `src/mobius/models/` with Microsoft MIT copyright header
 - [ ] Class has `default_task` and `category` attributes (if not standard text-generation)
 - [ ] Class has a descriptive docstring (first paragraph used in generated docs)
 - [ ] `preprocess_weights` handles any key mismatches

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 ONNX Runtime
+Copyright (c) 2026 Microsoft Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+
 """Root conftest: ensure the local worktree src/ is on sys.path first."""
 
 from __future__ import annotations

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Root conftest: ensure the local worktree src/ is on sys.path first."""
 
 from __future__ import annotations

--- a/docs/_ext/dashboard.py
+++ b/docs/_ext/dashboard.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+
 """Sphinx extension: generate the confidence dashboard after build.
 
 Hooks into ``build-finished`` to run ``scripts/generate_dashboard.py``

--- a/docs/_ext/dashboard.py
+++ b/docs/_ext/dashboard.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Sphinx extension: generate the confidence dashboard after build.
 
 Hooks into ``build-finished`` to run ``scripts/generate_dashboard.py``

--- a/docs/_ext/flags_gen.py
+++ b/docs/_ext/flags_gen.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+
 """Sphinx extension: generate feature flags documentation at build time.
 
 Hooks into ``builder-inited`` to generate ``docs/feature-flags.md`` from

--- a/docs/_ext/flags_gen.py
+++ b/docs/_ext/flags_gen.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Sphinx extension: generate feature flags documentation at build time.
 
 Hooks into ``builder-inited`` to generate ``docs/feature-flags.md`` from

--- a/docs/_ext/models_gen.py
+++ b/docs/_ext/models_gen.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Sphinx extension: generate model documentation pages at build time.
 
 Hooks into ``builder-inited`` to run the existing model page generator

--- a/docs/_ext/models_gen.py
+++ b/docs/_ext/models_gen.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+
 """Sphinx extension: generate model documentation pages at build time.
 
 Hooks into ``builder-inited`` to run the existing model page generator

--- a/docs/_generate_flags_docs.py
+++ b/docs/_generate_flags_docs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Auto-generate docs/feature-flags.md from the _Flags dataclass.
 

--- a/docs/_generate_models.py
+++ b/docs/_generate_models.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+
 """Generate model documentation pages from the registry.
 
 Run before building docs:

--- a/docs/_generate_models.py
+++ b/docs/_generate_models.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Generate model documentation pages from the registry.
 
 Run before building docs:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Configuration file for the Sphinx documentation builder.
 
 To build the documentation: python -m sphinx docs docs/_build/html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+
 """Configuration file for the Sphinx documentation builder.
 
 To build the documentation: python -m sphinx docs docs/_build/html
@@ -16,8 +17,8 @@ sys.path.insert(0, os.path.abspath("_ext"))
 # -- Project information -----------------------------------------------------
 
 project = "mobius"
-copyright = "2026, ONNX Project Contributors"
-author = "ONNX Project Contributors"
+copyright = "2026, Microsoft Corporation"
+author = "Microsoft Corporation"
 
 # -- General configuration ---------------------------------------------------
 

--- a/examples/build_and_save.py
+++ b/examples/build_and_save.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Build and save — the simplest possible example.
 

--- a/examples/diffusion.py
+++ b/examples/diffusion.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Diffusion model example — build and save ONNX image generation models.
 

--- a/examples/ep_comparison.py
+++ b/examples/ep_comparison.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """EP comparison example — see how the optimization pipeline differs per EP.
 

--- a/examples/model_builder_comparison.py
+++ b/examples/model_builder_comparison.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 r"""Compare ONNX model graph structure between ORT GenAI's model builder and mobius.
 

--- a/examples/multimodal_generation.py
+++ b/examples/multimodal_generation.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Multimodal generation example — image captioning with Gemma 3.
 

--- a/examples/nemotron_3_nano_text_generation.py
+++ b/examples/nemotron_3_nano_text_generation.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """NemotronH text generation — standalone greedy decoding (no onnxruntime-genai).
 

--- a/examples/phi4mm_multimodal.py
+++ b/examples/phi4mm_multimodal.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 r"""Phi-4 Multimodal generation -- text, vision, audio, and combined.
 

--- a/examples/phi4mm_ort_genai.py
+++ b/examples/phi4mm_ort_genai.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 r"""Phi-4 Multimodal generation with onnxruntime-genai.
 

--- a/examples/qwen25_vl_ort_genai.py
+++ b/examples/qwen25_vl_ort_genai.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Qwen2.5-VL generation with onnxruntime-genai.
 

--- a/examples/qwen35_text_generation.py
+++ b/examples/qwen35_text_generation.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Qwen3.5 text generation — standalone greedy decoding (no onnxruntime-genai).
 

--- a/examples/qwen35_vl_ort_genai.py
+++ b/examples/qwen35_vl_ort_genai.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Qwen3.5-VL generation with onnxruntime-genai tokenizer + ONNX Runtime.
 

--- a/examples/qwen3_asr.py
+++ b/examples/qwen3_asr.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Qwen3-ASR speech recognition with ONNX models.
 

--- a/examples/qwen3_forced_aligner.py
+++ b/examples/qwen3_forced_aligner.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Qwen3-ForcedAligner — speech-text alignment with ONNX models.
 

--- a/examples/qwen3_tts.py
+++ b/examples/qwen3_tts.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Qwen3-TTS full multi-head text-to-speech with 4 ONNX models.
 

--- a/examples/qwen3_tts_voice_clone.py
+++ b/examples/qwen3_tts_voice_clone.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Qwen3-TTS voice cloning: record your voice, then speak as you.
 

--- a/examples/qwen3_vl_ort_genai.py
+++ b/examples/qwen3_vl_ort_genai.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Qwen3-VL generation with onnxruntime-genai.
 

--- a/examples/static_cache_generation.py
+++ b/examples/static_cache_generation.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Static-cache text generation example — greedy decoding with pre-allocated KV buffers.
 

--- a/examples/text_generation.py
+++ b/examples/text_generation.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Text generation example — greedy decoding with a causal LM.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,11 @@ name = "mobius-ai"
 dynamic = ["version"]
 description = "ONNX model definitions for GenAI using onnxscript.nn"
 authors = [
-    { name = "ONNX Contributors", email = "onnx-technical-discuss@lists.lfaidata.foundation" },
+    { name = "Microsoft Corporation" },
 ]
 readme = "README.md"
 requires-python = ">=3.10"
-license = "Apache-2.0"
+license = "MIT"
 dependencies = [
     "huggingface_hub",
     "numpy>=1.24.0",

--- a/scripts/arch_diff.py
+++ b/scripts/arch_diff.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 r"""Architecture diff CLI.
 

--- a/scripts/detect_affected_models.py
+++ b/scripts/detect_affected_models.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 r"""Detect which model_types are affected by a set of changed files.
 

--- a/scripts/detect_affected_models_test.py
+++ b/scripts/detect_affected_models_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Unit tests for scripts/detect_affected_models.py.
 

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 r"""Generate a static HTML confidence dashboard for model testing coverage.
 

--- a/scripts/generate_golden.py
+++ b/scripts/generate_golden.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 r"""Generate golden reference files for L4/L5 testing.
 

--- a/scripts/generate_golden_test.py
+++ b/scripts/generate_golden_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Unit tests for scripts/generate_golden.py."""
 

--- a/src/mobius/__init__.py
+++ b/src/mobius/__init__.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Command-line interface for mobius."""
 

--- a/src/mobius/_build_context.py
+++ b/src/mobius/_build_context.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Build-time EP context for components.
 

--- a/src/mobius/_build_context_test.py
+++ b/src/mobius/_build_context_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/_builder.py
+++ b/src/mobius/_builder.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Model building API.
 

--- a/src/mobius/_config_resolver.py
+++ b/src/mobius/_config_resolver.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Configuration resolution for HuggingFace models.
 

--- a/src/mobius/_config_resolver_test.py
+++ b/src/mobius/_config_resolver_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for _config_resolver.py — pure function input/output tests."""
 

--- a/src/mobius/_configs.py
+++ b/src/mobius/_configs.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/_configs_test.py
+++ b/src/mobius/_configs_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for ArchitectureConfig."""
 

--- a/src/mobius/_constants.py
+++ b/src/mobius/_constants.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Package-wide constants."""
 

--- a/src/mobius/_diffusers_builder.py
+++ b/src/mobius/_diffusers_builder.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Diffusers pipeline building support.
 

--- a/src/mobius/_diffusers_builder_test.py
+++ b/src/mobius/_diffusers_builder_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for _diffusers_builder.py — diffusers pipeline building."""
 

--- a/src/mobius/_diffusers_configs.py
+++ b/src/mobius/_diffusers_configs.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Configuration for diffusers models."""
 

--- a/src/mobius/_execution_providers.py
+++ b/src/mobius/_execution_providers.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Execution provider capability registry.
 

--- a/src/mobius/_exporter_test.py
+++ b/src/mobius/_exporter_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for the build API (build, build_from_module, registry)."""
 

--- a/src/mobius/_flags.py
+++ b/src/mobius/_flags.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Runtime feature flags for mobius.
 

--- a/src/mobius/_flags_test.py
+++ b/src/mobius/_flags_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for the feature flag system."""
 

--- a/src/mobius/_graph_diff.py
+++ b/src/mobius/_graph_diff.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Architecture diff: canonical graph comparison for ONNX models.
 

--- a/src/mobius/_graph_diff_test.py
+++ b/src/mobius/_graph_diff_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Unit tests for the _graph_diff module.
 

--- a/src/mobius/_model_package.py
+++ b/src/mobius/_model_package.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """ModelPackage: a collection of named ONNX models forming a complete model.
 

--- a/src/mobius/_model_package_test.py
+++ b/src/mobius/_model_package_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for ModelPackage."""
 

--- a/src/mobius/_optimizations.py
+++ b/src/mobius/_optimizations.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """EP-aware model optimization pipeline.
 

--- a/src/mobius/_passes/__init__.py
+++ b/src/mobius/_passes/__init__.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Graph optimization passes for mobius ONNX models.
 

--- a/src/mobius/_passes/_fold_concat.py
+++ b/src/mobius/_passes/_fold_concat.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Pass that folds Concat(init_0, init_1, ...) into a single pre-packed initializer.
 

--- a/src/mobius/_passes/_fold_concat_test.py
+++ b/src/mobius/_passes/_fold_concat_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for FoldConcatInitializersPass."""
 

--- a/src/mobius/_passes/_fold_transpose.py
+++ b/src/mobius/_passes/_fold_transpose.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Pass that folds Transpose(initializer, perm=[1, 0]) into a pre-transposed weight.
 

--- a/src/mobius/_passes/_fold_transpose_test.py
+++ b/src/mobius/_passes/_fold_transpose_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for FoldTransposedInitializerPass."""
 

--- a/src/mobius/_registry.py
+++ b/src/mobius/_registry.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Model registry mapping architecture names to module classes.
 

--- a/src/mobius/_registry_test.py
+++ b/src/mobius/_registry_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/_testing/__init__.py
+++ b/src/mobius/_testing/__init__.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Shared test utilities for mobius tests."""
 

--- a/src/mobius/_testing/code_paths.py
+++ b/src/mobius/_testing/code_paths.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Implicit code-path detection from config field values.
 

--- a/src/mobius/_testing/code_paths_test.py
+++ b/src/mobius/_testing/code_paths_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/_testing/comparison.py
+++ b/src/mobius/_testing/comparison.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Numerical comparison utilities for integration testing."""
 

--- a/src/mobius/_testing/generation.py
+++ b/src/mobius/_testing/generation.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Autoregressive text generation using ONNX Runtime.
 

--- a/src/mobius/_testing/golden.py
+++ b/src/mobius/_testing/golden.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Golden file loading, saving, and test case discovery for L4/L5 tests.
 

--- a/src/mobius/_testing/golden_test.py
+++ b/src/mobius/_testing/golden_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Unit tests for the golden file I/O library."""
 

--- a/src/mobius/_testing/ort_inference.py
+++ b/src/mobius/_testing/ort_inference.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """ONNX Runtime inference session wrapper for ir.Model objects.
 

--- a/src/mobius/_testing/parity.py
+++ b/src/mobius/_testing/parity.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Multi-metric evaluation utilities for ONNX↔HF parity testing.
 

--- a/src/mobius/_testing/parity_test.py
+++ b/src/mobius/_testing/parity_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Unit tests for the parity comparison utilities."""
 

--- a/src/mobius/_testing/torch_reference.py
+++ b/src/mobius/_testing/torch_reference.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """PyTorch/HuggingFace reference model helpers for integration testing."""
 

--- a/src/mobius/_weight_loading.py
+++ b/src/mobius/_weight_loading.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 # SECURITY: Do NOT use torch.load() or pickle deserialization anywhere in this
 # module.  Only safetensors is permitted for weight loading to prevent arbitrary

--- a/src/mobius/_weight_loading_test.py
+++ b/src/mobius/_weight_loading_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Defensive security regression tests for the weight loading path.
 

--- a/src/mobius/_weight_utils.py
+++ b/src/mobius/_weight_utils.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Shared weight preprocessing utilities for HuggingFace → ONNX conversion.
 

--- a/src/mobius/_weight_utils_test.py
+++ b/src/mobius/_weight_utils_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for _weight_utils.py — shared weight preprocessing utilities."""
 

--- a/src/mobius/components/__init__.py
+++ b/src/mobius/components/__init__.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 __all__ = [
     "AdaLayerNormOutput",

--- a/src/mobius/components/_activations.py
+++ b/src/mobius/components/_activations.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/components/_activations_test.py
+++ b/src/mobius/components/_activations_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for activation functions."""
 

--- a/src/mobius/components/_attention.py
+++ b/src/mobius/components/_attention.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/components/_attention_test.py
+++ b/src/mobius/components/_attention_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for Attention components."""
 

--- a/src/mobius/components/_audio.py
+++ b/src/mobius/components/_audio.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Audio encoder components (Conformer-style).
 

--- a/src/mobius/components/_audio_test.py
+++ b/src/mobius/components/_audio_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for audio encoder components (Conformer-style)."""
 

--- a/src/mobius/components/_codec_conv.py
+++ b/src/mobius/components/_codec_conv.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Convolution and activation components for the Qwen3-TTS codec tokenizer.
 

--- a/src/mobius/components/_codec_transformer.py
+++ b/src/mobius/components/_codec_transformer.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Transformer components for the Qwen3-TTS codec tokenizer.
 

--- a/src/mobius/components/_codec_vq.py
+++ b/src/mobius/components/_codec_vq.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Vector quantization components for the Qwen3-TTS codec tokenizer.
 

--- a/src/mobius/components/_common.py
+++ b/src/mobius/components/_common.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/components/_common_test.py
+++ b/src/mobius/components/_common_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for Linear, Embedding, and attention bias utilities."""
 

--- a/src/mobius/components/_components_test.py
+++ b/src/mobius/components/_components_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for Attention, MLP, and DecoderLayer modules."""
 

--- a/src/mobius/components/_conv.py
+++ b/src/mobius/components/_conv.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Convolution building blocks."""
 

--- a/src/mobius/components/_conv_test.py
+++ b/src/mobius/components/_conv_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for convolution components."""
 

--- a/src/mobius/components/_decoder.py
+++ b/src/mobius/components/_decoder.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/components/_decoder_test.py
+++ b/src/mobius/components/_decoder_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for DecoderLayer component."""
 

--- a/src/mobius/components/_deepseek_mla.py
+++ b/src/mobius/components/_deepseek_mla.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Multi-head Latent Attention (MLA) for DeepSeek-V3.
 

--- a/src/mobius/components/_deepseek_mla_test.py
+++ b/src/mobius/components/_deepseek_mla_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for DeepSeek Multi-head Latent Attention (MLA) component."""
 

--- a/src/mobius/components/_diffusion.py
+++ b/src/mobius/components/_diffusion.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Shared building blocks for diffusion transformer models.
 

--- a/src/mobius/components/_diffusion_test.py
+++ b/src/mobius/components/_diffusion_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for shared diffusion transformer components."""
 

--- a/src/mobius/components/_ecapa_tdnn.py
+++ b/src/mobius/components/_ecapa_tdnn.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """ECAPA-TDNN speaker encoder components for Qwen3-TTS.
 

--- a/src/mobius/components/_encoder.py
+++ b/src/mobius/components/_encoder.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Encoder-only components for BERT-like models."""
 

--- a/src/mobius/components/_encoder_decoder_attention.py
+++ b/src/mobius/components/_encoder_decoder_attention.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Encoder-decoder attention module for seq2seq models (BART, T5, etc.)."""
 

--- a/src/mobius/components/_encoder_decoder_attention_test.py
+++ b/src/mobius/components/_encoder_decoder_attention_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for EncoderDecoderAttention component."""
 

--- a/src/mobius/components/_encoder_test.py
+++ b/src/mobius/components/_encoder_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for encoder components (EncoderAttention, EncoderLayer, BertEmbeddings)."""
 

--- a/src/mobius/components/_gated_deltanet.py
+++ b/src/mobius/components/_gated_deltanet.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Gated DeltaNet: linear attention component for Qwen3.5 hybrid models.
 

--- a/src/mobius/components/_gated_deltanet_test.py
+++ b/src/mobius/components/_gated_deltanet_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for GatedDeltaNet linear attention component."""
 

--- a/src/mobius/components/_lightning_attention.py
+++ b/src/mobius/components/_lightning_attention.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Lightning Attention component for MiniMax hybrid models.
 

--- a/src/mobius/components/_lora.py
+++ b/src/mobius/components/_lora.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """LoRA (Low-Rank Adaptation) components."""
 

--- a/src/mobius/components/_lora_test.py
+++ b/src/mobius/components/_lora_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for LoRALinear component."""
 

--- a/src/mobius/components/_mamba_block.py
+++ b/src/mobius/components/_mamba_block.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Mamba block component: Conv1D → SSM → gated output projection.
 

--- a/src/mobius/components/_mamba_block_test.py
+++ b/src/mobius/components/_mamba_block_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for the MambaBlock component."""
 

--- a/src/mobius/components/_mlp.py
+++ b/src/mobius/components/_mlp.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/components/_mlp_test.py
+++ b/src/mobius/components/_mlp_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for MLP component."""
 

--- a/src/mobius/components/_moe.py
+++ b/src/mobius/components/_moe.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Mixture of Experts (MoE) components."""
 

--- a/src/mobius/components/_moe_test.py
+++ b/src/mobius/components/_moe_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for MoE components."""
 

--- a/src/mobius/components/_multimodal.py
+++ b/src/mobius/components/_multimodal.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Multimodal components for bridging vision and text models.
 

--- a/src/mobius/components/_multimodal_test.py
+++ b/src/mobius/components/_multimodal_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for multimodal components."""
 

--- a/src/mobius/components/_pixtral_vision.py
+++ b/src/mobius/components/_pixtral_vision.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Pixtral vision encoder components for Mistral-3 multimodal models.
 

--- a/src/mobius/components/_pixtral_vision_test.py
+++ b/src/mobius/components/_pixtral_vision_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Unit tests for Pixtral vision encoder components."""
 

--- a/src/mobius/components/_qformer.py
+++ b/src/mobius/components/_qformer.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Q-Former (Querying Transformer) component for BLIP-2 style VLMs.
 

--- a/src/mobius/components/_qformer_test.py
+++ b/src/mobius/components/_qformer_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for Q-Former component."""
 

--- a/src/mobius/components/_quantized_linear.py
+++ b/src/mobius/components/_quantized_linear.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Quantized linear layer using MatMulNBits (com.microsoft domain)."""
 

--- a/src/mobius/components/_quantized_linear_test.py
+++ b/src/mobius/components/_quantized_linear_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for QuantizedLinear component."""
 

--- a/src/mobius/components/_qwen25_vl_vision.py
+++ b/src/mobius/components/_qwen25_vl_vision.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Qwen2.5-VL vision encoder components.
 

--- a/src/mobius/components/_qwen3_asr_audio.py
+++ b/src/mobius/components/_qwen3_asr_audio.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Qwen3-ASR audio encoder components.
 

--- a/src/mobius/components/_qwen3_vl_vision.py
+++ b/src/mobius/components/_qwen3_vl_vision.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Qwen3-VL vision encoder components.
 

--- a/src/mobius/components/_rms_norm.py
+++ b/src/mobius/components/_rms_norm.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/components/_rms_norm_test.py
+++ b/src/mobius/components/_rms_norm_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for RMSNorm component."""
 

--- a/src/mobius/components/_rotary_embedding.py
+++ b/src/mobius/components/_rotary_embedding.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/components/_rotary_embedding_test.py
+++ b/src/mobius/components/_rotary_embedding_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for rotary embeddings."""
 

--- a/src/mobius/components/_sam_vision.py
+++ b/src/mobius/components/_sam_vision.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """SAM ViT-B vision encoder for DeepSeek-OCR-2.
 

--- a/src/mobius/components/_scan_utils.py
+++ b/src/mobius/components/_scan_utils.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Utilities for building ONNX Scan subgraphs.
 

--- a/src/mobius/components/_scan_utils_test.py
+++ b/src/mobius/components/_scan_utils_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for Scan subgraph utilities."""
 

--- a/src/mobius/components/_ssm.py
+++ b/src/mobius/components/_ssm.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Selective State Space Model (S6) component for Mamba architectures.
 

--- a/src/mobius/components/_ssm_test.py
+++ b/src/mobius/components/_ssm_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for the SelectiveScan (S6) component."""
 

--- a/src/mobius/components/_vision.py
+++ b/src/mobius/components/_vision.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Vision encoder components (SigLIP-style).
 

--- a/src/mobius/components/_vision_test.py
+++ b/src/mobius/components/_vision_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for vision encoder components."""
 

--- a/src/mobius/components/_whisper.py
+++ b/src/mobius/components/_whisper.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Whisper encoder-decoder components.
 

--- a/src/mobius/components/_whisper_test.py
+++ b/src/mobius/components/_whisper_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for Whisper encoder/decoder components."""
 

--- a/src/mobius/functions/__init__.py
+++ b/src/mobius/functions/__init__.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """ONNX Function definitions for proposed linear attention operators.
 

--- a/src/mobius/functions/causal_conv.py
+++ b/src/mobius/functions/causal_conv.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Reference ir.Function for the CausalConvWithState operator.
 

--- a/src/mobius/functions/causal_conv_test.py
+++ b/src/mobius/functions/causal_conv_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Unit tests for the CausalConvWithState ir.Function builder."""
 

--- a/src/mobius/functions/linear_attention.py
+++ b/src/mobius/functions/linear_attention.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Reference ir.Function for the proposed LinearAttention operator.
 

--- a/src/mobius/functions/linear_attention_test.py
+++ b/src/mobius/functions/linear_attention_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Unit tests for the LinearAttention ir.Function builder."""
 

--- a/src/mobius/functions/packed_multi_head_attention.py
+++ b/src/mobius/functions/packed_multi_head_attention.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Standard-ONNX ir.Function body for PackedMultiHeadAttention.
 

--- a/src/mobius/functions/skip_layer_normalization.py
+++ b/src/mobius/functions/skip_layer_normalization.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Standard-ONNX ir.Function bodies for SkipLayerNormalization operators.
 

--- a/src/mobius/integrations/__init__.py
+++ b/src/mobius/integrations/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Integration modules for external runtimes."""

--- a/src/mobius/integrations/gguf/__init__.py
+++ b/src/mobius/integrations/gguf/__init__.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """GGUF model import support for mobius.
 

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """GGUF → ONNX build pipeline.
 

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for the quantized GGUF → ONNX build pipeline."""
 

--- a/src/mobius/integrations/gguf/_config_mapping.py
+++ b/src/mobius/integrations/gguf/_config_mapping.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """GGUF metadata → ArchitectureConfig mapping.
 

--- a/src/mobius/integrations/gguf/_reader.py
+++ b/src/mobius/integrations/gguf/_reader.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """GGUF file reading and metadata/tensor extraction.
 

--- a/src/mobius/integrations/gguf/_reader_test.py
+++ b/src/mobius/integrations/gguf/_reader_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for the GGUF reader and config mapping modules.
 

--- a/src/mobius/integrations/gguf/_repacker.py
+++ b/src/mobius/integrations/gguf/_repacker.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Repack GGUF quantized blocks into ORT MatMulNBits format.
 

--- a/src/mobius/integrations/gguf/_repacker_test.py
+++ b/src/mobius/integrations/gguf/_repacker_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/integrations/gguf/_tensor_mapping.py
+++ b/src/mobius/integrations/gguf/_tensor_mapping.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """GGUF → HuggingFace tensor name mapping.
 

--- a/src/mobius/integrations/gguf/_tensor_mapping_test.py
+++ b/src/mobius/integrations/gguf/_tensor_mapping_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for GGUF → HF tensor name mapping."""
 

--- a/src/mobius/integrations/gguf/_tensor_processors.py
+++ b/src/mobius/integrations/gguf/_tensor_processors.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Architecture-specific tensor processors for GGUF import.
 

--- a/src/mobius/integrations/gguf/_tensor_processors_test.py
+++ b/src/mobius/integrations/gguf/_tensor_processors_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for GGUF tensor processors."""
 

--- a/src/mobius/integrations/ort_genai/__init__.py
+++ b/src/mobius/integrations/ort_genai/__init__.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """ORT-GenAI integration: genai_config.json generation and runtime helpers.
 

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Auto-export pipeline for onnxruntime-genai.
 

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for the ORT-GenAI auto-export pipeline."""
 

--- a/src/mobius/integrations/ort_genai/ep_config.py
+++ b/src/mobius/integrations/ort_genai/ep_config.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Generate EP-specific genai_config.json sections for onnxruntime-genai.
 

--- a/src/mobius/integrations/ort_genai/ep_config_test.py
+++ b/src/mobius/integrations/ort_genai/ep_config_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for _genai_config module."""
 

--- a/src/mobius/integrations/ort_genai/genai_config.py
+++ b/src/mobius/integrations/ort_genai/genai_config.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Generate genai_config.json for onnxruntime-genai.
 

--- a/src/mobius/integrations/ort_genai/genai_config_test.py
+++ b/src/mobius/integrations/ort_genai/genai_config_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for GenaiConfigGenerator."""
 

--- a/src/mobius/models/__init__.py
+++ b/src/mobius/models/__init__.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/models/_models_test.py
+++ b/src/mobius/models/_models_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for model building — base class and infrastructure unit tests.
 

--- a/src/mobius/models/adapters.py
+++ b/src/mobius/models/adapters.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """T2I-Adapter and IP-Adapter for conditioning image generation.
 

--- a/src/mobius/models/apertus.py
+++ b/src/mobius/models/apertus.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Apertus causal language model.
 

--- a/src/mobius/models/arcee.py
+++ b/src/mobius/models/arcee.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Arcee causal language model.
 

--- a/src/mobius/models/bamba.py
+++ b/src/mobius/models/bamba.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Bamba hybrid Mamba2/SSD + Attention causal language model.
 

--- a/src/mobius/models/bart.py
+++ b/src/mobius/models/bart.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """BART encoder-decoder model."""
 

--- a/src/mobius/models/base.py
+++ b/src/mobius/models/base.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Base causal language model for standard decoder-only transformers.
 

--- a/src/mobius/models/bert.py
+++ b/src/mobius/models/bert.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """BERT encoder-only model with HF-aligned weight naming.
 

--- a/src/mobius/models/blip.py
+++ b/src/mobius/models/blip.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """BLIP vision model for image feature extraction.
 

--- a/src/mobius/models/blip2.py
+++ b/src/mobius/models/blip2.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """BLIP-2 multimodal model (vision + text) — 3-model split.
 

--- a/src/mobius/models/chatglm.py
+++ b/src/mobius/models/chatglm.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/models/clip.py
+++ b/src/mobius/models/clip.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """CLIP vision and text models for feature extraction."""
 

--- a/src/mobius/models/cogvideox.py
+++ b/src/mobius/models/cogvideox.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """CogVideoX 3D transformer denoiser for video generation.
 

--- a/src/mobius/models/cohere.py
+++ b/src/mobius/models/cohere.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Cohere and Cohere2 causal language models.
 

--- a/src/mobius/models/controlnet.py
+++ b/src/mobius/models/controlnet.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """ControlNet model for conditional image generation.
 

--- a/src/mobius/models/ctrl.py
+++ b/src/mobius/models/ctrl.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """CTRL causal language model with sinusoidal positional embeddings.
 

--- a/src/mobius/models/deepseek.py
+++ b/src/mobius/models/deepseek.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """DeepSeek-V3 model with Multi-head Latent Attention (MLA) and MoE.
 

--- a/src/mobius/models/deepseek_ocr2.py
+++ b/src/mobius/models/deepseek_ocr2.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """DeepSeek-OCR-2 vision-language model.
 

--- a/src/mobius/models/depth_anything.py
+++ b/src/mobius/models/depth_anything.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Depth Anything model for monocular depth estimation.
 

--- a/src/mobius/models/diffllama.py
+++ b/src/mobius/models/diffllama.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/models/distilbert.py
+++ b/src/mobius/models/distilbert.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """DistilBERT encoder-only model."""
 

--- a/src/mobius/models/dit.py
+++ b/src/mobius/models/dit.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """DiT (Diffusion Transformer) 2D model.
 

--- a/src/mobius/models/doge.py
+++ b/src/mobius/models/doge.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """DOGE causal language model.
 

--- a/src/mobius/models/ernie.py
+++ b/src/mobius/models/ernie.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/models/exaone4.py
+++ b/src/mobius/models/exaone4.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """ExaOne4 causal language model.
 

--- a/src/mobius/models/falcon.py
+++ b/src/mobius/models/falcon.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Falcon and Bloom CausalLM models.
 

--- a/src/mobius/models/flux_sd3.py
+++ b/src/mobius/models/flux_sd3.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """SD3 and Flux transformer denoisers.
 

--- a/src/mobius/models/gemma.py
+++ b/src/mobius/models/gemma.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Gemma and Gemma2 causal language models.
 

--- a/src/mobius/models/gemma3.py
+++ b/src/mobius/models/gemma3.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Gemma3 multimodal model (vision + text) — 3-model split.
 

--- a/src/mobius/models/gemma3_text.py
+++ b/src/mobius/models/gemma3_text.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/models/gemma3n.py
+++ b/src/mobius/models/gemma3n.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Gemma3n text model with AltUp, Laurel, and per-layer input gating.
 

--- a/src/mobius/models/glm.py
+++ b/src/mobius/models/glm.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """GLM and GLM4 causal language models.
 

--- a/src/mobius/models/gpt2.py
+++ b/src/mobius/models/gpt2.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """GPT-2 model with absolute positional embeddings and pre-norm LayerNorm.
 

--- a/src/mobius/models/gpt_neox.py
+++ b/src/mobius/models/gpt_neox.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """GPT-NeoX / Pythia causal LM with parallel residual connections.
 

--- a/src/mobius/models/gptj_codegen.py
+++ b/src/mobius/models/gptj_codegen.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """GPT-J and CodeGen causal LMs with single-norm parallel residual.
 

--- a/src/mobius/models/gptoss.py
+++ b/src/mobius/models/gptoss.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """GPT-OSS causal language model with Mixture-of-Experts and attention sinks.
 

--- a/src/mobius/models/granite.py
+++ b/src/mobius/models/granite.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/models/granitemoehybrid.py
+++ b/src/mobius/models/granitemoehybrid.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """GraniteMoeHybrid: Mamba2/SSD + Attention hybrid with MoE FFN on all layers.
 

--- a/src/mobius/models/hunyuan_dit.py
+++ b/src/mobius/models/hunyuan_dit.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """HunyuanDiT (Hunyuan Diffusion Transformer) 2D model.
 

--- a/src/mobius/models/hunyuan_v1.py
+++ b/src/mobius/models/hunyuan_v1.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """HunYuan V1 Dense causal language model.
 

--- a/src/mobius/models/internlm.py
+++ b/src/mobius/models/internlm.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """InternLM2 CausalLM model with HF-aligned weight naming.
 

--- a/src/mobius/models/internvl.py
+++ b/src/mobius/models/internvl.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """InternVL2 multimodal model (vision + text) — 3-model split.
 

--- a/src/mobius/models/jamba.py
+++ b/src/mobius/models/jamba.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Jamba hybrid SSM+Attention causal language model.
 

--- a/src/mobius/models/jetmoe.py
+++ b/src/mobius/models/jetmoe.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """JetMoE causal language model with Mixture-of-Attention (MoA).
 

--- a/src/mobius/models/layoutlmv3.py
+++ b/src/mobius/models/layoutlmv3.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """LayoutLMv3 model for document understanding.
 

--- a/src/mobius/models/llama4.py
+++ b/src/mobius/models/llama4.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Llama4 causal language model.
 

--- a/src/mobius/models/llava.py
+++ b/src/mobius/models/llava.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """LLaVA multimodal model (vision + text) — 3-model split.
 

--- a/src/mobius/models/longcat_flash.py
+++ b/src/mobius/models/longcat_flash.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """LongCat Flash model with dual-sublayer architecture.
 

--- a/src/mobius/models/mamba.py
+++ b/src/mobius/models/mamba.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Mamba and Mamba2 (Selective State Space) causal language models.
 

--- a/src/mobius/models/minimax.py
+++ b/src/mobius/models/minimax.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """MiniMax causal language model with Lightning Attention.
 

--- a/src/mobius/models/mllama.py
+++ b/src/mobius/models/mllama.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Mllama (Meta Llama 3.2 Vision) multimodal model.
 

--- a/src/mobius/models/modernbert.py
+++ b/src/mobius/models/modernbert.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """ModernBERT encoder and decoder models.
 

--- a/src/mobius/models/moe.py
+++ b/src/mobius/models/moe.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/models/nanochat.py
+++ b/src/mobius/models/nanochat.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """NanoChat causal language model.
 

--- a/src/mobius/models/nemotron.py
+++ b/src/mobius/models/nemotron.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/models/nemotron_h.py
+++ b/src/mobius/models/nemotron_h.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """NemotronH hybrid Mamba2 + Attention + MLP causal language model.
 

--- a/src/mobius/models/olmo.py
+++ b/src/mobius/models/olmo.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/models/opt.py
+++ b/src/mobius/models/opt.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """OPT model with absolute positional embeddings."""
 

--- a/src/mobius/models/persimmon.py
+++ b/src/mobius/models/persimmon.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Persimmon causal LM with fused QKV and QK LayerNorm.
 

--- a/src/mobius/models/phi.py
+++ b/src/mobius/models/phi.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Phi model variants: Phi-1/2, Phi-4MM (multimodal), Phi-3 Small.
 

--- a/src/mobius/models/phi3.py
+++ b/src/mobius/models/phi3.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Phi-3 / Phi-3.5 causal language model.
 

--- a/src/mobius/models/qwen.py
+++ b/src/mobius/models/qwen.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/models/qwen35.py
+++ b/src/mobius/models/qwen35.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/models/qwen3_asr.py
+++ b/src/mobius/models/qwen3_asr.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Qwen3-ASR: Audio speech recognition with Qwen3 text decoder.
 

--- a/src/mobius/models/qwen3_next.py
+++ b/src/mobius/models/qwen3_next.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Qwen3-Coder-Next: Hybrid DeltaNet + Gated Attention with MoE.
 

--- a/src/mobius/models/qwen3_tts.py
+++ b/src/mobius/models/qwen3_tts.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Qwen3-TTS: Text-to-speech with Qwen3-like talker and code predictor.
 

--- a/src/mobius/models/qwen3_tts_tokenizer.py
+++ b/src/mobius/models/qwen3_tts_tokenizer.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Qwen3-TTS Codec Tokenizer 12Hz — ONNX model classes.
 

--- a/src/mobius/models/qwen_image.py
+++ b/src/mobius/models/qwen_image.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """QwenImage transformer denoiser for text-to-image generation.
 

--- a/src/mobius/models/qwen_image_vae.py
+++ b/src/mobius/models/qwen_image_vae.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """QwenImage 3D causal VAE for video/image latent encoding.
 

--- a/src/mobius/models/qwen_vl.py
+++ b/src/mobius/models/qwen_vl.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/models/sam2.py
+++ b/src/mobius/models/sam2.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """SAM2 (Segment Anything Model 2) vision encoder.
 

--- a/src/mobius/models/segformer.py
+++ b/src/mobius/models/segformer.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Segformer hierarchical vision transformer for semantic segmentation.
 

--- a/src/mobius/models/smollm.py
+++ b/src/mobius/models/smollm.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/models/starcoder2.py
+++ b/src/mobius/models/starcoder2.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """StarCoder2 causal language model.
 

--- a/src/mobius/models/t5.py
+++ b/src/mobius/models/t5.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """T5 encoder-decoder model."""
 

--- a/src/mobius/models/t5_test.py
+++ b/src/mobius/models/t5_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Unit tests for T5 model — relative position bias and weight renaming."""
 

--- a/src/mobius/models/trocr.py
+++ b/src/mobius/models/trocr.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """TrOCR decoder model for OCR.
 

--- a/src/mobius/models/unet.py
+++ b/src/mobius/models/unet.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """UNet2DConditionModel for Stable Diffusion denoisers.
 

--- a/src/mobius/models/vae.py
+++ b/src/mobius/models/vae.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """AutoencoderKL (VAE) model for diffusers.
 

--- a/src/mobius/models/video_vae.py
+++ b/src/mobius/models/video_vae.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Video autoencoder model for 3D (temporal) diffusion.
 

--- a/src/mobius/models/vit.py
+++ b/src/mobius/models/vit.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """ViT (Vision Transformer) model for image feature extraction."""
 

--- a/src/mobius/models/wav2vec2.py
+++ b/src/mobius/models/wav2vec2.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Wav2Vec2 encoder-only audio model.
 

--- a/src/mobius/models/whisper.py
+++ b/src/mobius/models/whisper.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Whisper encoder-decoder model for speech-to-text.
 

--- a/src/mobius/models/xlm.py
+++ b/src/mobius/models/xlm.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """XLM causal language model.
 

--- a/src/mobius/models/yolos.py
+++ b/src/mobius/models/yolos.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """YOLOS (You Only Look at One Sequence) model for object detection.
 

--- a/src/mobius/rewrite_rules/__init__.py
+++ b/src/mobius/rewrite_rules/__init__.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Rewrite rules for graph transformations.
 

--- a/src/mobius/rewrite_rules/_bias_gelu.py
+++ b/src/mobius/rewrite_rules/_bias_gelu.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Rewrite rules for fusing Add + Gelu into BiasGelu.
 

--- a/src/mobius/rewrite_rules/_bias_gelu_test.py
+++ b/src/mobius/rewrite_rules/_bias_gelu_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/rewrite_rules/_eliminate_shape.py
+++ b/src/mobius/rewrite_rules/_eliminate_shape.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Rewrite rule for eliminating Shape ops on attention masks for WebGPU.
 

--- a/src/mobius/rewrite_rules/_eliminate_shape_test.py
+++ b/src/mobius/rewrite_rules/_eliminate_shape_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/rewrite_rules/_gelu_fusion.py
+++ b/src/mobius/rewrite_rules/_gelu_fusion.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Rewrite rules for fusing decomposed GeLU into the native Gelu op.
 

--- a/src/mobius/rewrite_rules/_gelu_fusion_test.py
+++ b/src/mobius/rewrite_rules/_gelu_fusion_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/rewrite_rules/_group_query_attention.py
+++ b/src/mobius/rewrite_rules/_group_query_attention.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Rewrite rules for fusing Attention into GroupQueryAttention.
 

--- a/src/mobius/rewrite_rules/_group_query_attention_test.py
+++ b/src/mobius/rewrite_rules/_group_query_attention_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/rewrite_rules/_layer_norm_fusion.py
+++ b/src/mobius/rewrite_rules/_layer_norm_fusion.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Rewrite rules for fusing decomposed LayerNorm into LayerNormalization.
 

--- a/src/mobius/rewrite_rules/_layer_norm_fusion_test.py
+++ b/src/mobius/rewrite_rules/_layer_norm_fusion_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/rewrite_rules/_packed_attention.py
+++ b/src/mobius/rewrite_rules/_packed_attention.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Rewrite rules for replacing block-diagonal packed attention with custom ops.
 

--- a/src/mobius/rewrite_rules/_packed_attention_test.py
+++ b/src/mobius/rewrite_rules/_packed_attention_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Unit tests for packed attention rewrite rules."""
 

--- a/src/mobius/rewrite_rules/_separate_rope.py
+++ b/src/mobius/rewrite_rules/_separate_rope.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Rewrite rule for separating fused RoPE from GroupQueryAttention.
 

--- a/src/mobius/rewrite_rules/_separate_rope_test.py
+++ b/src/mobius/rewrite_rules/_separate_rope_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/rewrite_rules/_skip_layer_norm.py
+++ b/src/mobius/rewrite_rules/_skip_layer_norm.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Rewrite rules for fusing Add + LayerNormalization into SkipLayerNormalization.
 

--- a/src/mobius/rewrite_rules/_skip_layer_norm_test.py
+++ b/src/mobius/rewrite_rules/_skip_layer_norm_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/rewrite_rules/_skip_norm.py
+++ b/src/mobius/rewrite_rules/_skip_norm.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Rewrite rules for fusing Add + RMSNormalization into SkipSimplifiedLayerNormalization.
 

--- a/src/mobius/rewrite_rules/_skip_norm_test.py
+++ b/src/mobius/rewrite_rules/_skip_norm_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/rewrite_rules/_testing_utils.py
+++ b/src/mobius/rewrite_rules/_testing_utils.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Shared test utilities for rewrite rule tests."""
 

--- a/src/mobius/rewrite_rules/_unpack_qkv.py
+++ b/src/mobius/rewrite_rules/_unpack_qkv.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Rewrite rule for unpacking packed QKV back into separate Q/K/V projections.
 

--- a/src/mobius/rewrite_rules/_unpack_qkv_test.py
+++ b/src/mobius/rewrite_rules/_unpack_qkv_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 from __future__ import annotations
 

--- a/src/mobius/tasks/__init__.py
+++ b/src/mobius/tasks/__init__.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Model tasks that define graph I/O structure for different use cases.
 

--- a/src/mobius/tasks/_adapter.py
+++ b/src/mobius/tasks/_adapter.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Adapter task for T2I-Adapter and IP-Adapter models."""
 

--- a/src/mobius/tasks/_audio_feature_extraction.py
+++ b/src/mobius/tasks/_audio_feature_extraction.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Audio feature extraction task.
 

--- a/src/mobius/tasks/_base.py
+++ b/src/mobius/tasks/_base.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Base class for model tasks and shared graph construction helpers."""
 

--- a/src/mobius/tasks/_cache_utils.py
+++ b/src/mobius/tasks/_cache_utils.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """KV cache and linear attention utility functions for task graph construction."""
 

--- a/src/mobius/tasks/_causal_lm.py
+++ b/src/mobius/tasks/_causal_lm.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Causal language model tasks with internal and static KV cache."""
 

--- a/src/mobius/tasks/_codec.py
+++ b/src/mobius/tasks/_codec.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Codec tokenizer 2-model task for Qwen3-TTS-Tokenizer-12Hz.
 

--- a/src/mobius/tasks/_controlnet.py
+++ b/src/mobius/tasks/_controlnet.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """ControlNet task: produces residuals for UNet conditioning."""
 

--- a/src/mobius/tasks/_denoising.py
+++ b/src/mobius/tasks/_denoising.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Denoising task for diffusion models (UNet, DiT, etc.).
 

--- a/src/mobius/tasks/_feature_extraction.py
+++ b/src/mobius/tasks/_feature_extraction.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Feature extraction task for encoder-only models (BERT, RoBERTa, etc.)."""
 

--- a/src/mobius/tasks/_image_classification.py
+++ b/src/mobius/tasks/_image_classification.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Image classification task for ViT-like models."""
 

--- a/src/mobius/tasks/_multimodal.py
+++ b/src/mobius/tasks/_multimodal.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Multimodal model task (vision + audio + text)."""
 

--- a/src/mobius/tasks/_object_detection.py
+++ b/src/mobius/tasks/_object_detection.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Object detection task for models like YOLOS and DETR."""
 

--- a/src/mobius/tasks/_phi4mm_multimodal.py
+++ b/src/mobius/tasks/_phi4mm_multimodal.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Phi4MM four-model split task (vision, speech, embedding, decoder).
 

--- a/src/mobius/tasks/_qwen_image_vae.py
+++ b/src/mobius/tasks/_qwen_image_vae.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """QwenImage 3D VAE task for encoder/decoder with 5D (video) inputs.
 

--- a/src/mobius/tasks/_seq2seq.py
+++ b/src/mobius/tasks/_seq2seq.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Seq2Seq task for encoder-decoder models (T5, BART, etc.)."""
 

--- a/src/mobius/tasks/_speech_language.py
+++ b/src/mobius/tasks/_speech_language.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Speech-language 3-model split task for ASR / forced alignment.
 

--- a/src/mobius/tasks/_speech_to_text.py
+++ b/src/mobius/tasks/_speech_to_text.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Speech-to-text task for encoder-decoder models (e.g. Whisper)."""
 

--- a/src/mobius/tasks/_ssm_causal_lm.py
+++ b/src/mobius/tasks/_ssm_causal_lm.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """SSM causal language model task with conv_state + ssm_state carry.
 

--- a/src/mobius/tasks/_task_test.py
+++ b/src/mobius/tasks/_task_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for task classes.
 

--- a/src/mobius/tasks/_tts.py
+++ b/src/mobius/tasks/_tts.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """TTS 4-model split task for Qwen3-TTS.
 

--- a/src/mobius/tasks/_vae.py
+++ b/src/mobius/tasks/_vae.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """VAE encode/decode task for diffusers autoencoders.
 

--- a/src/mobius/tasks/_video_denoising.py
+++ b/src/mobius/tasks/_video_denoising.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Video denoising task for 3D diffusion models (CogVideoX, etc.).
 

--- a/src/mobius/tasks/_vision_language.py
+++ b/src/mobius/tasks/_vision_language.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Vision-language model task."""
 

--- a/src/mobius/tasks/_vision_language_3model.py
+++ b/src/mobius/tasks/_vision_language_3model.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Vision-language 3-model split tasks.
 

--- a/tests/_test_configs.py
+++ b/tests/_test_configs.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Shared test configurations for all test tiers.
 

--- a/tests/arch_validation_test.py
+++ b/tests/arch_validation_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """L2 Architecture Validation Tests — real HF config, no weights.
 

--- a/tests/benchmark_build.py
+++ b/tests/benchmark_build.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Benchmarks for ONNX graph construction times and memory usage.
 

--- a/tests/benchmark_compare.py
+++ b/tests/benchmark_compare.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 r"""Compare benchmark results between two commits for regression detection.
 

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Unit tests: build ONNX graphs for all supported architectures (no weights).
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Unit tests for the CLI (``__main__.py``).
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Shared pytest configuration and fixtures for mobius tests."""
 

--- a/tests/e2e_golden_test.py
+++ b/tests/e2e_golden_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """L4 (Checkpoint Verified) and L5 (Generation E2E) golden tests.
 

--- a/tests/ep_optimization_test.py
+++ b/tests/ep_optimization_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tests for EP-aware optimization pipeline.
 

--- a/tests/gguf_test.py
+++ b/tests/gguf_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Unit tests for GGUF import support.
 

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Integration tests: numerical accuracy of ONNX models vs HuggingFace PyTorch.
 

--- a/tests/mamba2_integration_test.py
+++ b/tests/mamba2_integration_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Integration tests: Mamba2 numerical parity against HuggingFace.
 

--- a/tests/model_coverage_test.py
+++ b/tests/model_coverage_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Model test-coverage audit: every registered architecture must have L1-L5 data.
 

--- a/tests/moe_integration_test.py
+++ b/tests/moe_integration_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Integration tests: MoE (Mixture of Experts) models.
 

--- a/tests/multimodal_integration_test.py
+++ b/tests/multimodal_integration_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Integration tests: multimodal (vision + language) models.
 

--- a/tests/ort_genai_test.py
+++ b/tests/ort_genai_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Integration tests for onnxruntime-genai inference.
 

--- a/tests/phi4mm_integration_test.py
+++ b/tests/phi4mm_integration_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Integration tests: Phi4-MM multimodal (vision + audio + language).
 

--- a/tests/quantization_integration_test.py
+++ b/tests/quantization_integration_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """End-to-end integration tests for quantized (GPTQ/AWQ) model pipelines.
 

--- a/tests/seq2seq_integration_test.py
+++ b/tests/seq2seq_integration_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Integration tests: T5 and BART encoder-decoder seq2seq models.
 

--- a/tests/synthetic_parity_test.py
+++ b/tests/synthetic_parity_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """L3 Synthetic Parity Tests — registered model types.
 

--- a/tests/vision_integration_test.py
+++ b/tests/vision_integration_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Integration tests for standalone vision encoder models.
 

--- a/tests/weight_alignment_test.py
+++ b/tests/weight_alignment_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Tier 1: Weight alignment tests for preprocess_weights().
 

--- a/tests/whisper_integration_test.py
+++ b/tests/whisper_integration_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Integration tests: Whisper encoder-decoder speech-to-text.
 

--- a/tests/yaml_schema_test.py
+++ b/tests/yaml_schema_test.py
@@ -1,5 +1,5 @@
-# Copyright (c) ONNX Project Contributors
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 """Schema validation tests for YAML test case files in testdata/cases/.
 


### PR DESCRIPTION
Replace ONNX Project Contributors / Apache-2.0 header with Microsoft Corporation / MIT License header across all Python files.