### PR TITLE
ci: add codecov upload step to all CI pipelines

### DIFF
--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -69,6 +69,7 @@ jobs:
             -v \
             --timeout=300 \
             --junitxml=junit-l4.xml \
+            --cov=src --cov-report=xml --cov-branch \
             --tb=short
         timeout-minutes: 30
 
@@ -81,8 +82,32 @@ jobs:
             -v \
             --timeout=300 \
             --junitxml=junit-l5.xml \
+            --cov=src --cov-report=xml --cov-append --cov-branch \
             --tb=short
         timeout-minutes: 30
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: gpu
+      - name: Upload L4 test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: gpu-l4
+          report-type: test_results
+          files: junit-l4.xml
+      - name: Upload L5 test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: gpu-l5
+          report-type: test_results
+          files: junit-l5.xml
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -233,13 +233,13 @@ jobs:
             --junitxml golden-results.xml
         timeout-minutes: 30
       - name: Upload coverage to Codecov
-        if: always()
+        if: steps.check_golden.outputs.has_golden == 'true'
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: golden
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
+        if: steps.check_golden.outputs.has_golden == 'true' && !cancelled()
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,8 +84,22 @@ jobs:
           pip install -e '.[testing]'
       - name: Run L1 smoke tests (all model configs)
         run: |
-          pytest tests/build_graph_test.py -v --tb=short -n auto
+          pytest tests/build_graph_test.py -v --tb=short -n auto \
+            --cov=src --cov-report=xml --cov-branch --junitxml junit.xml
         timeout-minutes: 10
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: smoke
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: smoke
+          report-type: test_results
 
   synthetic-parity:
     name: L3 Synthetic Parity
@@ -125,7 +139,8 @@ jobs:
              [ "${{ needs.detect-affected.outputs.run_all }}" = "true" ] || \
              [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "Running all synthetic parity tests"
-            pytest tests/synthetic_parity_test.py -v --tb=short -n auto
+            pytest tests/synthetic_parity_test.py -v --tb=short -n auto \
+              --cov=src --cov-report=xml --cov-branch --junitxml junit.xml
           else
             AFFECTED='${{ needs.detect-affected.outputs.affected }}'
             echo "Running parity for affected models: $AFFECTED"
@@ -137,12 +152,26 @@ jobs:
           print(' or '.join(escaped))
           ")
             if [ -n "$FILTER" ]; then
-              pytest tests/synthetic_parity_test.py -v --tb=short -n auto -k "$FILTER"
+              pytest tests/synthetic_parity_test.py -v --tb=short -n auto -k "$FILTER" \
+                --cov=src --cov-report=xml --cov-branch --junitxml junit.xml
             else
               echo "No affected models — skipping"
             fi
           fi
         timeout-minutes: 20
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: synthetic-parity
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: synthetic-parity
+          report-type: test_results
 
   golden-comparison:
     name: L4 Golden Comparison
@@ -200,8 +229,23 @@ jobs:
             exit 0
           fi
           pytest tests/e2e_golden_test.py -m golden -v --tb=short \
+            --cov=src --cov-report=xml --cov-branch \
             --junitxml golden-results.xml
         timeout-minutes: 30
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: golden
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: golden
+          report-type: test_results
+          files: golden-results.xml
       - name: Upload golden test results
         if: always() && steps.check_golden.outputs.has_golden == 'true'
         uses: actions/upload-artifact@v7
@@ -240,6 +284,19 @@ jobs:
       - name: Run tests
         run: |
           pytest -n auto -m 'not integration and not arch_validation' --cov=src --cov-report=xml --cov-branch --junitxml junit.xml
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unittests
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unittests
+          report-type: test_results
 
   integration-fast:
     name: Integration (fast)
@@ -269,8 +326,22 @@ jobs:
       - name: Run fast integration tests
         run: |
           pytest tests/integration_test.py -m integration_fast -v \
-            -k "smollm-135m or albert-base or t5-small or dinov2-small or wav2vec2-base or whisper-tiny or test_gemma3_multimodal or test_qwen35 or test_qwen3_next or test_deepseek or test_sam_vit or test_ocr2"
+            -k "smollm-135m or albert-base or t5-small or dinov2-small or wav2vec2-base or whisper-tiny or test_gemma3_multimodal or test_qwen35 or test_qwen3_next or test_deepseek or test_sam_vit or test_ocr2" \
+            --cov=src --cov-report=xml --cov-branch --junitxml junit.xml
         timeout-minutes: 15
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: integration
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: integration
+          report-type: test_results
 
   build:
     name: Build

--- a/.github/workflows/nightly_l2.yml
+++ b/.github/workflows/nightly_l2.yml
@@ -62,8 +62,22 @@ jobs:
             -p no:xdist \
             --timeout=300 \
             --junitxml=junit.xml \
+            --cov=src --cov-report=xml --cov-branch \
             --tb=short
         timeout-minutes: 45
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: arch-validation
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: arch-validation
+          report-type: test_results
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
## Summary

Adds coverage collection and Codecov upload steps to all test jobs across the CI pipeline, matching the pattern from [onnx/ir-py](https://github.com/onnx/ir-py/blob/5291b8bb0b7104e9034dda6b9be9d43baf0d70ad/.github/workflows/main.yml#L64-L74).

## Changes

### `main.yml`
| Job | Flag | Notes |
|-----|------|-------|
| `smoke-test` | `smoke` | Added `--cov` to pytest |
| `synthetic-parity` | `synthetic-parity` | Added `--cov` to both pytest invocations |
| `golden-comparison` | `golden` | Added `--cov` to pytest |
| `test` | `unittests` | Already had `--cov`; added upload steps |
| `integration-fast` | `integration` | Added `--cov` to pytest |

### `gpu_tests.yml`
| Job | Flag | Notes |
|-----|------|-------|
| `golden-tests` (L4) | `gpu-l4` | Added `--cov` to L4 pytest |
| `golden-tests` (L5) | `gpu-l5` | Added `--cov --cov-append` to L5 pytest; combined coverage upload with `gpu` flag |

### `nightly_l2.yml`
| Job | Flag | Notes |
|-----|------|-------|
| `arch-validation` | `arch-validation` | Added `--cov` to pytest |

## Pattern used

Each job now uploads both:
1. **Coverage** (`coverage.xml`) using `codecov/codecov-action@v6` with `if: always()`

Token: `${{ secrets.CODECOV_TOKEN }}` (set as a repo secret for private repos; tokenless upload works for public repos).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>