### PR TITLE
docs: update skills with Gemma 4 architecture patterns (MoE, Any-to-Any, KV sharing)

### DIFF
--- a/.github/skills/adding-a-new-model/SKILL.md
+++ b/.github/skills/adding-a-new-model/SKILL.md
@@ -819,3 +819,122 @@ When adding a new model, use these files as canonical references:
 | **Minimal** — encoder subclass | `models/layoutlmv3.py` | Extends `BertModel`, only overrides `preprocess_weights()`. Same pattern for encoder-only models. |
 | **Moderate** — custom components | `models/gemma.py` | Adds custom attention (soft-capping), custom MLP (GeGLU), and custom normalization. Good example of component subclassing. |
 | **Complex** — multi-model architecture | `models/qwen3_tts.py` | 4-model TTS split with talker, code predictor, embedding, and speaker encoder sub-modules. Shows how to structure multi-model architectures. |
+
+## KV sharing across layers (num_kv_shared_layers)
+
+Some models (e.g. Gemma 4) use **KV weight sharing** where the last N decoder
+layers reuse the Key and Value projections computed by an earlier layer.
+This is controlled by `num_kv_shared_layers` in the HuggingFace config.
+
+### What it means
+
+```
+first_shared_idx = num_hidden_layers - num_kv_shared_layers
+Layers [0 .. first_shared_idx-1]: normal — each has its own k_proj, v_proj, k_norm, v_norm
+Layers [first_shared_idx .. end]: shared — NO k_proj/v_proj weights; reuse KV from source
+```
+
+Each shared layer finds the **last non-shared layer of the same attention type**
+(e.g. sliding vs. full attention) and borrows its K/V states at runtime.
+Only Q is computed fresh per shared layer.
+
+### Impact on weights
+
+Shared layers have **no `k_proj`, `v_proj`, `k_norm`, `v_norm`** — these keys
+are absent from the HuggingFace checkpoint. In `preprocess_weights`, do NOT
+assert these keys exist for shared-layer indices; skip them silently.
+
+```python
+def preprocess_weights(self, state_dict):
+    n_shared = self.config.num_kv_shared_layers or 0
+    first_shared = self.config.num_hidden_layers - n_shared
+    # Do not try to load k_proj/v_proj for shared layers
+    for i in range(first_shared, self.config.num_hidden_layers):
+        for key in (f"layers.{i}.self_attn.k_proj.weight",
+                    f"layers.{i}.self_attn.v_proj.weight",
+                    f"layers.{i}.self_attn.k_norm.weight",
+                    f"layers.{i}.self_attn.v_norm.weight"):
+            state_dict.pop(key, None)
+    return state_dict
+```
+
+### Impact on KV cache
+
+Shared layers **do not update** the KV cache — they never call
+`past_key_values.update()`. The KV cache has only
+`num_hidden_layers - num_kv_shared_layers` entries (not `num_hidden_layers`).
+
+This affects:
+- The number of KV cache slots in `CausalLMTask`
+- The `past_key_values` list unpacking in the text model's forward loop
+
+### Gemma4SharedKVAttention subclass pattern
+
+Create a subclass of `Attention` that takes `shared_key` and `shared_value`
+as explicit graph inputs instead of computing its own K/V projections:
+
+```python
+class Gemma4SharedKVAttention(Attention):
+    """Attention that reuses K/V from a source layer (no k_proj/v_proj weights)."""
+
+    def __init__(self, config, layer_idx):
+        super().__init__(config, layer_idx)
+        # Remove the K/V projection modules — they have no weights
+        del self.k_proj
+        del self.v_proj
+
+    def forward(self, op, hidden_states, attention_bias, position_embeddings,
+                shared_key, shared_value, past_key_value=None):
+        # Compute Q from this layer's own q_proj (each shared layer has unique Q)
+        query_states = self.q_proj(op, hidden_states)
+        # Reuse K/V from the source layer passed as explicit graph values
+        key_states = shared_key
+        value_states = shared_value
+        return self._attend(op, query_states, key_states, value_states,
+                            attention_bias, past_key_value)
+```
+
+### Source layer emits K/V as extra outputs
+
+The last non-shared layer of each attention type must expose its K/V so the
+graph can route them to all downstream shared layers:
+
+```python
+class Gemma4SourceAttention(Attention):
+    """Attention that additionally outputs K/V for sharing with later layers."""
+
+    def forward(self, op, hidden_states, ...):
+        result, present_kv = super().forward(...)
+        # Also return K, V for the shared layers to consume
+        return result, present_kv, self._last_key, self._last_value
+```
+
+The text model's forward loop passes these K/V values as explicit arguments:
+
+```python
+shared_key, shared_value = None, None
+for i, layer in enumerate(self.layers):
+    if layer.is_kv_shared:
+        hidden_states, kv = layer(op, hidden_states, ...,
+                                  shared_key=shared_key, shared_value=shared_value)
+    else:
+        hidden_states, kv, shared_key, shared_value = layer(op, hidden_states, ...)
+```
+
+### Type-aware sharing (sliding vs. full attention)
+
+When a model has multiple attention types (e.g. Gemma 4's 5:1 sliding/full
+pattern), each shared layer finds the last non-shared layer of the **same
+type**. Maintain separate `shared_key/value` per attention type:
+
+```python
+source_kvs = {}  # keyed by layer_type (e.g. "sliding", "full")
+for i, layer in enumerate(self.layers):
+    layer_type = self.config.layer_types[i]
+    if layer.is_kv_shared:
+        sk, sv = source_kvs[layer_type]
+        hidden, kv = layer(op, hidden, ..., shared_key=sk, shared_value=sv)
+    else:
+        hidden, kv, sk, sv = layer(op, hidden, ...)
+        source_kvs[layer_type] = (sk, sv)
+```

--- a/.github/skills/moe-models/SKILL.md
+++ b/.github/skills/moe-models/SKILL.md
@@ -250,6 +250,109 @@ Integration tests use a random-weight HF model with reduced layers and
 experts (e.g. 4 layers, 4 experts, top-2 routing).  See
 `test_qwen35_moe_prefill_logits_match` in `tests/integration_test.py`.
 
+## Direct MoE op emission (com.microsoft.MoE)
+
+OnnxRuntime ships a fused `com.microsoft.MoE` contrib op available on CUDA
+(float32/fp16/bf16) and CPU (float32/fp16). Emitting it directly — like GQA —
+is preferred over relying on a rewrite rule for new models.
+
+### Op variants
+
+| Op name | Purpose |
+|---------|---------|
+| `com.microsoft.MoE` | Standard dense weights |
+| `com.microsoft.QMoE` | INT4/INT8 quantized weights with scales and zero-points |
+| `com.microsoft.ShardedMoE` | Tensor-parallel (CUDA only) |
+
+### Input schema (com.microsoft.MoE)
+
+| Index | Name | Shape | Required |
+|-------|------|-------|---------|
+| 0 | `input` | `(num_tokens, hidden_size)` | ✅ |
+| 1 | `router_probs` | `(num_tokens, num_experts)` — **full pre-topk distribution** | ✅ |
+| 2 | `fc1_experts_weights` | `(num_experts, hidden_size, inter_size)` | ✅ |
+| 3 | `fc1_experts_bias` | `(num_experts, inter_size)` | Optional |
+| 4 | `fc2_experts_weights` | `(num_experts, inter_size, hidden_size)` | ✅ |
+| 5 | `fc2_experts_bias` | `(num_experts, hidden_size)` | Optional |
+| 6 | `fc3_experts_weights` | `(num_experts, hidden_size, inter_size)` | Optional (SwiGLU gate path) |
+| 7 | `fc3_experts_bias` | Optional |
+
+**Output:** single tensor, same shape as `input`.
+
+### Attributes
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `k` | int64 | ✅ | Top-k experts per token |
+| `activation_type` | string | ✅ | `"silu"`, `"gelu"`, `"relu"`, `"swiglu"`, `"identity"` |
+| `normalize_routing_weights` | int64 | default 0 | Renormalize top-k weights to sum=1 |
+| `use_sparse_mixer` | int64 | default 0 | SparseMixer routing (k=2 only) |
+| `swiglu_fusion` | int64 | default 0 | Interleaved SwiGLU weights; **CPU requires =1** |
+
+### Emission pattern
+
+```python
+# In MoELayer.forward(), when supports_fused_moe() is True:
+router_probs = self.gate.get_router_probs(op, hidden_states)  # full (tokens, num_experts)
+result = op.MoE(
+    hidden_states,
+    router_probs,
+    self.fc1_experts_weights,   # 3D packed: (N, hidden, inter)
+    None,                        # fc1_bias (optional)
+    self.fc2_experts_weights,   # 3D packed: (N, inter, hidden)
+    _domain="com.microsoft",
+    k=self.top_k,
+    activation_type="silu",
+    normalize_routing_weights=int(self.gate.normalize_routing_weights),
+)
+```
+
+### Critical: router_probs must be the FULL distribution
+
+The op performs top-k selection internally using the `k` attribute. It expects
+the **full** `(num_tokens, num_experts)` pre-topk probability tensor — NOT the
+post-topk selected values.
+
+Each gate variant must expose a `get_router_probs()` method returning the full
+distribution before `TopK`:
+
+| Gate | router_probs |
+|------|-------------|
+| `TopKGate` | `Softmax(MatMul(hidden, weight_t))` |
+| `SoftmaxTopKGate` | `Softmax(MatMul(hidden, weight_t))` |
+| `SigmoidTopKGate` | `Sigmoid(MatMul(hidden, weight_t))` |
+| `SparseMixerGate` | Raw router logits (identity) |
+
+### Rewrite rule vs. direct emission
+
+**A rewrite rule is NOT feasible** for MoE. The loop-over-experts pattern
+(N experts → N MatMul chains, N conditional branches, N Adds) does not produce
+a regular, pattern-matchable subgraph.
+
+**Direct emission is the right approach**, exactly like GQA. Use
+`supports_fused_moe()` from the EP context system to gate the emission path.
+
+### preprocess_weights: stacking per-expert weights into 3D tensors
+
+The ORT op expects all expert weights packed into 3D tensors
+`(num_experts, in_dim, out_dim)`. HuggingFace checkpoints typically store
+them as individual matrices per expert.
+
+```python
+def preprocess_weights(self, state_dict):
+    n = self.config.num_local_experts
+    # Stack gate_proj: (N, inter_size, hidden_size)
+    gate = torch.stack([state_dict.pop(f"experts.{i}.gate_proj.weight") for i in range(n)])
+    # Stack down_proj: (N, hidden_size, inter_size)
+    down = torch.stack([state_dict.pop(f"experts.{i}.down_proj.weight") for i in range(n)])
+    state_dict["fc1_experts_weights"] = gate
+    state_dict["fc2_experts_weights"] = down
+    return state_dict
+```
+
+Some checkpoints already store fused `gate_up_proj` (e.g., Qwen3.5-MoE).
+Split along `dim=1` before stacking if `inter_size` is known.
+
 ## Testing MoE models
 
 MoE integration tests require a model with MoE layers.  A good test model

--- a/.github/skills/multimodal-models/SKILL.md
+++ b/.github/skills/multimodal-models/SKILL.md
@@ -330,6 +330,88 @@ into 1 token:
 ```
 The merge reduces token count by 4× and projects to text model dimension.
 
+## Any-to-Any 4-model tasks (vision + audio + text)
+
+Some model families come in two tiers:
+
+| Tier | Models | Modalities | ONNX split |
+|------|--------|-----------|------------|
+| **Small (Any-to-Any)** | E2B, E4B | Vision + Audio + Text | **4 models** |
+| **Large (Image-Text-to-Text)** | 26B-A4B, 31B | Vision + Text only (no audio) | **3 models** |
+
+Example: `google/gemma-4-E2B-it`, `google/gemma-4-E4B-it` are Any-to-Any;
+`google/gemma-4-26B-A4B-it`, `google/gemma-4-31B-it` are Image-Text-to-Text.
+
+Check the config to decide which split to use:
+
+```python
+has_audio = getattr(config, "audio_config", None) is not None
+```
+
+### 4-model split layout
+
+```
+[vision.onnx]    pixel_values → image_features
+[audio.onnx]     input_features → audio_features
+[embedding.onnx] input_ids, image_features, audio_features → inputs_embeds
+[model.onnx]     inputs_embeds, attention_mask, past_kv → logits, present_kv
+```
+
+### Reference: Phi4MMMultiModalTask
+
+Use `Phi4MMMultiModalTask` in `tasks/` as the template for 4-model tasks.
+It already implements the 4-way split with audio + vision encoders:
+
+```python
+from mobius.tasks import Phi4MMMultiModalTask
+
+pkg = build_from_module(module, config, task=Phi4MMMultiModalTask())
+# pkg["model"]     → decoder
+# pkg["vision"]    → vision encoder
+# pkg["audio"]     → audio encoder
+# pkg["embedding"] → embedding + InputMixer
+```
+
+### Audio encoder wiring
+
+The audio encoder takes raw speech features and produces embeddings that the
+`InputMixer` scatters into the text embedding stream alongside vision tokens:
+
+```
+input_features: (batch, mel_frames, mel_bins)
+    → AudioEncoder
+    → audio_features: (batch, num_audio_tokens, hidden_size)
+    → InputMixer (alongside vision_features)
+    → inputs_embeds
+```
+
+The `InputMixer` handles both image and audio token positions. Audio tokens
+are marked with `audio_token_id` in `input_ids` — the mixer replaces those
+positions with `audio_features`.
+
+### Task class pattern
+
+```python
+class MyAnyToAnyTask(TaskBase):
+    def build(self, module, config):
+        has_audio = getattr(config, "audio_config", None) is not None
+        if has_audio:
+            return self._build_4model(module, config)
+        else:
+            return self._build_3model(module, config)
+
+    def _build_4model(self, module, config):
+        # Build vision, audio, embedding, decoder separately
+        ...
+
+    def _build_3model(self, module, config):
+        # Vision + embedding + decoder only (reuse VisionLanguageTask pattern)
+        ...
+```
+
+This conditional ensures the same task class handles both tier splits without
+requiring separate registration.
+
 ## Qwen3.5-VL
 
 Qwen3.5-VL uses the same **3-model split** as Qwen3-VL (decoder + vision +


### PR DESCRIPTION
Updates three skills with patterns discovered during Gemma 4 implementation:

- moe-models: direct com.microsoft.MoE emission, QMoE, router_probs pattern, preprocess_weights stacking
- multimodal-models: Any-to-Any 4-model task pattern, tier split (E2B/E4B vs 26B/31B), audio wiring
- adding-a-new-model: num_kv_shared_layers semantics, absent weights, KV cache sizing, Gemma4SharedKVAttention pattern