### PR TITLE
docs(skill): add lintrunner -a requirement to quality checklist

### DIFF
--- a/.github/skills/quality-checklist/SKILL.md
+++ b/.github/skills/quality-checklist/SKILL.md
@@ -38,6 +38,8 @@ before the PR is merged.
 - [ ] Tensor shapes are annotated in comments after non-trivial operations
 - [ ] Automated code review (Copilot/PR review) has been run and all
       findings are resolved or explicitly dismissed with a reason
+- [ ] `lintrunner -a` is clean — zero lint errors before merging
+      (`lintrunner f --output oneline --all-files` to auto-fix, then re-run to confirm)
 
 ### 2. L1 — Graph builds
 
@@ -182,6 +184,10 @@ Unchecked items without a waiver are grounds to request changes before merge.
 ## Quick reference commands
 
 ```bash
+# Lint (auto-fix then verify clean)
+lintrunner f --output oneline --all-files
+lintrunner -a
+
 # L1 – graph build
 python -m pytest tests/build_graph_test.py -k "<model_type>"
 


### PR DESCRIPTION
Adds lintrunner -a clean requirement to the quality-checklist skill definition of done.

- Added checklist item to Section 1 (Code quality): `lintrunner -a` must be clean (zero lint errors) before merging, with note to auto-fix using `lintrunner f`
- Added `lintrunner` commands to the Quick Reference section