### PR TITLE
fix: --config mode model_type and token ID propagation

### DIFF
--- a/src/mobius/_configs.py
+++ b/src/mobius/_configs.py
@@ -770,6 +770,12 @@ class ArchitectureConfig(BaseModelConfig):
     codec_encoder: CodecEncoderConfig | None = None
     quantization: QuantizationConfig | None = None
 
+    # HuggingFace model_type and special token IDs — populated by from_transformers()
+    # so that genai_config.json can be written without re-fetching the HF config.
+    model_type: str | None = None
+    bos_token_id: int | None = None
+    eos_token_id: int | list[int] | None = None
+
     @classmethod
     def from_transformers(cls, config, parent_config=None) -> ArchitectureConfig:
         model_type = config.model_type
@@ -846,6 +852,9 @@ class ArchitectureConfig(BaseModelConfig):
             linear_num_key_heads=(getattr(config, "linear_num_key_heads", None)),
             linear_num_value_heads=(getattr(config, "linear_num_value_heads", None)),
             pad_token_id=(getattr(config, "pad_token_id", 0)),
+            model_type=model_type,
+            bos_token_id=getattr(config, "bos_token_id", None),
+            eos_token_id=getattr(config, "eos_token_id", None),
             rms_norm_eps=(
                 getattr(config, "rms_norm_eps", None)
                 or getattr(config, "layer_norm_eps", None)

--- a/src/mobius/_configs_test.py
+++ b/src/mobius/_configs_test.py
@@ -206,6 +206,32 @@ class TestArchitectureConfig:
         assert config.rope_type == "llama3"
         assert config.original_max_position_embeddings == 8192
 
+    def test_from_transformers_stores_model_type_and_token_ids(self):
+        """model_type, bos_token_id, eos_token_id are preserved on ArchitectureConfig."""
+
+        class FakeConfig:
+            model_type = "gemma2"
+            num_attention_heads = 8
+            num_key_value_heads = 4
+            num_hidden_layers = 2
+            vocab_size = 256
+            hidden_size = 64
+            intermediate_size = 128
+            hidden_act = "gelu"
+            max_position_embeddings = 128
+            head_dim = 8
+            pad_token_id = 0
+            bos_token_id = 2
+            eos_token_id = 1
+            rms_norm_eps = 1e-6
+            rope_theta = 10000.0
+            rope_scaling = None
+
+        config = ArchitectureConfig.from_transformers(FakeConfig())
+        assert config.model_type == "gemma2"
+        assert config.bos_token_id == 2
+        assert config.eos_token_id == 1
+
 
 class TestExtractRopeConfig:
     """Unit tests for _extract_rope_config helper."""

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -263,7 +263,8 @@ def write_ort_genai_config(
         # when --config is used with a local directory).
         bos_token_id = getattr(config, "bos_token_id", None)
         eos_token_id = getattr(config, "eos_token_id", None)
-        # pad_token_id is in BaseModelConfig; map DEFAULT_INT sentinel to None
+        # pad_token_id lives in BaseModelConfig with DEFAULT_INT (-42) as the
+        # "not set" sentinel (negative IDs are never valid token positions).
         _pad = getattr(config, "pad_token_id", None)
         pad_token_id = None if (_pad is None or _pad < 0) else _pad
 

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -248,11 +248,9 @@ def write_ort_genai_config(
         eos_token_id = getattr(hf_config, "eos_token_id", None)
         pad_token_id = getattr(hf_config, "pad_token_id", None)
     else:
-        # Fall back to model_type from the mobius ArchitectureConfig.
-        # This path is taken when hf_model_id is not provided, so HF config
-        # is unavailable. The ArchitectureConfig.model_type may be absent on
-        # older configs, producing 'unknown' — ORT-GenAI may reject it.
-        raw_type = getattr(config, "model_type", "unknown")
+        # Fall back to fields stored in ArchitectureConfig (set by from_transformers()).
+        # This path is taken when hf_model_id is not provided (e.g. --config mode).
+        raw_type = getattr(config, "model_type", None) or "unknown"
         ort_model_type = _resolve_ort_genai_model_type(raw_type)
         if ort_model_type == "unknown":
             logger.warning(
@@ -261,6 +259,13 @@ def write_ort_genai_config(
                 "the HuggingFace config, or the generated genai_config.json "
                 "may not load correctly."
             )
+        # Read token IDs from ArchitectureConfig (populated by from_transformers()
+        # when --config is used with a local directory).
+        bos_token_id = getattr(config, "bos_token_id", None)
+        eos_token_id = getattr(config, "eos_token_id", None)
+        # pad_token_id is in BaseModelConfig; map DEFAULT_INT sentinel to None
+        _pad = getattr(config, "pad_token_id", None)
+        pad_token_id = None if (_pad is None or _pad < 0) else _pad
 
     # Detect multimodal capabilities from the package keys
     is_vlm = "vision" in pkg and "embedding" in pkg

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -195,8 +195,10 @@ def write_ort_genai_config(
         directory: Output directory (created if needed).
         hf_model_id: HuggingFace model ID. When provided, used to fetch token
             IDs (``bos``/``eos``/``pad``) and download tokenizer files.
-            When ``None``, token IDs default to ``None`` and tokenizer files
-            are not copied.
+            When ``None``, token IDs are read from ``pkg.config`` fields
+            (``bos_token_id``, ``eos_token_id``, ``pad_token_id``) populated
+            by :meth:`~mobius._configs.ArchitectureConfig.from_transformers`,
+            and tokenizer files are not copied.
         ep: Execution provider for ``session_options`` in
             ``genai_config.json`` (e.g. ``"cpu"``, ``"cuda"``, ``"dml"``,
             ``"trt-rtx"``). Defaults to ``"cpu"``.
@@ -254,10 +256,11 @@ def write_ort_genai_config(
         ort_model_type = _resolve_ort_genai_model_type(raw_type)
         if ort_model_type == "unknown":
             logger.warning(
-                "Could not determine ORT-GenAI model type: pkg.config has no "
-                "'model_type' attribute. Pass hf_model_id to resolve it from "
-                "the HuggingFace config, or the generated genai_config.json "
-                "may not load correctly."
+                "Could not determine ORT-GenAI model type: pkg.config.model_type "
+                "is missing, None, or not mapped to an ORT-GenAI type (got %r). "
+                "Pass hf_model_id to resolve it from the HuggingFace config, or "
+                "the generated genai_config.json may not load correctly.",
+                raw_type,
             )
         # Read token IDs from ArchitectureConfig (populated by from_transformers()
         # when --config is used with a local directory).

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -313,6 +313,34 @@ class TestExportForOrtGenai:
         assert data["model"]["eos_token_id"] == 2
         assert data["model"]["pad_token_id"] == 0
 
+    def test_config_mode_eos_token_id_as_list(self, tmp_path):
+        """eos_token_id can be a list[int] (e.g. Gemma multi-stop tokens)."""
+        import dataclasses
+
+        from mobius._model_package import ModelPackage
+        from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
+
+        @dataclasses.dataclass
+        class FakeConfig:
+            model_type: str = "gemma2"
+            vocab_size: int = 256
+            hidden_size: int = 64
+            num_hidden_layers: int = 2
+            num_attention_heads: int = 4
+            num_key_value_heads: int = 2
+            head_dim: int = 16
+            max_position_embeddings: int = 128
+            bos_token_id: int = 2
+            eos_token_id: list = dataclasses.field(default_factory=lambda: [1, 106])
+            pad_token_id: int = 0
+
+        pkg = ModelPackage({"model": mock.MagicMock()}, config=FakeConfig())
+        result = write_ort_genai_config(pkg, str(tmp_path), hf_model_id=None)
+
+        with open(result["genai_config"]) as f:
+            data = json.load(f)
+        assert data["model"]["eos_token_id"] == [1, 106]
+
 
 @pytest.mark.integration
 class TestAutoExportEndToEnd:

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -256,6 +256,63 @@ class TestExportForOrtGenai:
             if saved is not None:
                 sys.modules["onnxruntime_genai"] = saved
 
+    def test_config_mode_model_type_propagated(self, tmp_path):
+        """model.type in genai_config.json is correct when hf_model_id=None."""
+        import dataclasses
+
+        from mobius._model_package import ModelPackage
+        from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
+
+        @dataclasses.dataclass
+        class FakeConfig:
+            # model_type now stored on ArchitectureConfig for --config mode
+            model_type: str = "gemma2"
+            vocab_size: int = 256
+            hidden_size: int = 64
+            num_hidden_layers: int = 2
+            num_attention_heads: int = 4
+            num_key_value_heads: int = 2
+            head_dim: int = 16
+            max_position_embeddings: int = 128
+
+        pkg = ModelPackage({"model": mock.MagicMock()}, config=FakeConfig())
+        result = write_ort_genai_config(pkg, str(tmp_path), hf_model_id=None)
+
+        with open(result["genai_config"]) as f:
+            data = json.load(f)
+        # "gemma2" maps to "gemma" in _ORT_GENAI_MODEL_TYPE
+        assert data["model"]["type"] == "gemma"
+
+    def test_config_mode_token_ids_propagated(self, tmp_path):
+        """bos/eos token IDs in genai_config.json come from config fields in --config mode."""
+        import dataclasses
+
+        from mobius._model_package import ModelPackage
+        from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
+
+        @dataclasses.dataclass
+        class FakeConfig:
+            model_type: str = "llama"
+            vocab_size: int = 256
+            hidden_size: int = 64
+            num_hidden_layers: int = 2
+            num_attention_heads: int = 4
+            num_key_value_heads: int = 2
+            head_dim: int = 16
+            max_position_embeddings: int = 128
+            bos_token_id: int = 1
+            eos_token_id: int = 2
+            pad_token_id: int = 0
+
+        pkg = ModelPackage({"model": mock.MagicMock()}, config=FakeConfig())
+        result = write_ort_genai_config(pkg, str(tmp_path), hf_model_id=None)
+
+        with open(result["genai_config"]) as f:
+            data = json.load(f)
+        assert data["model"]["bos_token_id"] == 1
+        assert data["model"]["eos_token_id"] == 2
+        assert data["model"]["pad_token_id"] == 0
+
 
 @pytest.mark.integration
 class TestAutoExportEndToEnd:


### PR DESCRIPTION
Fixes model.type=unknown and missing bos/eos token IDs when using local --config path. Addresses Issues 1 and 2 from Edge LLM evaluation.

## Problem

When building with `--config <local_dir>` instead of a HuggingFace model ID:

1. **Issue 1**: `genai_config.json` always contained `"type": "unknown"` because `ArchitectureConfig` had no `model_type` field — it was read from the HF config but never stored.

2. **Issue 2**: `bos_token_id` / `eos_token_id` were absent from `genai_config.json` because token IDs were only fetched via `AutoConfig.from_pretrained()`, which is skipped when `hf_model_id=None`.

## Fix

- Added `model_type`, `bos_token_id`, `eos_token_id` fields to `ArchitectureConfig`
- Populated them in `from_transformers()` (called by the `--config` path)
- In `write_ort_genai_config()`, the `else` branch (no `hf_model_id`) now reads all three from `ArchitectureConfig` instead of leaving them as `None`

## Tests

- `_configs_test.py`: verifies `from_transformers()` stores the new fields
- `auto_export_test.py`: two new tests — `test_config_mode_model_type_propagated` and `test_config_mode_token_ids_propagated`
