### PR TITLE
fix: share tied weights as single ONNX initializer instead of copying

### DIFF
--- a/src/mobius/_registry.py
+++ b/src/mobius/_registry.py
@@ -707,7 +707,7 @@ _TEST_MODEL_IDS: dict[str, str] = {
     "command_r": "CohereForAI/c4ai-command-r-v01",
     "csm": "sesame/csm-1b",
     "evolla": "westlake-repl/Evolla-10B-hf",
-    "nemotron_h": "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1",
+    "nemotron_h": "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16",
     "open-llama": "openlm-research/open_llama_3b",
     "persimmon": "adept/persimmon-8b-base",
     "shieldgemma2": "google/shieldgemma-2b",

--- a/src/mobius/_weight_loading.py
+++ b/src/mobius/_weight_loading.py
@@ -103,6 +103,11 @@ def apply_weights(model: ir.Model, state_dict: dict[str, torch.Tensor]) -> None:
     # Map tensor id → the ir.Value of the first initializer assigned for that tensor.
     # Enables genuine weight sharing: if lm_head.weight IS embed_tokens.weight
     # (same Python object), the second initializer is merged into the first.
+    # Prefer embed_tokens.weight as the canonical name regardless of state_dict
+    # insertion order — this keeps initializer names consistent even when a
+    # checkpoint supplies only lm_head.weight and tie_word_embeddings() adds
+    # model.embed_tokens.weight afterwards (making lm_head appear first).
+    _embed_suffix = "embed_tokens.weight"
     tensor_id_to_value: dict[int, ir.Value] = {}
 
     for name, tensor in state_dict.items():
@@ -117,17 +122,32 @@ def apply_weights(model: ir.Model, state_dict: dict[str, torch.Tensor]) -> None:
         tid = id(tensor)
 
         if tid in tensor_id_to_value:
-            # This tensor was already assigned to another initializer.
-            # Redirect all graph uses of this initializer to the canonical one,
-            # then delete this initializer — genuine single-copy weight sharing.
             canonical = tensor_id_to_value[tid]
-            initializer.replace_all_uses_with(canonical)
-            del model.graph.initializers[name]
-            logger.debug(
-                "Weight tying: '%s' shares initializer with '%s'",
-                name,
-                canonical.name,
-            )
+            # If the current initializer has the preferred embedding name but the
+            # existing canonical does not, swap them so embedding is always canonical.
+            if name.endswith(_embed_suffix) and not (canonical.name or "").endswith(
+                _embed_suffix
+            ):
+                # Promote this initializer to canonical; demote the previous one.
+                _assign_weight(initializer, tensor, name)
+                canonical.replace_all_uses_with(initializer)
+                del model.graph.initializers[canonical.name]
+                tensor_id_to_value[tid] = initializer
+                logger.debug(
+                    "Weight tying: '%s' promoted to canonical (was '%s')",
+                    name,
+                    canonical.name,
+                )
+            else:
+                # Redirect all graph uses of this initializer to the canonical one,
+                # then delete this initializer — genuine single-copy weight sharing.
+                initializer.replace_all_uses_with(canonical)
+                del model.graph.initializers[name]
+                logger.debug(
+                    "Weight tying: '%s' shares initializer with '%s'",
+                    name,
+                    canonical.name,
+                )
         else:
             _assign_weight(initializer, tensor, name)
             tensor_id_to_value[tid] = initializer

--- a/src/mobius/_weight_loading.py
+++ b/src/mobius/_weight_loading.py
@@ -100,12 +100,17 @@ def apply_weights(model: ir.Model, state_dict: dict[str, torch.Tensor]) -> None:
         model: The ONNX IR model.
         state_dict: Mapping of parameter names to torch tensors.
     """
-    # Map tensor id → the ir.Value of the first initializer assigned for that tensor.
-    # Enables genuine weight sharing: if lm_head.weight IS embed_tokens.weight
-    # (same Python object), the second initializer is merged into the first.
-    # The canonical key is simply whichever name appears first in state_dict
-    # iteration order, which is deterministic (PEP 468, Python 3.7+).
-    tensor_id_to_value: dict[int, ir.Value] = {}
+    # Map tensor storage identity → the ir.Value of the first initializer
+    # assigned for that tensor.  Enables genuine weight sharing: if
+    # lm_head.weight and embed_tokens.weight share the same underlying
+    # storage (common when HF ties weights), only one ONNX initializer is
+    # created and all graph uses point to it.
+    #
+    # We key on ``data_ptr()`` rather than ``id(tensor)`` because HF
+    # safetensors deserialization may create distinct Python objects that
+    # share the same storage (same data_ptr).  Using data_ptr catches both
+    # cases: same Python object *and* same-storage-different-object.
+    storage_to_value: dict[int, ir.Value] = {}
 
     for name, tensor in state_dict.items():
         if name not in model.graph.initializers:
@@ -116,13 +121,13 @@ def apply_weights(model: ir.Model, state_dict: dict[str, torch.Tensor]) -> None:
             continue
 
         initializer = model.graph.initializers[name]
-        tid = id(tensor)
+        storage_key = tensor.data_ptr()
 
-        if tid in tensor_id_to_value:
-            # This tensor was already assigned to another initializer.
+        if storage_key in storage_to_value:
+            # This tensor shares storage with an already-assigned initializer.
             # Redirect all graph uses of this initializer to the canonical one,
             # then delete this initializer — genuine single-copy weight sharing.
-            canonical = tensor_id_to_value[tid]
+            canonical = storage_to_value[storage_key]
             initializer.replace_all_uses_with(canonical)
             del model.graph.initializers[name]
             logger.debug(
@@ -132,7 +137,7 @@ def apply_weights(model: ir.Model, state_dict: dict[str, torch.Tensor]) -> None:
             )
         else:
             _assign_weight(initializer, tensor, name)
-            tensor_id_to_value[tid] = initializer
+            storage_to_value[storage_key] = initializer
 
     fold_initializers_after_weights(model)
 

--- a/src/mobius/_weight_loading.py
+++ b/src/mobius/_weight_loading.py
@@ -103,11 +103,8 @@ def apply_weights(model: ir.Model, state_dict: dict[str, torch.Tensor]) -> None:
     # Map tensor id → the ir.Value of the first initializer assigned for that tensor.
     # Enables genuine weight sharing: if lm_head.weight IS embed_tokens.weight
     # (same Python object), the second initializer is merged into the first.
-    # Prefer embed_tokens.weight as the canonical name regardless of state_dict
-    # insertion order — this keeps initializer names consistent even when a
-    # checkpoint supplies only lm_head.weight and tie_word_embeddings() adds
-    # model.embed_tokens.weight afterwards (making lm_head appear first).
-    _embed_suffix = "embed_tokens.weight"
+    # The canonical key is simply whichever name appears first in state_dict
+    # iteration order, which is deterministic (PEP 468, Python 3.7+).
     tensor_id_to_value: dict[int, ir.Value] = {}
 
     for name, tensor in state_dict.items():
@@ -122,32 +119,17 @@ def apply_weights(model: ir.Model, state_dict: dict[str, torch.Tensor]) -> None:
         tid = id(tensor)
 
         if tid in tensor_id_to_value:
+            # This tensor was already assigned to another initializer.
+            # Redirect all graph uses of this initializer to the canonical one,
+            # then delete this initializer — genuine single-copy weight sharing.
             canonical = tensor_id_to_value[tid]
-            # If the current initializer has the preferred embedding name but the
-            # existing canonical does not, swap them so embedding is always canonical.
-            if name.endswith(_embed_suffix) and not (canonical.name or "").endswith(
-                _embed_suffix
-            ):
-                # Promote this initializer to canonical; demote the previous one.
-                _assign_weight(initializer, tensor, name)
-                canonical.replace_all_uses_with(initializer)
-                del model.graph.initializers[canonical.name]
-                tensor_id_to_value[tid] = initializer
-                logger.debug(
-                    "Weight tying: '%s' promoted to canonical (was '%s')",
-                    name,
-                    canonical.name,
-                )
-            else:
-                # Redirect all graph uses of this initializer to the canonical one,
-                # then delete this initializer — genuine single-copy weight sharing.
-                initializer.replace_all_uses_with(canonical)
-                del model.graph.initializers[name]
-                logger.debug(
-                    "Weight tying: '%s' shares initializer with '%s'",
-                    name,
-                    canonical.name,
-                )
+            initializer.replace_all_uses_with(canonical)
+            del model.graph.initializers[name]
+            logger.debug(
+                "Weight tying: '%s' shares initializer with '%s'",
+                name,
+                canonical.name,
+            )
         else:
             _assign_weight(initializer, tensor, name)
             tensor_id_to_value[tid] = initializer

--- a/src/mobius/_weight_loading.py
+++ b/src/mobius/_weight_loading.py
@@ -85,7 +85,13 @@ def apply_weights(model: ir.Model, state_dict: dict[str, torch.Tensor]) -> None:
     """Apply weights from a state dict to an ONNX model.
 
     Assigns each tensor in *state_dict* to the matching initializer in the
-    model.  After all weights are assigned,
+    model.  When two entries in *state_dict* are the **same Python object**
+    (i.e. genuinely tied weights such as ``lm_head.weight`` /
+    ``embed_tokens.weight``), the second initializer's value is redirected to
+    share the first one — a single ONNX initializer is emitted instead of two
+    identical copies.
+
+    After all weights are assigned,
     :func:`~mobius._optimizations.fold_initializers_after_weights` is called to
     fold ``Transpose`` and ``Concat`` nodes over initializers into pre-computed
     weights and remove unused source initializers.
@@ -94,6 +100,11 @@ def apply_weights(model: ir.Model, state_dict: dict[str, torch.Tensor]) -> None:
         model: The ONNX IR model.
         state_dict: Mapping of parameter names to torch tensors.
     """
+    # Map tensor id → the ir.Value of the first initializer assigned for that tensor.
+    # Enables genuine weight sharing: if lm_head.weight IS embed_tokens.weight
+    # (same Python object), the second initializer is merged into the first.
+    tensor_id_to_value: dict[int, ir.Value] = {}
+
     for name, tensor in state_dict.items():
         if name not in model.graph.initializers:
             logger.warning(
@@ -102,7 +113,24 @@ def apply_weights(model: ir.Model, state_dict: dict[str, torch.Tensor]) -> None:
             )
             continue
 
-        _assign_weight(model.graph.initializers[name], tensor, name)
+        initializer = model.graph.initializers[name]
+        tid = id(tensor)
+
+        if tid in tensor_id_to_value:
+            # This tensor was already assigned to another initializer.
+            # Redirect all graph uses of this initializer to the canonical one,
+            # then delete this initializer — genuine single-copy weight sharing.
+            canonical = tensor_id_to_value[tid]
+            initializer.replace_all_uses_with(canonical)
+            del model.graph.initializers[name]
+            logger.debug(
+                "Weight tying: '%s' shares initializer with '%s'",
+                name,
+                canonical.name,
+            )
+        else:
+            _assign_weight(initializer, tensor, name)
+            tensor_id_to_value[tid] = initializer
 
     fold_initializers_after_weights(model)
 

--- a/src/mobius/_weight_loading_test.py
+++ b/src/mobius/_weight_loading_test.py
@@ -534,6 +534,38 @@ class TestWeightTying:
         assert "lm_head.weight" not in sd3
         assert "model.embed_tokens.weight" in sd3
 
+    def test_apply_weights_dedup_canonical_is_always_embed_key(self):
+        """apply_weights dedup (safety-net path) must always use embed_tokens as canonical.
+
+        When a model still uses two graph initializers (old-style, no __init__ aliasing),
+        and the state_dict has lm_head.weight before model.embed_tokens.weight (e.g.,
+        from a checkpoint where only lm_head.weight was saved and tie_word_embeddings()
+        added embed_tokens.weight after), the canonical initializer must still be
+        model.embed_tokens.weight — not lm_head.weight.
+        """
+        # Build an untied model so the graph has both initializers.
+        config = make_config(tie_word_embeddings=False)
+        module = CausalLMModel(config)
+        pkg = build_from_module(module, config)
+        model = pkg["model"]
+
+        weight = torch.zeros(config.vocab_size, config.hidden_size)
+        # Simulate: checkpoint only had lm_head.weight; tie_word_embeddings() added
+        # embed_tokens.weight — so lm_head.weight appears first in the dict.
+        sd = {
+            "lm_head.weight": weight,
+            "model.embed_tokens.weight": weight,  # same object, lm_head first
+        }
+        apply_weights(model, sd)
+
+        # Regardless of insertion order, model.embed_tokens.weight must be canonical.
+        assert "model.embed_tokens.weight" in model.graph.initializers, (
+            "model.embed_tokens.weight must be the canonical initializer"
+        )
+        assert "lm_head.weight" not in model.graph.initializers, (
+            "lm_head.weight must be removed — merged into embed_tokens"
+        )
+
     def test_untied_weights_have_separate_initializers(self):
         """When tie_word_embeddings=False, both initializers remain independent."""
         config = make_config(tie_word_embeddings=False)

--- a/src/mobius/_weight_loading_test.py
+++ b/src/mobius/_weight_loading_test.py
@@ -461,6 +461,92 @@ class TestCorruptedFileHandling:
 
 
 # ===========================================================================
+# (6b) Weight tying — genuine ONNX initializer sharing
+# ===========================================================================
+
+
+class TestWeightTying:
+    """Verify that tied weights (lm_head = embed_tokens) share one ONNX initializer."""
+
+    def _build_tied_model(self) -> tuple[ir.Model, CausalLMModel]:
+        config = make_config(tie_word_embeddings=True)
+        module = CausalLMModel(config)
+        pkg = build_from_module(module, config)
+        return pkg["model"], module
+
+    def test_tied_weights_share_single_initializer(self):
+        """When tie_word_embeddings=True, lm_head.weight must NOT be a separate initializer."""
+        model, module = self._build_tied_model()
+        weight = torch.zeros(make_config().vocab_size, make_config().hidden_size)
+        sd = module.preprocess_weights({"model.embed_tokens.weight": weight})
+        assert sd["model.embed_tokens.weight"] is sd["lm_head.weight"], (
+            "preprocess_weights must produce the same tensor object for tied weights"
+        )
+
+        apply_weights(model, sd)
+
+        assert "lm_head.weight" not in model.graph.initializers, (
+            "lm_head.weight initializer should be removed — merged into embed_tokens"
+        )
+        assert "model.embed_tokens.weight" in model.graph.initializers, (
+            "embed_tokens initializer must remain as the canonical shared weight"
+        )
+
+    def test_untied_weights_have_separate_initializers(self):
+        """When tie_word_embeddings=False, both initializers remain independent."""
+        config = make_config(tie_word_embeddings=False)
+        module = CausalLMModel(config)
+        pkg = build_from_module(module, config)
+        model = pkg["model"]
+
+        vocab_size = config.vocab_size
+        hidden_size = config.hidden_size
+        sd = {
+            "model.embed_tokens.weight": torch.zeros(vocab_size, hidden_size),
+            "lm_head.weight": torch.zeros(vocab_size, hidden_size),
+        }
+        apply_weights(model, sd)
+
+        assert "model.embed_tokens.weight" in model.graph.initializers
+        assert "lm_head.weight" in model.graph.initializers
+
+    def test_tied_model_initializer_count_lower_than_untied(self):
+        """Tied model must have fewer initializers than untied (one embed weight, not two)."""
+        from mobius._testing import make_config as mc
+
+        config_tied = mc(tie_word_embeddings=True)
+        module_tied = CausalLMModel(config_tied)
+        pkg_tied = build_from_module(module_tied, config_tied)
+        model_tied = pkg_tied["model"]
+        sd_tied = module_tied.preprocess_weights(
+            {
+                "model.embed_tokens.weight": torch.zeros(
+                    config_tied.vocab_size, config_tied.hidden_size
+                )
+            }
+        )
+        apply_weights(model_tied, sd_tied)
+
+        config_untied = mc(tie_word_embeddings=False)
+        module_untied = CausalLMModel(config_untied)
+        pkg_untied = build_from_module(module_untied, config_untied)
+        model_untied = pkg_untied["model"]
+        sd_untied = {
+            "model.embed_tokens.weight": torch.zeros(
+                config_untied.vocab_size, config_untied.hidden_size
+            ),
+            "lm_head.weight": torch.zeros(config_untied.vocab_size, config_untied.hidden_size),
+        }
+        apply_weights(model_untied, sd_untied)
+
+        n_tied = len(model_tied.graph.initializers)
+        n_untied = len(model_untied.graph.initializers)
+        assert n_tied < n_untied, (
+            f"Tied model should have fewer initializers ({n_tied}) than untied ({n_untied})"
+        )
+
+
+# ===========================================================================
 # (6) build_from_module contract preservation
 # ===========================================================================
 

--- a/src/mobius/_weight_loading_test.py
+++ b/src/mobius/_weight_loading_test.py
@@ -534,14 +534,12 @@ class TestWeightTying:
         assert "lm_head.weight" not in sd3
         assert "model.embed_tokens.weight" in sd3
 
-    def test_apply_weights_dedup_canonical_is_always_embed_key(self):
-        """apply_weights dedup (safety-net path) must always use embed_tokens as canonical.
+    def test_apply_weights_dedup_canonical_is_first_insertion_order(self):
+        """apply_weights dedup picks the first key in state_dict insertion order as canonical.
 
-        When a model still uses two graph initializers (old-style, no __init__ aliasing),
-        and the state_dict has lm_head.weight before model.embed_tokens.weight (e.g.,
-        from a checkpoint where only lm_head.weight was saved and tie_word_embeddings()
-        added embed_tokens.weight after), the canonical initializer must still be
-        model.embed_tokens.weight — not lm_head.weight.
+        Python dicts are insertion-ordered (PEP 468, Python 3.7+), so whichever
+        key appears first in the state_dict becomes the canonical initializer.
+        No model-specific name preference is applied.
         """
         # Build an untied model so the graph has both initializers.
         config = make_config(tie_word_embeddings=False)
@@ -550,20 +548,21 @@ class TestWeightTying:
         model = pkg["model"]
 
         weight = torch.zeros(config.vocab_size, config.hidden_size)
-        # Simulate: checkpoint only had lm_head.weight; tie_word_embeddings() added
-        # embed_tokens.weight — so lm_head.weight appears first in the dict.
+        # embed_tokens.weight is first — it must become the canonical initializer.
         sd = {
-            "lm_head.weight": weight,
-            "model.embed_tokens.weight": weight,  # same object, lm_head first
+            "model.embed_tokens.weight": weight,
+            "lm_head.weight": weight,  # same object, comes second
         }
         apply_weights(model, sd)
 
-        # Regardless of insertion order, model.embed_tokens.weight must be canonical.
-        assert "model.embed_tokens.weight" in model.graph.initializers, (
-            "model.embed_tokens.weight must be the canonical initializer"
+        # The first key in insertion order is the canonical; the second is removed.
+        first_key = next(iter(sd))
+        second_key = next(k for k in sd if k != first_key)
+        assert first_key in model.graph.initializers, (
+            f"'{first_key}' (first in state_dict) must be the canonical initializer"
         )
-        assert "lm_head.weight" not in model.graph.initializers, (
-            "lm_head.weight must be removed — merged into embed_tokens"
+        assert second_key not in model.graph.initializers, (
+            f"'{second_key}' (second in state_dict) must be merged away"
         )
 
     def test_untied_weights_have_separate_initializers(self):

--- a/src/mobius/_weight_loading_test.py
+++ b/src/mobius/_weight_loading_test.py
@@ -506,19 +506,27 @@ class TestWeightTying:
             "model.embed_tokens.weight initializer must be referenced by at least one node"
         )
 
-    def test_preprocess_weights_drops_lm_head_key(self):
-        """preprocess_weights must remove lm_head.weight from the state dict when tied."""
+    def test_preprocess_weights_ensures_both_tied_keys(self):
+        """preprocess_weights ensures both lm_head.weight and embed_tokens.weight exist.
+
+        tie_word_embeddings(state_dict) adds the missing key rather than removing
+        the present one, so that apply_weights can assign each initializer and the
+        id()-based dedup unifies them at load time via replace_all_uses_with.
+        """
         _, module = self._build_tied_model()
         vocab_size = make_config().vocab_size
         hidden_size = make_config().hidden_size
         weight = torch.zeros(vocab_size, hidden_size)
 
-        # Case 1: checkpoint has only embed_tokens.weight (typical tied checkpoint)
+        # Case 1: checkpoint has only embed_tokens.weight (typical tied checkpoint).
+        # lm_head.weight must be synthesised as an alias.
         sd = module.preprocess_weights({"model.embed_tokens.weight": weight})
-        assert "lm_head.weight" not in sd
         assert "model.embed_tokens.weight" in sd
+        assert "lm_head.weight" in sd
+        # Both point to the same tensor object so apply_weights dedup fires.
+        assert sd["lm_head.weight"] is sd["model.embed_tokens.weight"]
 
-        # Case 2: checkpoint has both keys (some checkpoints save both even when tied)
+        # Case 2: checkpoint has both keys — both must remain (no key is dropped).
         lm_head_weight = torch.ones(vocab_size, hidden_size)
         sd2 = module.preprocess_weights(
             {
@@ -526,13 +534,15 @@ class TestWeightTying:
                 "lm_head.weight": lm_head_weight,
             }
         )
-        assert "lm_head.weight" not in sd2
         assert "model.embed_tokens.weight" in sd2
+        assert "lm_head.weight" in sd2
 
-        # Case 3: checkpoint has only lm_head.weight
+        # Case 3: checkpoint has only lm_head.weight.
+        # embed_tokens.weight must be synthesised as an alias.
         sd3 = module.preprocess_weights({"lm_head.weight": weight})
-        assert "lm_head.weight" not in sd3
+        assert "lm_head.weight" in sd3
         assert "model.embed_tokens.weight" in sd3
+        assert sd3["lm_head.weight"] is sd3["model.embed_tokens.weight"]
 
     def test_apply_weights_dedup_canonical_is_first_insertion_order(self):
         """apply_weights dedup picks the first key in state_dict insertion order as canonical.

--- a/src/mobius/_weight_loading_test.py
+++ b/src/mobius/_weight_loading_test.py
@@ -474,23 +474,65 @@ class TestWeightTying:
         pkg = build_from_module(module, config)
         return pkg["model"], module
 
-    def test_tied_weights_share_single_initializer(self):
-        """When tie_word_embeddings=True, lm_head.weight must NOT be a separate initializer."""
-        model, module = self._build_tied_model()
-        weight = torch.zeros(make_config().vocab_size, make_config().hidden_size)
-        sd = module.preprocess_weights({"model.embed_tokens.weight": weight})
-        assert sd["model.embed_tokens.weight"] is sd["lm_head.weight"], (
-            "preprocess_weights must produce the same tensor object for tied weights"
-        )
+    def test_graph_level_tying_no_lm_head_initializer(self):
+        """With tie_word_embeddings=True, lm_head.weight must not be in the graph — at all.
 
-        apply_weights(model, sd)
-
+        The Parameter aliasing in __init__ ensures a single ir.Value is used for
+        both the embedding Gather and the lm_head MatMul, so no lm_head.weight
+        initializer is ever registered.
+        """
+        model, _ = self._build_tied_model()
         assert "lm_head.weight" not in model.graph.initializers, (
-            "lm_head.weight initializer should be removed — merged into embed_tokens"
+            "lm_head.weight must not be a graph initializer when tie_word_embeddings=True "
+            "(graph-level aliasing should produce a single embed_tokens initializer)"
         )
         assert "model.embed_tokens.weight" in model.graph.initializers, (
-            "embed_tokens initializer must remain as the canonical shared weight"
+            "model.embed_tokens.weight must be registered as the sole embedding initializer"
         )
+
+    def test_graph_level_tying_same_ir_value(self):
+        """The embed Gather and lm_head MatMul must both reference the same ir.Value."""
+        model, _ = self._build_tied_model()
+        embed_initializer = model.graph.initializers["model.embed_tokens.weight"]
+
+        # Collect all ir.Value inputs used across all nodes
+        all_inputs: set[int] = set()
+        for node in model.graph:
+            for inp in node.inputs:
+                if inp is not None:
+                    all_inputs.add(id(inp))
+
+        assert id(embed_initializer) in all_inputs, (
+            "model.embed_tokens.weight initializer must be referenced by at least one node"
+        )
+
+    def test_preprocess_weights_drops_lm_head_key(self):
+        """preprocess_weights must remove lm_head.weight from the state dict when tied."""
+        _, module = self._build_tied_model()
+        vocab_size = make_config().vocab_size
+        hidden_size = make_config().hidden_size
+        weight = torch.zeros(vocab_size, hidden_size)
+
+        # Case 1: checkpoint has only embed_tokens.weight (typical tied checkpoint)
+        sd = module.preprocess_weights({"model.embed_tokens.weight": weight})
+        assert "lm_head.weight" not in sd
+        assert "model.embed_tokens.weight" in sd
+
+        # Case 2: checkpoint has both keys (some checkpoints save both even when tied)
+        lm_head_weight = torch.ones(vocab_size, hidden_size)
+        sd2 = module.preprocess_weights(
+            {
+                "model.embed_tokens.weight": weight,
+                "lm_head.weight": lm_head_weight,
+            }
+        )
+        assert "lm_head.weight" not in sd2
+        assert "model.embed_tokens.weight" in sd2
+
+        # Case 3: checkpoint has only lm_head.weight
+        sd3 = module.preprocess_weights({"lm_head.weight": weight})
+        assert "lm_head.weight" not in sd3
+        assert "model.embed_tokens.weight" in sd3
 
     def test_untied_weights_have_separate_initializers(self):
         """When tie_word_embeddings=False, both initializers remain independent."""
@@ -518,26 +560,11 @@ class TestWeightTying:
         module_tied = CausalLMModel(config_tied)
         pkg_tied = build_from_module(module_tied, config_tied)
         model_tied = pkg_tied["model"]
-        sd_tied = module_tied.preprocess_weights(
-            {
-                "model.embed_tokens.weight": torch.zeros(
-                    config_tied.vocab_size, config_tied.hidden_size
-                )
-            }
-        )
-        apply_weights(model_tied, sd_tied)
 
         config_untied = mc(tie_word_embeddings=False)
         module_untied = CausalLMModel(config_untied)
         pkg_untied = build_from_module(module_untied, config_untied)
         model_untied = pkg_untied["model"]
-        sd_untied = {
-            "model.embed_tokens.weight": torch.zeros(
-                config_untied.vocab_size, config_untied.hidden_size
-            ),
-            "lm_head.weight": torch.zeros(config_untied.vocab_size, config_untied.hidden_size),
-        }
-        apply_weights(model_untied, sd_untied)
 
         n_tied = len(model_tied.graph.initializers)
         n_untied = len(model_untied.graph.initializers)

--- a/src/mobius/_weight_loading_test.py
+++ b/src/mobius/_weight_loading_test.py
@@ -576,7 +576,14 @@ class TestWeightTying:
         )
 
     def test_untied_weights_have_separate_initializers(self):
-        """When tie_word_embeddings=False, both initializers remain independent."""
+        """When tie_word_embeddings=False, both initializers remain independent.
+
+        The fold-transpose pass may rename ``lm_head.weight`` to
+        ``lm_head.weight_t`` (pre-transposing the single-user Transpose
+        node).  This is correct for untied weights because ``lm_head.weight``
+        has exactly one consumer.  In the tied case, the shared initializer
+        has multiple consumers and fold is correctly skipped.
+        """
         config = make_config(tie_word_embeddings=False)
         module = CausalLMModel(config)
         pkg = build_from_module(module, config)
@@ -591,7 +598,12 @@ class TestWeightTying:
         apply_weights(model, sd)
 
         assert "model.embed_tokens.weight" in model.graph.initializers
-        assert "lm_head.weight" in model.graph.initializers
+        # fold_initializers_after_weights may pre-transpose lm_head.weight
+        # into lm_head.weight_t (single-user Transpose fold).
+        assert (
+            "lm_head.weight" in model.graph.initializers
+            or "lm_head.weight_t" in model.graph.initializers
+        )
 
     def test_tied_model_initializer_count_lower_than_untied(self):
         """Tied model must have fewer initializers than untied (one embed weight, not two)."""
@@ -612,6 +624,35 @@ class TestWeightTying:
         assert n_tied < n_untied, (
             f"Tied model should have fewer initializers ({n_tied}) than untied ({n_untied})"
         )
+
+    def test_apply_weights_dedup_same_storage_different_objects(self):
+        """Dedup catches separate tensor objects sharing the same storage.
+
+        HuggingFace safetensors may deserialize tied weights as distinct
+        Python objects that share the same underlying storage (same
+        data_ptr).  apply_weights must detect this and merge them.
+        """
+        config = make_config(tie_word_embeddings=False)
+        module = CausalLMModel(config)
+        pkg = build_from_module(module, config)
+        model = pkg["model"]
+
+        # Create a base tensor and a view that shares storage but is a
+        # different Python object (simulates safetensors deserialization).
+        base = torch.zeros(config.vocab_size, config.hidden_size)
+        view = base[:]  # same storage, different id()
+        assert id(base) != id(view), "Precondition: must be different objects"
+        assert base.data_ptr() == view.data_ptr(), "Precondition: same storage"
+
+        sd = {
+            "model.embed_tokens.weight": base,
+            "lm_head.weight": view,
+        }
+        apply_weights(model, sd)
+
+        # One should be merged away
+        assert "model.embed_tokens.weight" in model.graph.initializers
+        assert "lm_head.weight" not in model.graph.initializers
 
 
 # ===========================================================================

--- a/src/mobius/models/bamba.py
+++ b/src/mobius/models/bamba.py
@@ -35,7 +35,6 @@ from onnxscript import nn
 from onnxscript._internal import builder
 
 from mobius._configs import BambaConfig
-from mobius._weight_utils import tie_word_embeddings
 from mobius.components import (
     MLP,
     Attention,
@@ -247,6 +246,8 @@ class BambaCausalLMModel(nn.Module):
         self.config = config
         self.model = _BambaTextModel(config)
         self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+        if config.tie_word_embeddings:
+            self.lm_head.weight = self.model.embed_tokens.weight
 
     def forward(
         self,
@@ -275,7 +276,9 @@ class BambaCausalLMModel(nn.Module):
         1. Weight tying (embed_tokens ↔ lm_head)
         """
         if self.config.tie_word_embeddings:
-            tie_word_embeddings(state_dict)
+            if "model.embed_tokens.weight" not in state_dict:
+                state_dict["model.embed_tokens.weight"] = state_dict["lm_head.weight"]
+            state_dict.pop("lm_head.weight", None)
 
         # HF and ONNX naming match directly — no renaming needed.
         return state_dict

--- a/src/mobius/models/base.py
+++ b/src/mobius/models/base.py
@@ -23,7 +23,6 @@ from mobius._configs import ArchitectureConfig, CausalLMConfig
 from mobius._weight_utils import (
     preprocess_awq_weights,
     preprocess_gptq_weights,
-    tie_word_embeddings,
 )
 from mobius.components import (
     DecoderLayer,
@@ -203,6 +202,10 @@ class CausalLMModel(nn.Module):
         self.config = config
         self.model = TextModel(config)
         self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+        # Share a single ONNX initializer: lm_head and embed_tokens point to
+        # the same nn.Parameter so only one ir.Value appears in the graph.
+        if config.tie_word_embeddings:
+            self.lm_head.weight = self.model.embed_tokens.weight
 
     def forward(
         self,
@@ -236,7 +239,12 @@ class CausalLMModel(nn.Module):
                 state_dict, bits=qc.bits, group_size=qc.group_size
             )
         if self.config.tie_word_embeddings:
-            tie_word_embeddings(state_dict)
+            # lm_head.weight is tied at graph level (same ir.Value as embed_tokens.weight).
+            # Ensure embed_tokens.weight is present; remove lm_head.weight if it
+            # was saved separately in the checkpoint to avoid a spurious warning.
+            if "model.embed_tokens.weight" not in state_dict:
+                state_dict["model.embed_tokens.weight"] = state_dict["lm_head.weight"]
+            state_dict.pop("lm_head.weight", None)
         return state_dict
 
 

--- a/src/mobius/models/base.py
+++ b/src/mobius/models/base.py
@@ -23,6 +23,7 @@ from mobius._configs import ArchitectureConfig, CausalLMConfig
 from mobius._weight_utils import (
     preprocess_awq_weights,
     preprocess_gptq_weights,
+    tie_word_embeddings,
 )
 from mobius.components import (
     DecoderLayer,
@@ -239,12 +240,15 @@ class CausalLMModel(nn.Module):
                 state_dict, bits=qc.bits, group_size=qc.group_size
             )
         if self.config.tie_word_embeddings:
-            # lm_head.weight is tied at graph level (same ir.Value as embed_tokens.weight).
-            # Ensure embed_tokens.weight is present; remove lm_head.weight if it
-            # was saved separately in the checkpoint to avoid a spurious warning.
-            if "model.embed_tokens.weight" not in state_dict:
-                state_dict["model.embed_tokens.weight"] = state_dict["lm_head.weight"]
-            state_dict.pop("lm_head.weight", None)
+            # Ensure both embed_tokens.weight and lm_head.weight are present so
+            # apply_weights can assign each to its initializer.  For graph-level
+            # tied models (standard CausalLMModel) both ir.Values are the same
+            # object, so apply_weights' id()-dedup redirects lm_head uses to the
+            # embed_tokens canonical and drops the duplicate initializer.  For
+            # subclasses that override self.model after super().__init__ (e.g.
+            # Cohere, GPT-2 family), the ir.Values differ but the dedup still
+            # unifies them at load time via replace_all_uses_with.
+            tie_word_embeddings(state_dict)
         return state_dict
 
 

--- a/src/mobius/models/falcon.py
+++ b/src/mobius/models/falcon.py
@@ -515,6 +515,9 @@ class FalconCausalLMModel(nn.Module):
         self.config = config
         self.transformer = _FalconTextModel(config)
         self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+        if config.tie_word_embeddings:
+            # _FalconTextModel uses self.word_embeddings (not embed_tokens)
+            self.lm_head.weight = self.transformer.word_embeddings.weight
 
     def forward(
         self,
@@ -587,12 +590,13 @@ class FalconCausalLMModel(nn.Module):
             for k, v in new_state_dict.items()
         }
 
-        # Handle weight tying
+        # Handle weight tying: lm_head.weight is tied at graph level.
+        # Discard lm_head.weight if present; transformer.word_embeddings.weight covers both.
         if self.config.tie_word_embeddings:
             embed_key = "transformer.word_embeddings.weight"
-            head_key = "lm_head.weight"
-            if head_key not in new_state_dict and embed_key in new_state_dict:
-                new_state_dict[head_key] = new_state_dict[embed_key]
+            if embed_key not in new_state_dict:
+                new_state_dict[embed_key] = new_state_dict["lm_head.weight"]
+            new_state_dict.pop("lm_head.weight", None)
 
         return new_state_dict
 

--- a/src/mobius/models/granitemoehybrid.py
+++ b/src/mobius/models/granitemoehybrid.py
@@ -31,7 +31,6 @@ from onnxscript import nn
 from onnxscript._internal import builder
 
 from mobius._configs import GraniteMoeHybridConfig
-from mobius._weight_utils import tie_word_embeddings
 from mobius.components import (
     Attention,
     Embedding,
@@ -413,6 +412,8 @@ class GraniteMoeHybridCausalLMModel(nn.Module):
         self.config = config
         self.model = _GraniteMoeHybridTextModel(config)
         self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+        if config.tie_word_embeddings:
+            self.lm_head.weight = self.model.embed_tokens.weight
 
     def forward(
         self,
@@ -446,7 +447,9 @@ class GraniteMoeHybridCausalLMModel(nn.Module):
         fused layout as HuggingFace.
         """
         if self.config.tie_word_embeddings:
-            tie_word_embeddings(state_dict)
+            if "model.embed_tokens.weight" not in state_dict:
+                state_dict["model.embed_tokens.weight"] = state_dict["lm_head.weight"]
+            state_dict.pop("lm_head.weight", None)
 
         new_state_dict: dict[str, torch.Tensor] = {}
         for key, value in state_dict.items():

--- a/src/mobius/models/internlm.py
+++ b/src/mobius/models/internlm.py
@@ -24,7 +24,6 @@ from onnxscript import nn
 from onnxscript._internal import builder
 
 from mobius._configs import ArchitectureConfig
-from mobius._weight_utils import tie_word_embeddings
 from mobius.components import (
     Attention,
     Embedding,
@@ -167,6 +166,8 @@ class InternLM2CausalLMModel(nn.Module):
         self.config = config
         self.model = _InternLMTextModel(config)
         self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+        if config.tie_word_embeddings:
+            self.lm_head.weight = self.model.embed_tokens.weight
 
     def forward(
         self,
@@ -196,9 +197,17 @@ class InternLM2CausalLMModel(nn.Module):
         2. wo → o_proj (Attention component uses o_proj)
         3. Grouped/interleaved wqkv split into separate q/k/v
         """
-        # Weight tying
+        # Weight tying: lm_head is tied at graph level; only embed_tokens.weight is needed.
+        # Handle both tok_embeddings (HF) → embed_tokens (our) rename for tied checkpoints.
         if self.config.tie_word_embeddings:
-            tie_word_embeddings(state_dict)
+            if "model.embed_tokens.weight" not in state_dict:
+                # HF key before rename, or tied checkpoint with only lm_head.weight
+                src = state_dict.get("model.tok_embeddings.weight") or state_dict.get(
+                    "lm_head.weight"
+                )
+                if src is not None:
+                    state_dict["model.embed_tokens.weight"] = src
+            state_dict.pop("lm_head.weight", None)
 
         q_size = self.config.num_attention_heads * self.config.head_dim
         kv_size = self.config.num_key_value_heads * self.config.head_dim

--- a/src/mobius/models/jamba.py
+++ b/src/mobius/models/jamba.py
@@ -29,7 +29,6 @@ from onnxscript import nn
 from onnxscript._internal import builder
 
 from mobius._configs import JambaConfig
-from mobius._weight_utils import tie_word_embeddings
 from mobius.components import (
     MLP,
     Attention,
@@ -274,6 +273,8 @@ class JambaCausalLMModel(nn.Module):
         self.config = config
         self.model = _JambaTextModel(config)
         self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+        if config.tie_word_embeddings:
+            self.lm_head.weight = self.model.embed_tokens.weight
 
     def forward(
         self,
@@ -306,7 +307,9 @@ class JambaCausalLMModel(nn.Module):
         5. Attribute name mapping (mamba_mixer → mamba)
         """
         if self.config.tie_word_embeddings:
-            tie_word_embeddings(state_dict)
+            if "model.embed_tokens.weight" not in state_dict:
+                state_dict["model.embed_tokens.weight"] = state_dict["lm_head.weight"]
+            state_dict.pop("lm_head.weight", None)
 
         new_state_dict: dict[str, torch.Tensor] = {}
         for key, value in state_dict.items():

--- a/src/mobius/models/jetmoe.py
+++ b/src/mobius/models/jetmoe.py
@@ -24,7 +24,6 @@ from onnxscript import nn
 from onnxscript._internal import builder
 
 from mobius._configs import ArchitectureConfig
-from mobius._weight_utils import tie_word_embeddings
 from mobius.components import (
     Embedding,
     Linear,
@@ -485,5 +484,5 @@ class JetMoeCausalLMModel(CausalLMModel):
             renamed[key] = value
 
         if self.config.tie_word_embeddings:
-            tie_word_embeddings(renamed)
+            renamed.pop("lm_head.weight", None)
         return renamed

--- a/src/mobius/models/mamba.py
+++ b/src/mobius/models/mamba.py
@@ -183,6 +183,9 @@ class MambaCausalLMModel(nn.Module):
         self.config = config
         self.model = MambaBackbone(config)
         self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+        if config.tie_word_embeddings:
+            # MambaBackbone uses self.embeddings (not embed_tokens)
+            self.lm_head.weight = self.model.embeddings.weight
 
     def forward(
         self,
@@ -243,12 +246,12 @@ class MambaCausalLMModel(nn.Module):
         for old_key, new_key in renames.items():
             state_dict[new_key] = state_dict.pop(old_key)
 
-        # Tied embeddings
+        # Tied embeddings: lm_head.weight shares graph initializer with model.embeddings.weight.
+        # Ensure model.embeddings.weight is present; discard lm_head.weight.
         if self.config.tie_word_embeddings:
-            if "lm_head.weight" in state_dict:
+            if "model.embeddings.weight" not in state_dict:
                 state_dict["model.embeddings.weight"] = state_dict["lm_head.weight"]
-            elif "model.embeddings.weight" in state_dict:
-                state_dict["lm_head.weight"] = state_dict["model.embeddings.weight"]
+            state_dict.pop("lm_head.weight", None)
 
         return state_dict
 
@@ -404,6 +407,9 @@ class Mamba2CausalLMModel(nn.Module):
         self.config = config
         self.backbone = Mamba2Backbone(config)
         self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+        if config.tie_word_embeddings:
+            # Mamba2Backbone uses self.embeddings (not embed_tokens)
+            self.lm_head.weight = self.backbone.embeddings.weight
 
     def forward(
         self,
@@ -441,9 +447,8 @@ class Mamba2CausalLMModel(nn.Module):
         """
         # Tied embeddings (Mamba2 uses self.backbone, not self.model)
         if self.config.tie_word_embeddings:
-            if "lm_head.weight" in state_dict:
+            if "backbone.embeddings.weight" not in state_dict:
                 state_dict["backbone.embeddings.weight"] = state_dict["lm_head.weight"]
-            elif "backbone.embeddings.weight" in state_dict:
-                state_dict["lm_head.weight"] = state_dict["backbone.embeddings.weight"]
+            state_dict.pop("lm_head.weight", None)
 
         return state_dict

--- a/src/mobius/models/nemotron_h.py
+++ b/src/mobius/models/nemotron_h.py
@@ -518,6 +518,8 @@ class NemotronHCausalLMModel(nn.Module):
         self.config = config
         self.model = _NemotronHTextModel(config)
         self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+        if config.tie_word_embeddings:
+            self.lm_head.weight = self.model.embed_tokens.weight
 
     def forward(
         self,

--- a/src/mobius/models/qwen_vl.py
+++ b/src/mobius/models/qwen_vl.py
@@ -121,13 +121,12 @@ class Qwen25VLCausalLMModel(nn.Module):
                 renamed[f"decoder.{key}"] = value
                 stripped = key[len("model.") :]
                 renamed[f"embedding.{stripped}"] = value
-                # Weight tying: also use as lm_head
-                if self.config.tie_word_embeddings and key == "model.embed_tokens.weight":
-                    renamed["decoder.lm_head.weight"] = value
+                # lm_head.weight is tied at graph level; no separate entry needed.
             elif key.startswith("model."):
                 renamed[f"decoder.{key}"] = value
             elif key.startswith("lm_head."):
-                renamed[f"decoder.{key}"] = value
+                if not self.config.tie_word_embeddings:
+                    renamed[f"decoder.{key}"] = value
         return renamed
 
 
@@ -146,6 +145,8 @@ class Qwen25VLDecoderModel(nn.Module):
         self.config = config
         self.model = TextModel(config)
         self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+        if config.tie_word_embeddings:
+            self.lm_head.weight = self.model.embed_tokens.weight
 
     def forward(
         self,
@@ -182,10 +183,9 @@ class Qwen25VLDecoderModel(nn.Module):
                 continue
             renamed[key] = value
 
-        # Handle weight tying
+        # Handle weight tying: lm_head.weight is tied at graph level.
         if self.config.tie_word_embeddings:
-            if "lm_head.weight" not in renamed and "model.embed_tokens.weight" in renamed:
-                renamed["lm_head.weight"] = renamed["model.embed_tokens.weight"]
+            renamed.pop("lm_head.weight", None)
         return renamed
 
 
@@ -561,6 +561,8 @@ class _Qwen3VLForMultimodalLM(nn.Module):
         self.config = config
         self.model = _Qwen3VLTextModel(config)
         self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+        if config.tie_word_embeddings:
+            self.lm_head.weight = self.model.embed_tokens.weight
 
     def forward(
         self,
@@ -708,15 +710,10 @@ class Qwen3VLCausalLMModel(nn.Module):
                 new_key = new_key.replace("language_model.", "language_model.model.", 1)
             renamed[new_key] = value
 
-        # Handle weight tying
+        # lm_head.weight is tied at graph level; discard any separate checkpoint entry.
         config = self.config
         if config.tie_word_embeddings:
-            embed_key = "language_model.model.embed_tokens.weight"
-            head_key = "language_model.lm_head.weight"
-            if head_key not in renamed and embed_key in renamed:
-                renamed[head_key] = renamed[embed_key]
-            elif embed_key not in renamed and head_key in renamed:
-                renamed[embed_key] = renamed[head_key]
+            renamed.pop("language_model.lm_head.weight", None)
         return renamed
 
 
@@ -783,14 +780,10 @@ class Qwen3VL3ModelCausalLMModel(nn.Module):
                 suffix = stripped[len("language_model.") :]
                 renamed[f"decoder.model.{suffix}"] = value
                 renamed[f"embedding.{suffix}"] = value
-                # Weight tying
-                if (
-                    self.config.tie_word_embeddings
-                    and stripped == "language_model.embed_tokens.weight"
-                ):
-                    renamed["decoder.lm_head.weight"] = value
+                # lm_head.weight is tied at graph level; no separate entry needed.
             elif stripped.startswith("language_model.lm_head."):
-                renamed[f"decoder.{stripped[len('language_model.') :]}"] = value
+                if not self.config.tie_word_embeddings:
+                    renamed[f"decoder.{stripped[len('language_model.') :]}"] = value
             elif stripped.startswith("language_model."):
                 # language_model.layers.* → decoder.model.layers.*
                 suffix = stripped[len("language_model.") :]
@@ -810,6 +803,8 @@ class Qwen3VLDecoderModel(nn.Module):
         self.config = config
         self.model = TextModel(config)
         self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+        if config.tie_word_embeddings:
+            self.lm_head.weight = self.model.embed_tokens.weight
 
     def forward(
         self,
@@ -847,8 +842,8 @@ class Qwen3VLDecoderModel(nn.Module):
             renamed[stripped] = value
 
         if self.config.tie_word_embeddings:
-            if "lm_head.weight" not in renamed and "model.embed_tokens.weight" in renamed:
-                renamed["lm_head.weight"] = renamed["model.embed_tokens.weight"]
+            # lm_head.weight is tied at graph level; discard any separate key.
+            renamed.pop("lm_head.weight", None)
         return renamed
 
 


### PR DESCRIPTION
## Summary

Implements genuine ONNX initializer sharing for tied weights (`lm_head.weight = embed_tokens.weight`) at **graph construction time**, and robust deduplication at **weight loading time**.

### Graph-level aliasing (nn.Parameter)

Instead of copying tied weights in `preprocess_weights`, we alias `lm_head.weight → embed_tokens.weight` as a Python `nn.Parameter` in each model's `__init__`:

```python
if config.tie_word_embeddings:
    self.lm_head.weight = self.model.embed_tokens.weight  # same ir.Value
```

`Parameter._realize()` is idempotent — the second call for the aliased parameter is a no-op, so **only one ONNX initializer is ever created**. The embed `Gather` and lm_head `MatMul` both reference the same `ir.Value` before any weights are loaded.

### Weight loading dedup (data_ptr)

`apply_weights()` detects tied weights using `tensor.data_ptr()` instead of `id(tensor)`. HuggingFace safetensors may deserialize tied weights as distinct Python objects sharing the same underlying storage — `data_ptr()` catches both same-object and same-storage-different-object cases. When a duplicate is detected, the second initializer is merged into the first via `replace_all_uses_with`.

### preprocess_weights updates

`preprocess_weights` uses `tie_word_embeddings()` to ensure both embed and lm_head keys are present in the state dict, handling all checkpoint variations (embed-only, lm_head-only, both).

### Models Updated

- **`CausalLMModel` (base)** — covers Llama, Mistral, Qwen2, Phi, Gemma, and ~60 other architectures inheriting from it
- **`BambaCausalLMModel`, `JambaCausalLMModel`**
- **`InternLM2CausalLMModel`**, **`NemotronHCausalLMModel`**, **`GraniteMoeHybridCausalLMModel`**
- **`MambaCausalLMModel`** (uses `model.embeddings`), **`Mamba2CausalLMModel`** (uses `backbone.embeddings`)
- **`FalconCausalLMModel`** (uses `transformer.word_embeddings`), covering Bloom and MPT subclasses
- **`JetMoeCausalLMModel`** — preprocess_weights only (inherits base __init__ fix)
- **Qwen VL decoders**: `Qwen25VLDecoderModel`, `Qwen3VLDecoderModel`, `_Qwen3VLForMultimodalLM`

### Other fixes

- **nemotron_h dashboard**: Fixed `test_model_id` in registry to match the YAML test case (`nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16`), so nemotron_h now appears on the dashboard.

### Tests

- `test_graph_level_tying_no_lm_head_initializer`: `lm_head.weight` absent from `graph.initializers` before `apply_weights`
- `test_graph_level_tying_same_ir_value`: the single initializer is referenced by graph nodes
- `test_preprocess_weights_ensures_both_tied_keys`: all 3 checkpoint cases (embed only, both, lm_head only)
- `test_apply_weights_dedup_canonical_is_first_insertion_order`: first state_dict key wins
- `test_apply_weights_dedup_same_storage_different_objects`: separate tensor objects with shared storage are detected and merged
- `test_untied_weights_have_separate_initializers`: untied case unchanged
- `test_tied_model_initializer_count_lower_than_untied`: structural size difference verified
