### PR TITLE
refactor: keep gate_up_proj fused, split activations in MLP forward

### DIFF
--- a/src/mobius/components/__init__.py
+++ b/src/mobius/components/__init__.py
@@ -29,6 +29,7 @@ __all__ = [
     "EncoderDecoderAttention",
     "EncoderLayer",
     "FCMLP",
+    "FusedGateUpMLP",
     "GatedDeltaNet",
     "GatedMLP",
     "GatedRMSNorm",
@@ -175,7 +176,7 @@ from mobius.components._gated_deltanet import GatedDeltaNet
 from mobius.components._lightning_attention import LightningAttention
 from mobius.components._lora import LoRALinear
 from mobius.components._mamba_block import Mamba2Block, MambaBlock
-from mobius.components._mlp import FCMLP, MLP, GatedMLP
+from mobius.components._mlp import FCMLP, MLP, FusedGateUpMLP, GatedMLP
 from mobius.components._moe import (
     MoELayer,
     SigmoidTopKGate,

--- a/src/mobius/components/_decoder.py
+++ b/src/mobius/components/_decoder.py
@@ -41,6 +41,10 @@ class DecoderLayer(nn.Module):
         linear_class: Factory callable ``(in_features, out_features, bias=...)``
             for creating projection layers in Attention and MLP. Defaults to
             ``Linear``. Pass a LoRA factory for LoRA-adapted layers.
+        mlp_class: MLP module class to use (default: :class:`~mobius.components.MLP`).
+            Pass :class:`~mobius.components.FusedGateUpMLP` for models that store
+            the gate and up projections as a single fused ``gate_up_proj`` weight
+            (e.g. Phi-3, Phi-4, GLM).
     """
 
     def __init__(
@@ -52,10 +56,13 @@ class DecoderLayer(nn.Module):
         attention_scale: float | None = None,
         post_norm: bool = False,
         linear_class: type | None = None,
+        mlp_class: type | None = None,
     ):
         super().__init__()
         if norm_class is None:
             norm_class = RMSNorm
+        if mlp_class is None:
+            mlp_class = MLP
 
         self._post_norm = post_norm
         self._residual_multiplier = residual_multiplier
@@ -66,7 +73,7 @@ class DecoderLayer(nn.Module):
             scale=attention_scale,
             linear_class=linear_class,
         )
-        self.mlp = MLP(config, linear_class=linear_class)
+        self.mlp = mlp_class(config, linear_class=linear_class)
 
         if post_norm:
             self.post_attention_layernorm = norm_class(
@@ -185,6 +192,7 @@ def create_decoder_layer(
     norm_class: type[nn.Module] | None = None,
     post_norm: bool = False,
     linear_class: type | None = None,
+    mlp_class: type | None = None,
 ) -> DecoderLayer:
     """Config-driven factory for creating decoder layers.
 
@@ -200,6 +208,8 @@ def create_decoder_layer(
         post_norm: If True, use post-norm residual connections (OLMo-2 style).
         linear_class: Factory callable for projection layers. Pass a LoRA
             factory for LoRA-adapted layers.
+        mlp_class: MLP module class override (default: MLP). Pass
+            FusedGateUpMLP for models with fused gate_up_proj weights.
 
     Returns:
         A configured DecoderLayer instance.
@@ -214,6 +224,7 @@ def create_decoder_layer(
         attention_scale=attention_scale,
         post_norm=post_norm,
         linear_class=linear_class,
+        mlp_class=mlp_class,
     )
 
 

--- a/src/mobius/components/_mlp.py
+++ b/src/mobius/components/_mlp.py
@@ -98,6 +98,53 @@ class GatedMLP(nn.Module):
         return self.down_proj(op, op.Mul(gate, self.up_proj(op, x)))
 
 
+class FusedGateUpMLP(nn.Module):
+    """Gated MLP that keeps gate and up projections as one fused weight.
+
+    The ``gate_up_proj`` tensor (shape ``[2*intermediate_size, hidden_size]``)
+    is stored as a single parameter, matching HuggingFace checkpoints for
+    Phi-3, Phi-4, and GLM family models. Activations are split after the
+    fused MatMul — no weight splitting is required in ``preprocess_weights``.
+
+    Forward pass::
+
+        gate_up = gate_up_proj(x)           # [*, 2 * intermediate_size]
+        gate, up = split(gate_up, axis=-1)  # each [*, intermediate_size]
+        return down_proj(act(gate) * up)
+
+    Use this instead of :class:`MLP` when the HuggingFace checkpoint stores
+    gate and up projections as a single fused ``gate_up_proj`` weight.  This
+    avoids splitting the weight tensor at load time, which fails for GPTQ
+    int32-packed weights where dim 0 is ``original / pack_factor``.
+
+    Args:
+        config: Architecture configuration.
+        linear_class: Factory callable ``(in_features, out_features, bias=...)``
+            for creating projection layers. Defaults to ``Linear``.
+    """
+
+    def __init__(self, config: ArchitectureConfig, linear_class: type | None = None):
+        super().__init__()
+        if linear_class is None:
+            linear_class = Linear
+        # Single fused weight: [2*intermediate_size, hidden_size]
+        self.gate_up_proj = linear_class(
+            config.hidden_size, 2 * config.intermediate_size, bias=config.mlp_bias
+        )
+        self.down_proj = linear_class(
+            config.intermediate_size, config.hidden_size, bias=config.mlp_bias
+        )
+        self.act_fn = get_activation(config.hidden_act)
+
+    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+        # Fused matmul → [*, 2 * intermediate_size]
+        gate_up = self.gate_up_proj(op, x)
+        # Split activations at intermediate_size boundary
+        gate, up = op.Split(gate_up, axis=-1, num_outputs=2, _outputs=2)
+        # SwiGLU: act(gate) * up → down_proj
+        return self.down_proj(op, op.Mul(self.act_fn(op, gate), up))
+
+
 class FCMLP(nn.Module):
     """Two-layer fully-connected MLP: ``up_proj → activation → down_proj``.
 

--- a/src/mobius/components/_mlp.py
+++ b/src/mobius/components/_mlp.py
@@ -141,7 +141,7 @@ class FusedGateUpMLP(nn.Module):
         gate_up = self.gate_up_proj(op, x)
         # Split activations at intermediate_size boundary
         gate, up = op.Split(gate_up, axis=-1, num_outputs=2, _outputs=2)
-        # SwiGLU: act(gate) * up → down_proj
+        # gated activation (e.g. SiLU(gate) * up) → down_proj
         return self.down_proj(op, op.Mul(self.act_fn(op, gate), up))
 
 

--- a/src/mobius/components/_mlp_test.py
+++ b/src/mobius/components/_mlp_test.py
@@ -11,7 +11,7 @@ from mobius._testing import (
     create_test_input,
     make_config,
 )
-from mobius.components._mlp import FCMLP, MLP, GatedMLP
+from mobius.components._mlp import FCMLP, MLP, FusedGateUpMLP, GatedMLP
 
 
 class TestMLP:
@@ -229,4 +229,59 @@ class TestGatedMLP:
         assert len(created) == 3
         assert isinstance(mlp.gate_proj, TrackingLinear)
         assert isinstance(mlp.up_proj, TrackingLinear)
+        assert isinstance(mlp.down_proj, TrackingLinear)
+
+
+class TestFusedGateUpMLP:
+    """Tests for FusedGateUpMLP (fused gate_up_proj, split activations)."""
+
+    def test_projection_shapes(self):
+        config = make_config(hidden_size=64, intermediate_size=128)
+        mlp = FusedGateUpMLP(config)
+        # gate_up_proj: [2*intermediate, hidden]
+        assert list(mlp.gate_up_proj.weight.shape) == [256, 64]
+        assert list(mlp.down_proj.weight.shape) == [64, 128]
+
+    def test_parameter_count(self):
+        config = make_config(hidden_size=64, intermediate_size=128)
+        mlp = FusedGateUpMLP(config)
+        # gate_up_proj.weight + down_proj.weight = 2 (no bias by default)
+        assert len(list(mlp.parameters())) == 2
+
+    def test_forward_builds_graph(self):
+        config = make_config(hidden_size=64, intermediate_size=128)
+        mlp = FusedGateUpMLP(config)
+        builder, op, graph = create_test_builder()
+        x = create_test_input(builder, "x", [1, 8, 64])
+        result = mlp(op, x)
+        builder._adapt_outputs([result])
+        assert graph.num_nodes() > 0
+        # gate_up_proj MatMul + down_proj MatMul = 2
+        assert count_op_type(graph, "MatMul") == 2
+        # Split activations along last axis
+        assert count_op_type(graph, "Split") == 1
+
+    def test_forward_uses_silu_by_default(self):
+        config = make_config(hidden_size=64, intermediate_size=128, hidden_act="silu")
+        mlp = FusedGateUpMLP(config)
+        builder, op, graph = create_test_builder()
+        x = create_test_input(builder, "x", [1, 8, 64])
+        mlp(op, x)
+        # SiLU = x * sigmoid(x)
+        assert count_op_type(graph, "Sigmoid") >= 1
+
+    def test_linear_class_applied(self):
+        from mobius.components._common import Linear
+
+        created = []
+
+        class TrackingLinear(Linear):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                created.append(self)
+
+        config = make_config(hidden_size=64, intermediate_size=128)
+        mlp = FusedGateUpMLP(config, linear_class=TrackingLinear)
+        assert len(created) == 2
+        assert isinstance(mlp.gate_up_proj, TrackingLinear)
         assert isinstance(mlp.down_proj, TrackingLinear)

--- a/src/mobius/models/__init__.py
+++ b/src/mobius/models/__init__.py
@@ -16,6 +16,7 @@ __all__ = [
     "CLIPVisionModel",
     "CTRLCausalLMModel",
     "CausalLMModel",
+    "FusedGateUpCausalLMModel",
     "ChatGLMCausalLMModel",
     "CodeGenCausalLMModel",
     "CogVideoXTransformer3DModel",
@@ -125,7 +126,7 @@ from mobius.models.apertus import ApertusCausalLMModel
 from mobius.models.arcee import ArceeCausalLMModel
 from mobius.models.bamba import BambaCausalLMModel
 from mobius.models.bart import BartForConditionalGeneration
-from mobius.models.base import CausalLMModel, LayerNormCausalLMModel
+from mobius.models.base import CausalLMModel, FusedGateUpCausalLMModel, LayerNormCausalLMModel
 from mobius.models.bert import BertModel
 from mobius.models.blip2 import Blip2Model
 from mobius.models.chatglm import ChatGLMCausalLMModel

--- a/src/mobius/models/base.py
+++ b/src/mobius/models/base.py
@@ -297,5 +297,5 @@ class FusedGateUpCausalLMModel(CausalLMModel):
 
     def __init__(self, config: ArchitectureConfig):
         super().__init__(config)
-        # Replace TextModel with FusedGateUpMLP layers.
+        # Parameterize TextModel to use FusedGateUpMLP for each decoder layer.
         self.model = TextModel(config, mlp_class=FusedGateUpMLP)

--- a/src/mobius/models/base.py
+++ b/src/mobius/models/base.py
@@ -28,6 +28,7 @@ from mobius._weight_utils import (
 from mobius.components import (
     DecoderLayer,
     Embedding,
+    FusedGateUpMLP,
     LayerNorm,
     Linear,
     RMSNorm,
@@ -42,7 +43,7 @@ from mobius.components._rotary_embedding import BaseRope, _MRopeBase
 class TextModel(nn.Module):
     """Base text model with embedding, decoder layers, and final norm."""
 
-    def __init__(self, config: ArchitectureConfig):
+    def __init__(self, config: ArchitectureConfig, mlp_class: type | None = None):
         super().__init__()
         self._dtype = config.dtype
 
@@ -62,7 +63,7 @@ class TextModel(nn.Module):
         )
         self.layers = nn.ModuleList(
             [
-                DecoderLayer(config, linear_class=linear_class)
+                DecoderLayer(config, linear_class=linear_class, mlp_class=mlp_class)
                 for _ in range(config.num_hidden_layers)
             ]
         )
@@ -277,3 +278,24 @@ class LayerNormCausalLMModel(CausalLMModel):
         super().__init__(config)
         # Replace TextModel with the LayerNorm-based variant.
         self.model = LayerNormTextModel(config)
+
+
+class FusedGateUpCausalLMModel(CausalLMModel):
+    """CausalLM variant that keeps gate_up_proj fused (no weight splitting).
+
+    Use this instead of ``CausalLMModel`` for architectures where HuggingFace
+    stores the gate and up projections as a single fused ``gate_up_proj``
+    weight — e.g. Phi-3, Phi-4, and GLM.
+
+    The MLP forward pass does a single ``gate_up_proj`` MatMul and splits the
+    resulting activations, rather than splitting the weights at load time.
+    This is robust to GPTQ int32-packed weights where dimension 0 is
+    ``original / pack_factor`` and weight splitting would fail.
+
+    ``preprocess_weights`` does NOT need to split ``gate_up_proj``.
+    """
+
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__(config)
+        # Replace TextModel with FusedGateUpMLP layers.
+        self.model = TextModel(config, mlp_class=FusedGateUpMLP)

--- a/src/mobius/models/glm.py
+++ b/src/mobius/models/glm.py
@@ -24,56 +24,28 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import torch
 from onnxscript import nn
 from onnxscript._internal import builder
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._attention import StaticCacheState
 from mobius.components._decoder import DecoderLayer
+from mobius.components._mlp import FusedGateUpMLP
 from mobius.components._rms_norm import RMSNorm
-from mobius.models.base import CausalLMModel, TextModel
+from mobius.models.base import CausalLMModel, FusedGateUpCausalLMModel, TextModel
 
 if TYPE_CHECKING:
     import onnx_ir as ir
 
 
-def _split_gate_up_proj(
-    state_dict: dict[str, torch.Tensor],
-) -> dict[str, torch.Tensor]:
-    """Split fused ``gate_up_proj`` into separate ``gate_proj`` + ``up_proj``.
-
-    HF GLM/GLM4 store: ``mlp.gate_up_proj.weight`` [2*intermediate, hidden]
-    ONNX MLP expects: ``mlp.gate_proj.weight`` [intermediate, hidden]
-                      ``mlp.up_proj.weight``   [intermediate, hidden]
-    """
-    new_state_dict: dict[str, torch.Tensor] = {}
-    for key, value in state_dict.items():
-        if ".mlp.gate_up_proj." in key:
-            # Split along dim 0: first half = gate, second half = up
-            mid = value.shape[0] // 2
-            gate_key = key.replace(".gate_up_proj.", ".gate_proj.")
-            up_key = key.replace(".gate_up_proj.", ".up_proj.")
-            new_state_dict[gate_key] = value[:mid]
-            new_state_dict[up_key] = value[mid:]
-        else:
-            new_state_dict[key] = value
-    return new_state_dict
-
-
-class GlmCausalLMModel(CausalLMModel):
+class GlmCausalLMModel(FusedGateUpCausalLMModel):
     """GLM text model (standard pre-norm + fused gate_up_proj).
 
     GLM is architecturally identical to LLaMA except for the fused
-    ``gate_up_proj`` in the MLP.  ``preprocess_weights`` splits it into
-    separate ``gate_proj`` + ``up_proj`` tensors.
+    ``gate_up_proj`` in the MLP.  The weight stays fused; activations
+    are split in the MLP forward pass (see
+    :class:`~mobius.models.base.FusedGateUpCausalLMModel`).
     """
-
-    def preprocess_weights(
-        self, state_dict: dict[str, torch.Tensor]
-    ) -> dict[str, torch.Tensor]:
-        state_dict = _split_gate_up_proj(state_dict)
-        return super().preprocess_weights(state_dict)
 
 
 # ---------------------------------------------------------------------------
@@ -102,9 +74,8 @@ class Glm4DecoderLayer(DecoderLayer):
     """
 
     def __init__(self, config: ArchitectureConfig):
-        # Initialize the base DecoderLayer (pre-norm mode) to get
-        # input_layernorm, post_attention_layernorm, self_attn, mlp.
-        super().__init__(config)
+        # Initialize the base DecoderLayer with FusedGateUpMLP
+        super().__init__(config, mlp_class=FusedGateUpMLP)
 
         # Add the two extra post-sub-layer norms
         self.post_self_attn_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
@@ -156,8 +127,9 @@ class Glm4DecoderLayer(DecoderLayer):
 class Glm4CausalLMModel(CausalLMModel):
     """GLM4 text model (4-norm decoder + fused gate_up_proj).
 
-    Uses ``Glm4DecoderLayer`` with pre+post norms on both sub-layers,
-    and splits the fused ``gate_up_proj`` in ``preprocess_weights``.
+    Uses ``Glm4DecoderLayer`` with pre+post norms on both sub-layers.
+    ``gate_up_proj`` is kept fused — activations are split in the MLP
+    forward pass (via :class:`FusedGateUpMLP` in ``Glm4DecoderLayer``).
     """
 
     def __init__(self, config: ArchitectureConfig):
@@ -168,12 +140,6 @@ class Glm4CausalLMModel(CausalLMModel):
         from mobius.components import Linear
 
         self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
-
-    def preprocess_weights(
-        self, state_dict: dict[str, torch.Tensor]
-    ) -> dict[str, torch.Tensor]:
-        state_dict = _split_gate_up_proj(state_dict)
-        return super().preprocess_weights(state_dict)
 
 
 class Glm4TextModel(TextModel):

--- a/src/mobius/models/phi.py
+++ b/src/mobius/models/phi.py
@@ -17,11 +17,12 @@ from onnxscript import nn
 from onnxscript._internal import builder
 
 from mobius._configs import ArchitectureConfig
-from mobius._weight_utils import split_fused_qkv, split_gate_up_proj
+from mobius._weight_utils import split_fused_qkv
 from mobius.components import (
     FCMLP,
     ConformerEncoder,
     Embedding,
+    FusedGateUpMLP,
     InputMixer,
     LayerNorm,
     Linear,
@@ -241,7 +242,7 @@ class _LoRATextModel(TextModel):
         )
         self.layers = nn.ModuleList(
             [
-                DecoderLayer(config, linear_class=lora_factory)
+                DecoderLayer(config, linear_class=lora_factory, mlp_class=FusedGateUpMLP)
                 for _ in range(config.num_hidden_layers)
             ]
         )
@@ -252,9 +253,17 @@ class _LoRATextModel(TextModel):
 def _preprocess_phi4mm_weights(
     config: ArchitectureConfig, state_dict: dict[str, torch.Tensor]
 ) -> dict[str, torch.Tensor]:
-    """Shared weight preprocessing for Phi4MM models (LoRA + fused weight splitting)."""
-    intermediate_size = config.intermediate_size
+    """Shared weight preprocessing for Phi4MM models (LoRA + fused QKV splitting).
 
+    Handles:
+    - Stripping ``base_layer.`` from LoRA-wrapped weight names
+    - Splitting fused ``qkv_proj`` into separate q/k/v weights
+
+    ``gate_up_proj`` is NOT split here — the model uses
+    :class:`~mobius.models.base.FusedGateUpCausalLMModel` which keeps the
+    fused weight and splits activations in the MLP forward pass instead.
+    LoRA weights on ``gate_up_proj`` are passed through unchanged.
+    """
     # Strip "base_layer." from LoRA-wrapped weight names
     # HF stores e.g. "qkv_proj.base_layer.weight" → we need "qkv_proj.weight"
     for key in list(state_dict.keys()):
@@ -302,33 +311,8 @@ def _preprocess_phi4mm_weights(
             state_dict[f"{base}k_proj.{suffix}"] = w.clone()
             state_dict[f"{base}v_proj.{suffix}"] = w.clone()
 
-        # Split gate_up_proj base weight/bias
-        elif (
-            "gate_up_proj.weight" in key or "gate_up_proj.bias" in key
-        ) and "lora" not in key:
-            w = state_dict.pop(key)
-            base = key.split("gate_up_proj.")[0]
-            suffix = key.split("gate_up_proj.")[1]
-            gate, up = split_gate_up_proj(w, intermediate_size)
-            state_dict[f"{base}gate_proj.{suffix}"] = gate
-            state_dict[f"{base}up_proj.{suffix}"] = up
-
-        # Split gate_up_proj LoRA B weights (output dim split)
-        elif "gate_up_proj.lora_B." in key:
-            w = state_dict.pop(key)
-            base = key.split("gate_up_proj.")[0]
-            suffix = key.split("gate_up_proj.")[1]
-            gate, up = split_gate_up_proj(w, intermediate_size)
-            state_dict[f"{base}gate_proj.{suffix}"] = gate
-            state_dict[f"{base}up_proj.{suffix}"] = up
-
-        # Split gate_up_proj LoRA A weights (same A for gate/up)
-        elif "gate_up_proj.lora_A." in key:
-            w = state_dict.pop(key)
-            base = key.split("gate_up_proj.")[0]
-            suffix = key.split("gate_up_proj.")[1]
-            state_dict[f"{base}gate_proj.{suffix}"] = w
-            state_dict[f"{base}up_proj.{suffix}"] = w.clone()
+        # gate_up_proj weights (base and LoRA) pass through unchanged —
+        # FusedGateUpMLP keeps the fused weight and splits activations.
 
     # Weight tying
     if config.tie_word_embeddings:
@@ -522,7 +506,7 @@ class _Phi4MMMultiModalTextModel(nn.Module):
         self.embed_tokens_extend = _Phi4MMImageAudioEmbedding(config)
         self.layers = nn.ModuleList(
             [
-                DecoderLayer(config, linear_class=lora_factory)
+                DecoderLayer(config, linear_class=lora_factory, mlp_class=FusedGateUpMLP)
                 for _ in range(config.num_hidden_layers)
             ]
         )
@@ -756,7 +740,7 @@ class _Phi4MMDecoderModel(nn.Module):
 
         self.layers = nn.ModuleList(
             [
-                DecoderLayer(config, linear_class=lora_factory)
+                DecoderLayer(config, linear_class=lora_factory, mlp_class=FusedGateUpMLP)
                 for _ in range(config.num_hidden_layers)
             ]
         )

--- a/src/mobius/models/phi3.py
+++ b/src/mobius/models/phi3.py
@@ -3,23 +3,29 @@
 
 """Phi-3 / Phi-3.5 causal language model.
 
-Replicates HuggingFace's ``Phi3ForCausalLM``. The main difference from
-the base CausalLMModel is that HuggingFace fuses QKV and gate-up projections
-into single tensors, so ``preprocess_weights`` splits them.
+Replicates HuggingFace's ``Phi3ForCausalLM``. Phi-3/3.5 fuse QKV and
+gate-up projections into single tensors. The QKV fusion is resolved by
+splitting weights in ``preprocess_weights``; the gate-up fusion is handled
+natively by inheriting from ``FusedGateUpCausalLMModel``, which keeps
+``gate_up_proj`` fused and splits activations in the MLP forward pass.
+This approach works for both fp16/bf16 and GPTQ int32-packed checkpoints.
 """
 
 from __future__ import annotations
 
 import torch
 
-from mobius._weight_utils import split_fused_qkv, split_gate_up_proj
-from mobius.models.base import CausalLMModel
+from mobius._weight_utils import split_fused_qkv
+from mobius.models.base import FusedGateUpCausalLMModel
 
 
-class Phi3CausalLMModel(CausalLMModel):
-    """Phi-3 / Phi-3.5 model with SuRoPE and fused QKV/gate-up weight splitting.
+class Phi3CausalLMModel(FusedGateUpCausalLMModel):
+    """Phi-3 / Phi-3.5 model with SuRoPE and fused QKV weight splitting.
 
     Replicates HuggingFace's ``Phi3ForCausalLM``.
+
+    ``gate_up_proj`` is kept fused (see :class:`~mobius.models.base.FusedGateUpCausalLMModel`).
+    Only the QKV fusion is resolved via ``preprocess_weights``.
     """
 
     def preprocess_weights(
@@ -37,11 +43,4 @@ class Phi3CausalLMModel(CausalLMModel):
                 state_dict[key.replace("qkv_proj", "q_proj")] = q
                 state_dict[key.replace("qkv_proj", "k_proj")] = k
                 state_dict[key.replace("qkv_proj", "v_proj")] = v
-            elif "gate_up_proj" in key:
-                gate, up = split_gate_up_proj(
-                    state_dict.pop(key),
-                    self.config.intermediate_size,
-                )
-                state_dict[key.replace("gate_up_proj", "gate_proj")] = gate
-                state_dict[key.replace("gate_up_proj", "up_proj")] = up
         return state_dict


### PR DESCRIPTION
## Problem

`split_gate_up_proj` in `preprocess_weights` assumes an uncompressed weight tensor. For GPTQ int32-packed weights, `dim 0 = original_dim / pack_factor`, causing a build failure:

```
gate_up weight dim 0 is 2048, expected 16384
```

## Solution

Instead of fixing the split logic, remove all weight splitting entirely. The `gate_up_proj` weight stays fused; activations are split after the matmul:

```python
gate_up = gate_up_proj(x)            # [*, 2 * intermediate_size]
gate, up = Split(gate_up, axis=-1)   # each [*, intermediate_size]
return down_proj(act(gate) * up)
```

This is cleaner, future-proof, and matches HuggingFace weight names exactly — no `preprocess_weights` renames needed for `gate_up_proj`.

## Changes

- **`components/_mlp.py`**: Add `FusedGateUpMLP` — single `gate_up_proj` param, split activations in forward
- **`components/_decoder.py`**: Add `mlp_class` param to `DecoderLayer` / `create_decoder_layer`
- **`models/base.py`**: Add `FusedGateUpCausalLMModel`; `TextModel` accepts `mlp_class`
- **`models/phi3.py`**: Extend `FusedGateUpCausalLMModel`; remove gate_up split from `preprocess_weights`
- **`models/phi.py`**: Remove gate_up_proj split from `_preprocess_phi4mm_weights`; all LoRA decoder layers use `FusedGateUpMLP`; fix `num_kv_heads` → `num_key_value_heads` bug in LoRA B split
- **`models/glm.py`**: Remove `_split_gate_up_proj` private function; `GlmCausalLMModel` extends `FusedGateUpCausalLMModel`; `Glm4DecoderLayer` uses `FusedGateUpMLP`
- **`models/__init__.py`**: Export `FusedGateUpCausalLMModel`

## Testing

2352 tests pass, 29 skipped. Lintrunner clean.