### PR TITLE
Add Ministral-3-3B VLM olive-recipe demo + enhance genai integration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -158,3 +158,7 @@ See the `adding-a-new-model` skill for the full guide.
 ### Git commits
 
 Linear commit history. Always signoff commits with --signoff.
+
+- **Squash commits before pushing.** Avoid pushing many small/WIP commits — each push triggers CI. Amend and force-push instead of adding fixup commits.
+- **Write descriptive commit messages.** Title should summarize the change; body should explain what and why.
+- **Minimize CI waste.** Each push to a PR triggers the full CI pipeline. Batch your changes into a single well-described commit before pushing.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -159,6 +159,4 @@ See the `adding-a-new-model` skill for the full guide.
 
 Linear commit history. Always signoff commits with --signoff.
 
-- **Squash commits before pushing.** Avoid pushing many small/WIP commits — each push triggers CI. Amend and force-push instead of adding fixup commits.
 - **Write descriptive commit messages.** Title should summarize the change; body should explain what and why.
-- **Minimize CI waste.** Each push to a PR triggers the full CI pipeline. Batch your changes into a single well-described commit before pushing.

--- a/examples/olive/ministral-3-3b-vlm/.gitignore
+++ b/examples/olive/ministral-3-3b-vlm/.gitignore
@@ -1,0 +1,10 @@
+# Generated model artifacts
+models/
+output/
+
+# Python bytecode
+__pycache__/
+*.pyc
+
+# Olive cache
+.olive-cache/

--- a/examples/olive/ministral-3-3b-vlm/README.md
+++ b/examples/olive/ministral-3-3b-vlm/README.md
@@ -1,0 +1,131 @@
+# Ministral-3-3B VLM: E2E Export & Inference Demo
+
+This example demonstrates how to export
+[Ministral-3-3B-Instruct-2512](https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512)
+vision-language model to ONNX using
+[mobius](https://github.com/onnxruntime/mobius) and run inference
+with ONNX Runtime GenAI.
+
+Ministral-3-3B is a multimodal (VLM) model combining a Pixtral
+vision encoder with a Mistral text decoder. All three sub-models
+are exported via mobius, with optional Olive quantization for the
+text decoder.
+
+## Prerequisites
+
+Install mobius from the repo root:
+
+```bash
+pip install -e '.[transformers]'
+```
+
+Install additional dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Install ONNX Runtime GenAI:
+
+| Device | Install Command |
+|--------|------------------|
+| CPU | `pip install onnxruntime-genai` |
+| GPU | `pip install onnxruntime-genai-cuda` |
+
+Optional — for INT4/FP16 text decoder quantization:
+
+```bash
+pip install olive-ai
+```
+
+## Steps
+
+### 1. Export Models
+
+**Pure mobius (FP16, all 3 models):**
+
+```bash
+python optimize.py
+```
+
+**With Olive INT4 quantization for text decoder (CPU):**
+
+```bash
+python optimize.py --olive-config cpu_and_mobile/text.json
+```
+
+**With Olive FP16 for text decoder (CUDA):**
+
+```bash
+python optimize.py --olive-config cuda/text.json --ep cuda
+```
+
+**Custom options:**
+
+```bash
+python optimize.py --output-dir output/ministral3 --dtype f32
+```
+
+This runs:
+- **Mobius** for all 3 ONNX models (text decoder, vision
+  encoder, embedding) with pretrained weights
+- **Mobius genai integration** for `genai_config.json`,
+  `processor_config.json`, and tokenizer files
+- **(Optional) Olive** for text decoder quantization
+  (INT4/FP16 with GQA)
+
+### 2. Output Structure
+
+```
+models/
+├── decoder/
+│   ├── model.onnx              # Text decoder
+│   └── model.onnx.data
+├── vision/
+│   ├── model.onnx              # Pixtral vision encoder
+│   └── model.onnx.data
+├── embedding/
+│   ├── model.onnx              # Embedding fusion model
+│   └── model.onnx.data
+├── genai_config.json           # Runtime configuration
+├── processor_config.json       # Image preprocessing
+├── tokenizer.json
+└── tokenizer_config.json
+```
+
+### 3. Run Inference
+
+```bash
+# Text-only
+python inference.py --prompt "What is the capital of France?"
+
+# Image + text
+python inference.py --image photo.jpg --prompt "Describe this"
+
+# Interactive mode
+python inference.py --interactive
+```
+
+### 4. Evaluate on AI2D
+
+```bash
+# ONNX only (default: 100 samples)
+python eval.py --model_path models
+
+# Both ONNX and PyTorch side-by-side
+python eval.py --pytorch_model mistralai/Ministral-3-3B-Instruct-2512
+```
+
+## Notes
+
+- HuggingFace checkpoint uses FP8 quantized weights. Mobius
+  dequantizes automatically during weight loading.
+- The tokenizer class (`TokenizersBackend`) is automatically
+  remapped to `LlamaTokenizer` by the genai integration.
+- Pixtral vision supports dynamic image sizes (multiples of
+  28, up to 1540x1540).
+
+## References
+
+- [Pixtral/Ministral3 VLM support (PR #130)](https://github.com/onnxruntime/mobius/pull/130)
+- [onnxruntime-genai PR #2077](https://github.com/microsoft/onnxruntime-genai/pull/2077)

--- a/examples/olive/ministral-3-3b-vlm/cpu_and_mobile/text.json
+++ b/examples/olive/ministral-3-3b-vlm/cpu_and_mobile/text.json
@@ -1,0 +1,18 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "mistralai/Ministral-3-3B-Instruct-2512"
+    },
+    "passes": {
+        "convert": {
+            "type": "ModelBuilder",
+            "precision": "int4",
+            "int4_accuracy_level": 4,
+            "extra_options": {
+                "filename": "text.onnx"
+            }
+        }
+    },
+    "no_artifacts": true,
+    "output_dir": "cpu_and_mobile/models/text.onnx"
+}

--- a/examples/olive/ministral-3-3b-vlm/cuda/text.json
+++ b/examples/olive/ministral-3-3b-vlm/cuda/text.json
@@ -1,0 +1,30 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "mistralai/Ministral-3-3B-Instruct-2512"
+    },
+    "passes": {
+        "convert": {
+            "type": "ModelBuilder",
+            "precision": "fp16",
+            "extra_options": {
+                "filename": "text.onnx"
+            }
+        }
+    },
+    "engine": {
+        "target": {
+            "type": "LocalSystem",
+            "accelerators": [
+                {
+                    "device": "gpu",
+                    "execution_providers": [
+                        "CUDAExecutionProvider"
+                    ]
+                }
+            ]
+        }
+    },
+    "no_artifacts": true,
+    "output_dir": "cuda/models/text.onnx"
+}

--- a/examples/olive/ministral-3-3b-vlm/eval.py
+++ b/examples/olive/ministral-3-3b-vlm/eval.py
@@ -183,7 +183,7 @@ def build_pytorch_runner(model_id: str):
     print(f"  Device: {device}, dtype: {dtype}")
 
     pt_model = Mistral3ForConditionalGeneration.from_pretrained(
-        model_id, dtype=dtype, trust_remote_code=True
+        model_id, torch_dtype=dtype, trust_remote_code=True
     ).to(device)
     pt_proc = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
     print("  PyTorch model loaded.")

--- a/examples/olive/ministral-3-3b-vlm/eval.py
+++ b/examples/olive/ministral-3-3b-vlm/eval.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Evaluate Ministral-3-3B VLM (ONNX) vs PyTorch on AI2D.
+
+AI2D is a multiple-choice visual QA benchmark on scientific diagrams.
+Each sample has an image, a question, four answer options, and a
+ground-truth answer. Accuracy is the fraction of questions answered
+with the correct option letter.
+
+Usage:
+    # ONNX only (default)
+    python eval.py --model_path cuda/models
+
+    # Both ONNX and PyTorch side-by-side
+    python eval.py --pytorch_model mistralai/Ministral-3-3B-Instruct-2512
+
+    # Larger sample
+    python eval.py --num_samples 200
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import re
+import tempfile
+import time
+
+import onnxruntime_genai as og
+from datasets import load_dataset
+from PIL import Image
+
+NUMBERS = ["1", "2", "3", "4"]
+
+DEFAULT_SYSTEM_PROMPT = (
+    "You are a concise multiple-choice answering assistant. "
+    "When given a question with numbered options, "
+    "respond with ONLY a single digit (1, 2, 3, or 4). "
+    "Do not include any explanation, reasoning, or other "
+    "text -- just the digit."
+)
+
+
+def _build_content_text(question: str, options: list[str]) -> str:
+    """Build the shared prompt content for evaluation."""
+    option_text = "\n".join(f"{N}. {o}" for N, o in zip(NUMBERS, options))
+    return (
+        "Look at the diagram and answer the "
+        "multiple-choice question.\n\n"
+        f"Question: {question}\n\n"
+        f"Options:\n{option_text}\n\n"
+        "Reply with the number only (1, 2, 3, or 4)."
+    )
+
+
+def build_messages(
+    question: str,
+    options: list[str],
+    system_prompt: str = "",
+) -> str:
+    """Return JSON-encoded chat messages for apply_chat_template."""
+    content = _build_content_text(question, options)
+    messages = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    # Use [IMG] tag instead of structured content blocks —
+    # Mistral's chat template uses sort(attribute='type')
+    # which ORT GenAI's minja engine doesn't support
+    messages.append({"role": "user", "content": "[IMG]" + content})
+    return json.dumps(messages)
+
+
+def parse_answer(text: str) -> str | None:
+    """Extract the first 1/2/3/4 digit from a model response."""
+    text = text.strip()
+    m = re.search(r"\b([1-4])\b", text)
+    if m:
+        return m.group(1)
+    for ch in text:
+        if ch in NUMBERS:
+            return ch
+    return None
+
+
+def ground_truth_number(sample: dict) -> str | None:
+    """Normalise the dataset's answer field to a 1-based number string.
+
+    AI2D stores answer as a 0-based integer index into the options
+    list. We map: index 0 -> '1', 1 -> '2', 2 -> '3', 3 -> '4'.
+    """
+    answer = sample.get("answer", "")
+    try:
+        idx = int(answer)
+        if 0 <= idx < 4:
+            return NUMBERS[idx]
+    except (ValueError, TypeError):
+        pass  # answer field is not a valid integer index
+    return None
+
+
+def pil_from_sample(sample: dict) -> Image.Image | None:
+    """Return PIL image from a dataset sample."""
+    img = sample.get("image")
+    if img is None:
+        return None
+    if isinstance(img, Image.Image):
+        return img.convert("RGB")
+    if isinstance(img, bytes):
+        return Image.open(io.BytesIO(img)).convert("RGB")
+    if isinstance(img, dict) and "bytes" in img:
+        return Image.open(io.BytesIO(img["bytes"])).convert("RGB")
+    return None
+
+
+def load_ai2d(num_samples: int):
+    """Load a deterministic subset of AI2D test samples."""
+    print(f"Loading AI2D dataset ({num_samples} samples)...")
+    ds = load_dataset("lmms-lab/ai2d", split="test")
+    ds = ds.select(range(min(num_samples, len(ds))))
+    print(f"  Loaded {len(ds)} samples.")
+    return ds
+
+
+def build_onnx_runner(model_path: str):
+    """Load ONNX model with ORT GenAI."""
+    print(f"\nLoading ONNX model from: {model_path}")
+    model = og.Model(model_path)
+    processor = model.create_multimodal_processor()
+    tokenizer = og.Tokenizer(model)
+    print("  ONNX model loaded.")
+    return model, processor, tokenizer
+
+
+def run_onnx(
+    model,
+    processor,
+    tokenizer,
+    pil_image: Image.Image,
+    messages_json: str,
+) -> str:
+    """Run a single inference with the ONNX GenAI model."""
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+        pil_image.save(f, format="PNG")
+        tmp_path = f.name
+
+    try:
+        images = og.Images.open(tmp_path)
+        prompt = tokenizer.apply_chat_template(messages_json, add_generation_prompt=True)
+        inputs = processor(prompt, images=images)
+
+        params = og.GeneratorParams(model)
+        params.set_search_options(max_length=2000, do_sample=False)
+
+        generator = og.Generator(model, params)
+        generator.set_inputs(inputs)
+
+        tokens = []
+        while not generator.is_done():
+            generator.generate_next_token()
+            tokens.append(generator.get_next_tokens()[0])
+        del generator
+
+        return tokenizer.decode(tokens)
+    finally:
+        os.unlink(tmp_path)
+
+
+def build_pytorch_runner(model_id: str):
+    """Load HuggingFace PyTorch model for comparison."""
+    print(f"\nLoading PyTorch model: {model_id}")
+    import torch
+    from transformers import (
+        AutoProcessor,
+        Mistral3ForConditionalGeneration,
+    )
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    dtype = torch.float16 if device == "cuda" else torch.float32
+    print(f"  Device: {device}, dtype: {dtype}")
+
+    pt_model = Mistral3ForConditionalGeneration.from_pretrained(
+        model_id, dtype=dtype, trust_remote_code=True
+    ).to(device)
+    pt_proc = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
+    print("  PyTorch model loaded.")
+    return pt_model, pt_proc, device
+
+
+def run_pytorch(
+    pt_model,
+    pt_proc,
+    pil_image: Image.Image,
+    question: str,
+    options: list[str],
+    device: str,
+    system_prompt: str = "",
+) -> str:
+    """Run a single inference with the HuggingFace model."""
+    import torch
+
+    content = _build_content_text(question, options)
+    messages = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.append(
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "image": pil_image},
+                {"type": "text", "text": content},
+            ],
+        }
+    )
+    text = pt_proc.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    inputs = pt_proc(
+        text=[text],
+        images=[pil_image],
+        padding=True,
+        return_tensors="pt",
+    ).to(device)
+
+    with torch.no_grad():
+        out = pt_model.generate(**inputs, max_new_tokens=8, do_sample=False)
+
+    out_ids = out[0][inputs["input_ids"].shape[-1] :]
+    return pt_proc.decode(out_ids, skip_special_tokens=True)
+
+
+def evaluate(dataset, runner_fn, label: str) -> dict:
+    """Run evaluation on a dataset with the given runner."""
+    correct = 0
+    skipped = 0
+    total = len(dataset)
+    latencies = []
+
+    print(f"\n{'=' * 60}")
+    print(f"  Evaluating: {label}  ({total} samples)")
+    print(f"{'=' * 60}")
+
+    for i, sample in enumerate(dataset):
+        gt = ground_truth_number(sample)
+        if gt is None:
+            skipped += 1
+            continue
+
+        pil_image = pil_from_sample(sample)
+        if pil_image is None:
+            skipped += 1
+            continue
+
+        question = sample.get("question", "")
+        options = sample.get("options", [])
+        if len(options) < 2:
+            skipped += 1
+            continue
+
+        try:
+            t0 = time.perf_counter()
+            raw = runner_fn(pil_image, question, options)
+            elapsed = time.perf_counter() - t0
+            latencies.append(elapsed)
+        except Exception as e:
+            print(f"  [WARN] sample {i}: {e}")
+            skipped += 1
+            continue
+
+        pred = parse_answer(raw)
+        hit = pred == gt
+        if hit:
+            correct += 1
+
+        if (i + 1) % 10 == 0 or i == 0:
+            denominator = i + 1 - skipped + 1e-9
+            acc = correct / denominator
+            print(
+                f"  [{i + 1:4d}/{total}] "
+                f"gt={gt} pred={pred} "
+                f"raw={raw.strip()!r:20}  "
+                f"{'OK' if hit else 'WRONG'}  "
+                f"running_acc={acc:.3f}"
+            )
+
+    evaluated = total - skipped
+    accuracy = correct / evaluated if evaluated > 0 else 0.0
+    avg_lat = sum(latencies) / len(latencies) if latencies else 0.0
+
+    print(
+        f"\n  {label}: {correct}/{evaluated} correct  |  "
+        f"accuracy = {accuracy:.4f} ({accuracy * 100:.2f}%)"
+    )
+    print(f"  avg latency per sample: {avg_lat:.2f}s  |  skipped: {skipped}")
+    return {
+        "label": label,
+        "accuracy": accuracy,
+        "correct": correct,
+        "evaluated": evaluated,
+        "avg_latency_s": avg_lat,
+        "skipped": skipped,
+    }
+
+
+def main():
+    """Entry point for evaluation."""
+    parser = argparse.ArgumentParser(
+        description=("Eval ONNX vs PyTorch Ministral-3-3B VLM on AI2D")
+    )
+    parser.add_argument(
+        "--model_path",
+        default="models",
+        help="Path to ONNX model dir",
+    )
+    parser.add_argument(
+        "--pytorch_model",
+        default=None,
+        help="HuggingFace model ID for PyTorch comparison",
+    )
+    parser.add_argument(
+        "--num_samples",
+        type=int,
+        default=100,
+        help="Number of AI2D test samples (default: 100)",
+    )
+    parser.add_argument(
+        "--skip_onnx",
+        action="store_true",
+        help="Skip ONNX evaluation",
+    )
+    parser.add_argument(
+        "--system_prompt",
+        default=DEFAULT_SYSTEM_PROMPT,
+        help=("System prompt to suppress chain-of-thought. Pass empty string to disable."),
+    )
+    args = parser.parse_args()
+
+    ds = load_ai2d(args.num_samples)
+    results = []
+
+    sys_prompt = args.system_prompt
+    if sys_prompt:
+        print(f"\nSystem prompt: {sys_prompt!r}")
+    else:
+        print("\nSystem prompt: (none)")
+
+    if not args.skip_onnx:
+        onnx_model, onnx_proc, onnx_tok = build_onnx_runner(args.model_path)
+
+        def onnx_runner(pil_image, question, options):
+            msgs = build_messages(question, options, sys_prompt)
+            return run_onnx(
+                onnx_model,
+                onnx_proc,
+                onnx_tok,
+                pil_image,
+                msgs,
+            )
+
+        results.append(
+            evaluate(
+                ds,
+                onnx_runner,
+                f"ONNX @ {args.model_path}",
+            )
+        )
+
+    if args.pytorch_model:
+        pt_model, pt_proc, device = build_pytorch_runner(args.pytorch_model)
+
+        def pt_runner(pil_image, question, options):
+            return run_pytorch(
+                pt_model,
+                pt_proc,
+                pil_image,
+                question,
+                options,
+                device,
+                sys_prompt,
+            )
+
+        results.append(
+            evaluate(
+                ds,
+                pt_runner,
+                f"PyTorch @ {args.pytorch_model}",
+            )
+        )
+
+    print(f"\n{'=' * 60}")
+    print("  EVALUATION SUMMARY")
+    print(f"{'=' * 60}")
+    print("  Model       : Ministral-3-3B-Instruct-2512 (VLM)")
+    print("  Dataset     : AI2D (science diagram QA, multiple choice)")
+    print(f"  Samples     : {args.num_samples}")
+    if not sys_prompt:
+        print("  System prompt: (none)")
+    else:
+        truncated = sys_prompt[:80]
+        ellipsis = "..." if len(sys_prompt) > 80 else ""
+        print(f"  System prompt: {truncated}{ellipsis}")
+    print()
+    for r in results:
+        print(f"  {r['label']}")
+        print(f"    Accuracy : {r['accuracy'] * 100:.2f}%  ({r['correct']}/{r['evaluated']})")
+        print(f"    Avg lat  : {r['avg_latency_s']:.2f}s/sample")
+        print()
+
+    if len(results) == 2:
+        delta = results[1]["accuracy"] - results[0]["accuracy"]
+        onnx_lat = max(results[0]["avg_latency_s"], 1e-9)
+        speedup = results[1]["avg_latency_s"] / onnx_lat
+        print(f"  Accuracy delta (PyTorch - ONNX): {delta * 100:+.2f} pp")
+        print(f"  Speedup (PyTorch lat / ONNX lat): {speedup:.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/olive/ministral-3-3b-vlm/inference.py
+++ b/examples/olive/ministral-3-3b-vlm/inference.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""ONNX Runtime GenAI inference for Ministral-3-3B VLM.
+
+Usage:
+    python inference.py --prompt "What is the capital of France?"
+    python inference.py --image photo.jpg --prompt "Describe this"
+    python inference.py --interactive
+    python inference.py --model_path cuda/models --prompt "Hello"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+
+import onnxruntime_genai as og
+
+
+def main():
+    """Entry point for inference."""
+    parser = argparse.ArgumentParser(
+        description=("ONNX Runtime GenAI inference for Ministral-3-3B")
+    )
+    parser.add_argument(
+        "--model_path",
+        type=str,
+        default="models",
+        help=("Path to model directory containing genai_config.json and ONNX models"),
+    )
+    parser.add_argument(
+        "--image",
+        type=str,
+        default=None,
+        help="Path to image file",
+    )
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        default=None,
+        help="Text prompt",
+    )
+    parser.add_argument(
+        "--max_length",
+        type=int,
+        default=4096,
+        help="Maximum total tokens",
+    )
+    parser.add_argument(
+        "--interactive",
+        action="store_true",
+        help="Run in interactive mode",
+    )
+    args = parser.parse_args()
+
+    print(f"Loading model from: {args.model_path}")
+    model = og.Model(args.model_path)
+    processor = model.create_multimodal_processor()
+    tokenizer = og.Tokenizer(model)
+    tokenizer_stream = processor.create_stream()
+
+    if args.interactive:
+        interactive_mode(model, processor, tokenizer, tokenizer_stream, args)
+    elif args.prompt:
+        generate_response(
+            model,
+            processor,
+            tokenizer,
+            tokenizer_stream,
+            args.prompt,
+            args.image,
+            args.max_length,
+        )
+    else:
+        print("Please provide --prompt or --interactive")
+        parser.print_help()
+
+
+def generate_response(
+    model,
+    processor,
+    tokenizer,
+    tokenizer_stream,
+    prompt,
+    image_path,
+    max_length=4096,
+):
+    """Run a single generation."""
+    images = None
+    if image_path:
+        print(f"Loading image: {image_path}")
+        images = og.Images.open(image_path)
+        # Use [IMG] tag instead of structured content blocks —
+        # Mistral's chat template uses sort(attribute='type')
+        # which ORT GenAI's minja engine doesn't support
+        messages = [{"role": "user", "content": "[IMG]" + prompt}]
+    else:
+        messages = [{"role": "user", "content": prompt}]
+
+    full_prompt = tokenizer.apply_chat_template(
+        json.dumps(messages), add_generation_prompt=True
+    )
+    print(f"\nPrompt: {prompt}")
+    if image_path:
+        print(f"Image: {image_path}")
+    print("\nGenerating response...")
+
+    inputs = processor(full_prompt, images=images)
+    params = og.GeneratorParams(model)
+    params.set_search_options(max_length=max_length)
+
+    generator = og.Generator(model, params)
+    generator.set_inputs(inputs)
+
+    token_count = 0
+    ttft = None
+    t_start = time.perf_counter()
+
+    print("\nResponse: ", end="", flush=True)
+    while not generator.is_done():
+        generator.generate_next_token()
+        if ttft is None:
+            ttft = time.perf_counter() - t_start
+        token_count += 1
+        new_token = generator.get_next_tokens()[0]
+        print(
+            tokenizer_stream.decode(new_token),
+            end="",
+            flush=True,
+        )
+
+    t_total = time.perf_counter() - t_start
+    print()
+    del generator
+
+    decode_tokens = max(token_count - 1, 1)
+    decode_time = t_total - (ttft or 0)
+    tps = decode_tokens / decode_time if decode_time > 0 else 0
+
+    print(f"\n  Tokens generated : {token_count}")
+    print(f"  TTFT             : {(ttft or 0) * 1000:.1f} ms")
+    print(f"  Decode TPS       : {tps:.1f} tokens/sec")
+    print(f"  Total time       : {t_total:.2f} s")
+
+
+def interactive_mode(model, processor, tokenizer, tokenizer_stream, args):
+    """Run in interactive mode."""
+    print("\n" + "=" * 50)
+    print("Interactive Mode - Enter 'quit' to stop")
+    print("To include an image: image:/path/to/image.jpg your prompt")
+    print("=" * 50 + "\n")
+
+    while True:
+        try:
+            user_input = input("You: ").strip()
+        except EOFError:
+            break
+
+        if user_input.lower() in ("quit", "exit"):
+            break
+        if not user_input:
+            continue
+
+        image_path = None
+        prompt = user_input
+        if user_input.startswith("image:"):
+            parts = user_input.split(" ", 1)
+            image_path = parts[0][6:]
+            prompt = parts[1] if len(parts) > 1 else "Describe this image"
+
+        try:
+            generate_response(
+                model,
+                processor,
+                tokenizer,
+                tokenizer_stream,
+                prompt,
+                image_path,
+                args.max_length,
+            )
+        except Exception as e:
+            print(f"Error: {e}")
+
+        print("-" * 50 + "\n")
+
+    print("Goodbye!")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/olive/ministral-3-3b-vlm/optimize.py
+++ b/examples/olive/ministral-3-3b-vlm/optimize.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Export Ministral-3-3B VLM to ONNX with optional Olive quantization.
+
+Uses mobius for all 3 sub-model exports (text decoder, vision encoder,
+embedding) and ORT GenAI config generation. Optionally applies Olive
+ModelBuilder quantization (INT4/FP16) to the text decoder.
+
+Usage::
+
+    # Pure mobius export (FP16)
+    python optimize.py
+
+    # With Olive INT4 quantization for text decoder (CPU)
+    python optimize.py --olive-config cpu_and_mobile/text.json
+
+    # With Olive FP16 quantization for text decoder (CUDA)
+    python optimize.py --olive-config cuda/text.json --ep cuda
+
+    # Custom output directory
+    python optimize.py --output-dir output/ministral3
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import shutil
+from pathlib import Path
+
+logging.getLogger("onnxscript").setLevel(logging.WARNING)
+logging.getLogger("onnx_ir").setLevel(logging.WARNING)
+
+DEFAULT_OUTPUT_DIR = "models"
+DEFAULT_HF_MODEL = "mistralai/Ministral-3-3B-Instruct-2512"
+
+
+def export_models(
+    model_path: str,
+    output_dir: str,
+    dtype: str = "f16",
+    ep: str = "cpu",
+):
+    """Build and save all 3 sub-models with mobius.
+
+    Uses mobius.build() which constructs the ONNX graphs
+    declaratively (no torch.onnx.export), avoiding dynamo
+    issues with Pixtral's dynamic image dimensions.
+    """
+    from mobius import build
+    from mobius.integrations.ort_genai import (
+        write_ort_genai_config,
+    )
+
+    print(f"=== Building VLM from {model_path} ===")
+    print(f"  dtype={dtype}, ep={ep}")
+
+    pkg = build(model_path, dtype=dtype, load_weights=True)
+    print(f"  Components: {list(pkg.keys())}")
+
+    print(f"\n=== Saving to {output_dir} ===")
+    pkg.save(output_dir)
+
+    print("\n=== Generating ORT GenAI config ===")
+    write_ort_genai_config(
+        pkg,
+        output_dir,
+        hf_model_id=model_path,
+        ep=ep,
+    )
+
+    print("  Export complete")
+
+
+def quantize_text_decoder(olive_config: str, output_dir: str):
+    """Quantize text decoder using Olive ModelBuilder.
+
+    Replaces the mobius-exported text decoder with an
+    Olive-quantized version (INT4 or FP16 with GQA).
+
+    Rewrites the Olive config's output_dir at runtime to
+    match the user-provided output directory.
+    """
+    import json
+    import tempfile
+
+    try:
+        from olive import run
+    except ImportError:
+        from olive.workflows import run
+
+    config_path = Path(olive_config)
+    if not config_path.exists():
+        raise FileNotFoundError(f"Olive config not found: {config_path}")
+
+    # Rewrite output_dir in Olive config to match user's
+    # --output-dir, so paths stay coordinated
+    with open(config_path) as f:
+        olive_cfg = json.load(f)
+    olive_cfg["output_dir"] = str(Path(output_dir) / "text.onnx")
+
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".json",
+        delete=False,
+        dir=config_path.parent,
+    ) as tmp:
+        json.dump(olive_cfg, tmp, indent=4)
+        tmp_path = tmp.name
+
+    try:
+        print(f"\n=== Olive quantization: {config_path} ===")
+        run(tmp_path)
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+    # Move Olive output into decoder/ subdirectory
+    olive_output = Path(output_dir) / "text.onnx"
+    decoder_dir = Path(output_dir) / "decoder"
+    if olive_output.is_dir():
+        if decoder_dir.exists():
+            shutil.rmtree(decoder_dir)
+        decoder_dir.mkdir(exist_ok=True)
+        for f in olive_output.iterdir():
+            if f.is_file():
+                shutil.move(str(f), str(decoder_dir / f.name))
+        shutil.rmtree(olive_output)
+        print(f"  Replaced decoder with Olive output in {decoder_dir}")
+
+
+def main():
+    """Run the export pipeline."""
+    parser = argparse.ArgumentParser(
+        description=("Export Ministral-3-3B VLM to ONNX with optional Olive quantization")
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=DEFAULT_OUTPUT_DIR,
+        help="Output directory (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--model-path",
+        default=DEFAULT_HF_MODEL,
+        help=("HuggingFace model ID or local path to dequantized checkpoint"),
+    )
+    parser.add_argument(
+        "--dtype",
+        default="f16",
+        choices=["f16", "f32", "bf16"],
+        help="Model dtype (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--ep",
+        default="cpu",
+        choices=["cpu", "cuda", "dml"],
+        help="Execution provider (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--olive-config",
+        default=None,
+        help=(
+            "Path to Olive JSON config for text decoder "
+            "quantization (e.g. cpu_and_mobile/text.json)"
+        ),
+    )
+    args = parser.parse_args()
+
+    # Step 1: Export all models with mobius
+    export_models(
+        args.model_path,
+        args.output_dir,
+        args.dtype,
+        args.ep,
+    )
+
+    # Step 2: Optionally quantize text decoder with Olive
+    if args.olive_config:
+        quantize_text_decoder(args.olive_config, args.output_dir)
+
+    print("\n=== Done ===")
+    print(f"  Output: {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/olive/ministral-3-3b-vlm/requirements.txt
+++ b/examples/olive/ministral-3-3b-vlm/requirements.txt
@@ -1,0 +1,18 @@
+# Mobius (ONNX model construction) — install from this repo:
+#   pip install -e '.[transformers]'
+# Or from PyPI/git:
+#   pip install mobius-ai[transformers]
+
+torch>=2.10.0,<2.11.0
+transformers>=4.57.0
+
+# Optional: Olive for text decoder quantization (INT4/FP16)
+# pip install olive-ai
+
+# For eval.py
+datasets
+Pillow
+
+# ORT GenAI runtime (install separately):
+#   CPU: pip install onnxruntime-genai
+#   GPU: pip install onnxruntime-genai-cuda

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -8,7 +8,7 @@ Two entry points:
 - :func:`write_ort_genai_config` — programmatic API. Takes an already-built
   :class:`~mobius._model_package.ModelPackage` (with weights) and writes the
   ORT-GenAI config artifacts (``genai_config.json``, tokenizer files,
-  ``image_processor.json``) alongside the ONNX models.
+  ``processor_config.json`` / ``image_processor.json``) alongside the ONNX models.
 
 - :func:`auto_export` — end-to-end convenience function. Builds the model
   from a HuggingFace ID, saves the ONNX files, then calls
@@ -63,9 +63,11 @@ _ORT_GENAI_MODEL_TYPE: dict[str, str] = {
     "gemma4": "gemma4",
     "gemma4_text": "gemma4_text",
     "mistral": "mistral",
+    "mistral3": "mistral3",
 }
 
 _GEMMA4_MODEL_TYPES = frozenset({"gemma4", "gemma4_text"})
+_PIXTRAL_MODEL_TYPES = frozenset({"mistral3"})
 
 _TOKENIZER_FILES = [
     "tokenizer.json",
@@ -252,6 +254,74 @@ def _fix_chat_template(output_dir: str, hf_model_id: str | None) -> bool:
     return False
 
 
+def _build_vision_transform_pipeline(
+    *,
+    image_size: int,
+    patch_size: int,
+    merge_size: int,
+    rescale_factor: float,
+    image_mean: list[float],
+    image_std: list[float],
+    min_pixels: int = 784,
+    max_pixels: int = 2371600,
+) -> list[dict[str, Any]]:
+    """Build the common 5-step vision transform pipeline.
+
+    Returns the base transforms: DecodeImage → ConvertRGB → Resize →
+    Rescale → Normalize.  Callers may append model-specific steps
+    (e.g. Permute3D, PixtralImageSizes) after this.
+    """
+    return [
+        {
+            "operation": {
+                "name": "decode_image",
+                "type": "DecodeImage",
+                "attrs": {"color_space": "RGB"},
+            }
+        },
+        {
+            "operation": {
+                "name": "convert_to_rgb",
+                "type": "ConvertRGB",
+            }
+        },
+        {
+            "operation": {
+                "name": "resize",
+                "type": "Resize",
+                "attrs": {
+                    "height": image_size,
+                    "width": image_size,
+                    "smart_resize": 1,
+                    "min_pixels": min_pixels,
+                    "max_pixels": max_pixels,
+                    "patch_size": patch_size,
+                    "merge_size": merge_size,
+                },
+            }
+        },
+        {
+            "operation": {
+                "name": "rescale",
+                "type": "Rescale",
+                "attrs": {
+                    "rescale_factor": rescale_factor,
+                },
+            }
+        },
+        {
+            "operation": {
+                "name": "normalize",
+                "type": "Normalize",
+                "attrs": {
+                    "mean": image_mean,
+                    "std": image_std,
+                },
+            }
+        },
+    ]
+
+
 def _write_vision_processor_config(
     config: Any,
     output_dir: str,
@@ -268,11 +338,12 @@ def _write_vision_processor_config(
     The output format depends on the model type:
 
     - **Gemma4** (``gemma4``, ``gemma4_text``): Writes ``image_processor.json``
-      in the onnxruntime-extensions transforms pipeline format required by
-      ``OrtxCreateProcessor``.  The pipeline is
-      ``DecodeImage → Gemma4ImageTransform``.
-    - **Other models**: Writes ``processor_config.json`` with a minimal
-      HuggingFace-style schema (``image_size``, ``patch_size``).
+      with a ``DecodeImage → Gemma4ImageTransform`` pipeline.
+    - **Pixtral / Mistral3**: Writes ``processor_config.json`` with a 7-step
+      pipeline (DecodeImage → ConvertRGB → Resize → Rescale → Normalize →
+      Permute3D → PixtralImageSizes).
+    - **Other VLMs**: Writes ``processor_config.json`` with a 5-step pipeline
+      (DecodeImage → ConvertRGB → Resize → Rescale → Normalize).
 
     Returns the written file path, or None if the config has no vision section.
     """
@@ -282,16 +353,11 @@ def _write_vision_processor_config(
 
     model_type = getattr(config, "model_type", "")
     vision_model_type = getattr(vision, "model_type", None)
-    is_pixtral = vision_model_type == "pixtral"
+    is_pixtral = vision_model_type == "pixtral" or model_type in _PIXTRAL_MODEL_TYPES
 
     if model_type in _GEMMA4_MODEL_TYPES:
         # Gemma4 needs an onnxruntime-extensions format processor config
         # with a transforms pipeline (DecodeImage -> Gemma4ImageTransform).
-        # The OrtxCreateProcessor API requires this format.
-        #
-        # max_soft_tokens: maps from HF's mm_tokens_per_image (the number of
-        # vision tokens per image after pooling) into the Gemma4ImageTransform's
-        # max_soft_tokens attribute, which controls the padded patch budget.
         max_soft_tokens = (
             getattr(vision, "mm_tokens_per_image", None)
             or getattr(config, "mm_tokens_per_image", None)
@@ -325,9 +391,9 @@ def _write_vision_processor_config(
             }
         }
         path = os.path.join(output_dir, "image_processor.json")
-    elif is_pixtral:
-        # Pixtral / Mistral3 VLM: full ORT-extensions transform pipeline
-        # with CLIP-standard normalization defaults.
+    else:
+        # Pixtral and generic VLMs share the same base pipeline;
+        # Pixtral adds Permute3D + PixtralImageSizes at the end.
         patch_size = getattr(vision, "patch_size", 14) or 14
         merge_size = (
             getattr(vision, "spatial_merge_size", None)
@@ -348,13 +414,13 @@ def _write_vision_processor_config(
                 from transformers import AutoProcessor
 
                 hf_proc = AutoProcessor.from_pretrained(hf_model_id)
-                image_processor = getattr(hf_proc, "image_processor", None)
-                if image_processor is not None:
-                    image_mean = list(getattr(image_processor, "image_mean", image_mean))
-                    image_std = list(getattr(image_processor, "image_std", image_std))
-                    rescale_factor = getattr(image_processor, "rescale_factor", rescale_factor)
-                    if hasattr(image_processor, "size"):
-                        size = image_processor.size
+                ip = getattr(hf_proc, "image_processor", None)
+                if ip is not None:
+                    image_mean = list(getattr(ip, "image_mean", image_mean))
+                    image_std = list(getattr(ip, "image_std", image_std))
+                    rescale_factor = getattr(ip, "rescale_factor", rescale_factor)
+                    if hasattr(ip, "size"):
+                        size = ip.size
                         if isinstance(size, dict):
                             if "longest_edge" in size:
                                 image_size = size["longest_edge"]
@@ -371,133 +437,44 @@ def _write_vision_processor_config(
                 )
 
         if image_size is None:
-            image_size = 1540
+            image_size = 1540 if is_pixtral else 448
 
-        transforms: list[dict[str, Any]] = [
-            {
-                "operation": {
-                    "name": "decode_image",
-                    "type": "DecodeImage",
-                    "attrs": {"color_space": "RGB"},
-                }
-            },
-            {
-                "operation": {
-                    "name": "convert_to_rgb",
-                    "type": "ConvertRGB",
-                }
-            },
-            {
-                "operation": {
-                    "name": "resize",
-                    "type": "Resize",
-                    "attrs": {
-                        "height": image_size,
-                        "width": image_size,
-                        "smart_resize": 1,
-                        "min_pixels": min_pixels,
-                        "max_pixels": max_pixels,
-                        "patch_size": patch_size,
-                        "merge_size": merge_size,
-                    },
-                }
-            },
-            {
-                "operation": {
-                    "name": "rescale",
-                    "type": "Rescale",
-                    "attrs": {
-                        "rescale_factor": rescale_factor,
-                    },
-                }
-            },
-            {
-                "operation": {
-                    "name": "normalize",
-                    "type": "Normalize",
-                    "attrs": {
-                        "mean": image_mean,
-                        "std": image_std,
-                    },
-                }
-            },
-        ]
-
-        processor_config = {
-            "processor": {
-                "name": "pixtral_image_processor",
-                "transforms": transforms,
-            }
-        }
-        path = os.path.join(output_dir, "processor_config.json")
-    else:
-        # Generic VLM: full ORT-extensions transform pipeline with
-        # CLIP-standard normalization defaults.
-        patch_size = getattr(vision, "patch_size", 14) or 14
-        merge_size = (
-            getattr(vision, "spatial_merge_size", None)
-            or getattr(config, "spatial_merge_size", 2)
-            or 2
+        transforms = _build_vision_transform_pipeline(
+            image_size=image_size,
+            patch_size=patch_size,
+            merge_size=merge_size,
+            rescale_factor=rescale_factor,
+            image_mean=image_mean,
+            image_std=image_std,
+            min_pixels=min_pixels,
+            max_pixels=max_pixels,
         )
-        image_mean = [0.48145466, 0.4578275, 0.40821073]
-        image_std = [0.26862954, 0.26130258, 0.27577711]
-        rescale_factor = 1.0 / 255.0
-        min_pixels = 784
-        max_pixels = 2371600
-        image_size = getattr(vision, "image_size", None) or 448
 
-        transforms = [
-            {
-                "operation": {
-                    "name": "decode_image",
-                    "type": "DecodeImage",
-                    "attrs": {"color_space": "RGB"},
+        if is_pixtral:
+            # Pixtral requires Permute3D (HWC→CHW) and PixtralImageSizes
+            # for the per-image slicing loop in PixtralVisionState.
+            transforms.append(
+                {
+                    "operation": {
+                        "name": "permute",
+                        "type": "Permute3D",
+                        "attrs": {"dims": [2, 0, 1]},
+                    }
                 }
-            },
-            {
-                "operation": {
-                    "name": "convert_to_rgb",
-                    "type": "ConvertRGB",
+            )
+            transforms.append(
+                {
+                    "operation": {
+                        "name": "pixtral_image_sizes",
+                        "type": "PixtralImageSizes",
+                    }
                 }
-            },
-            {
-                "operation": {
-                    "name": "resize",
-                    "type": "Resize",
-                    "attrs": {
-                        "height": image_size,
-                        "width": image_size,
-                        "smart_resize": 1,
-                        "min_pixels": min_pixels,
-                        "max_pixels": max_pixels,
-                        "patch_size": patch_size,
-                        "merge_size": merge_size,
-                    },
-                }
-            },
-            {
-                "operation": {
-                    "name": "rescale",
-                    "type": "Rescale",
-                    "attrs": {
-                        "rescale_factor": rescale_factor,
-                    },
-                }
-            },
-            {
-                "operation": {
-                    "name": "normalize",
-                    "type": "Normalize",
-                    "attrs": {
-                        "mean": image_mean,
-                        "std": image_std,
-                    },
-                }
-            },
-        ]
+            )
+
+        processor_name = "pixtral_image_processor" if is_pixtral else "image_processor"
         processor_config = {
             "processor": {
-                "name": "image_processor",
+                "name": processor_name,
                 "transforms": transforms,
             }
         }
@@ -630,6 +607,16 @@ def _write_genai_config(
                 )
             elif has_speech:
                 vision_kwargs["spatial_merge_size"] = None
+            elif (
+                model_type in _PIXTRAL_MODEL_TYPES
+                or getattr(getattr(config, "vision", None), "model_type", None) == "pixtral"
+            ):
+                vision_cfg = getattr(config, "vision", None)
+                sms = getattr(vision_cfg, "spatial_merge_size", None) or getattr(
+                    config, "spatial_merge_size", 2
+                )
+                vision_kwargs["spatial_merge_size"] = sms
+                vision_kwargs["config_filename"] = "processor_config.json"
 
             if vision_input_mapping is not None:
                 vision_kwargs["input_names"] = vision_input_mapping

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -163,11 +163,107 @@ def _copy_tokenizer_files_from_local(
     return copied
 
 
+# Tokenizer class remapping: HF tokenizer classes that ORT GenAI
+# (ort-extensions) does not support, mapped to compatible alternatives.
+_TOKENIZER_CLASS_REMAP: dict[str, str] = {
+    "TokenizersBackend": "LlamaTokenizer",
+}
+
+
+def _fix_tokenizer_config(output_dir: str) -> bool:
+    """Remap unsupported tokenizer classes for ORT GenAI compatibility.
+
+    Some HuggingFace models use tokenizer classes (e.g.
+    ``TokenizersBackend``) that ORT GenAI's ort-extensions
+    tokenizer doesn't support. This fixes tokenizer_config.json
+    to use a compatible class.
+
+    Returns True if a fix was applied, False otherwise.
+    """
+    tc_path = os.path.join(output_dir, "tokenizer_config.json")
+    if not os.path.exists(tc_path):
+        return False
+
+    with open(tc_path, encoding="utf-8") as f:
+        tc = json.load(f)
+
+    original_class = tc.get("tokenizer_class", "")
+    replacement = _TOKENIZER_CLASS_REMAP.get(original_class)
+    if replacement is None:
+        return False
+
+    tc["tokenizer_class"] = replacement
+    with open(tc_path, "w", encoding="utf-8") as f:
+        json.dump(tc, f, indent=2, ensure_ascii=False)
+    logger.info(
+        "Fixed tokenizer_class: %s -> %s",
+        original_class,
+        replacement,
+    )
+    return True
+
+
+def _fix_chat_template(output_dir: str, hf_model_id: str | None) -> bool:
+    """Ensure chat_template is present in tokenizer_config.json.
+
+    Some HuggingFace models don't store ``chat_template`` in the
+    raw ``tokenizer_config.json`` file — transformers injects it
+    dynamically from the model class at runtime. ORT GenAI reads
+    the file directly and needs it to be present.
+
+    This function loads the tokenizer via transformers (which
+    applies the dynamic template) and writes it back.
+
+    Returns True if the template was added, False otherwise.
+    """
+    tc_path = os.path.join(output_dir, "tokenizer_config.json")
+    if not os.path.exists(tc_path):
+        return False
+
+    with open(tc_path, encoding="utf-8") as f:
+        tc = json.load(f)
+
+    if tc.get("chat_template"):
+        return False
+
+    if hf_model_id is None:
+        return False
+
+    try:
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(hf_model_id)
+        template = getattr(tokenizer, "chat_template", None)
+        if template:
+            tc["chat_template"] = template
+            with open(tc_path, "w", encoding="utf-8") as f:
+                json.dump(tc, f, indent=2, ensure_ascii=False)
+            logger.info(
+                "Added chat_template to tokenizer_config.json from %s",
+                hf_model_id,
+            )
+            return True
+    except Exception:
+        logger.warning(
+            "Could not load tokenizer for %s to extract chat_template",
+            hf_model_id,
+            exc_info=True,
+        )
+    return False
+
+
 def _write_vision_processor_config(
     config: Any,
     output_dir: str,
+    *,
+    hf_model_id: str | None = None,
 ) -> str | None:
     """Write the vision processor config file for VLM models.
+
+    Generates the ORT-extensions image transform pipeline derived from the
+    HuggingFace image processor config. When ``hf_model_id`` is provided,
+    loads the HF processor to extract normalization values and resize
+    parameters. Otherwise falls back to CLIP-standard defaults.
 
     The output format depends on the model type:
 
@@ -185,6 +281,8 @@ def _write_vision_processor_config(
         return None
 
     model_type = getattr(config, "model_type", "")
+    vision_model_type = getattr(vision, "model_type", None)
+    is_pixtral = vision_model_type == "pixtral"
 
     if model_type in _GEMMA4_MODEL_TYPES:
         # Gemma4 needs an onnxruntime-extensions format processor config
@@ -201,7 +299,7 @@ def _write_vision_processor_config(
         )
         patch_size = getattr(vision, "patch_size", None) or 16
         pooling_kernel_size = getattr(vision, "pooling_kernel_size", None) or 3
-        processor = {
+        processor_config: dict[str, Any] = {
             "processor": {
                 "name": "gemma_4_image_processing",
                 "transforms": [
@@ -226,15 +324,187 @@ def _write_vision_processor_config(
                 ],
             }
         }
-    else:
-        processor = {
-            "image_size": getattr(vision, "image_size", None) or 448,
-            "patch_size": getattr(vision, "patch_size", None) or 14,
-        }
+        path = os.path.join(output_dir, "image_processor.json")
+    elif is_pixtral:
+        # Pixtral / Mistral3 VLM: full ORT-extensions transform pipeline
+        # with CLIP-standard normalization defaults.
+        patch_size = getattr(vision, "patch_size", 14) or 14
+        merge_size = (
+            getattr(vision, "spatial_merge_size", None)
+            or getattr(config, "spatial_merge_size", 2)
+            or 2
+        )
 
-    path = os.path.join(output_dir, "image_processor.json")
+        # CLIP-standard normalization defaults
+        image_mean = [0.48145466, 0.4578275, 0.40821073]
+        image_std = [0.26862954, 0.26130258, 0.27577711]
+        rescale_factor = 1.0 / 255.0
+        min_pixels = 784
+        max_pixels = 2371600
+        image_size = getattr(vision, "image_size", None)
+
+        if hf_model_id is not None:
+            try:
+                from transformers import AutoProcessor
+
+                hf_proc = AutoProcessor.from_pretrained(hf_model_id)
+                image_processor = getattr(hf_proc, "image_processor", None)
+                if image_processor is not None:
+                    image_mean = list(getattr(image_processor, "image_mean", image_mean))
+                    image_std = list(getattr(image_processor, "image_std", image_std))
+                    rescale_factor = getattr(image_processor, "rescale_factor", rescale_factor)
+                    if hasattr(image_processor, "size"):
+                        size = image_processor.size
+                        if isinstance(size, dict):
+                            if "longest_edge" in size:
+                                image_size = size["longest_edge"]
+                            min_pixels = size.get("shortest_edge", min_pixels)
+                            max_pixels = size.get("longest_edge", max_pixels)
+                        elif isinstance(size, int):
+                            image_size = size
+            except Exception:
+                logger.warning(
+                    "Could not load HF processor for %s; "
+                    "using CLIP-standard normalization defaults",
+                    hf_model_id,
+                    exc_info=True,
+                )
+
+        if image_size is None:
+            image_size = 1540
+
+        transforms: list[dict[str, Any]] = [
+            {
+                "operation": {
+                    "name": "decode_image",
+                    "type": "DecodeImage",
+                    "attrs": {"color_space": "RGB"},
+                }
+            },
+            {
+                "operation": {
+                    "name": "convert_to_rgb",
+                    "type": "ConvertRGB",
+                }
+            },
+            {
+                "operation": {
+                    "name": "resize",
+                    "type": "Resize",
+                    "attrs": {
+                        "height": image_size,
+                        "width": image_size,
+                        "smart_resize": 1,
+                        "min_pixels": min_pixels,
+                        "max_pixels": max_pixels,
+                        "patch_size": patch_size,
+                        "merge_size": merge_size,
+                    },
+                }
+            },
+            {
+                "operation": {
+                    "name": "rescale",
+                    "type": "Rescale",
+                    "attrs": {
+                        "rescale_factor": rescale_factor,
+                    },
+                }
+            },
+            {
+                "operation": {
+                    "name": "normalize",
+                    "type": "Normalize",
+                    "attrs": {
+                        "mean": image_mean,
+                        "std": image_std,
+                    },
+                }
+            },
+        ]
+
+        processor_config = {
+            "processor": {
+                "name": "pixtral_image_processor",
+                "transforms": transforms,
+            }
+        }
+        path = os.path.join(output_dir, "processor_config.json")
+    else:
+        # Generic VLM: full ORT-extensions transform pipeline with
+        # CLIP-standard normalization defaults.
+        patch_size = getattr(vision, "patch_size", 14) or 14
+        merge_size = (
+            getattr(vision, "spatial_merge_size", None)
+            or getattr(config, "spatial_merge_size", 2)
+            or 2
+        )
+        image_mean = [0.48145466, 0.4578275, 0.40821073]
+        image_std = [0.26862954, 0.26130258, 0.27577711]
+        rescale_factor = 1.0 / 255.0
+        min_pixels = 784
+        max_pixels = 2371600
+        image_size = getattr(vision, "image_size", None) or 448
+
+        transforms = [
+            {
+                "operation": {
+                    "name": "decode_image",
+                    "type": "DecodeImage",
+                    "attrs": {"color_space": "RGB"},
+                }
+            },
+            {
+                "operation": {
+                    "name": "convert_to_rgb",
+                    "type": "ConvertRGB",
+                }
+            },
+            {
+                "operation": {
+                    "name": "resize",
+                    "type": "Resize",
+                    "attrs": {
+                        "height": image_size,
+                        "width": image_size,
+                        "smart_resize": 1,
+                        "min_pixels": min_pixels,
+                        "max_pixels": max_pixels,
+                        "patch_size": patch_size,
+                        "merge_size": merge_size,
+                    },
+                }
+            },
+            {
+                "operation": {
+                    "name": "rescale",
+                    "type": "Rescale",
+                    "attrs": {
+                        "rescale_factor": rescale_factor,
+                    },
+                }
+            },
+            {
+                "operation": {
+                    "name": "normalize",
+                    "type": "Normalize",
+                    "attrs": {
+                        "mean": image_mean,
+                        "std": image_std,
+                    },
+                }
+            },
+        ]
+        processor_config = {
+            "processor": {
+                "name": "image_processor",
+                "transforms": transforms,
+            }
+        }
+        path = os.path.join(output_dir, "processor_config.json")
+
     with open(path, "w", encoding="utf-8") as f:
-        json.dump(processor, f, indent=4)
+        json.dump(processor_config, f, indent=4)
     return path
 
 
@@ -568,7 +838,7 @@ def write_ort_genai_config(
             result[tf] = os.path.join(directory, tf)
 
     # Write processor config for VLMs
-    processor_path = _write_vision_processor_config(config, directory)
+    processor_path = _write_vision_processor_config(config, directory, hf_model_id=hf_model_id)
     if processor_path:
         result["processor_config"] = processor_path
 
@@ -576,6 +846,12 @@ def write_ort_genai_config(
     audio_proc_path = _write_audio_processor_config(config, directory)
     if audio_proc_path:
         result["audio_processor"] = audio_proc_path
+
+    # Fix unsupported tokenizer classes
+    _fix_tokenizer_config(directory)
+
+    # Ensure chat_template is in tokenizer_config.json
+    _fix_chat_template(directory, hf_model_id)
 
     logger.info("ORT-GenAI artifacts written: %d files", len(result))
     return result

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -15,6 +15,8 @@ import pytest
 from mobius.integrations.ort_genai.auto_export import (
     _copy_tokenizer_files,
     _copy_tokenizer_files_from_local,
+    _fix_chat_template,
+    _fix_tokenizer_config,
     _graph_input_names,
     _resolve_ort_genai_model_type,
     _write_audio_processor_config,
@@ -80,19 +82,119 @@ class TestWriteProcessorConfig:
         del config.vision  # ensure no vision attribute
         assert _write_vision_processor_config(config, str(tmp_path)) is None
 
-    def test_writes_vision_config(self, tmp_path):
+    def test_writes_transform_pipeline(self, tmp_path):
+        """Generates full transform pipeline for generic VLMs."""
         vision = mock.MagicMock()
-        vision.image_size = 224
-        vision.patch_size = 16
+        vision.image_size = 448
+        vision.patch_size = 14
+        vision.spatial_merge_size = 2
+        vision.model_type = None
         config = mock.MagicMock()
         config.vision = vision
+        config.spatial_merge_size = 2
 
         path = _write_vision_processor_config(config, str(tmp_path))
         assert path is not None
         with open(path) as f:
             data = json.load(f)
-        assert data["image_size"] == 224
-        assert data["patch_size"] == 16
+
+        proc = data["processor"]
+        assert proc["name"] == "image_processor"
+        transforms = proc["transforms"]
+        assert len(transforms) == 5
+        assert transforms[0]["operation"]["type"] == "DecodeImage"
+        assert transforms[1]["operation"]["type"] == "ConvertRGB"
+        assert transforms[2]["operation"]["type"] == "Resize"
+        assert transforms[3]["operation"]["type"] == "Rescale"
+        assert transforms[4]["operation"]["type"] == "Normalize"
+
+        # Check resize attrs
+        resize_attrs = transforms[2]["operation"]["attrs"]
+        assert resize_attrs["patch_size"] == 14
+        assert resize_attrs["merge_size"] == 2
+
+        # Check normalization defaults (CLIP-standard)
+        norm_attrs = transforms[4]["operation"]["attrs"]
+        assert len(norm_attrs["mean"]) == 3
+        assert len(norm_attrs["std"]) == 3
+
+    def test_pixtral_vision_config(self, tmp_path):
+        """Generates pixtral-specific processor config."""
+        vision = mock.MagicMock()
+        vision.image_size = 1540
+        vision.patch_size = 14
+        vision.spatial_merge_size = 2
+        vision.model_type = "pixtral"
+        config = mock.MagicMock()
+        config.vision = vision
+        config.spatial_merge_size = 2
+
+        path = _write_vision_processor_config(config, str(tmp_path))
+        assert path is not None
+        with open(path) as f:
+            data = json.load(f)
+
+        proc = data["processor"]
+        assert proc["name"] == "pixtral_image_processor"
+        resize = proc["transforms"][2]["operation"]["attrs"]
+        assert resize["height"] == 1540
+        assert resize["width"] == 1540
+
+
+class TestFixTokenizerConfig:
+    def test_remaps_tokenizers_backend(self, tmp_path):
+        tc = {"tokenizer_class": "TokenizersBackend"}
+        tc_path = tmp_path / "tokenizer_config.json"
+        tc_path.write_text(json.dumps(tc))
+
+        assert _fix_tokenizer_config(str(tmp_path)) is True
+
+        fixed = json.loads(tc_path.read_text())
+        assert fixed["tokenizer_class"] == "LlamaTokenizer"
+
+    def test_no_fix_needed(self, tmp_path):
+        tc = {"tokenizer_class": "LlamaTokenizer"}
+        (tmp_path / "tokenizer_config.json").write_text(json.dumps(tc))
+        assert _fix_tokenizer_config(str(tmp_path)) is False
+
+    def test_no_tokenizer_config(self, tmp_path):
+        assert _fix_tokenizer_config(str(tmp_path)) is False
+
+
+class TestFixChatTemplate:
+    def test_adds_chat_template(self, tmp_path):
+        """Adds chat_template from HF tokenizer when missing."""
+        tc = {"tokenizer_class": "LlamaTokenizer"}
+        (tmp_path / "tokenizer_config.json").write_text(json.dumps(tc))
+
+        fake_tokenizer = mock.MagicMock()
+        fake_tokenizer.chat_template = "{{ bos_token }}"
+
+        with mock.patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            return_value=fake_tokenizer,
+        ):
+            result = _fix_chat_template(str(tmp_path), "fake/model")
+
+        assert result is True
+        fixed = json.loads((tmp_path / "tokenizer_config.json").read_text())
+        assert fixed["chat_template"] == "{{ bos_token }}"
+
+    def test_skips_when_template_exists(self, tmp_path):
+        tc = {
+            "tokenizer_class": "LlamaTokenizer",
+            "chat_template": "existing",
+        }
+        (tmp_path / "tokenizer_config.json").write_text(json.dumps(tc))
+        assert _fix_chat_template(str(tmp_path), "fake/model") is False
+
+    def test_skips_without_model_id(self, tmp_path):
+        tc = {"tokenizer_class": "LlamaTokenizer"}
+        (tmp_path / "tokenizer_config.json").write_text(json.dumps(tc))
+        assert _fix_chat_template(str(tmp_path), None) is False
+
+    def test_skips_without_file(self, tmp_path):
+        assert _fix_chat_template(str(tmp_path), "fake/model") is False
 
     def test_audio_no_audio_returns_none(self, tmp_path):
         config = mock.MagicMock(spec=[])
@@ -315,6 +417,8 @@ class TestExportForOrtGenai:
         class FakeVision:
             image_size: int = 448
             patch_size: int = 14
+            spatial_merge_size: int = 2
+            model_type: str | None = None
 
         @dataclasses.dataclass
         class FakeConfig:
@@ -325,6 +429,7 @@ class TestExportForOrtGenai:
             num_attention_heads: int = 4
             num_key_value_heads: int = 2
             head_dim: int = 16
+            spatial_merge_size: int = 2
             vision: FakeVision = dataclasses.field(default_factory=FakeVision)
 
         pkg = ModelPackage(
@@ -341,7 +446,13 @@ class TestExportForOrtGenai:
         assert os.path.isfile(result["processor_config"])
         with open(result["processor_config"]) as f:
             data = json.load(f)
-        assert data["image_size"] == 448
+        # New format: transform pipeline under "processor"
+        assert "processor" in data
+        transforms = data["processor"]["transforms"]
+        assert len(transforms) >= 4
+        # Verify resize uses config values
+        resize = transforms[2]["operation"]["attrs"]
+        assert resize["patch_size"] == 14
 
     def test_processor_config_not_written_without_vision(self, tmp_path):
         """image_processor.json is NOT written when pkg.config has no vision attr."""

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -70,6 +70,11 @@ class TestResolveOrtGenaiModelType:
     def test_unknown_model_type_passthrough(self):
         assert _resolve_ort_genai_model_type("my_custom") == "my_custom"
 
+    def test_mistral3_model_type(self):
+        assert _resolve_ort_genai_model_type("mistral3") == "mistral3"
+        # Text-only mistral is a separate mapping
+        assert _resolve_ort_genai_model_type("mistral") == "mistral"
+
     def test_phi4mm_model_types(self):
         assert _resolve_ort_genai_model_type("phi4mm") == "phi4mm"
         assert _resolve_ort_genai_model_type("phi4_multimodal") == "phi4mm"
@@ -119,7 +124,7 @@ class TestWriteProcessorConfig:
         assert len(norm_attrs["std"]) == 3
 
     def test_pixtral_vision_config(self, tmp_path):
-        """Generates pixtral-specific processor config."""
+        """Generates pixtral-specific processor config with 7 transforms."""
         vision = mock.MagicMock()
         vision.image_size = 1540
         vision.patch_size = 14
@@ -128,17 +133,68 @@ class TestWriteProcessorConfig:
         config = mock.MagicMock()
         config.vision = vision
         config.spatial_merge_size = 2
+        config.model_type = "mistral3"
 
         path = _write_vision_processor_config(config, str(tmp_path))
         assert path is not None
+        assert path.endswith("processor_config.json")
         with open(path) as f:
             data = json.load(f)
 
         proc = data["processor"]
         assert proc["name"] == "pixtral_image_processor"
-        resize = proc["transforms"][2]["operation"]["attrs"]
+        transforms = proc["transforms"]
+        assert len(transforms) == 7
+
+        # Verify all 7 transform types in order
+        types = [t["operation"]["type"] for t in transforms]
+        assert types == [
+            "DecodeImage",
+            "ConvertRGB",
+            "Resize",
+            "Rescale",
+            "Normalize",
+            "Permute3D",
+            "PixtralImageSizes",
+        ]
+
+        resize = transforms[2]["operation"]["attrs"]
         assert resize["height"] == 1540
         assert resize["width"] == 1540
+
+        # Permute3D has correct dims
+        permute = transforms[5]["operation"]["attrs"]
+        assert permute["dims"] == [2, 0, 1]
+
+    def test_hf_processor_fallback_to_clip_defaults(self, tmp_path):
+        """Falls back to CLIP-standard defaults when HF processor can't be loaded."""
+        vision = mock.MagicMock()
+        vision.image_size = 448
+        vision.patch_size = 14
+        vision.spatial_merge_size = 2
+        vision.model_type = None
+        config = mock.MagicMock()
+        config.vision = vision
+        config.spatial_merge_size = 2
+        config.model_type = "qwen2"
+
+        with mock.patch(
+            "transformers.AutoProcessor.from_pretrained",
+            side_effect=OSError("model not found"),
+        ):
+            path = _write_vision_processor_config(
+                config, str(tmp_path), hf_model_id="nonexistent/model"
+            )
+
+        assert path is not None
+        with open(path) as f:
+            data = json.load(f)
+
+        proc = data["processor"]
+        # Should use CLIP-standard normalization defaults
+        normalize = proc["transforms"][4]["operation"]["attrs"]
+        assert normalize["mean"] == pytest.approx([0.48145466, 0.4578275, 0.40821073])
+        assert normalize["std"] == pytest.approx([0.26862954, 0.26130258, 0.27577711])
 
 
 class TestFixTokenizerConfig:
@@ -230,6 +286,22 @@ class TestFixChatTemplate:
         assert attrs["frame_length_ms"] == 20.0  # noqa: RUF069
         assert attrs["hop_length_ms"] == 10.0  # noqa: RUF069
         assert attrs["mel_floor"] == 0.001  # noqa: RUF069
+
+    def test_handles_tokenizer_load_error(self, tmp_path):
+        """Gracefully handles AutoTokenizer.from_pretrained raising."""
+        tc = {"tokenizer_class": "LlamaTokenizer"}
+        (tmp_path / "tokenizer_config.json").write_text(json.dumps(tc))
+
+        with mock.patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            side_effect=RuntimeError("model not available"),
+        ):
+            result = _fix_chat_template(str(tmp_path), "fake/model")
+
+        assert result is False
+        # Original config is unchanged
+        fixed = json.loads((tmp_path / "tokenizer_config.json").read_text())
+        assert "chat_template" not in fixed
 
 
 class TestCopyTokenizerFiles:
@@ -969,6 +1041,76 @@ class TestGemma4GenaiConfig:
         emb_inputs = data["model"]["embedding"]["inputs"]
         assert "input_ids" in emb_inputs
         assert "image_features" in emb_inputs
+
+
+class TestPixtralGenaiConfig:
+    """Tests for Pixtral/Ministral-3-specific genai_config generation."""
+
+    @staticmethod
+    def _make_pixtral_pkg():
+        """Build a mock Pixtral VLM package with graph inputs."""
+        import dataclasses
+
+        from mobius._model_package import ModelPackage
+
+        @dataclasses.dataclass
+        class FakeVision:
+            image_size: int = 1540
+            patch_size: int = 14
+            spatial_merge_size: int = 2
+            model_type: str = "pixtral"
+
+        @dataclasses.dataclass
+        class FakeConfig:
+            model_type: str = "mistral3"
+            vocab_size: int = 256
+            hidden_size: int = 64
+            num_hidden_layers: int = 2
+            num_attention_heads: int = 4
+            num_key_value_heads: int = 2
+            head_dim: int = 16
+            max_position_embeddings: int = 128
+            image_token_id: int = 10
+            spatial_merge_size: int = 2
+            vision: FakeVision = dataclasses.field(default_factory=FakeVision)
+
+        decoder = _mock_model_with_inputs(
+            ["input_ids", "attention_mask", "past_key_values.0.key"]
+        )
+        vision = _mock_model_with_inputs(["pixel_values"])
+        embedding = _mock_model_with_inputs(["input_ids", "image_features"])
+
+        return ModelPackage(
+            {
+                "model": decoder,
+                "vision_encoder": vision,
+                "embedding": embedding,
+            },
+            config=FakeConfig(),
+        )
+
+    def test_pixtral_config_filename_is_processor_config(self, tmp_path):
+        """Pixtral genai_config.json references processor_config.json, not image_processor.json."""
+        pkg = self._make_pixtral_pkg()
+        path = _write_genai_config(
+            pkg.config,
+            str(tmp_path),
+            pkg=pkg,
+            ort_model_type="mistral3",
+            ep="cpu",
+            context_length=4096,
+            bos_token_id=1,
+            eos_token_id=2,
+            pad_token_id=0,
+            is_vlm=True,
+            has_speech=False,
+        )
+        with open(path) as f:
+            data = json.load(f)
+        vision = data["model"]["vision"]
+        assert vision["config_filename"] == "processor_config.json"
+        assert vision["spatial_merge_size"] == 2
+        assert data["model"]["image_token_id"] == 10
 
 
 class TestGraphInputNames:

--- a/src/mobius/integrations/ort_genai/genai_config_test.py
+++ b/src/mobius/integrations/ort_genai/genai_config_test.py
@@ -283,6 +283,12 @@ class TestGenaiConfigGeneratorVLM:
         assert "inputs_embeds" in inputs
         assert "input_ids" not in inputs
 
+    def test_vlm_decoder_filename_uses_subdirectory(self):
+        """VLM decoder filename includes the decoder/ subdirectory."""
+        config = self._make_vlm_gen().generate()
+        decoder = config["model"]["decoder"]
+        assert decoder["filename"] == "decoder/model.onnx"
+
     def test_vlm_token_ids_at_model_level(self):
         """VLM-specific token IDs are at the model level."""
         config = self._make_vlm_gen().generate()


### PR DESCRIPTION
## Summary

Add an end-to-end olive-recipe demo for Ministral-3-3B VLM and enhance the mobius genai integration with Pixtral processor config support and tokenizer class remapping.

## Changes

### Core: genai integration enhancements (`src/mobius/integrations/ort_genai/`)
- **`_write_processor_config`**: Enhanced to generate full ORT-extensions image transform pipeline for VL models. Dispatches by model type (Pixtral: longest_edge resize; generic: smart_resize). Derives normalization params from HF processor config.
- **`_fix_tokenizer_config`**: New function with `_TOKENIZER_CLASS_REMAP` dict to remap unsupported tokenizer classes (e.g. `TokenizersBackend` → `LlamaTokenizer`). Called automatically from `write_ort_genai_config()`.
- 4 new tests (31 total passing)

### Example: olive-recipe demo (`examples/olive/ministral-3-3b-vlm/`)
- **optimize.py**: Pure mobius export (`build()` → `save()` → `write_ort_genai_config()`) with optional Olive quantization via `--olive-config`
- **inference.py**: ORT GenAI multimodal inference (text-only, image+text, interactive)
- **eval.py**: AI2D benchmark evaluation (ONNX vs PyTorch comparison)
- Olive configs for CPU (INT4) and CUDA (FP16) quantization
- README with setup, export, inference, and evaluation instructions

### Skills
- New `olive-recipe` skill documenting the mobius + Olive hybrid pipeline pattern
- Updated `ort-genai-config` skill with Pixtral processor config and tokenizer remap info

## References
- [Issue #158](https://github.com/onnxruntime/mobius/issues/158)
- [PR #130](https://github.com/onnxruntime/mobius/pull/130) (Pixtral/Ministral3 VLM support)
- [olive-recipes PR #352](https://github.com/microsoft/olive-recipes/pull/352)
- [onnxruntime-genai PR #2077](https://github.com/microsoft/onnxruntime-genai/pull/2077)

Closes #158