### PR TITLE
docs: update stale opset 23 references to opset 24

### DIFF
--- a/src/mobius/components/_audio.py
+++ b/src/mobius/components/_audio.py
@@ -345,7 +345,7 @@ class ConformerConvModule(nn.Module):
 class ConformerAttention(nn.Module):
     """Multi-head attention with relative position bias.
 
-    Uses the ONNX Attention op (opset 23) with separate Q/K/V/O projections.
+    Uses the ONNX Attention op (opset 24) with separate Q/K/V/O projections.
     The T5 relative bias is passed as ``attn_mask`` (attention bias) to the
     Attention op.
     """

--- a/src/mobius/components/_codec_transformer.py
+++ b/src/mobius/components/_codec_transformer.py
@@ -119,7 +119,7 @@ class _CodecDecoderAttention(nn.Module):
     """Multi-head attention with RoPE for the codec decoder transformer.
 
     Uses ``op.RotaryEmbedding`` on Q and K before passing them
-    to the ONNX ``Attention`` op (opset 23).
+    to the ONNX ``Attention`` op (opset 24).
 
     Parameters:
         hidden_size: Model hidden dimension.

--- a/src/mobius/components/_pixtral_vision.py
+++ b/src/mobius/components/_pixtral_vision.py
@@ -178,7 +178,7 @@ class PixtralAttention(nn.Module):
         # Bidirectional attention (no causal mask, no KV cache).
         # Use com.microsoft.MultiHeadAttention for all EPs that support
         # custom-domain ops (it has fused kernels on CUDA/DML and runs
-        # correctly on CPU). Fall back to standard opset-23 Attention
+        # correctly on CPU). Fall back to standard opset-24 Attention
         # for onnx-standard EP which prohibits custom-domain ops.
         scale = float(1.0 / (self._head_dim**0.5))
         if ep_capabilities().name == "onnx-standard":

--- a/src/mobius/components/_pixtral_vision_test.py
+++ b/src/mobius/components/_pixtral_vision_test.py
@@ -154,7 +154,7 @@ def test_patch_merger_matches_hf_unfold_ordering():
         outputs=[],
         nodes=[],
         name="test_merge_ordering",
-        opset_imports={"": 23},
+        opset_imports={"": 24},
     )
     gb = GraphBuilder(graph)
     op = gb.op

--- a/src/mobius/components/_pixtral_vision_test.py
+++ b/src/mobius/components/_pixtral_vision_test.py
@@ -10,6 +10,7 @@ import onnx_ir as ir
 import onnxruntime as ort
 
 from mobius._configs import ArchitectureConfig, VisionConfig
+from mobius._constants import OPSET_VERSION
 from mobius.components._pixtral_vision import (
     Mistral3MultiModalProjector,
     Mistral3PatchMerger,
@@ -154,7 +155,7 @@ def test_patch_merger_matches_hf_unfold_ordering():
         outputs=[],
         nodes=[],
         name="test_merge_ordering",
-        opset_imports={"": 24},
+        opset_imports={"": OPSET_VERSION},
     )
     gb = GraphBuilder(graph)
     op = gb.op

--- a/src/mobius/components/_qwen3_vl_vision.py
+++ b/src/mobius/components/_qwen3_vl_vision.py
@@ -143,7 +143,7 @@ class Qwen3VLVisionAttention(nn.Module):
     """Packed bidirectional multi-head attention for the vision encoder.
 
     Iterates over sub-sequences delimited by ``cu_seqlens`` and applies
-    standard ONNX Attention (opset 23) to each independently.  This avoids
+    standard ONNX Attention (opset 24) to each independently.  This avoids
     cross-image attention while processing all patches in a single flat
     sequence.
     """

--- a/src/mobius/components/_rms_norm.py
+++ b/src/mobius/components/_rms_norm.py
@@ -11,7 +11,7 @@ from mobius._flags import flags
 
 
 class RMSNorm(nn.Module):
-    """RMS Layer Normalization using the ONNX RMSNormalization op (opset 23)."""
+    """RMS Layer Normalization using the ONNX RMSNormalization op (opset 24)."""
 
     def __init__(self, hidden_size: int, eps: float = 1e-6):
         super().__init__()

--- a/src/mobius/components/_rotary_embedding.py
+++ b/src/mobius/components/_rotary_embedding.py
@@ -61,7 +61,7 @@ def apply_rotary_pos_emb(
 ):
     """Apply Rotary Positional Embedding (RoPE) to the input.
 
-    Uses the ONNX opset 23 ``RotaryEmbedding`` op with pre-gathered
+    Uses the ONNX opset 24 ``RotaryEmbedding`` op with pre-gathered
     cos/sin embeddings (3D tensors without position_ids).
 
     Args:

--- a/src/mobius/components/_vision.py
+++ b/src/mobius/components/_vision.py
@@ -89,7 +89,7 @@ class PatchEmbedding(nn.Module):
 class VisionAttention(nn.Module):
     """Bidirectional multi-head attention for vision encoders.
 
-    Uses the ONNX Attention op (opset 23). Unlike text attention,
+    Uses the ONNX Attention op (opset 24). Unlike text attention,
     this has no causal mask and no KV cache.
     """
 

--- a/src/mobius/models/gemma.py
+++ b/src/mobius/models/gemma.py
@@ -127,7 +127,7 @@ class Gemma2Attention(Attention):
 
     This bounds attention weights to [-softcap, softcap], preventing
     extreme attention concentrations. Uses the ONNX Attention op's
-    native ``softcap`` attribute (opset 23).
+    native ``softcap`` attribute (opset 24).
 
     Also uses ``query_pre_attn_scalar`` for attention scaling instead
     of the default ``1/sqrt(head_dim)``.
@@ -185,7 +185,7 @@ class Gemma2Attention(Attention):
                 interleaved=self._rope_interleave,
             )
 
-        # ONNX Attention op (opset 23) with native softcap support
+        # ONNX Attention op (opset 24) with native softcap support
         attn_output, present_key, present_value = op.Attention(
             query_states,
             key_states,

--- a/src/mobius/rewrite_rules/_separate_rope.py
+++ b/src/mobius/rewrite_rules/_separate_rope.py
@@ -31,7 +31,7 @@ node back to explicit ``RotaryEmbedding`` ops applied before GQA.
 
 The ``position_ids`` graph input is looked up by name and used to index
 into the cosine/sine cache tables before applying the standard
-``RotaryEmbedding`` op (standard ONNX opset 23).
+``RotaryEmbedding`` op (standard ONNX opset 24).
 
 These rules are applied automatically by
 :func:`~mobius._optimizations.optimize_model` for EPs that do not support

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1917,7 +1917,7 @@ class TestQwenImageVAEDecoder:
         )
         module = AutoencoderKLQwenImageModel(config)
         task = QwenImageVAETask()
-        dec_model = task._build_decoder_graph(module, config, 23)
+        dec_model = task._build_decoder_graph(module, config)
         sd = module.preprocess_weights(dict(hf.state_dict()))
         apply_weights(dec_model, sd)
 
@@ -1970,7 +1970,7 @@ class TestQwenImageVAEDecoder:
         )
         module = AutoencoderKLQwenImageModel(config)
         task = QwenImageVAETask()
-        enc_model = task._build_encoder_graph(module, config, 23)
+        enc_model = task._build_encoder_graph(module, config)
         sd = module.preprocess_weights(dict(hf.state_dict()))
         apply_weights(enc_model, sd)
 


### PR DESCRIPTION
## Summary

`OPSET_VERSION` is already `24` in `_constants.py`. This PR cleans up all remaining stale `opset 23` references.

## Code fixes

- **`_pixtral_vision_test.py`**: `opset_imports={"":23}` → `{"":24}`
- **`tests/integration_test.py`**: Remove stale positional `23` arg from `QwenImageVAETask._build_decoder_graph` and `_build_encoder_graph` calls — those methods no longer accept an opset version argument (was a silent bug)

## Documentation updates (comments/docstrings)

- `components/_vision.py`, `_qwen3_vl_vision.py`, `_rotary_embedding.py`, `_audio.py`, `_codec_transformer.py`, `_rms_norm.py`, `_pixtral_vision.py`
- `models/gemma.py` (2 occurrences)
- `rewrite_rules/_separate_rope.py`

## Testing

2391 tests pass, lintrunner clean.