### PR TITLE
CI: Fix GPU workflow dependencies and increase timeouts

### DIFF
--- a/.github/workflows/golden_regen.yml
+++ b/.github/workflows/golden_regen.yml
@@ -73,6 +73,14 @@ jobs:
         if: inputs.device == 'cuda'
         run: pip install torch --index-url https://download.pytorch.org/whl/cu124
 
+      - name: Install onnxruntime (CPU)
+        if: inputs.device != 'cuda'
+        run: pip install onnxruntime
+
+      - name: Install onnxruntime (GPU)
+        if: inputs.device == 'cuda'
+        run: pip install onnxruntime-gpu
+
       - name: Install dependencies
         run: |
           pip install -r requirements/ci/requirements.txt

--- a/.github/workflows/gpu_l4_golden_parity.yml
+++ b/.github/workflows/gpu_l4_golden_parity.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements/ci/requirements.txt
+          pip install onnxruntime-gpu
           pip install -e '.[testing,transformers]'
 
       - name: Run L4 checkpoint-verified tests

--- a/.github/workflows/gpu_l4_golden_parity.yml
+++ b/.github/workflows/gpu_l4_golden_parity.yml
@@ -71,7 +71,7 @@ jobs:
             --junitxml=junit-l4.xml \
             --cov=src --cov-report=xml --cov-branch \
             --tb=short
-        timeout-minutes: 30
+        timeout-minutes: 60
 
       - name: Upload coverage to Codecov
         if: always()

--- a/.github/workflows/gpu_l5_generation_e2e.yml
+++ b/.github/workflows/gpu_l5_generation_e2e.yml
@@ -71,7 +71,7 @@ jobs:
             --junitxml=junit-l5.xml \
             --cov=src --cov-report=xml --cov-branch \
             --tb=short
-        timeout-minutes: 30
+        timeout-minutes: 60
 
       - name: Upload coverage to Codecov
         if: always()

--- a/.github/workflows/gpu_l5_generation_e2e.yml
+++ b/.github/workflows/gpu_l5_generation_e2e.yml
@@ -72,7 +72,7 @@ jobs:
             --junitxml=junit-l5.xml \
             --cov=src --cov-report=xml --cov-branch \
             --tb=short
-        timeout-minutes: 30
+        timeout-minutes: 60
 
       - name: Upload coverage to Codecov
         if: always()

--- a/.github/workflows/gpu_l5_generation_e2e.yml
+++ b/.github/workflows/gpu_l5_generation_e2e.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements/ci/requirements.txt
+          pip install onnxruntime-gpu
           pip install -e '.[testing,transformers]'
 
       - name: Run L5 generation E2E tests
@@ -71,7 +72,7 @@ jobs:
             --junitxml=junit-l5.xml \
             --cov=src --cov-report=xml --cov-branch \
             --tb=short
-        timeout-minutes: 60
+        timeout-minutes: 30
 
       - name: Upload coverage to Codecov
         if: always()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -235,7 +235,7 @@ jobs:
           pytest tests/e2e_golden_test.py -m golden -v --tb=short \
             --cov=src --cov-report=xml --cov-branch \
             --junitxml golden-results.xml
-        timeout-minutes: 30
+        timeout-minutes: 60
       - name: Upload coverage to Codecov
         if: steps.check_golden.outputs.has_golden == 'true'
         uses: codecov/codecov-action@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -207,8 +207,8 @@ jobs:
           key: hf-golden-${{ hashFiles('testdata/cases/**/*.yaml') }}
           restore-keys: |
             hf-golden-
-      - name: Install PyTorch CPU
-        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+      - name: Install PyTorch CUDA
+        run: pip install torch --index-url https://download.pytorch.org/whl/cu124
       - name: Install dependencies
         run: |
           pip install -r requirements/ci/requirements.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,6 +81,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements/ci/requirements.txt
+          pip install onnxruntime
           pip install -e '.[testing]'
       - name: Run L1 smoke tests (all model configs)
         run: |
@@ -128,6 +129,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements/ci/requirements.txt
+          pip install onnxruntime
           pip install -e '.[testing,transformers]'
       - name: Run L3 synthetic parity tests
         env:
@@ -212,6 +214,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements/ci/requirements.txt
+          pip install onnxruntime-gpu
           pip install -e '.[testing,transformers]'
       - name: Check for golden test data
         id: check_golden
@@ -284,6 +287,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements/ci/requirements.txt
+          pip install onnxruntime
           pip install -e '.[testing]'
       - name: Run tests
         run: |
@@ -326,6 +330,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements/ci/requirements.txt
+          pip install onnxruntime-gpu
           pip install -e '.[testing]'
       - name: Run fast integration tests
         env:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements/ci/requirements.txt
+          pip install onnxruntime
           pip install -r docs/requirements.txt
           pip install -e '.[testing]'
 

--- a/.github/workflows/validation_examples_gpu.yml
+++ b/.github/workflows/validation_examples_gpu.yml
@@ -89,6 +89,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements/ci/requirements.txt
+          pip install onnxruntime-gpu
           pip install -e '.[testing,transformers,ort-genai]'
           pip install soundfile librosa ml_dtypes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ mobius = "mobius.__main__:main"
 transformers = ["transformers", "safetensors"]
 gguf = ["gguf>=0.10.0"]
 testing = [
-    "onnxruntime-easy",
+    "onnxruntime-easy>=0.1.1",
     "torch",
     "transformers>=5.0",
     "safetensors",


### PR DESCRIPTION
## CI: Fix GPU workflow dependencies and increase timeouts

### Summary

Ensures all GPU CI jobs use CUDA-enabled dependencies (`torch` with CUDA index, `onnxruntime-gpu`) and increases test step timeouts to 60 minutes across GPU workflows.

### Changes

#### 1. Bump `onnxruntime-easy` minimum version
- **pyproject.toml**: `onnxruntime-easy` → `onnxruntime-easy>=0.1.1`
- `>=0.1.1` no longer bundles a specific `onnxruntime` variant, allowing explicit control over CPU vs GPU installs without conflicts.

#### 2. Explicit `onnxruntime` / `onnxruntime-gpu` installs

Since `onnxruntime-easy>=0.1.1` no longer pulls in `onnxruntime` itself, every workflow now explicitly installs the correct variant:

| Workflow | Job | Package |
|----------|-----|---------|
| main.yml | `smoke-tests` | `onnxruntime` |
| main.yml | `synthetic-parity` | `onnxruntime` |
| main.yml | `multi-python` | `onnxruntime` |
| main.yml | `golden-comparison` | `onnxruntime-gpu` |
| main.yml | `integration-fast` | `onnxruntime-gpu` |
| gpu_l4_golden_parity.yml | `golden-tests` | `onnxruntime-gpu` |
| gpu_l5_generation_e2e.yml | `generation-tests` | `onnxruntime-gpu` |
| validation_examples_gpu.yml | `run-example` | `onnxruntime-gpu` |
| golden_regen.yml | `regenerate` | conditional (`onnxruntime` or `onnxruntime-gpu` based on `inputs.device`) |
| pages.yml | `build` | `onnxruntime` |

#### 3. Fix PyTorch install on GPU runner
- **main.yml** (`golden-comparison`): Changed from `pip install torch --index-url .../cpu` to `pip install torch --index-url .../cu124`. This job runs on an A10 GPU but was previously installing CPU-only PyTorch.

#### 4. Increase GPU test step timeouts to 60 minutes

| Workflow | Previous | New |
|----------|----------|-----|
| gpu_l5_generation_e2e.yml (step) | 30 min | 60 min |
| gpu_l4_golden_parity.yml (step) | 30 min | 60 min |
| main.yml — `golden-comparison` (step) | 30 min | 60 min |

Job-level timeouts on the dedicated GPU workflows were already 60 minutes; only the step-level timeouts were lagging behind.

### Testing

No code changes — CI configuration only. Changes can be verified by observing the next workflow runs install the correct packages.