### PR TITLE
ci: add MOBIUS_TEST_DEVICE environment variable for CUDA in workflows

### DIFF
--- a/.github/workflows/gpu_l4_golden_parity.yml
+++ b/.github/workflows/gpu_l4_golden_parity.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Run L4 checkpoint-verified tests
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          MOBIUS_TEST_DEVICE: cuda
         run: |
           pytest tests/e2e_golden_test.py \
             -m golden \

--- a/.github/workflows/gpu_l5_generation_e2e.yml
+++ b/.github/workflows/gpu_l5_generation_e2e.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Run L5 generation E2E tests
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          MOBIUS_TEST_DEVICE: cuda
         run: |
           pytest tests/e2e_golden_test.py \
             -m generation \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -230,6 +230,7 @@ jobs:
         if: steps.check_golden.outputs.has_golden == 'true'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          MOBIUS_TEST_DEVICE: cuda
         run: |
           if [ ! -f tests/e2e_golden_test.py ]; then
             echo "tests/e2e_golden_test.py not found — skipping"


### PR DESCRIPTION
## Run L4/L5 golden tests on CUDA

### What

Sets `MOBIUS_TEST_DEVICE=cuda` in the workflow `env:` blocks for the L4 and L5 golden test steps so ORT inference runs on the GPU instead of CPU.

### Why

The L4/L5 jobs already provision A10 GPU runners and install `onnxruntime-gpu`, but without `MOBIUS_TEST_DEVICE` set, `_get_test_device_kwargs()` in `tests/e2e_golden_test.py` falls back to CPU. The GPU was effectively unused. This change makes these jobs actually exercise the CUDA EP path.

### Changes

- `.github/workflows/main.yml` — L4 golden comparison step (PR CI)
- `.github/workflows/gpu_l4_golden_parity.yml` — L4 nightly
- `.github/workflows/gpu_l5_generation_e2e.yml` — L5 nightly

Each gains:

```yaml
env:
  HF_TOKEN: ${{ secrets.HF_TOKEN }}
  MOBIUS_TEST_DEVICE: cuda