### PR TITLE
refactor: wire --optimize through EP capabilities system

### DIFF
--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING
 import tqdm
 
 if TYPE_CHECKING:
-    import onnx_ir as ir
     import torch
 
 from mobius._builder import (
@@ -70,45 +69,6 @@ def _load_weights_from_dir(model_dir: str) -> dict[str, torch.Tensor]:
     return state_dict
 
 
-def _apply_optimize(model: ir.Model, optimize: str | None) -> None:
-    """Apply rewrite rules if --optimize is specified."""
-    if not optimize:
-        return
-
-    from onnxscript.rewriter import rewrite
-
-    from mobius.rewrite_rules import (
-        bias_gelu_rules,
-        group_query_attention_rules,
-        packed_attention_rules,
-        skip_layer_norm_rules,
-        skip_norm_rules,
-    )
-
-    rule_map = {
-        "bias_gelu": bias_gelu_rules,
-        "group_query_attention": group_query_attention_rules,
-        "packed_attention": packed_attention_rules,
-        "skip_layer_norm": skip_layer_norm_rules,
-        "skip_norm": skip_norm_rules,
-    }
-
-    if optimize == "all":
-        rule_names = list(rule_map)
-    else:
-        rule_names = [r.strip() for r in optimize.split(",")]
-        for name in rule_names:
-            if name not in rule_map:
-                raise ValueError(
-                    f"Unknown rewrite rule '{name}'. Available: {sorted(rule_map)}"
-                )
-
-    for name in rule_names:
-        rules = rule_map[name]()
-        rewrite(model, pattern_rewrite_rules=rules)
-        print(f"Applied rewrite rule: {name}")
-
-
 def _cmd_build(args: argparse.Namespace) -> None:
     """Execute the 'build' subcommand."""
     import dataclasses
@@ -142,9 +102,53 @@ def _cmd_build(args: argparse.Namespace) -> None:
     output_dir = args.output_dir
     os.makedirs(output_dir, exist_ok=True)
     dtype_override = resolve_dtype(args.dtype)
-    optimize = args.optimize
     component_filter = args.component
     execution_provider = args.execution_provider
+
+    # Handle --optimize + --ep conflict
+    if args.optimize and execution_provider != "default":
+        raise ValueError("Cannot use both --optimize and --ep. Use --ep alone.")
+
+    # If --optimize is specified, build a synthetic EP from the flags
+    if args.optimize:
+        import warnings
+
+        import onnx_ir as ir
+
+        from mobius._execution_providers import (
+            EpCapabilities,
+            ep_registry,
+        )
+
+        warnings.warn(
+            "--optimize is deprecated. Use --ep to select an execution "
+            "provider that enables the desired optimizations "
+            "(e.g. --ep cuda for GQA + SkipNorm).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        if args.optimize == "all":
+            execution_provider = "cpu"
+        else:
+            rule_names = [r.strip() for r in args.optimize.split(",")]
+            valid_rules = {
+                "group_query_attention",
+                "packed_attention",
+                "skip_layer_norm",
+                "skip_norm",
+                "bias_gelu",
+            }
+            for name in rule_names:
+                if name not in valid_rules:
+                    raise ValueError(
+                        f"Unknown optimization rule '{name}'. Available: {sorted(valid_rules)}"
+                    )
+
+            dtype = dtype_override or ir.DataType.FLOAT
+            caps = EpCapabilities.from_optimize_flags(rule_names, dtype=dtype)
+            ep_registry.register(caps, overwrite=True)
+            execution_provider = "custom"
 
     # Auto-detect diffusers pipelines
     if args.model and not args.config:
@@ -158,7 +162,7 @@ def _cmd_build(args: argparse.Namespace) -> None:
                 dtype=dtype_override,
                 load_weights=load_weights,
             )
-            _save_package(pkg, output_dir, args, optimize, component_filter)
+            _save_package(pkg, output_dir, args, component_filter)
             return
 
     # Build from HuggingFace model ID or local config
@@ -200,18 +204,12 @@ def _cmd_build(args: argparse.Namespace) -> None:
             execution_provider=execution_provider,
         )
 
-    _save_package(pkg, output_dir, args, optimize, component_filter)
+    _save_package(pkg, output_dir, args, component_filter)
 
 
-def _save_package(
-    pkg, output_dir: str, args, optimize: str | None, component_filter: str | None
-) -> None:
-    """Save a ModelPackage to disk, applying optimizations and runtime configs."""
+def _save_package(pkg, output_dir: str, args, component_filter: str | None) -> None:
+    """Save a ModelPackage to disk with runtime configs."""
     components = (lambda name: name == component_filter) if component_filter else None
-    for name, model in pkg.items():
-        if components is not None and not components(name):
-            continue
-        _apply_optimize(model, optimize)
 
     max_shard_size_bytes = _parse_size(args.max_shard_size) if args.max_shard_size else None
     pkg.save(

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 import tqdm
 
 if TYPE_CHECKING:
+    import onnx_ir as ir
     import torch
 
 from mobius._builder import (
@@ -30,6 +31,16 @@ from mobius._config_resolver import (
 from mobius._registry import registry
 
 logger = logging.getLogger(__name__)
+
+# Rules handled by the EP pipeline (via capabilities):
+EP_MAPPED_RULES = {
+    "group_query_attention",
+    "skip_norm",
+    "skip_layer_norm",
+}
+
+# Rules that need post-hoc application (no EP equivalent):
+POST_HOC_RULES = {"bias_gelu", "packed_attention"}
 
 
 def _parse_size(size_str: str) -> int:
@@ -69,6 +80,24 @@ def _load_weights_from_dir(model_dir: str) -> dict[str, torch.Tensor]:
     return state_dict
 
 
+def _apply_posthoc_rules(model: ir.Model, rule_names: list[str]) -> None:
+    """Apply rewrite rules that aren't covered by the EP pipeline."""
+    from onnxscript.rewriter import rewrite
+
+    from mobius.rewrite_rules import (
+        bias_gelu_rules,
+        packed_attention_rules,
+    )
+
+    rule_map = {
+        "bias_gelu": bias_gelu_rules,
+        "packed_attention": packed_attention_rules,
+    }
+    for name in rule_names:
+        if name in rule_map:
+            rewrite(model, pattern_rewrite_rules=rule_map[name]())
+
+
 def _cmd_build(args: argparse.Namespace) -> None:
     """Execute the 'build' subcommand."""
     import dataclasses
@@ -104,6 +133,7 @@ def _cmd_build(args: argparse.Namespace) -> None:
     dtype_override = resolve_dtype(args.dtype)
     component_filter = args.component
     execution_provider = args.execution_provider
+    posthoc_rules: list[str] = []
 
     # Handle --optimize + --ep conflict
     if args.optimize and execution_provider != "default":
@@ -121,34 +151,36 @@ def _cmd_build(args: argparse.Namespace) -> None:
         )
 
         warnings.warn(
-            "--optimize is deprecated. Use --ep to select an execution "
-            "provider that enables the desired optimizations "
-            "(e.g. --ep cuda for GQA + SkipNorm).",
+            "--optimize is deprecated. Use --ep to select an "
+            "execution provider that enables the desired "
+            "optimizations (e.g. --ep cuda for GQA + SkipNorm).",
             DeprecationWarning,
             stacklevel=2,
         )
 
+        dtype = dtype_override or ir.DataType.FLOAT
+
         if args.optimize == "all":
-            execution_provider = "cpu"
+            # Enable all EP-mapped fusions + all post-hoc rules
+            caps = EpCapabilities.from_optimize_flags(list(EP_MAPPED_RULES), dtype=dtype)
+            ep_registry.register(caps, overwrite=True)
+            execution_provider = "_optimize_custom"
+            posthoc_rules = list(POST_HOC_RULES)
         else:
             rule_names = [r.strip() for r in args.optimize.split(",")]
-            valid_rules = {
-                "group_query_attention",
-                "packed_attention",
-                "skip_layer_norm",
-                "skip_norm",
-                "bias_gelu",
-            }
+            valid_rules = EP_MAPPED_RULES | POST_HOC_RULES
             for name in rule_names:
                 if name not in valid_rules:
                     raise ValueError(
                         f"Unknown optimization rule '{name}'. Available: {sorted(valid_rules)}"
                     )
 
-            dtype = dtype_override or ir.DataType.FLOAT
-            caps = EpCapabilities.from_optimize_flags(rule_names, dtype=dtype)
+            ep_rules = [r for r in rule_names if r in EP_MAPPED_RULES]
+            posthoc_rules = [r for r in rule_names if r in POST_HOC_RULES]
+
+            caps = EpCapabilities.from_optimize_flags(ep_rules, dtype=dtype)
             ep_registry.register(caps, overwrite=True)
-            execution_provider = "custom"
+            execution_provider = "_optimize_custom"
 
     # Auto-detect diffusers pipelines
     if args.model and not args.config:
@@ -157,6 +189,9 @@ def _cmd_build(args: argparse.Namespace) -> None:
             print(
                 f"Detected diffusers pipeline: {pipeline_index.get('_class_name', 'Unknown')}"
             )
+            # TODO: Thread execution_provider through diffusers
+            # pipeline. EP-aware optimizations are currently not
+            # applied to diffusers models.
             pkg = build_diffusers_pipeline(
                 args.model,
                 dtype=dtype_override,
@@ -204,11 +239,29 @@ def _cmd_build(args: argparse.Namespace) -> None:
             execution_provider=execution_provider,
         )
 
-    _save_package(pkg, output_dir, args, component_filter)
+    _save_package(
+        pkg,
+        output_dir,
+        args,
+        component_filter,
+        posthoc_rules=posthoc_rules,
+    )
 
 
-def _save_package(pkg, output_dir: str, args, component_filter: str | None) -> None:
+def _save_package(
+    pkg,
+    output_dir: str,
+    args,
+    component_filter: str | None,
+    posthoc_rules: list[str] | None = None,
+) -> None:
     """Save a ModelPackage to disk with runtime configs."""
+    # Apply post-hoc rewrite rules (bias_gelu, packed_attention) that
+    # aren't covered by the EP capability pipeline.
+    if posthoc_rules:
+        for model in pkg.values():
+            _apply_posthoc_rules(model, posthoc_rules)
+
     components = (lambda name: name == component_filter) if component_filter else None
 
     max_shard_size_bytes = _parse_size(args.max_shard_size) if args.max_shard_size else None

--- a/src/mobius/_execution_providers.py
+++ b/src/mobius/_execution_providers.py
@@ -114,10 +114,24 @@ class EpCapabilities:
         skip_norm = "skip_norm" in rules or "skip_layer_norm" in rules
         packed_attn = "packed_attention" in rules
 
+        # Enable all dtypes so --optimize=all works regardless
+        # of the user's --dtype choice.
+        gqa_dtypes = (
+            frozenset(
+                {
+                    ir.DataType.FLOAT,
+                    ir.DataType.FLOAT16,
+                    ir.DataType.BFLOAT16,
+                }
+            )
+            if gqa
+            else frozenset()
+        )
+
         return cls(
-            name="custom",
-            gqa_dtypes=frozenset({dtype}) if gqa else frozenset(),
-            qkv_pack_dtypes=frozenset({dtype}) if gqa else frozenset(),
+            name="_optimize_custom",
+            gqa_dtypes=gqa_dtypes,
+            qkv_pack_dtypes=gqa_dtypes,
             supports_fused_rope=True,
             supports_skip_layer_norm=skip_norm,
             supports_packed_multi_head_attention=packed_attn,

--- a/src/mobius/_execution_providers.py
+++ b/src/mobius/_execution_providers.py
@@ -99,6 +99,30 @@ class EpCapabilities:
                 f"this EP, so packing would be immediately undone."
             )
 
+    @classmethod
+    def from_optimize_flags(
+        cls,
+        rules: list[str],
+        dtype: ir.DataType = ir.DataType.FLOAT16,
+    ) -> EpCapabilities:
+        """Build a synthetic EpCapabilities from --optimize rule names.
+
+        This maps optimization rule names to the EP capability flags
+        that would enable those optimizations in the EP pipeline.
+        """
+        gqa = "group_query_attention" in rules
+        skip_norm = "skip_norm" in rules or "skip_layer_norm" in rules
+        packed_attn = "packed_attention" in rules
+
+        return cls(
+            name="custom",
+            gqa_dtypes=frozenset({dtype}) if gqa else frozenset(),
+            qkv_pack_dtypes=frozenset({dtype}) if gqa else frozenset(),
+            supports_fused_rope=True,
+            supports_skip_layer_norm=skip_norm,
+            supports_packed_multi_head_attention=packed_attn,
+        )
+
 
 class EpRegistry:
     """Central registry mapping EP name → :class:`EpCapabilities`.

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+import warnings
 from unittest import mock
 
 import onnx
@@ -227,3 +228,106 @@ class TestCLIBuildRuntime:
                     "tensorrt",  # not a supported value
                 ]
             )
+
+
+class TestCLIOptimize:
+    """Test the deprecated --optimize flag."""
+
+    def test_optimize_gqa_produces_gqa_nodes(self):
+        """--optimize=group_query_attention produces GQA nodes."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                main(
+                    [
+                        "build",
+                        "--model",
+                        "Qwen/Qwen2.5-0.5B",
+                        tmpdir,
+                        "--no-weights",
+                        "--optimize=group_query_attention",
+                    ]
+                )
+            model = onnx.load(os.path.join(tmpdir, "model.onnx"))
+            op_types = {n.op_type for n in model.graph.node}
+            assert "GroupQueryAttention" in op_types
+
+    def test_optimize_bias_gelu_applies(self):
+        """--optimize=bias_gelu is accepted and builds."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                main(
+                    [
+                        "build",
+                        "--model",
+                        "Qwen/Qwen2.5-0.5B",
+                        tmpdir,
+                        "--no-weights",
+                        "--optimize=bias_gelu",
+                    ]
+                )
+            assert os.path.isfile(os.path.join(tmpdir, "model.onnx"))
+
+    def test_optimize_all_with_float16(self):
+        """--optimize=all --dtype f16 produces GQA nodes."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                main(
+                    [
+                        "build",
+                        "--model",
+                        "Qwen/Qwen2.5-0.5B",
+                        tmpdir,
+                        "--no-weights",
+                        "--optimize",
+                        "--dtype",
+                        "f16",
+                    ]
+                )
+            model = onnx.load(os.path.join(tmpdir, "model.onnx"))
+            op_types = {n.op_type for n in model.graph.node}
+            assert "GroupQueryAttention" in op_types
+
+    def test_optimize_with_ep_raises(self):
+        """--optimize + --ep raises error."""
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            pytest.raises(ValueError, match="Cannot use both"),
+        ):
+            main(
+                [
+                    "build",
+                    "--model",
+                    "Qwen/Qwen2.5-0.5B",
+                    tmpdir,
+                    "--no-weights",
+                    "--optimize=group_query_attention",
+                    "--ep",
+                    "cuda",
+                ]
+            )
+
+    def test_optimize_emits_deprecation_warning(self):
+        """--optimize emits DeprecationWarning."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                main(
+                    [
+                        "build",
+                        "--model",
+                        "Qwen/Qwen2.5-0.5B",
+                        tmpdir,
+                        "--no-weights",
+                        "--optimize=group_query_attention",
+                    ]
+                )
+            dep_warnings = [
+                x
+                for x in w
+                if issubclass(x.category, DeprecationWarning)
+                and "--optimize is deprecated" in str(x.message)
+            ]
+            assert len(dep_warnings) >= 1


### PR DESCRIPTION
Replace post-hoc `_apply_optimize()` rewrite rule application with synthetic EP construction.

## Changes

- **`EpCapabilities.from_optimize_flags()`**: New factory method that maps `--optimize` rule names to EP capability flags
- **`_cmd_build()`**: `--optimize` now builds an `EpCapabilities` from the requested rules and passes it as the execution provider to `build()`/`build_from_module()`, ensuring EP-aware graph construction, dead input removal, and correct KV cache sizing
- **`_apply_optimize()` removed**: No longer needed — the EP pipeline handles everything
- **`_save_package()`**: Removed `optimize` parameter
- **Deprecation warning**: `--optimize` emits a warning suggesting `--ep` instead
- **Conflict guard**: `--optimize` + `--ep` (non-default) raises `ValueError`

## Why

`--optimize=group_query_attention` previously applied GQA rewrite rules AFTER `build()`, on a model built without EP-awareness. This meant graph construction didn't know about GQA (KV cache sizing, position_ids), dead input removal didn't happen, and the model could have incorrect structure for fused ops. Now `--optimize` produces the same quality models as `--ep`.