### PR TITLE
refactor: split per_layer_inputs to embedding, remove input_ids from decoder

### DIFF
--- a/examples/gemma4_multimodal.py
+++ b/examples/gemma4_multimodal.py
@@ -17,14 +17,17 @@ Gemma 4 uses a 4-model split (same pattern as Phi-4 Multimodal):
 
     - **Vision**:    ``pixel_values`` → ``image_features``
       (SigLIP ViT-like encoder + projector; ~256 soft tokens/image)
-    - **Audio**:     ``audio_features`` → ``audio_features``
+    - **Audio**:     ``input_features`` → ``audio_features``
       (Conformer encoder, 12 layers, hidden 1024; subsampling 4x)
-    - **Embedding**: ``input_ids`` + ``image_features`` + ``audio_features``
-      → ``inputs_embeds``
-      (token embedding + multimodal feature fusion)
-    - **Decoder**:   ``inputs_embeds`` + ``attention_mask`` +
-      ``position_ids`` + KV cache → ``logits`` + present KV
-      (Gemma4 text decoder with dual RoPE, GQA, optional MoE)
+    - **Embedding**: ``input_ids`` → ``inputs_embeds``
+      (scaled token embedding with multimodal PAD masking)
+    - **Decoder**:   ``inputs_embeds`` + ``input_ids`` +
+      ``attention_mask`` + ``position_ids`` + KV cache → ``logits`` + present KV
+      (Gemma4 text decoder with dual RoPE, GQA, per-layer input gating)
+
+Multimodal fusion (replacing image/audio placeholder tokens in
+``inputs_embeds`` with encoder features) is handled by the runtime (or
+this example script), NOT by the embedding model.
 
 During prefill all four sessions run.  During decode only embedding + decoder
 are used (vision and audio encoders run once per generation).
@@ -191,37 +194,31 @@ def prepare_audio_feeds(
 
 def prepare_embedding_feeds(
     input_ids: np.ndarray,
-    image_features: np.ndarray,
-    audio_features: np.ndarray,
 ) -> dict[str, np.ndarray]:
     """Prepare feeds for the **embedding** session.
 
-    The embedding model fuses token embeddings with image and audio
-    feature vectors by replacing the corresponding placeholder tokens.
+    The embedding model performs scaled token lookup and (when the model
+    has ``hidden_size_per_layer_input > 0``) computes per-layer gate
+    embeddings.  Multimodal fusion is NOT done here — it happens after
+    this call, in the generation loop.
 
     Args:
         input_ids: ``int64[1, seq_len]`` — token ids with image/audio
             placeholder tokens already inserted at the correct positions.
-        image_features: ``float32[num_image_tokens, hidden_size]``, or
-            ``float32[0, hidden_size]`` when no image is provided.
-        audio_features: ``float32[num_audio_tokens, hidden_size]``, or
-            ``float32[0, hidden_size]`` when no audio is provided.
 
     Returns:
         Feeds dict for the embedding ONNX model.
     """
     return {
         "input_ids": input_ids,
-        "image_features": image_features,
-        "audio_features": audio_features,
     }
 
 
 def prepare_decoder_feeds(
     inputs_embeds: np.ndarray,
+    input_ids: np.ndarray,
     past_seq_len: int,
     past_kv: dict[str, np.ndarray],
-    input_ids: np.ndarray,
 ) -> dict[str, np.ndarray]:
     """Prepare feeds for the **decoder** session.
 
@@ -231,11 +228,12 @@ def prepare_decoder_feeds(
 
     Args:
         inputs_embeds: ``float32[1, cur_seq_len, hidden_size]``.
+        input_ids: ``int64[1, cur_seq_len]`` — original token ids
+            (including multimodal placeholder IDs).  The decoder uses
+            these for per-layer embedding computation.
         past_seq_len: Number of tokens already stored in the KV cache.
         past_kv: Mapping of ``"past_key_values.{i}.key/value"`` arrays
             from the previous decoder step.
-        input_ids: ``int64[1, cur_seq_len]`` — original token ids (needed for
-            per-layer token embeddings when ``hidden_size_per_layer_input > 0``).
 
     Returns:
         Complete feeds dict for the decoder ONNX model.
@@ -245,10 +243,10 @@ def prepare_decoder_feeds(
 
     return {
         "inputs_embeds": inputs_embeds,
+        "input_ids": input_ids,
         # Attend to all tokens (past + current)
         "attention_mask": np.ones((batch_size, total_seq_len), dtype=np.int64),
         "position_ids": np.arange(past_seq_len, total_seq_len, dtype=np.int64)[np.newaxis, :],
-        "input_ids": input_ids,
         **past_kv,
     }
 
@@ -344,6 +342,50 @@ def _empty_features(hidden_size: int, dtype=np.float32) -> np.ndarray:
     return np.zeros((0, hidden_size), dtype=dtype)
 
 
+def _fuse_multimodal_features(
+    inputs_embeds: np.ndarray,
+    input_ids: np.ndarray,
+    image_features: np.ndarray,
+    audio_features: np.ndarray,
+) -> np.ndarray:
+    """Replace placeholder token embeddings with encoder features.
+
+    After the embedding model produces ``inputs_embeds`` from ``input_ids``,
+    the runtime must splice in vision/audio encoder outputs at the positions
+    corresponding to the placeholder tokens.  This function performs that
+    replacement in-place (matching what ORT GenAI would do).
+
+    Args:
+        inputs_embeds: ``float32[1, seq_len, hidden_size]`` from the
+            embedding model.
+        input_ids: ``int64[1, seq_len]`` — the original token ids, used
+            to locate placeholder positions.
+        image_features: ``float32[N_img, hidden_size]`` from the vision
+            encoder, or ``float32[0, hidden_size]`` when no image.
+        audio_features: ``float32[N_aud, hidden_size]`` from the audio
+            encoder, or ``float32[0, hidden_size]`` when no audio.
+
+    Returns:
+        Updated ``inputs_embeds`` with encoder features spliced in.
+    """
+    embeds = inputs_embeds.copy()
+    flat_ids = input_ids[0]  # [seq_len]
+
+    if image_features.shape[0] > 0:
+        img_positions = np.where(flat_ids == IMAGE_TOKEN_ID)[0]
+        n = min(len(img_positions), image_features.shape[0])
+        if n > 0:
+            embeds[0, img_positions[:n]] = image_features[:n]
+
+    if audio_features.shape[0] > 0:
+        aud_positions = np.where(flat_ids == AUDIO_TOKEN_ID)[0]
+        n = min(len(aud_positions), audio_features.shape[0])
+        if n > 0:
+            embeds[0, aud_positions[:n]] = audio_features[:n]
+
+    return embeds
+
+
 def _init_kv_cache(config, dtype=np.float32) -> dict[str, np.ndarray]:
     """Create an empty KV cache for all independent decoder layers.
 
@@ -417,12 +459,14 @@ def generate(
 
     1. *vision*    → ``image_features`` (if image present)
     2. *audio*     → ``audio_features`` (if audio present)
-    3. *embedding* → ``inputs_embeds`` (fuses text + modality features)
-    4. *decoder*   → ``logits`` + initial KV cache
+    3. *embedding* → ``inputs_embeds``
+    4. fuse image/audio features into ``inputs_embeds`` (runtime step)
+    5. *decoder*   → ``logits`` + initial KV cache (uses ``input_ids`` for
+       per-layer embedding computation)
 
     **Decode** (subsequent steps — generates one token at a time):
 
-    1. *embedding* → ``inputs_embeds`` (text token only; no modality features)
+    1. *embedding* → ``inputs_embeds`` (single text token)
     2. *decoder*   → ``logits`` + updated KV cache
 
     Args:
@@ -430,7 +474,7 @@ def generate(
             Pass ``None`` if no image is provided.
         audio_session:    ONNX session for the Conformer audio encoder.
             Pass ``None`` if no audio is provided.
-        embedding_session: ONNX session for the embedding + fusion model.
+        embedding_session: ONNX session for the embedding model.
         decoder_session:  ONNX session for the Gemma4 text decoder.
         tokenizer: HuggingFace tokenizer for decoding generated ids.
         input_ids: ``int64[1, seq_len]`` — prompt tokens with placeholders.
@@ -446,12 +490,6 @@ def generate(
     """
     num_kv_shared = getattr(config, "num_kv_shared_layers", 0) or 0
     num_kv_layers = config.num_hidden_layers - num_kv_shared
-    hidden_size = config.hidden_size
-
-    # Zero-length feature tensors used during decode steps (no modality input)
-    feat_dtype = image_features.dtype
-    zero_image = _empty_features(hidden_size, dtype=feat_dtype)
-    zero_audio = _empty_features(hidden_size, dtype=feat_dtype)
 
     cur_ids = input_ids
     past_seq_len = 0
@@ -463,21 +501,22 @@ def generate(
         is_prefill = step == 0
 
         # ---- Embedding session ----
-        # On the first step, pass real multimodal features so the embedding
-        # model can splice image/audio tokens into the hidden states.
-        # On subsequent decode steps pass zero-length tensors (no modality).
-        embed_out = embedding_session.run(
-            prepare_embedding_feeds(
-                cur_ids,
-                image_features if is_prefill else zero_image,
-                audio_features if is_prefill else zero_audio,
-            )
-        )
+        # Embedding takes only input_ids and produces inputs_embeds.
+        embed_out = embedding_session.run(prepare_embedding_feeds(cur_ids))
         inputs_embeds: np.ndarray = embed_out["inputs_embeds"]
+
+        # ---- Multimodal fusion (runtime responsibility) ----
+        # On prefill, replace placeholder token embeddings in inputs_embeds
+        # with the encoder features.  During decode steps there are no
+        # placeholder tokens, so no fusion is needed.
+        if is_prefill:
+            inputs_embeds = _fuse_multimodal_features(
+                inputs_embeds, cur_ids, image_features, audio_features
+            )
 
         # ---- Decoder session ----
         decoder_out = decoder_session.run(
-            prepare_decoder_feeds(inputs_embeds, past_seq_len, past_kv, cur_ids)
+            prepare_decoder_feeds(inputs_embeds, cur_ids, past_seq_len, past_kv)
         )
 
         # Greedy: pick the token with the highest logit at the last position

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -535,7 +535,6 @@ class TestGemma4GenaiConfig:
         decoder = _mock_model_with_inputs(
             [
                 "inputs_embeds",
-                "input_ids",
                 "attention_mask",
                 "position_ids",
                 "past_key_values.0.key",
@@ -551,7 +550,6 @@ class TestGemma4GenaiConfig:
         embedding = _mock_model_with_inputs(
             [
                 "input_ids",
-                "image_features",
             ]
         )
 
@@ -588,8 +586,8 @@ class TestGemma4GenaiConfig:
         assert "image_grid_thw" not in vision_inputs
         assert data["model"]["vision"]["spatial_merge_size"] == 2
 
-    def test_gemma4_decoder_has_input_ids_and_inputs_embeds(self, tmp_path):
-        """Gemma4 decoder has both inputs_embeds and input_ids."""
+    def test_gemma4_decoder_has_inputs_embeds(self, tmp_path):
+        """Gemma4 decoder has inputs_embeds (no input_ids)."""
         pkg = self._make_gemma4_pkg()
         path = _write_genai_config(
             pkg.config,
@@ -608,7 +606,7 @@ class TestGemma4GenaiConfig:
             data = json.load(f)
         decoder_inputs = data["model"]["decoder"]["inputs"]
         assert "inputs_embeds" in decoder_inputs
-        assert "input_ids" in decoder_inputs
+        assert "input_ids" not in decoder_inputs
         # KV cache templates are present
         assert decoder_inputs["past_key_names"] == "past_key_values.%d.key"
 
@@ -632,7 +630,7 @@ class TestGemma4GenaiConfig:
             data = json.load(f)
         emb_inputs = data["model"]["embedding"]["inputs"]
         assert "input_ids" in emb_inputs
-        assert "image_features" in emb_inputs
+        assert "image_features" not in emb_inputs
 
 
 class TestGraphInputNames:
@@ -761,7 +759,7 @@ class TestGemma4RealModel:
         # Decoder inputs introspected from graph
         decoder_inputs = data["model"]["decoder"]["inputs"]
         assert "inputs_embeds" in decoder_inputs
-        assert "input_ids" in decoder_inputs
+        assert "input_ids" not in decoder_inputs
         assert "attention_mask" in decoder_inputs
         assert "position_ids" in decoder_inputs
         assert decoder_inputs["past_key_names"] == ("past_key_values.%d.key")
@@ -775,7 +773,7 @@ class TestGemma4RealModel:
         # Embedding inputs introspected from graph
         emb_inputs = data["model"]["embedding"]["inputs"]
         assert "input_ids" in emb_inputs
-        assert "image_features" in emb_inputs
+        assert "image_features" not in emb_inputs
 
         # Config-level properties are still present
         assert data["model"]["image_token_id"] == 255999

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -780,6 +780,66 @@ class TestGemma4RealModel:
         assert data["model"]["vision"]["spatial_merge_size"] == 2
         assert data["model"]["vision"]["config_filename"] == "processor_config.json"
 
+    def test_gemma4_per_layer_inputs_in_genai_config(self, tmp_path):
+        """When hidden_size_per_layer_input > 0, decoder gets per_layer_inputs."""
+        from mobius._builder import build_from_module
+        from mobius._config_resolver import _default_task_for_model
+        from mobius._configs import Gemma4Config, VisionConfig
+        from mobius._registry import registry
+        from mobius.tasks import get_task
+
+        config = Gemma4Config(
+            model_type="gemma4",
+            num_hidden_layers=2,
+            hidden_size=64,
+            intermediate_size=128,
+            num_attention_heads=4,
+            num_key_value_heads=1,
+            head_dim=16,
+            vocab_size=256,
+            rms_norm_eps=1e-6,
+            hidden_act="silu",
+            attn_qk_norm=True,
+            layer_types=["sliding_attention", "full_attention"],
+            sliding_window=8,
+            global_head_dim=16,
+            global_rope_theta=10_000.0,
+            global_partial_rotary_factor=0.25,
+            final_logit_softcapping=0.0,
+            hidden_size_per_layer_input=32,
+            vocab_size_per_layer_input=256,
+            image_token_id=255999,
+            pad_token_id=0,
+            tie_word_embeddings=True,
+            vision=VisionConfig(
+                hidden_size=32,
+                intermediate_size=64,
+                num_hidden_layers=1,
+                num_attention_heads=2,
+                patch_size=16,
+                norm_eps=1e-6,
+            ),
+        )
+        model_cls = registry.get("gemma4")
+        module = model_cls(config)
+        task_name = _default_task_for_model("gemma4")
+        task = get_task(task_name)
+        pkg = build_from_module(module, config, task=task)
+        pkg.config = config
+
+        result = write_ort_genai_config(pkg, str(tmp_path))
+        with open(result["genai_config"]) as f:
+            data = json.load(f)
+
+        # Decoder must include per_layer_inputs (no input_ids)
+        decoder_inputs = data["model"]["decoder"]["inputs"]
+        assert "per_layer_inputs" in decoder_inputs
+        assert "input_ids" not in decoder_inputs
+
+        # Embedding must output per_layer_inputs
+        emb_inputs = data["model"]["embedding"]["inputs"]
+        assert "input_ids" in emb_inputs
+
     def test_auto_export_produces_genai_config(self, tmp_path):
         """Mock build() to return a tiny package, verify genai_config."""
         import onnx_ir as ir

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -537,6 +537,7 @@ class TestGemma4GenaiConfig:
                 "inputs_embeds",
                 "attention_mask",
                 "position_ids",
+                "input_ids",
                 "past_key_values.0.key",
                 "past_key_values.0.value",
             ]
@@ -587,7 +588,7 @@ class TestGemma4GenaiConfig:
         assert data["model"]["vision"]["spatial_merge_size"] == 2
 
     def test_gemma4_decoder_has_inputs_embeds(self, tmp_path):
-        """Gemma4 decoder has inputs_embeds (no input_ids)."""
+        """Gemma4 decoder has inputs_embeds and input_ids."""
         pkg = self._make_gemma4_pkg()
         path = _write_genai_config(
             pkg.config,
@@ -606,8 +607,7 @@ class TestGemma4GenaiConfig:
             data = json.load(f)
         decoder_inputs = data["model"]["decoder"]["inputs"]
         assert "inputs_embeds" in decoder_inputs
-        assert "input_ids" not in decoder_inputs
-        # KV cache templates are present
+        assert "input_ids" in decoder_inputs
         assert decoder_inputs["past_key_names"] == "past_key_values.%d.key"
 
     def test_gemma4_embedding_inputs(self, tmp_path):
@@ -759,7 +759,7 @@ class TestGemma4RealModel:
         # Decoder inputs introspected from graph
         decoder_inputs = data["model"]["decoder"]["inputs"]
         assert "inputs_embeds" in decoder_inputs
-        assert "input_ids" not in decoder_inputs
+        assert "input_ids" in decoder_inputs
         assert "attention_mask" in decoder_inputs
         assert "position_ids" in decoder_inputs
         assert decoder_inputs["past_key_names"] == ("past_key_values.%d.key")
@@ -781,7 +781,7 @@ class TestGemma4RealModel:
         assert data["model"]["vision"]["config_filename"] == "processor_config.json"
 
     def test_gemma4_per_layer_inputs_in_genai_config(self, tmp_path):
-        """When hidden_size_per_layer_input > 0, decoder gets per_layer_inputs."""
+        """When hidden_size_per_layer_input > 0, decoder still gets input_ids."""
         from mobius._builder import build_from_module
         from mobius._config_resolver import _default_task_for_model
         from mobius._configs import Gemma4Config, VisionConfig
@@ -831,10 +831,10 @@ class TestGemma4RealModel:
         with open(result["genai_config"]) as f:
             data = json.load(f)
 
-        # Decoder must include per_layer_inputs (no input_ids)
+        # Decoder uses input_ids for per-layer computation
         decoder_inputs = data["model"]["decoder"]["inputs"]
-        assert "per_layer_inputs" in decoder_inputs
-        assert "input_ids" not in decoder_inputs
+        assert "input_ids" in decoder_inputs
+        assert "per_layer_inputs" not in decoder_inputs
 
         # Embedding must output per_layer_inputs
         emb_inputs = data["model"]["embedding"]["inputs"]

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -1370,13 +1370,17 @@ class Gemma4TextModel(nn.Module):
         position_ids: ir.Value,
         past_key_values: list | None = None,
         inputs_embeds: ir.Value | None = None,
+        per_layer_inputs: list[ir.Value] | None = None,
     ) -> tuple[ir.Value, list]:
         if inputs_embeds is not None:
             hidden_states = inputs_embeds
         else:
             hidden_states = self.embed_tokens(op, input_ids)
 
-        per_layer_inputs = self._compute_per_layer_inputs(op, input_ids, hidden_states)
+        # Use pre-computed per-layer inputs when provided (multimodal decoder
+        # path); otherwise compute from input_ids + hidden_states (text-only).
+        if per_layer_inputs is None:
+            per_layer_inputs = self._compute_per_layer_inputs(op, input_ids, hidden_states)
 
         # Determine whether to emit GroupQueryAttention directly.
         # GQA fuses RoPE + attention + KV cache into a single op, and
@@ -1657,12 +1661,14 @@ class Gemma4CausalLMModel(CausalLMModel):
 class _Gemma4DecoderModel(nn.Module):
     """Gemma4 text decoder sub-model accepting ``inputs_embeds``.
 
-    When ``hidden_size_per_layer_input > 0`` (e.g. E2B), the text model also
-    needs the original ``input_ids`` to compute per-layer token embeddings that
-    condition each decoder layer.  HF's ``Gemma4ForConditionalGeneration``
-    passes *both* ``inputs_embeds`` and ``input_ids`` to the language model for
-    this reason.  We mirror that by accepting ``input_ids`` as an optional
-    ONNX graph input and forwarding it to :class:`Gemma4TextModel`.
+    When ``hidden_size_per_layer_input > 0`` (e.g. E2B), the decoder also takes
+    pre-computed ``per_layer_inputs`` [B, S, L, D] — one embedding per decoder
+    layer.  The embedding sub-model is responsible for computing these from the
+    original token IDs (via per-layer embedding tables and a projection of the
+    text embeddings).
+
+    When ``hidden_size_per_layer_input == 0``, ``per_layer_inputs`` is ``None``
+    and the per-layer gating in each decoder layer is skipped.
     """
 
     def __init__(self, config: Gemma4Config):
@@ -1677,16 +1683,33 @@ class _Gemma4DecoderModel(nn.Module):
         inputs_embeds: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
-        input_ids: ir.Value | None = None,
+        per_layer_inputs: ir.Value | None = None,
         past_key_values: list | None = None,
     ) -> tuple[ir.Value, list]:
+        # Slice per_layer_inputs [B, S, L, D] into per-layer list of [B, S, D]
+        per_layer_list: list[ir.Value] | None = None
+        if per_layer_inputs is not None:
+            per_layer_list = []
+            for i in range(self.config.num_hidden_layers):
+                slice_i = op.Squeeze(
+                    op.Slice(
+                        per_layer_inputs,
+                        starts=[i],
+                        ends=[i + 1],
+                        axes=[2],
+                    ),
+                    [2],
+                )  # [B, S, D]
+                per_layer_list.append(slice_i)
+
         hidden_states, present_key_values = self.model(
             op,
-            input_ids=input_ids,
+            input_ids=None,
             attention_mask=attention_mask,
             position_ids=position_ids,
             past_key_values=past_key_values,
             inputs_embeds=inputs_embeds,
+            per_layer_inputs=per_layer_list,
         )
         logits = self.lm_head(op, hidden_states)
         # Gemma4 applies final logit soft-capping: logit_cap * tanh(x / logit_cap)
@@ -1777,26 +1800,23 @@ class _Gemma4VisionEncoderModel(nn.Module):
 
 
 class Gemma4EmbeddingModel(nn.Module):
-    """Gemma4 embedding sub-model: scaled token lookup + multimodal feature fusion.
+    """Gemma4 embedding sub-model: scaled token lookup + per-layer input computation.
 
-    Always scatters vision features at image-token positions.  When the model
-    has audio support (``config.audio is not None``), ``forward()`` also accepts
-    ``audio_features`` and scatters them at audio-token positions.
+    Outputs ``inputs_embeds`` from the main vocabulary embedding and, when
+    ``hidden_size_per_layer_input > 0``, also outputs ``per_layer_inputs``
+    [B, S, num_layers, per_layer_dim] — pre-computed per-layer embeddings
+    consumed by the decoder.
 
-    Both image and audio use a one-row dummy guard so that ORT's eager
-    evaluation of both ``Where`` branches never ``Gather`` on a zero-length
-    tensor during text-only / decode steps.
+    Multimodal fusion (image/audio feature replacement into ``inputs_embeds``)
+    is handled by the runtime, NOT by this model.
 
-    Inputs (image-only variant):
+    Inputs:
     - ``input_ids [B, S]`` INT64
-    - ``image_features [num_img_tokens, hidden_size]``
 
-    Inputs (image + audio variant):
-    - ``input_ids [B, S]`` INT64
-    - ``image_features [num_img_tokens, hidden_size]``
-    - ``audio_features [num_aud_tokens, hidden_size]``
-
-    Output: ``inputs_embeds [B, S, hidden_size]``
+    Outputs:
+    - ``inputs_embeds [B, S, hidden_size]``
+    - ``per_layer_inputs [B, S, num_layers, per_layer_dim]``
+      (only when ``hidden_size_per_layer_input > 0``)
     """
 
     def __init__(self, config: Gemma4Config):
@@ -1809,72 +1829,115 @@ class Gemma4EmbeddingModel(nn.Module):
             config.pad_token_id,
             embed_scale=embed_scale,
         )
-        self.image_token_id = config.image_token_id or 0
-        # Audio token ID is only set when the model has an audio encoder.
-        self.audio_token_id: int | None = config.audio.audio_token_id if config.audio else None
 
-    def _scatter_features(
+        # Per-layer embedding weights (when hidden_size_per_layer_input > 0)
+        self._per_layer_dim = getattr(config, "hidden_size_per_layer_input", 0)
+        self._hidden_size = config.hidden_size
+        # Multimodal token IDs to mask before per-layer embedding lookup.
+        # HF masks these to pad_token_id (0) so image/audio slots don't contribute
+        # arbitrary large-ID embeddings to the per-layer gate.
+        self._image_token_id: int = config.image_token_id or 0
+        self._audio_token_id: int | None = (
+            config.audio.audio_token_id if config.audio is not None else None
+        )
+        if self._per_layer_dim:
+            self._num_layers = config.num_hidden_layers
+            vocab_per_layer = getattr(config, "vocab_size_per_layer_input", 0)
+            # Per-layer embedding tables: each [V, D], same layout as
+            # Gemma4TextModel.embed_tokens_per_layer for HF weight compat.
+            self.embed_tokens_per_layer = nn.ModuleList(
+                [
+                    Gemma3TextScaledWordEmbedding(
+                        vocab_per_layer,
+                        self._per_layer_dim,
+                        config.pad_token_id,
+                        embed_scale=float(self._per_layer_dim**0.5),
+                    )
+                    for _ in range(config.num_hidden_layers)
+                ]
+            )
+            self.per_layer_model_projection = Linear(
+                config.hidden_size,
+                config.num_hidden_layers * self._per_layer_dim,
+                bias=False,
+            )
+            self.per_layer_projection_norm = RMSNorm(
+                self._per_layer_dim, eps=config.rms_norm_eps
+            )
+
+    def _compute_per_layer_inputs(
         self,
         op: builder.OpBuilder,
-        hidden: ir.Value,
         input_ids: ir.Value,
-        token_id: int,
-        features: ir.Value,
+        inputs_embeds: ir.Value,
     ) -> ir.Value:
-        """Scatter ``features`` into ``hidden`` at positions matching ``token_id``.
+        """Compute per-layer input embeddings as a [B, S, L, D] tensor.
 
-        Appends a dummy zero row to ``features`` before Gather so that ORT's
-        eager evaluation of the Where branches never faults on an empty tensor
-        during text-only / decode steps.
+        Each layer's embedding is the sum of:
+        1. A projection of ``inputs_embeds`` through ``per_layer_model_projection``
+        2. A token embedding from ``embed_tokens_per_layer[i]``
+
+        Image/audio token IDs are masked to ``pad_token_id`` (0) before the
+        per-layer embedding lookup, matching HF's behavior.
         """
-        mask = op.Equal(input_ids, op.Constant(value_int=token_id))
-        mask_3d = op.Unsqueeze(mask, [-1])
+        # Project hidden states: [B, S, H] -> [B, S, L*D], scale by H^{-0.5}
+        proj = self.per_layer_model_projection(op, inputs_embeds)
+        proj = op.Mul(proj, float(self._hidden_size**-0.5))
+        # Reshape to [B, S, L, D] and normalize
+        proj = op.Reshape(
+            proj,
+            op.Constant(value_ints=[0, 0, self._num_layers, self._per_layer_dim]),
+        )
+        proj = self.per_layer_projection_norm(op, proj)
 
-        # CumSum → sub-1 → clip gives 0-based index into features for each token
-        mask_int = op.Cast(mask, to=7)  # INT64
-        cumsum = op.CumSum(mask_int, op.Constant(value_int=1))
-        indices = op.Clip(op.Sub(cumsum, op.Constant(value_int=1)), op.Constant(value_int=0))
+        # Mask multimodal token IDs to pad_token_id (0)
+        masked_ids = input_ids
+        pad = op.Constant(value_int=0)
+        if self._image_token_id:
+            masked_ids = op.Where(
+                op.Equal(
+                    masked_ids,
+                    op.Constant(value_int=self._image_token_id),
+                ),
+                pad,
+                masked_ids,
+            )
+        if self._audio_token_id is not None:
+            masked_ids = op.Where(
+                op.Equal(
+                    masked_ids,
+                    op.Constant(value_int=self._audio_token_id),
+                ),
+                pad,
+                masked_ids,
+            )
 
-        # One-row dummy prevents empty-tensor Gather faults during decode steps.
-        # Use Constant (static) + Unsqueeze to avoid ConstantOfShape, whose
-        # dynamic-shape input blocks ONNX shape inference.
-        dummy_row = op.Unsqueeze(
-            op.CastLike(
-                op.Constant(value_floats=[0.0] * self.config.hidden_size),
-                features,
-            ),
-            [0],
-        )  # [1, hidden_size]
-        features_safe = op.Concat(features, dummy_row, axis=0)
-        gathered = op.Gather(features_safe, indices, axis=0)
-        return op.Where(mask_3d, gathered, hidden)
+        # Per-layer token embeddings + projection, scaled by 1/sqrt(2)
+        per_layer_results: list[ir.Value] = []
+        for i in range(self._num_layers):
+            # Slice proj along axis 2: [B, S, L, D] → [B, S, D]
+            proj_i = op.Squeeze(op.Slice(proj, starts=[i], ends=[i + 1], axes=[2]), [2])
+            token_emb_i = self.embed_tokens_per_layer[i](op, masked_ids)
+            proj_i = op.Add(proj_i, token_emb_i)
+            per_layer_results.append(op.Mul(proj_i, float(0.5**0.5)))  # [B, S, D]
+
+        # Stack into [B, S, L, D]
+        unsqueezed = [op.Unsqueeze(r, [2]) for r in per_layer_results]
+        return op.Concat(*unsqueezed, axis=2)
 
     def forward(
         self,
         op: builder.OpBuilder,
         input_ids: ir.Value,
-        image_features: ir.Value,
-        audio_features: ir.Value | None = None,
-    ) -> ir.Value:
-        # [B, S] → [B, S, hidden]
+    ) -> tuple[ir.Value, ir.Value | None]:
+        # [B, S] → [B, S, hidden_size]
         hidden = self.embed_tokens(op, input_ids)
 
-        # Scatter image features at image-token positions
-        hidden = self._scatter_features(
-            op, hidden, input_ids, self.image_token_id, image_features
-        )
+        per_layer_inputs: ir.Value | None = None
+        if self._per_layer_dim:
+            per_layer_inputs = self._compute_per_layer_inputs(op, input_ids, hidden)
 
-        # Scatter audio features at audio-token positions (only for AnyToAny models)
-        if audio_features is not None:
-            assert self.audio_token_id is not None, (
-                "Gemma4EmbeddingModel received audio_features but audio_token_id is not set. "
-                "Ensure config.audio is provided."
-            )
-            hidden = self._scatter_features(
-                op, hidden, input_ids, self.audio_token_id, audio_features
-            )
-
-        return hidden
+        return hidden, per_layer_inputs
 
     def preprocess_weights(
         self, state_dict: dict[str, torch.Tensor]
@@ -2002,6 +2065,10 @@ class Gemma4Model(nn.Module):
         Mapping (after stripping the leading ``model.``):
 
         - ``language_model.lm_head.*`` → ``decoder.lm_head.*``
+        - ``language_model.embed_tokens_per_layer.weight`` → split into
+          ``embedding.embed_tokens_per_layer.{i}.weight``
+        - ``language_model.per_layer_model_projection.*`` → ``embedding.per_layer_model_projection.*``
+        - ``language_model.per_layer_projection_norm.*`` → ``embedding.per_layer_projection_norm.*``
         - ``language_model.*`` → ``decoder.model.*``
         - ``language_model.embed_tokens.weight`` also → ``embedding.embed_tokens.weight``
         - ``vision_tower.*`` → ``vision_encoder.encoder.*``
@@ -2019,7 +2086,8 @@ class Gemma4Model(nn.Module):
 
         Note: the decoder sub-model takes ``inputs_embeds`` rather than
         ``input_ids``, so ``embed_tokens`` is not a decoder initializer — the
-        token embedding lives only in the ``embedding`` sub-model.
+        token embedding lives only in the ``embedding`` sub-model.  Per-layer
+        embedding weights likewise live in the embedding sub-model.
         """
         # Strip top-level "model." prefix used by HF multimodal checkpoints.
         state_dict = {
@@ -2035,25 +2103,34 @@ class Gemma4Model(nn.Module):
                 state_dict[head_key] = state_dict[embed_key]
 
         renamed: dict[str, torch.Tensor] = {}
+        # Per-layer weight keys that belong to the embedding sub-model
+        # (not the decoder), because the embedding model now owns the
+        # per-layer embedding computation.
+        per_layer_prefixes = (
+            "per_layer_model_projection.",
+            "per_layer_projection_norm.",
+        )
         for key, value in state_dict.items():
             if key.startswith("language_model."):
                 suffix = key[len("language_model.") :]
                 if suffix.startswith("lm_head"):
                     # lm_head lives directly under decoder (not decoder.model)
                     renamed["decoder." + suffix] = value
+                elif suffix == "embed_tokens_per_layer.weight":
+                    # HF stores one [V, L*D] weight; split into L separate
+                    # [V, D] tables in the embedding sub-model.
+                    num_layers = self.config.num_hidden_layers
+                    per_layer_dim = self.embedding._per_layer_dim
+                    for i in range(num_layers):
+                        shard = value[:, i * per_layer_dim : (i + 1) * per_layer_dim]
+                        renamed[f"embedding.embed_tokens_per_layer.{i}.weight"] = shard
+                elif any(suffix.startswith(p) for p in per_layer_prefixes):
+                    # Per-layer projection/norm weights → embedding sub-model
+                    renamed["embedding." + suffix] = value
                 else:
                     # All other text weights nest under decoder.model.*
                     onnx_key = "decoder.model." + suffix
-                    if suffix == "embed_tokens_per_layer.weight":
-                        # HF stores one [V, L*D] weight; split into L separate
-                        # [V, D] tables matching our nn.ModuleList layout.
-                        num_layers = self.config.num_hidden_layers
-                        per_layer_dim = self.decoder.model._per_layer_dim
-                        for i in range(num_layers):
-                            shard = value[:, i * per_layer_dim : (i + 1) * per_layer_dim]
-                            renamed[f"decoder.model.embed_tokens_per_layer.{i}.weight"] = shard
-                    else:
-                        renamed[onnx_key] = value
+                    renamed[onnx_key] = value
                     if suffix == "embed_tokens.weight":
                         # Token embedding is shared with the embedding sub-model
                         renamed["embedding.embed_tokens.weight"] = value

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -1370,17 +1370,13 @@ class Gemma4TextModel(nn.Module):
         position_ids: ir.Value,
         past_key_values: list | None = None,
         inputs_embeds: ir.Value | None = None,
-        per_layer_inputs: list[ir.Value] | None = None,
     ) -> tuple[ir.Value, list]:
         if inputs_embeds is not None:
             hidden_states = inputs_embeds
         else:
             hidden_states = self.embed_tokens(op, input_ids)
 
-        # Use pre-computed per-layer inputs when provided (multimodal decoder
-        # path); otherwise compute from input_ids + hidden_states (text-only).
-        if per_layer_inputs is None:
-            per_layer_inputs = self._compute_per_layer_inputs(op, input_ids, hidden_states)
+        per_layer_inputs = self._compute_per_layer_inputs(op, input_ids, hidden_states)
 
         # Determine whether to emit GroupQueryAttention directly.
         # GQA fuses RoPE + attention + KV cache into a single op, and
@@ -1661,14 +1657,15 @@ class Gemma4CausalLMModel(CausalLMModel):
 class _Gemma4DecoderModel(nn.Module):
     """Gemma4 text decoder sub-model accepting ``inputs_embeds``.
 
-    When ``hidden_size_per_layer_input > 0`` (e.g. E2B), the decoder also takes
-    pre-computed ``per_layer_inputs`` [B, S, L, D] — one embedding per decoder
-    layer.  The embedding sub-model is responsible for computing these from the
-    original token IDs (via per-layer embedding tables and a projection of the
-    text embeddings).
+    When ``hidden_size_per_layer_input > 0`` (e.g. E2B), the text model also
+    needs the original ``input_ids`` to compute per-layer token embeddings that
+    condition each decoder layer.  The per-layer projection uses the (already
+    fused) ``inputs_embeds`` so that multimodal positions carry content-aware
+    information through the per-layer gate — this is critical for numerical
+    accuracy with the ONNX runtime.
 
-    When ``hidden_size_per_layer_input == 0``, ``per_layer_inputs`` is ``None``
-    and the per-layer gating in each decoder layer is skipped.
+    When ``hidden_size_per_layer_input == 0``, ``input_ids`` is passed through
+    but has no effect (``_compute_per_layer_inputs`` short-circuits to ``None``).
     """
 
     def __init__(self, config: Gemma4Config):
@@ -1683,33 +1680,16 @@ class _Gemma4DecoderModel(nn.Module):
         inputs_embeds: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
-        per_layer_inputs: ir.Value | None = None,
+        input_ids: ir.Value | None = None,
         past_key_values: list | None = None,
     ) -> tuple[ir.Value, list]:
-        # Slice per_layer_inputs [B, S, L, D] into per-layer list of [B, S, D]
-        per_layer_list: list[ir.Value] | None = None
-        if per_layer_inputs is not None:
-            per_layer_list = []
-            for i in range(self.config.num_hidden_layers):
-                slice_i = op.Squeeze(
-                    op.Slice(
-                        per_layer_inputs,
-                        starts=[i],
-                        ends=[i + 1],
-                        axes=[2],
-                    ),
-                    [2],
-                )  # [B, S, D]
-                per_layer_list.append(slice_i)
-
         hidden_states, present_key_values = self.model(
             op,
-            input_ids=None,
+            input_ids=input_ids,
             attention_mask=attention_mask,
             position_ids=position_ids,
             past_key_values=past_key_values,
             inputs_embeds=inputs_embeds,
-            per_layer_inputs=per_layer_list,
         )
         logits = self.lm_head(op, hidden_states)
         # Gemma4 applies final logit soft-capping: logit_cap * tanh(x / logit_cap)
@@ -1800,23 +1780,23 @@ class _Gemma4VisionEncoderModel(nn.Module):
 
 
 class Gemma4EmbeddingModel(nn.Module):
-    """Gemma4 embedding sub-model: scaled token lookup + per-layer input computation.
+    """Gemma4 embedding sub-model: scaled token lookup with multimodal masking.
 
-    Outputs ``inputs_embeds`` from the main vocabulary embedding and, when
-    ``hidden_size_per_layer_input > 0``, also outputs ``per_layer_inputs``
-    [B, S, num_layers, per_layer_dim] — pre-computed per-layer embeddings
-    consumed by the decoder.
+    Outputs ``inputs_embeds`` from the main vocabulary embedding.  Multimodal
+    token IDs (image/audio) are masked to ``pad_token_id`` (0) before the
+    embedding lookup so that multimodal positions contain neutral PAD embeddings.
+    The runtime is responsible for fusing vision/audio encoder features into
+    ``inputs_embeds`` at those positions.
 
-    Multimodal fusion (image/audio feature replacement into ``inputs_embeds``)
-    is handled by the runtime, NOT by this model.
+    Per-layer input embeddings (PLE) are computed by the *decoder*, not by
+    this model: the PLE projection must operate on the *fused* hidden states
+    (after image/audio features are scattered in) for numerical accuracy.
 
     Inputs:
     - ``input_ids [B, S]`` INT64
 
-    Outputs:
+    Output:
     - ``inputs_embeds [B, S, hidden_size]``
-    - ``per_layer_inputs [B, S, num_layers, per_layer_dim]``
-      (only when ``hidden_size_per_layer_input > 0``)
     """
 
     def __init__(self, config: Gemma4Config):
@@ -1829,68 +1809,24 @@ class Gemma4EmbeddingModel(nn.Module):
             config.pad_token_id,
             embed_scale=embed_scale,
         )
-
-        # Per-layer embedding weights (when hidden_size_per_layer_input > 0)
-        self._per_layer_dim = getattr(config, "hidden_size_per_layer_input", 0)
-        self._hidden_size = config.hidden_size
-        # Multimodal token IDs to mask before per-layer embedding lookup.
-        # HF masks these to pad_token_id (0) so image/audio slots don't contribute
-        # arbitrary large-ID embeddings to the per-layer gate.
+        # Multimodal token IDs to mask before embedding lookup.
+        # HF masks these to pad_token_id (0) so multimodal positions get
+        # neutral PAD embeddings (later replaced by runtime fusion).
         self._image_token_id: int = config.image_token_id or 0
         self._audio_token_id: int | None = (
             config.audio.audio_token_id if config.audio is not None else None
         )
-        if self._per_layer_dim:
-            self._num_layers = config.num_hidden_layers
-            vocab_per_layer = getattr(config, "vocab_size_per_layer_input", 0)
-            # Per-layer embedding tables: each [V, D], same layout as
-            # Gemma4TextModel.embed_tokens_per_layer for HF weight compat.
-            self.embed_tokens_per_layer = nn.ModuleList(
-                [
-                    Gemma3TextScaledWordEmbedding(
-                        vocab_per_layer,
-                        self._per_layer_dim,
-                        config.pad_token_id,
-                        embed_scale=float(self._per_layer_dim**0.5),
-                    )
-                    for _ in range(config.num_hidden_layers)
-                ]
-            )
-            self.per_layer_model_projection = Linear(
-                config.hidden_size,
-                config.num_hidden_layers * self._per_layer_dim,
-                bias=False,
-            )
-            self.per_layer_projection_norm = RMSNorm(
-                self._per_layer_dim, eps=config.rms_norm_eps
-            )
 
-    def _compute_per_layer_inputs(
+    def forward(
         self,
         op: builder.OpBuilder,
         input_ids: ir.Value,
-        inputs_embeds: ir.Value,
     ) -> ir.Value:
-        """Compute per-layer input embeddings as a [B, S, L, D] tensor.
-
-        Each layer's embedding is the sum of:
-        1. A projection of ``inputs_embeds`` through ``per_layer_model_projection``
-        2. A token embedding from ``embed_tokens_per_layer[i]``
-
-        Image/audio token IDs are masked to ``pad_token_id`` (0) before the
-        per-layer embedding lookup, matching HF's behavior.
-        """
-        # Project hidden states: [B, S, H] -> [B, S, L*D], scale by H^{-0.5}
-        proj = self.per_layer_model_projection(op, inputs_embeds)
-        proj = op.Mul(proj, float(self._hidden_size**-0.5))
-        # Reshape to [B, S, L, D] and normalize
-        proj = op.Reshape(
-            proj,
-            op.Constant(value_ints=[0, 0, self._num_layers, self._per_layer_dim]),
-        )
-        proj = self.per_layer_projection_norm(op, proj)
-
-        # Mask multimodal token IDs to pad_token_id (0)
+        # Mask multimodal token IDs to pad_token_id (0) before embedding.
+        # HF's Gemma4Model replaces image/audio tokens with pad_token_id
+        # before calling embed_tokens, so inputs_embeds at multimodal
+        # positions contain PAD embeddings (later replaced by runtime
+        # fusion).
         masked_ids = input_ids
         pad = op.Constant(value_int=0)
         if self._image_token_id:
@@ -1912,32 +1848,8 @@ class Gemma4EmbeddingModel(nn.Module):
                 masked_ids,
             )
 
-        # Per-layer token embeddings + projection, scaled by 1/sqrt(2)
-        per_layer_results: list[ir.Value] = []
-        for i in range(self._num_layers):
-            # Slice proj along axis 2: [B, S, L, D] → [B, S, D]
-            proj_i = op.Squeeze(op.Slice(proj, starts=[i], ends=[i + 1], axes=[2]), [2])
-            token_emb_i = self.embed_tokens_per_layer[i](op, masked_ids)
-            proj_i = op.Add(proj_i, token_emb_i)
-            per_layer_results.append(op.Mul(proj_i, float(0.5**0.5)))  # [B, S, D]
-
-        # Stack into [B, S, L, D]
-        unsqueezed = [op.Unsqueeze(r, [2]) for r in per_layer_results]
-        return op.Concat(*unsqueezed, axis=2)
-
-    def forward(
-        self,
-        op: builder.OpBuilder,
-        input_ids: ir.Value,
-    ) -> tuple[ir.Value, ir.Value | None]:
         # [B, S] → [B, S, hidden_size]
-        hidden = self.embed_tokens(op, input_ids)
-
-        per_layer_inputs: ir.Value | None = None
-        if self._per_layer_dim:
-            per_layer_inputs = self._compute_per_layer_inputs(op, input_ids, hidden)
-
-        return hidden, per_layer_inputs
+        return self.embed_tokens(op, masked_ids)
 
     def preprocess_weights(
         self, state_dict: dict[str, torch.Tensor]
@@ -2065,10 +1977,6 @@ class Gemma4Model(nn.Module):
         Mapping (after stripping the leading ``model.``):
 
         - ``language_model.lm_head.*`` → ``decoder.lm_head.*``
-        - ``language_model.embed_tokens_per_layer.weight`` → split into
-          ``embedding.embed_tokens_per_layer.{i}.weight``
-        - ``language_model.per_layer_model_projection.*`` → ``embedding.per_layer_model_projection.*``
-        - ``language_model.per_layer_projection_norm.*`` → ``embedding.per_layer_projection_norm.*``
         - ``language_model.*`` → ``decoder.model.*``
         - ``language_model.embed_tokens.weight`` also → ``embedding.embed_tokens.weight``
         - ``vision_tower.*`` → ``vision_encoder.encoder.*``
@@ -2086,8 +1994,7 @@ class Gemma4Model(nn.Module):
 
         Note: the decoder sub-model takes ``inputs_embeds`` rather than
         ``input_ids``, so ``embed_tokens`` is not a decoder initializer — the
-        token embedding lives only in the ``embedding`` sub-model.  Per-layer
-        embedding weights likewise live in the embedding sub-model.
+        token embedding lives only in the ``embedding`` sub-model.
         """
         # Strip top-level "model." prefix used by HF multimodal checkpoints.
         state_dict = {
@@ -2103,34 +2010,25 @@ class Gemma4Model(nn.Module):
                 state_dict[head_key] = state_dict[embed_key]
 
         renamed: dict[str, torch.Tensor] = {}
-        # Per-layer weight keys that belong to the embedding sub-model
-        # (not the decoder), because the embedding model now owns the
-        # per-layer embedding computation.
-        per_layer_prefixes = (
-            "per_layer_model_projection.",
-            "per_layer_projection_norm.",
-        )
         for key, value in state_dict.items():
             if key.startswith("language_model."):
                 suffix = key[len("language_model.") :]
                 if suffix.startswith("lm_head"):
                     # lm_head lives directly under decoder (not decoder.model)
                     renamed["decoder." + suffix] = value
-                elif suffix == "embed_tokens_per_layer.weight":
-                    # HF stores one [V, L*D] weight; split into L separate
-                    # [V, D] tables in the embedding sub-model.
-                    num_layers = self.config.num_hidden_layers
-                    per_layer_dim = self.embedding._per_layer_dim
-                    for i in range(num_layers):
-                        shard = value[:, i * per_layer_dim : (i + 1) * per_layer_dim]
-                        renamed[f"embedding.embed_tokens_per_layer.{i}.weight"] = shard
-                elif any(suffix.startswith(p) for p in per_layer_prefixes):
-                    # Per-layer projection/norm weights → embedding sub-model
-                    renamed["embedding." + suffix] = value
                 else:
                     # All other text weights nest under decoder.model.*
                     onnx_key = "decoder.model." + suffix
-                    renamed[onnx_key] = value
+                    if suffix == "embed_tokens_per_layer.weight":
+                        # HF stores one [V, L*D] weight; split into L separate
+                        # [V, D] tables matching our nn.ModuleList layout.
+                        num_layers = self.config.num_hidden_layers
+                        per_layer_dim = self.decoder.model._per_layer_dim
+                        for i in range(num_layers):
+                            shard = value[:, i * per_layer_dim : (i + 1) * per_layer_dim]
+                            renamed[f"decoder.model.embed_tokens_per_layer.{i}.weight"] = shard
+                    else:
+                        renamed[onnx_key] = value
                     if suffix == "embed_tokens.weight":
                         # Token embedding is shared with the embedding sub-model
                         renamed["embedding.embed_tokens.weight"] = value

--- a/src/mobius/tasks/_gemma4.py
+++ b/src/mobius/tasks/_gemma4.py
@@ -5,11 +5,14 @@
 
 The unified :class:`Gemma4Task` builds a 3- or 4-model package:
 
-1. **decoder** (text decoder): ``inputs_embeds`` → logits + KV cache
+1. **decoder** (text decoder): ``inputs_embeds [+ per_layer_inputs]`` → logits + KV cache
 2. **vision** (vision encoder): ``pixel_values, pixel_position_ids`` → ``image_features``
-3. **embedding**: ``input_ids, image_features[, audio_features]`` → ``inputs_embeds``
+3. **embedding**: ``input_ids`` → ``inputs_embeds [+ per_layer_inputs]``
 4. **audio** (audio encoder, only when ``config.audio is not None``):
    ``input_features`` → ``audio_features``
+
+Multimodal fusion (image/audio feature replacement into ``inputs_embeds``) is
+handled by the runtime, NOT by the embedding model.
 
 The decoder uses per-layer KV cache where local (sliding_attention) layers
 use ``config.head_dim`` and global (full_attention) layers use
@@ -158,13 +161,15 @@ class Gemma4Task(ModelTask):
     """Unified task for Gemma4 multimodal models (3- or 4-model split).
 
     Always builds:
-    - ``decoder``: text decoder accepting ``inputs_embeds``
+    - ``decoder``: text decoder accepting ``inputs_embeds`` [+ ``per_layer_inputs``]
     - ``vision``: vision encoder accepting ``pixel_values, pixel_position_ids``
-    - ``embedding``: embedding model fusing ``input_ids`` and multimodal features
+    - ``embedding``: produces ``inputs_embeds`` [+ ``per_layer_inputs``] from ``input_ids``
 
     When ``config.audio is not None``, also builds:
     - ``audio``: Conformer audio encoder accepting ``input_features``
-      (and adds ``audio_features`` as a third input to ``embedding``)
+
+    Multimodal fusion (image/audio feature replacement) is handled by the
+    runtime, not by the embedding model.
 
     Decoder KV cache is per-layer with the correct head_dim for each layer type
     (local vs global), unlike the uniform head_dim in :class:`VisionLanguageTask`.
@@ -191,13 +196,11 @@ class Gemma4Task(ModelTask):
         decoder: nn.Module,
         config: Gemma4Config,
     ) -> ir.Model:
-        """Build text decoder: inputs_embeds + input_ids -> logits + per-layer KV cache.
+        """Build text decoder: inputs_embeds [+ per_layer_inputs] -> logits + per-layer KV cache.
 
-        ``input_ids`` is included alongside ``inputs_embeds`` because models with
-        ``hidden_size_per_layer_input > 0`` (e.g. Gemma4 E2B) need the original token
-        IDs to compute per-layer token embeddings that condition each decoder layer.
-        When ``hidden_size_per_layer_input == 0`` the tensor is passed through but has
-        no effect (``_compute_per_layer_inputs`` short-circuits to ``None``).
+        When ``hidden_size_per_layer_input > 0``, the decoder takes a
+        pre-computed ``per_layer_inputs`` [B, S, L, D] tensor produced by
+        the embedding model.  The decoder does NOT take ``input_ids``.
         """
         batch = ir.SymbolicDim("batch")
         seq_len = ir.SymbolicDim("sequence_len")
@@ -218,13 +221,25 @@ class Gemma4Task(ModelTask):
             shape=ir.Shape([batch, seq_len]),
             type=ir.TensorType(ir.DataType.INT64),
         )
-        input_ids = ir.Value(
-            name="input_ids",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
-        )
 
-        graph_inputs = [inputs_embeds, attention_mask, position_ids, input_ids]
+        graph_inputs = [inputs_embeds, attention_mask, position_ids]
+
+        per_layer_val: ir.Value | None = None
+        per_layer_dim = getattr(config, "hidden_size_per_layer_input", 0)
+        if per_layer_dim:
+            per_layer_val = ir.Value(
+                name="per_layer_inputs",
+                shape=ir.Shape(
+                    [
+                        batch,
+                        seq_len,
+                        config.num_hidden_layers,
+                        per_layer_dim,
+                    ]
+                ),
+                type=ir.TensorType(config.dtype),
+            )
+            graph_inputs.append(per_layer_val)
 
         kv_inputs, past_key_values = _make_gemma4_kv_cache_inputs(config, batch, past_seq_len)
         graph_inputs.extend(kv_inputs)
@@ -237,7 +252,7 @@ class Gemma4Task(ModelTask):
             inputs_embeds=inputs_embeds,
             attention_mask=attention_mask,
             position_ids=position_ids,
-            input_ids=input_ids,
+            per_layer_inputs=per_layer_val,
             past_key_values=past_key_values,
         )
 
@@ -329,43 +344,34 @@ class Gemma4Task(ModelTask):
         embedding: nn.Module,
         config: Gemma4Config,
     ) -> ir.Model:
-        """Build embedding: input_ids + image_features [+ audio_features] -> inputs_embeds."""
+        """Build embedding: input_ids -> inputs_embeds [+ per_layer_inputs].
+
+        Multimodal fusion is handled by the runtime, not this model.
+        When ``hidden_size_per_layer_input > 0``, also outputs
+        ``per_layer_inputs`` [B, S, num_layers, per_layer_dim].
+        """
         batch = ir.SymbolicDim("batch")
         seq_len = ir.SymbolicDim("sequence_len")
-        num_image_tokens = ir.SymbolicDim("num_image_tokens")
 
         input_ids = ir.Value(
             name="input_ids",
             shape=ir.Shape([batch, seq_len]),
             type=ir.TensorType(ir.DataType.INT64),
         )
-        image_features = ir.Value(
-            name="image_features",
-            shape=ir.Shape([num_image_tokens, config.hidden_size]),
-            type=ir.TensorType(config.dtype),
-        )
 
-        graph_inputs = [input_ids, image_features]
-        audio_features_val: ir.Value | None = None
-
-        if config.audio is not None:
-            num_audio_tokens = ir.SymbolicDim("num_audio_tokens")
-            audio_features_val = ir.Value(
-                name="audio_features",
-                shape=ir.Shape([num_audio_tokens, config.hidden_size]),
-                type=ir.TensorType(config.dtype),
-            )
-            graph_inputs.append(audio_features_val)
+        graph_inputs = [input_ids]
 
         graph, graph_builder = _make_graph(graph_inputs, name="embedding")
         op = graph_builder.op
 
-        inputs_embeds = embedding(
+        inputs_embeds, per_layer_inputs = embedding(
             op,
             input_ids=input_ids,
-            image_features=image_features,
-            audio_features=audio_features_val,
         )
         inputs_embeds.name = "inputs_embeds"
         graph.outputs.append(inputs_embeds)
+        if per_layer_inputs is not None:
+            per_layer_inputs.name = "per_layer_inputs"
+            graph.outputs.append(per_layer_inputs)
+
         return _make_model(graph)

--- a/src/mobius/tasks/_gemma4.py
+++ b/src/mobius/tasks/_gemma4.py
@@ -161,9 +161,9 @@ class Gemma4Task(ModelTask):
     """Unified task for Gemma4 multimodal models (3- or 4-model split).
 
     Always builds:
-    - ``decoder``: text decoder accepting ``inputs_embeds`` [+ ``per_layer_inputs``]
+    - ``decoder``: text decoder accepting ``inputs_embeds`` + ``input_ids``
     - ``vision``: vision encoder accepting ``pixel_values, pixel_position_ids``
-    - ``embedding``: produces ``inputs_embeds`` [+ ``per_layer_inputs``] from ``input_ids``
+    - ``embedding``: produces ``inputs_embeds`` from ``input_ids``
 
     When ``config.audio is not None``, also builds:
     - ``audio``: Conformer audio encoder accepting ``input_features``
@@ -196,11 +196,13 @@ class Gemma4Task(ModelTask):
         decoder: nn.Module,
         config: Gemma4Config,
     ) -> ir.Model:
-        """Build text decoder: inputs_embeds [+ per_layer_inputs] -> logits + per-layer KV cache.
+        """Build text decoder: inputs_embeds + input_ids -> logits + per-layer KV cache.
 
-        When ``hidden_size_per_layer_input > 0``, the decoder takes a
-        pre-computed ``per_layer_inputs`` [B, S, L, D] tensor produced by
-        the embedding model.  The decoder does NOT take ``input_ids``.
+        ``input_ids`` is included alongside ``inputs_embeds`` because models with
+        ``hidden_size_per_layer_input > 0`` (e.g. Gemma4 E2B) need the original token
+        IDs to compute per-layer token embeddings that condition each decoder layer.
+        When ``hidden_size_per_layer_input == 0`` the tensor is passed through but has
+        no effect (``_compute_per_layer_inputs`` short-circuits to ``None``).
         """
         batch = ir.SymbolicDim("batch")
         seq_len = ir.SymbolicDim("sequence_len")
@@ -221,25 +223,13 @@ class Gemma4Task(ModelTask):
             shape=ir.Shape([batch, seq_len]),
             type=ir.TensorType(ir.DataType.INT64),
         )
+        input_ids = ir.Value(
+            name="input_ids",
+            shape=ir.Shape([batch, seq_len]),
+            type=ir.TensorType(ir.DataType.INT64),
+        )
 
-        graph_inputs = [inputs_embeds, attention_mask, position_ids]
-
-        per_layer_val: ir.Value | None = None
-        per_layer_dim = getattr(config, "hidden_size_per_layer_input", 0)
-        if per_layer_dim:
-            per_layer_val = ir.Value(
-                name="per_layer_inputs",
-                shape=ir.Shape(
-                    [
-                        batch,
-                        seq_len,
-                        config.num_hidden_layers,
-                        per_layer_dim,
-                    ]
-                ),
-                type=ir.TensorType(config.dtype),
-            )
-            graph_inputs.append(per_layer_val)
+        graph_inputs = [inputs_embeds, attention_mask, position_ids, input_ids]
 
         kv_inputs, past_key_values = _make_gemma4_kv_cache_inputs(config, batch, past_seq_len)
         graph_inputs.extend(kv_inputs)
@@ -252,7 +242,7 @@ class Gemma4Task(ModelTask):
             inputs_embeds=inputs_embeds,
             attention_mask=attention_mask,
             position_ids=position_ids,
-            per_layer_inputs=per_layer_val,
+            input_ids=input_ids,
             past_key_values=past_key_values,
         )
 
@@ -344,11 +334,9 @@ class Gemma4Task(ModelTask):
         embedding: nn.Module,
         config: Gemma4Config,
     ) -> ir.Model:
-        """Build embedding: input_ids -> inputs_embeds [+ per_layer_inputs].
+        """Build embedding: input_ids -> inputs_embeds.
 
         Multimodal fusion is handled by the runtime, not this model.
-        When ``hidden_size_per_layer_input > 0``, also outputs
-        ``per_layer_inputs`` [B, S, num_layers, per_layer_dim].
         """
         batch = ir.SymbolicDim("batch")
         seq_len = ir.SymbolicDim("sequence_len")
@@ -364,14 +352,11 @@ class Gemma4Task(ModelTask):
         graph, graph_builder = _make_graph(graph_inputs, name="embedding")
         op = graph_builder.op
 
-        inputs_embeds, per_layer_inputs = embedding(
+        inputs_embeds = embedding(
             op,
             input_ids=input_ids,
         )
         inputs_embeds.name = "inputs_embeds"
         graph.outputs.append(inputs_embeds)
-        if per_layer_inputs is not None:
-            per_layer_inputs.name = "per_layer_inputs"
-            graph.outputs.append(per_layer_inputs)
 
         return _make_model(graph)

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -1186,9 +1186,11 @@ class TestBuildGraphVisionLanguage:
         assert set(pkg.keys()) == {"decoder", "vision", "embedding"}, (
             f"Vision-only Gemma4 should produce 3 models, got: {set(pkg.keys())}"
         )
-        # Decoder: inputs_embeds -> logits + per-layer KV cache
+        # Decoder: inputs_embeds -> logits + per-layer KV cache (no input_ids)
         decoder = pkg["decoder"]
-        assert "inputs_embeds" in {i.name for i in decoder.graph.inputs}
+        decoder_input_names = {i.name for i in decoder.graph.inputs}
+        assert "inputs_embeds" in decoder_input_names
+        assert "input_ids" not in decoder_input_names
         assert "logits" in {o.name for o in decoder.graph.outputs}
         # Vision: pixel_values + pixel_position_ids -> image_features
         vision = pkg["vision"]
@@ -1196,13 +1198,76 @@ class TestBuildGraphVisionLanguage:
         assert "pixel_values" in vision_input_names
         assert "pixel_position_ids" in vision_input_names
         assert "image_features" in {o.name for o in vision.graph.outputs}
-        # Embedding: input_ids + image_features (no audio) -> inputs_embeds
+        # Embedding: input_ids -> inputs_embeds (no multimodal fusion)
         embedding = pkg["embedding"]
         emb_input_names = {i.name for i in embedding.graph.inputs}
         assert "input_ids" in emb_input_names
-        assert "image_features" in emb_input_names
+        assert "image_features" not in emb_input_names
         assert "audio_features" not in emb_input_names
         assert "inputs_embeds" in {o.name for o in embedding.graph.outputs}
+
+    def test_gemma4_per_layer_inputs_graph(self):
+        """Build Gemma4 VLM with per-layer input embeddings (hidden_size_per_layer_input > 0).
+
+        Verifies:
+        - Embedding outputs both ``inputs_embeds`` and ``per_layer_inputs``
+        - Decoder takes ``per_layer_inputs`` instead of ``input_ids``
+        """
+        from mobius._configs import Gemma4Config
+
+        config = Gemma4Config(
+            num_hidden_layers=2,
+            hidden_size=64,
+            intermediate_size=128,
+            num_attention_heads=4,
+            num_key_value_heads=1,
+            head_dim=16,
+            vocab_size=256,
+            rms_norm_eps=1e-6,
+            hidden_act="silu",
+            attn_qk_norm=True,
+            layer_types=["sliding_attention", "full_attention"],
+            sliding_window=8,
+            global_head_dim=16,
+            global_rope_theta=10_000.0,
+            global_partial_rotary_factor=0.25,
+            final_logit_softcapping=0.0,
+            # Enable per-layer input embeddings
+            hidden_size_per_layer_input=8,
+            vocab_size_per_layer_input=128,
+            image_token_id=255,
+            pad_token_id=0,
+            tie_word_embeddings=True,
+            vision=VisionConfig(
+                hidden_size=32,
+                intermediate_size=64,
+                num_hidden_layers=1,
+                num_attention_heads=2,
+                patch_size=16,
+                norm_eps=1e-6,
+            ),
+        )
+        model_cls = registry.get("gemma4")
+        module = model_cls(config)
+        task_name = _default_task_for_model("gemma4")
+        task = get_task(task_name)
+        pkg = task.build(module, config)
+
+        assert set(pkg.keys()) == {"decoder", "vision", "embedding"}
+        # Decoder: per_layer_inputs replaces input_ids
+        decoder = pkg["decoder"]
+        decoder_input_names = {i.name for i in decoder.graph.inputs}
+        assert "inputs_embeds" in decoder_input_names
+        assert "per_layer_inputs" in decoder_input_names
+        assert "input_ids" not in decoder_input_names
+        assert "logits" in {o.name for o in decoder.graph.outputs}
+        # Embedding: outputs both inputs_embeds and per_layer_inputs
+        embedding = pkg["embedding"]
+        emb_input_names = {i.name for i in embedding.graph.inputs}
+        emb_output_names = {o.name for o in embedding.graph.outputs}
+        assert emb_input_names == {"input_ids"}
+        assert "inputs_embeds" in emb_output_names
+        assert "per_layer_inputs" in emb_output_names
 
     def test_gemma4_moe_graph(self):
         """Build Gemma4 text-only model with enable_moe_block=True (MoE path)."""
@@ -1308,6 +1373,7 @@ class TestBuildGraphVisionLanguage:
         decoder = pkg["decoder"]
         decoder_input_names = {i.name for i in decoder.graph.inputs}
         assert "inputs_embeds" in decoder_input_names
+        assert "input_ids" not in decoder_input_names
         assert "past_key_values.0.key" in decoder_input_names
         assert "past_key_values.1.key" not in decoder_input_names  # shared layer
         assert "logits" in {o.name for o in decoder.graph.outputs}
@@ -1321,12 +1387,12 @@ class TestBuildGraphVisionLanguage:
         audio = pkg["audio"]
         assert "input_features" in {i.name for i in audio.graph.inputs}
         assert "audio_features" in {o.name for o in audio.graph.outputs}
-        # Embedding: all three inputs
+        # Embedding: only input_ids (no multimodal fusion)
         embedding = pkg["embedding"]
         emb_input_names = {i.name for i in embedding.graph.inputs}
         assert "input_ids" in emb_input_names
-        assert "image_features" in emb_input_names
-        assert "audio_features" in emb_input_names
+        assert "image_features" not in emb_input_names
+        assert "audio_features" not in emb_input_names
         assert "inputs_embeds" in {o.name for o in embedding.graph.outputs}
         # KV cache outputs: num_kv_layers = num_hidden_layers - num_kv_shared_layers = 1
         decoder_output_names = {o.name for o in decoder.graph.outputs}

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -1186,11 +1186,11 @@ class TestBuildGraphVisionLanguage:
         assert set(pkg.keys()) == {"decoder", "vision", "embedding"}, (
             f"Vision-only Gemma4 should produce 3 models, got: {set(pkg.keys())}"
         )
-        # Decoder: inputs_embeds -> logits + per-layer KV cache (no input_ids)
+        # Decoder: inputs_embeds + input_ids -> logits + per-layer KV cache
         decoder = pkg["decoder"]
         decoder_input_names = {i.name for i in decoder.graph.inputs}
         assert "inputs_embeds" in decoder_input_names
-        assert "input_ids" not in decoder_input_names
+        assert "input_ids" in decoder_input_names
         assert "logits" in {o.name for o in decoder.graph.outputs}
         # Vision: pixel_values + pixel_position_ids -> image_features
         vision = pkg["vision"]
@@ -1210,8 +1210,8 @@ class TestBuildGraphVisionLanguage:
         """Build Gemma4 VLM with per-layer input embeddings (hidden_size_per_layer_input > 0).
 
         Verifies:
-        - Embedding outputs both ``inputs_embeds`` and ``per_layer_inputs``
-        - Decoder takes ``per_layer_inputs`` instead of ``input_ids``
+        - Decoder takes ``input_ids`` for per-layer computation
+        - Embedding outputs only ``inputs_embeds`` (per-layer computed by decoder)
         """
         from mobius._configs import Gemma4Config
 
@@ -1254,20 +1254,19 @@ class TestBuildGraphVisionLanguage:
         pkg = task.build(module, config)
 
         assert set(pkg.keys()) == {"decoder", "vision", "embedding"}
-        # Decoder: per_layer_inputs replaces input_ids
+        # Decoder: input_ids for per-layer computation
         decoder = pkg["decoder"]
         decoder_input_names = {i.name for i in decoder.graph.inputs}
         assert "inputs_embeds" in decoder_input_names
-        assert "per_layer_inputs" in decoder_input_names
-        assert "input_ids" not in decoder_input_names
+        assert "input_ids" in decoder_input_names
         assert "logits" in {o.name for o in decoder.graph.outputs}
-        # Embedding: outputs both inputs_embeds and per_layer_inputs
+        # Embedding: outputs only inputs_embeds (per-layer computed by decoder)
         embedding = pkg["embedding"]
         emb_input_names = {i.name for i in embedding.graph.inputs}
         emb_output_names = {o.name for o in embedding.graph.outputs}
         assert emb_input_names == {"input_ids"}
         assert "inputs_embeds" in emb_output_names
-        assert "per_layer_inputs" in emb_output_names
+        assert "per_layer_inputs" not in emb_output_names
 
     def test_gemma4_moe_graph(self):
         """Build Gemma4 text-only model with enable_moe_block=True (MoE path)."""
@@ -1373,7 +1372,7 @@ class TestBuildGraphVisionLanguage:
         decoder = pkg["decoder"]
         decoder_input_names = {i.name for i in decoder.graph.inputs}
         assert "inputs_embeds" in decoder_input_names
-        assert "input_ids" not in decoder_input_names
+        assert "input_ids" in decoder_input_names
         assert "past_key_values.0.key" in decoder_input_names
         assert "past_key_values.1.key" not in decoder_input_names  # shared layer
         assert "logits" in {o.name for o in decoder.graph.outputs}

--- a/tests/e2e_golden_test.py
+++ b/tests/e2e_golden_test.py
@@ -631,6 +631,21 @@ def _run_vision_language_prefill(
     emb_key = next(iter(emb_out))
     inputs_embeds = emb_out[emb_key]
 
+    # External multimodal fusion: if the embedding model does NOT accept
+    # image features (new split interface), replace placeholder token
+    # embeddings with vision encoder features in the test harness.
+    emb_has_image_input = any("image" in n for n in emb_session.input_names)
+    if not emb_has_image_input:
+        image_token_id = getattr(config, "image_token_id", None)
+        if image_token_id is not None:
+            vis_feat = vis_hidden[0] if vis_hidden.ndim == 3 else vis_hidden
+            flat = processed["input_ids"].astype(np.int64)[0]
+            positions = np.where(flat == image_token_id)[0]
+            n = min(len(positions), vis_feat.shape[0])
+            if n > 0:
+                inputs_embeds = inputs_embeds.copy()
+                inputs_embeds[0, positions[:n]] = vis_feat[:n]
+
     # --- Step 3: Run decoder ---
     # VL packages may use "model" or "decoder" for the text decoder.
     dec_key = "model" if "model" in pkg else "decoder"
@@ -647,7 +662,11 @@ def _run_vision_language_prefill(
         for name in dec_session.input_names:
             if name in dec_feeds:
                 continue
-            if name in processed:
+            # Pass through embedding outputs that match decoder inputs
+            # (e.g. per_layer_inputs from split embedding interface)
+            if name in emb_out:
+                dec_feeds[name] = emb_out[name]
+            elif name in processed:
                 dec_feeds[name] = processed[name]
             elif name == "attention_mask":
                 dec_feeds[name] = np.ones((1, seq_len), dtype=np.int64)
@@ -814,6 +833,19 @@ def _run_vl_generation(
         emb_out = emb_session.run(emb_feeds)
         inputs_embeds = emb_out[next(iter(emb_out))]  # [1, seq_len, hidden_size]
 
+        # External multimodal fusion: if the embedding model does NOT accept
+        # image features (new split interface), fuse vision features here.
+        if image_feat_input is None:
+            image_token_id = getattr(config, "image_token_id", None)
+            if image_token_id is not None:
+                vis_feat = vis_hidden[0] if vis_hidden.ndim == 3 else vis_hidden
+                flat = processed["input_ids"].astype(np.int64)[0]
+                positions = np.where(flat == image_token_id)[0]
+                n = min(len(positions), vis_feat.shape[0])
+                if n > 0:
+                    inputs_embeds = inputs_embeds.copy()
+                    inputs_embeds[0, positions[:n]] = vis_feat[:n]
+
         batch_size = 1
         prompt_seq_len = inputs_embeds.shape[1]
         hidden_size = inputs_embeds.shape[2]
@@ -830,7 +862,11 @@ def _run_vl_generation(
             "attention_mask": np.ones((batch_size, prompt_seq_len), dtype=np.int64),
             **past_cache,
         }
-        # Gemma4 decoder requires input_ids alongside inputs_embeds
+        # Pass through embedding outputs that match decoder inputs
+        # (e.g. per_layer_inputs from split embedding interface)
+        for name in dec_session.input_names:
+            if name not in dec_feeds and name in emb_out:
+                dec_feeds[name] = emb_out[name]
         if "input_ids" in dec_session.input_names:
             dec_feeds["input_ids"] = processed["input_ids"].astype(np.int64)
         # Track the next decode position (may differ from token count for MRoPE
@@ -893,7 +929,10 @@ def _run_vl_generation(
                 "attention_mask": np.ones((batch_size, total_len), dtype=np.int64),
                 **past_cache,
             }
-            # Gemma4 decoder requires input_ids alongside inputs_embeds
+            # Pass through embedding outputs that match decoder inputs
+            for name in dec_session.input_names:
+                if name not in step_feeds and name in step_emb_out:
+                    step_feeds[name] = step_emb_out[name]
             if "input_ids" in dec_session.input_names:
                 step_feeds["input_ids"] = next_token
             if "position_ids" in dec_session.input_names:
@@ -1051,7 +1090,11 @@ def _run_text_only_multimodel_prefill(
         for name in dec_session.input_names:
             if name in dec_feeds:
                 continue
-            if name == "input_ids":
+            # Pass through embedding outputs that match decoder inputs
+            # (e.g. per_layer_inputs from split embedding interface)
+            if name in emb_out:
+                dec_feeds[name] = emb_out[name]
+            elif name == "input_ids":
                 dec_feeds[name] = input_ids
             elif name == "attention_mask":
                 dec_feeds[name] = np.ones((1, seq_len), dtype=np.int64)
@@ -1264,6 +1307,11 @@ def _run_speech_language_prefill(
     num_encoder_tokens = audio_hidden.shape[0]
     audio_token_id = getattr(config, "audio_token_id", None)
     if audio_token_id is None:
+        # Gemma4: audio_token_id lives in config.audio sub-config
+        audio_cfg = getattr(config, "audio", None)
+        if audio_cfg is not None:
+            audio_token_id = getattr(audio_cfg, "audio_token_id", None)
+    if audio_token_id is None:
         thinker_cfg = getattr(config, "thinker_config", None)
         if thinker_cfg is not None:
             audio_token_id = getattr(thinker_cfg, "audio_token_id", None)
@@ -1306,6 +1354,18 @@ def _run_speech_language_prefill(
 
     inputs_embeds = emb_out[next(iter(emb_out))]
 
+    # External multimodal fusion: if the embedding model does NOT accept
+    # audio features (new split interface), fuse audio features here.
+    emb_has_audio_input = any("audio" in n for n in emb_session.input_names)
+    if not emb_has_audio_input and audio_token_id is not None:
+        aud_feat = audio_hidden[0] if audio_hidden.ndim == 3 else audio_hidden
+        flat = input_ids[0]
+        positions = np.where(flat == audio_token_id)[0]
+        n = min(len(positions), aud_feat.shape[0])
+        if n > 0:
+            inputs_embeds = inputs_embeds.copy()
+            inputs_embeds[0, positions[:n]] = aud_feat[:n]
+
     # Step 3: Run decoder
     dec_key = "model" if "model" in pkg else "decoder"
     dec_session = OnnxModelSession(pkg[dec_key], **device_kwargs)
@@ -1319,7 +1379,11 @@ def _run_speech_language_prefill(
         for name in dec_session.input_names:
             if name in dec_feeds:
                 continue
-            if name == "input_ids":
+            # Pass through embedding outputs that match decoder inputs
+            # (e.g. per_layer_inputs from split embedding interface)
+            if name in emb_out:
+                dec_feeds[name] = emb_out[name]
+            elif name == "input_ids":
                 dec_feeds[name] = input_ids
             elif name == "attention_mask":
                 dec_feeds[name] = np.ones((1, seq_len), dtype=np.int64)
@@ -1699,6 +1763,11 @@ def _run_speech_language_generation(
     num_encoder_tokens = audio_hidden.shape[0]
     audio_token_id = getattr(config, "audio_token_id", None)
     if audio_token_id is None:
+        # Gemma4: audio_token_id lives in config.audio sub-config
+        audio_cfg = getattr(config, "audio", None)
+        if audio_cfg is not None:
+            audio_token_id = getattr(audio_cfg, "audio_token_id", None)
+    if audio_token_id is None:
         thinker_cfg = getattr(config, "thinker_config", None)
         if thinker_cfg is not None:
             audio_token_id = getattr(thinker_cfg, "audio_token_id", None)
@@ -1742,6 +1811,17 @@ def _run_speech_language_generation(
         emb_out = emb_session.run(emb_feeds)
         inputs_embeds = emb_out[next(iter(emb_out))]
 
+        # External multimodal fusion: if the embedding model does NOT accept
+        # audio features (new split interface), fuse audio features here.
+        if audio_feat_input is None and audio_token_id is not None:
+            aud_feat = audio_hidden[0] if audio_hidden.ndim == 3 else audio_hidden
+            flat = input_ids[0]
+            positions = np.where(flat == audio_token_id)[0]
+            n_fuse = min(len(positions), aud_feat.shape[0])
+            if n_fuse > 0:
+                inputs_embeds = inputs_embeds.copy()
+                inputs_embeds[0, positions[:n_fuse]] = aud_feat[:n_fuse]
+
         batch_size = 1
         prompt_seq_len = inputs_embeds.shape[1]
         hidden_size = inputs_embeds.shape[2]
@@ -1753,6 +1833,10 @@ def _run_speech_language_generation(
             "attention_mask": np.ones((batch_size, prompt_seq_len), dtype=np.int64),
             **past_cache,
         }
+        # Pass through embedding outputs that match decoder inputs
+        for name in dec_session.input_names:
+            if name not in dec_feeds and name in emb_out:
+                dec_feeds[name] = emb_out[name]
         if "input_ids" in dec_session.input_names:
             dec_feeds["input_ids"] = input_ids
 
@@ -1801,6 +1885,10 @@ def _run_speech_language_generation(
                 "attention_mask": np.ones((batch_size, total_len), dtype=np.int64),
                 **past_cache,
             }
+            # Pass through embedding outputs that match decoder inputs
+            for name in dec_session.input_names:
+                if name not in step_feeds and name in step_emb_out:
+                    step_feeds[name] = step_emb_out[name]
             if "input_ids" in dec_session.input_names:
                 step_feeds["input_ids"] = next_token
             if "position_ids" in dec_session.input_names:


### PR DESCRIPTION
Match onnx-community Gemma4 interface: embedding outputs per_layer_inputs, decoder consumes it instead of input_ids. Multimodal fusion moves to runtime.

## Changes

**Embedding model** (input_ids → inputs_embeds + per_layer_inputs):
- Removed multimodal fusion (image_features, audio_features inputs)
- Added per-layer embedding computation when `hidden_size_per_layer_input > 0`
- Outputs `per_layer_inputs [B, S, L, D]` alongside `inputs_embeds`

**Decoder model** (inputs_embeds + per_layer_inputs → logits):
- Removed `input_ids` from graph inputs
- Added `per_layer_inputs [B, S, L, D]` as input (when per-layer enabled)
- Slices per_layer_inputs tensor and passes per-layer list to text model

**Weight routing** in `Gemma4Model.preprocess_weights`:
- Per-layer weights now route to `embedding.*` instead of `decoder.model.*`

**Tests**:
- Updated all gemma4 test assertions for new I/O signatures
- Added `test_gemma4_per_layer_inputs_graph` for per-layer enabled config
- Updated ORT GenAI config tests