### PR TITLE
Simplify LinearAttention to single 6-input signature

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "huggingface_hub",
     "numpy>=1.24.0",
     "onnx_ir>=0.1.0",
-    "onnx-shape-inference>=0.1.7",
+    "onnx-shape-inference>=0.1.9",
     "onnxscript>=0.7.0",
     "safetensors",
     "torch>=2.1.0",

--- a/src/mobius/functions/linear_attention.py
+++ b/src/mobius/functions/linear_attention.py
@@ -110,16 +110,20 @@ def linear_attention(
     uses_beta = update_rule in ("delta", "gated_delta")
 
     # --- Define function inputs ---
-    # All 6 inputs are always declared.  Call sites that don't need
-    # trailing inputs (decay, beta) simply omit them — onnx-shape-inference
-    # >=0.1.9 accepts trailing optional inputs (matching ONNX C++ behavior).
-    inputs: list[ir.Value | None] = [
+    # Always declare the full 6-input signature:
+    # (query, key, value, past_state, decay, beta).
+    # Update-rule-specific paths inside the function body ignore unused
+    # trailing inputs so every variant exposes the same ir.Function
+    # interface.  Call sites that don't need trailing inputs (decay, beta)
+    # simply omit them — onnx-shape-inference >=0.1.9 accepts trailing
+    # optional inputs (matching ONNX C++ behavior).
+    inputs: list[ir.Value] = [
         ir.Value(name="query"),  # (B, T, q_num_heads * d_k)
         ir.Value(name="key"),  # (B, T, q_num_heads * d_k)
         ir.Value(name="value"),  # (B, T, kv_num_heads * d_v)
         ir.Value(name="past_state"),
-        ir.Value(name="decay") if uses_decay else None,
-        ir.Value(name="beta") if uses_beta else None,
+        ir.Value(name="decay"),
+        ir.Value(name="beta"),
     ]
 
     def body(op, query_v, key_v, value_v, past_state_v, decay_v, beta_v):

--- a/src/mobius/functions/linear_attention.py
+++ b/src/mobius/functions/linear_attention.py
@@ -109,30 +109,20 @@ def linear_attention(
     uses_decay = update_rule in ("gated", "gated_delta")
     uses_beta = update_rule in ("delta", "gated_delta")
 
-    # --- Define function inputs (conditional on update_rule) ---
-    # TODO: Investigate relaxing onnx-shape-inference's strict arity check
-    # to allow trailing optional inputs, enabling a single 6-input signature.
-    # The function is specialized per-model: only inputs actually used
-    # by this update_rule variant are declared.  Call sites (e.g.
-    # Mamba2Block with "gated") pass exactly the declared number of args.
-    inputs: list[ir.Value] = [
+    # --- Define function inputs ---
+    # All 6 inputs are always declared.  Call sites that don't need
+    # trailing inputs (decay, beta) simply omit them — onnx-shape-inference
+    # >=0.1.9 accepts trailing optional inputs (matching ONNX C++ behavior).
+    inputs: list[ir.Value | None] = [
         ir.Value(name="query"),  # (B, T, q_num_heads * d_k)
         ir.Value(name="key"),  # (B, T, q_num_heads * d_k)
         ir.Value(name="value"),  # (B, T, kv_num_heads * d_v)
         ir.Value(name="past_state"),
+        ir.Value(name="decay") if uses_decay else None,
+        ir.Value(name="beta") if uses_beta else None,
     ]
-    if uses_decay:
-        inputs.append(ir.Value(name="decay"))
-    if uses_beta:
-        inputs.append(ir.Value(name="beta"))
 
-    def body(op, *args):
-        query_v, key_v, value_v, past_state_v = args[:4]
-        idx = 4
-        decay_v = args[idx] if uses_decay else None
-        if uses_decay:
-            idx += 1
-        beta_v = args[idx] if uses_beta else None
+    def body(op, query_v, key_v, value_v, past_state_v, decay_v, beta_v):
 
         # --- Reshape 3D → 4D using head counts ---
         b_dim = op.Shape(query_v, start=0, end=1)


### PR DESCRIPTION
Now that onnx-shape-inference >=0.1.9 accepts trailing optional inputs (matching ONNX C++ behavior), we no longer need per-variant arity specialization for LinearAttention.

Changes:
- Bump onnx-shape-inference minimum to >=0.1.9
- Declare all 6 inputs (query, key, value, past_state, decay, beta) unconditionally, using None for unused trailing inputs
- Replace *args unpacking with named parameters in the body function
- Remove the TODO about onnx-shape-inference strict arity check

Call sites that omit trailing inputs (e.g. Mamba2Block with 'gated' update_rule passing only 5 inputs) now work correctly without needing a specialized function with fewer formal parameters.