### PR TITLE
Migrate task files to new GraphBuilder input/output APIs

### DIFF
--- a/src/mobius/tasks/_adapter.py
+++ b/src/mobius/tasks/_adapter.py
@@ -23,33 +23,23 @@ class AdapterTask(ModelTask):
         module,
         config,
     ) -> ModelPackage:
+        graph, builder = _make_graph()
+        op = builder.op
+
         # Determine input shape based on adapter type
         if hasattr(config, "in_channels"):
             # T2I-Adapter: conditioning image input
-            condition = ir.Value(
-                name="condition",
-                type=ir.TensorType(ir.DataType.FLOAT),
-                shape=ir.Shape(("batch", config.in_channels, "height", "width")),
-            )
+            condition = builder.input("condition", dtype=ir.DataType.FLOAT, shape=["batch", config.in_channels, "height", "width"])
         else:
             # IP-Adapter: image embedding input
-            condition = ir.Value(
-                name="image_embeds",
-                type=ir.TensorType(ir.DataType.FLOAT),
-                shape=ir.Shape(("batch", config.image_embed_dim)),
-            )
-
-        graph, builder = _make_graph([condition])
-        op = builder.op
+            condition = builder.input("image_embeds", dtype=ir.DataType.FLOAT, shape=["batch", config.image_embed_dim])
 
         outputs = module(op, condition)
 
         if isinstance(outputs, list):
             for i, out in enumerate(outputs):
-                out.name = f"feature_{i}"
-                graph.outputs.append(out)
+                builder.add_output(out, f"feature_{i}")
         else:
-            outputs.name = "adapter_output"
-            graph.outputs.append(outputs)
+            builder.add_output(outputs, "adapter_output")
 
         return ModelPackage({"model": _make_model(graph)}, config=config)

--- a/src/mobius/tasks/_adapter.py
+++ b/src/mobius/tasks/_adapter.py
@@ -29,10 +29,18 @@ class AdapterTask(ModelTask):
         # Determine input shape based on adapter type
         if hasattr(config, "in_channels"):
             # T2I-Adapter: conditioning image input
-            condition = builder.input("condition", dtype=ir.DataType.FLOAT, shape=["batch", config.in_channels, "height", "width"])
+            condition = builder.input(
+                "condition",
+                dtype=ir.DataType.FLOAT,
+                shape=["batch", config.in_channels, "height", "width"],
+            )
         else:
             # IP-Adapter: image embedding input
-            condition = builder.input("image_embeds", dtype=ir.DataType.FLOAT, shape=["batch", config.image_embed_dim])
+            condition = builder.input(
+                "image_embeds",
+                dtype=ir.DataType.FLOAT,
+                shape=["batch", config.image_embed_dim],
+            )
 
         outputs = module(op, condition)
 

--- a/src/mobius/tasks/_audio_feature_extraction.py
+++ b/src/mobius/tasks/_audio_feature_extraction.py
@@ -31,7 +31,9 @@ class AudioFeatureExtractionTask(ModelTask):
         graph, builder = _make_graph()
         op = builder.op
 
-        input_values = builder.input("input_values", dtype=ir.DataType.FLOAT, shape=["batch", "time"])
+        input_values = builder.input(
+            "input_values", dtype=ir.DataType.FLOAT, shape=["batch", "time"]
+        )
 
         last_hidden_state = module(op, input_values=input_values)
 

--- a/src/mobius/tasks/_audio_feature_extraction.py
+++ b/src/mobius/tasks/_audio_feature_extraction.py
@@ -28,18 +28,13 @@ class AudioFeatureExtractionTask(ModelTask):
         module,
         config: ArchitectureConfig,
     ) -> ModelPackage:
-        input_values = ir.Value(
-            name="input_values",
-            type=ir.TensorType(ir.DataType.FLOAT),
-            shape=ir.Shape(("batch", "time")),
-        )
-
-        graph, builder = _make_graph([input_values])
+        graph, builder = _make_graph()
         op = builder.op
+
+        input_values = builder.input("input_values", dtype=ir.DataType.FLOAT, shape=["batch", "time"])
 
         last_hidden_state = module(op, input_values=input_values)
 
-        last_hidden_state.name = "last_hidden_state"
-        graph.outputs.append(last_hidden_state)
+        builder.add_output(last_hidden_state, "last_hidden_state")
 
         return ModelPackage({"model": _make_model(graph)}, config=config)

--- a/src/mobius/tasks/_base.py
+++ b/src/mobius/tasks/_base.py
@@ -103,16 +103,17 @@ class ComponentSpec:
 
 
 def _make_graph(
-    inputs: list[ir.Value],
     name: str = "main_graph",
 ) -> tuple[ir.Graph, GraphBuilder]:
     """Create an empty graph and its builder.
+
+    Inputs should be added after creation via ``builder.input()``.
 
     Returns:
         ``(graph, builder)`` — call ``builder.op`` to get the op handle.
     """
     graph = ir.Graph(
-        inputs,
+        [],
         [],
         nodes=[],
         name=name,
@@ -237,35 +238,36 @@ def build_decoder_from_embeds(
     seq_len = ir.SymbolicDim("sequence_len")
     past_seq_len = ir.SymbolicDim("past_sequence_len")
 
-    inputs_embeds = ir.Value(
-        name="inputs_embeds",
-        shape=ir.Shape([batch, seq_len, config.hidden_size]),
-        type=ir.TensorType(config.dtype),
+    graph, builder = _make_graph()
+    inputs_embeds = builder.input(
+        "inputs_embeds",
+        dtype=config.dtype,
+        shape=[batch, seq_len, config.hidden_size],
     )
-    attention_mask = ir.Value(
-        name="attention_mask",
-        shape=ir.Shape([batch, "past_seq_len + seq_len"]),
-        type=ir.TensorType(ir.DataType.INT64),
+    attention_mask = builder.input(
+        "attention_mask",
+        dtype=ir.DataType.INT64,
+        shape=[batch, "past_seq_len + seq_len"],
     )
     # MRoPE: 3D position IDs (temporal, height, width) — shape [3, batch, seq_len]
     # Standard: shape [batch, seq_len]
-    position_ids = ir.Value(
-        name="position_ids",
-        shape=ir.Shape([3, batch, seq_len] if mrope else [batch, seq_len]),
-        type=ir.TensorType(ir.DataType.INT64),
+    position_ids = builder.input(
+        "position_ids",
+        dtype=ir.DataType.INT64,
+        shape=[3, batch, seq_len] if mrope else [batch, seq_len],
     )
 
-    graph_inputs = [inputs_embeds, attention_mask, position_ids]
-
     if hybrid:
-        cache_inputs, past_key_values = _make_hybrid_cache_inputs(
+        past_key_values = _make_hybrid_cache_inputs(
+            builder,
             config,
             config.dtype,
             batch,
             past_seq_len,
         )
     else:
-        cache_inputs, past_key_values = _make_kv_cache_inputs(
+        past_key_values = _make_kv_cache_inputs(
+            builder,
             config.num_hidden_layers,
             config.num_key_value_heads,
             config.head_dim,
@@ -273,9 +275,7 @@ def build_decoder_from_embeds(
             batch,
             past_seq_len,
         )
-    graph_inputs.extend(cache_inputs)
 
-    graph, builder = _make_graph(graph_inputs)
     logits, present_key_values = decoder(
         builder.op,
         inputs_embeds=inputs_embeds,
@@ -284,12 +284,11 @@ def build_decoder_from_embeds(
         past_key_values=past_key_values,
     )
 
-    logits.name = "logits"
-    graph.outputs.append(logits)
+    builder.add_output(logits, "logits")
 
     if hybrid:
         _register_hybrid_cache_outputs(
-            graph,
+            builder,
             present_key_values,
             config.layer_types or [],
         )
@@ -297,7 +296,7 @@ def build_decoder_from_embeds(
         _register_linear_attention_functions(model, config)
         return model
     else:
-        _register_kv_cache_outputs(graph, present_key_values)
+        _register_kv_cache_outputs(builder, present_key_values)
         return _make_model(graph)
 
 
@@ -328,24 +327,23 @@ def build_embedding_from_features(
     seq_len = ir.SymbolicDim("sequence_len")
     num_feature_tokens = ir.SymbolicDim("num_feature_tokens")
 
-    input_ids = ir.Value(
-        name="input_ids",
-        shape=ir.Shape([batch, seq_len]),
-        type=ir.TensorType(ir.DataType.INT64),
+    graph, builder = _make_graph(name="embedding")
+    input_ids = builder.input(
+        "input_ids",
+        dtype=ir.DataType.INT64,
+        shape=[batch, seq_len],
     )
-    features = ir.Value(
-        name=feature_name,
-        shape=ir.Shape([num_feature_tokens, feature_dim]),
-        type=ir.TensorType(config.dtype),
+    features = builder.input(
+        feature_name,
+        dtype=config.dtype,
+        shape=[num_feature_tokens, feature_dim],
     )
 
-    graph, builder = _make_graph([input_ids, features], name="embedding")
     inputs_embeds = embedding(
         builder.op,
         input_ids=input_ids,
         **{feature_name: features},
     )
 
-    inputs_embeds.name = "inputs_embeds"
-    graph.outputs.append(inputs_embeds)
+    builder.add_output(inputs_embeds, "inputs_embeds")
     return _make_model(graph)

--- a/src/mobius/tasks/_base.py
+++ b/src/mobius/tasks/_base.py
@@ -9,8 +9,7 @@ from abc import ABC, abstractmethod
 from typing import ClassVar
 
 import onnx_ir as ir
-from onnxscript import nn
-from onnxscript._internal.builder import GraphBuilder
+from onnxscript import GraphBuilder, nn
 
 import mobius
 from mobius._configs import BaseModelConfig
@@ -108,6 +107,7 @@ def _make_graph(
     """Create an empty graph and its builder.
 
     Inputs should be added after creation via ``builder.input()``.
+    Outputs should be registered via ``builder.add_output()``.
 
     Returns:
         ``(graph, builder)`` — call ``builder.op`` to get the op handle.

--- a/src/mobius/tasks/_cache_utils.py
+++ b/src/mobius/tasks/_cache_utils.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from typing import NamedTuple
 
 import onnx_ir as ir
-from onnxscript._internal.builder import GraphBuilder
+from onnxscript import GraphBuilder
 
 from mobius._configs import BaseModelConfig
 

--- a/src/mobius/tasks/_cache_utils.py
+++ b/src/mobius/tasks/_cache_utils.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from typing import NamedTuple
 
 import onnx_ir as ir
+from onnxscript._internal.builder import GraphBuilder
 
 from mobius._configs import BaseModelConfig
 
@@ -64,6 +65,7 @@ def linear_attention_dims(config: BaseModelConfig) -> LinearAttentionDims:
 
 
 def _make_kv_cache_inputs(
+    builder: GraphBuilder,
     num_layers: int,
     num_kv_heads: int,
     head_dim: int,
@@ -74,42 +76,41 @@ def _make_kv_cache_inputs(
     prefix: str = "past_key_values",
     key_head_dim: int | None = None,
     value_head_dim: int | None = None,
-) -> tuple[list[ir.Value], list[tuple[ir.Value, ir.Value]]]:
+) -> list[tuple[ir.Value, ir.Value]]:
     """Create KV cache input values for ``num_layers`` layers.
 
+    Uses ``builder.input()`` to create and register graph inputs directly.
+
     Args:
+        builder: The graph builder to register inputs on.
         key_head_dim: Head dim for keys. Defaults to ``head_dim``.
             For MLA attention, this is ``qk_nope_head_dim + qk_rope_head_dim``.
         value_head_dim: Head dim for values. Defaults to ``head_dim``.
             For MLA attention, this is ``v_head_dim``.
 
     Returns:
-        ``(flat_inputs, kv_pairs)`` where *flat_inputs* is a flat list
-        suitable for extending ``graph_inputs`` and *kv_pairs* is a list
-        of ``(key, value)`` tuples for passing to the module.
+        A list of ``(key, value)`` tuples for passing to the module.
     """
     k_dim = key_head_dim if key_head_dim is not None else head_dim
     v_dim = value_head_dim if value_head_dim is not None else head_dim
-    flat: list[ir.Value] = []
     pairs: list[tuple[ir.Value, ir.Value]] = []
     for i in range(num_layers):
-        past_key = ir.Value(
-            name=f"{prefix}.{i}.key",
-            shape=ir.Shape([batch, num_kv_heads, past_seq_len, k_dim]),
-            type=ir.TensorType(dtype),
+        past_key = builder.input(
+            f"{prefix}.{i}.key",
+            dtype=dtype,
+            shape=[batch, num_kv_heads, past_seq_len, k_dim],
         )
-        past_value = ir.Value(
-            name=f"{prefix}.{i}.value",
-            shape=ir.Shape([batch, num_kv_heads, past_seq_len, v_dim]),
-            type=ir.TensorType(dtype),
+        past_value = builder.input(
+            f"{prefix}.{i}.value",
+            dtype=dtype,
+            shape=[batch, num_kv_heads, past_seq_len, v_dim],
         )
-        flat.extend([past_key, past_value])
         pairs.append((past_key, past_value))
-    return flat, pairs
+    return pairs
 
 
 def _register_kv_cache_outputs(
-    graph: ir.Graph,
+    builder: GraphBuilder,
     present_key_values: list[tuple[ir.Value, ir.Value]],
     *,
     prefix: str = "present",
@@ -120,22 +121,22 @@ def _register_kv_cache_outputs(
     that runs during model optimization.
     """
     for i, (present_key, present_value) in enumerate(present_key_values):
-        present_key.name = f"{prefix}.{i}.key"
-        present_value.name = f"{prefix}.{i}.value"
-
-        graph.outputs.append(present_key)
-        graph.outputs.append(present_value)
+        builder.add_output(present_key, f"{prefix}.{i}.key")
+        builder.add_output(present_value, f"{prefix}.{i}.value")
 
 
 def _make_hybrid_cache_inputs(
+    builder: GraphBuilder,
     config: BaseModelConfig,
     dtype: ir.DataType,
     batch: ir.SymbolicDim,
     past_seq_len: ir.SymbolicDim,
     *,
     prefix: str = "past_key_values",
-) -> tuple[list[ir.Value], list[StatePair]]:
+) -> list[StatePair]:
     """Create cache inputs for hybrid models with mixed layer types.
+
+    Uses ``builder.input()`` to create and register graph inputs directly.
 
     Supported layer types:
         ``"full_attention"`` — standard KV cache (key + value).
@@ -146,13 +147,10 @@ def _make_hybrid_cache_inputs(
         ``"mlp"`` — stateless, produces ``(None, None)`` pair.
 
     Returns:
-        ``(flat_inputs, state_pairs)`` — *flat_inputs* contains only
-        the ``ir.Value`` entries (no graph inputs for MLP layers);
-        *state_pairs* has one entry per layer, with ``(None, None)``
+        A list of state pairs, one per layer, with ``(None, None)``
         for stateless MLP layers.
     """
     layer_types = config.layer_types or []
-    flat: list[ir.Value] = []
     pairs: list[StatePair] = []
 
     # DeltaNet dimensions from config (computed once via shared helper)
@@ -187,91 +185,79 @@ def _make_hybrid_cache_inputs(
         if ltype == "lightning_attention":
             # Lightning Attention: single recurrent state only (no conv_state)
             # State: (B, num_heads, head_dim, head_dim) — square matrix accumulator
-            rec_state = ir.Value(
-                name=f"{prefix}.{i}.recurrent_state",
-                shape=ir.Shape(
-                    [batch, config.num_attention_heads, config.head_dim, config.head_dim]
-                ),
-                type=ir.TensorType(dtype),
+            rec_state = builder.input(
+                f"{prefix}.{i}.recurrent_state",
+                dtype=dtype,
+                shape=[batch, config.num_attention_heads, config.head_dim, config.head_dim],
             )
-            flat.append(rec_state)
             pairs.append((rec_state,))  # 1-tuple: lightning has no conv_state
         elif ltype == "linear_attention":
-            conv_state = ir.Value(
-                name=f"{prefix}.{i}.conv_state",
-                shape=ir.Shape([batch, dims.conv_dim, dims.conv_kernel - 1]),
-                type=ir.TensorType(dtype),
+            conv_state = builder.input(
+                f"{prefix}.{i}.conv_state",
+                dtype=dtype,
+                shape=[batch, dims.conv_dim, dims.conv_kernel - 1],
             )
-            rec_state = ir.Value(
-                name=f"{prefix}.{i}.recurrent_state",
-                shape=ir.Shape([batch, dims.num_v_heads, dims.head_k_dim, dims.head_v_dim]),
-                type=ir.TensorType(dtype),
+            rec_state = builder.input(
+                f"{prefix}.{i}.recurrent_state",
+                dtype=dtype,
+                shape=[batch, dims.num_v_heads, dims.head_k_dim, dims.head_v_dim],
             )
-            flat.extend([conv_state, rec_state])
             pairs.append((conv_state, rec_state))
         elif ltype == "conv":
             # ShortConv layers: conv_state only (no SSM state)
             # State: (batch, hidden_size, short_conv_kernel - 1)
             short_conv_kernel = getattr(config, "short_conv_kernel", 3)
-            conv_state = ir.Value(
-                name=f"{prefix}.{i}.conv_state",
-                shape=ir.Shape([batch, config.hidden_size, short_conv_kernel - 1]),
-                type=ir.TensorType(dtype),
+            conv_state = builder.input(
+                f"{prefix}.{i}.conv_state",
+                dtype=dtype,
+                shape=[batch, config.hidden_size, short_conv_kernel - 1],
             )
-            flat.append(conv_state)
             pairs.append((conv_state,))  # 1-tuple: conv has no second state
         elif ltype in ("mlp", "moe"):
             # MLP and MoE layers are stateless — no cache inputs needed
             pairs.append((None, None))
         elif ltype == "mamba":
-            conv_state = ir.Value(
-                name=f"{prefix}.{i}.conv_state",
-                shape=ir.Shape([batch, mamba_d_inner, mamba_d_conv - 1]),
-                type=ir.TensorType(dtype),
+            conv_state = builder.input(
+                f"{prefix}.{i}.conv_state",
+                dtype=dtype,
+                shape=[batch, mamba_d_inner, mamba_d_conv - 1],
             )
-            ssm_state = ir.Value(
-                name=f"{prefix}.{i}.ssm_state",
-                shape=ir.Shape([batch, mamba_d_inner, mamba_d_state]),
-                type=ir.TensorType(dtype),
+            ssm_state = builder.input(
+                f"{prefix}.{i}.ssm_state",
+                dtype=dtype,
+                shape=[batch, mamba_d_inner, mamba_d_state],
             )
-            flat.extend([conv_state, ssm_state])
             pairs.append((conv_state, ssm_state))
         elif ltype == "mamba2":
-            conv_state = ir.Value(
-                name=f"{prefix}.{i}.conv_state",
-                shape=ir.Shape([batch, mamba2_conv_dim, mamba_d_conv - 1]),
-                type=ir.TensorType(dtype),
+            conv_state = builder.input(
+                f"{prefix}.{i}.conv_state",
+                dtype=dtype,
+                shape=[batch, mamba2_conv_dim, mamba_d_conv - 1],
             )
-            ssm_state = ir.Value(
-                name=f"{prefix}.{i}.ssm_state",
-                shape=ir.Shape([batch, mamba2_n_heads, mamba2_d_state, mamba2_d_head]),
-                type=ir.TensorType(dtype),
+            ssm_state = builder.input(
+                f"{prefix}.{i}.ssm_state",
+                dtype=dtype,
+                shape=[batch, mamba2_n_heads, mamba2_d_state, mamba2_d_head],
             )
-            flat.extend([conv_state, ssm_state])
             pairs.append((conv_state, ssm_state))
         else:
-            past_key = ir.Value(
-                name=f"{prefix}.{i}.key",
-                shape=ir.Shape(
-                    [batch, config.num_key_value_heads, past_seq_len, config.head_dim]
-                ),
-                type=ir.TensorType(dtype),
+            past_key = builder.input(
+                f"{prefix}.{i}.key",
+                dtype=dtype,
+                shape=[batch, config.num_key_value_heads, past_seq_len, config.head_dim],
             )
-            past_value = ir.Value(
-                name=f"{prefix}.{i}.value",
-                shape=ir.Shape(
-                    [batch, config.num_key_value_heads, past_seq_len, config.head_dim]
-                ),
-                type=ir.TensorType(dtype),
+            past_value = builder.input(
+                f"{prefix}.{i}.value",
+                dtype=dtype,
+                shape=[batch, config.num_key_value_heads, past_seq_len, config.head_dim],
             )
-            flat.extend([past_key, past_value])
             pairs.append((past_key, past_value))
 
-    return flat, pairs
+    return pairs
 
 
 def _register_hybrid_cache_outputs(
-    graph: ir.Graph,
+    builder: GraphBuilder,
     present_key_values: list[tuple[ir.Value, ...]],
     layer_types: list[str],
     *,
@@ -295,27 +281,22 @@ def _register_hybrid_cache_outputs(
         if ltype == "lightning_attention":
             # Single recurrent state only (no conv_state for lightning)
             (state_a,) = states
-            state_a.name = f"{prefix}.{i}.recurrent_state"
-            graph.outputs.append(state_a)
+            builder.add_output(state_a, f"{prefix}.{i}.recurrent_state")
         elif ltype == "conv":
             # ShortConv: single conv_state only
             (state_a,) = states
-            state_a.name = f"{prefix}.{i}.conv_state"
-            graph.outputs.append(state_a)
+            builder.add_output(state_a, f"{prefix}.{i}.conv_state")
         else:
             state_a, state_b = states
             if ltype == "linear_attention":
-                state_a.name = f"{prefix}.{i}.conv_state"
-                state_b.name = f"{prefix}.{i}.recurrent_state"
+                builder.add_output(state_a, f"{prefix}.{i}.conv_state")
+                builder.add_output(state_b, f"{prefix}.{i}.recurrent_state")
             elif ltype in ("mamba", "mamba2"):
-                state_a.name = f"{prefix}.{i}.conv_state"
-                state_b.name = f"{prefix}.{i}.ssm_state"
+                builder.add_output(state_a, f"{prefix}.{i}.conv_state")
+                builder.add_output(state_b, f"{prefix}.{i}.ssm_state")
             else:
-                state_a.name = f"{prefix}.{i}.key"
-                state_b.name = f"{prefix}.{i}.value"
-
-            graph.outputs.append(state_a)
-            graph.outputs.append(state_b)
+                builder.add_output(state_a, f"{prefix}.{i}.key")
+                builder.add_output(state_b, f"{prefix}.{i}.value")
 
 
 def _register_linear_attention_functions(

--- a/src/mobius/tasks/_causal_lm.py
+++ b/src/mobius/tasks/_causal_lm.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import onnx_ir as ir
 from onnxscript import nn
+from onnxscript._internal.builder import GraphBuilder
 
 from mobius._configs import ArchitectureConfig
 from mobius._model_package import ModelPackage
@@ -110,23 +111,19 @@ class CausalLMTask(ModelTask):
         batch = ir.SymbolicDim("batch")
         seq_len = ir.SymbolicDim("sequence_len")
 
+        # --- Build graph first, then create inputs via builder ---
+        graph, builder = _make_graph()
+        op = builder.op
+
         # --- Inputs common to both modes ---
-        input_ids = ir.Value(
-            name="input_ids",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
-        )
-        position_ids = ir.Value(
-            name="position_ids",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
-        )
+        input_ids = builder.input("input_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len])
 
         # --- Cache setup (static vs dynamic) ---
         if static:
             attention_mask = None
-            graph_inputs = [input_ids, position_ids]
-            cache_inputs, past_key_values = _make_static_cache_inputs(
+            position_ids = builder.input("position_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len])
+            past_key_values = _make_static_cache_inputs(
+                builder,
                 config.num_hidden_layers,
                 config.num_key_value_heads,
                 config.head_dim,
@@ -136,12 +133,10 @@ class CausalLMTask(ModelTask):
             )
         else:
             past_seq_len = ir.SymbolicDim("past_sequence_len")
-            attention_mask = ir.Value(
-                name="attention_mask",
-                shape=ir.Shape([batch, "past_seq_len + seq_len"]),
-                type=ir.TensorType(ir.DataType.INT64),
+            attention_mask = builder.input(
+                "attention_mask", dtype=ir.DataType.INT64, shape=[batch, "past_seq_len + seq_len"],
             )
-            graph_inputs = [input_ids, attention_mask, position_ids]
+            position_ids = builder.input("position_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len])
 
             # MLA attention: K/V heads equal q heads (no GQA reduction in
             # latent space).  The ONNX Attention op is called with
@@ -154,7 +149,8 @@ class CausalLMTask(ModelTask):
                 config.num_attention_heads if use_mla else config.num_key_value_heads
             )
 
-            cache_inputs, past_key_values = _make_kv_cache_inputs(
+            past_key_values = _make_kv_cache_inputs(
+                builder,
                 config.num_hidden_layers,
                 num_kv_cache_heads,
                 config.head_dim,
@@ -166,12 +162,6 @@ class CausalLMTask(ModelTask):
                 value_head_dim=config.v_head_dim or None,
             )
 
-        graph_inputs.extend(cache_inputs)
-
-        # --- Build graph, invoke module, collect outputs ---
-        graph, builder = _make_graph(graph_inputs)
-        op = builder.op
-
         logits, present_key_values = module(
             op,
             input_ids=input_ids,
@@ -180,18 +170,17 @@ class CausalLMTask(ModelTask):
             past_key_values=past_key_values,
         )
 
-        logits.name = "logits"
-        graph.outputs.append(logits)
+        builder.add_output(logits, "logits")
 
         # --- Output registration (static vs dynamic) ---
         if static:
             _register_static_cache_outputs(
-                graph,
+                builder,
                 present_key_values,
             )
         else:
             _register_kv_cache_outputs(
-                graph,
+                builder,
                 present_key_values,
             )
 
@@ -228,34 +217,22 @@ class HybridCausalLMTask(ModelTask):
         seq_len = ir.SymbolicDim("sequence_len")
         past_seq_len = ir.SymbolicDim("past_sequence_len")
 
-        input_ids = ir.Value(
-            name="input_ids",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
-        )
-        attention_mask = ir.Value(
-            name="attention_mask",
-            shape=ir.Shape([batch, "past_seq_len + seq_len"]),
-            type=ir.TensorType(ir.DataType.INT64),
-        )
-        position_ids = ir.Value(
-            name="position_ids",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
-        )
+        graph, builder = _make_graph()
+        op = builder.op
 
-        graph_inputs = [input_ids, attention_mask, position_ids]
+        input_ids = builder.input("input_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len])
+        attention_mask = builder.input(
+            "attention_mask", dtype=ir.DataType.INT64, shape=[batch, "past_seq_len + seq_len"],
+        )
+        position_ids = builder.input("position_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len])
 
-        cache_inputs, past_key_values = _make_hybrid_cache_inputs(
+        past_key_values = _make_hybrid_cache_inputs(
+            builder,
             config,
             config.dtype,
             batch,
             past_seq_len,
         )
-        graph_inputs.extend(cache_inputs)
-
-        graph, builder = _make_graph(graph_inputs)
-        op = builder.op
 
         logits, present_key_values = module(
             op,
@@ -265,10 +242,9 @@ class HybridCausalLMTask(ModelTask):
             past_key_values=past_key_values,
         )
 
-        logits.name = "logits"
-        graph.outputs.append(logits)
+        builder.add_output(logits, "logits")
         _register_hybrid_cache_outputs(
-            graph,
+            builder,
             present_key_values,
             config.layer_types or [],
         )
@@ -279,51 +255,45 @@ class HybridCausalLMTask(ModelTask):
 
 
 def _make_static_cache_inputs(
+    builder: GraphBuilder,
     num_layers: int,
     num_key_value_heads: int,
     head_dim: int,
     dtype: ir.DataType,
     batch: ir.SymbolicDim,
     max_seq_len: int,
-) -> tuple[list[ir.Value], list[StaticCacheState]]:
+) -> list[StaticCacheState]:
     """Create static KV cache inputs for ``num_layers`` layers.
 
+    Uses ``builder.input()`` to create and register graph inputs directly.
+
     Returns:
-        ``(flat_inputs, static_caches)`` where *flat_inputs* is a flat
-        list suitable for extending ``graph_inputs``, and
-        *static_caches* is a list of :class:`StaticCacheState` tuples
-        for passing to the module via ``past_key_values``.
+        A list of :class:`StaticCacheState` tuples for passing to the
+        module via ``past_key_values``.
     """
     kv_hidden = num_key_value_heads * head_dim
-    flat: list[ir.Value] = []
     cache_pairs: list[tuple[ir.Value, ir.Value]] = []
 
     for i in range(num_layers):
-        key_cache = ir.Value(
-            name=f"key_cache.{i}",
-            shape=ir.Shape([batch, max_seq_len, kv_hidden]),
-            type=ir.TensorType(dtype),
+        key_cache = builder.input(
+            f"key_cache.{i}",
+            dtype=dtype,
+            shape=[batch, max_seq_len, kv_hidden],
         )
-        value_cache = ir.Value(
-            name=f"value_cache.{i}",
-            shape=ir.Shape([batch, max_seq_len, kv_hidden]),
-            type=ir.TensorType(dtype),
+        value_cache = builder.input(
+            f"value_cache.{i}",
+            dtype=dtype,
+            shape=[batch, max_seq_len, kv_hidden],
         )
-        flat.extend([key_cache, value_cache])
         cache_pairs.append((key_cache, value_cache))
 
     # Shared inputs across all layers
-    write_indices = ir.Value(
-        name="write_indices",
-        shape=ir.Shape([batch]),
-        type=ir.TensorType(ir.DataType.INT64),
+    write_indices = builder.input(
+        "write_indices", dtype=ir.DataType.INT64, shape=[batch],
     )
-    nonpad_kv_seqlen = ir.Value(
-        name="nonpad_kv_seqlen",
-        shape=ir.Shape([batch]),
-        type=ir.TensorType(ir.DataType.INT64),
+    nonpad_kv_seqlen = builder.input(
+        "nonpad_kv_seqlen", dtype=ir.DataType.INT64, shape=[batch],
     )
-    flat.extend([write_indices, nonpad_kv_seqlen])
 
     # Build StaticCacheState for each layer (shared indices)
     static_caches: list[StaticCacheState] = []
@@ -337,11 +307,11 @@ def _make_static_cache_inputs(
             )
         )
 
-    return flat, static_caches
+    return static_caches
 
 
 def _register_static_cache_outputs(
-    graph: ir.Graph,
+    builder: GraphBuilder,
     present_key_values: list[tuple[ir.Value, ir.Value]],
 ) -> None:
     """Name and register static cache outputs on the graph.
@@ -350,10 +320,8 @@ def _register_static_cache_outputs(
     that runs during model optimization.
     """
     for i, (updated_key, updated_value) in enumerate(present_key_values):
-        updated_key.name = f"updated_key_cache.{i}"
-        updated_value.name = f"updated_value_cache.{i}"
-        graph.outputs.append(updated_key)
-        graph.outputs.append(updated_value)
+        builder.add_output(updated_key, f"updated_key_cache.{i}")
+        builder.add_output(updated_value, f"updated_value_cache.{i}")
 
 
 def _validate_static_cache_support(module: nn.Module) -> None:

--- a/src/mobius/tasks/_causal_lm.py
+++ b/src/mobius/tasks/_causal_lm.py
@@ -6,8 +6,7 @@
 from __future__ import annotations
 
 import onnx_ir as ir
-from onnxscript import nn
-from onnxscript._internal.builder import GraphBuilder
+from onnxscript import GraphBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius._model_package import ModelPackage
@@ -121,7 +120,9 @@ class CausalLMTask(ModelTask):
         # --- Cache setup (static vs dynamic) ---
         if static:
             attention_mask = None
-            position_ids = builder.input("position_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len])
+            position_ids = builder.input(
+                "position_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len]
+            )
             past_key_values = _make_static_cache_inputs(
                 builder,
                 config.num_hidden_layers,
@@ -134,9 +135,13 @@ class CausalLMTask(ModelTask):
         else:
             past_seq_len = ir.SymbolicDim("past_sequence_len")
             attention_mask = builder.input(
-                "attention_mask", dtype=ir.DataType.INT64, shape=[batch, "past_seq_len + seq_len"],
+                "attention_mask",
+                dtype=ir.DataType.INT64,
+                shape=[batch, "past_seq_len + seq_len"],
             )
-            position_ids = builder.input("position_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len])
+            position_ids = builder.input(
+                "position_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len]
+            )
 
             # MLA attention: K/V heads equal q heads (no GQA reduction in
             # latent space).  The ONNX Attention op is called with
@@ -222,9 +227,13 @@ class HybridCausalLMTask(ModelTask):
 
         input_ids = builder.input("input_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len])
         attention_mask = builder.input(
-            "attention_mask", dtype=ir.DataType.INT64, shape=[batch, "past_seq_len + seq_len"],
+            "attention_mask",
+            dtype=ir.DataType.INT64,
+            shape=[batch, "past_seq_len + seq_len"],
         )
-        position_ids = builder.input("position_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len])
+        position_ids = builder.input(
+            "position_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len]
+        )
 
         past_key_values = _make_hybrid_cache_inputs(
             builder,
@@ -289,10 +298,14 @@ def _make_static_cache_inputs(
 
     # Shared inputs across all layers
     write_indices = builder.input(
-        "write_indices", dtype=ir.DataType.INT64, shape=[batch],
+        "write_indices",
+        dtype=ir.DataType.INT64,
+        shape=[batch],
     )
     nonpad_kv_seqlen = builder.input(
-        "nonpad_kv_seqlen", dtype=ir.DataType.INT64, shape=[batch],
+        "nonpad_kv_seqlen",
+        dtype=ir.DataType.INT64,
+        shape=[batch],
     )
 
     # Build StaticCacheState for each layer (shared indices)

--- a/src/mobius/tasks/_codec.py
+++ b/src/mobius/tasks/_codec.py
@@ -89,7 +89,9 @@ class CodecTask(ModelTask):
         audio_len = ir.SymbolicDim("audio_length")
 
         graph, builder = _make_graph(name="encoder")
-        waveform = builder.input("waveform", dtype=ir.DataType.FLOAT, shape=[batch, 1, audio_len])
+        waveform = builder.input(
+            "waveform", dtype=ir.DataType.FLOAT, shape=[batch, 1, audio_len]
+        )
 
         codes = encoder(builder.op, waveform)
 

--- a/src/mobius/tasks/_codec.py
+++ b/src/mobius/tasks/_codec.py
@@ -65,17 +65,12 @@ class CodecTask(ModelTask):
         num_q = ir.SymbolicDim("num_quantizers")
         seq_len = ir.SymbolicDim("sequence_len")
 
-        codes = ir.Value(
-            name="codes",
-            shape=ir.Shape([batch, num_q, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
-        )
+        graph, builder = _make_graph()
+        codes = builder.input("codes", dtype=ir.DataType.INT64, shape=[batch, num_q, seq_len])
 
-        graph, builder = _make_graph([codes])
         waveform = decoder(builder.op, codes)
 
-        waveform.name = "waveform"
-        graph.outputs.append(waveform)
+        builder.add_output(waveform, "waveform")
         return _make_model(graph)
 
     def _build_encoder(
@@ -93,15 +88,10 @@ class CodecTask(ModelTask):
         batch = ir.SymbolicDim("batch")
         audio_len = ir.SymbolicDim("audio_length")
 
-        waveform = ir.Value(
-            name="waveform",
-            shape=ir.Shape([batch, 1, audio_len]),
-            type=ir.TensorType(ir.DataType.FLOAT),
-        )
+        graph, builder = _make_graph(name="encoder")
+        waveform = builder.input("waveform", dtype=ir.DataType.FLOAT, shape=[batch, 1, audio_len])
 
-        graph, builder = _make_graph([waveform], name="encoder")
         codes = encoder(builder.op, waveform)
 
-        codes.name = "codes"
-        graph.outputs.append(codes)
+        builder.add_output(codes, "codes")
         return _make_model(graph)

--- a/src/mobius/tasks/_controlnet.py
+++ b/src/mobius/tasks/_controlnet.py
@@ -31,10 +31,22 @@ class ControlNetTask(ModelTask):
         graph, builder = _make_graph()
         op = builder.op
 
-        sample = builder.input("sample", dtype=ir.DataType.FLOAT, shape=["batch", config.in_channels, "height", "width"])
+        sample = builder.input(
+            "sample",
+            dtype=ir.DataType.FLOAT,
+            shape=["batch", config.in_channels, "height", "width"],
+        )
         timestep = builder.input("timestep", dtype=ir.DataType.INT64, shape=["batch"])
-        encoder_hidden_states = builder.input("encoder_hidden_states", dtype=ir.DataType.FLOAT, shape=["batch", "sequence_length", config.cross_attention_dim])
-        controlnet_cond = builder.input("controlnet_cond", dtype=ir.DataType.FLOAT, shape=["batch", config.conditioning_channels, "cond_height", "cond_width"])
+        encoder_hidden_states = builder.input(
+            "encoder_hidden_states",
+            dtype=ir.DataType.FLOAT,
+            shape=["batch", "sequence_length", config.cross_attention_dim],
+        )
+        controlnet_cond = builder.input(
+            "controlnet_cond",
+            dtype=ir.DataType.FLOAT,
+            shape=["batch", config.conditioning_channels, "cond_height", "cond_width"],
+        )
 
         down_outputs, mid_output = module(
             op,

--- a/src/mobius/tasks/_controlnet.py
+++ b/src/mobius/tasks/_controlnet.py
@@ -28,33 +28,13 @@ class ControlNetTask(ModelTask):
         module,
         config: ControlNetConfig,
     ) -> ModelPackage:
-        sample = ir.Value(
-            name="sample",
-            type=ir.TensorType(ir.DataType.FLOAT),
-            shape=ir.Shape(("batch", config.in_channels, "height", "width")),
-        )
-        timestep = ir.Value(
-            name="timestep",
-            type=ir.TensorType(ir.DataType.INT64),
-            shape=ir.Shape(("batch",)),
-        )
-        encoder_hidden_states = ir.Value(
-            name="encoder_hidden_states",
-            type=ir.TensorType(ir.DataType.FLOAT),
-            shape=ir.Shape(("batch", "sequence_length", config.cross_attention_dim)),
-        )
-        controlnet_cond = ir.Value(
-            name="controlnet_cond",
-            type=ir.TensorType(ir.DataType.FLOAT),
-            shape=ir.Shape(
-                ("batch", config.conditioning_channels, "cond_height", "cond_width")
-            ),
-        )
-
-        graph, builder = _make_graph(
-            [sample, timestep, encoder_hidden_states, controlnet_cond]
-        )
+        graph, builder = _make_graph()
         op = builder.op
+
+        sample = builder.input("sample", dtype=ir.DataType.FLOAT, shape=["batch", config.in_channels, "height", "width"])
+        timestep = builder.input("timestep", dtype=ir.DataType.INT64, shape=["batch"])
+        encoder_hidden_states = builder.input("encoder_hidden_states", dtype=ir.DataType.FLOAT, shape=["batch", "sequence_length", config.cross_attention_dim])
+        controlnet_cond = builder.input("controlnet_cond", dtype=ir.DataType.FLOAT, shape=["batch", config.conditioning_channels, "cond_height", "cond_width"])
 
         down_outputs, mid_output = module(
             op,
@@ -66,9 +46,7 @@ class ControlNetTask(ModelTask):
 
         # Register outputs
         for i, out in enumerate(down_outputs):
-            out.name = f"down_block_res_{i}"
-            graph.outputs.append(out)
-        mid_output.name = "mid_block_res"
-        graph.outputs.append(mid_output)
+            builder.add_output(out, f"down_block_res_{i}")
+        builder.add_output(mid_output, "mid_block_res")
 
         return ModelPackage({"model": _make_model(graph)}, config=config)

--- a/src/mobius/tasks/_denoising.py
+++ b/src/mobius/tasks/_denoising.py
@@ -31,9 +31,17 @@ class DenoisingTask(ModelTask):
         graph, builder = _make_graph()
         op = builder.op
 
-        sample = builder.input("sample", dtype=ir.DataType.FLOAT, shape=["batch", config.in_channels, "height", "width"])
+        sample = builder.input(
+            "sample",
+            dtype=ir.DataType.FLOAT,
+            shape=["batch", config.in_channels, "height", "width"],
+        )
         timestep = builder.input("timestep", dtype=ir.DataType.INT64, shape=["batch"])
-        encoder_hidden_states = builder.input("encoder_hidden_states", dtype=ir.DataType.FLOAT, shape=["batch", "sequence_length", config.cross_attention_dim])
+        encoder_hidden_states = builder.input(
+            "encoder_hidden_states",
+            dtype=ir.DataType.FLOAT,
+            shape=["batch", "sequence_length", config.cross_attention_dim],
+        )
 
         noise_pred = module(
             op,

--- a/src/mobius/tasks/_denoising.py
+++ b/src/mobius/tasks/_denoising.py
@@ -28,24 +28,12 @@ class DenoisingTask(ModelTask):
         module,
         config: UNet2DConfig,
     ) -> ModelPackage:
-        sample = ir.Value(
-            name="sample",
-            type=ir.TensorType(ir.DataType.FLOAT),
-            shape=ir.Shape(("batch", config.in_channels, "height", "width")),
-        )
-        timestep = ir.Value(
-            name="timestep",
-            type=ir.TensorType(ir.DataType.INT64),
-            shape=ir.Shape(("batch",)),
-        )
-        encoder_hidden_states = ir.Value(
-            name="encoder_hidden_states",
-            type=ir.TensorType(ir.DataType.FLOAT),
-            shape=ir.Shape(("batch", "sequence_length", config.cross_attention_dim)),
-        )
-
-        graph, builder = _make_graph([sample, timestep, encoder_hidden_states])
+        graph, builder = _make_graph()
         op = builder.op
+
+        sample = builder.input("sample", dtype=ir.DataType.FLOAT, shape=["batch", config.in_channels, "height", "width"])
+        timestep = builder.input("timestep", dtype=ir.DataType.INT64, shape=["batch"])
+        encoder_hidden_states = builder.input("encoder_hidden_states", dtype=ir.DataType.FLOAT, shape=["batch", "sequence_length", config.cross_attention_dim])
 
         noise_pred = module(
             op,
@@ -54,7 +42,6 @@ class DenoisingTask(ModelTask):
             encoder_hidden_states=encoder_hidden_states,
         )
 
-        noise_pred.name = "noise_pred"
-        graph.outputs.append(noise_pred)
+        builder.add_output(noise_pred, "noise_pred")
 
         return ModelPackage({"model": _make_model(graph)}, config=config)

--- a/src/mobius/tasks/_feature_extraction.py
+++ b/src/mobius/tasks/_feature_extraction.py
@@ -41,8 +41,12 @@ class FeatureExtractionTask(ModelTask):
         op = builder.op
 
         input_ids = builder.input("input_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len])
-        attention_mask = builder.input("attention_mask", dtype=ir.DataType.INT64, shape=[batch, seq_len])
-        token_type_ids = builder.input("token_type_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len])
+        attention_mask = builder.input(
+            "attention_mask", dtype=ir.DataType.INT64, shape=[batch, seq_len]
+        )
+        token_type_ids = builder.input(
+            "token_type_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len]
+        )
 
         last_hidden_state = module(
             op,

--- a/src/mobius/tasks/_feature_extraction.py
+++ b/src/mobius/tasks/_feature_extraction.py
@@ -37,24 +37,12 @@ class FeatureExtractionTask(ModelTask):
         batch = ir.SymbolicDim("batch")
         seq_len = ir.SymbolicDim("sequence_len")
 
-        input_ids = ir.Value(
-            name="input_ids",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
-        )
-        attention_mask = ir.Value(
-            name="attention_mask",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
-        )
-        token_type_ids = ir.Value(
-            name="token_type_ids",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
-        )
-
-        graph, builder = _make_graph([input_ids, attention_mask, token_type_ids])
+        graph, builder = _make_graph()
         op = builder.op
+
+        input_ids = builder.input("input_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len])
+        attention_mask = builder.input("attention_mask", dtype=ir.DataType.INT64, shape=[batch, seq_len])
+        token_type_ids = builder.input("token_type_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len])
 
         last_hidden_state = module(
             op,
@@ -63,7 +51,6 @@ class FeatureExtractionTask(ModelTask):
             token_type_ids=token_type_ids,
         )
 
-        last_hidden_state.name = "last_hidden_state"
-        graph.outputs.append(last_hidden_state)
+        builder.add_output(last_hidden_state, "last_hidden_state")
 
         return ModelPackage({"model": _make_model(graph)}, config=config)

--- a/src/mobius/tasks/_gemma4.py
+++ b/src/mobius/tasks/_gemma4.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import onnx_ir as ir
 from onnxscript import nn
+from onnxscript._internal.builder import GraphBuilder
 
 from mobius._configs import Gemma4Config
 from mobius._model_package import ModelPackage
@@ -37,11 +38,14 @@ from mobius.tasks._cache_utils import (
 
 
 def _make_gemma4_kv_cache_inputs(
+    graph_builder: GraphBuilder,
     config: Gemma4Config,
     batch: ir.SymbolicDim,
     past_seq_len: ir.SymbolicDim,
-) -> tuple[list[ir.Value], list[tuple[ir.Value, ir.Value]]]:
+) -> list[tuple[ir.Value, ir.Value]]:
     """Create per-layer KV cache inputs accounting for dual head_dim and KV sharing.
+
+    Uses ``graph_builder.input()`` to create and register graph inputs directly.
 
     Local (sliding_attention) layers use ``config.head_dim``;
     global (full_attention) layers use ``config.global_head_dim``.
@@ -66,25 +70,23 @@ def _make_gemma4_kv_cache_inputs(
             f"num_hidden_layers ({config.num_hidden_layers})"
         )
 
-    flat: list[ir.Value] = []
     pairs: list[tuple[ir.Value, ir.Value]] = []
     for i in range(num_kv_layers):
         layer_type = layer_types[i] if i < len(layer_types) else "sliding_attention"
         hd = global_head_dim if layer_type == "full_attention" else local_head_dim
         kv_heads = config.num_key_value_heads
-        past_key = ir.Value(
-            name=f"past_key_values.{i}.key",
-            shape=ir.Shape([batch, kv_heads, past_seq_len, hd]),
-            type=ir.TensorType(config.dtype),
+        past_key = graph_builder.input(
+            f"past_key_values.{i}.key",
+            dtype=config.dtype,
+            shape=[batch, kv_heads, past_seq_len, hd],
         )
-        past_value = ir.Value(
-            name=f"past_key_values.{i}.value",
-            shape=ir.Shape([batch, kv_heads, past_seq_len, hd]),
-            type=ir.TensorType(config.dtype),
+        past_value = graph_builder.input(
+            f"past_key_values.{i}.value",
+            dtype=config.dtype,
+            shape=[batch, kv_heads, past_seq_len, hd],
         )
-        flat.extend([past_key, past_value])
         pairs.append((past_key, past_value))
-    return flat, pairs
+    return pairs
 
 
 class Gemma4TextCausalLMTask(ModelTask):
@@ -117,28 +119,26 @@ class Gemma4TextCausalLMTask(ModelTask):
         seq_len = ir.SymbolicDim("sequence_len")
         past_seq_len = ir.SymbolicDim("past_sequence_len")
 
-        input_ids = ir.Value(
-            name="input_ids",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
-        )
-        attention_mask = ir.Value(
-            name="attention_mask",
-            shape=ir.Shape([batch, "past_seq_len + seq_len"]),
-            type=ir.TensorType(ir.DataType.INT64),
-        )
-        position_ids = ir.Value(
-            name="position_ids",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
-        )
-
-        graph_inputs = [input_ids, attention_mask, position_ids]
-        kv_inputs, past_key_values = _make_gemma4_kv_cache_inputs(config, batch, past_seq_len)
-        graph_inputs.extend(kv_inputs)
-
-        graph, graph_builder = _make_graph(graph_inputs)
+        graph, graph_builder = _make_graph()
         op = graph_builder.op
+
+        input_ids = graph_builder.input(
+            "input_ids",
+            dtype=ir.DataType.INT64,
+            shape=[batch, seq_len],
+        )
+        attention_mask = graph_builder.input(
+            "attention_mask",
+            dtype=ir.DataType.INT64,
+            shape=[batch, "past_seq_len + seq_len"],
+        )
+        position_ids = graph_builder.input(
+            "position_ids",
+            dtype=ir.DataType.INT64,
+            shape=[batch, seq_len],
+        )
+
+        past_key_values = _make_gemma4_kv_cache_inputs(graph_builder, config, batch, past_seq_len)
 
         logits, present_key_values = module(
             op,
@@ -147,9 +147,8 @@ class Gemma4TextCausalLMTask(ModelTask):
             position_ids=position_ids,
             past_key_values=past_key_values,
         )
-        logits.name = "logits"
-        graph.outputs.append(logits)
-        _register_kv_cache_outputs(graph, present_key_values)
+        graph_builder.add_output(logits, "logits")
+        _register_kv_cache_outputs(graph_builder, present_key_values)
 
         return ModelPackage({"model": _make_model(graph)}, config=config)
 
@@ -226,34 +225,31 @@ class Gemma4Task(ModelTask):
         seq_len = ir.SymbolicDim("sequence_len")
         past_seq_len = ir.SymbolicDim("past_sequence_len")
 
-        inputs_embeds = ir.Value(
-            name="inputs_embeds",
-            shape=ir.Shape([batch, seq_len, config.hidden_size]),
-            type=ir.TensorType(config.dtype),
-        )
-        attention_mask = ir.Value(
-            name="attention_mask",
-            shape=ir.Shape([batch, "past_seq_len + seq_len"]),
-            type=ir.TensorType(ir.DataType.INT64),
-        )
-        position_ids = ir.Value(
-            name="position_ids",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
-        )
-        input_ids = ir.Value(
-            name="input_ids",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
-        )
-
-        graph_inputs = [inputs_embeds, attention_mask, position_ids, input_ids]
-
-        kv_inputs, past_key_values = _make_gemma4_kv_cache_inputs(config, batch, past_seq_len)
-        graph_inputs.extend(kv_inputs)
-
-        graph, graph_builder = _make_graph(graph_inputs, name="decoder")
+        graph, graph_builder = _make_graph(name="decoder")
         op = graph_builder.op
+
+        inputs_embeds = graph_builder.input(
+            "inputs_embeds",
+            dtype=config.dtype,
+            shape=[batch, seq_len, config.hidden_size],
+        )
+        attention_mask = graph_builder.input(
+            "attention_mask",
+            dtype=ir.DataType.INT64,
+            shape=[batch, "past_seq_len + seq_len"],
+        )
+        position_ids = graph_builder.input(
+            "position_ids",
+            dtype=ir.DataType.INT64,
+            shape=[batch, seq_len],
+        )
+        input_ids = graph_builder.input(
+            "input_ids",
+            dtype=ir.DataType.INT64,
+            shape=[batch, seq_len],
+        )
+
+        past_key_values = _make_gemma4_kv_cache_inputs(graph_builder, config, batch, past_seq_len)
 
         logits, present_key_values = decoder(
             op,
@@ -264,9 +260,8 @@ class Gemma4Task(ModelTask):
             past_key_values=past_key_values,
         )
 
-        logits.name = "logits"
-        graph.outputs.append(logits)
-        _register_kv_cache_outputs(graph, present_key_values)
+        graph_builder.add_output(logits, "logits")
+        _register_kv_cache_outputs(graph_builder, present_key_values)
 
         return _make_model(graph)
 
@@ -293,21 +288,19 @@ class Gemma4Task(ModelTask):
         patch_size = config.vision.patch_size or 16 if config.vision else 16
         pixel_dim = 3 * patch_size * patch_size
 
-        pixel_values = ir.Value(
-            name="pixel_values",
-            shape=ir.Shape([batch, num_patches, pixel_dim]),
-            type=ir.TensorType(config.dtype),
-        )
-        pixel_position_ids = ir.Value(
-            name="pixel_position_ids",
-            shape=ir.Shape([batch, num_patches, 2]),
-            type=ir.TensorType(ir.DataType.INT64),
-        )
-
-        graph_inputs = [pixel_values, pixel_position_ids]
-
-        graph, graph_builder = _make_graph(graph_inputs, name="vision_encoder")
+        graph, graph_builder = _make_graph(name="vision_encoder")
         op = graph_builder.op
+
+        pixel_values = graph_builder.input(
+            "pixel_values",
+            dtype=config.dtype,
+            shape=[batch, num_patches, pixel_dim],
+        )
+        pixel_position_ids = graph_builder.input(
+            "pixel_position_ids",
+            dtype=ir.DataType.INT64,
+            shape=[batch, num_patches, 2],
+        )
 
         image_features = vision(
             op,
@@ -315,8 +308,7 @@ class Gemma4Task(ModelTask):
             pixel_position_ids=pixel_position_ids,
         )
 
-        image_features.name = "image_features"
-        graph.outputs.append(image_features)
+        graph_builder.add_output(image_features, "image_features")
 
         return _make_model(graph)
 
@@ -348,33 +340,29 @@ class Gemma4Task(ModelTask):
         time = ir.SymbolicDim("time")
         input_size = (config.audio.input_size if config.audio else None) or 128
 
-        input_features = ir.Value(
-            name="input_features",
-            shape=ir.Shape([batch, time, input_size]),
-            type=ir.TensorType(config.dtype),
-        )
-        input_features_mask = ir.Value(
-            name="input_features_mask",
-            shape=ir.Shape([batch, time]),
-            type=ir.TensorType(ir.DataType.BOOL),
-        )
-
-        graph, graph_builder = _make_graph(
-            [input_features, input_features_mask], name="audio_encoder"
-        )
+        graph, graph_builder = _make_graph(name="audio_encoder")
         op = graph_builder.op
+
+        input_features = graph_builder.input(
+            "input_features",
+            dtype=config.dtype,
+            shape=[batch, time, input_size],
+        )
+        input_features_mask = graph_builder.input(
+            "input_features_mask",
+            dtype=ir.DataType.BOOL,
+            shape=[batch, time],
+        )
 
         audio_features, downsampled_mask = audio(
             op,
             input_features,
             input_features_mask=input_features_mask,
         )
-        audio_features.name = "audio_features"
-        graph.outputs.append(audio_features)
+        graph_builder.add_output(audio_features, "audio_features")
 
         if downsampled_mask is not None:
-            downsampled_mask.name = "audio_features_mask"
-            graph.outputs.append(downsampled_mask)
+            graph_builder.add_output(downsampled_mask, "audio_features_mask")
 
         return _make_model(graph)
 
@@ -388,31 +376,29 @@ class Gemma4Task(ModelTask):
         seq_len = ir.SymbolicDim("sequence_len")
         num_image_tokens = ir.SymbolicDim("num_image_tokens")
 
-        input_ids = ir.Value(
-            name="input_ids",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
+        graph, graph_builder = _make_graph(name="embedding")
+        op = graph_builder.op
+
+        input_ids = graph_builder.input(
+            "input_ids",
+            dtype=ir.DataType.INT64,
+            shape=[batch, seq_len],
         )
-        image_features = ir.Value(
-            name="image_features",
-            shape=ir.Shape([num_image_tokens, config.hidden_size]),
-            type=ir.TensorType(config.dtype),
+        image_features = graph_builder.input(
+            "image_features",
+            dtype=config.dtype,
+            shape=[num_image_tokens, config.hidden_size],
         )
 
-        graph_inputs = [input_ids, image_features]
         audio_features_val: ir.Value | None = None
 
         if config.audio is not None:
             num_audio_tokens = ir.SymbolicDim("num_audio_tokens")
-            audio_features_val = ir.Value(
-                name="audio_features",
-                shape=ir.Shape([num_audio_tokens, config.hidden_size]),
-                type=ir.TensorType(config.dtype),
+            audio_features_val = graph_builder.input(
+                "audio_features",
+                dtype=config.dtype,
+                shape=[num_audio_tokens, config.hidden_size],
             )
-            graph_inputs.append(audio_features_val)
-
-        graph, graph_builder = _make_graph(graph_inputs, name="embedding")
-        op = graph_builder.op
 
         inputs_embeds = embedding(
             op,
@@ -420,6 +406,5 @@ class Gemma4Task(ModelTask):
             image_features=image_features,
             audio_features=audio_features_val,
         )
-        inputs_embeds.name = "inputs_embeds"
-        graph.outputs.append(inputs_embeds)
+        graph_builder.add_output(inputs_embeds, "inputs_embeds")
         return _make_model(graph)

--- a/src/mobius/tasks/_gemma4.py
+++ b/src/mobius/tasks/_gemma4.py
@@ -22,8 +22,7 @@ entries for the first ``num_hidden_layers - num_kv_shared_layers`` layers.
 from __future__ import annotations
 
 import onnx_ir as ir
-from onnxscript import nn
-from onnxscript._internal.builder import GraphBuilder
+from onnxscript import GraphBuilder, nn
 
 from mobius._configs import Gemma4Config
 from mobius._model_package import ModelPackage
@@ -38,14 +37,14 @@ from mobius.tasks._cache_utils import (
 
 
 def _make_gemma4_kv_cache_inputs(
-    graph_builder: GraphBuilder,
+    builder: GraphBuilder,
     config: Gemma4Config,
     batch: ir.SymbolicDim,
     past_seq_len: ir.SymbolicDim,
 ) -> list[tuple[ir.Value, ir.Value]]:
     """Create per-layer KV cache inputs accounting for dual head_dim and KV sharing.
 
-    Uses ``graph_builder.input()`` to create and register graph inputs directly.
+    Uses ``builder.input()`` to create and register graph inputs directly.
 
     Local (sliding_attention) layers use ``config.head_dim``;
     global (full_attention) layers use ``config.global_head_dim``.
@@ -75,12 +74,12 @@ def _make_gemma4_kv_cache_inputs(
         layer_type = layer_types[i] if i < len(layer_types) else "sliding_attention"
         hd = global_head_dim if layer_type == "full_attention" else local_head_dim
         kv_heads = config.num_key_value_heads
-        past_key = graph_builder.input(
+        past_key = builder.input(
             f"past_key_values.{i}.key",
             dtype=config.dtype,
             shape=[batch, kv_heads, past_seq_len, hd],
         )
-        past_value = graph_builder.input(
+        past_value = builder.input(
             f"past_key_values.{i}.value",
             dtype=config.dtype,
             shape=[batch, kv_heads, past_seq_len, hd],
@@ -119,26 +118,26 @@ class Gemma4TextCausalLMTask(ModelTask):
         seq_len = ir.SymbolicDim("sequence_len")
         past_seq_len = ir.SymbolicDim("past_sequence_len")
 
-        graph, graph_builder = _make_graph()
-        op = graph_builder.op
+        graph, builder = _make_graph()
+        op = builder.op
 
-        input_ids = graph_builder.input(
+        input_ids = builder.input(
             "input_ids",
             dtype=ir.DataType.INT64,
             shape=[batch, seq_len],
         )
-        attention_mask = graph_builder.input(
+        attention_mask = builder.input(
             "attention_mask",
             dtype=ir.DataType.INT64,
             shape=[batch, "past_seq_len + seq_len"],
         )
-        position_ids = graph_builder.input(
+        position_ids = builder.input(
             "position_ids",
             dtype=ir.DataType.INT64,
             shape=[batch, seq_len],
         )
 
-        past_key_values = _make_gemma4_kv_cache_inputs(graph_builder, config, batch, past_seq_len)
+        past_key_values = _make_gemma4_kv_cache_inputs(builder, config, batch, past_seq_len)
 
         logits, present_key_values = module(
             op,
@@ -147,8 +146,8 @@ class Gemma4TextCausalLMTask(ModelTask):
             position_ids=position_ids,
             past_key_values=past_key_values,
         )
-        graph_builder.add_output(logits, "logits")
-        _register_kv_cache_outputs(graph_builder, present_key_values)
+        builder.add_output(logits, "logits")
+        _register_kv_cache_outputs(builder, present_key_values)
 
         return ModelPackage({"model": _make_model(graph)}, config=config)
 
@@ -225,31 +224,31 @@ class Gemma4Task(ModelTask):
         seq_len = ir.SymbolicDim("sequence_len")
         past_seq_len = ir.SymbolicDim("past_sequence_len")
 
-        graph, graph_builder = _make_graph(name="decoder")
-        op = graph_builder.op
+        graph, builder = _make_graph(name="decoder")
+        op = builder.op
 
-        inputs_embeds = graph_builder.input(
+        inputs_embeds = builder.input(
             "inputs_embeds",
             dtype=config.dtype,
             shape=[batch, seq_len, config.hidden_size],
         )
-        attention_mask = graph_builder.input(
+        attention_mask = builder.input(
             "attention_mask",
             dtype=ir.DataType.INT64,
             shape=[batch, "past_seq_len + seq_len"],
         )
-        position_ids = graph_builder.input(
+        position_ids = builder.input(
             "position_ids",
             dtype=ir.DataType.INT64,
             shape=[batch, seq_len],
         )
-        input_ids = graph_builder.input(
+        input_ids = builder.input(
             "input_ids",
             dtype=ir.DataType.INT64,
             shape=[batch, seq_len],
         )
 
-        past_key_values = _make_gemma4_kv_cache_inputs(graph_builder, config, batch, past_seq_len)
+        past_key_values = _make_gemma4_kv_cache_inputs(builder, config, batch, past_seq_len)
 
         logits, present_key_values = decoder(
             op,
@@ -260,8 +259,8 @@ class Gemma4Task(ModelTask):
             past_key_values=past_key_values,
         )
 
-        graph_builder.add_output(logits, "logits")
-        _register_kv_cache_outputs(graph_builder, present_key_values)
+        builder.add_output(logits, "logits")
+        _register_kv_cache_outputs(builder, present_key_values)
 
         return _make_model(graph)
 
@@ -288,15 +287,15 @@ class Gemma4Task(ModelTask):
         patch_size = config.vision.patch_size or 16 if config.vision else 16
         pixel_dim = 3 * patch_size * patch_size
 
-        graph, graph_builder = _make_graph(name="vision_encoder")
-        op = graph_builder.op
+        graph, builder = _make_graph(name="vision_encoder")
+        op = builder.op
 
-        pixel_values = graph_builder.input(
+        pixel_values = builder.input(
             "pixel_values",
             dtype=config.dtype,
             shape=[batch, num_patches, pixel_dim],
         )
-        pixel_position_ids = graph_builder.input(
+        pixel_position_ids = builder.input(
             "pixel_position_ids",
             dtype=ir.DataType.INT64,
             shape=[batch, num_patches, 2],
@@ -308,7 +307,7 @@ class Gemma4Task(ModelTask):
             pixel_position_ids=pixel_position_ids,
         )
 
-        graph_builder.add_output(image_features, "image_features")
+        builder.add_output(image_features, "image_features")
 
         return _make_model(graph)
 
@@ -340,15 +339,15 @@ class Gemma4Task(ModelTask):
         time = ir.SymbolicDim("time")
         input_size = (config.audio.input_size if config.audio else None) or 128
 
-        graph, graph_builder = _make_graph(name="audio_encoder")
-        op = graph_builder.op
+        graph, builder = _make_graph(name="audio_encoder")
+        op = builder.op
 
-        input_features = graph_builder.input(
+        input_features = builder.input(
             "input_features",
             dtype=config.dtype,
             shape=[batch, time, input_size],
         )
-        input_features_mask = graph_builder.input(
+        input_features_mask = builder.input(
             "input_features_mask",
             dtype=ir.DataType.BOOL,
             shape=[batch, time],
@@ -359,10 +358,10 @@ class Gemma4Task(ModelTask):
             input_features,
             input_features_mask=input_features_mask,
         )
-        graph_builder.add_output(audio_features, "audio_features")
+        builder.add_output(audio_features, "audio_features")
 
         if downsampled_mask is not None:
-            graph_builder.add_output(downsampled_mask, "audio_features_mask")
+            builder.add_output(downsampled_mask, "audio_features_mask")
 
         return _make_model(graph)
 
@@ -376,15 +375,15 @@ class Gemma4Task(ModelTask):
         seq_len = ir.SymbolicDim("sequence_len")
         num_image_tokens = ir.SymbolicDim("num_image_tokens")
 
-        graph, graph_builder = _make_graph(name="embedding")
-        op = graph_builder.op
+        graph, builder = _make_graph(name="embedding")
+        op = builder.op
 
-        input_ids = graph_builder.input(
+        input_ids = builder.input(
             "input_ids",
             dtype=ir.DataType.INT64,
             shape=[batch, seq_len],
         )
-        image_features = graph_builder.input(
+        image_features = builder.input(
             "image_features",
             dtype=config.dtype,
             shape=[num_image_tokens, config.hidden_size],
@@ -394,7 +393,7 @@ class Gemma4Task(ModelTask):
 
         if config.audio is not None:
             num_audio_tokens = ir.SymbolicDim("num_audio_tokens")
-            audio_features_val = graph_builder.input(
+            audio_features_val = builder.input(
                 "audio_features",
                 dtype=config.dtype,
                 shape=[num_audio_tokens, config.hidden_size],
@@ -406,5 +405,5 @@ class Gemma4Task(ModelTask):
             image_features=image_features,
             audio_features=audio_features_val,
         )
-        graph_builder.add_output(inputs_embeds, "inputs_embeds")
+        builder.add_output(inputs_embeds, "inputs_embeds")
         return _make_model(graph)

--- a/src/mobius/tasks/_image_classification.py
+++ b/src/mobius/tasks/_image_classification.py
@@ -37,18 +37,13 @@ class ImageClassificationTask(ModelTask):
         image_size = getattr(config, "image_size", 224)
         num_channels = getattr(config, "num_channels", 3)
 
-        pixel_values = ir.Value(
-            name="pixel_values",
-            shape=ir.Shape([batch, num_channels, image_size, image_size]),
-            type=ir.TensorType(ir.DataType.FLOAT),
-        )
-
-        graph, builder = _make_graph([pixel_values])
+        graph, builder = _make_graph()
         op = builder.op
+
+        pixel_values = builder.input("pixel_values", dtype=ir.DataType.FLOAT, shape=[batch, num_channels, image_size, image_size])
 
         last_hidden_state = module(op, pixel_values=pixel_values)
 
-        last_hidden_state.name = "last_hidden_state"
-        graph.outputs.append(last_hidden_state)
+        builder.add_output(last_hidden_state, "last_hidden_state")
 
         return ModelPackage({"model": _make_model(graph)}, config=config)

--- a/src/mobius/tasks/_image_classification.py
+++ b/src/mobius/tasks/_image_classification.py
@@ -40,7 +40,11 @@ class ImageClassificationTask(ModelTask):
         graph, builder = _make_graph()
         op = builder.op
 
-        pixel_values = builder.input("pixel_values", dtype=ir.DataType.FLOAT, shape=[batch, num_channels, image_size, image_size])
+        pixel_values = builder.input(
+            "pixel_values",
+            dtype=ir.DataType.FLOAT,
+            shape=[batch, num_channels, image_size, image_size],
+        )
 
         last_hidden_state = module(op, pixel_values=pixel_values)
 

--- a/src/mobius/tasks/_multimodal.py
+++ b/src/mobius/tasks/_multimodal.py
@@ -52,39 +52,34 @@ class MultiModalTask(ModelTask):
         seq_len = ir.SymbolicDim("sequence_len")
         past_seq_len = ir.SymbolicDim("past_sequence_len")
 
-        input_ids = ir.Value(
-            name="input_ids",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
+        graph, builder = _make_graph()
+        op = builder.op
+
+        input_ids = builder.input(
+            "input_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len],
         )
-        attention_mask = ir.Value(
-            name="attention_mask",
-            shape=ir.Shape([batch, "past_seq_len + seq_len"]),
-            type=ir.TensorType(ir.DataType.INT64),
+        attention_mask = builder.input(
+            "attention_mask", dtype=ir.DataType.INT64,
+            shape=[batch, "past_seq_len + seq_len"],
         )
-        position_ids = ir.Value(
-            name="position_ids",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
+        position_ids = builder.input(
+            "position_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len],
         )
 
         image_size = config.vision.image_size or 224 if config.vision else 224
-        pixel_values = ir.Value(
-            name="pixel_values",
-            shape=ir.Shape([batch, 3, image_size, image_size]),
-            type=ir.TensorType(config.dtype),
+        pixel_values = builder.input(
+            "pixel_values", dtype=config.dtype,
+            shape=[batch, 3, image_size, image_size],
         )
 
         audio_input_size = (config.audio.input_size if config.audio else None) or 80
-        audio_features = ir.Value(
-            name="audio_features",
-            shape=ir.Shape([batch, "audio_seq_len", audio_input_size]),
-            type=ir.TensorType(config.dtype),
+        audio_features = builder.input(
+            "audio_features", dtype=config.dtype,
+            shape=[batch, "audio_seq_len", audio_input_size],
         )
 
-        graph_inputs = [input_ids, attention_mask, position_ids, pixel_values, audio_features]
-
-        kv_inputs, past_key_values = _make_kv_cache_inputs(
+        past_key_values = _make_kv_cache_inputs(
+            builder,
             config.num_hidden_layers,
             config.num_key_value_heads,
             config.head_dim,
@@ -92,10 +87,6 @@ class MultiModalTask(ModelTask):
             batch,
             past_seq_len,
         )
-        graph_inputs.extend(kv_inputs)
-
-        graph, builder = _make_graph(graph_inputs)
-        op = builder.op
 
         logits, present_key_values = module(
             op,
@@ -107,8 +98,7 @@ class MultiModalTask(ModelTask):
             past_key_values=past_key_values,
         )
 
-        logits.name = "logits"
-        graph.outputs.append(logits)
-        _register_kv_cache_outputs(graph, present_key_values)
+        builder.add_output(logits, "logits")
+        _register_kv_cache_outputs(builder, present_key_values)
 
         return ModelPackage({"model": _make_model(graph)}, config=config)

--- a/src/mobius/tasks/_multimodal.py
+++ b/src/mobius/tasks/_multimodal.py
@@ -56,25 +56,32 @@ class MultiModalTask(ModelTask):
         op = builder.op
 
         input_ids = builder.input(
-            "input_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len],
+            "input_ids",
+            dtype=ir.DataType.INT64,
+            shape=[batch, seq_len],
         )
         attention_mask = builder.input(
-            "attention_mask", dtype=ir.DataType.INT64,
+            "attention_mask",
+            dtype=ir.DataType.INT64,
             shape=[batch, "past_seq_len + seq_len"],
         )
         position_ids = builder.input(
-            "position_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len],
+            "position_ids",
+            dtype=ir.DataType.INT64,
+            shape=[batch, seq_len],
         )
 
         image_size = config.vision.image_size or 224 if config.vision else 224
         pixel_values = builder.input(
-            "pixel_values", dtype=config.dtype,
+            "pixel_values",
+            dtype=config.dtype,
             shape=[batch, 3, image_size, image_size],
         )
 
         audio_input_size = (config.audio.input_size if config.audio else None) or 80
         audio_features = builder.input(
-            "audio_features", dtype=config.dtype,
+            "audio_features",
+            dtype=config.dtype,
             shape=[batch, "audio_seq_len", audio_input_size],
         )
 

--- a/src/mobius/tasks/_object_detection.py
+++ b/src/mobius/tasks/_object_detection.py
@@ -38,20 +38,14 @@ class ObjectDetectionTask(ModelTask):
         image_size = getattr(config, "image_size", 224)
         num_channels = getattr(config, "num_channels", 3)
 
-        pixel_values = ir.Value(
-            name="pixel_values",
-            shape=ir.Shape([batch, num_channels, image_size, image_size]),
-            type=ir.TensorType(ir.DataType.FLOAT),
-        )
-
-        graph, builder = _make_graph([pixel_values])
+        graph, builder = _make_graph()
         op = builder.op
+
+        pixel_values = builder.input("pixel_values", dtype=ir.DataType.FLOAT, shape=[batch, num_channels, image_size, image_size])
 
         logits, pred_boxes = module(op, pixel_values=pixel_values)
 
-        logits.name = "logits"
-        pred_boxes.name = "pred_boxes"
-        graph.outputs.append(logits)
-        graph.outputs.append(pred_boxes)
+        builder.add_output(logits, "logits")
+        builder.add_output(pred_boxes, "pred_boxes")
 
         return ModelPackage({"model": _make_model(graph)}, config=config)

--- a/src/mobius/tasks/_object_detection.py
+++ b/src/mobius/tasks/_object_detection.py
@@ -41,7 +41,11 @@ class ObjectDetectionTask(ModelTask):
         graph, builder = _make_graph()
         op = builder.op
 
-        pixel_values = builder.input("pixel_values", dtype=ir.DataType.FLOAT, shape=[batch, num_channels, image_size, image_size])
+        pixel_values = builder.input(
+            "pixel_values",
+            dtype=ir.DataType.FLOAT,
+            shape=[batch, num_channels, image_size, image_size],
+        )
 
         logits, pred_boxes = module(op, pixel_values=pixel_values)
 

--- a/src/mobius/tasks/_phi4mm_multimodal.py
+++ b/src/mobius/tasks/_phi4mm_multimodal.py
@@ -84,22 +84,20 @@ class Phi4MMMultiModalTask(ModelTask):
         num_images = ir.SymbolicDim("num_images")
         image_size = (config.vision.image_size if config.vision else None) or 448
 
-        pixel_values = ir.Value(
-            name="pixel_values",
-            shape=ir.Shape([batch, 3, image_size, image_size]),
-            type=ir.TensorType(config.dtype),
+        graph, builder = _make_graph(name="vision_encoder")
+
+        pixel_values = builder.input(
+            "pixel_values", dtype=config.dtype,
+            shape=[batch, 3, image_size, image_size],
         )
-        image_sizes = ir.Value(
-            name="image_sizes",
-            shape=ir.Shape([num_images, 2]),
-            type=ir.TensorType(ir.DataType.INT64),
+        image_sizes = builder.input(
+            "image_sizes", dtype=ir.DataType.INT64,
+            shape=[num_images, 2],
         )
 
-        graph, builder = _make_graph([pixel_values, image_sizes], name="vision_encoder")
         image_features = vision(builder.op, pixel_values, image_sizes=image_sizes)
 
-        image_features.name = "image_features"
-        graph.outputs.append(image_features)
+        builder.add_output(image_features, "image_features")
         return _make_model(graph)
 
     def _build_speech(
@@ -117,26 +115,21 @@ class Phi4MMMultiModalTask(ModelTask):
         num_audio_clips = ir.SymbolicDim("num_audio_clips")
         input_size = (config.audio.input_size if config.audio else None) or 80
 
-        audio_embeds = ir.Value(
-            name="audio_embeds",
-            shape=ir.Shape([batch, audio_seq_len, input_size]),
-            type=ir.TensorType(config.dtype),
+        graph, builder = _make_graph(name="audio_encoder")
+
+        audio_embeds = builder.input(
+            "audio_embeds", dtype=config.dtype,
+            shape=[batch, audio_seq_len, input_size],
         )
-        audio_sizes = ir.Value(
-            name="audio_sizes",
-            shape=ir.Shape([num_audio_clips]),
-            type=ir.TensorType(ir.DataType.INT64),
+        audio_sizes = builder.input(
+            "audio_sizes", dtype=ir.DataType.INT64,
+            shape=[num_audio_clips],
         )
-        audio_projection_mode = ir.Value(
-            name="audio_projection_mode",
-            shape=ir.Shape([]),
-            type=ir.TensorType(ir.DataType.INT64),
+        audio_projection_mode = builder.input(
+            "audio_projection_mode", dtype=ir.DataType.INT64,
+            shape=[],
         )
 
-        graph, builder = _make_graph(
-            [audio_embeds, audio_sizes, audio_projection_mode],
-            name="audio_encoder",
-        )
         speech_out = speech(
             builder.op,
             audio_embeds,
@@ -144,8 +137,7 @@ class Phi4MMMultiModalTask(ModelTask):
             audio_projection_mode=audio_projection_mode,
         )
 
-        speech_out.name = "audio_features"
-        graph.outputs.append(speech_out)
+        builder.add_output(speech_out, "audio_features")
         return _make_model(graph)
 
     def _build_embedding(
@@ -159,26 +151,21 @@ class Phi4MMMultiModalTask(ModelTask):
         num_image_tokens = ir.SymbolicDim("num_image_tokens")
         num_speech_tokens = ir.SymbolicDim("num_speech_tokens")
 
-        input_ids = ir.Value(
-            name="input_ids",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
+        graph, builder = _make_graph(name="embedding")
+
+        input_ids = builder.input(
+            "input_ids", dtype=ir.DataType.INT64,
+            shape=[batch, seq_len],
         )
-        image_features = ir.Value(
-            name="image_features",
-            shape=ir.Shape([num_image_tokens, config.hidden_size]),
-            type=ir.TensorType(config.dtype),
+        image_features = builder.input(
+            "image_features", dtype=config.dtype,
+            shape=[num_image_tokens, config.hidden_size],
         )
-        audio_features = ir.Value(
-            name="audio_features",
-            shape=ir.Shape([num_speech_tokens, config.hidden_size]),
-            type=ir.TensorType(config.dtype),
+        audio_features = builder.input(
+            "audio_features", dtype=config.dtype,
+            shape=[num_speech_tokens, config.hidden_size],
         )
 
-        graph, builder = _make_graph(
-            [input_ids, image_features, audio_features],
-            name="embedding",
-        )
         inputs_embeds = embedding(
             builder.op,
             input_ids=input_ids,
@@ -186,6 +173,5 @@ class Phi4MMMultiModalTask(ModelTask):
             audio_features=audio_features,
         )
 
-        inputs_embeds.name = "inputs_embeds"
-        graph.outputs.append(inputs_embeds)
+        builder.add_output(inputs_embeds, "inputs_embeds")
         return _make_model(graph)

--- a/src/mobius/tasks/_phi4mm_multimodal.py
+++ b/src/mobius/tasks/_phi4mm_multimodal.py
@@ -87,11 +87,13 @@ class Phi4MMMultiModalTask(ModelTask):
         graph, builder = _make_graph(name="vision_encoder")
 
         pixel_values = builder.input(
-            "pixel_values", dtype=config.dtype,
+            "pixel_values",
+            dtype=config.dtype,
             shape=[batch, 3, image_size, image_size],
         )
         image_sizes = builder.input(
-            "image_sizes", dtype=ir.DataType.INT64,
+            "image_sizes",
+            dtype=ir.DataType.INT64,
             shape=[num_images, 2],
         )
 
@@ -118,15 +120,18 @@ class Phi4MMMultiModalTask(ModelTask):
         graph, builder = _make_graph(name="audio_encoder")
 
         audio_embeds = builder.input(
-            "audio_embeds", dtype=config.dtype,
+            "audio_embeds",
+            dtype=config.dtype,
             shape=[batch, audio_seq_len, input_size],
         )
         audio_sizes = builder.input(
-            "audio_sizes", dtype=ir.DataType.INT64,
+            "audio_sizes",
+            dtype=ir.DataType.INT64,
             shape=[num_audio_clips],
         )
         audio_projection_mode = builder.input(
-            "audio_projection_mode", dtype=ir.DataType.INT64,
+            "audio_projection_mode",
+            dtype=ir.DataType.INT64,
             shape=[],
         )
 
@@ -154,15 +159,18 @@ class Phi4MMMultiModalTask(ModelTask):
         graph, builder = _make_graph(name="embedding")
 
         input_ids = builder.input(
-            "input_ids", dtype=ir.DataType.INT64,
+            "input_ids",
+            dtype=ir.DataType.INT64,
             shape=[batch, seq_len],
         )
         image_features = builder.input(
-            "image_features", dtype=config.dtype,
+            "image_features",
+            dtype=config.dtype,
             shape=[num_image_tokens, config.hidden_size],
         )
         audio_features = builder.input(
-            "audio_features", dtype=config.dtype,
+            "audio_features",
+            dtype=config.dtype,
             shape=[num_speech_tokens, config.hidden_size],
         )
 

--- a/src/mobius/tasks/_qwen_image_vae.py
+++ b/src/mobius/tasks/_qwen_image_vae.py
@@ -43,7 +43,9 @@ class QwenImageVAETask(ModelTask):
         graph, builder = _make_graph(name="vae_encoder")
         op = builder.op
 
-        sample = builder.input("sample", dtype=ir.DataType.FLOAT, shape=["batch", 3, "frames", "height", "width"])
+        sample = builder.input(
+            "sample", dtype=ir.DataType.FLOAT, shape=["batch", 3, "frames", "height", "width"]
+        )
 
         hidden_states = module.encoder(op, sample)
         hidden_states = module.quant_conv(op, hidden_states)
@@ -60,7 +62,11 @@ class QwenImageVAETask(ModelTask):
         graph, builder = _make_graph(name="vae_decoder")
         op = builder.op
 
-        latent_sample = builder.input("latent_sample", dtype=ir.DataType.FLOAT, shape=["batch", config.z_dim, "frames", "height", "width"])
+        latent_sample = builder.input(
+            "latent_sample",
+            dtype=ir.DataType.FLOAT,
+            shape=["batch", config.z_dim, "frames", "height", "width"],
+        )
 
         hidden_states = module.post_quant_conv(op, latent_sample)
         hidden_states = module.decoder(op, hidden_states)

--- a/src/mobius/tasks/_qwen_image_vae.py
+++ b/src/mobius/tasks/_qwen_image_vae.py
@@ -40,20 +40,15 @@ class QwenImageVAETask(ModelTask):
         module,
         config: QwenImageVAEConfig,
     ) -> ir.Model:
-        sample = ir.Value(
-            name="sample",
-            type=ir.TensorType(ir.DataType.FLOAT),
-            shape=ir.Shape(("batch", 3, "frames", "height", "width")),
-        )
-
-        graph, builder = _make_graph([sample], name="vae_encoder")
+        graph, builder = _make_graph(name="vae_encoder")
         op = builder.op
+
+        sample = builder.input("sample", dtype=ir.DataType.FLOAT, shape=["batch", 3, "frames", "height", "width"])
 
         hidden_states = module.encoder(op, sample)
         hidden_states = module.quant_conv(op, hidden_states)
 
-        hidden_states.name = "latent_dist"
-        graph.outputs.append(hidden_states)
+        builder.add_output(hidden_states, "latent_dist")
 
         return _make_model(graph)
 
@@ -62,19 +57,14 @@ class QwenImageVAETask(ModelTask):
         module,
         config: QwenImageVAEConfig,
     ) -> ir.Model:
-        latent_sample = ir.Value(
-            name="latent_sample",
-            type=ir.TensorType(ir.DataType.FLOAT),
-            shape=ir.Shape(("batch", config.z_dim, "frames", "height", "width")),
-        )
-
-        graph, builder = _make_graph([latent_sample], name="vae_decoder")
+        graph, builder = _make_graph(name="vae_decoder")
         op = builder.op
+
+        latent_sample = builder.input("latent_sample", dtype=ir.DataType.FLOAT, shape=["batch", config.z_dim, "frames", "height", "width"])
 
         hidden_states = module.post_quant_conv(op, latent_sample)
         hidden_states = module.decoder(op, hidden_states)
 
-        hidden_states.name = "sample"
-        graph.outputs.append(hidden_states)
+        builder.add_output(hidden_states, "sample")
 
         return _make_model(graph)

--- a/src/mobius/tasks/_seq2seq.py
+++ b/src/mobius/tasks/_seq2seq.py
@@ -59,7 +59,9 @@ class Seq2SeqTask(ModelTask):
         op = builder.op
 
         input_ids = builder.input("input_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len])
-        attention_mask = builder.input("attention_mask", dtype=ir.DataType.INT64, shape=[batch, seq_len])
+        attention_mask = builder.input(
+            "attention_mask", dtype=ir.DataType.INT64, shape=[batch, seq_len]
+        )
 
         encoder_hidden_states = module.encoder(
             op, input_ids=input_ids, attention_mask=attention_mask
@@ -83,14 +85,18 @@ class Seq2SeqTask(ModelTask):
         op = builder.op
 
         input_ids = builder.input(
-            "input_ids", dtype=ir.DataType.INT64, shape=[batch, dec_seq_len],
+            "input_ids",
+            dtype=ir.DataType.INT64,
+            shape=[batch, dec_seq_len],
         )
         encoder_hidden_states = builder.input(
-            "encoder_hidden_states", dtype=config.dtype,
+            "encoder_hidden_states",
+            dtype=config.dtype,
             shape=[batch, enc_seq_len, config.hidden_size],
         )
         attention_mask = builder.input(
-            "attention_mask", dtype=ir.DataType.INT64,
+            "attention_mask",
+            dtype=ir.DataType.INT64,
             shape=[batch, "past_seq_len + dec_seq_len"],
         )
 
@@ -102,11 +108,13 @@ class Seq2SeqTask(ModelTask):
         past_self_kvs: list[tuple[ir.Value, ir.Value]] = []
         for i in range(num_decoder_layers):
             past_key = builder.input(
-                f"past_key_values.{i}.self.key", dtype=config.dtype,
+                f"past_key_values.{i}.self.key",
+                dtype=config.dtype,
                 shape=[batch, num_heads, past_seq_len, head_dim],
             )
             past_value = builder.input(
-                f"past_key_values.{i}.self.value", dtype=config.dtype,
+                f"past_key_values.{i}.self.value",
+                dtype=config.dtype,
                 shape=[batch, num_heads, past_seq_len, head_dim],
             )
             past_self_kvs.append((past_key, past_value))
@@ -115,11 +123,13 @@ class Seq2SeqTask(ModelTask):
         cross_past_kvs: list[tuple[ir.Value, ir.Value]] = []
         for i in range(num_decoder_layers):
             past_key = builder.input(
-                f"past_key_values.{i}.cross.key", dtype=config.dtype,
+                f"past_key_values.{i}.cross.key",
+                dtype=config.dtype,
                 shape=[batch, num_heads, enc_seq_len, head_dim],
             )
             past_value = builder.input(
-                f"past_key_values.{i}.cross.value", dtype=config.dtype,
+                f"past_key_values.{i}.cross.value",
+                dtype=config.dtype,
                 shape=[batch, num_heads, enc_seq_len, head_dim],
             )
             cross_past_kvs.append((past_key, past_value))

--- a/src/mobius/tasks/_seq2seq.py
+++ b/src/mobius/tasks/_seq2seq.py
@@ -18,9 +18,6 @@ from mobius.tasks._base import (
     _make_graph,
     _make_model,
 )
-from mobius.tasks._cache_utils import (
-    _make_kv_cache_inputs,
-)
 
 
 class Seq2SeqTask(ModelTask):
@@ -58,26 +55,17 @@ class Seq2SeqTask(ModelTask):
         batch = ir.SymbolicDim("batch")
         seq_len = ir.SymbolicDim("sequence_len")
 
-        input_ids = ir.Value(
-            name="input_ids",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
-        )
-        attention_mask = ir.Value(
-            name="attention_mask",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
-        )
-
-        graph, builder = _make_graph([input_ids, attention_mask], name="encoder")
+        graph, builder = _make_graph(name="encoder")
         op = builder.op
+
+        input_ids = builder.input("input_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len])
+        attention_mask = builder.input("attention_mask", dtype=ir.DataType.INT64, shape=[batch, seq_len])
 
         encoder_hidden_states = module.encoder(
             op, input_ids=input_ids, attention_mask=attention_mask
         )
 
-        encoder_hidden_states.name = "last_hidden_state"
-        graph.outputs.append(encoder_hidden_states)
+        builder.add_output(encoder_hidden_states, "last_hidden_state")
 
         return _make_model(graph)
 
@@ -91,63 +79,50 @@ class Seq2SeqTask(ModelTask):
         enc_seq_len = ir.SymbolicDim("encoder_sequence_len")
         past_seq_len = ir.SymbolicDim("past_sequence_len")
 
-        input_ids = ir.Value(
-            name="input_ids",
-            shape=ir.Shape([batch, dec_seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
-        )
-        encoder_hidden_states = ir.Value(
-            name="encoder_hidden_states",
-            shape=ir.Shape([batch, enc_seq_len, config.hidden_size]),
-            type=ir.TensorType(config.dtype),
-        )
-        attention_mask = ir.Value(
-            name="attention_mask",
-            shape=ir.Shape([batch, "past_seq_len + dec_seq_len"]),
-            type=ir.TensorType(ir.DataType.INT64),
-        )
+        graph, builder = _make_graph()
+        op = builder.op
 
-        graph_inputs = [input_ids, encoder_hidden_states, attention_mask]
+        input_ids = builder.input(
+            "input_ids", dtype=ir.DataType.INT64, shape=[batch, dec_seq_len],
+        )
+        encoder_hidden_states = builder.input(
+            "encoder_hidden_states", dtype=config.dtype,
+            shape=[batch, enc_seq_len, config.hidden_size],
+        )
+        attention_mask = builder.input(
+            "attention_mask", dtype=ir.DataType.INT64,
+            shape=[batch, "past_seq_len + dec_seq_len"],
+        )
 
         num_heads = config.num_attention_heads
         head_dim = config.head_dim
         num_decoder_layers = getattr(config, "num_decoder_layers", config.num_hidden_layers)
 
-        # Self-attention KV cache
-        self_kv_inputs, past_self_kvs = _make_kv_cache_inputs(
-            num_decoder_layers,
-            num_heads,
-            head_dim,
-            config.dtype,
-            batch,
-            past_seq_len,
-            prefix="past_key_values",
-        )
-        # Use .self. naming for seq2seq self-attention KVs
-        for v in self_kv_inputs:
-            idx = v.name.split(".")[1]
-            kv_type = v.name.rsplit(".", 1)[-1]
-            v.name = f"past_key_values.{idx}.self.{kv_type}"
-        graph_inputs.extend(self_kv_inputs)
+        # Self-attention KV cache (named past_key_values.{i}.self.key/value)
+        past_self_kvs: list[tuple[ir.Value, ir.Value]] = []
+        for i in range(num_decoder_layers):
+            past_key = builder.input(
+                f"past_key_values.{i}.self.key", dtype=config.dtype,
+                shape=[batch, num_heads, past_seq_len, head_dim],
+            )
+            past_value = builder.input(
+                f"past_key_values.{i}.self.value", dtype=config.dtype,
+                shape=[batch, num_heads, past_seq_len, head_dim],
+            )
+            past_self_kvs.append((past_key, past_value))
 
-        # Cross-attention KV cache
-        cross_kv_inputs, cross_past_kvs = _make_kv_cache_inputs(
-            num_decoder_layers,
-            num_heads,
-            head_dim,
-            config.dtype,
-            batch,
-            enc_seq_len,
-            prefix="past_key_values",
-        )
-        for v in cross_kv_inputs:
-            idx = v.name.split(".")[1]
-            kv_type = v.name.rsplit(".", 1)[-1]
-            v.name = f"past_key_values.{idx}.cross.{kv_type}"
-        graph_inputs.extend(cross_kv_inputs)
-
-        graph, builder = _make_graph(graph_inputs)
-        op = builder.op
+        # Cross-attention KV cache (named past_key_values.{i}.cross.key/value)
+        cross_past_kvs: list[tuple[ir.Value, ir.Value]] = []
+        for i in range(num_decoder_layers):
+            past_key = builder.input(
+                f"past_key_values.{i}.cross.key", dtype=config.dtype,
+                shape=[batch, num_heads, enc_seq_len, head_dim],
+            )
+            past_value = builder.input(
+                f"past_key_values.{i}.cross.value", dtype=config.dtype,
+                shape=[batch, num_heads, enc_seq_len, head_dim],
+            )
+            cross_past_kvs.append((past_key, past_value))
 
         logits, present_self_kvs, present_cross_kvs = module.decoder(
             op,
@@ -158,17 +133,14 @@ class Seq2SeqTask(ModelTask):
             cross_past_key_values=cross_past_kvs,
         )
 
-        logits.name = "logits"
-        graph.outputs.append(logits)
+        builder.add_output(logits, "logits")
 
         for i, (k, v) in enumerate(present_self_kvs):
-            k.name = f"present.{i}.self.key"
-            v.name = f"present.{i}.self.value"
-            graph.outputs.extend([k, v])
+            builder.add_output(k, f"present.{i}.self.key")
+            builder.add_output(v, f"present.{i}.self.value")
 
         for i, (k, v) in enumerate(present_cross_kvs):
-            k.name = f"present.{i}.cross.key"
-            v.name = f"present.{i}.cross.value"
-            graph.outputs.extend([k, v])
+            builder.add_output(k, f"present.{i}.cross.key")
+            builder.add_output(v, f"present.{i}.cross.value")
 
         return _make_model(graph)

--- a/src/mobius/tasks/_speech_language.py
+++ b/src/mobius/tasks/_speech_language.py
@@ -82,15 +82,14 @@ class SpeechLanguageTask(ModelTask):
         mel_seq = ir.SymbolicDim("mel_sequence_len")
         n_mels = (config.audio.num_mel_bins if config.audio else None) or 128
 
-        input_features = ir.Value(
-            name="input_features",
-            shape=ir.Shape([batch, n_mels, mel_seq]),
-            type=ir.TensorType(config.dtype),
+        graph, builder = _make_graph(name="audio_encoder")
+
+        input_features = builder.input(
+            "input_features", dtype=config.dtype,
+            shape=[batch, n_mels, mel_seq],
         )
 
-        graph, builder = _make_graph([input_features], name="audio_encoder")
         audio_features = audio_encoder(builder.op, input_features)
 
-        audio_features.name = "audio_features"
-        graph.outputs.append(audio_features)
+        builder.add_output(audio_features, "audio_features")
         return _make_model(graph)

--- a/src/mobius/tasks/_speech_language.py
+++ b/src/mobius/tasks/_speech_language.py
@@ -85,7 +85,8 @@ class SpeechLanguageTask(ModelTask):
         graph, builder = _make_graph(name="audio_encoder")
 
         input_features = builder.input(
-            "input_features", dtype=config.dtype,
+            "input_features",
+            dtype=config.dtype,
             shape=[batch, n_mels, mel_seq],
         )
 

--- a/src/mobius/tasks/_speech_to_text.py
+++ b/src/mobius/tasks/_speech_to_text.py
@@ -69,19 +69,17 @@ class SpeechToTextTask(ModelTask):
         batch = ir.SymbolicDim("batch")
         audio_seq_len = ir.SymbolicDim("audio_seq_len")
 
-        input_features = ir.Value(
-            name="input_features",
-            shape=ir.Shape([batch, config.num_mel_bins, audio_seq_len]),
-            type=ir.TensorType(ir.DataType.FLOAT),
-        )
-
-        graph, builder = _make_graph([input_features], name="encoder")
+        graph, builder = _make_graph(name="encoder")
         op = builder.op
+
+        input_features = builder.input(
+            "input_features", dtype=ir.DataType.FLOAT,
+            shape=[batch, config.num_mel_bins, audio_seq_len],
+        )
 
         encoder_hidden_states = encoder(op, input_features=input_features)
 
-        encoder_hidden_states.name = "encoder_hidden_states"
-        graph.outputs.append(encoder_hidden_states)
+        builder.add_output(encoder_hidden_states, "encoder_hidden_states")
 
         return _make_model(graph)
 
@@ -95,25 +93,22 @@ class SpeechToTextTask(ModelTask):
         past_seq_len = ir.SymbolicDim("past_sequence_len")
         encoder_seq_len = ir.SymbolicDim("encoder_sequence_len")
 
-        decoder_input_ids = ir.Value(
-            name="decoder_input_ids",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
+        graph, builder = _make_graph()
+        op = builder.op
+
+        decoder_input_ids = builder.input(
+            "decoder_input_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len],
         )
-        encoder_hidden_states = ir.Value(
-            name="encoder_hidden_states",
-            shape=ir.Shape([batch, encoder_seq_len, config.hidden_size]),
-            type=ir.TensorType(config.dtype),
+        encoder_hidden_states = builder.input(
+            "encoder_hidden_states", dtype=config.dtype,
+            shape=[batch, encoder_seq_len, config.hidden_size],
         )
-        position_ids = ir.Value(
-            name="position_ids",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
+        position_ids = builder.input(
+            "position_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len],
         )
 
-        graph_inputs = [decoder_input_ids, encoder_hidden_states, position_ids]
-
-        kv_inputs, past_key_values = _make_kv_cache_inputs(
+        past_key_values = _make_kv_cache_inputs(
+            builder,
             config.num_hidden_layers,
             config.num_key_value_heads,
             config.head_dim,
@@ -121,10 +116,6 @@ class SpeechToTextTask(ModelTask):
             batch,
             past_seq_len,
         )
-        graph_inputs.extend(kv_inputs)
-
-        graph, builder = _make_graph(graph_inputs)
-        op = builder.op
 
         logits, present_key_values = decoder(
             op,
@@ -134,8 +125,7 @@ class SpeechToTextTask(ModelTask):
             past_key_values=past_key_values,
         )
 
-        logits.name = "logits"
-        graph.outputs.append(logits)
-        _register_kv_cache_outputs(graph, present_key_values)
+        builder.add_output(logits, "logits")
+        _register_kv_cache_outputs(builder, present_key_values)
 
         return _make_model(graph)

--- a/src/mobius/tasks/_speech_to_text.py
+++ b/src/mobius/tasks/_speech_to_text.py
@@ -73,7 +73,8 @@ class SpeechToTextTask(ModelTask):
         op = builder.op
 
         input_features = builder.input(
-            "input_features", dtype=ir.DataType.FLOAT,
+            "input_features",
+            dtype=ir.DataType.FLOAT,
             shape=[batch, config.num_mel_bins, audio_seq_len],
         )
 
@@ -97,14 +98,19 @@ class SpeechToTextTask(ModelTask):
         op = builder.op
 
         decoder_input_ids = builder.input(
-            "decoder_input_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len],
+            "decoder_input_ids",
+            dtype=ir.DataType.INT64,
+            shape=[batch, seq_len],
         )
         encoder_hidden_states = builder.input(
-            "encoder_hidden_states", dtype=config.dtype,
+            "encoder_hidden_states",
+            dtype=config.dtype,
             shape=[batch, encoder_seq_len, config.hidden_size],
         )
         position_ids = builder.input(
-            "position_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len],
+            "position_ids",
+            dtype=ir.DataType.INT64,
+            shape=[batch, seq_len],
         )
 
         past_key_values = _make_kv_cache_inputs(

--- a/src/mobius/tasks/_ssm_causal_lm.py
+++ b/src/mobius/tasks/_ssm_causal_lm.py
@@ -56,11 +56,13 @@ def _build_ssm_task(
     past_states: list[tuple[ir.Value, ir.Value]] = []
     for i in range(config.num_hidden_layers):
         conv_state = builder.input(
-            f"past_states.{i}.conv_state", dtype=config.dtype,
+            f"past_states.{i}.conv_state",
+            dtype=config.dtype,
             shape=[batch, *conv_state_shape],
         )
         ssm_state = builder.input(
-            f"past_states.{i}.ssm_state", dtype=config.dtype,
+            f"past_states.{i}.ssm_state",
+            dtype=config.dtype,
             shape=[batch, *ssm_state_shape],
         )
         past_states.append((conv_state, ssm_state))

--- a/src/mobius/tasks/_ssm_causal_lm.py
+++ b/src/mobius/tasks/_ssm_causal_lm.py
@@ -49,42 +49,32 @@ def _build_ssm_task(
     batch = ir.SymbolicDim("batch")
     seq_len = ir.SymbolicDim("sequence_len")
 
-    input_ids = ir.Value(
-        name="input_ids",
-        shape=ir.Shape([batch, seq_len]),
-        type=ir.TensorType(ir.DataType.INT64),
-    )
-    graph_inputs: list[ir.Value] = [input_ids]
+    graph, builder = _make_graph()
+
+    input_ids = builder.input("input_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len])
 
     past_states: list[tuple[ir.Value, ir.Value]] = []
     for i in range(config.num_hidden_layers):
-        conv_state = ir.Value(
-            name=f"past_states.{i}.conv_state",
-            shape=ir.Shape([batch, *conv_state_shape]),
-            type=ir.TensorType(config.dtype),
+        conv_state = builder.input(
+            f"past_states.{i}.conv_state", dtype=config.dtype,
+            shape=[batch, *conv_state_shape],
         )
-        ssm_state = ir.Value(
-            name=f"past_states.{i}.ssm_state",
-            shape=ir.Shape([batch, *ssm_state_shape]),
-            type=ir.TensorType(config.dtype),
+        ssm_state = builder.input(
+            f"past_states.{i}.ssm_state", dtype=config.dtype,
+            shape=[batch, *ssm_state_shape],
         )
-        graph_inputs.extend([conv_state, ssm_state])
         past_states.append((conv_state, ssm_state))
 
-    graph, builder = _make_graph(graph_inputs)
     logits, present_states = module(
         builder.op,
         input_ids=input_ids,
         past_states=past_states,
     )
 
-    logits.name = "logits"
-    graph.outputs.append(logits)
+    builder.add_output(logits, "logits")
     for i, (conv_state, ssm_state) in enumerate(present_states):
-        conv_state.name = f"present.{i}.conv_state"
-        ssm_state.name = f"present.{i}.ssm_state"
-        graph.outputs.append(conv_state)
-        graph.outputs.append(ssm_state)
+        builder.add_output(conv_state, f"present.{i}.conv_state")
+        builder.add_output(ssm_state, f"present.{i}.ssm_state")
 
     return ModelPackage({"model": _make_model(graph)}, config=config)
 

--- a/src/mobius/tasks/_tts.py
+++ b/src/mobius/tasks/_tts.py
@@ -90,26 +90,24 @@ class TTSTask(ModelTask):
         seq_len = ir.SymbolicDim("sequence_len")
         past_seq_len = ir.SymbolicDim("past_sequence_len")
 
-        inputs_embeds = ir.Value(
-            name="inputs_embeds",
-            shape=ir.Shape([batch, seq_len, config.hidden_size]),
-            type=ir.TensorType(config.dtype),
+        graph, builder = _make_graph(name="talker")
+
+        inputs_embeds = builder.input(
+            "inputs_embeds", dtype=config.dtype,
+            shape=[batch, seq_len, config.hidden_size],
         )
-        attention_mask = ir.Value(
-            name="attention_mask",
-            shape=ir.Shape([batch, "past_seq_len + seq_len"]),
-            type=ir.TensorType(ir.DataType.INT64),
+        attention_mask = builder.input(
+            "attention_mask", dtype=ir.DataType.INT64,
+            shape=[batch, "past_seq_len + seq_len"],
         )
         # MRoPE: 3D position_ids (3, batch, seq_len)
-        position_ids = ir.Value(
-            name="position_ids",
-            shape=ir.Shape([3, batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
+        position_ids = builder.input(
+            "position_ids", dtype=ir.DataType.INT64,
+            shape=[3, batch, seq_len],
         )
 
-        graph_inputs = [inputs_embeds, attention_mask, position_ids]
-
-        kv_inputs, past_key_values = _make_kv_cache_inputs(
+        past_key_values = _make_kv_cache_inputs(
+            builder,
             config.num_hidden_layers,
             config.num_key_value_heads,
             config.head_dim,
@@ -117,9 +115,7 @@ class TTSTask(ModelTask):
             batch,
             past_seq_len,
         )
-        graph_inputs.extend(kv_inputs)
 
-        graph, builder = _make_graph(graph_inputs, name="talker")
         logits, last_hidden_state, present_key_values = talker(
             builder.op,
             inputs_embeds=inputs_embeds,
@@ -128,11 +124,9 @@ class TTSTask(ModelTask):
             past_key_values=past_key_values,
         )
 
-        logits.name = "logits"
-        last_hidden_state.name = "last_hidden_state"
-        graph.outputs.append(logits)
-        graph.outputs.append(last_hidden_state)
-        _register_kv_cache_outputs(graph, present_key_values)
+        builder.add_output(logits, "logits")
+        builder.add_output(last_hidden_state, "last_hidden_state")
+        _register_kv_cache_outputs(builder, present_key_values)
         return _make_model(graph)
 
     def _build_code_predictor(
@@ -166,39 +160,29 @@ class TTSTask(ModelTask):
         seq_len = ir.SymbolicDim("sequence_len")
         past_seq_len = ir.SymbolicDim("past_sequence_len")
 
+        graph, builder = _make_graph(name="code_predictor")
+
         # Pre-embedded input in talker_hidden space (constructed by
         # generation loop). The model projects to cp_hidden internally.
-        inputs_embeds = ir.Value(
-            name="inputs_embeds",
-            shape=ir.Shape([batch, seq_len, config.hidden_size]),
-            type=ir.TensorType(config.dtype),
+        inputs_embeds = builder.input(
+            "inputs_embeds", dtype=config.dtype,
+            shape=[batch, seq_len, config.hidden_size],
         )
         # Step index: selects which lm_head to use (0..14)
-        step_index = ir.Value(
-            name="step_index",
-            shape=ir.Shape([]),
-            type=ir.TensorType(ir.DataType.INT64),
+        step_index = builder.input(
+            "step_index", dtype=ir.DataType.INT64, shape=[],
         )
-        attention_mask = ir.Value(
-            name="attention_mask",
-            shape=ir.Shape([batch, "past_seq_len + seq_len"]),
-            type=ir.TensorType(ir.DataType.INT64),
+        attention_mask = builder.input(
+            "attention_mask", dtype=ir.DataType.INT64,
+            shape=[batch, "past_seq_len + seq_len"],
         )
         # 1D RoPE: 2D position_ids (batch, seq_len)
-        position_ids = ir.Value(
-            name="position_ids",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
+        position_ids = builder.input(
+            "position_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len],
         )
 
-        graph_inputs = [
-            inputs_embeds,
-            step_index,
-            attention_mask,
-            position_ids,
-        ]
-
-        kv_inputs, past_key_values = _make_kv_cache_inputs(
+        past_key_values = _make_kv_cache_inputs(
+            builder,
             cp_num_hidden_layers,
             cp_num_key_value_heads,
             cp_head_dim,
@@ -206,9 +190,7 @@ class TTSTask(ModelTask):
             batch,
             past_seq_len,
         )
-        graph_inputs.extend(kv_inputs)
 
-        graph, builder = _make_graph(graph_inputs, name="code_predictor")
         logits, present_key_values, codec_embeddings = code_predictor(
             builder.op,
             inputs_embeds=inputs_embeds,
@@ -218,14 +200,12 @@ class TTSTask(ModelTask):
             past_key_values=past_key_values,
         )
 
-        logits.name = "logits"
-        graph.outputs.append(logits)
+        builder.add_output(logits, "logits")
         # Expose stacked codec embeddings for generation loop to extract.
         # The Identity node ensures renaming the output doesn't affect
         # the initializer name used for weight loading.
-        codec_embeddings.name = "codec_embeddings"
-        graph.outputs.append(codec_embeddings)
-        _register_kv_cache_outputs(graph, present_key_values)
+        builder.add_output(codec_embeddings, "codec_embeddings")
+        _register_kv_cache_outputs(builder, present_key_values)
         return _make_model(graph)
 
     def _build_embedding(
@@ -238,28 +218,23 @@ class TTSTask(ModelTask):
         text_seq = ir.SymbolicDim("text_sequence_len")
         codec_seq = ir.SymbolicDim("codec_sequence_len")
 
-        text_ids = ir.Value(
-            name="text_ids",
-            shape=ir.Shape([batch, text_seq]),
-            type=ir.TensorType(ir.DataType.INT64),
+        graph, builder = _make_graph(name="embedding")
+
+        text_ids = builder.input(
+            "text_ids", dtype=ir.DataType.INT64, shape=[batch, text_seq],
         )
-        codec_ids = ir.Value(
-            name="codec_ids",
-            shape=ir.Shape([batch, codec_seq]),
-            type=ir.TensorType(ir.DataType.INT64),
+        codec_ids = builder.input(
+            "codec_ids", dtype=ir.DataType.INT64, shape=[batch, codec_seq],
         )
 
-        graph, builder = _make_graph([text_ids, codec_ids], name="embedding")
         text_embeds, codec_embeds = embedding(
             builder.op,
             text_ids=text_ids,
             codec_ids=codec_ids,
         )
 
-        text_embeds.name = "text_embeds"
-        codec_embeds.name = "codec_embeds"
-        graph.outputs.append(text_embeds)
-        graph.outputs.append(codec_embeds)
+        builder.add_output(text_embeds, "text_embeds")
+        builder.add_output(codec_embeds, "codec_embeds")
         return _make_model(graph)
 
     def _build_speaker_encoder(
@@ -274,15 +249,13 @@ class TTSTask(ModelTask):
         se = tts.speaker_encoder if tts else None
         mel_dim = se.mel_dim if se else 128
 
-        mel_input = ir.Value(
-            name="mel_input",
-            shape=ir.Shape([batch, mel_seq, mel_dim]),
-            type=ir.TensorType(config.dtype),
+        graph, builder = _make_graph(name="speaker_encoder")
+
+        mel_input = builder.input(
+            "mel_input", dtype=config.dtype, shape=[batch, mel_seq, mel_dim],
         )
 
-        graph, builder = _make_graph([mel_input], name="speaker_encoder")
         speaker_embedding = speaker_encoder(builder.op, mel_input)
 
-        speaker_embedding.name = "speaker_embedding"
-        graph.outputs.append(speaker_embedding)
+        builder.add_output(speaker_embedding, "speaker_embedding")
         return _make_model(graph)

--- a/src/mobius/tasks/_tts.py
+++ b/src/mobius/tasks/_tts.py
@@ -93,16 +93,19 @@ class TTSTask(ModelTask):
         graph, builder = _make_graph(name="talker")
 
         inputs_embeds = builder.input(
-            "inputs_embeds", dtype=config.dtype,
+            "inputs_embeds",
+            dtype=config.dtype,
             shape=[batch, seq_len, config.hidden_size],
         )
         attention_mask = builder.input(
-            "attention_mask", dtype=ir.DataType.INT64,
+            "attention_mask",
+            dtype=ir.DataType.INT64,
             shape=[batch, "past_seq_len + seq_len"],
         )
         # MRoPE: 3D position_ids (3, batch, seq_len)
         position_ids = builder.input(
-            "position_ids", dtype=ir.DataType.INT64,
+            "position_ids",
+            dtype=ir.DataType.INT64,
             shape=[3, batch, seq_len],
         )
 
@@ -165,20 +168,26 @@ class TTSTask(ModelTask):
         # Pre-embedded input in talker_hidden space (constructed by
         # generation loop). The model projects to cp_hidden internally.
         inputs_embeds = builder.input(
-            "inputs_embeds", dtype=config.dtype,
+            "inputs_embeds",
+            dtype=config.dtype,
             shape=[batch, seq_len, config.hidden_size],
         )
         # Step index: selects which lm_head to use (0..14)
         step_index = builder.input(
-            "step_index", dtype=ir.DataType.INT64, shape=[],
+            "step_index",
+            dtype=ir.DataType.INT64,
+            shape=[],
         )
         attention_mask = builder.input(
-            "attention_mask", dtype=ir.DataType.INT64,
+            "attention_mask",
+            dtype=ir.DataType.INT64,
             shape=[batch, "past_seq_len + seq_len"],
         )
         # 1D RoPE: 2D position_ids (batch, seq_len)
         position_ids = builder.input(
-            "position_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len],
+            "position_ids",
+            dtype=ir.DataType.INT64,
+            shape=[batch, seq_len],
         )
 
         past_key_values = _make_kv_cache_inputs(
@@ -221,10 +230,14 @@ class TTSTask(ModelTask):
         graph, builder = _make_graph(name="embedding")
 
         text_ids = builder.input(
-            "text_ids", dtype=ir.DataType.INT64, shape=[batch, text_seq],
+            "text_ids",
+            dtype=ir.DataType.INT64,
+            shape=[batch, text_seq],
         )
         codec_ids = builder.input(
-            "codec_ids", dtype=ir.DataType.INT64, shape=[batch, codec_seq],
+            "codec_ids",
+            dtype=ir.DataType.INT64,
+            shape=[batch, codec_seq],
         )
 
         text_embeds, codec_embeds = embedding(
@@ -252,7 +265,9 @@ class TTSTask(ModelTask):
         graph, builder = _make_graph(name="speaker_encoder")
 
         mel_input = builder.input(
-            "mel_input", dtype=config.dtype, shape=[batch, mel_seq, mel_dim],
+            "mel_input",
+            dtype=config.dtype,
+            shape=[batch, mel_seq, mel_dim],
         )
 
         speaker_embedding = speaker_encoder(builder.op, mel_input)

--- a/src/mobius/tasks/_vae.py
+++ b/src/mobius/tasks/_vae.py
@@ -43,7 +43,11 @@ class VAETask(ModelTask):
         graph, builder = _make_graph(name="vae_encoder")
         op = builder.op
 
-        sample = builder.input("sample", dtype=ir.DataType.FLOAT, shape=["batch", config.in_channels, "height", "width"])
+        sample = builder.input(
+            "sample",
+            dtype=ir.DataType.FLOAT,
+            shape=["batch", config.in_channels, "height", "width"],
+        )
 
         hidden_states = module.encoder(op, sample=sample)
         if module.quant_conv is not None:
@@ -61,7 +65,11 @@ class VAETask(ModelTask):
         graph, builder = _make_graph(name="vae_decoder")
         op = builder.op
 
-        latent_sample = builder.input("latent_sample", dtype=ir.DataType.FLOAT, shape=["batch", config.latent_channels, "height", "width"])
+        latent_sample = builder.input(
+            "latent_sample",
+            dtype=ir.DataType.FLOAT,
+            shape=["batch", config.latent_channels, "height", "width"],
+        )
 
         hidden_states = latent_sample
         if module.post_quant_conv is not None:

--- a/src/mobius/tasks/_vae.py
+++ b/src/mobius/tasks/_vae.py
@@ -40,21 +40,16 @@ class VAETask(ModelTask):
         module,
         config: VAEConfig,
     ) -> ir.Model:
-        sample = ir.Value(
-            name="sample",
-            type=ir.TensorType(ir.DataType.FLOAT),
-            shape=ir.Shape(("batch", config.in_channels, "height", "width")),
-        )
-
-        graph, builder = _make_graph([sample], name="vae_encoder")
+        graph, builder = _make_graph(name="vae_encoder")
         op = builder.op
+
+        sample = builder.input("sample", dtype=ir.DataType.FLOAT, shape=["batch", config.in_channels, "height", "width"])
 
         hidden_states = module.encoder(op, sample=sample)
         if module.quant_conv is not None:
             hidden_states = module.quant_conv(op, hidden_states)
 
-        hidden_states.name = "latent_dist"
-        graph.outputs.append(hidden_states)
+        builder.add_output(hidden_states, "latent_dist")
 
         return _make_model(graph)
 
@@ -63,21 +58,16 @@ class VAETask(ModelTask):
         module,
         config: VAEConfig,
     ) -> ir.Model:
-        latent_sample = ir.Value(
-            name="latent_sample",
-            type=ir.TensorType(ir.DataType.FLOAT),
-            shape=ir.Shape(("batch", config.latent_channels, "height", "width")),
-        )
-
-        graph, builder = _make_graph([latent_sample], name="vae_decoder")
+        graph, builder = _make_graph(name="vae_decoder")
         op = builder.op
+
+        latent_sample = builder.input("latent_sample", dtype=ir.DataType.FLOAT, shape=["batch", config.latent_channels, "height", "width"])
 
         hidden_states = latent_sample
         if module.post_quant_conv is not None:
             hidden_states = module.post_quant_conv(op, hidden_states)
         hidden_states = module.decoder(op, latent_sample=hidden_states)
 
-        hidden_states.name = "sample"
-        graph.outputs.append(hidden_states)
+        builder.add_output(hidden_states, "sample")
 
         return _make_model(graph)

--- a/src/mobius/tasks/_video_denoising.py
+++ b/src/mobius/tasks/_video_denoising.py
@@ -29,32 +29,12 @@ class VideoDenoisingTask(ModelTask):
         module,
         config: CogVideoXConfig,
     ) -> ModelPackage:
-        sample = ir.Value(
-            name="sample",
-            type=ir.TensorType(ir.DataType.FLOAT),
-            shape=ir.Shape(
-                (
-                    "batch",
-                    "num_frames",
-                    config.in_channels,
-                    "height",
-                    "width",
-                )
-            ),
-        )
-        timestep = ir.Value(
-            name="timestep",
-            type=ir.TensorType(ir.DataType.INT64),
-            shape=ir.Shape(("batch",)),
-        )
-        encoder_hidden_states = ir.Value(
-            name="encoder_hidden_states",
-            type=ir.TensorType(ir.DataType.FLOAT),
-            shape=ir.Shape(("batch", "sequence_length", config.cross_attention_dim)),
-        )
-
-        graph, builder = _make_graph([sample, timestep, encoder_hidden_states])
+        graph, builder = _make_graph()
         op = builder.op
+
+        sample = builder.input("sample", dtype=ir.DataType.FLOAT, shape=["batch", "num_frames", config.in_channels, "height", "width"])
+        timestep = builder.input("timestep", dtype=ir.DataType.INT64, shape=["batch"])
+        encoder_hidden_states = builder.input("encoder_hidden_states", dtype=ir.DataType.FLOAT, shape=["batch", "sequence_length", config.cross_attention_dim])
 
         noise_pred = module(
             op,
@@ -63,7 +43,6 @@ class VideoDenoisingTask(ModelTask):
             encoder_hidden_states=encoder_hidden_states,
         )
 
-        noise_pred.name = "noise_pred"
-        graph.outputs.append(noise_pred)
+        builder.add_output(noise_pred, "noise_pred")
 
         return ModelPackage({"model": _make_model(graph)}, config=config)

--- a/src/mobius/tasks/_video_denoising.py
+++ b/src/mobius/tasks/_video_denoising.py
@@ -32,9 +32,17 @@ class VideoDenoisingTask(ModelTask):
         graph, builder = _make_graph()
         op = builder.op
 
-        sample = builder.input("sample", dtype=ir.DataType.FLOAT, shape=["batch", "num_frames", config.in_channels, "height", "width"])
+        sample = builder.input(
+            "sample",
+            dtype=ir.DataType.FLOAT,
+            shape=["batch", "num_frames", config.in_channels, "height", "width"],
+        )
         timestep = builder.input("timestep", dtype=ir.DataType.INT64, shape=["batch"])
-        encoder_hidden_states = builder.input("encoder_hidden_states", dtype=ir.DataType.FLOAT, shape=["batch", "sequence_length", config.cross_attention_dim])
+        encoder_hidden_states = builder.input(
+            "encoder_hidden_states",
+            dtype=ir.DataType.FLOAT,
+            shape=["batch", "sequence_length", config.cross_attention_dim],
+        )
 
         noise_pred = module(
             op,

--- a/src/mobius/tasks/_vision_language.py
+++ b/src/mobius/tasks/_vision_language.py
@@ -51,15 +51,20 @@ class Qwen3VLVisionLanguageTask(ModelTask):
         op = builder.op
 
         input_ids = builder.input(
-            "input_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len],
+            "input_ids",
+            dtype=ir.DataType.INT64,
+            shape=[batch, seq_len],
         )
         attention_mask = builder.input(
-            "attention_mask", dtype=ir.DataType.INT64,
+            "attention_mask",
+            dtype=ir.DataType.INT64,
             shape=[batch, "past_seq_len + seq_len"],
         )
         # MRoPE: 3D position IDs (temporal, height, width)
         position_ids = builder.input(
-            "position_ids", dtype=ir.DataType.INT64, shape=[3, batch, seq_len],
+            "position_ids",
+            dtype=ir.DataType.INT64,
+            shape=[3, batch, seq_len],
         )
         # Flattened image patches
         patch_size = config.vision.patch_size or 16 if config.vision else 16
@@ -67,12 +72,16 @@ class Qwen3VLVisionLanguageTask(ModelTask):
         in_channels = config.vision.in_channels if config.vision else 3
         pixel_dim = in_channels * temporal_patch_size * patch_size * patch_size
         pixel_values = builder.input(
-            "pixel_values", dtype=config.dtype, shape=[total_patches, pixel_dim],
+            "pixel_values",
+            dtype=config.dtype,
+            shape=[total_patches, pixel_dim],
         )
         # Image grid dimensions for position embedding interpolation
         num_images = ir.SymbolicDim("num_images")
         grid_thw = builder.input(
-            "grid_thw", dtype=ir.DataType.INT64, shape=[num_images, 3],
+            "grid_thw",
+            dtype=ir.DataType.INT64,
+            shape=[num_images, 3],
         )
 
         past_key_values = _make_kv_cache_inputs(

--- a/src/mobius/tasks/_vision_language.py
+++ b/src/mobius/tasks/_vision_language.py
@@ -47,49 +47,36 @@ class Qwen3VLVisionLanguageTask(ModelTask):
         past_seq_len = ir.SymbolicDim("past_sequence_len")
         total_patches = ir.SymbolicDim("total_patches")
 
-        input_ids = ir.Value(
-            name="input_ids",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
+        graph, builder = _make_graph()
+        op = builder.op
+
+        input_ids = builder.input(
+            "input_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len],
         )
-        attention_mask = ir.Value(
-            name="attention_mask",
-            shape=ir.Shape([batch, "past_seq_len + seq_len"]),
-            type=ir.TensorType(ir.DataType.INT64),
+        attention_mask = builder.input(
+            "attention_mask", dtype=ir.DataType.INT64,
+            shape=[batch, "past_seq_len + seq_len"],
         )
         # MRoPE: 3D position IDs (temporal, height, width)
-        position_ids = ir.Value(
-            name="position_ids",
-            shape=ir.Shape([3, batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
+        position_ids = builder.input(
+            "position_ids", dtype=ir.DataType.INT64, shape=[3, batch, seq_len],
         )
         # Flattened image patches
         patch_size = config.vision.patch_size or 16 if config.vision else 16
         temporal_patch_size = config.temporal_patch_size
         in_channels = config.vision.in_channels if config.vision else 3
         pixel_dim = in_channels * temporal_patch_size * patch_size * patch_size
-        pixel_values = ir.Value(
-            name="pixel_values",
-            shape=ir.Shape([total_patches, pixel_dim]),
-            type=ir.TensorType(config.dtype),
+        pixel_values = builder.input(
+            "pixel_values", dtype=config.dtype, shape=[total_patches, pixel_dim],
         )
         # Image grid dimensions for position embedding interpolation
         num_images = ir.SymbolicDim("num_images")
-        grid_thw = ir.Value(
-            name="grid_thw",
-            shape=ir.Shape([num_images, 3]),
-            type=ir.TensorType(ir.DataType.INT64),
+        grid_thw = builder.input(
+            "grid_thw", dtype=ir.DataType.INT64, shape=[num_images, 3],
         )
 
-        graph_inputs = [
-            input_ids,
-            attention_mask,
-            position_ids,
-            pixel_values,
-            grid_thw,
-        ]
-
-        kv_inputs, past_key_values = _make_kv_cache_inputs(
+        past_key_values = _make_kv_cache_inputs(
+            builder,
             config.num_hidden_layers,
             config.num_key_value_heads,
             config.head_dim,
@@ -97,10 +84,6 @@ class Qwen3VLVisionLanguageTask(ModelTask):
             batch,
             past_seq_len,
         )
-        graph_inputs.extend(kv_inputs)
-
-        graph, builder = _make_graph(graph_inputs)
-        op = builder.op
 
         logits, present_key_values = module(
             op,
@@ -112,8 +95,7 @@ class Qwen3VLVisionLanguageTask(ModelTask):
             past_key_values=past_key_values,
         )
 
-        logits.name = "logits"
-        graph.outputs.append(logits)
-        _register_kv_cache_outputs(graph, present_key_values)
+        builder.add_output(logits, "logits")
+        _register_kv_cache_outputs(builder, present_key_values)
 
         return ModelPackage({"model": _make_model(graph)}, config=config)

--- a/src/mobius/tasks/_vision_language_3model.py
+++ b/src/mobius/tasks/_vision_language_3model.py
@@ -82,17 +82,15 @@ class VisionLanguageTask(ModelTask):
         batch = ir.SymbolicDim("batch")
         image_size = (config.vision.image_size if config.vision else None) or 224
 
-        pixel_values = ir.Value(
-            name="pixel_values",
-            shape=ir.Shape([batch, 3, image_size, image_size]),
-            type=ir.TensorType(config.dtype),
+        graph, graph_builder = _make_graph(name="vision_encoder")
+        pixel_values = graph_builder.input(
+            "pixel_values",
+            dtype=config.dtype,
+            shape=[batch, 3, image_size, image_size],
         )
-
-        graph, graph_builder = _make_graph([pixel_values], name="vision_encoder")
         image_features = vision(graph_builder.op, pixel_values=pixel_values)
 
-        image_features.name = "image_features"
-        graph.outputs.append(image_features)
+        graph_builder.add_output(image_features, "image_features")
         return _make_model(graph)
 
 
@@ -135,28 +133,25 @@ class QwenVLTask(VisionLanguageTask):
         in_channels = config.vision.in_channels if config.vision else 3
         pixel_dim = in_channels * temporal_patch_size * patch_size * patch_size
 
-        pixel_values = ir.Value(
-            name="pixel_values",
-            shape=ir.Shape([total_patches, pixel_dim]),
-            type=ir.TensorType(config.dtype),
+        graph, graph_builder = _make_graph(name="vision_encoder")
+        pixel_values = graph_builder.input(
+            "pixel_values",
+            dtype=config.dtype,
+            shape=[total_patches, pixel_dim],
         )
-        image_grid_thw = ir.Value(
-            name="image_grid_thw",
-            shape=ir.Shape([num_images, 3]),
-            type=ir.TensorType(ir.DataType.INT64),
+        image_grid_thw = graph_builder.input(
+            "image_grid_thw",
+            dtype=ir.DataType.INT64,
+            shape=[num_images, 3],
         )
 
-        graph, graph_builder = _make_graph(
-            [pixel_values, image_grid_thw], name="vision_encoder"
-        )
         image_features = vision(
             graph_builder.op,
             pixel_values=pixel_values,
             image_grid_thw=image_grid_thw,
         )
 
-        image_features.name = "image_features"
-        graph.outputs.append(image_features)
+        graph_builder.add_output(image_features, "image_features")
         return _make_model(graph)
 
 
@@ -213,15 +208,12 @@ class PixtralVLTask(VisionLanguageTask):
         height = ir.SymbolicDim("height")
         width = ir.SymbolicDim("width")
 
-        pixel_values = ir.Value(
-            name="pixel_values",
-            shape=ir.Shape([batch, 3, height, width]),
-            type=ir.TensorType(config.dtype),
+        graph, graph_builder = _make_graph(name="vision_encoder")
+        pixel_values = graph_builder.input(
+            "pixel_values",
+            dtype=config.dtype,
+            shape=[batch, 3, height, width],
         )
-
-        graph_inputs = [pixel_values]
-
-        graph, graph_builder = _make_graph(graph_inputs, name="vision_encoder")
         op = graph_builder.op
 
         image_features = vision(
@@ -234,8 +226,7 @@ class PixtralVLTask(VisionLanguageTask):
         # vision encoder always processes one image at a time.
         image_features = op.Squeeze(image_features, [0])
 
-        image_features.name = "image_features"
-        graph.outputs.append(image_features)
+        graph_builder.add_output(image_features, "image_features")
 
         return _make_model(graph)
 
@@ -294,59 +285,48 @@ class MllamaVisionLanguageTask(VisionLanguageTask):
         cross_seq_len = ir.SymbolicDim("cross_sequence_len")
         cross_past_seq_len = ir.SymbolicDim("cross_past_seq_len")
 
-        inputs_embeds = ir.Value(
-            name="inputs_embeds",
-            shape=ir.Shape([batch, seq_len, config.hidden_size]),
-            type=ir.TensorType(config.dtype),
+        graph, graph_builder = _make_graph()
+        inputs_embeds = graph_builder.input(
+            "inputs_embeds",
+            dtype=config.dtype,
+            shape=[batch, seq_len, config.hidden_size],
         )
-        attention_mask = ir.Value(
-            name="attention_mask",
-            shape=ir.Shape([batch, "past_seq_len + seq_len"]),
-            type=ir.TensorType(ir.DataType.INT64),
+        attention_mask = graph_builder.input(
+            "attention_mask",
+            dtype=ir.DataType.INT64,
+            shape=[batch, "past_seq_len + seq_len"],
         )
-        position_ids = ir.Value(
-            name="position_ids",
-            shape=ir.Shape([batch, seq_len]),
-            type=ir.TensorType(ir.DataType.INT64),
+        position_ids = graph_builder.input(
+            "position_ids",
+            dtype=ir.DataType.INT64,
+            shape=[batch, seq_len],
         )
         # Vision features: full on prefill, empty (0-length) on decode
-        cross_attention_states = ir.Value(
-            name="cross_attention_states",
-            shape=ir.Shape([batch, cross_seq_len, config.hidden_size]),
-            type=ir.TensorType(config.dtype),
+        cross_attention_states = graph_builder.input(
+            "cross_attention_states",
+            dtype=config.dtype,
+            shape=[batch, cross_seq_len, config.hidden_size],
         )
-
-        graph_inputs = [
-            inputs_embeds,
-            attention_mask,
-            position_ids,
-            cross_attention_states,
-        ]
 
         # Per-layer KV cache with separate dims for self-attention
         # (past_seq_len) and cross-attention (cross_past_seq_len)
         cross_attention_layers = set(config.cross_attention_layers or [])
-        flat_kv: list[ir.Value] = []
         past_key_values: list[tuple[ir.Value, ir.Value]] = []
 
         for i in range(config.num_hidden_layers):
             psl = cross_past_seq_len if i in cross_attention_layers else past_seq_len
-            past_key = ir.Value(
-                name=f"past_key_values.{i}.key",
-                shape=ir.Shape([batch, config.num_key_value_heads, psl, config.head_dim]),
-                type=ir.TensorType(config.dtype),
+            past_key = graph_builder.input(
+                f"past_key_values.{i}.key",
+                dtype=config.dtype,
+                shape=[batch, config.num_key_value_heads, psl, config.head_dim],
             )
-            past_value = ir.Value(
-                name=f"past_key_values.{i}.value",
-                shape=ir.Shape([batch, config.num_key_value_heads, psl, config.head_dim]),
-                type=ir.TensorType(config.dtype),
+            past_value = graph_builder.input(
+                f"past_key_values.{i}.value",
+                dtype=config.dtype,
+                shape=[batch, config.num_key_value_heads, psl, config.head_dim],
             )
-            flat_kv.extend([past_key, past_value])
             past_key_values.append((past_key, past_value))
 
-        graph_inputs.extend(flat_kv)
-
-        graph, graph_builder = _make_graph(graph_inputs)
         op = graph_builder.op
 
         logits, present_key_values = decoder(
@@ -358,8 +338,7 @@ class MllamaVisionLanguageTask(VisionLanguageTask):
             past_key_values=past_key_values,
         )
 
-        logits.name = "logits"
-        graph.outputs.append(logits)
-        _register_kv_cache_outputs(graph, present_key_values)
+        graph_builder.add_output(logits, "logits")
+        _register_kv_cache_outputs(graph_builder, present_key_values)
 
         return _make_model(graph)

--- a/src/mobius/tasks/_vision_language_3model.py
+++ b/src/mobius/tasks/_vision_language_3model.py
@@ -82,15 +82,15 @@ class VisionLanguageTask(ModelTask):
         batch = ir.SymbolicDim("batch")
         image_size = (config.vision.image_size if config.vision else None) or 224
 
-        graph, graph_builder = _make_graph(name="vision_encoder")
-        pixel_values = graph_builder.input(
+        graph, builder = _make_graph(name="vision_encoder")
+        pixel_values = builder.input(
             "pixel_values",
             dtype=config.dtype,
             shape=[batch, 3, image_size, image_size],
         )
-        image_features = vision(graph_builder.op, pixel_values=pixel_values)
+        image_features = vision(builder.op, pixel_values=pixel_values)
 
-        graph_builder.add_output(image_features, "image_features")
+        builder.add_output(image_features, "image_features")
         return _make_model(graph)
 
 
@@ -133,25 +133,25 @@ class QwenVLTask(VisionLanguageTask):
         in_channels = config.vision.in_channels if config.vision else 3
         pixel_dim = in_channels * temporal_patch_size * patch_size * patch_size
 
-        graph, graph_builder = _make_graph(name="vision_encoder")
-        pixel_values = graph_builder.input(
+        graph, builder = _make_graph(name="vision_encoder")
+        pixel_values = builder.input(
             "pixel_values",
             dtype=config.dtype,
             shape=[total_patches, pixel_dim],
         )
-        image_grid_thw = graph_builder.input(
+        image_grid_thw = builder.input(
             "image_grid_thw",
             dtype=ir.DataType.INT64,
             shape=[num_images, 3],
         )
 
         image_features = vision(
-            graph_builder.op,
+            builder.op,
             pixel_values=pixel_values,
             image_grid_thw=image_grid_thw,
         )
 
-        graph_builder.add_output(image_features, "image_features")
+        builder.add_output(image_features, "image_features")
         return _make_model(graph)
 
 
@@ -208,13 +208,13 @@ class PixtralVLTask(VisionLanguageTask):
         height = ir.SymbolicDim("height")
         width = ir.SymbolicDim("width")
 
-        graph, graph_builder = _make_graph(name="vision_encoder")
-        pixel_values = graph_builder.input(
+        graph, builder = _make_graph(name="vision_encoder")
+        pixel_values = builder.input(
             "pixel_values",
             dtype=config.dtype,
             shape=[batch, 3, height, width],
         )
-        op = graph_builder.op
+        op = builder.op
 
         image_features = vision(
             op,
@@ -226,7 +226,7 @@ class PixtralVLTask(VisionLanguageTask):
         # vision encoder always processes one image at a time.
         image_features = op.Squeeze(image_features, [0])
 
-        graph_builder.add_output(image_features, "image_features")
+        builder.add_output(image_features, "image_features")
 
         return _make_model(graph)
 
@@ -285,24 +285,24 @@ class MllamaVisionLanguageTask(VisionLanguageTask):
         cross_seq_len = ir.SymbolicDim("cross_sequence_len")
         cross_past_seq_len = ir.SymbolicDim("cross_past_seq_len")
 
-        graph, graph_builder = _make_graph()
-        inputs_embeds = graph_builder.input(
+        graph, builder = _make_graph()
+        inputs_embeds = builder.input(
             "inputs_embeds",
             dtype=config.dtype,
             shape=[batch, seq_len, config.hidden_size],
         )
-        attention_mask = graph_builder.input(
+        attention_mask = builder.input(
             "attention_mask",
             dtype=ir.DataType.INT64,
             shape=[batch, "past_seq_len + seq_len"],
         )
-        position_ids = graph_builder.input(
+        position_ids = builder.input(
             "position_ids",
             dtype=ir.DataType.INT64,
             shape=[batch, seq_len],
         )
         # Vision features: full on prefill, empty (0-length) on decode
-        cross_attention_states = graph_builder.input(
+        cross_attention_states = builder.input(
             "cross_attention_states",
             dtype=config.dtype,
             shape=[batch, cross_seq_len, config.hidden_size],
@@ -315,19 +315,19 @@ class MllamaVisionLanguageTask(VisionLanguageTask):
 
         for i in range(config.num_hidden_layers):
             psl = cross_past_seq_len if i in cross_attention_layers else past_seq_len
-            past_key = graph_builder.input(
+            past_key = builder.input(
                 f"past_key_values.{i}.key",
                 dtype=config.dtype,
                 shape=[batch, config.num_key_value_heads, psl, config.head_dim],
             )
-            past_value = graph_builder.input(
+            past_value = builder.input(
                 f"past_key_values.{i}.value",
                 dtype=config.dtype,
                 shape=[batch, config.num_key_value_heads, psl, config.head_dim],
             )
             past_key_values.append((past_key, past_value))
 
-        op = graph_builder.op
+        op = builder.op
 
         logits, present_key_values = decoder(
             op,
@@ -338,7 +338,7 @@ class MllamaVisionLanguageTask(VisionLanguageTask):
             past_key_values=past_key_values,
         )
 
-        graph_builder.add_output(logits, "logits")
-        _register_kv_cache_outputs(graph_builder, present_key_values)
+        builder.add_output(logits, "logits")
+        _register_kv_cache_outputs(builder, present_key_values)
 
         return _make_model(graph)


### PR DESCRIPTION
## Summary

Migrate all 24 task files under `src/mobius/tasks/` to use the new onnxscript `GraphBuilder.input()` and `GraphBuilder.add_output()` APIs, replacing manual `ir.Value()` construction and `graph.outputs.append()` patterns.

## Changes

- **`_base.py`**: `_make_graph()` no longer takes an inputs parameter. Inputs are now created via `builder.input(name, dtype, shape)` which auto-registers them on the graph.
- **`_cache_utils.py`**: Cache helper functions (`_make_kv_cache_inputs`, `_make_hybrid_cache_inputs`, `_register_kv_cache_outputs`, `_register_hybrid_cache_outputs`) now take `builder` as first parameter. Return types simplified — flat input lists removed since `builder.input()` auto-registers.
- **All 24 task files**: `ir.Value(name=..., shape=ir.Shape(...), type=ir.TensorType(...))` → `builder.input(name, dtype=..., shape=[...])`; `value.name = name; graph.outputs.append(value)` → `builder.add_output(value, name)`
- **Import cleanup**: `GraphBuilder` imported from public `onnxscript` namespace instead of `onnxscript._internal.builder`
- **Naming consistency**: Standardized `builder` variable name across all files

## Impact

- 24 files changed, 571 insertions, 903 deletions (net -332 lines)
- Eliminates dual-bookkeeping anti-pattern (separate input list + graph registration)
- Input ordering structurally guaranteed by call order
- Output registration is atomic (single call vs two-step name+append)
- All 2662 tests pass

## Note

`op.call()` migration for module/function invocations is out of scope — `op.call()` currently only accepts `ir.Function`, not `nn.Module`, and treats kwargs as ONNX attributes rather than tensor inputs. This requires upstream onnxscript changes.