### PR TITLE
Add Gemma4 GGUF support with per-layer KV heads fix

### DIFF
--- a/src/mobius/_configs.py
+++ b/src/mobius/_configs.py
@@ -1741,6 +1741,10 @@ class Gemma4Config(VisionLanguageConfig):
       (1_000_000 for Gemma4).
     - ``global_partial_rotary_factor``: fraction of head_dim to rotate for
       global attention (0.25, so rotary_dim = 512 * 0.25 = 128).
+    - ``num_global_key_value_heads``: KV head count for full-attention layers
+      (4 for Gemma4 31B).  When ``None``, all layers use
+      ``num_key_value_heads``.  HF calls this ``num_global_key_value_heads``
+      and gates it behind ``attention_k_eq_v``.
     - ``hidden_size_per_layer_input``: per-layer input gating dimension
       (256 for Gemma4); 0 disables per-layer input entirely.
     - ``vocab_size_per_layer_input``: vocabulary size for per-layer embeddings.
@@ -1762,6 +1766,7 @@ class Gemma4Config(VisionLanguageConfig):
     global_head_dim: int | None = None
     global_rope_theta: float = 1_000_000.0
     global_partial_rotary_factor: float = 0.25
+    num_global_key_value_heads: int | None = None
     hidden_size_per_layer_input: int = 0
     vocab_size_per_layer_input: int = 0
     num_kv_shared_layers: int = 0
@@ -1818,11 +1823,18 @@ class Gemma4Config(VisionLanguageConfig):
             # Override with the correct sliding-attention theta (e.g. 10_000 for E2B/E4B).
             base = dataclasses.replace(base, rope_theta=float(sliding_rope["rope_theta"]))
 
+        # num_global_key_value_heads: only set when attention_k_eq_v is True
+        # (full-attention layers use fewer KV heads than sliding layers).
+        num_global_kv = None
+        if getattr(config, "attention_k_eq_v", False):
+            num_global_kv = getattr(config, "num_global_key_value_heads", None)
+
         return cls(
             **_shallow_fields(base),
             global_head_dim=getattr(config, "global_head_dim", None),
             global_rope_theta=float(full_rope.get("rope_theta", 1_000_000.0)),
             global_partial_rotary_factor=float(full_rope.get("partial_rotary_factor", 0.25)),
+            num_global_key_value_heads=num_global_kv,
             hidden_size_per_layer_input=int(
                 getattr(config, "hidden_size_per_layer_input", 0) or 0
             ),

--- a/src/mobius/integrations/gguf/_config_mapping.py
+++ b/src/mobius/integrations/gguf/_config_mapping.py
@@ -402,6 +402,13 @@ def _gemma4_postprocess(
     sliding_pattern = metadata.get(f"{arch}.attention.sliding_window_pattern")
     layer_types: list[str] | None = None
     if sliding_pattern is not None:
+        if len(sliding_pattern) != config.num_hidden_layers:
+            raise ValueError(
+                f"GGUF metadata length mismatch: "
+                f"attention.sliding_window_pattern has "
+                f"{len(sliding_pattern)} entries but "
+                f"num_hidden_layers is {config.num_hidden_layers}."
+            )
         layer_types = [
             "sliding_attention" if is_sliding else "full_attention"
             for is_sliding in sliding_pattern
@@ -430,6 +437,14 @@ def _gemma4_postprocess(
     num_global_key_value_heads: int | None = None
     raw_kv_heads = metadata.get(f"{arch}.attention.head_count_kv")
     if isinstance(raw_kv_heads, (list, np.ndarray)) and sliding_pattern is not None:
+        if len(raw_kv_heads) != len(sliding_pattern):
+            raise ValueError(
+                f"GGUF metadata length mismatch: "
+                f"attention.head_count_kv has {len(raw_kv_heads)} entries "
+                f"but attention.sliding_window_pattern has "
+                f"{len(sliding_pattern)} entries. "
+                f"Both must equal num_hidden_layers."
+            )
         full_kv_heads = {
             int(raw_kv_heads[i])
             for i, is_sliding in enumerate(sliding_pattern)

--- a/src/mobius/integrations/gguf/_config_mapping.py
+++ b/src/mobius/integrations/gguf/_config_mapping.py
@@ -357,6 +357,14 @@ def _gemma4_postprocess(
     global_head_dim = metadata.get(f"{arch}.attention.key_length")
     if swa_head_dim is not None:
         config = dataclasses.replace(config, head_dim=int(swa_head_dim))
+    elif global_head_dim is not None:
+        logger.warning(
+            "GGUF file missing non-standard key '%s.attention.key_length_swa'. "
+            "Using global head_dim (%d) for sliding-window layers — "
+            "this may be incorrect for Gemma4.",
+            arch,
+            int(global_head_dim),
+        )
 
     # --- Dual RoPE theta ---
     # Base extractor sets rope_theta from rope.freq_base (global, 1M).
@@ -365,6 +373,14 @@ def _gemma4_postprocess(
     global_rope_theta = metadata.get(f"{arch}.rope.freq_base")
     if swa_rope_theta is not None:
         config = dataclasses.replace(config, rope_theta=float(swa_rope_theta))
+    elif global_rope_theta is not None:
+        logger.warning(
+            "GGUF file missing non-standard key '%s.rope.freq_base_swa'. "
+            "Using global rope_theta (%.1f) for sliding-window layers — "
+            "this may be incorrect for Gemma4.",
+            arch,
+            float(global_rope_theta),
+        )
 
     # --- Partial rotary factor ---
     # Global layers use partial rotation: rotary_dim / global_head_dim.
@@ -372,6 +388,8 @@ def _gemma4_postprocess(
     # but the actual HF partial_rotary_factor is 0.25, meaning only 128
     # of 512 dims are rotated.  This isn't directly in GGUF metadata,
     # so use the known Gemma4 default.
+    # Source: HF Gemma4Config.global_partial_rotary_factor default value
+    # https://github.com/huggingface/transformers/blob/main/src/transformers/models/gemma4/configuration_gemma4.py
     global_partial_rotary_factor = 0.25
 
     # SWA layers use full rotation (partial_rotary_factor = 1.0), which

--- a/src/mobius/integrations/gguf/_config_mapping.py
+++ b/src/mobius/integrations/gguf/_config_mapping.py
@@ -22,10 +22,13 @@ from __future__ import annotations
 
 __all__ = ["gguf_to_config"]
 
+import dataclasses
 import logging
 from typing import Any
 
-from mobius._configs import ArchitectureConfig
+import numpy as np
+
+from mobius._configs import ArchitectureConfig, Gemma4Config
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +47,7 @@ GGUF_ARCH_TO_MODEL_TYPE: dict[str, str] = {
     "gemma3": "gemma3_text",
     # Gemma 4 GGUF contains the text backbone only — no vision or audio encoder.
     # Vision and audio encoders are exported separately from the HuggingFace checkpoint.
-    "gemma4": "gemma4",
+    "gemma4": "gemma4_text",
     "phi3": "phi3",
     "falcon": "falcon",
     "gpt2": "gpt2",
@@ -209,8 +212,14 @@ def gguf_to_config(
     elif head_dim is None:
         head_dim = hidden_size // num_attention_heads
 
-    # Handle num_key_value_heads defaulting to num_attention_heads
+    # Handle num_key_value_heads defaulting to num_attention_heads.
+    # Gemma4 GGUF stores per-layer KV head counts as an array; use the
+    # most common (mode) value as the scalar config value.
     num_kv_heads = hf_fields.get("num_key_value_heads", num_attention_heads)
+    if isinstance(num_kv_heads, (list, np.ndarray)):
+        # Per-layer array → pick the majority value (sliding layers dominate)
+        values = list(num_kv_heads)
+        num_kv_heads = max(set(values), key=values.count)
 
     # Map activation function
     hidden_act = hf_fields.get("hidden_act")
@@ -287,6 +296,14 @@ def gguf_to_config(
     config._gguf_model_type = model_type
     config.model_type = model_type
 
+    # Apply architecture-specific postprocessing to produce the correct
+    # config subclass (e.g. Gemma4Config instead of plain ArchitectureConfig).
+    postprocessor = _CONFIG_POSTPROCESSORS.get(model_type)
+    if postprocessor is not None:
+        config = postprocessor(config, metadata)
+        config._gguf_model_type = model_type
+        config.model_type = model_type
+
     logger.info(
         "Extracted config from GGUF: arch=%s, model_type=%s, "
         "hidden=%d, layers=%d, heads=%d, vocab=%d",
@@ -299,6 +316,125 @@ def gguf_to_config(
     )
 
     return config
+
+
+def _gemma4_postprocess(
+    config: ArchitectureConfig,
+    metadata: dict[str, Any],
+) -> Gemma4Config:
+    """Convert a base config to Gemma4Config with architecture-specific fields.
+
+    Gemma4 GGUF metadata uses dual-regime keys (global/full-attention vs
+    SWA/sliding-window) for head_dim, RoPE theta, and RoPE rotary count.
+    The base extractor picks up the global values; this postprocessor
+    corrects them for the sliding-window default and stores the global
+    values in Gemma4Config's dedicated fields.
+
+    GGUF key mapping (``gemma4.`` prefix omitted for readability):
+
+    =================================== ======================================
+    GGUF key                            Gemma4Config / ArchitectureConfig field
+    =================================== ======================================
+    attention.key_length                global_head_dim
+    attention.key_length_swa            head_dim (sliding-window, default)
+    rope.freq_base                      global_rope_theta
+    rope.freq_base_swa                  rope_theta (sliding-window, default)
+    rope.dimension_count                (global rotary dim → partial_rotary_factor)
+    rope.dimension_count_swa            (local rotary dim — full rotation)
+    attention.sliding_window            sliding_window
+    attention.sliding_window_pattern    layer_types (bool[] → str[])
+    final_logit_softcapping             final_logit_softcapping
+    attention.shared_kv_layers          num_kv_shared_layers
+    embedding_length_per_layer_input    hidden_size_per_layer_input
+    =================================== ======================================
+    """
+    arch = "gemma4"
+
+    # --- Dual head_dim ---
+    # Base extractor sets head_dim from attention.key_length (global, 512).
+    # Override with sliding-window head_dim (256) as the default.
+    swa_head_dim = metadata.get(f"{arch}.attention.key_length_swa")
+    global_head_dim = metadata.get(f"{arch}.attention.key_length")
+    if swa_head_dim is not None:
+        config = dataclasses.replace(config, head_dim=int(swa_head_dim))
+
+    # --- Dual RoPE theta ---
+    # Base extractor sets rope_theta from rope.freq_base (global, 1M).
+    # Override with sliding-window theta (10K) as the default.
+    swa_rope_theta = metadata.get(f"{arch}.rope.freq_base_swa")
+    global_rope_theta = metadata.get(f"{arch}.rope.freq_base")
+    if swa_rope_theta is not None:
+        config = dataclasses.replace(config, rope_theta=float(swa_rope_theta))
+
+    # --- Partial rotary factor ---
+    # Global layers use partial rotation: rotary_dim / global_head_dim.
+    # GGUF provides rope.dimension_count (global rotary dim, e.g. 512)
+    # but the actual HF partial_rotary_factor is 0.25, meaning only 128
+    # of 512 dims are rotated.  This isn't directly in GGUF metadata,
+    # so use the known Gemma4 default.
+    global_partial_rotary_factor = 0.25
+
+    # SWA layers use full rotation (partial_rotary_factor = 1.0), which
+    # is already the base config default.  Reset the base partial_rotary_factor
+    # to 1.0 since the base extractor may have derived it incorrectly.
+    config = dataclasses.replace(config, partial_rotary_factor=1.0)
+
+    # --- Layer types from sliding_window_pattern ---
+    # GGUF stores a bool array: True = sliding, False = full_attention
+    sliding_pattern = metadata.get(f"{arch}.attention.sliding_window_pattern")
+    layer_types: list[str] | None = None
+    if sliding_pattern is not None:
+        layer_types = [
+            "sliding_attention" if is_sliding else "full_attention"
+            for is_sliding in sliding_pattern
+        ]
+    config = dataclasses.replace(config, layer_types=layer_types)
+
+    # --- Sliding window size ---
+    sliding_window = metadata.get(f"{arch}.attention.sliding_window")
+    if sliding_window is not None:
+        config = dataclasses.replace(config, sliding_window=int(sliding_window))
+
+    # --- Softcapping ---
+    final_logit_softcapping = metadata.get(f"{arch}.final_logit_softcapping")
+    attn_logit_softcapping = metadata.get(f"{arch}.attention.logit_softcapping")
+
+    # --- KV sharing ---
+    num_kv_shared_layers = metadata.get(f"{arch}.attention.shared_kv_layers")
+
+    # --- Per-layer input gating ---
+    hidden_size_per_layer_input = metadata.get(f"{arch}.embedding_length_per_layer_input")
+
+    return Gemma4Config(
+        # Inherit all base ArchitectureConfig fields
+        **{f.name: getattr(config, f.name) for f in dataclasses.fields(ArchitectureConfig)},
+        # Gemma4-specific fields
+        global_head_dim=int(global_head_dim) if global_head_dim is not None else None,
+        global_rope_theta=float(global_rope_theta)
+        if global_rope_theta is not None
+        else 1_000_000.0,
+        global_partial_rotary_factor=global_partial_rotary_factor,
+        final_logit_softcapping=float(final_logit_softcapping or 0.0),
+        attn_logit_softcapping=float(attn_logit_softcapping or 0.0),
+        num_kv_shared_layers=int(num_kv_shared_layers)
+        if num_kv_shared_layers is not None
+        else 0,
+        hidden_size_per_layer_input=int(hidden_size_per_layer_input)
+        if hidden_size_per_layer_input is not None
+        else 0,
+        # Fields without GGUF metadata — use Gemma4Config defaults
+        vocab_size_per_layer_input=config.vocab_size
+        if (hidden_size_per_layer_input or 0) > 0
+        else 0,
+    )
+
+
+# Architecture-specific config postprocessors.
+# Each takes a base ArchitectureConfig + raw metadata and returns
+# an architecture-specific config subclass.
+_CONFIG_POSTPROCESSORS: dict[str, Any] = {
+    "gemma4_text": _gemma4_postprocess,
+}
 
 
 def _default_activation(model_type: str) -> str:

--- a/src/mobius/integrations/gguf/_config_mapping.py
+++ b/src/mobius/integrations/gguf/_config_mapping.py
@@ -405,6 +405,23 @@ def _gemma4_postprocess(
     # --- Per-layer input gating ---
     hidden_size_per_layer_input = metadata.get(f"{arch}.embedding_length_per_layer_input")
 
+    # --- Per-layer KV heads (num_global_key_value_heads) ---
+    # GGUF stores per-layer KV head counts as an array.  When full-attention
+    # layers use fewer KV heads than sliding layers, extract the minority
+    # value as num_global_key_value_heads.
+    num_global_key_value_heads: int | None = None
+    raw_kv_heads = metadata.get(f"{arch}.attention.head_count_kv")
+    if isinstance(raw_kv_heads, (list, np.ndarray)) and sliding_pattern is not None:
+        full_kv_heads = {
+            int(raw_kv_heads[i])
+            for i, is_sliding in enumerate(sliding_pattern)
+            if not is_sliding
+        }
+        if len(full_kv_heads) == 1:
+            global_kv = full_kv_heads.pop()
+            if global_kv != config.num_key_value_heads:
+                num_global_key_value_heads = global_kv
+
     return Gemma4Config(
         # Inherit all base ArchitectureConfig fields
         **{f.name: getattr(config, f.name) for f in dataclasses.fields(ArchitectureConfig)},
@@ -414,6 +431,7 @@ def _gemma4_postprocess(
         if global_rope_theta is not None
         else 1_000_000.0,
         global_partial_rotary_factor=global_partial_rotary_factor,
+        num_global_key_value_heads=num_global_key_value_heads,
         final_logit_softcapping=float(final_logit_softcapping or 0.0),
         attn_logit_softcapping=float(attn_logit_softcapping or 0.0),
         num_kv_shared_layers=int(num_kv_shared_layers)

--- a/src/mobius/integrations/gguf/_reader_test.py
+++ b/src/mobius/integrations/gguf/_reader_test.py
@@ -582,6 +582,24 @@ class TestGemma4ConfigMapping:
         assert config.hidden_size_per_layer_input == 16
         assert config.vocab_size_per_layer_input == 256  # = vocab_size
 
+    def test_gemma4_global_kv_heads_from_mixed_array(self, tmp_path: Path):
+        """When GGUF has mixed per-layer KV heads, extract num_global_key_value_heads."""
+        path = tmp_path / "gemma4_mixed_kv.gguf"
+        _write_gemma4_test_gguf(path, num_kv_heads_full=1)
+        model = GGUFModel(path)
+        config = gguf_to_config(model)
+        # Sliding layers have 2 KV heads, full layers have 1
+        assert config.num_key_value_heads == 2  # majority (sliding)
+        assert config.num_global_key_value_heads == 1  # minority (full)
+
+    def test_gemma4_uniform_kv_heads_no_global(self, gemma4_gguf: Path):
+        """When all layers have the same KV heads, num_global_key_value_heads is None."""
+        model = GGUFModel(gemma4_gguf)
+        config = gguf_to_config(model)
+        # Default fixture has uniform KV heads (2 for all layers)
+        assert config.num_key_value_heads == 2
+        assert config.num_global_key_value_heads is None
+
 
 class TestBuildFromGguf:
     """Tests for the build_from_gguf pipeline (integration)."""

--- a/src/mobius/integrations/gguf/_reader_test.py
+++ b/src/mobius/integrations/gguf/_reader_test.py
@@ -142,6 +142,168 @@ def tied_gguf(tmp_path: Path) -> Path:
     return path
 
 
+def _write_gemma4_test_gguf(
+    path: Path,
+    hidden_size: int = 64,
+    num_layers: int = 6,
+    num_heads: int = 4,
+    num_kv_heads_sliding: int = 2,
+    num_kv_heads_full: int = 2,
+    intermediate_size: int = 128,
+    vocab_size: int = 256,
+    context_length: int = 512,
+    sliding_window: int = 128,
+    global_head_dim: int = 32,
+    swa_head_dim: int = 16,
+    global_rope_theta: float = 1_000_000.0,
+    swa_rope_theta: float = 10_000.0,
+    final_logit_softcapping: float = 30.0,
+    num_kv_shared_layers: int = 0,
+    hidden_size_per_layer_input: int = 0,
+) -> None:
+    """Write a minimal Gemma4 GGUF file for testing.
+
+    Creates a syntactically valid GGUF with Gemma4-specific metadata:
+    dual head_dim, dual RoPE theta, sliding_window_pattern, softcapping,
+    and per-layer KV head counts.
+    """
+    from gguf import GGUFWriter
+
+    writer = GGUFWriter(str(path), "gemma4")
+
+    # Core metadata
+    writer.add_context_length(context_length)
+    writer.add_embedding_length(hidden_size)
+    writer.add_feed_forward_length(intermediate_size)
+    writer.add_block_count(num_layers)
+    writer.add_head_count(num_heads)
+    writer.add_vocab_size(vocab_size)
+
+    # Per-layer KV head counts: sliding layers get more, full layers get fewer.
+    # Pattern: every 3rd layer (0-indexed: 2, 5, ...) is full_attention.
+    sliding_pattern = [(i + 1) % 3 != 0 for i in range(num_layers)]
+    kv_heads_per_layer = [
+        num_kv_heads_sliding if is_sliding else num_kv_heads_full
+        for is_sliding in sliding_pattern
+    ]
+    writer.add_head_count_kv(kv_heads_per_layer)
+    writer.add_sliding_window_pattern(sliding_pattern)
+
+    # Dual head_dim
+    writer.add_key_length(global_head_dim)
+    # key_length_swa is a non-standard extension — write it as a raw key
+    writer.add_uint32("gemma4.attention.key_length_swa", swa_head_dim)
+
+    # Dual RoPE theta
+    writer.add_rope_freq_base(global_rope_theta)
+    writer.add_rope_freq_base_swa(swa_rope_theta)
+    writer.add_rope_dimension_count(global_head_dim)
+
+    # Gemma4-specific metadata
+    writer.add_sliding_window(sliding_window)
+    writer.add_final_logit_softcapping(final_logit_softcapping)
+    writer.add_layer_norm_rms_eps(1e-6)
+    writer.add_shared_kv_layers(num_kv_shared_layers)
+    writer.add_embedding_length_per_layer_input(hidden_size_per_layer_input)
+
+    # Tensors
+    # token_embd.weight: (vocab_size, hidden_size)
+    writer.add_tensor(
+        "token_embd.weight",
+        np.random.randn(vocab_size, hidden_size).astype(np.float32),
+    )
+
+    for i in range(num_layers):
+        is_sliding = sliding_pattern[i]
+        head_dim = swa_head_dim if is_sliding else global_head_dim
+        kv_heads = num_kv_heads_sliding if is_sliding else num_kv_heads_full
+
+        writer.add_tensor(
+            f"blk.{i}.attn_q.weight",
+            np.random.randn(num_heads * head_dim, hidden_size).astype(np.float32),
+        )
+        writer.add_tensor(
+            f"blk.{i}.attn_k.weight",
+            np.random.randn(kv_heads * head_dim, hidden_size).astype(np.float32),
+        )
+        writer.add_tensor(
+            f"blk.{i}.attn_v.weight",
+            np.random.randn(kv_heads * head_dim, hidden_size).astype(np.float32),
+        )
+        writer.add_tensor(
+            f"blk.{i}.attn_output.weight",
+            np.random.randn(hidden_size, num_heads * head_dim).astype(np.float32),
+        )
+        # Q/K norms (per-head)
+        writer.add_tensor(
+            f"blk.{i}.attn_q_norm.weight",
+            np.ones(head_dim, dtype=np.float32),
+        )
+        writer.add_tensor(
+            f"blk.{i}.attn_k_norm.weight",
+            np.ones(head_dim, dtype=np.float32),
+        )
+        # MLP weights
+        writer.add_tensor(
+            f"blk.{i}.ffn_gate.weight",
+            np.random.randn(intermediate_size, hidden_size).astype(np.float32),
+        )
+        writer.add_tensor(
+            f"blk.{i}.ffn_up.weight",
+            np.random.randn(intermediate_size, hidden_size).astype(np.float32),
+        )
+        writer.add_tensor(
+            f"blk.{i}.ffn_down.weight",
+            np.random.randn(hidden_size, intermediate_size).astype(np.float32),
+        )
+        # Norm weights (Gemma4 has 4 norms per layer)
+        writer.add_tensor(
+            f"blk.{i}.attn_norm.weight",
+            np.ones(hidden_size, dtype=np.float32),
+        )
+        writer.add_tensor(
+            f"blk.{i}.post_attention_norm.weight",
+            np.ones(hidden_size, dtype=np.float32),
+        )
+        writer.add_tensor(
+            f"blk.{i}.ffn_norm.weight",
+            np.ones(hidden_size, dtype=np.float32),
+        )
+        writer.add_tensor(
+            f"blk.{i}.post_ffw_norm.weight",
+            np.ones(hidden_size, dtype=np.float32),
+        )
+        # Layer scalar
+        writer.add_tensor(
+            f"blk.{i}.layer_output_scale.weight",
+            np.ones(1, dtype=np.float32),
+        )
+
+    # Output norm
+    writer.add_tensor(
+        "output_norm.weight",
+        np.ones(hidden_size, dtype=np.float32),
+    )
+    # Output (lm_head)
+    writer.add_tensor(
+        "output.weight",
+        np.random.randn(vocab_size, hidden_size).astype(np.float32),
+    )
+
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_tensors_to_file()
+    writer.close()
+
+
+@pytest.fixture
+def gemma4_gguf(tmp_path: Path) -> Path:
+    """Create a minimal Gemma4 GGUF file for testing."""
+    path = tmp_path / "test_gemma4.gguf"
+    _write_gemma4_test_gguf(path)
+    return path
+
+
 class TestGGUFModelReader:
     """Tests for GGUFModel reading and metadata extraction."""
 
@@ -318,6 +480,109 @@ class TestConfigMapping:
             gguf_to_config(model)
 
 
+class TestGemma4ConfigMapping:
+    """Tests for Gemma4-specific GGUF → Gemma4Config extraction."""
+
+    def test_gemma4_maps_to_text_model_type(self):
+        assert GGUF_ARCH_TO_MODEL_TYPE["gemma4"] == "gemma4_text"
+
+    def test_gemma4_returns_gemma4_config(self, gemma4_gguf: Path):
+        from mobius._configs import Gemma4Config
+
+        model = GGUFModel(gemma4_gguf)
+        config = gguf_to_config(model)
+        assert isinstance(config, Gemma4Config)
+        assert config.model_type == "gemma4_text"
+
+    def test_gemma4_dual_head_dim(self, gemma4_gguf: Path):
+        """head_dim should be the SWA value; global_head_dim the full value."""
+        model = GGUFModel(gemma4_gguf)
+        config = gguf_to_config(model)
+        assert config.head_dim == 16  # SWA head_dim
+        assert config.global_head_dim == 32  # global head_dim
+
+    def test_gemma4_dual_rope_theta(self, gemma4_gguf: Path):
+        """rope_theta should be the SWA value; global_rope_theta the full value."""
+        model = GGUFModel(gemma4_gguf)
+        config = gguf_to_config(model)
+        assert config.rope_theta == pytest.approx(10_000.0)  # SWA
+        assert config.global_rope_theta == pytest.approx(1_000_000.0)  # global
+
+    def test_gemma4_layer_types(self, gemma4_gguf: Path):
+        """sliding_window_pattern bool[] → layer_types str[]."""
+        model = GGUFModel(gemma4_gguf)
+        config = gguf_to_config(model)
+        # 6 layers, every 3rd (idx 2, 5) is full_attention
+        assert config.layer_types == [
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+        ]
+
+    def test_gemma4_sliding_window(self, gemma4_gguf: Path):
+        model = GGUFModel(gemma4_gguf)
+        config = gguf_to_config(model)
+        assert config.sliding_window == 128
+
+    def test_gemma4_softcapping(self, gemma4_gguf: Path):
+        model = GGUFModel(gemma4_gguf)
+        config = gguf_to_config(model)
+        assert config.final_logit_softcapping == pytest.approx(30.0)
+        # attn_logit_softcapping not set in test fixture → defaults to 0.0
+        assert config.attn_logit_softcapping == pytest.approx(0.0)
+
+    def test_gemma4_kv_shared_layers(self, gemma4_gguf: Path):
+        model = GGUFModel(gemma4_gguf)
+        config = gguf_to_config(model)
+        assert config.num_kv_shared_layers == 0
+
+    def test_gemma4_per_layer_input(self, gemma4_gguf: Path):
+        model = GGUFModel(gemma4_gguf)
+        config = gguf_to_config(model)
+        # hidden_size_per_layer_input=0 → vocab_size_per_layer_input=0
+        assert config.hidden_size_per_layer_input == 0
+        assert config.vocab_size_per_layer_input == 0
+
+    def test_gemma4_per_layer_kv_heads_uses_majority(self, tmp_path: Path):
+        """Per-layer KV head array should collapse to the majority value."""
+        path = tmp_path / "gemma4_mixed_kv.gguf"
+        _write_gemma4_test_gguf(path, num_kv_heads_full=1)
+        model = GGUFModel(path)
+        config = gguf_to_config(model)
+        # 4 sliding layers with 2 kv_heads, 2 full layers with 1 → majority is 2
+        assert config.num_key_value_heads == 2
+
+    def test_gemma4_partial_rotary_factor(self, gemma4_gguf: Path):
+        """Base partial_rotary_factor should be 1.0 (full rotation for SWA)."""
+        model = GGUFModel(gemma4_gguf)
+        config = gguf_to_config(model)
+        assert config.partial_rotary_factor == pytest.approx(1.0)
+        assert config.global_partial_rotary_factor == pytest.approx(0.25)
+
+    def test_gemma4_basic_fields(self, gemma4_gguf: Path):
+        """Verify basic fields are correctly extracted."""
+        model = GGUFModel(gemma4_gguf)
+        config = gguf_to_config(model)
+        assert config.hidden_size == 64
+        assert config.intermediate_size == 128
+        assert config.num_hidden_layers == 6
+        assert config.num_attention_heads == 4
+        assert config.vocab_size == 256
+        assert config.rms_norm_eps == pytest.approx(1e-6)
+
+    def test_gemma4_per_layer_input_enables_vocab(self, tmp_path: Path):
+        """When hidden_size_per_layer_input > 0, vocab_size_per_layer_input = vocab_size."""
+        path = tmp_path / "gemma4_pli.gguf"
+        _write_gemma4_test_gguf(path, hidden_size_per_layer_input=16)
+        model = GGUFModel(path)
+        config = gguf_to_config(model)
+        assert config.hidden_size_per_layer_input == 16
+        assert config.vocab_size_per_layer_input == 256  # = vocab_size
+
+
 class TestBuildFromGguf:
     """Tests for the build_from_gguf pipeline (integration)."""
 
@@ -344,5 +609,14 @@ class TestBuildFromGguf:
         pkg = build_from_gguf(llama_gguf)
         assert "model" in pkg
         # Check the model has a graph
+        model = pkg["model"]
+        assert model.graph is not None
+
+    def test_build_gemma4_from_gguf(self, gemma4_gguf: Path):
+        """Build a Gemma4 text model from GGUF and verify the graph."""
+        from mobius.integrations.gguf import build_from_gguf
+
+        pkg = build_from_gguf(gemma4_gguf)
+        assert "model" in pkg
         model = pkg["model"]
         assert model.graph is not None

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -591,9 +591,17 @@ class Gemma4TextAttention(nn.Module):
     ):
         super().__init__()
         self.num_attention_heads = config.num_attention_heads
-        self.num_key_value_heads = config.num_key_value_heads
         self.head_dim = head_dim
         self.scaling = 1.0
+
+        # Full-attention layers may use fewer KV heads than sliding layers
+        # (HF: attention_k_eq_v + num_global_key_value_heads).
+        layer_type = layer_types[layer_idx]
+        is_full = layer_type == "full_attention"
+        if is_full and config.num_global_key_value_heads is not None:
+            self.num_key_value_heads = config.num_global_key_value_heads
+        else:
+            self.num_key_value_heads = config.num_key_value_heads
         # attn_logit_softcapping maps directly to the ONNX Attention op's
         # native ``softcap`` attribute (opset 24). No manual Tanh/scale ops needed.
         self.softcap = config.attn_logit_softcapping
@@ -633,10 +641,10 @@ class Gemma4TextAttention(nn.Module):
         # KV-shared layers borrow K,V — no projections needed
         if not self.is_kv_shared_layer:
             self.k_proj = Linear(
-                config.hidden_size, config.num_key_value_heads * head_dim, bias=False
+                config.hidden_size, self.num_key_value_heads * head_dim, bias=False
             )
             self.v_proj = Linear(
-                config.hidden_size, config.num_key_value_heads * head_dim, bias=False
+                config.hidden_size, self.num_key_value_heads * head_dim, bias=False
             )
             self.k_norm = RMSNorm(head_dim, eps=config.rms_norm_eps)
 

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -925,6 +925,11 @@ class Gemma4DecoderLayer(nn.Module):
     def __init__(self, config: Gemma4Config, layer_idx: int):
         super().__init__()
         layer_types = config.layer_types or ["sliding_attention"] * config.num_hidden_layers
+        if len(layer_types) != config.num_hidden_layers:
+            raise ValueError(
+                f"Gemma4Config.layer_types length ({len(layer_types)}) "
+                f"must match num_hidden_layers ({config.num_hidden_layers})"
+            )
         first_kv_shared = config.num_hidden_layers - config.num_kv_shared_layers
         layer_type = layer_types[layer_idx]
         is_full = layer_type == "full_attention"

--- a/src/mobius/tasks/_gemma4.py
+++ b/src/mobius/tasks/_gemma4.py
@@ -73,7 +73,11 @@ def _make_gemma4_kv_cache_inputs(
     for i in range(num_kv_layers):
         layer_type = layer_types[i] if i < len(layer_types) else "sliding_attention"
         hd = global_head_dim if layer_type == "full_attention" else local_head_dim
-        kv_heads = config.num_key_value_heads
+        kv_heads = (
+            config.num_global_key_value_heads
+            if layer_type == "full_attention" and config.num_global_key_value_heads is not None
+            else config.num_key_value_heads
+        )
         past_key = builder.input(
             f"past_key_values.{i}.key",
             dtype=config.dtype,


### PR DESCRIPTION
## Summary

Add GGUF support for Gemma4 (text-only) and fix a pre-existing bug where full-attention layers used wrong KV head counts.

## Changes

### 1. GGUF model_type mapping fix (1-line)
- `gemma4` → `gemma4_text` in `GGUF_ARCH_TO_MODEL_TYPE` — GGUF only has text weights, not multimodal. Follows the gemma3 → gemma3_text pattern.

### 2. Gemma4 GGUF config extraction
- Added `_gemma4_postprocess()` in `_config_mapping.py` — extracts dual head_dim, dual RoPE theta, layer_types, sliding_window, softcapping, KV sharing, and per-layer-input gating from GGUF metadata.
- Handles non-standard unsloth SWA keys (`key_length_swa`, `freq_base_swa`) with warnings when missing.
- Extracts `num_global_key_value_heads` from per-layer KV head arrays.

### 3. Per-layer KV heads bug fix
- **Bug**: Gemma4 full-attention layers used `num_key_value_heads=16` (sliding) instead of `num_global_key_value_heads=4` (full-attention).
- **Fix**: Updated `Gemma4TextAttention`, `Gemma4Config`, `Gemma4TextCausalLMTask` KV cache, and GGUF config extraction.

### 4. Tests
- 15 new unit tests for Gemma4 GGUF config extraction (synthetic GGUF writer)
- 1 e2e test for `build_from_gguf()` with synthetic GGUF
- All existing tests pass (2678 passed)

## Verified
- Real GGUF build: `unsloth/gemma-4-31B-it-UD-IQ2_XXS.gguf` → 833 tensors, 1962 nodes, SUCCESS
- `build_from_gguf()` correctly produces single text-only model (not multimodal)
- Config extraction matches HF config exactly