### PR TITLE
Fix Gemma4 weight mapping for 26b MoE and 31b alternative attention

### DIFF
--- a/src/mobius/_configs.py
+++ b/src/mobius/_configs.py
@@ -1774,6 +1774,7 @@ class Gemma4Config(VisionLanguageConfig):
     final_logit_softcapping: float = 0.0
     attn_logit_softcapping: float = 0.0
     enable_moe_block: bool = False
+    attention_k_eq_v: bool = False
     boa_token_id: int | None = None
 
     @classmethod
@@ -1846,6 +1847,7 @@ class Gemma4Config(VisionLanguageConfig):
             final_logit_softcapping=(getattr(config, "final_logit_softcapping", 0.0) or 0.0),
             attn_logit_softcapping=(getattr(config, "attn_logit_softcapping", 0.0) or 0.0),
             enable_moe_block=getattr(config, "enable_moe_block", False),
+            attention_k_eq_v=getattr(config, "attention_k_eq_v", False),
             boa_token_id=getattr(parent_config, "boa_token_id", None),
         )
 

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -1474,8 +1474,7 @@ class Gemma4TextModel(nn.Module):
         query_input = input_ids if input_ids is not None else hidden_states
         fallback_bias_dict: dict[str, ir.Value | None] = {}
         need_fallback = not use_gqa or any(
-            layer.self_attn.is_kv_shared_layer or layer.self_attn.head_dim > 256
-            for layer in self.layers
+            layer.self_attn.is_kv_shared_layer for layer in self.layers
         )
         if need_fallback:
             if use_gqa:
@@ -1550,11 +1549,9 @@ class Gemma4TextModel(nn.Module):
             per_layer_input = per_layer_inputs[i] if per_layer_inputs is not None else None
 
             # Per-layer decision: use GQA for non-shared layers when
-            # available, fall back to standard Attention for KV-shared layers
-            # and layers where head_dim exceeds CUDA GQA MAX_HEAD_SIZE (256).
+            # available, fall back to standard Attention for KV-shared layers.
             is_shared = layer.self_attn.is_kv_shared_layer
-            gqa_head_dim_ok = layer.self_attn.head_dim <= 256
-            if use_gqa and not is_shared and gqa_head_dim_ok:
+            if use_gqa and not is_shared:
                 attn_bias = gqa_ctx_dict[layer_type]
                 pos_emb = None
             else:

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -593,15 +593,6 @@ class Gemma4TextAttention(nn.Module):
         self.num_attention_heads = config.num_attention_heads
         self.head_dim = head_dim
         self.scaling = 1.0
-
-        # Full-attention layers may use fewer KV heads than sliding layers
-        # (HF: attention_k_eq_v + num_global_key_value_heads).
-        layer_type = layer_types[layer_idx]
-        is_full = layer_type == "full_attention"
-        if is_full and config.num_global_key_value_heads is not None:
-            self.num_key_value_heads = config.num_global_key_value_heads
-        else:
-            self.num_key_value_heads = config.num_key_value_heads
         # attn_logit_softcapping maps directly to the ONNX Attention op's
         # native ``softcap`` attribute (opset 24). No manual Tanh/scale ops needed.
         self.softcap = config.attn_logit_softcapping
@@ -609,6 +600,18 @@ class Gemma4TextAttention(nn.Module):
         self.rotary_embedding_dim = rotary_embedding_dim
         self._rope_interleave = config.rope_interleave
         self.layer_idx = layer_idx
+
+        # Alternative attention: full_attention layers with k_eq_v share V=K
+        # (no separate v_proj). Uses fewer KV heads (num_global_key_value_heads).
+        is_sliding = layer_types[layer_idx] == "sliding_attention"
+        self._use_alternative_attention = (
+            getattr(config, "attention_k_eq_v", False) and not is_sliding
+        )
+        self.num_key_value_heads = (
+            (config.num_global_key_value_heads or config.num_key_value_heads)
+            if self._use_alternative_attention
+            else config.num_key_value_heads
+        )
 
         # KV sharing: layers >= first_kv_shared_layer_idx borrow K,V from source
         self.is_kv_shared_layer = layer_idx >= first_kv_shared_layer_idx > 0
@@ -643,9 +646,11 @@ class Gemma4TextAttention(nn.Module):
             self.k_proj = Linear(
                 config.hidden_size, self.num_key_value_heads * head_dim, bias=False
             )
-            self.v_proj = Linear(
-                config.hidden_size, self.num_key_value_heads * head_dim, bias=False
-            )
+            # Alternative attention (k_eq_v): V = K, no separate v_proj
+            if not self._use_alternative_attention:
+                self.v_proj = Linear(
+                    config.hidden_size, self.num_key_value_heads * head_dim, bias=False
+                )
             self.k_norm = RMSNorm(head_dim, eps=config.rms_norm_eps)
 
     def forward(
@@ -721,15 +726,19 @@ class Gemma4TextAttention(nn.Module):
             gqa_ctx = attention_bias
 
             # K projection + per-head K norm (no manual RoPE — GQA does it)
-            key_states = self.k_proj(op, hidden_states)
-            key_states = op.Reshape(key_states, [0, 0, -1, self.head_dim])
+            key_raw = self.k_proj(op, hidden_states)
+            key_states = op.Reshape(key_raw, [0, 0, -1, self.head_dim])
             key_states = self.k_norm(op, key_states)
             key_states = op.Reshape(key_states, [0, 0, -1])
 
-            # V projection + parameterless per-head V normalisation
-            value_states = self.v_proj(op, hidden_states)
+            # V: separate projection, or V=K (alternative attention)
+            if self._use_alternative_attention:
+                value_raw = key_raw
+            else:
+                value_raw = self.v_proj(op, hidden_states)
+            # Parameterless per-head V normalisation
             value_states = op.Reshape(
-                value_states,
+                value_raw,
                 op.Constant(value_ints=[0, 0, self.num_key_value_heads, self.head_dim]),
             )
             sq = op.Mul(value_states, value_states)
@@ -780,8 +789,8 @@ class Gemma4TextAttention(nn.Module):
                 )
         else:
             # K projection + per-head K norm + optional RoPE
-            key_states = self.k_proj(op, hidden_states)
-            key_states = op.Reshape(key_states, [0, 0, -1, self.head_dim])
+            key_raw = self.k_proj(op, hidden_states)
+            key_states = op.Reshape(key_raw, [0, 0, -1, self.head_dim])
             key_states = self.k_norm(op, key_states)
             key_states = op.Reshape(key_states, [0, 0, -1])
 
@@ -795,10 +804,14 @@ class Gemma4TextAttention(nn.Module):
                     interleaved=self._rope_interleave,
                 )
 
-            # V projection + parameterless per-head V normalisation
-            value_states = self.v_proj(op, hidden_states)
+            # V: separate projection, or V=K (alternative attention)
+            if self._use_alternative_attention:
+                value_raw = key_raw
+            else:
+                value_raw = self.v_proj(op, hidden_states)
+            # Parameterless per-head V normalisation
             value_states = op.Reshape(
-                value_states,
+                value_raw,
                 op.Constant(value_ints=[0, 0, self.num_key_value_heads, self.head_dim]),
             )
             sq = op.Mul(value_states, value_states)

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -2151,4 +2151,22 @@ class Gemma4Model(nn.Module):
             else:
                 renamed[key] = value
 
+        # Map HF expert weight names to our 3D stacked parameter names.
+        # HF: decoder.model.layers.N.experts.gate_up_proj [E, 2*inter, H]
+        # Us: decoder.model.layers.N.fc1_experts_weights  [E, 2*inter, H]
+        for key in list(renamed.keys()):
+            if ".experts.gate_up_proj" in key:
+                new_key = key.replace(".experts.gate_up_proj", ".fc1_experts_weights")
+                renamed[new_key] = renamed.pop(key)
+            elif ".experts.down_proj" in key:
+                new_key = key.replace(".experts.down_proj", ".fc2_experts_weights")
+                renamed[new_key] = renamed.pop(key)
+
+        # Fold hidden_size^-0.5 into router.scale
+        if self.config.enable_moe_block:
+            scale_factor = float(self.config.hidden_size**-0.5)
+            for key in list(renamed.keys()):
+                if ".router.scale" in key and ".per_expert_scale" not in key:
+                    renamed[key] = renamed[key] * scale_factor
+
         return renamed

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -607,11 +607,12 @@ class Gemma4TextAttention(nn.Module):
         self._use_alternative_attention = (
             getattr(config, "attention_k_eq_v", False) and not is_sliding
         )
-        self.num_key_value_heads = (
-            (config.num_global_key_value_heads or config.num_key_value_heads)
-            if self._use_alternative_attention
-            else config.num_key_value_heads
-        )
+        # Full-attention layers use num_global_key_value_heads when set,
+        # independent of the k_eq_v flag.
+        if not is_sliding and config.num_global_key_value_heads is not None:
+            self.num_key_value_heads = config.num_global_key_value_heads
+        else:
+            self.num_key_value_heads = config.num_key_value_heads
 
         # KV sharing: layers >= first_kv_shared_layer_idx borrow K,V from source
         self.is_kv_shared_layer = layer_idx >= first_kv_shared_layer_idx > 0

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -1474,7 +1474,8 @@ class Gemma4TextModel(nn.Module):
         query_input = input_ids if input_ids is not None else hidden_states
         fallback_bias_dict: dict[str, ir.Value | None] = {}
         need_fallback = not use_gqa or any(
-            layer.self_attn.is_kv_shared_layer for layer in self.layers
+            layer.self_attn.is_kv_shared_layer or layer.self_attn.head_dim > 256
+            for layer in self.layers
         )
         if need_fallback:
             if use_gqa:

--- a/src/mobius/tasks/_gemma4.py
+++ b/src/mobius/tasks/_gemma4.py
@@ -54,8 +54,8 @@ def _make_gemma4_kv_cache_inputs(
     ``num_hidden_layers - num_kv_shared_layers`` entries are created.
 
     All layers use the original ``num_key_value_heads`` except
-    alternative-attention (``attention_k_eq_v``) full layers which use
-    ``num_global_key_value_heads`` (fewer KV heads).
+    full-attention layers when ``num_global_key_value_heads`` is set
+    (fewer KV heads, independent of the ``attention_k_eq_v`` flag).
     The Attention op supports GQA head counts natively.  CUDA EP limitations
     are tracked in microsoft/onnxruntime#28195 and #28196.
     """
@@ -75,13 +75,13 @@ def _make_gemma4_kv_cache_inputs(
     for i in range(num_kv_layers):
         layer_type = layer_types[i] if i < len(layer_types) else "sliding_attention"
         hd = global_head_dim if layer_type == "full_attention" else local_head_dim
-        # Alternative attention (k_eq_v) uses fewer KV heads for full_attention
-        use_alt = getattr(config, "attention_k_eq_v", False) and layer_type == "full_attention"
-        kv_heads = (
-            (config.num_global_key_value_heads or config.num_key_value_heads)
-            if use_alt
-            else config.num_key_value_heads
-        )
+        # Full-attention layers use num_global_key_value_heads when set,
+        # independent of the k_eq_v flag.
+        is_full = layer_type == "full_attention"
+        if is_full and config.num_global_key_value_heads is not None:
+            kv_heads = config.num_global_key_value_heads
+        else:
+            kv_heads = config.num_key_value_heads
         past_key = builder.input(
             f"past_key_values.{i}.key",
             dtype=config.dtype,

--- a/src/mobius/tasks/_gemma4.py
+++ b/src/mobius/tasks/_gemma4.py
@@ -53,7 +53,9 @@ def _make_gemma4_kv_cache_inputs(
     layers and do NOT have their own cache entries — only
     ``num_hidden_layers - num_kv_shared_layers`` entries are created.
 
-    All layers use the original ``num_key_value_heads`` (no expansion).
+    All layers use the original ``num_key_value_heads`` except
+    alternative-attention (``attention_k_eq_v``) full layers which use
+    ``num_global_key_value_heads`` (fewer KV heads).
     The Attention op supports GQA head counts natively.  CUDA EP limitations
     are tracked in microsoft/onnxruntime#28195 and #28196.
     """
@@ -73,9 +75,11 @@ def _make_gemma4_kv_cache_inputs(
     for i in range(num_kv_layers):
         layer_type = layer_types[i] if i < len(layer_types) else "sliding_attention"
         hd = global_head_dim if layer_type == "full_attention" else local_head_dim
+        # Alternative attention (k_eq_v) uses fewer KV heads for full_attention
+        use_alt = getattr(config, "attention_k_eq_v", False) and layer_type == "full_attention"
         kv_heads = (
-            config.num_global_key_value_heads
-            if layer_type == "full_attention" and config.num_global_key_value_heads is not None
+            (config.num_global_key_value_heads or config.num_key_value_heads)
+            if use_alt
             else config.num_key_value_heads
         )
         past_key = builder.input(

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -1415,6 +1415,74 @@ class TestBuildGraphVisionLanguage:
         assert "present.1.key" not in output_names
         assert "present.1.value" not in output_names
 
+    def test_gemma4_k_eq_v_with_global_kv_heads(self):
+        """Verify attention_k_eq_v removes v_proj and num_global_key_value_heads sets KV cache shapes.
+
+        Config: attention_k_eq_v=True, num_key_value_heads=4 (sliding),
+        num_global_key_value_heads=2 (full). Full-attention layers should:
+        - Have no v_proj initializer (V=K)
+        - Use num_global_key_value_heads=2 for KV cache shapes
+        Sliding layers should use num_key_value_heads=4.
+        """
+        from mobius._configs import Gemma4Config
+        from mobius.models.gemma4 import Gemma4CausalLMModel
+        from mobius.tasks._gemma4 import Gemma4TextCausalLMTask
+
+        config = Gemma4Config(
+            num_hidden_layers=2,
+            hidden_size=64,
+            intermediate_size=128,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            head_dim=16,
+            vocab_size=256,
+            rms_norm_eps=1e-6,
+            hidden_act="silu",
+            attn_qk_norm=True,
+            # Layer 0: sliding, Layer 1: full (k_eq_v + global heads)
+            layer_types=["sliding_attention", "full_attention"],
+            sliding_window=8,
+            global_head_dim=16,
+            global_rope_theta=10_000.0,
+            global_partial_rotary_factor=0.25,
+            final_logit_softcapping=0.0,
+            hidden_size_per_layer_input=0,
+            image_token_id=255999,
+            pad_token_id=0,
+            tie_word_embeddings=True,
+            attention_k_eq_v=True,
+            num_global_key_value_heads=2,
+        )
+        module = Gemma4CausalLMModel(config)
+        task = Gemma4TextCausalLMTask()
+        pkg = task.build(module, config)
+        decoder = pkg["model"]
+
+        # Check initializer names: full-attention layer (1) should have no v_proj
+        init_names = set(decoder.graph.initializers)
+        # Sliding layer 0 has k_proj, v_proj
+        assert "model.layers.0.self_attn.k_proj.weight" in init_names
+        assert "model.layers.0.self_attn.v_proj.weight" in init_names
+        # Full layer 1 has k_proj but NO v_proj (k_eq_v: V=K)
+        assert "model.layers.1.self_attn.k_proj.weight" in init_names
+        assert "model.layers.1.self_attn.v_proj.weight" not in init_names
+
+        # KV cache shapes:
+        # Layer 0 (sliding): num_key_value_heads=4
+        # Layer 1 (full): num_global_key_value_heads=2
+        input_shapes = {i.name: list(i.shape) for i in decoder.graph.inputs}
+        # Layer 0: kv_heads=4
+        layer0_key_shape = input_shapes["past_key_values.0.key"]
+        assert layer0_key_shape[1] == 4, (
+            f"Sliding layer 0 should have 4 KV heads, got {layer0_key_shape[1]}"
+        )
+        # Layer 1: kv_heads=2 (num_global_key_value_heads)
+        layer1_key_shape = input_shapes["past_key_values.1.key"]
+        assert layer1_key_shape[1] == 2, (
+            f"Full layer 1 should have 2 KV heads "
+            f"(num_global_key_value_heads), got {layer1_key_shape[1]}"
+        )
+
     def test_blip2_vision_language_graph(self):
         """Build BLIP-2 with ViT + Q-Former + LLM 3-model split."""
         config = _base_config(


### PR DESCRIPTION
## Summary

Two weight mapping fixes for Gemma4 models that use `attention_k_eq_v=True` (26b-a4b, 31b):

### Fix 1: Alternative attention (V=K) for full_attention layers
When `attention_k_eq_v=True`, full-attention layers derive V from K (no separate `v_proj`), matching HF `Gemma4TextAttention`. Changes:
- Skip `v_proj` creation for alternative-attention layers
- In forward: V = raw `k_proj` output (before k_norm/RoPE), then v_norm applied
- Per-layer KV head count: full_attention uses `num_global_key_value_heads`
- Update task KV cache inputs with per-layer head counts

### Fix 2: MoE expert weight mapping in Gemma4Model
`Gemma4Model` (multimodal) had its own `preprocess_weights` that was missing:
- Expert weight rename (`experts.gate_up_proj` → `fc1_experts_weights`)
- Router scale folding (`hidden_size^-0.5`)

These were only in `Gemma4CausalLMModel.preprocess_weights`.

### Testing
- 12/12 Gemma4 L1 tests pass
- 2662/2662 full suite pass
- Verified: decoder exports successfully for both 26b-a4b and 31b models

### Models affected
| Model | Issue | Fixed |
|-------|-------|-------|
| gemma-4-26b-a4b[-it] | MoE expert weights + V=K | ✅ |
| gemma-4-31b[-it] | V=K alternative attention | ✅ |
| gemma-4-e2b[-it] | No issue (no k_eq_v) | ✅ Unaffected |
| gemma-4-e4b[-it] | No issue (no k_eq_v) | ✅ Unaffected |
