### PR TITLE
Add Foundry Local deployment skill

### DIFF
--- a/.agents/skills/building-ort-genai/SKILL.md
+++ b/.agents/skills/building-ort-genai/SKILL.md
@@ -29,19 +29,19 @@ Use this skill when:
 ## Step 1: Install CUDA toolkit
 
 ```bash
-# CUDA 12.8
-wget https://developer.download.nvidia.com/compute/cuda/12.8.1/local_installers/cuda_12.8.1_570.124.06_linux.run
-sudo sh cuda_12.8.1_570.124.06_linux.run \
-  --toolkit --toolkitpath=$HOME/cuda12.8 \
+# CUDA 13.0
+wget https://developer.download.nvidia.com/compute/cuda/12.8.1/local_installers/cuda_13.0.1_575.51.03_linux.run
+sudo sh cuda_13.0.1_575.51.03_linux.run \
+  --toolkit --toolkitpath=$HOME/cuda13.0 \
   --silent --override --no-man-page
 
-# Or CUDA 13.0 if available — adjust the URL and path accordingly
+# Or adjust the URL and path for a different CUDA version
 ```
 
 Verify:
 
 ```bash
-$HOME/cuda12.8/bin/nvcc --version
+$HOME/cuda13.0/bin/nvcc --version
 ```
 
 ## Step 2: Install cuDNN 9.x
@@ -67,8 +67,8 @@ ln -sf $CUDNN_PKG/include/* ~/cudnn9/include/
 ## Step 3: Set environment
 
 ```bash
-export PATH=$HOME/cuda12.8/bin:$PATH
-export LD_LIBRARY_PATH=$HOME/cuda12.8/lib64:$HOME/cudnn9.8/lib:$LD_LIBRARY_PATH
+export PATH=$HOME/cuda13.0/bin:$PATH
+export LD_LIBRARY_PATH=$HOME/cuda13.0/lib64:$HOME/cudnn9.8/lib:$LD_LIBRARY_PATH
 ```
 
 Add these to your shell profile (`~/.bashrc`) or conda
@@ -83,7 +83,7 @@ cd ~/dev/onnxruntime
 ./build.sh \
   --config Release \
   --use_cuda \
-  --cuda_home $HOME/cuda12.8 \
+  --cuda_home $HOME/cuda13.0 \
   --cudnn_home $HOME/cudnn9.8 \
   --cmake_extra_defines \
     CMAKE_CUDA_ARCHITECTURES=native \
@@ -153,7 +153,7 @@ cd ~/dev/onnxruntime-genai
 python build.py \
   --config Release \
   --use_cuda \
-  --cuda_home $HOME/cuda12.8 \
+  --cuda_home $HOME/cuda13.0 \
   --ort_home ~/ort-install \
   --parallel \
   --skip_tests \
@@ -206,7 +206,7 @@ CUDA EP missing from providers.
 **Fix:**
 
 ```bash
-export LD_LIBRARY_PATH=$HOME/cuda12.8/lib64:$HOME/cudnn9.8/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$HOME/cuda13.0/lib64:$HOME/cudnn9.8/lib:$LD_LIBRARY_PATH
 ```
 
 ### 3. pip packages overriding custom builds

--- a/.agents/skills/building-ort-genai/SKILL.md
+++ b/.agents/skills/building-ort-genai/SKILL.md
@@ -47,16 +47,16 @@ $HOME/cuda13.0/bin/nvcc --version
 ## Step 2: Install cuDNN 9.x
 
 ```bash
-wget https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-9.8.0.87_cuda12-archive.tar.xz
+wget https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-9.8.0.87_cuda13-archive.tar.xz
 mkdir -p $HOME/cudnn9.8
-tar -xf cudnn-linux-x86_64-9.8.0.87_cuda12-archive.tar.xz \
+tar -xf cudnn-linux-x86_64-9.8.0.87_cuda13-archive.tar.xz \
   -C $HOME/cudnn9.8 --strip-components=1
 ```
 
 Alternative — install cuDNN via pip and create symlinks:
 
 ```bash
-pip install nvidia-cudnn-cu12
+pip install nvidia-cudnn-cu13
 mkdir -p ~/cudnn9/{lib,include}
 CUDNN_PKG=$(python -c "import nvidia.cudnn; import pathlib; print(pathlib.Path(nvidia.cudnn.__file__).parent)")
 ln -sf $CUDNN_PKG/lib/* ~/cudnn9/lib/

--- a/.agents/skills/building-ort-genai/SKILL.md
+++ b/.agents/skills/building-ort-genai/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: building-ort-genai
+description: >
+  Use this skill when building OnnxRuntime and onnxruntime-genai from
+  source with CUDA support. Covers CUDA toolkit and cuDNN setup,
+  ORT build flags, GenAI build linked to custom ORT, verification,
+  and common build issues.
+---
+
+# Skill: Building ORT and GenAI from Source
+
+## When to use
+
+Use this skill when:
+- You need a custom ORT build (e.g. unreleased features, CUDA support,
+  custom ops)
+- You need a custom GenAI build linked to your ORT build
+- Deploying to Foundry Local requires overriding bundled ORT/GenAI
+- Debugging inference issues that require source-level ORT changes
+- The pip-released ORT/GenAI version doesn't support your model
+
+## Prerequisites
+
+- Linux machine with NVIDIA GPU
+- conda or any Python 3.10+ environment
+- ~20 GB disk space for builds
+- CMake 3.26+, gcc/g++ 11+
+
+## Step 1: CUDA toolkit
+
+Install CUDA toolkit 12.8+ or 13.0 to a local directory if not
+system-installed:
+
+```bash
+# Check existing installation
+nvcc --version
+nvidia-smi
+
+# If not installed, download from:
+# https://developer.nvidia.com/cuda-downloads
+
+# Set environment (adjust path to your installation)
+export CUDA_HOME=/usr/local/cuda-13.0
+export PATH=$CUDA_HOME/bin:$PATH
+export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$LD_LIBRARY_PATH
+```
+
+## Step 2: cuDNN 9.x
+
+ORT requires cuDNN for conv and attention kernels. Install via pip
+and create a directory layout for the ORT build:
+
+```bash
+# Install cuDNN via pip
+pip install nvidia-cudnn-cu12
+
+# Create cuDNN home directory for the ORT build system
+mkdir -p ~/cudnn9/{lib,include}
+CUDNN_PKG=$(python -c "import nvidia.cudnn; import pathlib; print(pathlib.Path(nvidia.cudnn.__file__).parent)")
+ln -sf $CUDNN_PKG/lib/* ~/cudnn9/lib/
+ln -sf $CUDNN_PKG/include/* ~/cudnn9/include/
+export CUDNN_HOME=~/cudnn9
+```
+
+## Step 3: Build ORT from source
+
+```bash
+git clone https://github.com/microsoft/onnxruntime.git ~/dev/onnxruntime
+cd ~/dev/onnxruntime
+
+./build.sh \
+  --config Release \
+  --use_cuda \
+  --cuda_home $CUDA_HOME \
+  --cudnn_home $CUDNN_HOME \
+  --cmake_extra_defines \
+    CMAKE_CUDA_ARCHITECTURES=native \
+    onnxruntime_USE_FLASH_ATTENTION=ON \
+  --build_wheel \
+  --enable_pybind \
+  --parallel \
+  --skip_tests
+```
+
+### Build flag reference
+
+| Flag | Description |
+|------|-------------|
+| `--use_cuda` | Enable CUDA execution provider |
+| `--cuda_home <path>` | Path to CUDA toolkit installation |
+| `--cudnn_home <path>` | Path to cuDNN directory (lib/ + include/) |
+| `CMAKE_CUDA_ARCHITECTURES=native` | Compile for the GPU architecture on this machine |
+| `onnxruntime_USE_FLASH_ATTENTION=ON` | Enable Flash Attention kernels |
+| `--build_wheel` | Build a pip-installable wheel |
+| `--enable_pybind` | Build the Python bindings |
+| `--parallel` | Parallel compilation |
+| `--skip_tests` | Skip building test targets |
+
+### Install the wheel
+
+```bash
+pip install build/Linux/Release/dist/onnxruntime-*.whl \
+  --force-reinstall --no-deps
+```
+
+### Verify
+
+```python
+import onnxruntime as ort
+print(ort.__version__)
+print(ort.get_available_providers())
+# Should include 'CUDAExecutionProvider'
+print(ort.get_device())
+# Should print 'GPU'
+```
+
+## Step 4: Create ORT install layout for GenAI
+
+GenAI needs ORT headers and libraries in a specific layout:
+
+```bash
+mkdir -p ~/ort-install/{include,lib}
+
+# Headers
+cp ~/dev/onnxruntime/include/onnxruntime/core/session/*.h \
+  ~/ort-install/include/
+
+# Libraries
+cp ~/dev/onnxruntime/build/Linux/Release/libonnxruntime.so \
+  ~/ort-install/lib/
+cp ~/dev/onnxruntime/build/Linux/Release/libonnxruntime_providers_cuda.so \
+  ~/ort-install/lib/
+cp ~/dev/onnxruntime/build/Linux/Release/libonnxruntime_providers_shared.so \
+  ~/ort-install/lib/
+```
+
+## Step 5: Build GenAI from source
+
+```bash
+git clone https://github.com/microsoft/onnxruntime-genai.git \
+  ~/dev/onnxruntime-genai
+cd ~/dev/onnxruntime-genai
+
+python build.py \
+  --config Release \
+  --use_cuda \
+  --cuda_home $CUDA_HOME \
+  --ort_home ~/ort-install \
+  --parallel \
+  --skip_tests \
+  --skip_examples \
+  --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=native \
+  --update --build
+```
+
+### Install the wheel
+
+```bash
+pip install build/Linux/Release/wheel/onnxruntime_genai_cuda-*.whl \
+  --no-deps
+```
+
+### Verify
+
+```python
+import onnxruntime_genai as og
+print(og.__version__)
+print(og.is_cuda_available())  # Should print True
+```
+
+If `is_cuda_available()` returns `False`, check that the ORT CUDA
+provider `.so` files are in the library path (see troubleshooting).
+
+## Common issues
+
+### 1. cuDNN version mismatch
+
+**Symptom:** ORT build fails with cuDNN-related errors, or CUDA EP
+doesn't load at runtime.
+
+**Fix:** Ensure `nvidia-cudnn-cu12` pip package matches your CUDA
+version. cuDNN 9.x works with CUDA 12.x and 13.x:
+
+```bash
+pip install nvidia-cudnn-cu12
+# Verify version
+python -c "import nvidia.cudnn; print(nvidia.cudnn.__version__)"
+```
+
+### 2. LD_LIBRARY_PATH not set
+
+**Symptom:** `import onnxruntime` fails with `.so` not found errors,
+or CUDA EP is missing from available providers.
+
+**Fix:** Add CUDA and cuDNN libraries to `LD_LIBRARY_PATH`:
+
+```bash
+export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$CUDNN_HOME/lib:$LD_LIBRARY_PATH
+```
+
+Add this to your shell profile (`~/.bashrc` or conda
+`activate.d/env_vars.sh`) for persistence.
+
+### 3. pip packages overriding custom builds
+
+**Symptom:** After `pip install foundry-local-sdk` or
+`pip install onnxruntime-genai`, your custom build is replaced with
+the pip version. `ort.get_device()` returns `'CPU'` instead of `'GPU'`.
+
+**Fix:** Always reinstall custom wheels after installing packages that
+depend on ORT or GenAI:
+
+```bash
+pip install foundry-local-sdk
+# THEN reinstall your builds:
+pip install --force-reinstall ~/dev/onnxruntime/build/Linux/Release/dist/onnxruntime-*.whl
+pip install --force-reinstall ~/dev/onnxruntime-genai/build/Linux/Release/wheel/onnxruntime_genai_cuda-*.whl
+```
+
+See the `foundry-local` skill for more details on the Foundry
+dependency override mechanism.
+
+### 4. ABI mismatch between ORT and GenAI
+
+**Symptom:** GenAI build fails with undefined symbols or linker errors
+referencing ORT internal types.
+
+**Fix:** Both must be built with the same compiler and C++ ABI. Ensure:
+- Same gcc/g++ version for both builds
+- Same Python version
+- ORT install layout (Step 4) uses the exact libraries from your ORT
+  build, not from a different build or pip install
+
+### 5. Build fails on test targets
+
+**Symptom:** ORT build fails on `onnxruntime_perf_test` or similar
+test targets due to abseil linking errors.
+
+**Fix:** The core library and Python wheel still build successfully.
+Build the wheel manually:
+
+```bash
+cd ~/dev/onnxruntime/build/Linux/Release
+python ~/dev/onnxruntime/setup.py bdist_wheel
+pip install dist/onnxruntime-*.whl --force-reinstall --no-deps
+```
+
+### 6. Flash Attention not available
+
+**Symptom:** Attention ops are slow or fall back to non-fused path.
+
+**Fix:** Ensure `onnxruntime_USE_FLASH_ATTENTION=ON` was set during
+the ORT build. Flash Attention requires a GPU with compute capability
+≥ 8.0 (Ampere or newer).
+
+## Reference
+
+- [Full Gemma4 + Foundry Local tutorial](https://github.com/onnxruntime/mobius/issues/245)
+- [ORT build documentation](https://onnxruntime.ai/docs/build/)
+- [GenAI build documentation](https://github.com/microsoft/onnxruntime-genai/blob/main/BUILD.md)
+
+## Cross-references
+
+- **Foundry Local deployment:** `.agents/skills/foundry-local/SKILL.md`
+- **ONNX export:** `.agents/skills/onnx-export-quantization/SKILL.md`
+- **ORT GenAI config:** `.agents/skills/ort-genai-config/SKILL.md`

--- a/.agents/skills/building-ort-genai/SKILL.md
+++ b/.agents/skills/building-ort-genai/SKILL.md
@@ -2,7 +2,7 @@
 name: building-ort-genai
 description: >
   Use this skill when building OnnxRuntime and onnxruntime-genai from
-  source with CUDA support. Covers CUDA toolkit and cuDNN setup,
+  source with CUDA support. Covers CUDA toolkit and cuDNN installation,
   ORT build flags, GenAI build linked to custom ORT, verification,
   and common build issues.
 ---
@@ -16,53 +16,65 @@ Use this skill when:
   custom ops)
 - You need a custom GenAI build linked to your ORT build
 - Deploying to Foundry Local requires overriding bundled ORT/GenAI
-- Debugging inference issues that require source-level ORT changes
 - The pip-released ORT/GenAI version doesn't support your model
 
 ## Prerequisites
 
-- Linux machine with NVIDIA GPU
+- Linux (tested on Ubuntu)
+- NVIDIA GPU
 - conda or any Python 3.10+ environment
 - ~20 GB disk space for builds
 - CMake 3.26+, gcc/g++ 11+
 
-## Step 1: CUDA toolkit
-
-Install CUDA toolkit 12.8+ or 13.0 to a local directory if not
-system-installed:
+## Step 1: Install CUDA toolkit
 
 ```bash
-# Check existing installation
-nvcc --version
-nvidia-smi
+# CUDA 12.8
+wget https://developer.download.nvidia.com/compute/cuda/12.8.1/local_installers/cuda_12.8.1_570.124.06_linux.run
+sudo sh cuda_12.8.1_570.124.06_linux.run \
+  --toolkit --toolkitpath=$HOME/cuda12.8 \
+  --silent --override --no-man-page
 
-# If not installed, download from:
-# https://developer.nvidia.com/cuda-downloads
-
-# Set environment (adjust path to your installation)
-export CUDA_HOME=/usr/local/cuda-13.0
-export PATH=$CUDA_HOME/bin:$PATH
-export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$LD_LIBRARY_PATH
+# Or CUDA 13.0 if available — adjust the URL and path accordingly
 ```
 
-## Step 2: cuDNN 9.x
-
-ORT requires cuDNN for conv and attention kernels. Install via pip
-and create a directory layout for the ORT build:
+Verify:
 
 ```bash
-# Install cuDNN via pip
-pip install nvidia-cudnn-cu12
+$HOME/cuda12.8/bin/nvcc --version
+```
 
-# Create cuDNN home directory for the ORT build system
+## Step 2: Install cuDNN 9.x
+
+```bash
+wget https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-9.8.0.87_cuda12-archive.tar.xz
+mkdir -p $HOME/cudnn9.8
+tar -xf cudnn-linux-x86_64-9.8.0.87_cuda12-archive.tar.xz \
+  -C $HOME/cudnn9.8 --strip-components=1
+```
+
+Alternative — install cuDNN via pip and create symlinks:
+
+```bash
+pip install nvidia-cudnn-cu12
 mkdir -p ~/cudnn9/{lib,include}
 CUDNN_PKG=$(python -c "import nvidia.cudnn; import pathlib; print(pathlib.Path(nvidia.cudnn.__file__).parent)")
 ln -sf $CUDNN_PKG/lib/* ~/cudnn9/lib/
 ln -sf $CUDNN_PKG/include/* ~/cudnn9/include/
-export CUDNN_HOME=~/cudnn9
+# Then use ~/cudnn9 as CUDNN_HOME below
 ```
 
-## Step 3: Build ORT from source
+## Step 3: Set environment
+
+```bash
+export PATH=$HOME/cuda12.8/bin:$PATH
+export LD_LIBRARY_PATH=$HOME/cuda12.8/lib64:$HOME/cudnn9.8/lib:$LD_LIBRARY_PATH
+```
+
+Add these to your shell profile (`~/.bashrc`) or conda
+`activate.d/env_vars.sh` for persistence.
+
+## Step 4: Build ORT from source
 
 ```bash
 git clone https://github.com/microsoft/onnxruntime.git ~/dev/onnxruntime
@@ -71,8 +83,8 @@ cd ~/dev/onnxruntime
 ./build.sh \
   --config Release \
   --use_cuda \
-  --cuda_home $CUDA_HOME \
-  --cudnn_home $CUDNN_HOME \
+  --cuda_home $HOME/cuda12.8 \
+  --cudnn_home $HOME/cudnn9.8 \
   --cmake_extra_defines \
     CMAKE_CUDA_ARCHITECTURES=native \
     onnxruntime_USE_FLASH_ATTENTION=ON \
@@ -89,32 +101,29 @@ cd ~/dev/onnxruntime
 | `--use_cuda` | Enable CUDA execution provider |
 | `--cuda_home <path>` | Path to CUDA toolkit installation |
 | `--cudnn_home <path>` | Path to cuDNN directory (lib/ + include/) |
-| `CMAKE_CUDA_ARCHITECTURES=native` | Compile for the GPU architecture on this machine |
-| `onnxruntime_USE_FLASH_ATTENTION=ON` | Enable Flash Attention kernels |
+| `CMAKE_CUDA_ARCHITECTURES=native` | Compile for the GPU on this machine |
+| `onnxruntime_USE_FLASH_ATTENTION=ON` | Enable Flash Attention kernels (requires compute ≥ 8.0) |
 | `--build_wheel` | Build a pip-installable wheel |
-| `--enable_pybind` | Build the Python bindings |
 | `--parallel` | Parallel compilation |
-| `--skip_tests` | Skip building test targets |
+| `--skip_tests` | Skip test targets (may fail on abseil linking) |
 
-### Install the wheel
+### Install
 
 ```bash
 pip install build/Linux/Release/dist/onnxruntime-*.whl \
   --force-reinstall --no-deps
 ```
 
-### Verify
+> **Note:** If the build fails on test targets (`onnxruntime_perf_test`)
+> but the wheel was produced, you can still install it. Alternatively,
+> build the wheel manually:
+> ```bash
+> cd build/Linux/Release
+> python ~/dev/onnxruntime/setup.py bdist_wheel
+> pip install dist/onnxruntime-*.whl --force-reinstall --no-deps
+> ```
 
-```python
-import onnxruntime as ort
-print(ort.__version__)
-print(ort.get_available_providers())
-# Should include 'CUDAExecutionProvider'
-print(ort.get_device())
-# Should print 'GPU'
-```
-
-## Step 4: Create ORT install layout for GenAI
+## Step 5: Create ORT install layout for GenAI
 
 GenAI needs ORT headers and libraries in a specific layout:
 
@@ -134,7 +143,7 @@ cp ~/dev/onnxruntime/build/Linux/Release/libonnxruntime_providers_shared.so \
   ~/ort-install/lib/
 ```
 
-## Step 5: Build GenAI from source
+## Step 6: Build GenAI from source
 
 ```bash
 git clone https://github.com/microsoft/onnxruntime-genai.git \
@@ -144,7 +153,7 @@ cd ~/dev/onnxruntime-genai
 python build.py \
   --config Release \
   --use_cuda \
-  --cuda_home $CUDA_HOME \
+  --cuda_home $HOME/cuda12.8 \
   --ort_home ~/ort-install \
   --parallel \
   --skip_tests \
@@ -153,105 +162,85 @@ python build.py \
   --update --build
 ```
 
-### Install the wheel
+### Install
 
 ```bash
 pip install build/Linux/Release/wheel/onnxruntime_genai_cuda-*.whl \
   --no-deps
 ```
 
-### Verify
+## Step 7: Verify
 
-```python
-import onnxruntime_genai as og
-print(og.__version__)
-print(og.is_cuda_available())  # Should print True
+```bash
+python -c 'import onnxruntime; print(onnxruntime.__version__, onnxruntime.get_device())'
+# Expected: 1.x.x GPU
+
+python -c 'import onnxruntime_genai as og; print(og.__version__, og.is_cuda_available())'
+# Expected: 0.x.x True
 ```
 
-If `is_cuda_available()` returns `False`, check that the ORT CUDA
-provider `.so` files are in the library path (see troubleshooting).
+If `get_device()` returns `CPU` or `is_cuda_available()` returns
+`False`, check `LD_LIBRARY_PATH` and that you installed the correct
+wheels (not pip overrides — see below).
 
 ## Common issues
 
 ### 1. cuDNN version mismatch
 
-**Symptom:** ORT build fails with cuDNN-related errors, or CUDA EP
-doesn't load at runtime.
+**Symptom:** ORT build fails with cuDNN errors, or CUDA EP doesn't
+load at runtime.
 
-**Fix:** Ensure `nvidia-cudnn-cu12` pip package matches your CUDA
-version. cuDNN 9.x works with CUDA 12.x and 13.x:
+**Fix:** cuDNN 9.x works with CUDA 12.x and 13.x. Ensure the cuDNN
+version matches your CUDA major version:
 
 ```bash
-pip install nvidia-cudnn-cu12
-# Verify version
+# Check installed cuDNN version
 python -c "import nvidia.cudnn; print(nvidia.cudnn.__version__)"
 ```
 
 ### 2. LD_LIBRARY_PATH not set
 
-**Symptom:** `import onnxruntime` fails with `.so` not found errors,
-or CUDA EP is missing from available providers.
+**Symptom:** `import onnxruntime` fails with `.so` not found, or
+CUDA EP missing from providers.
 
-**Fix:** Add CUDA and cuDNN libraries to `LD_LIBRARY_PATH`:
+**Fix:**
 
 ```bash
-export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$CUDNN_HOME/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$HOME/cuda12.8/lib64:$HOME/cudnn9.8/lib:$LD_LIBRARY_PATH
 ```
-
-Add this to your shell profile (`~/.bashrc` or conda
-`activate.d/env_vars.sh`) for persistence.
 
 ### 3. pip packages overriding custom builds
 
-**Symptom:** After `pip install foundry-local-sdk` or
-`pip install onnxruntime-genai`, your custom build is replaced with
-the pip version. `ort.get_device()` returns `'CPU'` instead of `'GPU'`.
+**Symptom:** After `pip install foundry-local-sdk` or other packages,
+custom build is replaced. `ort.get_device()` returns `'CPU'`.
 
 **Fix:** Always reinstall custom wheels after installing packages that
-depend on ORT or GenAI:
+depend on ORT:
 
 ```bash
 pip install foundry-local-sdk
 # THEN reinstall your builds:
-pip install --force-reinstall ~/dev/onnxruntime/build/Linux/Release/dist/onnxruntime-*.whl
-pip install --force-reinstall ~/dev/onnxruntime-genai/build/Linux/Release/wheel/onnxruntime_genai_cuda-*.whl
+pip install --force-reinstall <your_ort_wheel>.whl
+pip install --force-reinstall <your_genai_wheel>.whl
 ```
 
-See the `foundry-local` skill for more details on the Foundry
-dependency override mechanism.
+See the **foundry-local** skill for the full dependency override
+mechanism.
 
 ### 4. ABI mismatch between ORT and GenAI
 
-**Symptom:** GenAI build fails with undefined symbols or linker errors
-referencing ORT internal types.
+**Symptom:** GenAI build fails with undefined symbols or linker errors.
 
-**Fix:** Both must be built with the same compiler and C++ ABI. Ensure:
-- Same gcc/g++ version for both builds
-- Same Python version
-- ORT install layout (Step 4) uses the exact libraries from your ORT
-  build, not from a different build or pip install
+**Fix:** Both must be built with the same compiler, Python version,
+and C++ ABI. The ORT install layout (Step 5) must use the exact
+libraries from your ORT build.
 
-### 5. Build fails on test targets
-
-**Symptom:** ORT build fails on `onnxruntime_perf_test` or similar
-test targets due to abseil linking errors.
-
-**Fix:** The core library and Python wheel still build successfully.
-Build the wheel manually:
-
-```bash
-cd ~/dev/onnxruntime/build/Linux/Release
-python ~/dev/onnxruntime/setup.py bdist_wheel
-pip install dist/onnxruntime-*.whl --force-reinstall --no-deps
-```
-
-### 6. Flash Attention not available
+### 5. Flash Attention not available
 
 **Symptom:** Attention ops are slow or fall back to non-fused path.
 
 **Fix:** Ensure `onnxruntime_USE_FLASH_ATTENTION=ON` was set during
-the ORT build. Flash Attention requires a GPU with compute capability
-≥ 8.0 (Ampere or newer).
+the ORT build. Requires GPU compute capability ≥ 8.0 (Ampere+).
 
 ## Reference
 

--- a/.agents/skills/foundry-local/SKILL.md
+++ b/.agents/skills/foundry-local/SKILL.md
@@ -1,0 +1,319 @@
+---
+name: foundry-local
+description: >
+  Use this skill when deploying mobius-exported ONNX models to
+  Microsoft Foundry Local for local inference. Covers custom model
+  registration via the cache directory, inference_model.json format,
+  CLI and API usage, SDK limitations, and GenAI version compatibility.
+---
+
+# Skill: Deploying to Foundry Local
+
+## When to use
+
+Use this skill when:
+- Deploying a mobius-exported ONNX model to Foundry Local for local
+  inference
+- Registering a custom model in the Foundry Local cache
+- Writing the `inference_model.json` descriptor for a custom model
+- Troubleshooting Foundry Local model loading or compatibility issues
+- Accessing the OpenAI-compatible API endpoint for local models
+
+## Prerequisites
+
+1. **Foundry Local SDK:**
+
+   ```bash
+   pip install foundry-local-sdk
+   ```
+
+2. **ONNX model exported by mobius** with `--runtime ort-genai`:
+
+   ```bash
+   mobius build --model <hf-model-id> --dtype f16 \
+     --ep default --runtime ort-genai \
+     --external-data safetensors --max-shard-size 5GB \
+     output/
+   ```
+
+   The output directory must contain `genai_config.json`, tokenizer
+   files, and the model sub-directories (decoder/, embedding/, etc.).
+
+## Custom model registration
+
+Foundry Local discovers models from its cache directory. To deploy a
+custom model, place it in the cache with an `inference_model.json`
+descriptor.
+
+### Step 1: Find the cache directory
+
+```bash
+foundry cache cd
+```
+
+This prints the cache path — typically `~/.foundry/cache/` on Linux
+or `%LOCALAPPDATA%\foundry\cache\` on Windows.
+
+### Step 2: Create the model directory
+
+```bash
+CACHE_DIR=$(foundry cache cd)
+MODEL_NAME="my-custom-model"
+mkdir -p "${CACHE_DIR}/models/Custom/${MODEL_NAME}"
+```
+
+### Step 3: Copy model files
+
+Copy the entire mobius export output into the model directory:
+
+```bash
+# Copy all model files
+cp -r output/decoder/ "${CACHE_DIR}/models/Custom/${MODEL_NAME}/"
+cp -r output/embedding/ "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
+cp -r output/vision_encoder/ "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
+cp -r output/audio_encoder/ "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
+cp output/genai_config.json "${CACHE_DIR}/models/Custom/${MODEL_NAME}/"
+cp output/tokenizer* "${CACHE_DIR}/models/Custom/${MODEL_NAME}/"
+cp output/image_processor.json "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
+cp output/audio_processor.json "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
+```
+
+### Step 4: Create `inference_model.json`
+
+Create an `inference_model.json` file in the model directory:
+
+```bash
+cat > "${CACHE_DIR}/models/Custom/${MODEL_NAME}/inference_model.json" << 'EOF'
+{
+  "Name": "my-custom-model",
+  "PromptTemplate": {
+    "system": "<|im_start|>system\n{Content}<|im_end|>\n",
+    "user": "<|im_start|>user\n{Content}<|im_end|>\n",
+    "assistant": "<|im_start|>assistant\n{Content}<|im_end|>\n",
+    "prompt": "{Messages}<|im_start|>assistant\n"
+  }
+}
+EOF
+```
+
+### Step 5: Verify registration
+
+```bash
+foundry cache ls
+```
+
+Your model should appear in the list.
+
+## `inference_model.json` format
+
+The `inference_model.json` descriptor tells Foundry Local how to
+identify and prompt the model:
+
+```json
+{
+  "Name": "<model-name>",
+  "PromptTemplate": {
+    "system": "<system-message-template>",
+    "user": "<user-message-template>",
+    "assistant": "<assistant-message-template>",
+    "prompt": "<full-prompt-template>"
+  }
+}
+```
+
+### Fields
+
+| Field | Description |
+|-------|-------------|
+| `Name` | Display name for the model. Used in CLI and API. |
+| `PromptTemplate.system` | Template for system messages. `{Content}` is replaced with the message text. |
+| `PromptTemplate.user` | Template for user messages. `{Content}` is replaced with the message text. |
+| `PromptTemplate.assistant` | Template for assistant messages. `{Content}` is replaced with the message text. |
+| `PromptTemplate.prompt` | Template for the full prompt. `{Messages}` is replaced with the concatenated formatted messages. |
+
+### Common prompt templates
+
+**ChatML (Qwen, many recent models):**
+
+```json
+{
+  "system": "<|im_start|>system\n{Content}<|im_end|>\n",
+  "user": "<|im_start|>user\n{Content}<|im_end|>\n",
+  "assistant": "<|im_start|>assistant\n{Content}<|im_end|>\n",
+  "prompt": "{Messages}<|im_start|>assistant\n"
+}
+```
+
+**Llama-style:**
+
+```json
+{
+  "system": "<|start_header_id|>system<|end_header_id|>\n\n{Content}<|eot_id|>",
+  "user": "<|start_header_id|>user<|end_header_id|>\n\n{Content}<|eot_id|>",
+  "assistant": "<|start_header_id|>assistant<|end_header_id|>\n\n{Content}<|eot_id|>",
+  "prompt": "<|begin_of_text|>{Messages}<|start_header_id|>assistant<|end_header_id|>\n\n"
+}
+```
+
+**Gemma-style:**
+
+```json
+{
+  "system": "",
+  "user": "<start_of_turn>user\n{Content}<end_of_turn>\n",
+  "assistant": "<start_of_turn>model\n{Content}<end_of_turn>\n",
+  "prompt": "{Messages}<start_of_turn>model\n"
+}
+```
+
+Match the template to your model's chat format. Check the HuggingFace
+`tokenizer_config.json` for the model's `chat_template` to determine
+the correct format.
+
+## Running the model
+
+### CLI
+
+```bash
+foundry model run my-custom-model
+```
+
+This starts a local inference server and opens an interactive chat.
+
+### API access
+
+Foundry Local exposes an **OpenAI-compatible API** endpoint. Once a
+model is running, you can access it via HTTP:
+
+```python
+import openai
+
+client = openai.OpenAI(
+    base_url="http://localhost:5273/v1",
+    api_key="foundry-local",  # any non-empty string
+)
+
+response = client.chat.completions.create(
+    model="my-custom-model",
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello!"},
+    ],
+    max_tokens=100,
+)
+print(response.choices[0].message.content)
+```
+
+The port (default 5273) may vary — check the Foundry Local output
+when starting the server.
+
+### Python SDK
+
+```python
+from foundry_local import FoundryLocalManager
+
+manager = FoundryLocalManager()
+# List available models
+print(manager.list_models())
+```
+
+> **Limitation:** The `FoundryLocalManager` SDK may not discover custom
+> models placed in the cache directory. If your model doesn't appear,
+> use the CLI (`foundry model run`) or access the HTTP API directly.
+
+## Known limitations
+
+### 1. Bundled GenAI version
+
+Foundry Local bundles its own version of `onnxruntime-genai`. Custom
+models must be compatible with the bundled GenAI version. If your model
+uses features from a newer GenAI version (e.g. new model_type support),
+it may not load.
+
+**Workaround:** Force-reinstall your target GenAI wheel after installing
+the Foundry Local SDK:
+
+```bash
+pip install foundry-local-sdk
+# Override with your specific GenAI build
+pip install onnxruntime-genai==<version> --force-reinstall --no-deps
+```
+
+This replaces the bundled GenAI with your version. Use `--no-deps` to
+avoid re-installing Foundry's other dependencies.
+
+### 2. No CUDA EP in pip SDK version
+
+The pip-installed `foundry-local-sdk` does not include CUDA execution
+provider support. Models run on CPU by default.
+
+For GPU inference, use the standalone Foundry Local application (not
+the pip package) or set up ORT GenAI with CUDA EP directly.
+
+### 3. Multimodal models require GenAI 0.14+
+
+Vision-language and audio-language models need `onnxruntime-genai`
+version 0.14 or later for multi-model pipeline support. Check your
+Foundry Local's bundled version:
+
+```python
+import onnxruntime_genai as og
+print(og.__version__)
+```
+
+### 4. Custom model discovery
+
+The Python SDK's `FoundryLocalManager.list_models()` uses a catalog
+service that may not index custom models in the cache. Use the CLI
+or direct HTTP API as a reliable alternative.
+
+### 5. Model type compatibility
+
+Foundry Local uses ORT GenAI internally, which has a model_type
+whitelist (see the `ort-genai-config` skill). If your model uses an
+unregistered model_type, set `model_type: "decoder"` in
+`genai_config.json` as a workaround.
+
+## End-to-end example
+
+Complete workflow from HuggingFace model to local inference:
+
+```bash
+# 1. Export with mobius
+mobius build --model Qwen/Qwen2.5-7B-Instruct \
+  --dtype f16 --ep default --runtime ort-genai \
+  --external-data safetensors --max-shard-size 5GB \
+  qwen2.5-7b/
+
+# 2. Register in Foundry Local cache
+CACHE_DIR=$(foundry cache cd)
+mkdir -p "${CACHE_DIR}/models/Custom/qwen2.5-7b"
+cp -r qwen2.5-7b/* "${CACHE_DIR}/models/Custom/qwen2.5-7b/"
+
+# 3. Create inference_model.json
+cat > "${CACHE_DIR}/models/Custom/qwen2.5-7b/inference_model.json" << 'EOF'
+{
+  "Name": "qwen2.5-7b",
+  "PromptTemplate": {
+    "system": "<|im_start|>system\n{Content}<|im_end|>\n",
+    "user": "<|im_start|>user\n{Content}<|im_end|>\n",
+    "assistant": "<|im_start|>assistant\n{Content}<|im_end|>\n",
+    "prompt": "{Messages}<|im_start|>assistant\n"
+  }
+}
+EOF
+
+# 4. Verify and run
+foundry cache ls
+foundry model run qwen2.5-7b
+```
+
+## Reference
+
+- [Deploying Custom Models with Olive and Foundry Local](https://techcommunity.microsoft.com/blog/educatordeveloperblog/deploying-custom-models-with-microsoft-olive-and-foundry-local/4489002)
+
+## Cross-references
+
+- **Exporting models:** `.agents/skills/onnx-export-quantization/SKILL.md`
+- **ORT GenAI config:** `.agents/skills/ort-genai-config/SKILL.md`
+- **Quality checklist (L5):** `.agents/skills/quality-checklist/SKILL.md`

--- a/.agents/skills/foundry-local/SKILL.md
+++ b/.agents/skills/foundry-local/SKILL.md
@@ -290,8 +290,11 @@ a new model_type registered), build both from source:
 3. Install both wheels, then install `foundry-local-sdk`, then
    **reinstall your custom wheels** (see warning above)
 
-For the full build tutorial with step-by-step instructions, see
-[issue #245](https://github.com/onnxruntime/mobius/issues/245).
+See the **building-ort-genai** skill
+(`.agents/skills/building-ort-genai/SKILL.md`) for the full
+step-by-step guide, and
+[issue #245](https://github.com/onnxruntime/mobius/issues/245) for a
+complete end-to-end tutorial.
 
 ### 3. No CUDA EP in pip SDK version
 
@@ -373,6 +376,7 @@ foundry model run qwen2.5-7b
 
 ## Cross-references
 
+- **Building ORT/GenAI:** `.agents/skills/building-ort-genai/SKILL.md`
 - **Exporting models:** `.agents/skills/onnx-export-quantization/SKILL.md`
 - **ORT GenAI config:** `.agents/skills/ort-genai-config/SKILL.md`
 - **Quality checklist (L5):** `.agents/skills/quality-checklist/SKILL.md`

--- a/.agents/skills/foundry-local/SKILL.md
+++ b/.agents/skills/foundry-local/SKILL.md
@@ -36,8 +36,11 @@ Use this skill when:
      output/
    ```
 
-   The output directory must contain `genai_config.json`, tokenizer
-   files, and the model sub-directories (decoder/, embedding/, etc.).
+   The output directory must contain `genai_config.json` and tokenizer
+   files. For single-model exports (text-only LLMs), model files
+   (`model.onnx` + external data) are in the output root. For
+   multi-model exports (VLMs, ALMs), sub-directories like `decoder/`,
+   `embedding/`, `vision_encoder/` contain each model.
 
 ## Custom model registration
 
@@ -64,18 +67,34 @@ mkdir -p "${CACHE_DIR}/models/Custom/${MODEL_NAME}"
 
 ### Step 3: Copy model files
 
-Copy the entire mobius export output into the model directory:
+Copy the entire mobius export output into the model directory. The
+simplest approach copies everything:
 
 ```bash
-# Copy all model files
-cp -r output/decoder/ "${CACHE_DIR}/models/Custom/${MODEL_NAME}/"
+cp -r output/* "${CACHE_DIR}/models/Custom/${MODEL_NAME}/"
+```
+
+Or copy selectively (handles both single-model and multi-model layouts):
+
+```bash
+# Model files — single-model (root-level) and multi-model (sub-dirs)
+cp output/model.onnx* "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
+cp -r output/decoder/ "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
 cp -r output/embedding/ "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
 cp -r output/vision_encoder/ "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
 cp -r output/audio_encoder/ "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
+
+# Config and tokenizer files (required)
 cp output/genai_config.json "${CACHE_DIR}/models/Custom/${MODEL_NAME}/"
 cp output/tokenizer* "${CACHE_DIR}/models/Custom/${MODEL_NAME}/"
+
+# Processor configs for VLMs (copy whichever exist)
 cp output/image_processor.json "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
+cp output/processor_config.json "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
 cp output/audio_processor.json "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
+
+# External data shards (single-model layout)
+cp output/*.safetensors "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
 ```
 
 ### Step 4: Create `inference_model.json`
@@ -271,8 +290,16 @@ or direct HTTP API as a reliable alternative.
 
 Foundry Local uses ORT GenAI internally, which has a model_type
 whitelist (see the `ort-genai-config` skill). If your model uses an
-unregistered model_type, set `model_type: "decoder"` in
-`genai_config.json` as a workaround.
+unregistered model_type, set `"type": "decoder"` under the `"model"`
+key in `genai_config.json` as a workaround:
+
+```json
+{
+  "model": {
+    "type": "decoder"
+  }
+}
+```
 
 ## End-to-end example
 

--- a/.agents/skills/foundry-local/SKILL.md
+++ b/.agents/skills/foundry-local/SKILL.md
@@ -27,6 +27,23 @@ Use this skill when:
    pip install foundry-local-sdk
    ```
 
+   > ⚠️ **WARNING: Dependency override.** `pip install foundry-local-sdk`
+   > installs its own versions of `onnxruntime` and
+   > `onnxruntime-genai`, which **override any custom builds** you may
+   > have installed. If you need a specific ORT or GenAI version (e.g.
+   > built from source with CUDA support), you must reinstall your
+   > wheels **after** installing foundry-local-sdk:
+   >
+   > ```bash
+   > pip install foundry-local-sdk
+   > pip install --force-reinstall <your_ort_wheel>.whl
+   > pip install --force-reinstall <your_genai_wheel>.whl
+   > ```
+   >
+   > This works because Foundry's native core symlinks to the
+   > Python-installed `.so` files — replacing them takes effect
+   > immediately.
+
 2. **ONNX model exported by mobius** with `--runtime ort-genai`:
 
    ```bash
@@ -254,14 +271,29 @@ the Foundry Local SDK:
 
 ```bash
 pip install foundry-local-sdk
-# Override with your specific GenAI build
-pip install onnxruntime-genai==<version> --force-reinstall --no-deps
+# Override with your specific GenAI build (and ORT if needed)
+pip install --force-reinstall <your_ort_wheel>.whl
+pip install --force-reinstall <your_genai_wheel>.whl
 ```
 
-This replaces the bundled GenAI with your version. Use `--no-deps` to
-avoid re-installing Foundry's other dependencies.
+This replaces the bundled GenAI with your version. Foundry's native
+core symlinks to the Python-installed `.so` files, so replacing them
+takes effect immediately.
 
-### 2. No CUDA EP in pip SDK version
+### 2. Building ORT and GenAI from source
+
+If you need a custom ORT GenAI build (e.g. with CUDA support, or with
+a new model_type registered), build both from source:
+
+1. **Build ORT** with CUDA EP enabled
+2. **Build GenAI** linked against your custom ORT build
+3. Install both wheels, then install `foundry-local-sdk`, then
+   **reinstall your custom wheels** (see warning above)
+
+For the full build tutorial with step-by-step instructions, see
+[issue #245](https://github.com/onnxruntime/mobius/issues/245).
+
+### 3. No CUDA EP in pip SDK version
 
 The pip-installed `foundry-local-sdk` does not include CUDA execution
 provider support. Models run on CPU by default.
@@ -269,7 +301,7 @@ provider support. Models run on CPU by default.
 For GPU inference, use the standalone Foundry Local application (not
 the pip package) or set up ORT GenAI with CUDA EP directly.
 
-### 3. Multimodal models require GenAI 0.14+
+### 4. Multimodal models require GenAI 0.14+
 
 Vision-language and audio-language models need `onnxruntime-genai`
 version 0.14 or later for multi-model pipeline support. Check your
@@ -280,13 +312,13 @@ import onnxruntime_genai as og
 print(og.__version__)
 ```
 
-### 4. Custom model discovery
+### 5. Custom model discovery
 
 The Python SDK's `FoundryLocalManager.list_models()` uses a catalog
 service that may not index custom models in the cache. Use the CLI
 or direct HTTP API as a reliable alternative.
 
-### 5. Model type compatibility
+### 6. Model type compatibility
 
 Foundry Local uses ORT GenAI internally, which has a model_type
 whitelist (see the `ort-genai-config` skill). If your model uses an


### PR DESCRIPTION
Document how to deploy mobius-exported ONNX models to Microsoft Foundry Local.

## What this adds

New skill at `.agents/skills/foundry-local/SKILL.md` covering:

- **Custom model registration** — cache directory structure, file copying, verification
- **inference_model.json format** — field reference + common prompt templates (ChatML, Llama, Gemma)
- **Running models** — CLI (`foundry model run`), OpenAI-compatible API, Python SDK
- **Known limitations** — bundled GenAI version, no CUDA in pip SDK, multimodal requirements, model_type workaround
- **End-to-end example** — complete workflow from `mobius build` to local inference

Reference: https://techcommunity.microsoft.com/blog/educatordeveloperblog/deploying-custom-models-with-microsoft-olive-and-foundry-local/4489002

Replaces #242 (closed due to wrong branch name).