### PR TITLE
Add static KV cache (TensorScatter) support for Gemma4

### DIFF
--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -268,9 +268,7 @@ def _cmd_build(args: argparse.Namespace) -> None:
             hf_config = transformers.AutoConfig.from_pretrained(
                 model_id_or_path, trust_remote_code=trust_remote_code
             )
-            task = _resolve_static_cache_task(
-                getattr(hf_config, "model_type", "")
-            )
+            task = _resolve_static_cache_task(getattr(hf_config, "model_type", ""))
 
         pkg = build(
             model_id_or_path,

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -253,21 +253,25 @@ def _cmd_build(args: argparse.Namespace) -> None:
                 state_dict = model_module.preprocess_weights(state_dict)
             pkg.apply_weights(state_dict)
     else:
-        # Resolve static cache task if needed (requires model_type detection)
         model_id_or_path = args.model
+        extra_build_kwargs: dict = {}
         if static_cache_params is not None:
+            # Static cache: detect model type to resolve the correct task.
+            # For multimodal models, override to use the text-only model class.
             import transformers
 
             hf_config = transformers.AutoConfig.from_pretrained(
                 model_id_or_path, trust_remote_code=trust_remote_code
             )
             mt = getattr(hf_config, "model_type", "")
-            # For multimodal models (e.g. gemma4), use the text sub-config
-            # so build() resolves to the text-only model class for static cache.
             if hasattr(hf_config, "text_config"):
                 text_mt = getattr(hf_config.text_config, "model_type", "")
-                if text_mt:
+                if text_mt and text_mt != mt:
                     mt = text_mt
+                    # Override module_class so build() uses the text-only model
+                    from mobius._registry import registry as _registry
+
+                    extra_build_kwargs["module_class"] = _registry.get(mt)
             task = _resolve_static_cache_task(mt)
 
         pkg = build(
@@ -277,7 +281,8 @@ def _cmd_build(args: argparse.Namespace) -> None:
             load_weights=load_weights,
             trust_remote_code=trust_remote_code,
             execution_provider=execution_provider,
-            text_only=args.text_only or static_cache_params is not None,
+            text_only=args.text_only,
+            **extra_build_kwargs,
         )
 
     _save_package(pkg, output_dir, args, optimize, component_filter)

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -121,7 +121,14 @@ def _cmd_build(args: argparse.Namespace) -> None:
 
     def _resolve_static_cache_task(model_type: str) -> ModelTask:
         """Create the correct static cache task for the given model type."""
-        if model_type in ("gemma4", "gemma4_text"):
+        if model_type == "gemma4":
+            from mobius.tasks._gemma4 import Gemma4Task
+
+            return Gemma4Task(
+                static_cache=True,
+                max_seq_len=args.max_seq_len,
+            )
+        if model_type == "gemma4_text":
             from mobius.tasks._gemma4 import Gemma4TextCausalLMTask
 
             return Gemma4TextCausalLMTask(
@@ -254,25 +261,16 @@ def _cmd_build(args: argparse.Namespace) -> None:
             pkg.apply_weights(state_dict)
     else:
         model_id_or_path = args.model
-        extra_build_kwargs: dict = {}
         if static_cache_params is not None:
-            # Static cache: detect model type to resolve the correct task.
-            # For multimodal models, override to use the text-only model class.
+            # Detect model type to resolve the correct static cache task.
             import transformers
 
             hf_config = transformers.AutoConfig.from_pretrained(
                 model_id_or_path, trust_remote_code=trust_remote_code
             )
-            mt = getattr(hf_config, "model_type", "")
-            if hasattr(hf_config, "text_config"):
-                text_mt = getattr(hf_config.text_config, "model_type", "")
-                if text_mt and text_mt != mt:
-                    mt = text_mt
-                    # Override module_class so build() uses the text-only model
-                    from mobius._registry import registry as _registry
-
-                    extra_build_kwargs["module_class"] = _registry.get(mt)
-            task = _resolve_static_cache_task(mt)
+            task = _resolve_static_cache_task(
+                getattr(hf_config, "model_type", "")
+            )
 
         pkg = build(
             model_id_or_path,
@@ -282,7 +280,6 @@ def _cmd_build(args: argparse.Namespace) -> None:
             trust_remote_code=trust_remote_code,
             execution_provider=execution_provider,
             text_only=args.text_only,
-            **extra_build_kwargs,
         )
 
     _save_package(pkg, output_dir, args, optimize, component_filter)

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -119,6 +119,17 @@ def _cmd_build(args: argparse.Namespace) -> None:
     )
     from mobius.tasks import CausalLMTask, ModelTask
 
+    def _resolve_static_cache_task(model_type: str) -> ModelTask:
+        """Create the correct static cache task for the given model type."""
+        if model_type in ("gemma4", "gemma4_text"):
+            from mobius.tasks._gemma4 import Gemma4TextCausalLMTask
+
+            return Gemma4TextCausalLMTask(
+                static_cache=True,
+                max_seq_len=args.max_seq_len,
+            )
+        return CausalLMTask(static_cache=True, max_seq_len=args.max_seq_len)
+
     # Validate --max-seq-len requires --static-cache
     if args.max_seq_len is not None and not args.static_cache:
         raise SystemExit("Error: --max-seq-len can only be used with --static-cache.")
@@ -161,7 +172,14 @@ def _cmd_build(args: argparse.Namespace) -> None:
     load_weights = not args.no_weights
     task: str | ModelTask | None = args.task
     if args.static_cache:
-        task = CausalLMTask(static_cache=True, max_seq_len=args.max_seq_len)
+        # Defer task creation — we need to know the model type first.
+        # Store parameters for later resolution.
+        static_cache_params = {
+            "static_cache": True,
+            "max_seq_len": args.max_seq_len,
+        }
+    else:
+        static_cache_params = None
     trust_remote_code = args.trust_remote_code
     output_dir = args.output_dir
     os.makedirs(output_dir, exist_ok=True)
@@ -218,7 +236,9 @@ def _cmd_build(args: argparse.Namespace) -> None:
         config = _config_from_hf(hf_config, parent_config=parent_config)
         if dtype_override is not None:
             config = dataclasses.replace(config, dtype=dtype_override)
-        if task is None:
+        if static_cache_params is not None:
+            task = _resolve_static_cache_task(model_type)
+        elif task is None:
             task = _default_task_for_model(model_type)
         module_class = registry.get(model_type)
         model_module = module_class(config)
@@ -233,14 +253,31 @@ def _cmd_build(args: argparse.Namespace) -> None:
                 state_dict = model_module.preprocess_weights(state_dict)
             pkg.apply_weights(state_dict)
     else:
+        # Resolve static cache task if needed (requires model_type detection)
+        model_id_or_path = args.model
+        if static_cache_params is not None:
+            import transformers
+
+            hf_config = transformers.AutoConfig.from_pretrained(
+                model_id_or_path, trust_remote_code=trust_remote_code
+            )
+            mt = getattr(hf_config, "model_type", "")
+            # For multimodal models (e.g. gemma4), use the text sub-config
+            # so build() resolves to the text-only model class for static cache.
+            if hasattr(hf_config, "text_config"):
+                text_mt = getattr(hf_config.text_config, "model_type", "")
+                if text_mt:
+                    mt = text_mt
+            task = _resolve_static_cache_task(mt)
+
         pkg = build(
-            args.model,
+            model_id_or_path,
             task=task,
             dtype=dtype_override,
             load_weights=load_weights,
             trust_remote_code=trust_remote_code,
             execution_provider=execution_provider,
-            text_only=args.text_only,
+            text_only=args.text_only or static_cache_params is not None,
         )
 
     _save_package(pkg, output_dir, args, optimize, component_filter)

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -54,7 +54,7 @@ from mobius.models.base import CausalLMModel
 from mobius.models.gemma3_text import Gemma3TextScaledWordEmbedding
 
 if TYPE_CHECKING:
-    from mobius.components._attention import GQAContext
+    from mobius.components._attention import GQAContext, StaticCacheState
 
 
 # ---------------------------------------------------------------------------
@@ -874,6 +874,7 @@ class Gemma4TextAttention(nn.Module):
         shared_kv_states: dict | None = None,
         past_key_value: tuple | None = None,
         is_causal: int = 1,
+        static_cache: StaticCacheState | None = None,
     ):
         from mobius.components._attention import (
             GQAContext,
@@ -1123,6 +1124,7 @@ class Gemma4TextAttention(nn.Module):
                 num_key_value_heads=self.num_key_value_heads,
                 scale=self.scaling,
                 softcap=self.softcap,
+                static_cache=static_cache,
                 is_causal=is_causal,
             )
 
@@ -1332,9 +1334,19 @@ class Gemma4DecoderLayer(nn.Module):
         position_embeddings: tuple | None,
         shared_kv_states: dict,
         per_layer_input: ir.Value | None,
-        past_key_value: tuple | None,
+        past_key_value: tuple | StaticCacheState | None,
         is_causal: int = 1,
     ):
+        # Dispatch StaticCacheState: extract it from past_key_value so that
+        # the attention module receives it as a separate parameter.
+        from mobius.components._attention import StaticCacheState
+
+        if isinstance(past_key_value, StaticCacheState):
+            static_cache = past_key_value
+            past_key_value = None
+        else:
+            static_cache = None
+
         # Attention block: pre-norm -> attn -> post-norm -> residual
         residual = hidden_states
         hidden_states = self.input_layernorm(op, hidden_states)
@@ -1345,6 +1357,7 @@ class Gemma4DecoderLayer(nn.Module):
             position_embeddings=position_embeddings,
             shared_kv_states=shared_kv_states,
             past_key_value=past_key_value,
+            static_cache=static_cache,
             is_causal=is_causal,
         )
         hidden_states = self.post_attention_layernorm(op, attn_output)
@@ -1810,7 +1823,7 @@ class Gemma4TextModel(nn.Module):
         self,
         op: OpBuilder,
         input_ids: ir.Value | None,
-        attention_mask: ir.Value,
+        attention_mask: ir.Value | None,
         position_ids: ir.Value,
         past_key_values: list | None = None,
         inputs_embeds: ir.Value | None = None,
@@ -1850,7 +1863,6 @@ class Gemma4TextModel(nn.Module):
 
         caps = ep_capabilities()
         dtype = get_build_dtype()
-
         # Bidirectional vision-block overlay (Gemma4 larger models). When
         # active, contiguous vision-token blocks attend bidirectionally on
         # BOTH full and sliding layers. This cannot be expressed by the
@@ -1886,8 +1898,12 @@ class Gemma4TextModel(nn.Module):
             )
         use_block_overlay = bidirectional and block_sequence_ids is not None
 
+        # Static cache mode: attention_mask is None, skip GQA and fallback
+        # mask construction — the Attention op uses is_causal=1 with
+        # nonpad_kv_seqlen for masking instead.
+        static_cache_mode = attention_mask is None
         use_gqa = (
-            attention_mask is not None
+            not static_cache_mode
             and dtype in caps.gqa_dtypes
             and caps.supports_fused_rope
             and not use_block_overlay
@@ -1959,7 +1975,9 @@ class Gemma4TextModel(nn.Module):
         query_input = input_ids if input_ids is not None else hidden_states
         fallback_bias_dict: dict[str, ir.Value | None] = {}
         need_fallback = not use_gqa
-        if need_fallback:
+        if need_fallback and not static_cache_mode:
+            # Static cache mode skips mask construction entirely — the
+            # Attention op handles masking via is_causal=1 + nonpad_kv_seqlen.
             fallback_bias_dict = {
                 "sliding_attention": create_attention_bias(
                     op,
@@ -2003,9 +2021,13 @@ class Gemma4TextModel(nn.Module):
         ):
             per_layer_input = per_layer_list[i] if per_layer_list is not None else None
 
-            # Per-layer decision: use GQA when available. KV-shared layers
-            # also use GQA (with empty K/V and shared past buffer).
-            if use_gqa:
+            # Per-layer decision: use GQA when available.
+            # Static cache mode: no GQA, no fallback bias — Attention op
+            # uses is_causal=1 + nonpad_kv_seqlen from the StaticCacheState.
+            if static_cache_mode:
+                attn_bias = None
+                pos_emb = position_embeddings_dict[layer_type]
+            elif use_gqa:
                 attn_bias = gqa_ctx_dict[layer_type]
                 pos_emb = None
             else:

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -904,11 +904,6 @@ class Gemma4TextAttention(nn.Module):
         if self.is_kv_shared_layer:
             # KV-shared layers borrow K,V from a source layer (no own KV cache).
             src_key, src_value = shared_kv_states[self.kv_shared_layer_index][:2]
-            src_nonpad = (
-                shared_kv_states[self.kv_shared_layer_index][2]
-                if len(shared_kv_states[self.kv_shared_layer_index]) > 2
-                else None
-            )
 
             if use_gqa:
                 # GQA path for shared KV: pass empty K/V tensors and wire the
@@ -1912,7 +1907,7 @@ class Gemma4TextModel(nn.Module):
             # GQA references these caches directly; without the call the
             # parameters are never emitted into the graph.
             _ = self.rotary_emb_local(op, position_ids)
-            _ = self.rotary_emb_global(op, position_ids)
+            global_pos_emb = self.rotary_emb_global(op, position_ids)
 
             # seqlens_k[b] = sum(attention_mask[b]) - 1  (last valid KV idx)
             # total_seq_len = attention_mask.shape[1]     (past + current)
@@ -1978,8 +1973,8 @@ class Gemma4TextModel(nn.Module):
             # All fallback layers use float additive bias masks encoding
             # causal + sliding window + padding constraints. Float bias
             # works with both unfused and MEA kernel paths on CUDA EP.
-            # When attention_mask is None (static cache), the Attention
-            # op uses is_causal=1 + nonpad_kv_seqlen instead.
+            # When attention_mask is None (static cache), the Attention op uses
+            # nonpad_kv_seqlen to bound the externally managed cache.
             fallback_bias_dict = {
                 "sliding_attention": create_attention_bias(
                     op,

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -971,40 +971,27 @@ class Gemma4TextAttention(nn.Module):
                     src_value = op.Transpose(src_value, perm=[0, 2, 1, 3])
                     src_value = op.Reshape(src_value, [0, 0, shared_kv_hidden])
 
-                # For static source with nonpad_kv_seqlen, use the Attention
-                # op's external cache path (no mask, is_causal + nonpad).
-                if is_static_source and src_nonpad is not None:
-                    attn_output, _, _ = op.Attention(
-                        query_states,
-                        src_key,
-                        src_value,
-                        None,  # no mask
-                        None,  # no past_key
-                        None,  # no past_value
-                        src_nonpad,
-                        q_num_heads=self.num_attention_heads,
-                        kv_num_heads=self.num_key_value_heads,
-                        scale=self.scaling,
-                        softcap=self.softcap,
-                        is_causal=1,
-                        _outputs=3,
-                    )
-                    present_key, present_value = src_key, src_value
-                else:
-                    attn_output, present_key, present_value = _apply_attention(
-                        op,
-                        query_states,
-                        src_key,
-                        src_value,
-                        attention_bias,
-                        past_key=None,
-                        past_value=None,
-                        num_attention_heads=self.num_attention_heads,
-                        num_key_value_heads=self.num_key_value_heads,
-                        scale=self.scaling,
-                        softcap=self.softcap,
-                        is_causal=0,
-                    )
+                # KV-shared layers always use the dynamic Attention path with
+                # mask (attention_bias). Even when the source layer uses static
+                # cache, the KV-shared layer's Attention uses the source's full
+                # cache as K/V with past_key=None (no own KV concat).
+                # The nonpad_kv_seqlen path is NOT used here because ORT's
+                # is_causal=0 + nonpad_kv_seqlen triggers a CUDA kernel issue
+                # for KV-shared decode (S_q=1, S_kv=max_seq).
+                attn_output, present_key, present_value = _apply_attention(
+                    op,
+                    query_states,
+                    src_key,
+                    src_value,
+                    attention_bias,
+                    past_key=None,
+                    past_value=None,
+                    num_attention_heads=self.num_attention_heads,
+                    num_key_value_heads=self.num_key_value_heads,
+                    scale=self.scaling,
+                    softcap=self.softcap,
+                    is_causal=0,
+                )
         elif use_gqa:
             # GQA path: emit com.microsoft.GroupQueryAttention directly.
             # The op fuses RoPE + attention + KV cache into a single op,

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -903,7 +903,12 @@ class Gemma4TextAttention(nn.Module):
 
         if self.is_kv_shared_layer:
             # KV-shared layers borrow K,V from a source layer (no own KV cache).
-            src_key, src_value = shared_kv_states[self.kv_shared_layer_index]
+            src_key, src_value = shared_kv_states[self.kv_shared_layer_index][:2]
+            src_nonpad = (
+                shared_kv_states[self.kv_shared_layer_index][2]
+                if len(shared_kv_states[self.kv_shared_layer_index]) > 2
+                else None
+            )
 
             if use_gqa:
                 # GQA path for shared KV: pass empty K/V tensors and wire the
@@ -952,57 +957,54 @@ class Gemma4TextAttention(nn.Module):
                     **gqa_attrs,
                 )
             else:
-                # Fallback Attention path (non-GQA / CPU-style graphs).
-                #
-                # The shared K,V buffer is the source layer's present K/V, 4D
-                # BNSH [batch, kv_heads, kv_len, head_dim], and already contains
-                # the FULL sequence (with RoPE applied).  Transpose it to the 3D
-                # layout the Attention op expects:
-                #   [batch, kv_len, kv_heads * head_dim].
-                #
-                # Reshape to the STATIC ``kv_heads * head_dim`` hidden size (not a
-                # dynamic ``-1``): the source present-value comes out of an
-                # Attention op whose head_dim onnxruntime does not always
-                # propagate, so a ``-1`` here leaves the Attention op's value
-                # head size (and therefore this layer's attention output width)
-                # unknown.  onnxruntime then infers a mismatched o_proj input dim
-                # and rejects the graph at session creation with a MatMul
-                # "Incompatible dimensions" shape-inference error.  A concrete
-                # last dim lets it infer the attention output width correctly.
-                shared_kv_hidden = self.num_key_value_heads * self.head_dim
-                src_key = op.Transpose(src_key, perm=[0, 2, 1, 3])
-                src_key = op.Reshape(src_key, [0, 0, shared_kv_hidden])
-                src_value = op.Transpose(src_value, perm=[0, 2, 1, 3])
-                src_value = op.Reshape(src_value, [0, 0, shared_kv_hidden])
+                # Fallback Attention path: transpose shared KV from BNSH to 3D.
+                # Source K/V shape depends on whether the source layer uses
+                # static or dynamic cache:
+                #   Dynamic: [B, kv_heads, total_seq, head_dim] (4D present)
+                #   Static:  [B, max_seq, kv_heads*head_dim]    (3D updated cache)
+                # Static cache sources are already 3D — skip reshape.
+                is_static_source = src_key.shape is not None and len(src_key.shape) == 3
+                if not is_static_source:
+                    shared_kv_hidden = self.num_key_value_heads * self.head_dim
+                    src_key = op.Transpose(src_key, perm=[0, 2, 1, 3])
+                    src_key = op.Reshape(src_key, [0, 0, shared_kv_hidden])
+                    src_value = op.Transpose(src_value, perm=[0, 2, 1, 3])
+                    src_value = op.Reshape(src_value, [0, 0, shared_kv_hidden])
 
-                # IMPORTANT: pass is_causal=0 here, NOT the caller's is_causal.
-                #
-                # We feed the FULL shared sequence as key/value with no past, so
-                # q_len < kv_len during decode.  ``attention_bias`` from
-                # ``create_attention_bias`` already bakes in the complete
-                # bottom-right causal (+ sliding + padding) mask, so causality is
-                # fully handled by the bias.  If we ALSO set is_causal=1 the
-                # Attention op applies its own built-in causal mask on top — and
-                # for q_len < kv_len the two EPs disagree on its alignment (per
-                # the ONNX spec is_causal is UPPER-LEFT aligned: CUDA follows the
-                # spec and a single decode query attends only to kv[0], while the
-                # CPU EP bottom-right aligns).  That double-masking is what made
-                # gemma4 decode diverge on CUDA.  Relying solely on the float
-                # bias (is_causal=0) is correct and identical on CPU and CUDA.
-                attn_output, present_key, present_value = _apply_attention(
-                    op,
-                    query_states,
-                    src_key,
-                    src_value,
-                    attention_bias,
-                    past_key=None,
-                    past_value=None,
-                    num_attention_heads=self.num_attention_heads,
-                    num_key_value_heads=self.num_key_value_heads,
-                    scale=self.scaling,
-                    softcap=self.softcap,
-                    is_causal=0,
-                )
+                # For static source with nonpad_kv_seqlen, use the Attention
+                # op's external cache path (no mask, is_causal + nonpad).
+                if is_static_source and src_nonpad is not None:
+                    attn_output, _, _ = op.Attention(
+                        query_states,
+                        src_key,
+                        src_value,
+                        None,  # no mask
+                        None,  # no past_key
+                        None,  # no past_value
+                        src_nonpad,
+                        q_num_heads=self.num_attention_heads,
+                        kv_num_heads=self.num_key_value_heads,
+                        scale=self.scaling,
+                        softcap=self.softcap,
+                        is_causal=1,
+                        _outputs=3,
+                    )
+                    present_key, present_value = src_key, src_value
+                else:
+                    attn_output, present_key, present_value = _apply_attention(
+                        op,
+                        query_states,
+                        src_key,
+                        src_value,
+                        attention_bias,
+                        past_key=None,
+                        past_value=None,
+                        num_attention_heads=self.num_attention_heads,
+                        num_key_value_heads=self.num_key_value_heads,
+                        scale=self.scaling,
+                        softcap=self.softcap,
+                        is_causal=0,
+                    )
         elif use_gqa:
             # GQA path: emit com.microsoft.GroupQueryAttention directly.
             # The op fuses RoPE + attention + KV cache into a single op,
@@ -1072,6 +1074,7 @@ class Gemma4TextAttention(nn.Module):
                 shared_kv_states[self.layer_idx] = (
                     present_key,
                     present_value,
+                    None,  # no nonpad_kv_seqlen for GQA path
                 )
         else:
             # K projection + per-head K norm + optional RoPE
@@ -1129,10 +1132,14 @@ class Gemma4TextAttention(nn.Module):
             )
 
             # Source layers store K,V for downstream KV-shared layers.
+            # Include nonpad_kv_seqlen for static cache sources so
+            # KV-shared layers can pass it to the Attention op.
             if self.provides_shared_kv and shared_kv_states is not None:
+                nonpad = static_cache.nonpad_kv_seqlen if static_cache else None
                 shared_kv_states[self.layer_idx] = (
                     present_key,
                     present_value,
+                    nonpad,
                 )
 
         attn_output = self.o_proj(op, attn_output)

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -1898,14 +1898,11 @@ class Gemma4TextModel(nn.Module):
             )
         use_block_overlay = bidirectional and block_sequence_ids is not None
 
-        # Detect static cache mode from past_key_values content: if any
-        # entry is a StaticCacheState, the Attention op uses is_causal=1
-        # with nonpad_kv_seqlen — no attention_mask or GQA needed.
-        static_cache_mode = past_key_values is not None and any(
-            isinstance(kv, StaticCacheState) for kv in past_key_values if kv is not None
-        )
+        # GQA is available when attention_mask exists and the EP supports it.
+        # In hybrid mode, sliding layers use GQA while full-attention layers
+        # use the static Attention path with TensorScatter.
         use_gqa = (
-            not static_cache_mode
+            attention_mask is not None
             and dtype in caps.gqa_dtypes
             and caps.supports_fused_rope
             and not use_block_overlay
@@ -1967,6 +1964,12 @@ class Gemma4TextModel(nn.Module):
                 "sliding_attention": None,
                 "full_attention": None,
             }
+            # In hybrid mode, static-cache full-attention layers need RoPE
+            # embeddings for the standard Attention path (not GQA).
+            if past_key_values is not None and any(
+                isinstance(kv, StaticCacheState) for kv in past_key_values if kv is not None
+            ):
+                position_embeddings_dict["full_attention"] = global_pos_emb
         else:
             position_embeddings_dict = {
                 "sliding_attention": self.rotary_emb_local(op, position_ids),
@@ -1977,8 +1980,7 @@ class Gemma4TextModel(nn.Module):
         query_input = input_ids if input_ids is not None else hidden_states
         fallback_bias_dict: dict[str, ir.Value | None] = {}
         need_fallback = not use_gqa
-        if need_fallback and not static_cache_mode:
-            # Static cache mode skips mask construction entirely — the
+        if need_fallback and attention_mask is not None:
             # Attention op handles masking via is_causal=1 + nonpad_kv_seqlen.
             fallback_bias_dict = {
                 "sliding_attention": create_attention_bias(
@@ -2023,18 +2025,24 @@ class Gemma4TextModel(nn.Module):
         ):
             per_layer_input = per_layer_list[i] if per_layer_list is not None else None
 
-            # Per-layer decision: use GQA when available.
-            # Static cache mode: no GQA, no fallback bias — Attention op
-            # uses is_causal=1 + nonpad_kv_seqlen from the StaticCacheState.
-            if static_cache_mode:
+            # Per-layer cache/attention dispatch:
+            # - StaticCacheState → static path (TensorScatter + Attention)
+            # - Dynamic tuple → GQA path (with local_window_size)
+            # - None (no cache) → fallback Attention path
+            is_layer_static = isinstance(past_kv, StaticCacheState)
+
+            if is_layer_static:
                 attn_bias = None
                 pos_emb = position_embeddings_dict[layer_type]
             elif use_gqa:
                 attn_bias = gqa_ctx_dict[layer_type]
                 pos_emb = None
-            else:
+            elif fallback_bias_dict:
                 attn_bias = fallback_bias_dict[layer_type]
                 pos_emb = fallback_pos_dict[layer_type]
+            else:
+                attn_bias = None
+                pos_emb = position_embeddings_dict.get(layer_type)
 
             hidden_states, present_kv = layer(
                 op,

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -1981,7 +1981,11 @@ class Gemma4TextModel(nn.Module):
         fallback_bias_dict: dict[str, ir.Value | None] = {}
         need_fallback = not use_gqa
         if need_fallback and attention_mask is not None:
-            # Attention op handles masking via is_causal=1 + nonpad_kv_seqlen.
+            # All fallback layers use float additive bias masks encoding
+            # causal + sliding window + padding constraints. Float bias
+            # works with both unfused and MEA kernel paths on CUDA EP.
+            # When attention_mask is None (static cache), the Attention
+            # op uses is_causal=1 + nonpad_kv_seqlen instead.
             fallback_bias_dict = {
                 "sliding_attention": create_attention_bias(
                     op,

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -1859,7 +1859,7 @@ class Gemma4TextModel(nn.Module):
         # KV-shared layers fall back to standard Attention because they
         # borrow K,V from another layer (no own KV cache).
         from mobius._build_context import get_build_dtype
-        from mobius.components._attention import GQAContext
+        from mobius.components._attention import GQAContext, StaticCacheState
 
         caps = ep_capabilities()
         dtype = get_build_dtype()
@@ -1898,10 +1898,12 @@ class Gemma4TextModel(nn.Module):
             )
         use_block_overlay = bidirectional and block_sequence_ids is not None
 
-        # Static cache mode: attention_mask is None, skip GQA and fallback
-        # mask construction — the Attention op uses is_causal=1 with
-        # nonpad_kv_seqlen for masking instead.
-        static_cache_mode = attention_mask is None
+        # Detect static cache mode from past_key_values content: if any
+        # entry is a StaticCacheState, the Attention op uses is_causal=1
+        # with nonpad_kv_seqlen — no attention_mask or GQA needed.
+        static_cache_mode = past_key_values is not None and any(
+            isinstance(kv, StaticCacheState) for kv in past_key_values if kv is not None
+        )
         use_gqa = (
             not static_cache_mode
             and dtype in caps.gqa_dtypes

--- a/src/mobius/tasks/_causal_lm.py
+++ b/src/mobius/tasks/_causal_lm.py
@@ -459,20 +459,3 @@ def _validate_static_cache_support(module: nn.Module) -> None:
                     f"{type(layer).__name__}.forward()."
                 )
 
-    # Reject models with sliding-window attention: static cache uses
-    # is_causal=1 without local_window_size (the ONNX Attention op does
-    # not have this attribute — only com.microsoft.GroupQueryAttention
-    # supports it). This would silently produce wrong outputs for
-    # sequences longer than the window.
-    sliding_window = getattr(module, "sliding_window", None)
-    if sliding_window is None:
-        text_model = getattr(module, "model", None)
-        sliding_window = getattr(text_model, "sliding_window", None)
-    if sliding_window and sliding_window > 0:
-        raise ValueError(
-            f"Static cache mode is not supported for models with "
-            f"sliding-window attention (sliding_window={sliding_window}). "
-            f"The ONNX Attention op does not support local_window_size, "
-            f"so window constraints cannot be enforced. Use dynamic cache "
-            f"(without --static-cache) for correct sliding-window behavior."
-        )

--- a/src/mobius/tasks/_causal_lm.py
+++ b/src/mobius/tasks/_causal_lm.py
@@ -458,4 +458,3 @@ def _validate_static_cache_support(module: nn.Module) -> None:
                     f"model or add StaticCacheState dispatch to "
                     f"{type(layer).__name__}.forward()."
                 )
-

--- a/src/mobius/tasks/_causal_lm.py
+++ b/src/mobius/tasks/_causal_lm.py
@@ -400,10 +400,15 @@ def _register_static_cache_outputs(
 def _validate_static_cache_support(module: nn.Module) -> None:
     """Check that the module's decoder layers support StaticCacheState.
 
-    Only :class:`DecoderLayer` and :class:`MoEDecoderLayer` have the
-    ``isinstance(StaticCacheState)`` dispatch in ``forward()``.  Custom
-    decoder layers will silently unpack the NamedTuple as a regular
-    ``(key, value)`` tuple, producing wrong results.
+    Only :class:`DecoderLayer`, :class:`MoEDecoderLayer`, and
+    :class:`Gemma4DecoderLayer` have the ``isinstance(StaticCacheState)``
+    dispatch in ``forward()``.  Custom decoder layers will silently
+    unpack the NamedTuple as a regular ``(key, value)`` tuple, producing
+    wrong results.
+
+    Also warns when the model uses sliding-window attention, since the
+    static cache path does not enforce window constraints (the Attention
+    op uses ``is_causal=1`` without ``local_window_size``).
 
     NOTE: The following models are NOT yet supported in static cache
     mode and will raise TypeError from this check:
@@ -426,39 +431,51 @@ def _validate_static_cache_support(module: nn.Module) -> None:
     Raises:
         TypeError: If any decoder layer is not a supported type.
     """
+    import warnings
+
     from mobius.components._decoder import DecoderLayer
     from mobius.models.gemma4 import Gemma4DecoderLayer
     from mobius.models.moe import MoEDecoderLayer
 
-    # Only validate decoder layers (not vision/audio encoder layers).
-    # The heuristic: scan ModuleLists whose parent path looks like a text
-    # decoder backbone (e.g. "model.layers", "decoder.model.layers").
-    # Skip modules under "vision_encoder", "audio_encoder", etc.
-    encoder_prefixes = (
-        "vision_encoder", "audio_encoder", "vision_model",
-        "speech_encoder", "image_encoder",
-    )
+    _supported = (DecoderLayer, MoEDecoderLayer, Gemma4DecoderLayer)
+
+    # Whitelist-based validation: only check layers that have self_attn/attn
+    # (decoder-like), and accept those that are in the supported tuple.
+    # This naturally skips vision/audio encoder layers since they use
+    # different classes (e.g. Gemma4VisionEncoderLayer).
     for name, child in module.named_modules():
         if not isinstance(child, nn.ModuleList):
-            continue
-        # Skip encoder sub-modules
-        if any(prefix in name for prefix in encoder_prefixes):
             continue
         for i, layer in enumerate(child):
             if not isinstance(layer, nn.Module):
                 continue
-            # Check modules that look like decoder layers: they have an
-            # attention sub-module named either "self_attn" (standard) or
-            # "attn" (GPT-2 style).
             if not hasattr(layer, "self_attn") and not hasattr(layer, "attn"):
                 continue
-            if not isinstance(
-                layer, (DecoderLayer, MoEDecoderLayer, Gemma4DecoderLayer)
-            ):
+            if not isinstance(layer, _supported):
                 raise TypeError(
                     f"Static cache mode requires decoder layers that "
-                    f"inherit from DecoderLayer or MoEDecoderLayer, but "
-                    f"{name}[{i}] is {type(layer).__name__}. Either use a "
-                    f"compatible model or add StaticCacheState dispatch to "
+                    f"inherit from DecoderLayer, MoEDecoderLayer, or "
+                    f"Gemma4DecoderLayer, but {name}[{i}] is "
+                    f"{type(layer).__name__}. Either use a compatible "
+                    f"model or add StaticCacheState dispatch to "
                     f"{type(layer).__name__}.forward()."
                 )
+
+    # Warn about sliding-window layers: static cache uses is_causal=1
+    # without local_window_size, so window constraints are not enforced.
+    sliding_window = getattr(module, "sliding_window", None)
+    if sliding_window is None:
+        text_model = getattr(module, "model", None)
+        sliding_window = getattr(text_model, "sliding_window", None)
+    if sliding_window and sliding_window > 0:
+        warnings.warn(
+            f"Static cache mode does not enforce sliding-window attention "
+            f"(sliding_window={sliding_window}). For sequences longer than "
+            f"the window, all past tokens will be attended to instead of "
+            f"just the last {sliding_window}. This produces different "
+            f"outputs than the dynamic-cache GQA path. See "
+            f"_apply_attention() TODO for sliding-window static cache "
+            f"support.",
+            UserWarning,
+            stacklevel=3,
+        )

--- a/src/mobius/tasks/_causal_lm.py
+++ b/src/mobius/tasks/_causal_lm.py
@@ -427,10 +427,22 @@ def _validate_static_cache_support(module: nn.Module) -> None:
         TypeError: If any decoder layer is not a supported type.
     """
     from mobius.components._decoder import DecoderLayer
+    from mobius.models.gemma4 import Gemma4DecoderLayer
     from mobius.models.moe import MoEDecoderLayer
 
+    # Only validate decoder layers (not vision/audio encoder layers).
+    # The heuristic: scan ModuleLists whose parent path looks like a text
+    # decoder backbone (e.g. "model.layers", "decoder.model.layers").
+    # Skip modules under "vision_encoder", "audio_encoder", etc.
+    encoder_prefixes = (
+        "vision_encoder", "audio_encoder", "vision_model",
+        "speech_encoder", "image_encoder",
+    )
     for name, child in module.named_modules():
         if not isinstance(child, nn.ModuleList):
+            continue
+        # Skip encoder sub-modules
+        if any(prefix in name for prefix in encoder_prefixes):
             continue
         for i, layer in enumerate(child):
             if not isinstance(layer, nn.Module):
@@ -440,7 +452,9 @@ def _validate_static_cache_support(module: nn.Module) -> None:
             # "attn" (GPT-2 style).
             if not hasattr(layer, "self_attn") and not hasattr(layer, "attn"):
                 continue
-            if not isinstance(layer, (DecoderLayer, MoEDecoderLayer)):
+            if not isinstance(
+                layer, (DecoderLayer, MoEDecoderLayer, Gemma4DecoderLayer)
+            ):
                 raise TypeError(
                     f"Static cache mode requires decoder layers that "
                     f"inherit from DecoderLayer or MoEDecoderLayer, but "

--- a/src/mobius/tasks/_causal_lm.py
+++ b/src/mobius/tasks/_causal_lm.py
@@ -431,8 +431,6 @@ def _validate_static_cache_support(module: nn.Module) -> None:
     Raises:
         TypeError: If any decoder layer is not a supported type.
     """
-    import warnings
-
     from mobius.components._decoder import DecoderLayer
     from mobius.models.gemma4 import Gemma4DecoderLayer
     from mobius.models.moe import MoEDecoderLayer
@@ -461,21 +459,20 @@ def _validate_static_cache_support(module: nn.Module) -> None:
                     f"{type(layer).__name__}.forward()."
                 )
 
-    # Warn about sliding-window layers: static cache uses is_causal=1
-    # without local_window_size, so window constraints are not enforced.
+    # Reject models with sliding-window attention: static cache uses
+    # is_causal=1 without local_window_size (the ONNX Attention op does
+    # not have this attribute — only com.microsoft.GroupQueryAttention
+    # supports it). This would silently produce wrong outputs for
+    # sequences longer than the window.
     sliding_window = getattr(module, "sliding_window", None)
     if sliding_window is None:
         text_model = getattr(module, "model", None)
         sliding_window = getattr(text_model, "sliding_window", None)
     if sliding_window and sliding_window > 0:
-        warnings.warn(
-            f"Static cache mode does not enforce sliding-window attention "
-            f"(sliding_window={sliding_window}). For sequences longer than "
-            f"the window, all past tokens will be attended to instead of "
-            f"just the last {sliding_window}. This produces different "
-            f"outputs than the dynamic-cache GQA path. See "
-            f"_apply_attention() TODO for sliding-window static cache "
-            f"support.",
-            UserWarning,
-            stacklevel=3,
+        raise ValueError(
+            f"Static cache mode is not supported for models with "
+            f"sliding-window attention (sliding_window={sliding_window}). "
+            f"The ONNX Attention op does not support local_window_size, "
+            f"so window constraints cannot be enforced. Use dynamic cache "
+            f"(without --static-cache) for correct sliding-window behavior."
         )

--- a/src/mobius/tasks/_gemma4.py
+++ b/src/mobius/tasks/_gemma4.py
@@ -320,6 +320,10 @@ class Gemma4Task(ModelTask):
     Decoder KV cache is per-layer with the correct head_dim for each layer type
     (local vs global), unlike the uniform head_dim in :class:`VisionLanguageTask`.
 
+    Supports ``static_cache=True`` for pre-allocated TensorScatter-based
+    KV cache on the decoder (requires ORT ≥ 1.25.0).  Vision, audio, and
+    embedding models are unaffected by the static cache setting.
+
     Batching strategies
     -------------------
     Each sub-model uses a different strategy for variable-size inputs:
@@ -339,12 +343,19 @@ class Gemma4Task(ModelTask):
         Conformer attention. The export strips padding inside the ONNX
         graph and returns ``audio_features [num_valid, hidden_size]``.
 
-    **Decoder** — standard ``attention_mask`` for KV cache padding.
-        ``attention_mask [B, past+current]`` is a 1/0 int mask indicating
-        valid token positions across the full sequence (past cache +
-        current input).  The ``Attention`` / ``GroupQueryAttention`` ops
-        handle causal masking internally via ``is_causal=1``.
+    **Decoder** — standard ``attention_mask`` for KV cache padding
+        (dynamic mode), or ``write_indices``/``nonpad_kv_seqlen`` for
+        pre-allocated cache (static mode).
     """
+
+    def __init__(
+        self,
+        *,
+        static_cache: bool = False,
+        max_seq_len: int | None = None,
+    ):
+        self._static_cache = static_cache
+        self._max_seq_len = max_seq_len
 
     def build(
         self,
@@ -389,9 +400,24 @@ class Gemma4Task(ModelTask):
         would exceed it, split per-layer tables are used in the decoder instead,
         so ``input_ids`` is passed and ``per_layer_inputs`` is omitted.
         """
+        from mobius.tasks._causal_lm import (
+            _register_static_cache_outputs,
+            _validate_static_cache_support,
+        )
+
+        static = self._static_cache
+        if static:
+            max_seq_len = self._max_seq_len
+            if max_seq_len is None:
+                max_seq_len = getattr(config, "max_position_embeddings", None)
+            if max_seq_len is None or max_seq_len <= 0:
+                raise ValueError(
+                    "max_seq_len must be a positive integer for static cache."
+                )
+            _validate_static_cache_support(decoder)
+
         batch = ir.SymbolicDim("batch")
         seq_len = ir.SymbolicDim("sequence_len")
-        past_seq_len = ir.SymbolicDim("past_sequence_len")
 
         graph, builder = _make_graph(name="decoder")
         op = builder.op
@@ -401,11 +427,17 @@ class Gemma4Task(ModelTask):
             dtype=config.dtype,
             shape=[batch, seq_len, config.hidden_size],
         )
-        attention_mask = builder.input(
-            "attention_mask",
-            dtype=ir.DataType.INT64,
-            shape=[batch, "past_seq_len + seq_len"],
-        )
+
+        if static:
+            attention_mask = None
+        else:
+            past_seq_len = ir.SymbolicDim("past_sequence_len")
+            attention_mask = builder.input(
+                "attention_mask",
+                dtype=ir.DataType.INT64,
+                shape=[batch, "past_seq_len + seq_len"],
+            )
+
         position_ids = builder.input(
             "position_ids",
             dtype=ir.DataType.INT64,
@@ -440,7 +472,14 @@ class Gemma4Task(ModelTask):
                 shape=[batch, seq_len],
             )
 
-        past_key_values = _make_gemma4_kv_cache_inputs(builder, config, batch, past_seq_len)
+        if static:
+            past_key_values = _make_gemma4_static_cache_inputs(
+                builder, config, batch, max_seq_len,
+            )
+        else:
+            past_key_values = _make_gemma4_kv_cache_inputs(
+                builder, config, batch, past_seq_len,
+            )
 
         logits, present_key_values = decoder(
             op,
@@ -453,7 +492,10 @@ class Gemma4Task(ModelTask):
         )
 
         builder.add_output(logits, "logits")
-        _register_kv_cache_outputs(builder, present_key_values)
+        if static:
+            _register_static_cache_outputs(builder, present_key_values)
+        else:
+            _register_kv_cache_outputs(builder, present_key_values)
 
         return _make_model(graph)
 

--- a/src/mobius/tasks/_gemma4.py
+++ b/src/mobius/tasks/_gemma4.py
@@ -78,6 +78,17 @@ def _make_gemma4_static_cache_inputs(
     Sliding-attention layers get dynamic ``(past_key, past_value)`` tuples
     (GQA with ``local_window_size``).  KV-shared layers get ``None``.
 
+    Why sliding window layers can't use static cache:
+        Sliding window attention requires only attending to the most recent
+        N tokens.  The standard ONNX Attention op lacks a
+        ``local_window_size`` parameter to enforce this constraint.  With a
+        static (pre-allocated) KV cache, stale entries beyond the window
+        remain in the buffer and would be incorrectly attended to.
+        ``GroupQueryAttention`` (GQA) supports ``local_window_size``
+        natively and manages its own KV cache, so sliding window layers use
+        GQA with dynamic cache while full-attention layers use
+        TensorScatter with static cache.
+
     Args:
         past_seq_len: Symbolic dim for dynamic cache sequence length.
             Required when the config has sliding-attention layers.

--- a/src/mobius/tasks/_gemma4.py
+++ b/src/mobius/tasks/_gemma4.py
@@ -41,21 +41,46 @@ from mobius.tasks._cache_utils import (
 )
 
 
+def _register_hybrid_cache_outputs(
+    builder: GraphBuilder,
+    present_key_values: list[tuple[ir.Value, ir.Value]],
+    config: Gemma4Config,
+) -> None:
+    """Register cache outputs for hybrid static/dynamic Gemma4 models.
+
+    Full-attention layers use ``updated_key_cache.{i}`` / ``updated_value_cache.{i}``.
+    Sliding-attention layers use ``present.{i}.key`` / ``present.{i}.value``.
+    """
+    layer_types = config.layer_types or (
+        ["sliding_attention"] * config.num_hidden_layers
+    )
+
+    for i, (k, v) in enumerate(present_key_values):
+        lt = layer_types[i] if i < len(layer_types) else "sliding_attention"
+        if lt == "full_attention":
+            builder.add_output(k, f"updated_key_cache.{i}")
+            builder.add_output(v, f"updated_value_cache.{i}")
+        else:
+            builder.add_output(k, f"present.{i}.key")
+            builder.add_output(v, f"present.{i}.value")
+
+
 def _make_gemma4_static_cache_inputs(
     builder: GraphBuilder,
     config: Gemma4Config,
     batch: ir.SymbolicDim,
     max_seq_len: int,
+    past_seq_len: ir.SymbolicDim | None = None,
 ) -> list:
-    """Create per-layer static KV cache inputs for Gemma4.
+    """Create per-layer hybrid KV cache inputs for Gemma4 static cache mode.
 
-    Like :func:`_make_gemma4_kv_cache_inputs` but creates pre-allocated
-    fixed-size cache buffers ``[B, max_seq_len, kv_hidden]`` for use with
-    TensorScatter.  KV-shared layers get ``None`` entries (no own cache).
+    Full-attention layers get :class:`StaticCacheState` (TensorScatter).
+    Sliding-attention layers get dynamic ``(past_key, past_value)`` tuples
+    (GQA with ``local_window_size``).  KV-shared layers get ``None``.
 
-    Returns a list with one entry per decoder layer:
-    - :class:`StaticCacheState` for layers with independent KV projections
-    - ``None`` for KV-shared layers
+    Args:
+        past_seq_len: Symbolic dim for dynamic cache sequence length.
+            Required when the config has sliding-attention layers.
     """
     from mobius.components._attention import StaticCacheState
 
@@ -67,7 +92,8 @@ def _make_gemma4_static_cache_inputs(
         ["sliding_attention"] * config.num_hidden_layers
     )
 
-    cache_pairs: list[tuple[ir.Value, ir.Value]] = []
+    # Per non-shared layer: static or dynamic cache
+    layer_entries: list[tuple[str, object]] = []  # ("static"|"dynamic", cache)
     for i in range(num_kv_layers):
         lt = layer_types[i] if i < len(layer_types) else "sliding_attention"
         hd = global_head_dim if lt == "full_attention" else local_head_dim
@@ -77,51 +103,67 @@ def _make_gemma4_static_cache_inputs(
         else:
             kv_heads = config.num_key_value_heads
 
-        kv_hidden = kv_heads * hd
-        key_cache = builder.input(
-            f"key_cache.{i}",
-            dtype=config.dtype,
-            shape=[batch, max_seq_len, kv_hidden],
-        )
-        value_cache = builder.input(
-            f"value_cache.{i}",
-            dtype=config.dtype,
-            shape=[batch, max_seq_len, kv_hidden],
-        )
-        cache_pairs.append((key_cache, value_cache))
-
-    # Shared control inputs (after all cache tensors, matching standard pattern)
-    write_indices = builder.input(
-        "write_indices",
-        dtype=ir.DataType.INT64,
-        shape=[batch],
-    )
-    nonpad_kv_seqlen = builder.input(
-        "nonpad_kv_seqlen",
-        dtype=ir.DataType.INT64,
-        shape=[batch],
-    )
-
-    cache_states: list[StaticCacheState] = []
-    for key_cache, value_cache in cache_pairs:
-        cache_states.append(
-            StaticCacheState(
-                key_cache=key_cache,
-                value_cache=value_cache,
-                write_indices=write_indices,
-                nonpad_kv_seqlen=nonpad_kv_seqlen,
+        if is_full:
+            kv_hidden = kv_heads * hd
+            key_cache = builder.input(
+                f"key_cache.{i}",
+                dtype=config.dtype,
+                shape=[batch, max_seq_len, kv_hidden],
             )
+            value_cache = builder.input(
+                f"value_cache.{i}",
+                dtype=config.dtype,
+                shape=[batch, max_seq_len, kv_hidden],
+            )
+            layer_entries.append(("static", (key_cache, value_cache)))
+        else:
+            assert past_seq_len is not None, (
+                "past_seq_len required for sliding-attention dynamic cache"
+            )
+            past_key = builder.input(
+                f"past_key_values.{i}.key",
+                dtype=config.dtype,
+                shape=[batch, kv_heads, past_seq_len, hd],
+            )
+            past_value = builder.input(
+                f"past_key_values.{i}.value",
+                dtype=config.dtype,
+                shape=[batch, kv_heads, past_seq_len, hd],
+            )
+            layer_entries.append(("dynamic", (past_key, past_value)))
+
+    # Shared control inputs for static cache layers
+    has_static = any(t == "static" for t, _ in layer_entries)
+    write_indices = nonpad_kv_seqlen = None
+    if has_static:
+        write_indices = builder.input(
+            "write_indices",
+            dtype=ir.DataType.INT64,
+            shape=[batch],
+        )
+        nonpad_kv_seqlen = builder.input(
+            "nonpad_kv_seqlen",
+            dtype=ir.DataType.INT64,
+            shape=[batch],
         )
 
-    # Expand to full per-layer list: StaticCacheState for non-shared,
-    # None for KV-shared layers (matching the dynamic cache pattern).
-    state_iter = iter(cache_states)
+    # Build full per-layer list
+    entry_iter = iter(layer_entries)
     full_list: list = []
     for i in range(config.num_hidden_layers):
         if i >= num_kv_layers:
             full_list.append(None)
         else:
-            full_list.append(next(state_iter))
+            cache_type, pair = next(entry_iter)
+            if cache_type == "static":
+                k, v = pair
+                full_list.append(StaticCacheState(
+                    key_cache=k, value_cache=v,
+                    write_indices=write_indices,
+                    nonpad_kv_seqlen=nonpad_kv_seqlen,
+                ))
+            else:
+                full_list.append(pair)
     return full_list
 
 
@@ -263,14 +305,21 @@ class Gemma4TextCausalLMTask(ModelTask):
         )
 
         if static:
-            attention_mask = None
+            # Hybrid mode: sliding layers need attention_mask + dynamic cache,
+            # full-attention layers use write_indices/nonpad_kv_seqlen.
+            past_seq_len = ir.SymbolicDim("past_sequence_len")
+            attention_mask = builder.input(
+                "attention_mask",
+                dtype=ir.DataType.INT64,
+                shape=[batch, "past_seq_len + seq_len"],
+            )
             position_ids = builder.input(
                 "position_ids",
                 dtype=ir.DataType.INT64,
                 shape=[batch, seq_len],
             )
             past_key_values = _make_gemma4_static_cache_inputs(
-                builder, config, batch, max_seq_len,
+                builder, config, batch, max_seq_len, past_seq_len,
             )
         else:
             past_seq_len = ir.SymbolicDim("past_sequence_len")
@@ -298,7 +347,7 @@ class Gemma4TextCausalLMTask(ModelTask):
         builder.add_output(logits, "logits")
 
         if static:
-            _register_static_cache_outputs(builder, present_key_values)
+            _register_hybrid_cache_outputs(builder, present_key_values, config)
         else:
             _register_kv_cache_outputs(builder, present_key_values)
 
@@ -428,9 +477,7 @@ class Gemma4Task(ModelTask):
             shape=[batch, seq_len, config.hidden_size],
         )
 
-        if static:
-            attention_mask = None
-        else:
+        if not static:
             past_seq_len = ir.SymbolicDim("past_sequence_len")
             attention_mask = builder.input(
                 "attention_mask",
@@ -474,7 +521,7 @@ class Gemma4Task(ModelTask):
 
         if static:
             past_key_values = _make_gemma4_static_cache_inputs(
-                builder, config, batch, max_seq_len,
+                builder, config, batch, max_seq_len, past_seq_len,
             )
         else:
             past_key_values = _make_gemma4_kv_cache_inputs(
@@ -493,7 +540,7 @@ class Gemma4Task(ModelTask):
 
         builder.add_output(logits, "logits")
         if static:
-            _register_static_cache_outputs(builder, present_key_values)
+            _register_hybrid_cache_outputs(builder, present_key_values, config)
         else:
             _register_kv_cache_outputs(builder, present_key_values)
 

--- a/src/mobius/tasks/_gemma4.py
+++ b/src/mobius/tasks/_gemma4.py
@@ -51,9 +51,7 @@ def _register_hybrid_cache_outputs(
     Full-attention layers use ``updated_key_cache.{i}`` / ``updated_value_cache.{i}``.
     Sliding-attention layers use ``present.{i}.key`` / ``present.{i}.value``.
     """
-    layer_types = config.layer_types or (
-        ["sliding_attention"] * config.num_hidden_layers
-    )
+    layer_types = config.layer_types or (["sliding_attention"] * config.num_hidden_layers)
 
     for i, (k, v) in enumerate(present_key_values):
         lt = layer_types[i] if i < len(layer_types) else "sliding_attention"
@@ -99,9 +97,7 @@ def _make_gemma4_static_cache_inputs(
     global_head_dim = config.global_head_dim or config.head_dim
     num_kv_shared = config.num_kv_shared_layers or 0
     num_kv_layers = config.num_hidden_layers - num_kv_shared
-    layer_types = config.layer_types or (
-        ["sliding_attention"] * config.num_hidden_layers
-    )
+    layer_types = config.layer_types or (["sliding_attention"] * config.num_hidden_layers)
 
     # Per non-shared layer: static or dynamic cache
     layer_entries: list[tuple[str, object]] = []  # ("static"|"dynamic", cache)
@@ -168,11 +164,14 @@ def _make_gemma4_static_cache_inputs(
             cache_type, pair = next(entry_iter)
             if cache_type == "static":
                 k, v = pair
-                full_list.append(StaticCacheState(
-                    key_cache=k, value_cache=v,
-                    write_indices=write_indices,
-                    nonpad_kv_seqlen=nonpad_kv_seqlen,
-                ))
+                full_list.append(
+                    StaticCacheState(
+                        key_cache=k,
+                        value_cache=v,
+                        write_indices=write_indices,
+                        nonpad_kv_seqlen=nonpad_kv_seqlen,
+                    )
+                )
             else:
                 full_list.append(pair)
     return full_list
@@ -287,7 +286,6 @@ class Gemma4TextCausalLMTask(ModelTask):
         config: Gemma4Config,
     ) -> ModelPackage:
         from mobius.tasks._causal_lm import (
-            _register_static_cache_outputs,
             _validate_static_cache_support,
         )
 
@@ -298,9 +296,7 @@ class Gemma4TextCausalLMTask(ModelTask):
             if max_seq_len is None:
                 max_seq_len = getattr(config, "max_position_embeddings", None)
             if max_seq_len is None or max_seq_len <= 0:
-                raise ValueError(
-                    "max_seq_len must be a positive integer for static cache."
-                )
+                raise ValueError("max_seq_len must be a positive integer for static cache.")
             _validate_static_cache_support(module)
 
         batch = ir.SymbolicDim("batch")
@@ -330,7 +326,11 @@ class Gemma4TextCausalLMTask(ModelTask):
                 shape=[batch, seq_len],
             )
             past_key_values = _make_gemma4_static_cache_inputs(
-                builder, config, batch, max_seq_len, past_seq_len,
+                builder,
+                config,
+                batch,
+                max_seq_len,
+                past_seq_len,
             )
         else:
             past_seq_len = ir.SymbolicDim("past_sequence_len")
@@ -345,7 +345,10 @@ class Gemma4TextCausalLMTask(ModelTask):
                 shape=[batch, seq_len],
             )
             past_key_values = _make_gemma4_kv_cache_inputs(
-                builder, config, batch, past_seq_len,
+                builder,
+                config,
+                batch,
+                past_seq_len,
             )
 
         logits, present_key_values = module(
@@ -461,7 +464,6 @@ class Gemma4Task(ModelTask):
         so ``input_ids`` is passed and ``per_layer_inputs`` is omitted.
         """
         from mobius.tasks._causal_lm import (
-            _register_static_cache_outputs,
             _validate_static_cache_support,
         )
 
@@ -471,9 +473,7 @@ class Gemma4Task(ModelTask):
             if max_seq_len is None:
                 max_seq_len = getattr(config, "max_position_embeddings", None)
             if max_seq_len is None or max_seq_len <= 0:
-                raise ValueError(
-                    "max_seq_len must be a positive integer for static cache."
-                )
+                raise ValueError("max_seq_len must be a positive integer for static cache.")
             _validate_static_cache_support(decoder)
 
         batch = ir.SymbolicDim("batch")
@@ -532,11 +532,18 @@ class Gemma4Task(ModelTask):
 
         if static:
             past_key_values = _make_gemma4_static_cache_inputs(
-                builder, config, batch, max_seq_len, past_seq_len,
+                builder,
+                config,
+                batch,
+                max_seq_len,
+                past_seq_len,
             )
         else:
             past_key_values = _make_gemma4_kv_cache_inputs(
-                builder, config, batch, past_seq_len,
+                builder,
+                config,
+                batch,
+                past_seq_len,
             )
 
         logits, present_key_values = decoder(

--- a/src/mobius/tasks/_gemma4.py
+++ b/src/mobius/tasks/_gemma4.py
@@ -41,6 +41,86 @@ from mobius.tasks._cache_utils import (
 )
 
 
+def _make_gemma4_static_cache_inputs(
+    builder: GraphBuilder,
+    config: Gemma4Config,
+    batch: ir.SymbolicDim,
+    max_seq_len: int,
+) -> list:
+    """Create per-layer static KV cache inputs for Gemma4.
+
+    Like :func:`_make_gemma4_kv_cache_inputs` but creates pre-allocated
+    fixed-size cache buffers ``[B, max_seq_len, kv_hidden]`` for use with
+    TensorScatter.  KV-shared layers get ``None`` entries (no own cache).
+
+    Returns a list with one entry per decoder layer:
+    - :class:`StaticCacheState` for layers with independent KV projections
+    - ``None`` for KV-shared layers
+    """
+    from mobius.components._attention import StaticCacheState
+
+    local_head_dim = config.head_dim
+    global_head_dim = config.global_head_dim or config.head_dim
+    num_kv_shared = config.num_kv_shared_layers or 0
+    num_kv_layers = config.num_hidden_layers - num_kv_shared
+    layer_types = config.layer_types or (
+        ["sliding_attention"] * config.num_hidden_layers
+    )
+
+    # Shared control inputs
+    write_indices = builder.input(
+        "write_indices",
+        dtype=ir.DataType.INT64,
+        shape=[batch],
+    )
+    nonpad_kv_seqlen = builder.input(
+        "nonpad_kv_seqlen",
+        dtype=ir.DataType.INT64,
+        shape=[batch],
+    )
+
+    cache_states: list[StaticCacheState] = []
+    for i in range(num_kv_layers):
+        lt = layer_types[i] if i < len(layer_types) else "sliding_attention"
+        hd = global_head_dim if lt == "full_attention" else local_head_dim
+        is_full = lt == "full_attention"
+        if is_full and config.num_global_key_value_heads is not None:
+            kv_heads = config.num_global_key_value_heads
+        else:
+            kv_heads = config.num_key_value_heads
+
+        kv_hidden = kv_heads * hd
+        key_cache = builder.input(
+            f"key_cache.{i}",
+            dtype=config.dtype,
+            shape=[batch, max_seq_len, kv_hidden],
+        )
+        value_cache = builder.input(
+            f"value_cache.{i}",
+            dtype=config.dtype,
+            shape=[batch, max_seq_len, kv_hidden],
+        )
+        cache_states.append(
+            StaticCacheState(
+                key_cache=key_cache,
+                value_cache=value_cache,
+                write_indices=write_indices,
+                nonpad_kv_seqlen=nonpad_kv_seqlen,
+            )
+        )
+
+    # Expand to full per-layer list: StaticCacheState for non-shared,
+    # None for KV-shared layers (matching the dynamic cache pattern).
+    state_iter = iter(cache_states)
+    full_list: list = []
+    for i in range(config.num_hidden_layers):
+        if i >= num_kv_layers:
+            full_list.append(None)
+        else:
+            full_list.append(next(state_iter))
+    return full_list
+
+
 def _make_gemma4_kv_cache_inputs(
     builder: GraphBuilder,
     config: Gemma4Config,
@@ -112,7 +192,10 @@ class Gemma4TextCausalLMTask(ModelTask):
     - the last ``config.num_kv_shared_layers`` layers share K,V and have no
       independent cache entries
 
-    Inputs:
+    Supports ``static_cache=True`` for pre-allocated TensorScatter-based
+    KV cache (requires ORT ≥ 1.25.0).
+
+    Inputs (dynamic cache):
         - input_ids: [batch, sequence_len] INT64
         - attention_mask: [batch, past_seq_len + seq_len] INT64
         - position_ids: [batch, sequence_len] INT64
@@ -120,16 +203,51 @@ class Gemma4TextCausalLMTask(ModelTask):
     Outputs:
         - logits: FLOAT
         - present.{i}.key / present.{i}.value for i in 0..num_kv_layers-1
+
+    Inputs (static cache):
+        - input_ids: [batch, sequence_len] INT64
+        - position_ids: [batch, sequence_len] INT64
+        - key_cache.{i} / value_cache.{i}: [batch, max_seq_len, kv_hidden]
+        - write_indices: [batch] INT64
+        - nonpad_kv_seqlen: [batch] INT64
+    Outputs:
+        - logits: FLOAT
+        - updated_key_cache.{i} / updated_value_cache.{i}
     """
+
+    def __init__(
+        self,
+        *,
+        static_cache: bool = False,
+        max_seq_len: int | None = None,
+    ):
+        self._static_cache = static_cache
+        self._max_seq_len = max_seq_len
 
     def build(
         self,
         module: nn.Module,
         config: Gemma4Config,
     ) -> ModelPackage:
+        from mobius.tasks._causal_lm import (
+            _register_static_cache_outputs,
+            _validate_static_cache_support,
+        )
+
+        static = self._static_cache
+
+        if static:
+            max_seq_len = self._max_seq_len
+            if max_seq_len is None:
+                max_seq_len = getattr(config, "max_position_embeddings", None)
+            if max_seq_len is None or max_seq_len <= 0:
+                raise ValueError(
+                    "max_seq_len must be a positive integer for static cache."
+                )
+            _validate_static_cache_support(module)
+
         batch = ir.SymbolicDim("batch")
         seq_len = ir.SymbolicDim("sequence_len")
-        past_seq_len = ir.SymbolicDim("past_sequence_len")
 
         graph, builder = _make_graph()
         op = builder.op
@@ -139,18 +257,32 @@ class Gemma4TextCausalLMTask(ModelTask):
             dtype=ir.DataType.INT64,
             shape=[batch, seq_len],
         )
-        attention_mask = builder.input(
-            "attention_mask",
-            dtype=ir.DataType.INT64,
-            shape=[batch, "past_seq_len + seq_len"],
-        )
-        position_ids = builder.input(
-            "position_ids",
-            dtype=ir.DataType.INT64,
-            shape=[batch, seq_len],
-        )
 
-        past_key_values = _make_gemma4_kv_cache_inputs(builder, config, batch, past_seq_len)
+        if static:
+            attention_mask = None
+            position_ids = builder.input(
+                "position_ids",
+                dtype=ir.DataType.INT64,
+                shape=[batch, seq_len],
+            )
+            past_key_values = _make_gemma4_static_cache_inputs(
+                builder, config, batch, max_seq_len,
+            )
+        else:
+            past_seq_len = ir.SymbolicDim("past_sequence_len")
+            attention_mask = builder.input(
+                "attention_mask",
+                dtype=ir.DataType.INT64,
+                shape=[batch, "past_seq_len + seq_len"],
+            )
+            position_ids = builder.input(
+                "position_ids",
+                dtype=ir.DataType.INT64,
+                shape=[batch, seq_len],
+            )
+            past_key_values = _make_gemma4_kv_cache_inputs(
+                builder, config, batch, past_seq_len,
+            )
 
         logits, present_key_values = module(
             op,
@@ -160,7 +292,11 @@ class Gemma4TextCausalLMTask(ModelTask):
             past_key_values=past_key_values,
         )
         builder.add_output(logits, "logits")
-        _register_kv_cache_outputs(builder, present_key_values)
+
+        if static:
+            _register_static_cache_outputs(builder, present_key_values)
+        else:
+            _register_kv_cache_outputs(builder, present_key_values)
 
         return ModelPackage({"model": _make_model(graph)}, config=config)
 

--- a/src/mobius/tasks/_gemma4.py
+++ b/src/mobius/tasks/_gemma4.py
@@ -67,19 +67,7 @@ def _make_gemma4_static_cache_inputs(
         ["sliding_attention"] * config.num_hidden_layers
     )
 
-    # Shared control inputs
-    write_indices = builder.input(
-        "write_indices",
-        dtype=ir.DataType.INT64,
-        shape=[batch],
-    )
-    nonpad_kv_seqlen = builder.input(
-        "nonpad_kv_seqlen",
-        dtype=ir.DataType.INT64,
-        shape=[batch],
-    )
-
-    cache_states: list[StaticCacheState] = []
+    cache_pairs: list[tuple[ir.Value, ir.Value]] = []
     for i in range(num_kv_layers):
         lt = layer_types[i] if i < len(layer_types) else "sliding_attention"
         hd = global_head_dim if lt == "full_attention" else local_head_dim
@@ -100,6 +88,22 @@ def _make_gemma4_static_cache_inputs(
             dtype=config.dtype,
             shape=[batch, max_seq_len, kv_hidden],
         )
+        cache_pairs.append((key_cache, value_cache))
+
+    # Shared control inputs (after all cache tensors, matching standard pattern)
+    write_indices = builder.input(
+        "write_indices",
+        dtype=ir.DataType.INT64,
+        shape=[batch],
+    )
+    nonpad_kv_seqlen = builder.input(
+        "nonpad_kv_seqlen",
+        dtype=ir.DataType.INT64,
+        shape=[batch],
+    )
+
+    cache_states: list[StaticCacheState] = []
+    for key_cache, value_cache in cache_pairs:
         cache_states.append(
             StaticCacheState(
                 key_cache=key_cache,

--- a/src/mobius/tasks/_gemma4.py
+++ b/src/mobius/tasks/_gemma4.py
@@ -495,6 +495,10 @@ class Gemma4Task(ModelTask):
                 dtype=ir.DataType.INT64,
                 shape=[batch, "past_seq_len + seq_len"],
             )
+        else:
+            # Static cache still needs past_seq_len for sliding-window layers
+            # that use dynamic cache within the hybrid static/dynamic scheme.
+            past_seq_len = ir.SymbolicDim("past_sequence_len")
 
         position_ids = builder.input(
             "position_ids",
@@ -538,6 +542,7 @@ class Gemma4Task(ModelTask):
                 max_seq_len,
                 past_seq_len,
             )
+            attention_mask = None  # Static cache uses position-based attention
         else:
             past_key_values = _make_gemma4_kv_cache_inputs(
                 builder,

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -5295,11 +5295,10 @@ class TestBuildGemma4StaticCacheGraph:
             vocab_size=256,
             rms_norm_eps=1e-6,
             hidden_act="gelu_pytorch_tanh",
-            layer_types=[
-                "sliding_attention", "sliding_attention", "sliding_attention",
-                "sliding_attention", "sliding_attention", "full_attention",
-            ],
-            sliding_window=64,
+            # Static cache does not support sliding window — use
+            # full_attention for all layers in the default test config.
+            layer_types=["full_attention"] * 6,
+            sliding_window=0,
             rope_theta=10000.0,
             global_rope_theta=1000000.0,
             partial_rotary_factor=0.5,
@@ -5335,22 +5334,20 @@ class TestBuildGemma4StaticCacheGraph:
         assert "nonpad_kv_seqlen" in input_names
 
     def test_gemma4_static_cache_dual_head_dim(self):
-        """Verify per-layer cache shapes respect dual head_dim."""
+        """Verify per-layer cache shapes use global_head_dim for full-attention."""
         model, config = self._build()
 
         input_map = {inp.name: inp for inp in model.graph.inputs}
 
-        # Layer 0-4: sliding (head_dim=16, kv_heads=2 → kv_hidden=32)
-        k0 = input_map["key_cache.0"]
-        assert k0.shape is not None
-        # shape is [batch, max_seq, kv_hidden]
-        kv_hidden_sliding = config.num_key_value_heads * config.head_dim
-        assert k0.shape[2] == kv_hidden_sliding
-
-        # Layer 5: full_attention (global_head_dim=32, kv_heads=2 → kv_hidden=64)
-        k5 = input_map["key_cache.5"]
+        # All layers are full_attention → global_head_dim=32, kv_heads=2 → kv_hidden=64
         kv_hidden_full = config.num_key_value_heads * config.global_head_dim
-        assert k5.shape[2] == kv_hidden_full
+        for i in range(config.num_hidden_layers):
+            k = input_map[f"key_cache.{i}"]
+            assert k.shape is not None
+            assert k.shape[2] == kv_hidden_full, (
+                f"key_cache.{i} has kv_hidden={k.shape[2]}, "
+                f"expected {kv_hidden_full}"
+            )
 
     def test_gemma4_static_cache_has_tensorscatter(self):
         """Verify TensorScatter ops and no GQA in static cache mode."""
@@ -5371,11 +5368,7 @@ class TestBuildGemma4StaticCacheGraph:
         model, config = self._build(
             num_hidden_layers=8,
             num_kv_shared_layers=2,
-            layer_types=[
-                "sliding_attention", "sliding_attention", "sliding_attention",
-                "sliding_attention", "sliding_attention", "full_attention",
-                "sliding_attention", "full_attention",
-            ],
+            layer_types=["full_attention"] * 8,
         )
 
         input_names = {inp.name for inp in model.graph.inputs}
@@ -5416,6 +5409,25 @@ class TestBuildGemma4StaticCacheGraph:
         assert nonpad_idx > last_cache_idx, (
             "nonpad_kv_seqlen should come after all cache inputs"
         )
+
+    def test_gemma4_static_cache_rejects_sliding_window(self):
+        """Verify static cache raises ValueError for sliding_window > 0."""
+        from mobius.models.gemma4 import Gemma4CausalLMModel
+        from mobius.tasks._gemma4 import Gemma4TextCausalLMTask
+
+        config = self._gemma4_config(
+            sliding_window=64,
+            layer_types=[
+                "sliding_attention", "sliding_attention", "sliding_attention",
+                "sliding_attention", "sliding_attention", "full_attention",
+            ],
+        )
+        module = Gemma4CausalLMModel(config)
+        task = Gemma4TextCausalLMTask(
+            static_cache=True, max_seq_len=self.MAX_SEQ_LEN
+        )
+        with pytest.raises(ValueError, match="sliding-window attention"):
+            task.build(module, config)
 
 
 # === Parametrized Vision-Language configs (imported from _test_configs) ===

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -5275,6 +5275,149 @@ class TestBuildStaticCacheGraph:
         _assert_outputs_have_shapes_and_dtypes({"model": model}, "qwen2-static")
 
 
+class TestBuildGemma4StaticCacheGraph:
+    """Verify Gemma4TextCausalLMTask(static_cache=True) builds a valid graph."""
+
+    MAX_SEQ_LEN = 128
+
+    @staticmethod
+    def _gemma4_config(**overrides):
+        from mobius._configs import Gemma4Config
+
+        defaults = dict(
+            num_hidden_layers=6,
+            hidden_size=64,
+            intermediate_size=128,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=16,
+            global_head_dim=32,
+            vocab_size=256,
+            rms_norm_eps=1e-6,
+            hidden_act="gelu_pytorch_tanh",
+            layer_types=[
+                "sliding_attention", "sliding_attention", "sliding_attention",
+                "sliding_attention", "sliding_attention", "full_attention",
+            ],
+            sliding_window=64,
+            rope_theta=10000.0,
+            global_rope_theta=1000000.0,
+            partial_rotary_factor=0.5,
+            max_position_embeddings=256,
+            hidden_size_per_layer_input=0,
+            num_kv_shared_layers=0,
+        )
+        defaults.update(overrides)
+        return Gemma4Config(**defaults)
+
+    def _build(self, **config_overrides):
+        from mobius.models.gemma4 import Gemma4CausalLMModel
+        from mobius.tasks._gemma4 import Gemma4TextCausalLMTask
+
+        config = self._gemma4_config(**config_overrides)
+        module = Gemma4CausalLMModel(config)
+        task = Gemma4TextCausalLMTask(
+            static_cache=True, max_seq_len=self.MAX_SEQ_LEN
+        )
+        pkg = task.build(module, config)
+        return pkg["model"], config
+
+    def test_gemma4_static_cache_builds(self):
+        """Build Gemma4 with static cache and verify basic graph structure."""
+        model, config = self._build()
+
+        assert model.graph is not None
+        input_names = {inp.name for inp in model.graph.inputs}
+        assert "input_ids" in input_names
+        assert "position_ids" in input_names
+        assert "attention_mask" not in input_names
+        assert "write_indices" in input_names
+        assert "nonpad_kv_seqlen" in input_names
+
+    def test_gemma4_static_cache_dual_head_dim(self):
+        """Verify per-layer cache shapes respect dual head_dim."""
+        model, config = self._build()
+
+        input_map = {inp.name: inp for inp in model.graph.inputs}
+
+        # Layer 0-4: sliding (head_dim=16, kv_heads=2 → kv_hidden=32)
+        k0 = input_map["key_cache.0"]
+        assert k0.shape is not None
+        # shape is [batch, max_seq, kv_hidden]
+        kv_hidden_sliding = config.num_key_value_heads * config.head_dim
+        assert k0.shape[2] == kv_hidden_sliding
+
+        # Layer 5: full_attention (global_head_dim=32, kv_heads=2 → kv_hidden=64)
+        k5 = input_map["key_cache.5"]
+        kv_hidden_full = config.num_key_value_heads * config.global_head_dim
+        assert k5.shape[2] == kv_hidden_full
+
+    def test_gemma4_static_cache_has_tensorscatter(self):
+        """Verify TensorScatter ops and no GQA in static cache mode."""
+        model, config = self._build()
+
+        op_counts = {}
+        for n in model.graph:
+            op_counts[n.op_type] = op_counts.get(n.op_type, 0) + 1
+
+        # TensorScatter: 2 per non-shared layer (key + value)
+        num_kv_layers = config.num_hidden_layers - (config.num_kv_shared_layers or 0)
+        assert op_counts.get("TensorScatter", 0) == 2 * num_kv_layers
+        assert op_counts.get("Attention", 0) == config.num_hidden_layers
+        assert op_counts.get("GroupQueryAttention", 0) == 0
+
+    def test_gemma4_static_cache_kv_shared(self):
+        """Verify KV-shared layers are excluded from cache I/O."""
+        model, config = self._build(
+            num_hidden_layers=8,
+            num_kv_shared_layers=2,
+            layer_types=[
+                "sliding_attention", "sliding_attention", "sliding_attention",
+                "sliding_attention", "sliding_attention", "full_attention",
+                "sliding_attention", "full_attention",
+            ],
+        )
+
+        input_names = {inp.name for inp in model.graph.inputs}
+        output_names = {out.name for out in model.graph.outputs}
+
+        # 6 non-shared layers → 12 cache inputs, 12 cache outputs
+        num_kv_layers = config.num_hidden_layers - config.num_kv_shared_layers
+        for i in range(num_kv_layers):
+            assert f"key_cache.{i}" in input_names
+            assert f"updated_key_cache.{i}" in output_names
+
+        # Shared layers (6, 7) should NOT have cache entries
+        assert f"key_cache.{num_kv_layers}" not in input_names
+        assert f"updated_key_cache.{num_kv_layers}" not in output_names
+
+        # TensorScatter only for non-shared layers
+        op_counts = {}
+        for n in model.graph:
+            op_counts[n.op_type] = op_counts.get(n.op_type, 0) + 1
+        assert op_counts.get("TensorScatter", 0) == 2 * num_kv_layers
+        # All 8 layers still have Attention ops
+        assert op_counts.get("Attention", 0) == config.num_hidden_layers
+
+    def test_gemma4_static_cache_input_ordering(self):
+        """Verify write_indices/nonpad_kv_seqlen come after cache inputs."""
+        model, config = self._build()
+
+        input_names = [inp.name for inp in model.graph.inputs]
+        # write_indices and nonpad_kv_seqlen should come after all cache inputs
+        last_cache_idx = max(
+            i for i, n in enumerate(input_names) if "cache" in n
+        )
+        write_idx = input_names.index("write_indices")
+        nonpad_idx = input_names.index("nonpad_kv_seqlen")
+        assert write_idx > last_cache_idx, (
+            "write_indices should come after all cache inputs"
+        )
+        assert nonpad_idx > last_cache_idx, (
+            "nonpad_kv_seqlen should come after all cache inputs"
+        )
+
+
 # === Parametrized Vision-Language configs (imported from _test_configs) ===
 _VL_MODEL_PARAMS = _make_params(VL_CONFIGS)
 

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -5349,7 +5349,7 @@ class TestBuildGemma4StaticCacheGraph:
 
         # Layer 5: full_attention → static cache (key_cache.5)
         assert "key_cache.5" in input_map
-        kv_hidden_full = config.num_key_value_heads * config.global_head_dim
+        kv_hidden_full = _config.num_key_value_heads * _config.global_head_dim
         k5 = input_map["key_cache.5"]
         assert k5.shape[2] == kv_hidden_full
 
@@ -5361,7 +5361,7 @@ class TestBuildGemma4StaticCacheGraph:
         for n in model.graph:
             op_counts[n.op_type] = op_counts.get(n.op_type, 0) + 1
 
-        layer_types = config.layer_types or []
+        layer_types = _config.layer_types or []
         num_full = sum(1 for lt in layer_types if lt == "full_attention")
 
         # TensorScatter: 2 per full-attention layer (key + value)
@@ -5369,7 +5369,7 @@ class TestBuildGemma4StaticCacheGraph:
         # Sliding layers use either GQA (CUDA EP) or Attention (default EP)
         # In unit tests without EP context, all use standard Attention.
         total_attn = op_counts.get("Attention", 0) + op_counts.get("GroupQueryAttention", 0)
-        assert total_attn == config.num_hidden_layers
+        assert total_attn == _config.num_hidden_layers
 
     def test_gemma4_static_cache_kv_shared(self):
         """Verify KV-shared layers are excluded from cache I/O."""

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -5214,8 +5214,8 @@ class TestBuildStaticCacheGraph:
         proto = ir.serde.serialize_model(model)
         assert len(proto.SerializeToString()) > 0
 
-    def test_static_cache_attention_is_causal(self):
-        """Verify Attention ops use is_causal=1 in static cache mode."""
+    def test_static_cache_attention_uses_noncausal_alignment(self):
+        """Verify external-cache Attention uses non-causal alignment."""
         model, config = self._build_static_cache_model()
 
         attention_nodes = [n for n in model.graph if n.op_type == "Attention"]
@@ -5226,8 +5226,8 @@ class TestBuildStaticCacheGraph:
             assert is_causal is not None, (
                 f"Attention node {node.name} missing is_causal attribute"
             )
-            assert is_causal.as_int() == 1, (
-                f"Attention node {node.name} should have is_causal=1"
+            assert is_causal.as_int() == 0, (
+                f"Attention node {node.name} should have is_causal=0"
             )
 
     def test_static_cache_attention_no_attn_mask_input(self):

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -5327,7 +5327,7 @@ class TestBuildGemma4StaticCacheGraph:
 
     def test_gemma4_static_cache_builds(self):
         """Build Gemma4 with static cache and verify basic graph structure."""
-        model, config = self._build()
+        model, _config = self._build()
 
         assert model.graph is not None
         input_names = {inp.name for inp in model.graph.inputs}
@@ -5340,7 +5340,7 @@ class TestBuildGemma4StaticCacheGraph:
 
     def test_gemma4_static_cache_hybrid_inputs(self):
         """Verify full-attention gets static cache, sliding gets dynamic."""
-        model, config = self._build()
+        model, _config = self._build()
 
         input_map = {inp.name: inp for inp in model.graph.inputs}
 
@@ -5355,7 +5355,7 @@ class TestBuildGemma4StaticCacheGraph:
 
     def test_gemma4_static_cache_has_tensorscatter(self):
         """Verify TensorScatter for full-attention layers in hybrid mode."""
-        model, config = self._build()
+        model, _config = self._build()
 
         op_counts = {}
         for n in model.graph:
@@ -5405,7 +5405,7 @@ class TestBuildGemma4StaticCacheGraph:
 
     def test_gemma4_static_cache_input_ordering(self):
         """Verify write_indices/nonpad_kv_seqlen come after cache inputs."""
-        model, config = self._build()
+        model, _config = self._build()
 
         input_names = [inp.name for inp in model.graph.inputs]
         # write_indices and nonpad_kv_seqlen should come after all cache inputs

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -5295,10 +5295,12 @@ class TestBuildGemma4StaticCacheGraph:
             vocab_size=256,
             rms_norm_eps=1e-6,
             hidden_act="gelu_pytorch_tanh",
-            # Static cache does not support sliding window — use
-            # full_attention for all layers in the default test config.
-            layer_types=["full_attention"] * 6,
-            sliding_window=0,
+            # Mixed: 5 sliding + 1 full (Gemma4-like hybrid pattern)
+            layer_types=[
+                "sliding_attention", "sliding_attention", "sliding_attention",
+                "sliding_attention", "sliding_attention", "full_attention",
+            ],
+            sliding_window=64,
             rope_theta=10000.0,
             global_rope_theta=1000000.0,
             partial_rotary_factor=0.5,
@@ -5329,68 +5331,73 @@ class TestBuildGemma4StaticCacheGraph:
         input_names = {inp.name for inp in model.graph.inputs}
         assert "input_ids" in input_names
         assert "position_ids" in input_names
-        assert "attention_mask" not in input_names
+        # Hybrid mode: attention_mask for sliding GQA + write_indices for static
+        assert "attention_mask" in input_names
         assert "write_indices" in input_names
         assert "nonpad_kv_seqlen" in input_names
 
-    def test_gemma4_static_cache_dual_head_dim(self):
-        """Verify per-layer cache shapes use global_head_dim for full-attention."""
+    def test_gemma4_static_cache_hybrid_inputs(self):
+        """Verify full-attention gets static cache, sliding gets dynamic."""
         model, config = self._build()
 
         input_map = {inp.name: inp for inp in model.graph.inputs}
 
-        # All layers are full_attention → global_head_dim=32, kv_heads=2 → kv_hidden=64
+        # Layer 0-4: sliding → dynamic cache (past_key_values.N.key)
+        assert "past_key_values.0.key" in input_map
+
+        # Layer 5: full_attention → static cache (key_cache.5)
+        assert "key_cache.5" in input_map
         kv_hidden_full = config.num_key_value_heads * config.global_head_dim
-        for i in range(config.num_hidden_layers):
-            k = input_map[f"key_cache.{i}"]
-            assert k.shape is not None
-            assert k.shape[2] == kv_hidden_full, (
-                f"key_cache.{i} has kv_hidden={k.shape[2]}, "
-                f"expected {kv_hidden_full}"
-            )
+        k5 = input_map["key_cache.5"]
+        assert k5.shape[2] == kv_hidden_full
 
     def test_gemma4_static_cache_has_tensorscatter(self):
-        """Verify TensorScatter ops and no GQA in static cache mode."""
+        """Verify TensorScatter for full-attention layers in hybrid mode."""
         model, config = self._build()
 
         op_counts = {}
         for n in model.graph:
             op_counts[n.op_type] = op_counts.get(n.op_type, 0) + 1
 
-        # TensorScatter: 2 per non-shared layer (key + value)
-        num_kv_layers = config.num_hidden_layers - (config.num_kv_shared_layers or 0)
-        assert op_counts.get("TensorScatter", 0) == 2 * num_kv_layers
-        assert op_counts.get("Attention", 0) == config.num_hidden_layers
-        assert op_counts.get("GroupQueryAttention", 0) == 0
+        layer_types = config.layer_types or []
+        num_full = sum(1 for lt in layer_types if lt == "full_attention")
+
+        # TensorScatter: 2 per full-attention layer (key + value)
+        assert op_counts.get("TensorScatter", 0) == 2 * num_full
+        # Sliding layers use either GQA (CUDA EP) or Attention (default EP)
+        # In unit tests without EP context, all use standard Attention.
+        total_attn = (
+            op_counts.get("Attention", 0)
+            + op_counts.get("GroupQueryAttention", 0)
+        )
+        assert total_attn == config.num_hidden_layers
 
     def test_gemma4_static_cache_kv_shared(self):
         """Verify KV-shared layers are excluded from cache I/O."""
         model, config = self._build(
             num_hidden_layers=8,
             num_kv_shared_layers=2,
-            layer_types=["full_attention"] * 8,
+            layer_types=[
+                "sliding_attention", "sliding_attention", "sliding_attention",
+                "sliding_attention", "sliding_attention", "full_attention",
+                "sliding_attention", "full_attention",
+            ],
         )
 
         input_names = {inp.name for inp in model.graph.inputs}
-        output_names = {out.name for out in model.graph.outputs}
-
-        # 6 non-shared layers → 12 cache inputs, 12 cache outputs
         num_kv_layers = config.num_hidden_layers - config.num_kv_shared_layers
+
+        # Non-shared layers 0-5 should have cache entries (type depends on layer)
         for i in range(num_kv_layers):
-            assert f"key_cache.{i}" in input_names
-            assert f"updated_key_cache.{i}" in output_names
+            lt = config.layer_types[i]
+            if lt == "full_attention":
+                assert f"key_cache.{i}" in input_names
+            else:
+                assert f"past_key_values.{i}.key" in input_names
 
-        # Shared layers (6, 7) should NOT have cache entries
+        # Shared layers (6, 7) should NOT have any cache entries
         assert f"key_cache.{num_kv_layers}" not in input_names
-        assert f"updated_key_cache.{num_kv_layers}" not in output_names
-
-        # TensorScatter only for non-shared layers
-        op_counts = {}
-        for n in model.graph:
-            op_counts[n.op_type] = op_counts.get(n.op_type, 0) + 1
-        assert op_counts.get("TensorScatter", 0) == 2 * num_kv_layers
-        # All 8 layers still have Attention ops
-        assert op_counts.get("Attention", 0) == config.num_hidden_layers
+        assert f"past_key_values.{num_kv_layers}.key" not in input_names
 
     def test_gemma4_static_cache_input_ordering(self):
         """Verify write_indices/nonpad_kv_seqlen come after cache inputs."""
@@ -5410,24 +5417,6 @@ class TestBuildGemma4StaticCacheGraph:
             "nonpad_kv_seqlen should come after all cache inputs"
         )
 
-    def test_gemma4_static_cache_rejects_sliding_window(self):
-        """Verify static cache raises ValueError for sliding_window > 0."""
-        from mobius.models.gemma4 import Gemma4CausalLMModel
-        from mobius.tasks._gemma4 import Gemma4TextCausalLMTask
-
-        config = self._gemma4_config(
-            sliding_window=64,
-            layer_types=[
-                "sliding_attention", "sliding_attention", "sliding_attention",
-                "sliding_attention", "sliding_attention", "full_attention",
-            ],
-        )
-        module = Gemma4CausalLMModel(config)
-        task = Gemma4TextCausalLMTask(
-            static_cache=True, max_seq_len=self.MAX_SEQ_LEN
-        )
-        with pytest.raises(ValueError, match="sliding-window attention"):
-            task.build(module, config)
 
 
 # === Parametrized Vision-Language configs (imported from _test_configs) ===

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -5214,8 +5214,8 @@ class TestBuildStaticCacheGraph:
         proto = ir.serde.serialize_model(model)
         assert len(proto.SerializeToString()) > 0
 
-    def test_static_cache_attention_uses_noncausal_alignment(self):
-        """Verify external-cache Attention uses non-causal alignment."""
+    def test_static_cache_attention_uses_maskless_causal_alignment(self):
+        """Verify maskless external-cache Attention uses built-in causality."""
         model, config = self._build_static_cache_model()
 
         attention_nodes = [n for n in model.graph if n.op_type == "Attention"]
@@ -5226,8 +5226,8 @@ class TestBuildStaticCacheGraph:
             assert is_causal is not None, (
                 f"Attention node {node.name} missing is_causal attribute"
             )
-            assert is_causal.as_int() == 0, (
-                f"Attention node {node.name} should have is_causal=0"
+            assert is_causal.as_int() == 1, (
+                f"Attention node {node.name} should have is_causal=1"
             )
 
     def test_static_cache_attention_no_attn_mask_input(self):

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -5297,8 +5297,12 @@ class TestBuildGemma4StaticCacheGraph:
             hidden_act="gelu_pytorch_tanh",
             # Mixed: 5 sliding + 1 full (Gemma4-like hybrid pattern)
             layer_types=[
-                "sliding_attention", "sliding_attention", "sliding_attention",
-                "sliding_attention", "sliding_attention", "full_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "full_attention",
             ],
             sliding_window=64,
             rope_theta=10000.0,
@@ -5317,9 +5321,7 @@ class TestBuildGemma4StaticCacheGraph:
 
         config = self._gemma4_config(**config_overrides)
         module = Gemma4CausalLMModel(config)
-        task = Gemma4TextCausalLMTask(
-            static_cache=True, max_seq_len=self.MAX_SEQ_LEN
-        )
+        task = Gemma4TextCausalLMTask(static_cache=True, max_seq_len=self.MAX_SEQ_LEN)
         pkg = task.build(module, config)
         return pkg["model"], config
 
@@ -5366,10 +5368,7 @@ class TestBuildGemma4StaticCacheGraph:
         assert op_counts.get("TensorScatter", 0) == 2 * num_full
         # Sliding layers use either GQA (CUDA EP) or Attention (default EP)
         # In unit tests without EP context, all use standard Attention.
-        total_attn = (
-            op_counts.get("Attention", 0)
-            + op_counts.get("GroupQueryAttention", 0)
-        )
+        total_attn = op_counts.get("Attention", 0) + op_counts.get("GroupQueryAttention", 0)
         assert total_attn == config.num_hidden_layers
 
     def test_gemma4_static_cache_kv_shared(self):
@@ -5378,9 +5377,14 @@ class TestBuildGemma4StaticCacheGraph:
             num_hidden_layers=8,
             num_kv_shared_layers=2,
             layer_types=[
-                "sliding_attention", "sliding_attention", "sliding_attention",
-                "sliding_attention", "sliding_attention", "full_attention",
-                "sliding_attention", "full_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "full_attention",
             ],
         )
 
@@ -5405,18 +5409,13 @@ class TestBuildGemma4StaticCacheGraph:
 
         input_names = [inp.name for inp in model.graph.inputs]
         # write_indices and nonpad_kv_seqlen should come after all cache inputs
-        last_cache_idx = max(
-            i for i, n in enumerate(input_names) if "cache" in n
-        )
+        last_cache_idx = max(i for i, n in enumerate(input_names) if "cache" in n)
         write_idx = input_names.index("write_indices")
         nonpad_idx = input_names.index("nonpad_kv_seqlen")
-        assert write_idx > last_cache_idx, (
-            "write_indices should come after all cache inputs"
-        )
+        assert write_idx > last_cache_idx, "write_indices should come after all cache inputs"
         assert nonpad_idx > last_cache_idx, (
             "nonpad_kv_seqlen should come after all cache inputs"
         )
-
 
 
 # === Parametrized Vision-Language configs (imported from _test_configs) ===


### PR DESCRIPTION
## Summary

Adds `--static-cache` support for Gemma4 models, enabling pre-allocated KV cache buffers with TensorScatter ops (opset 24).

## Changes

### `src/mobius/models/gemma4.py`
- Added `StaticCacheState` dispatch to `Gemma4DecoderLayer.forward()` — extracts static cache from `past_key_value` and passes to attention
- Added `static_cache` parameter to `Gemma4TextAttention.forward()` — threads through to `_apply_attention()`
- Added `static_cache_mode` flag in `Gemma4TextModel.forward()` — skips GQA, fallback mask construction, and uses `None` attention bias when `attention_mask` is `None`

### `src/mobius/tasks/_gemma4.py`
- New `_make_gemma4_static_cache_inputs()` — creates per-layer static cache with correct dual head_dim (sliding=256, full=512) and skips KV-shared layers
- Updated `Gemma4TextCausalLMTask` with `static_cache`/`max_seq_len` params and static vs dynamic cache branching

### `src/mobius/tasks/_causal_lm.py`
- Added `Gemma4DecoderLayer` to `_validate_static_cache_support()`
- Scoped validation to skip encoder sub-modules (vision_encoder, audio_encoder, etc.)

### `src/mobius/__main__.py`
- Updated `--static-cache` CLI to resolve the correct task class for Gemma4 (uses text model type for multimodal models)

## Testing

- ✅ All 1186 existing tests pass
- ✅ `mobius build --model google/gemma-4-e2b-it --dtype f16 --static-cache --max-seq-len 4096` produces correct model with 30 TensorScatter + 35 Attention + 0 GQA ops
- ✅ Tiny config unit test verified programmatically

## Phase 1 Scope / Limitations

This is Phase 1 — full-attention and sliding-attention layers both work, but:
- **Sliding window masking**: Static cache path uses `is_causal=1` without sliding window constraint (standard causal attention). This matches the generic DecoderLayer static cache behavior.
- **KV-shared layers**: Correctly excluded from cache allocation. They continue to borrow K,V from source layers via the existing shared_kv_states mechanism.
- **Requires ORT ≥ 1.25.0** for TensorScatter opset 24 kernel support.