### PR TITLE
Warn about safetensors CUDA alignment issue

### DIFF
--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -214,6 +214,16 @@ def _save_package(
         _apply_optimize(model, optimize)
 
     max_shard_size_bytes = _parse_size(args.max_shard_size) if args.max_shard_size else None
+
+    if args.external_data == "safetensors" and getattr(args, "ep", "default") == "cuda":
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "Safetensors external data does not guarantee 256-byte offset "
+            "alignment, which can cause CUBLAS misaligned address errors on "
+            "CUDA. Consider using --external-data onnx for CUDA builds."
+        )
+
     pkg.save(
         output_dir,
         external_data=args.external_data,

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -216,8 +216,6 @@ def _save_package(
     max_shard_size_bytes = _parse_size(args.max_shard_size) if args.max_shard_size else None
 
     if args.external_data == "safetensors" and getattr(args, "ep", "default") == "cuda":
-        import logging
-
         logging.getLogger(__name__).warning(
             "Safetensors external data does not guarantee 256-byte offset "
             "alignment, which can cause CUBLAS misaligned address errors on "

--- a/src/mobius/_model_package.py
+++ b/src/mobius/_model_package.py
@@ -78,6 +78,14 @@ class ModelPackage(UserDict[str, ir.Model]):
             external_data: External data format. ``"onnx"`` (default) saves
                 weights to ``model.onnx.data``. ``"safetensors"`` saves
                 weights in safetensors format.
+
+                .. warning::
+                    The safetensors format does not guarantee 256-byte offset
+                    alignment for tensor data within the file.  This can cause
+                    ``CUBLAS_STATUS_INVALID_VALUE`` ("misaligned address")
+                    errors on some CUDA/cuBLAS versions when loading weights
+                    via memory-mapped I/O.  Use ``"onnx"`` (the default) for
+                    models targeting CUDA execution.
             max_shard_size_bytes: Maximum shard size in bytes for safetensors
                 format.  Only used when *external_data* is ``"safetensors"``.
             components: Optional predicate ``(name) -> bool`` that selects


### PR DESCRIPTION
## Summary

Add documentation and runtime warning about safetensors external data format causing CUBLAS misaligned address errors on CUDA.

## Root Cause

Safetensors header size (variable, ~34KB) + 8-byte length prefix creates a data start offset that is not 256-byte aligned. ALL subsequent tensor offsets inherit this misalignment. When ORT memory-maps the safetensors file and passes the pointer to cuBLAS, the misaligned address triggers `CUBLAS_STATUS_INVALID_VALUE`.

Verified on gemma-4-e2b-it:
- **Safetensors**: 0/543 tensors 256-byte aligned ❌
- **ONNX .data**: 543/543 tensors 256-byte aligned ✅

## Changes

- Add warning in `ModelPackage.save()` docstring about safetensors alignment
- Add runtime warning in CLI when `--external-data safetensors` + `--ep cuda`

## Recommendation

Use `--external-data onnx` (the default) for CUDA builds. The safetensors format is fine for CPU and for inference via `cudaMemcpy` (which handles alignment internally), but can fail with mmap-based loading paths.

Ref: onnxruntime/mobius#2120
