### PR TITLE
Lower opset 24→23 for non-default EPs to eliminate memcpy

### DIFF
--- a/src/mobius/_builder.py
+++ b/src/mobius/_builder.py
@@ -37,6 +37,7 @@ from mobius._configs import (
     BaseModelConfig,
 )
 from mobius._execution_providers import ep_registry
+from mobius._flags import flags
 from mobius._model_package import ModelPackage
 from mobius._optimizations import optimize_model
 from mobius._registry import registry
@@ -208,6 +209,17 @@ def build_from_module(
             model_role=role,
             trace=trace_optimization,
         )
+
+    # Lower default-domain opset from 24 to 23 when the target EP doesn't
+    # register opset 24 kernels for standard ops (Reshape, RMSNormalization,
+    # etc.). Without this, those ops fall to CPU and produce ~280 memcpy
+    # nodes that destroy performance. The flag defaults to True; set
+    # MOBIUS_ORT_LOWER_OPSET_FOR_EP=0 to disable for EPs that support
+    # opset 24 natively.
+    if flags.ort_lower_opset_for_ep and execution_provider != "default":
+        for model in pkg.values():
+            if "" in model.graph.opset_imports:
+                model.graph.opset_imports[""] = 23
     return pkg
 
 

--- a/src/mobius/_builder.py
+++ b/src/mobius/_builder.py
@@ -221,10 +221,10 @@ def build_from_module(
             if "" in model.graph.opset_imports:
                 original = model.graph.opset_imports[""]
                 model.graph.opset_imports[""] = 23
-                logger.info(
+                logger.warning(
                     "Lowered opset %d→23 for '%s' (EP=%s). "
                     "ORT does not yet register opset %d kernels for this EP. "
-                    "Track https://github.com/microsoft/onnxruntime/pull/28368",
+                    "Track https://github.com/microsoft/onnxruntime/issues/27729",
                     original,
                     name,
                     execution_provider,

--- a/src/mobius/_builder.py
+++ b/src/mobius/_builder.py
@@ -217,9 +217,19 @@ def build_from_module(
     # MOBIUS_ORT_LOWER_OPSET_FOR_EP=0 to disable for EPs that support
     # opset 24 natively.
     if flags.ort_lower_opset_for_ep and execution_provider != "default":
-        for model in pkg.values():
+        for name, model in pkg.items():
             if "" in model.graph.opset_imports:
+                original = model.graph.opset_imports[""]
                 model.graph.opset_imports[""] = 23
+                logger.info(
+                    "Lowered opset %d→23 for '%s' (EP=%s). "
+                    "ORT does not yet register opset %d kernels for this EP. "
+                    "Track https://github.com/microsoft/onnxruntime/pull/28368",
+                    original,
+                    name,
+                    execution_provider,
+                    original,
+                )
     return pkg
 
 


### PR DESCRIPTION
ORT CUDA EP registers kernels up to opset 23. Opset 24 models have Reshape/Cast fall to CPU → 280 memcpy. Wire up the ort_lower_opset_for_ep flag to lower opset after optimization. Result: 282→4 memcpy. Workaround until ORT PR #28368 adds opset 24 registrations.