### PR TITLE
Fix CUDA EP provider_options and use float masks for fallback layers

### DIFF
--- a/src/mobius/_execution_providers.py
+++ b/src/mobius/_execution_providers.py
@@ -207,10 +207,12 @@ def _register_builtins() -> None:
                 {ir.DataType.FLOAT, ir.DataType.FLOAT16, ir.DataType.BFLOAT16}
             ),
             supports_packed_multi_head_attention=True,
-            provider_options={
-                "enable_cuda_graph": "0",
-                "enable_skip_layer_norm_strict_mode": "1",
-            },
+            # provider_options intentionally empty for CUDA EP.
+            # GenAI's C++ session setup handles CUDA EP configuration
+            # (including disable_mem_pattern). Explicit provider_options
+            # in genai_config.json conflict with GenAI's internal setup
+            # and cause NaN or crashes for multimodal models.
+            provider_options={},
         ),
         EpCapabilities(
             name="dml",

--- a/src/mobius/integrations/ort_genai/ep_config.py
+++ b/src/mobius/integrations/ort_genai/ep_config.py
@@ -45,7 +45,9 @@ def make_provider_options(
 
     Returns:
         A list with a single dict mapping the EP name to its options.
-        Empty list for CPU (no provider_options needed).
+        Empty list when no provider-specific options are needed (CPU,
+        or CUDA without explicit options — GenAI handles CUDA EP setup
+        internally).
     """
     if ep == "cpu":
         return []
@@ -60,6 +62,11 @@ def make_provider_options(
     elif ep == "webgpu" and enable_webgpu_graph:
         options["enableGraphCapture"] = "1"
         options["validationMode"] = "disabled"
+
+    # Return empty list when no options to avoid overriding GenAI's
+    # internal EP configuration (which handles multimodal CUDA setup).
+    if not options:
+        return []
 
     return [{ep_name: options}]
 

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -42,8 +42,6 @@ from mobius.components import (
     Linear,
     RMSNorm,
     create_attention_bias,
-    create_padding_mask,
-    create_sliding_window_mask,
     initialize_rope,
 )
 from mobius.components._activations import get_activation

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -1511,42 +1511,26 @@ class Gemma4TextModel(nn.Module):
             layer.self_attn.is_kv_shared_layer for layer in self.layers
         )
         if need_fallback:
-            if use_gqa:
-                # GQA is active for non-shared layers. KV-shared layers use
-                # the standard Attention op with is_causal=1, so we only need
-                # bool masks (not additive float bias). This avoids the
-                # CumSum/GreaterOrEqual chain used by create_attention_bias.
-                # Full-attention: simple padding mask (causality handled by op)
-                # Sliding-window: still needs CumSum for window constraint
-                fallback_bias_dict = {
-                    "sliding_attention": create_sliding_window_mask(
-                        op,
-                        input_ids=query_input,
-                        attention_mask=attention_mask,
-                        window_size=self.sliding_window or 512,
-                    ),
-                    "full_attention": create_padding_mask(
-                        op,
-                        input_ids=query_input,
-                        attention_mask=attention_mask,
-                    ),
-                }
-            else:
-                fallback_bias_dict = {
-                    "sliding_attention": create_attention_bias(
-                        op,
-                        input_ids=query_input,
-                        attention_mask=attention_mask,
-                        sliding_window=self.sliding_window,
-                        dtype=self._dtype,
-                    ),
-                    "full_attention": create_attention_bias(
-                        op,
-                        input_ids=query_input,
-                        attention_mask=attention_mask,
-                        dtype=self._dtype,
-                    ),
-                }
+            # Use float16 additive attention bias for all fallback layers.
+            # Bool masks (create_sliding_window_mask / create_padding_mask)
+            # cause NaN in ORT's CUDA Attention kernel due to a bug in the
+            # bool-to-float ConvertAttnMaskToBias path. Float16 masks work
+            # correctly and match the default EP model's behavior.
+            fallback_bias_dict = {
+                "sliding_attention": create_attention_bias(
+                    op,
+                    input_ids=query_input,
+                    attention_mask=attention_mask,
+                    sliding_window=self.sliding_window,
+                    dtype=self._dtype,
+                ),
+                "full_attention": create_attention_bias(
+                    op,
+                    input_ids=query_input,
+                    attention_mask=attention_mask,
+                    dtype=self._dtype,
+                ),
+            }
             # KV-shared layers also need position embeddings for the
             # standard Attention path (manual RoPE). Reuse the embeddings
             # already gathered when realizing cos/sin caches above.


### PR DESCRIPTION
1. Remove CUDA provider_options from EP defaults — explicit options conflict with GenAI's internal session setup, causing NaN. 2. Use float16 additive masks for all fallback Attention layers instead of bool masks (more robust on CUDA). 3. Return empty provider_options list when no options needed.