### PR TITLE
Clarify Gemma4 GQA dispatch comments for KV-shared layers

### DIFF
--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -1508,8 +1508,7 @@ class Gemma4TextModel(nn.Module):
         query_input = input_ids if input_ids is not None else hidden_states
         fallback_bias_dict: dict[str, ir.Value | None] = {}
         need_fallback = not use_gqa or any(
-            layer.self_attn.is_kv_shared_layer
-            for layer in self.layers
+            layer.self_attn.is_kv_shared_layer for layer in self.layers
         )
         if need_fallback:
             if use_gqa:

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -1508,7 +1508,8 @@ class Gemma4TextModel(nn.Module):
         query_input = input_ids if input_ids is not None else hidden_states
         fallback_bias_dict: dict[str, ir.Value | None] = {}
         need_fallback = not use_gqa or any(
-            layer.self_attn.is_kv_shared_layer for layer in self.layers
+            layer.self_attn.is_kv_shared_layer
+            for layer in self.layers
         )
         if need_fallback:
             if use_gqa:
@@ -1577,13 +1578,15 @@ class Gemma4TextModel(nn.Module):
         else:
             past_kvs = [None] * len(self.layers)
 
+        # All non-shared layers use GQA when available.
+        # KV-shared layers fall back to standard Attention.
         for i, (layer, layer_type, past_kv) in enumerate(
             zip(self.layers, self.layer_types, past_kvs)
         ):
             per_layer_input = per_layer_inputs[i] if per_layer_inputs is not None else None
 
-            # Per-layer decision: use GQA for non-shared layers when
-            # available, fall back to standard Attention for KV-shared layers.
+            # Per-layer decision: use GQA for non-shared layers,
+            # fall back to standard Attention for KV-shared layers.
             is_shared = layer.self_attn.is_kv_shared_layer
             if use_gqa and not is_shared:
                 attn_bias = gqa_ctx_dict[layer_type]


### PR DESCRIPTION
Update comments in `Gemma4TextModel.forward()` to clarify that all non-shared layers use GQA when available. Only KV-shared layers fall back to standard Attention.