### PR TITLE
Qwen3-ASR: feature_attention_mask + chunked conv for HF parity

### DIFF
--- a/examples/qwen3_asr.py
+++ b/examples/qwen3_asr.py
@@ -196,10 +196,21 @@ def compute_mel_spectrogram(
     n_mels: int = 128,
     n_fft: int = 400,
     hop_length: int = 160,
-) -> np.ndarray:
+) -> tuple[np.ndarray, np.ndarray]:
     """Compute log-mel spectrogram using WhisperFeatureExtractor.
 
-    Returns array of shape ``(1, n_mels, time_frames)``.
+    The Whisper extractor pads to a fixed 30-second window
+    (``max_length=3000`` mel frames). Without the matching padding
+    mask, the mobius audio encoder treats trailing zero-padded frames
+    as real audio and the LLM downstream emits degenerate loops. We
+    therefore always request ``return_attention_mask=True`` so the
+    encoder can crop padding from the audio token stream.
+
+    Returns:
+        ``(input_features, feature_attention_mask)`` where
+        ``input_features`` has shape ``(1, n_mels, time_frames)`` and
+        ``feature_attention_mask`` has shape ``(1, time_frames)``
+        (1 = real audio, 0 = padding).
     """
     from transformers import WhisperFeatureExtractor
 
@@ -213,11 +224,12 @@ def compute_mel_spectrogram(
         audio,
         sampling_rate=sample_rate,
         return_tensors="np",
-        padding=False,
+        return_attention_mask=True,
     )
-    return out["input_features"].astype(
-        np.float32
-    )  # Always float32; caller casts to model dtype
+    # Always float32 for input_features; caller casts to model dtype.
+    input_features = out["input_features"].astype(np.float32)
+    feature_attention_mask = out["attention_mask"].astype(np.int64)
+    return input_features, feature_attention_mask
 
 
 # ---------------------------------------------------------------------------
@@ -312,11 +324,24 @@ def transcribe(
     batch_size = 1
 
     # Step 1: Compute mel spectrogram
-    mel = compute_mel_spectrogram(audio).astype(model_dtype)  # (1, n_mels, time)
+    mel, feature_attention_mask = compute_mel_spectrogram(audio)
+    mel = mel.astype(model_dtype)  # (1, n_mels, time)
 
     # Step 2: Run audio encoder
-    audio_out = sessions["audio_encoder"].run({"input_features": mel})
+    audio_out = sessions["audio_encoder"].run(
+        {
+            "input_features": mel,
+            "feature_attention_mask": feature_attention_mask,
+        }
+    )
     audio_features = audio_out["audio_features"]  # (1, audio_seq, dim)
+    audio_feature_lengths = audio_out["audio_feature_lengths"]  # (1,)
+    # Crop padding-derived rows so they never reach the embedding's
+    # gather. The encoder emits a fixed-length output equal to the
+    # padded mel length / 8, but only ``audio_feature_lengths[0]`` of
+    # those rows correspond to real audio.
+    valid_audio_tokens = int(audio_feature_lengths[0])
+    audio_features = audio_features[:, :valid_audio_tokens, :]
     num_audio_tokens = audio_features.shape[1]
 
     # Flatten to (num_audio_tokens, output_dim) for the embedding model

--- a/examples/qwen3_asr.py
+++ b/examples/qwen3_asr.py
@@ -334,14 +334,7 @@ def transcribe(
             "feature_attention_mask": feature_attention_mask,
         }
     )
-    audio_features = audio_out["audio_features"]  # (1, audio_seq, dim)
-    audio_feature_lengths = audio_out["audio_feature_lengths"]  # (1,)
-    # Crop padding-derived rows so they never reach the embedding's
-    # gather. The encoder emits a fixed-length output equal to the
-    # padded mel length / 8, but only ``audio_feature_lengths[0]`` of
-    # those rows correspond to real audio.
-    valid_audio_tokens = int(audio_feature_lengths[0])
-    audio_features = audio_features[:, :valid_audio_tokens, :]
+    audio_features = audio_out["audio_features"]  # (1, valid_tokens, dim)
     num_audio_tokens = audio_features.shape[1]
 
     # Flatten to (num_audio_tokens, output_dim) for the embedding model

--- a/examples/qwen3_asr.py
+++ b/examples/qwen3_asr.py
@@ -334,7 +334,14 @@ def transcribe(
             "feature_attention_mask": feature_attention_mask,
         }
     )
-    audio_features = audio_out["audio_features"]  # (1, valid_tokens, dim)
+    audio_features = audio_out["audio_features"]  # (1, audio_seq, dim)
+    audio_feature_lengths = audio_out["audio_feature_lengths"]  # (1,)
+    # Crop padding-derived rows so they never reach the embedding's
+    # gather. The encoder emits a fixed-length output equal to the
+    # padded mel length / 8, but only ``audio_feature_lengths[0]`` of
+    # those rows correspond to real audio.
+    valid_audio_tokens = int(audio_feature_lengths[0])
+    audio_features = audio_features[:, :valid_audio_tokens, :]
     num_audio_tokens = audio_features.shape[1]
 
     # Flatten to (num_audio_tokens, output_dim) for the embedding model

--- a/examples/qwen3_forced_aligner.py
+++ b/examples/qwen3_forced_aligner.py
@@ -156,9 +156,18 @@ def run_alignment(
     alignment_text += "<timestamp><timestamp>"
 
     # Step 2: Compute mel spectrogram and run audio encoder
-    mel = compute_mel_spectrogram(audio)
-    audio_out = sessions["audio_encoder"].run({"input_features": mel})
+    mel, feature_attention_mask = compute_mel_spectrogram(audio)
+    audio_out = sessions["audio_encoder"].run(
+        {
+            "input_features": mel,
+            "feature_attention_mask": feature_attention_mask,
+        }
+    )
     audio_features = audio_out["audio_features"]
+    audio_feature_lengths = audio_out["audio_feature_lengths"]
+    # Crop padding-derived audio tokens
+    valid_audio_tokens = int(audio_feature_lengths[0])
+    audio_features = audio_features[:, :valid_audio_tokens, :]
     num_audio_tokens = audio_features.shape[1]
     audio_features_2d = audio_features.reshape(-1, audio_features.shape[-1])
 

--- a/src/mobius/_configs.py
+++ b/src/mobius/_configs.py
@@ -281,6 +281,16 @@ class AudioConfig:
     audio_start_token_id: int | None = None
     audio_end_token_id: int | None = None
     classify_num: int | None = None
+    # Qwen3-ASR chunked conv parameters. ``n_window`` is half the
+    # number of mel frames per conv chunk (so chunk_size = 2 *
+    # n_window). ``n_window_infer`` is the attention window in mel
+    # frames; encoder self-attention is block-diagonal with windows
+    # of n_window_infer / (2 * n_window) post-conv chunks (~=
+    # n_window_infer * tokens_per_chunk / chunk_size_mel post-conv
+    # tokens). HF reference: QwenLM/Qwen3-ASR
+    # qwen_asr/core/transformers_backend/modeling_qwen3_asr.py
+    n_window: int | None = None
+    n_window_infer: int | None = None
     # Fun-ASR / SenseVoice encoder config
     tp_num_blocks: int | None = None
     adaptor_proj_dim: int | None = None
@@ -712,6 +722,8 @@ def _extract_audio_config(config, parent_config, model_type: str) -> dict:
                 downsample_hidden_size=getattr(ac, "downsample_hidden_size", None),
                 output_dim=getattr(ac, "output_dim", None),
                 activation_function=getattr(ac, "activation_function", "gelu"),
+                n_window=getattr(ac, "n_window", None),
+                n_window_infer=getattr(ac, "n_window_infer", None),
             )
         # Special tokens from thinker config
         audio_fields["audio_token_id"] = getattr(tc, "audio_token_id", None)

--- a/src/mobius/components/_qwen3_asr_audio.py
+++ b/src/mobius/components/_qwen3_asr_audio.py
@@ -39,11 +39,20 @@ class Qwen3ASRAudioAttention(nn.Module):
         self._num_heads = num_heads
         self._head_dim = d_model // num_heads
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        hidden_states: ir.Value,
+        attention_mask: ir.Value | None = None,
+    ):
         """Bidirectional self-attention.
 
         Args:
             hidden_states: (batch, seq_len, d_model)
+            attention_mask: optional bool mask of shape ``(batch, seq_len, seq_len)``
+                (True = attend, False = mask out). Used to ignore padded
+                mel positions that were added by the HF processor when
+                padding to a fixed 30s window.
 
         Returns:
             output: (batch, seq_len, d_model)
@@ -57,6 +66,7 @@ class Qwen3ASRAudioAttention(nn.Module):
             q,
             k,
             v,
+            attention_mask,
             q_num_heads=self._num_heads,
             kv_num_heads=self._num_heads,
             scale=float(self._head_dim**-0.5),
@@ -88,11 +98,17 @@ class Qwen3ASRAudioEncoderLayer(nn.Module):
         self.fc2 = Linear(ffn_dim, d_model, bias=True)
         self.final_layer_norm = LayerNorm(d_model, eps=eps)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        hidden_states: ir.Value,
+        attention_mask: ir.Value | None = None,
+    ):
         """Pre-norm encoder layer with bidirectional attention.
 
         Args:
             hidden_states: (batch, seq_len, d_model)
+            attention_mask: optional bool mask, see ``Qwen3ASRAudioAttention``.
 
         Returns:
             hidden_states: (batch, seq_len, d_model)
@@ -100,7 +116,7 @@ class Qwen3ASRAudioEncoderLayer(nn.Module):
         # Self-attention with pre-norm and residual
         residual = hidden_states
         hidden_states = self.self_attn_layer_norm(op, hidden_states)
-        hidden_states = self.self_attn(op, hidden_states)
+        hidden_states = self.self_attn(op, hidden_states, attention_mask)
         hidden_states = op.Add(residual, hidden_states)
 
         # FFN with pre-norm, GELU, and residual

--- a/src/mobius/models/qwen3_asr.py
+++ b/src/mobius/models/qwen3_asr.py
@@ -228,6 +228,11 @@ class Qwen3ASRAudioEncoder(nn.Module):
         #    num_chunks, chunk_size_mel) → (B, num_chunks,
         #    num_mel_bins, chunk_size_mel) → (B*num_chunks, 1,
         #    num_mel_bins, chunk_size_mel) for batched 2D conv.
+        #
+        #    Requires mel_seq divisible by chunk_size_mel. The
+        #    WhisperFeatureExtractor always pads to 3000 frames
+        #    (30s * 100 fps), which is divisible by the default
+        #    chunk_size_mel (2 * n_window = 100).
         # ----------------------------------------------------------
         chunked = op.Reshape(
             input_features,

--- a/src/mobius/models/qwen3_asr.py
+++ b/src/mobius/models/qwen3_asr.py
@@ -89,6 +89,36 @@ class Qwen3ASRAudioEncoder(nn.Module):
         max_source_positions = audio.max_source_positions or 1500
         downsample_hidden_size = audio.downsample_hidden_size or 480
         output_dim = audio.output_dim or 1024
+        # Qwen3-ASR chunked conv constants. Defaults match both
+        # 0.6B and 1.7B (n_window=50, n_window_infer=800).
+        n_window = audio.n_window or 50
+        n_window_infer = audio.n_window_infer or 800
+
+        # Chunk geometry: HF runs the conv over fixed-size chunks of
+        # ``2 * n_window`` mel frames, each producing
+        # ``tokens_per_chunk`` post-conv tokens. Encoder self-attention
+        # is then block-diagonal with windows of ``block_size`` post-
+        # conv tokens. All three numbers are derived from config.
+        self._chunk_size_mel = 2 * n_window  # mel frames per conv chunk (100)
+        # tokens_per_chunk = 3x ceil-div-2 on chunk_size_mel
+        # = ceil(ceil(ceil(100/2)/2)/2) = 13 for the default
+        t = self._chunk_size_mel
+        for _ in range(3):
+            t = (t + 1) // 2
+        self._tokens_per_chunk = t  # post-conv tokens per chunk (13)
+        # block_size in post-conv tokens. Each attention block covers
+        # ``n_window_infer`` mel frames = (n_window_infer / chunk_size)
+        # full chunks = that many * tokens_per_chunk post-conv tokens.
+        # Requires n_window_infer to be a multiple of chunk_size_mel —
+        # both shipped Qwen3-ASR variants satisfy this (800 % 100 = 0).
+        if n_window_infer % self._chunk_size_mel != 0:
+            raise ValueError(
+                f"n_window_infer ({n_window_infer}) must be a multiple of "
+                f"2 * n_window ({self._chunk_size_mel})"
+            )
+        self._block_size = (
+            self._tokens_per_chunk * (n_window_infer // self._chunk_size_mel)
+        )
 
         # 3x Conv2d downsampling: (1, mel, seq) → (dhs, mel//8, seq//8)
         self.conv2d1 = Conv2d(
@@ -113,13 +143,18 @@ class Qwen3ASRAudioEncoder(nn.Module):
             padding=1,
         )
 
-        # Linear projection from flattened conv features to d_model
-        # After 3 strides of 2: freq_dim = (((mel+1)//2+1)//2+1)//2
+        # Linear projection from flattened conv features to d_model.
+        # After 3 strides of 2: freq_dim = (((mel+1)//2+1)//2+1)//2.
         freq_after_conv = (((num_mel_bins + 1) // 2 + 1) // 2 + 1) // 2
         conv_out_dim = downsample_hidden_size * freq_after_conv
+        self._conv_out_dim = conv_out_dim
+        self._d_model = d_model
+        self._num_mel_bins = num_mel_bins
         self.conv_out = Linear(conv_out_dim, d_model, bias=False)
 
-        # Sinusoidal positional embeddings (frozen)
+        # Sinusoidal positional embeddings (frozen). HF uses these
+        # PER-CHUNK (each chunk reuses PE[0:tokens_per_chunk]) — see
+        # forward() for the slicing logic.
         pe_data = _sinusoidal_position_embedding(max_source_positions, d_model)
         self.positional_embedding = nn.Parameter(
             [max_source_positions, d_model],
@@ -142,56 +177,219 @@ class Qwen3ASRAudioEncoder(nn.Module):
         self.proj1 = Linear(d_model, d_model, bias=True)
         self.proj2 = Linear(d_model, output_dim, bias=True)
 
-    def forward(self, op: builder.OpBuilder, input_features: ir.Value):
-        """Encode mel spectrogram to audio features.
+    def forward(
+        self,
+        op: builder.OpBuilder,
+        input_features: ir.Value,
+        feature_attention_mask: ir.Value,
+    ):
+        """Encode mel spectrogram to audio features (HF-faithful chunked conv).
+
+        Reproduces the HF Qwen3-ASR audio encoder architecture:
+        conv runs on fixed ``2 * n_window``-frame mel chunks (one
+        chunk's conv outputs are independent of its neighbours),
+        each chunk's post-conv tokens get the same per-chunk
+        positional embedding, and self-attention is block-diagonal
+        with ``block_size`` post-conv tokens per block. Without
+        chunking, the conv arithmetic produces ``ceil(mel_seq / 8)``
+        tokens per 30s instead of HF's ``30 * tokens_per_chunk``,
+        which misaligns the LLM and triggers repetition loops on
+        long inputs.
 
         Args:
-            input_features: (batch, num_mel_bins, seq_len) mel spectrogram
+            input_features: (batch, num_mel_bins, mel_seq_len) mel
+                spectrogram. ``mel_seq_len`` MUST be a multiple of
+                ``2 * n_window`` (= 100 for both 0.6B and 1.7B).
+                The HF processor pads to 3000 frames by default,
+                which satisfies this.
+            feature_attention_mask: (batch, mel_seq_len) int64 mask.
+                ``1`` = real audio frame, ``0`` = right-padding from
+                the processor. Required.
 
         Returns:
-            audio_features: (batch, out_seq_len, output_dim)
+            audio_features: (batch, mel_seq_len // chunk_size_mel *
+                tokens_per_chunk, output_dim). For 30s @ 100-frame
+                chunks: 390 tokens. Includes ``audio_feature_lengths``
+                padding-derived tokens at the tail; callers MUST crop
+                via ``audio_feature_lengths`` before feeding into the
+                embedding model.
+            audio_feature_lengths: (batch,) int64 — number of valid
+                audio tokens per batch item, computed via the same
+                formula HF uses
+                (``_get_feat_extract_output_lengths``).
         """
-        # Add channel dimension: (batch, mel, seq) → (batch, 1, mel, seq)
-        hidden_states = op.Unsqueeze(input_features, [1])
+        chunk_size_mel = self._chunk_size_mel
+        tokens_per_chunk = self._tokens_per_chunk
+        block_size = self._block_size
+        d_model = self._d_model
+        num_mel_bins = self._num_mel_bins
 
-        # 3x Conv2d downsampling with GELU
-        hidden_states = op.Gelu(self.conv2d1(op, hidden_states))
-        hidden_states = op.Gelu(self.conv2d2(op, hidden_states))
-        hidden_states = op.Gelu(self.conv2d3(op, hidden_states))
+        # ----------------------------------------------------------
+        # 1. Chunk the mel input.
+        #    (B, num_mel_bins, mel_seq) → (B, num_mel_bins,
+        #    num_chunks, chunk_size_mel) → (B, num_chunks,
+        #    num_mel_bins, chunk_size_mel) → (B*num_chunks, 1,
+        #    num_mel_bins, chunk_size_mel) for batched 2D conv.
+        # ----------------------------------------------------------
+        chunked = op.Reshape(
+            input_features,
+            op.Constant(value_ints=[0, 0, -1, chunk_size_mel]),
+        )  # (B, num_mel_bins, num_chunks, chunk_size_mel)
+        chunked = op.Transpose(chunked, perm=[0, 2, 1, 3])
+        # (B, num_chunks, num_mel_bins, chunk_size_mel)
+        flat_chunks = op.Reshape(
+            chunked,
+            op.Constant(value_ints=[-1, 1, num_mel_bins, chunk_size_mel]),
+        )  # (B*num_chunks, 1, num_mel_bins, chunk_size_mel)
 
-        # Reshape: (batch, channels, freq, time) → (batch, time, channels*freq)
-        # Permute to (batch, time, channels, freq) then flatten last two dims.
-        # Use 0 sentinel (copy from input) to avoid dynamic Shape ops.
-        hidden_states = op.Transpose(hidden_states, perm=[0, 3, 1, 2])
-        hidden_states = op.Reshape(hidden_states, op.Constant(value_ints=[0, 0, -1]))
+        # ----------------------------------------------------------
+        # 2. Apply the 3 strided convolutions independently to each
+        #    chunk. Same conv weights as HF (single shared set).
+        # ----------------------------------------------------------
+        conv_out = op.Gelu(self.conv2d1(op, flat_chunks))
+        conv_out = op.Gelu(self.conv2d2(op, conv_out))
+        conv_out = op.Gelu(self.conv2d3(op, conv_out))
+        # (B*num_chunks, dhs, freq_after_conv, tokens_per_chunk)
 
-        # Linear projection to d_model
-        hidden_states = self.conv_out(op, hidden_states)
+        # ----------------------------------------------------------
+        # 3. Permute and flatten: (B*nc, dhs, freq, t) →
+        #    (B*nc, t, dhs, freq) → (B*nc, t, dhs*freq).
+        # ----------------------------------------------------------
+        conv_out = op.Transpose(conv_out, perm=[0, 3, 1, 2])
+        conv_out = op.Reshape(conv_out, op.Constant(value_ints=[0, 0, -1]))
+        # (B*num_chunks, tokens_per_chunk, conv_out_dim)
 
-        # Add sinusoidal positional embeddings (up to seq_len)
-        seq_len = op.Shape(hidden_states, start=1, end=2)
-        # Slice PE to match actual sequence length
+        # ----------------------------------------------------------
+        # 4. Linear projection to d_model.
+        # ----------------------------------------------------------
+        chunked_features = self.conv_out(op, conv_out)
+        # (B*num_chunks, tokens_per_chunk, d_model)
+
+        # ----------------------------------------------------------
+        # 5. Add per-chunk positional embedding. HF reuses
+        #    PE[0:tokens_per_chunk] for EVERY chunk independently —
+        #    cross-chunk ordering comes from the attention mask, not
+        #    from PE.
+        # ----------------------------------------------------------
         pe_slice = op.Slice(
             self.positional_embedding,
             op.Constant(value_ints=[0]),
-            seq_len,
+            op.Constant(value_ints=[tokens_per_chunk]),
             op.Constant(value_ints=[0]),
+        )  # (tokens_per_chunk, d_model)
+        pe_slice = op.CastLike(pe_slice, chunked_features)
+        pe_slice = op.Unsqueeze(pe_slice, [0])  # (1, tokens_per_chunk, d_model)
+        chunked_features = op.Add(chunked_features, pe_slice)
+
+        # ----------------------------------------------------------
+        # 6. Reshape back to per-batch flat sequence:
+        #    (B*nc, t, d) → (B, nc*t, d).
+        # ----------------------------------------------------------
+        batch_size = op.Shape(input_features, start=0, end=1)  # (1,)
+        target_shape = op.Concat(
+            batch_size,
+            op.Constant(value_ints=[-1, d_model]),
+            axis=0,
         )
-        # CastLike ensures PE matches hidden_states dtype (f16/bf16)
-        pe_slice = op.CastLike(pe_slice, hidden_states)
-        hidden_states = op.Add(hidden_states, pe_slice)
+        hidden_states = op.Reshape(chunked_features, target_shape)
+        # (B, total_post_conv, d_model)
 
-        # Encoder layers
+        # ----------------------------------------------------------
+        # 7. Compute audio_feature_lengths via HF's
+        #    _get_feat_extract_output_lengths. For valid_mel ≥ 0
+        #    (always true since the mask has 0/1 values):
+        #      num_full_chunks = valid_mel // chunk_size_mel
+        #      remainder       = valid_mel % chunk_size_mel
+        #      tail_tokens     = ceil(ceil(ceil(rem/2)/2)/2)
+        #                      = (((rem+1)//2 + 1)//2 + 1)//2
+        #      length = num_full_chunks * tokens_per_chunk + tail_tokens
+        #    ONNX int Div truncates toward zero; identical to floor
+        #    div for non-negative operands.
+        # ----------------------------------------------------------
+        chunk_size_mel_const = op.Constant(value_ints=[chunk_size_mel])
+        tokens_per_chunk_const = op.Constant(value_ints=[tokens_per_chunk])
+        one_const = op.Constant(value_ints=[1])
+        two_const = op.Constant(value_ints=[2])
+
+        valid_mel = op.ReduceSum(
+            feature_attention_mask,
+            op.Constant(value_ints=[1]),
+            keepdims=0,
+        )  # (B,) int64
+        num_full_chunks = op.Div(valid_mel, chunk_size_mel_const)
+        full_contrib = op.Mul(num_full_chunks, tokens_per_chunk_const)
+        remainder = op.Sub(
+            valid_mel, op.Mul(num_full_chunks, chunk_size_mel_const)
+        )
+        s1 = op.Div(op.Add(remainder, one_const), two_const)
+        s2 = op.Div(op.Add(s1, one_const), two_const)
+        s3 = op.Div(op.Add(s2, one_const), two_const)
+        audio_feature_lengths = op.Add(full_contrib, s3)  # (B,) int64
+
+        # ----------------------------------------------------------
+        # 8. Build the block-diagonal attention mask.
+        #
+        #    HF's reference uses a varlen FlashAttention path with
+        #    cu_seqlens to enforce that token q only attends to
+        #    keys in the same ``block_size``-token window. With
+        #    fixed-shape ONNX we instead build a (B, S, S) bool
+        #    mask:
+        #        same_block(q, k) = (q // block_size) == (k // block_size)
+        #        valid(b, i)      = i < audio_feature_lengths[b]
+        #        mask(b, q, k)    = same_block(q, k)
+        #                           AND valid(b, q) AND valid(b, k)
+        #
+        #    BUT: rows where the query is past audio_feature_lengths
+        #    would have all-False keys, which produces NaN on
+        #    softmax. To keep ORT's Attention numerically safe, we
+        #    OR in the diagonal so every query has at least one
+        #    allowed key (itself). Padding queries then "attend to
+        #    themselves only", producing some finite (junk) value
+        #    that the caller throws away by cropping via
+        #    audio_feature_lengths.
+        # ----------------------------------------------------------
+        seq_dim = op.Shape(hidden_states, start=1, end=2)  # (1,)
+        seq_scalar = op.Squeeze(seq_dim, op.Constant(value_ints=[0]))
+        zero_scalar = op.Constant(value_int=0)
+        one_scalar = op.Constant(value_int=1)
+        block_size_scalar = op.Constant(value_int=block_size)
+        position = op.Range(zero_scalar, seq_scalar, one_scalar)  # (S,) int64
+
+        block_id = op.Div(position, block_size_scalar)  # (S,) int64
+        block_id_q = op.Unsqueeze(block_id, [1])  # (S, 1)
+        block_id_k = op.Unsqueeze(block_id, [0])  # (1, S)
+        same_block = op.Equal(block_id_q, block_id_k)  # (S, S) bool
+
+        pos_2d = op.Unsqueeze(position, [0])  # (1, S)
+        afl_2d = op.Unsqueeze(audio_feature_lengths, [1])  # (B, 1)
+        valid = op.Less(pos_2d, afl_2d)  # (B, S) bool
+
+        valid_q = op.Unsqueeze(valid, [2])  # (B, S, 1)
+        valid_k = op.Unsqueeze(valid, [1])  # (B, 1, S)
+        same_block_3d = op.Unsqueeze(same_block, [0])  # (1, S, S)
+        block_mask = op.And(op.And(same_block_3d, valid_q), valid_k)
+        # (B, S, S) bool
+
+        # Diagonal fallback so padded queries always have ≥1 key.
+        diag_eq = op.Equal(
+            op.Unsqueeze(position, [1]),  # (S, 1)
+            op.Unsqueeze(position, [0]),  # (1, S)
+        )  # (S, S) bool — True only on the diagonal
+        diag_3d = op.Unsqueeze(diag_eq, [0])  # (1, S, S)
+        attention_mask = op.Or(block_mask, diag_3d)  # (B, S, S) bool
+
+        # ----------------------------------------------------------
+        # 9. Encoder layers + post-encoder norm + output projection.
+        # ----------------------------------------------------------
         for layer in self.layers:
-            hidden_states = layer(op, hidden_states)
+            hidden_states = layer(op, hidden_states, attention_mask)
 
-        # Post-encoder norm + projection
         hidden_states = self.ln_post(op, hidden_states)
         hidden_states = self.proj1(op, hidden_states)
         hidden_states = op.Gelu(hidden_states)
         hidden_states = self.proj2(op, hidden_states)
 
-        return hidden_states
+        return hidden_states, audio_feature_lengths
 
 
 class Qwen3ASREmbeddingModel(nn.Module):

--- a/src/mobius/models/qwen3_asr.py
+++ b/src/mobius/models/qwen3_asr.py
@@ -116,9 +116,7 @@ class Qwen3ASRAudioEncoder(nn.Module):
                 f"n_window_infer ({n_window_infer}) must be a multiple of "
                 f"2 * n_window ({self._chunk_size_mel})"
             )
-        self._block_size = (
-            self._tokens_per_chunk * (n_window_infer // self._chunk_size_mel)
-        )
+        self._block_size = self._tokens_per_chunk * (n_window_infer // self._chunk_size_mel)
 
         # 3x Conv2d downsampling: (1, mel, seq) → (dhs, mel//8, seq//8)
         self.conv2d1 = Conv2d(
@@ -318,9 +316,7 @@ class Qwen3ASRAudioEncoder(nn.Module):
         )  # (B,) int64
         num_full_chunks = op.Div(valid_mel, chunk_size_mel_const)
         full_contrib = op.Mul(num_full_chunks, tokens_per_chunk_const)
-        remainder = op.Sub(
-            valid_mel, op.Mul(num_full_chunks, chunk_size_mel_const)
-        )
+        remainder = op.Sub(valid_mel, op.Mul(num_full_chunks, chunk_size_mel_const))
         s1 = op.Div(op.Add(remainder, one_const), two_const)
         s2 = op.Div(op.Add(s1, one_const), two_const)
         s3 = op.Div(op.Add(s2, one_const), two_const)

--- a/src/mobius/tasks/_speech_language.py
+++ b/src/mobius/tasks/_speech_language.py
@@ -108,5 +108,9 @@ class SpeechLanguageTask(ModelTask):
         # time downsampling. Callers must crop ``audio_features`` to
         # this length before feeding into the embedding model so the
         # decoder never sees padding-derived audio tokens.
+        #
+        # NOTE: ORT GenAI's speech pipeline does not yet wire this
+        # output. Custom inference scripts (e.g. examples/qwen3_asr.py)
+        # must read audio_feature_lengths and crop manually.
         builder.add_output(audio_feature_lengths, "audio_feature_lengths")
         return _make_model(graph)

--- a/src/mobius/tasks/_speech_language.py
+++ b/src/mobius/tasks/_speech_language.py
@@ -89,8 +89,24 @@ class SpeechLanguageTask(ModelTask):
             dtype=config.dtype,
             shape=[batch, n_mels, mel_seq],
         )
+        # Mask is required: without it the encoder consumes padded mel
+        # frames as if they were real audio, which causes the
+        # downstream LLM to emit degenerate loops on any input padded
+        # to 30s by the standard HF processor.
+        feature_attention_mask = builder.input(
+            "feature_attention_mask",
+            dtype=ir.DataType.INT64,
+            shape=[batch, mel_seq],
+        )
 
-        audio_features = audio_encoder(builder.op, input_features)
+        audio_features, audio_feature_lengths = audio_encoder(
+            builder.op, input_features, feature_attention_mask
+        )
 
         builder.add_output(audio_features, "audio_features")
+        # Number of valid audio tokens per batch item, after the 8x
+        # time downsampling. Callers must crop ``audio_features`` to
+        # this length before feeding into the embedding model so the
+        # decoder never sees padding-derived audio tokens.
+        builder.add_output(audio_feature_lengths, "audio_feature_lengths")
         return _make_model(graph)

--- a/src/mobius/tasks/_speech_language.py
+++ b/src/mobius/tasks/_speech_language.py
@@ -106,14 +106,20 @@ class SpeechLanguageTask(ModelTask):
             op, input_features, feature_attention_mask
         )
 
+        # Crop padding-derived tokens so the output contains only valid
+        # audio features.  The encoder emits a fixed-length output equal
+        # to ceil(padded_mel_length / 8), but only the first
+        # ``audio_feature_lengths`` tokens per batch item are real.
+        # Cropping inside the graph avoids callers needing to handle
+        # the extra output and manual slicing.
+        # audio_features: [batch, max_tokens, hidden_size]
+        # audio_feature_lengths: [batch] → reshape to [1] for Slice ends
+        audio_features = builder.op.Slice(
+            audio_features,
+            [0],  # starts
+            builder.op.Reshape(audio_feature_lengths, [-1]),  # ends
+            [1],  # axes (token dim)
+        )
+
         builder.add_output(audio_features, "audio_features")
-        # Number of valid audio tokens per batch item, after the 8x
-        # time downsampling. Callers must crop ``audio_features`` to
-        # this length before feeding into the embedding model so the
-        # decoder never sees padding-derived audio tokens.
-        #
-        # NOTE: ORT GenAI's speech pipeline does not yet wire this
-        # output. Custom inference scripts (e.g. examples/qwen3_asr.py)
-        # must read audio_feature_lengths and crop manually.
-        builder.add_output(audio_feature_lengths, "audio_feature_lengths")
         return _make_model(graph)

--- a/src/mobius/tasks/_speech_language.py
+++ b/src/mobius/tasks/_speech_language.py
@@ -107,7 +107,7 @@ class SpeechLanguageTask(ModelTask):
         )
 
         builder.add_output(audio_features, "audio_features")
-        # Number of valid audio tokens per batch item, after the 8×
+        # Number of valid audio tokens per batch item, after the 8x
         # time downsampling.  Callers must crop ``audio_features`` to
         # this length before feeding into the embedding model so the
         # decoder never sees padding-derived audio tokens.

--- a/src/mobius/tasks/_speech_language.py
+++ b/src/mobius/tasks/_speech_language.py
@@ -112,6 +112,12 @@ class SpeechLanguageTask(ModelTask):
         # ``audio_feature_lengths`` tokens per batch item are real.
         # Cropping inside the graph avoids callers needing to handle
         # the extra output and manual slicing.
+        #
+        # NOTE: This Slice uses a single ``ends`` value for the token
+        # axis, so it is only correct for batch_size=1 (the standard
+        # GenAI inference mode).  For batch>1 each item may have a
+        # different valid length; supporting that would require a
+        # per-batch crop (e.g. loop or ScatterND).
         # audio_features: [batch, max_tokens, hidden_size]
         # audio_feature_lengths: [batch] → reshape to [1] for Slice ends
         audio_features = builder.op.Slice(

--- a/src/mobius/tasks/_speech_language.py
+++ b/src/mobius/tasks/_speech_language.py
@@ -106,26 +106,10 @@ class SpeechLanguageTask(ModelTask):
             op, input_features, feature_attention_mask
         )
 
-        # Crop padding-derived tokens so the output contains only valid
-        # audio features.  The encoder emits a fixed-length output equal
-        # to ceil(padded_mel_length / 8), but only the first
-        # ``audio_feature_lengths`` tokens per batch item are real.
-        # Cropping inside the graph avoids callers needing to handle
-        # the extra output and manual slicing.
-        #
-        # NOTE: This Slice uses a single ``ends`` value for the token
-        # axis, so it is only correct for batch_size=1 (the standard
-        # GenAI inference mode).  For batch>1 each item may have a
-        # different valid length; supporting that would require a
-        # per-batch crop (e.g. loop or ScatterND).
-        # audio_features: [batch, max_tokens, hidden_size]
-        # audio_feature_lengths: [batch] → reshape to [1] for Slice ends
-        audio_features = builder.op.Slice(
-            audio_features,
-            [0],  # starts
-            builder.op.Reshape(audio_feature_lengths, [-1]),  # ends
-            [1],  # axes (token dim)
-        )
-
         builder.add_output(audio_features, "audio_features")
+        # Number of valid audio tokens per batch item, after the 8×
+        # time downsampling.  Callers must crop ``audio_features`` to
+        # this length before feeding into the embedding model so the
+        # decoder never sees padding-derived audio tokens.
+        builder.add_output(audio_feature_lengths, "audio_feature_lengths")
         return _make_model(graph)

--- a/src/mobius/tasks/_task_test.py
+++ b/src/mobius/tasks/_task_test.py
@@ -1173,8 +1173,13 @@ class TestSpeechLanguageTaskNoAudioConfig:
         from onnxscript import nn as onnx_nn
 
         class _StubAudio(onnx_nn.Module):
-            def forward(self, op, input_features):
-                return op.Identity(input_features)
+            def forward(self, op, input_features, feature_attention_mask):
+                # Return (audio_features, audio_feature_lengths) to match
+                # the SpeechLanguageTask contract.
+                lengths = op.ReduceSum(
+                    feature_attention_mask, keepdims=False
+                )
+                return op.Identity(input_features), lengths
 
         return _StubAudio()
 

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -2230,9 +2230,11 @@ class TestBuildGraphQwen3ASR:
 
         output_names = {out.name for out in encoder.graph.outputs}
         assert "audio_features" in output_names
-        # audio_feature_lengths is no longer a separate output —
-        # the encoder crops padding internally via Slice.
-        assert "audio_feature_lengths" not in output_names
+        # audio_feature_lengths exposes the valid token count after
+        # the encoder's 8x time downsampling so downstream callers can
+        # crop padding-derived rows out of audio_features before the
+        # embedding gather.
+        assert "audio_feature_lengths" in output_names
 
     def test_audio_encoder_attention_uses_mask(self):
         """The encoder's Attention ops must receive the mask input.
@@ -2364,10 +2366,13 @@ class TestBuildGraphQwen3ASR:
             }
         )
         audio_features = enc_out["audio_features"]
-        # The encoder now crops padding internally — output contains only
-        # valid tokens.
+        audio_feature_lengths = enc_out["audio_feature_lengths"]
+        # Crop padding-derived rows before passing to the embedding —
+        # this mirrors what production callers must do.
+        valid_len = int(audio_feature_lengths[0])
+        assert 0 < valid_len <= audio_features.shape[1]
+        audio_features = audio_features[:, :valid_len, :]
         num_audio_tokens = audio_features.shape[1]
-        assert num_audio_tokens > 0
         # Flatten to 2D: (num_audio_tokens, output_dim)
         audio_features_2d = audio_features.reshape(-1, audio_features.shape[-1])
         enc_sess.close()

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -2112,9 +2112,43 @@ class TestBuildGraphQwen3ASR:
 
         input_names = {inp.name for inp in encoder.graph.inputs}
         assert "input_features" in input_names
+        # feature_attention_mask is required so the encoder can ignore
+        # padded mel frames; without it the LLM emits degenerate loops
+        # on any input padded by the standard HF processor.
+        assert "feature_attention_mask" in input_names
 
         output_names = {out.name for out in encoder.graph.outputs}
         assert "audio_features" in output_names
+        # audio_feature_lengths exposes the valid token count after
+        # the encoder's 8x time downsampling so downstream callers can
+        # crop padding-derived rows out of audio_features before the
+        # embedding gather.
+        assert "audio_feature_lengths" in output_names
+
+    def test_audio_encoder_attention_uses_mask(self):
+        """The encoder's Attention ops must receive the mask input.
+
+        Guards against accidentally dropping the mask wiring inside
+        the encoder forward — the graph builds without it but the
+        encoder behaves the same as the pre-fix version.
+        """
+        from mobius.models.qwen3_asr import (
+            Qwen3ASRForConditionalGeneration,
+        )
+        from mobius.tasks import SpeechLanguageTask
+
+        config = self._asr_config()
+        module = Qwen3ASRForConditionalGeneration(config)
+        pkg = build_from_module(module, config, task=SpeechLanguageTask())
+        encoder = pkg["audio_encoder"]
+
+        attention_nodes = [n for n in encoder.graph if n.op_type == "Attention"]
+        assert attention_nodes, "audio encoder must contain Attention ops"
+        for node in attention_nodes:
+            # 4th positional input on op.Attention is attn_mask; must
+            # be a wired value, not None / empty.
+            assert len(node.inputs) >= 4
+            assert node.inputs[3] is not None
 
     def test_embedding_io(self):
         """Verify embedding model inputs/outputs."""
@@ -2207,9 +2241,26 @@ class TestBuildGraphQwen3ASR:
 
         # Step 1: Audio encoder — random mel input
         enc_sess = OnnxModelSession(pkg["audio_encoder"])
-        mel = np.random.randn(1, config.audio.num_mel_bins, 100).astype(np.float32)
-        enc_out = enc_sess.run({"input_features": mel})
+        mel_seq = 100
+        mel = np.random.randn(1, config.audio.num_mel_bins, mel_seq).astype(np.float32)
+        # Mark the last 20 mel frames as padding to exercise the mask
+        # path. The encoder must crop the corresponding audio rows so
+        # they don't leak into the embedding's Gather.
+        feature_attention_mask = np.ones((1, mel_seq), dtype=np.int64)
+        feature_attention_mask[:, -20:] = 0
+        enc_out = enc_sess.run(
+            {
+                "input_features": mel,
+                "feature_attention_mask": feature_attention_mask,
+            }
+        )
         audio_features = enc_out["audio_features"]
+        audio_feature_lengths = enc_out["audio_feature_lengths"]
+        # Crop padding-derived rows before passing to the embedding —
+        # this mirrors what production callers must do.
+        valid_len = int(audio_feature_lengths[0])
+        assert 0 < valid_len <= audio_features.shape[1]
+        audio_features = audio_features[:, :valid_len, :]
         num_audio_tokens = audio_features.shape[1]
         # Flatten to 2D: (num_audio_tokens, output_dim)
         audio_features_2d = audio_features.reshape(-1, audio_features.shape[-1])

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -2230,11 +2230,9 @@ class TestBuildGraphQwen3ASR:
 
         output_names = {out.name for out in encoder.graph.outputs}
         assert "audio_features" in output_names
-        # audio_feature_lengths exposes the valid token count after
-        # the encoder's 8x time downsampling so downstream callers can
-        # crop padding-derived rows out of audio_features before the
-        # embedding gather.
-        assert "audio_feature_lengths" in output_names
+        # audio_feature_lengths is no longer a separate output —
+        # the encoder crops padding internally via Slice.
+        assert "audio_feature_lengths" not in output_names
 
     def test_audio_encoder_attention_uses_mask(self):
         """The encoder's Attention ops must receive the mask input.
@@ -2366,13 +2364,10 @@ class TestBuildGraphQwen3ASR:
             }
         )
         audio_features = enc_out["audio_features"]
-        audio_feature_lengths = enc_out["audio_feature_lengths"]
-        # Crop padding-derived rows before passing to the embedding —
-        # this mirrors what production callers must do.
-        valid_len = int(audio_feature_lengths[0])
-        assert 0 < valid_len <= audio_features.shape[1]
-        audio_features = audio_features[:, :valid_len, :]
+        # The encoder now crops padding internally — output contains only
+        # valid tokens.
         num_audio_tokens = audio_features.shape[1]
+        assert num_audio_tokens > 0
         # Flatten to 2D: (num_audio_tokens, output_dim)
         audio_features_2d = audio_features.reshape(-1, audio_features.shape[-1])
         enc_sess.close()


### PR DESCRIPTION
Fixes two bugs in the audio encoder export that caused Qwen3-ASR ONNX outputs to drift on long audio:

1. feature_attention_mask was missing from the audio encoder graph, so padded mel frames produced finite values that fed the LLM and triggered runaway repetition

   - AudioEncoderLayer / AudioAttention now plumb attention_mask through to op.Attention as the 4th positional arg.
   - _build_audio_encoder declares feature_attention_mask (INT64) as graph input and audio_feature_lengths as output.
   - examples/qwen3_asr.py uses processor with return_attention_mask and crops audio_features by audio_feature_lengths.

2. The audio encoder used a single-shot conv over the full mel spectrogram (375 tokens / 30s) instead of HF's chunked conv with per-chunk positional embeddings and block-diagonal attention mask (390 tokens / 30s, 100-frame chunks, 13 tokens/chunk, 8-chunk blocks). This caused the 1.7B model to drift on 30s clips 

   - AudioConfig gains n_window / n_window_infer fields, derived from the HF config in _extract_audio_config.
   - Qwen3ASRAudioEncoder now reshapes mel into chunks, runs Conv2d batched across (B*num_chunks), broadcasts PE[0:tokens_per_chunk] over chunks, computes per-batch audio_feature_lengths via HF's _get_feat_extract_output_lengths formula, and builds an (B, S, S) block-diagonal attention mask. Empty rows for padded queries are OR'd with the identity matrix to avoid NaN in ORT softmax; padded outputs are cropped by callers.

Validated against HF reference on a 30s Chinese clip: mobius's 1.7B ONNX output now matches HF's reference output near byte-for-byte.

All 1201 build_graph tests pass.

Tests added:
  - test_audio_encoder_attention_uses_mask: every Attention op has 4 inputs with non-null attn_mask.
  - test_3model_pipeline_runs_with_ort updated to feed mask + crop by audio_feature_lengths.