### PR TITLE
Add use_gqa_for_kv_shared flag for hybrid GQA/Attention CUDA EP dispatch

### DIFF
--- a/src/mobius/_flags.py
+++ b/src/mobius/_flags.py
@@ -84,6 +84,11 @@ class _Flags:
          - ``True``
          - Lower the ONNX opset declaration to 23 for non-CPU EPs
            (ORT ≤1.24.x workaround).
+       * - ``use_gqa_for_kv_shared``
+         - ``MOBIUS_USE_GQA_FOR_KV_SHARED``
+         - ``False``
+         - Use GQA for KV-shared layers on CUDA EP. Requires ORT GQA
+           new_kv_length=0 support.
     """
 
     suppress_dedup_warning: bool = dataclasses.field(
@@ -101,6 +106,22 @@ class _Flags:
     """Decompose grouped RMSNormalization into basic ops to work around an
     ORT ≤1.24.4 CUDA kernel bug that produces wrong results when scale is 2D.
     Set ``MOBIUS_ORT_CUDA_GROUPED_RMSNORM_WORKAROUND=1`` when targeting CUDA.
+    """
+
+    use_gqa_for_kv_shared: bool = dataclasses.field(
+        default_factory=lambda: _env_bool("MOBIUS_USE_GQA_FOR_KV_SHARED", False)
+    )
+    """Use GroupQueryAttention for KV-shared layers on CUDA EP.
+
+    When ``False`` (default), KV-shared layers that borrow K/V from a
+    source layer use standard ONNX Attention (which falls back to unfused
+    attention on CUDA EP).  This avoids a CUTLASS MEA crash with the
+    aligned kernel for certain sequence lengths when ``past_key`` is
+    ``nullptr``.
+
+    Set ``MOBIUS_USE_GQA_FOR_KV_SHARED=1`` when the ORT GQA kernel
+    supports ``new_kv_length=0`` (KV-shared pattern), which will enable
+    fused attention for these layers.
     """
 
     ort_lower_opset_for_ep: bool = dataclasses.field(

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -1514,11 +1514,14 @@ class Gemma4TextModel(nn.Module):
         has_kv_shared = any(layer.self_attn.is_kv_shared_layer for layer in self.layers)
         need_fallback = not use_gqa or (has_kv_shared and not flags.use_gqa_for_kv_shared)
         if need_fallback:
-            # Sliding-window KV-shared layers need a float additive mask
-            # encoding the window constraint (is_causal=1 alone cannot
-            # express "attend only to the last N tokens").
-            # Full-attention KV-shared layers omit the mask entirely —
-            # is_causal=1 handles causality, and batch=1 has no padding.
+            # All fallback layers (KV-shared when use_gqa, or all layers
+            # otherwise) use float additive bias masks. This encodes:
+            #   - Causal constraint (q >= kv position)
+            #   - Sliding window (for sliding_attention layers)
+            #   - Padding mask (required for batch > 1 correctness)
+            # Float bias works with both unfused and MEA kernel paths
+            # on CUDA EP. is_causal=1 is also set on the Attention op
+            # as a redundant safety net.
             fallback_bias_dict = {
                 "sliding_attention": create_attention_bias(
                     op,
@@ -1527,18 +1530,13 @@ class Gemma4TextModel(nn.Module):
                     sliding_window=self.sliding_window,
                     dtype=self._dtype,
                 ),
-                "full_attention": None,
-            }
-            if not use_gqa:
-                # Non-GQA path: ALL layers use Attention, so full_attention
-                # layers also need an additive bias (no is_causal guarantee
-                # from GQA).
-                fallback_bias_dict["full_attention"] = create_attention_bias(
+                "full_attention": create_attention_bias(
                     op,
                     input_ids=query_input,
                     attention_mask=attention_mask,
                     dtype=self._dtype,
-                )
+                ),
+            }
             # KV-shared layers also need position embeddings for the
             # standard Attention path (manual RoPE). Reuse the embeddings
             # already gathered when realizing cos/sin caches above.

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -1514,10 +1514,11 @@ class Gemma4TextModel(nn.Module):
         has_kv_shared = any(layer.self_attn.is_kv_shared_layer for layer in self.layers)
         need_fallback = not use_gqa or (has_kv_shared and not flags.use_gqa_for_kv_shared)
         if need_fallback:
-            # KV-shared layers use the standard Attention op and need
-            # additive float masks. Float masks work with both the unfused
-            # and MEA kernel paths on CUDA EP (bool masks cause incorrect
-            # output on some CUDA code paths).
+            # Sliding-window KV-shared layers need a float additive mask
+            # encoding the window constraint (is_causal=1 alone cannot
+            # express "attend only to the last N tokens").
+            # Full-attention KV-shared layers omit the mask entirely —
+            # is_causal=1 handles causality, and batch=1 has no padding.
             fallback_bias_dict = {
                 "sliding_attention": create_attention_bias(
                     op,
@@ -1526,13 +1527,18 @@ class Gemma4TextModel(nn.Module):
                     sliding_window=self.sliding_window,
                     dtype=self._dtype,
                 ),
-                "full_attention": create_attention_bias(
+                "full_attention": None,
+            }
+            if not use_gqa:
+                # Non-GQA path: ALL layers use Attention, so full_attention
+                # layers also need an additive bias (no is_causal guarantee
+                # from GQA).
+                fallback_bias_dict["full_attention"] = create_attention_bias(
                     op,
                     input_ids=query_input,
                     attention_mask=attention_mask,
                     dtype=self._dtype,
-                ),
-            }
+                )
             # KV-shared layers also need position embeddings for the
             # standard Attention path (manual RoPE). Reuse the embeddings
             # already gathered when realizing cos/sin caches above.

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -35,6 +35,7 @@ from onnxscript._internal import builder
 
 from mobius._build_context import ep_capabilities
 from mobius._configs import ArchitectureConfig, Gemma4Config
+from mobius._flags import flags
 from mobius._weight_utils import vlm_decoder_weights, vlm_embedding_weights
 from mobius.components import (
     MLP,
@@ -42,8 +43,6 @@ from mobius.components import (
     Linear,
     RMSNorm,
     create_attention_bias,
-    create_padding_mask,
-    create_sliding_window_mask,
     initialize_rope,
 )
 from mobius.components._activations import get_activation
@@ -725,7 +724,11 @@ class Gemma4TextAttention(nn.Module):
             # KV-shared layers always use standard Attention path because
             # they borrow K,V from a source layer (no own KV cache).
             if use_gqa:
-                raise ValueError("KV-shared layers should not receive GQAContext")
+                raise ValueError(
+                    "KV-shared GQA path not yet implemented. "
+                    "Set MOBIUS_USE_GQA_FOR_KV_SHARED=0 or wait for "
+                    "ORT GQA new_kv_length=0 support."
+                )
             # Borrow full-history K,V from source layer.
             # present_key/value from the ONNX Attention op is 4D:
             #   [batch, kv_heads, total_seq, head_dim]
@@ -1503,50 +1506,33 @@ class Gemma4TextModel(nn.Module):
                 "full_attention": self.rotary_emb_global(op, position_ids),
             }
 
-        # Fallback attention bias for non-GQA layers (KV-shared layers always
-        # use this, plus all layers when use_gqa is False).
+        # Fallback attention bias for non-GQA layers (KV-shared layers use
+        # this when use_gqa_for_kv_shared is False, plus all layers when
+        # use_gqa is False).
         query_input = input_ids if input_ids is not None else hidden_states
         fallback_bias_dict: dict[str, ir.Value | None] = {}
-        need_fallback = not use_gqa or any(
-            layer.self_attn.is_kv_shared_layer for layer in self.layers
-        )
+        has_kv_shared = any(layer.self_attn.is_kv_shared_layer for layer in self.layers)
+        need_fallback = not use_gqa or (has_kv_shared and not flags.use_gqa_for_kv_shared)
         if need_fallback:
-            if use_gqa:
-                # GQA is active for non-shared layers. KV-shared layers use
-                # the standard Attention op with is_causal=1, so we only need
-                # bool masks (not additive float bias). This avoids the
-                # CumSum/GreaterOrEqual chain used by create_attention_bias.
-                # Full-attention: simple padding mask (causality handled by op)
-                # Sliding-window: still needs CumSum for window constraint
-                fallback_bias_dict = {
-                    "sliding_attention": create_sliding_window_mask(
-                        op,
-                        input_ids=query_input,
-                        attention_mask=attention_mask,
-                        window_size=self.sliding_window or 512,
-                    ),
-                    "full_attention": create_padding_mask(
-                        op,
-                        input_ids=query_input,
-                        attention_mask=attention_mask,
-                    ),
-                }
-            else:
-                fallback_bias_dict = {
-                    "sliding_attention": create_attention_bias(
-                        op,
-                        input_ids=query_input,
-                        attention_mask=attention_mask,
-                        sliding_window=self.sliding_window,
-                        dtype=self._dtype,
-                    ),
-                    "full_attention": create_attention_bias(
-                        op,
-                        input_ids=query_input,
-                        attention_mask=attention_mask,
-                        dtype=self._dtype,
-                    ),
-                }
+            # KV-shared layers use the standard Attention op and need
+            # additive float masks. Float masks work with both the unfused
+            # and MEA kernel paths on CUDA EP (bool masks cause incorrect
+            # output on some CUDA code paths).
+            fallback_bias_dict = {
+                "sliding_attention": create_attention_bias(
+                    op,
+                    input_ids=query_input,
+                    attention_mask=attention_mask,
+                    sliding_window=self.sliding_window,
+                    dtype=self._dtype,
+                ),
+                "full_attention": create_attention_bias(
+                    op,
+                    input_ids=query_input,
+                    attention_mask=attention_mask,
+                    dtype=self._dtype,
+                ),
+            }
             # KV-shared layers also need position embeddings for the
             # standard Attention path (manual RoPE). Reuse the embeddings
             # already gathered when realizing cos/sin caches above.
@@ -1583,9 +1569,11 @@ class Gemma4TextModel(nn.Module):
             per_layer_input = per_layer_inputs[i] if per_layer_inputs is not None else None
 
             # Per-layer decision: use GQA for non-shared layers when
-            # available, fall back to standard Attention for KV-shared layers.
+            # available, fall back to standard Attention for KV-shared
+            # layers (unless the use_gqa_for_kv_shared flag is set).
             is_shared = layer.self_attn.is_kv_shared_layer
-            if use_gqa and not is_shared:
+            use_gqa_this_layer = use_gqa and (not is_shared or flags.use_gqa_for_kv_shared)
+            if use_gqa_this_layer:
                 attn_bias = gqa_ctx_dict[layer_type]
                 pos_emb = None
             else:


### PR DESCRIPTION
## Summary

Adds a feature flag `MOBIUS_USE_GQA_FOR_KV_SHARED` (default `False`) to control whether KV-shared layers use GQA or standard ONNX Attention on CUDA EP.

### Background

Gemma4 has 35 decoder layers: 15 non-shared (layers 0-14) with their own KV cache, and 20 KV-shared (layers 15-34) that borrow K/V from source layers. On CUDA EP:

- **Non-shared layers**: Work correctly with GQA (fused RoPE + attention + KV cache)
- **KV-shared layers**: Cannot use GQA because they pass the full KV cache as K input with no `past_key` — the CUTLASS MEA aligned kernel crashes at sequence lengths that are multiples of 8 (tracked in microsoft/onnxruntime#28376)

### Changes

1. **`_flags.py`**: New `use_gqa_for_kv_shared` flag with `MOBIUS_USE_GQA_FOR_KV_SHARED` env var
2. **`gemma4.py`**:
   - Per-layer dispatch: GQA for normal layers, Attention for KV-shared (controlled by flag)
   - Always use float additive masks for fallback path (fixes CUDA EP output — bool masks caused incorrect results)
   - Remove unused `create_padding_mask`/`create_sliding_window_mask` imports

### Testing

- All 13 Gemma4 L1 tests pass
- Lint clean
- Pure ORT decoder test: all seq lengths 1-64 pass on CUDA EP
- GenAI end-to-end blocked by separate issue (Equal<int64> CPU kernel on CUDA input_ids, tracked in onnxruntime-genai PR #2123)

### Future

Set `MOBIUS_USE_GQA_FOR_KV_SHARED=1` once ORT GQA supports `new_kv_length=0` for KV-shared layers.