### PR TITLE
Fix Gemma4 GenAI regression: disable past_present_share_buffer for dual head_dim

### DIFF
--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -655,6 +655,14 @@ def _write_genai_config(
             **audio_kwargs,
         )
 
+    # Disable past_present_share_buffer for models with dual head_dim
+    # (e.g., different head_dim for sliding vs full-attention layers).
+    # Shared buffers require uniform head_dim across all KV cache layers.
+    global_head_dim = getattr(config, "global_head_dim", None)
+    head_dim = getattr(config, "head_dim", None)
+    if global_head_dim and head_dim and global_head_dim != head_dim:
+        generator._search_overrides["past_present_share_buffer"] = False
+
     return generator.write(output_dir)
 
 

--- a/src/mobius/integrations/ort_genai/genai_config.py
+++ b/src/mobius/integrations/ort_genai/genai_config.py
@@ -178,6 +178,9 @@ class GenaiConfigGenerator:
         # Optional audio fields (set via with_audio())
         self._audio: dict[str, Any] | None = None
 
+        # Search config overrides applied in generate()
+        self._search_overrides: dict[str, Any] = {}
+
     @classmethod
     def from_config(
         cls,
@@ -407,9 +410,12 @@ class GenaiConfigGenerator:
             model["speech"] = self._audio
         model.update(self._vlm_token_ids)
 
+        search = _default_search_params(ep=self.ep, context_length=self.context_length)
+        search.update(self._search_overrides)
+
         return {
             "model": model,
-            "search": _default_search_params(ep=self.ep, context_length=self.context_length),
+            "search": search,
         }
 
     def write(self, output_dir: str) -> str:


### PR DESCRIPTION
## Summary

Fix CPU regression where Gemma4 GenAI generation fails with:
```
inconsistent total_sequence_length (between attn_mask and past_key and past_value)
```

## Root Cause

`past_present_share_buffer` was set to `true` in genai_config.json because the `default` EP maps to `cpu` (which has `supports_past_present_share_buffer=True`). However, Gemma4 has dual head_dim (256 for sliding-window, 512 for full-attention), and shared buffers require uniform head_dim across all KV cache layers.

## Fix

Force `past_present_share_buffer=false` in genai_config.json for all Gemma4 model types.

## Testing

- 15 gemma4 tests pass
- 119 ort_genai tests pass
- Verified: Gemma4 CPU generation produces correct output with the fix
