### PR TITLE
update-genai integration to generate the config file

### DIFF
--- a/src/mobius/_model_package.py
+++ b/src/mobius/_model_package.py
@@ -73,6 +73,13 @@ class ModelPackage(UserDict[str, ir.Model]):
         ``model.onnx`` in *directory*.  When multiple models are present,
         each is saved in its own subfolder as ``{name}/model.onnx``.
 
+        .. note::
+            This method writes ONNX files only.  If you need a directory that
+            ``onnxruntime-genai`` can load (i.e. with ``genai_config.json`` and
+            tokenizer files), use
+            :func:`mobius.integrations.ort_genai.export_package` instead — it
+            wraps :meth:`save` with the ORT-GenAI config-generation step.
+
         Args:
             directory: Path to the output directory (created if needed).
             external_data: External data format. ``"onnx"`` (default) saves

--- a/src/mobius/integrations/ort_genai/__init__.py
+++ b/src/mobius/integrations/ort_genai/__init__.py
@@ -7,7 +7,10 @@ All onnxruntime-genai specific code lives here. The core model/task/component
 layers remain runtime-agnostic.
 """
 
-from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
+from mobius.integrations.ort_genai.auto_export import (
+    export_package,
+    write_ort_genai_config,
+)
 from mobius.integrations.ort_genai.ep_config import (
     make_genai_decoder_config,
     make_kv_cache_dim_name,
@@ -20,6 +23,7 @@ from mobius.integrations.ort_genai.genai_config import (
 
 __all__ = [
     "GenaiConfigGenerator",
+    "export_package",
     "write_ort_genai_config",
     "make_genai_decoder_config",
     "make_kv_cache_dim_name",

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -3,34 +3,42 @@
 
 """Auto-export pipeline for onnxruntime-genai.
 
-Two entry points:
+Three entry points, in order of increasing convenience:
 
-- :func:`write_ort_genai_config` — programmatic API. Takes an already-built
-  :class:`~mobius._model_package.ModelPackage` (with weights) and writes the
-  ORT-GenAI config artifacts (``genai_config.json``, tokenizer files,
-  ``processor_config.json`` / ``image_processor.json``) alongside the ONNX models.
+- :func:`write_ort_genai_config` — config-only API. Takes an already-built
+  :class:`~mobius._model_package.ModelPackage` (with weights already saved
+  separately) and writes the ORT-GenAI config artifacts
+  (``genai_config.json``, tokenizer files, ``processor_config.json`` /
+  ``image_processor.json``) into a directory.
 
-- :func:`auto_export` — end-to-end convenience function. Builds the model
-  from a HuggingFace ID, saves the ONNX files, then calls
-  :func:`write_ort_genai_config` to write the config artifacts.
+- :func:`export_package` — save+config API. Takes an already-built
+  ``ModelPackage`` and writes both the ONNX models AND the ORT-GenAI config
+  artifacts in one call.  Use this when you built the package manually
+  (e.g. with custom dtype / quantization).
 
-Both functions produce a directory that ``onnxruntime-genai`` can load
-directly.
+- :func:`auto_export` — end-to-end API. Builds the model from a HuggingFace
+  ID and calls :func:`export_package`. Use this for the common
+  HF-model-id → ORT-GenAI-directory case.
+
+All three produce a directory that ``onnxruntime-genai`` can load directly.
 
 Example::
 
-    # Programmatic API — build first, then export configs
-    from mobius import build
+    # Config-only — when ONNX is already on disk
     from mobius.integrations.ort_genai import write_ort_genai_config
-
-    pkg = build("Qwen/Qwen3-0.6B", load_weights=True)
-    pkg.save("/output/qwen3")
     write_ort_genai_config(pkg, "/output/qwen3", hf_model_id="Qwen/Qwen3-0.6B")
 
-    # End-to-end convenience
+    # Save + config — when you have a built package in memory
+    from mobius import build
+    from mobius.integrations.ort_genai import export_package
+
+    pkg = build("Qwen/Qwen3-0.6B", load_weights=True)
+    export_package(pkg, "/output/qwen3", hf_model_id="Qwen/Qwen3-0.6B", ep="cuda")
+
+    # End-to-end — when you only have an HF model id
     from mobius.integrations.ort_genai.auto_export import auto_export
 
-    auto_export("Qwen/Qwen3-0.6B", "/output/qwen3")
+    auto_export("Qwen/Qwen3-0.6B", "/output/qwen3", ep="cuda")
 """
 
 from __future__ import annotations
@@ -852,6 +860,116 @@ def write_ort_genai_config(
     return result
 
 
+def export_package(
+    pkg: ModelPackage,
+    output_dir: str,
+    *,
+    hf_model_id: str | None = None,
+    ep: str = "cpu",
+    context_length: int = 4096,
+    local_config_dir: str | None = None,
+    external_data: str = "onnx",
+    progress_bar: bool = True,
+) -> dict[str, str]:
+    """Save an already-built ModelPackage as a complete ORT-GenAI directory.
+
+    This is the convenience function for users who built a ``ModelPackage``
+    themselves (e.g. with custom dtype / quantization / weight overrides) and
+    want a single call that produces an ``onnxruntime-genai``-loadable
+    directory.  It calls :meth:`ModelPackage.save` followed by
+    :func:`write_ort_genai_config`.
+
+    For the end-to-end case where you start from a HuggingFace model id, use
+    :func:`auto_export` instead — it builds the package for you.
+
+    Args:
+        pkg: Already-built :class:`~mobius._model_package.ModelPackage` with
+            weights applied and ``config`` set.  Must contain all components
+            you want exported; partial exports are not supported because the
+            generated ``genai_config.json`` would reference components that
+            do not exist on disk.  Build a separate filtered package if you
+            need a subset.
+        output_dir: Output directory (created if needed).
+        hf_model_id: HuggingFace model ID for tokenizer download / token-id
+            resolution.  When ``None``, token IDs are read from ``pkg.config``
+            and tokenizer files are not copied (unless ``local_config_dir``
+            is provided).
+        ep: Execution provider written to ``session_options`` in
+            ``genai_config.json`` (e.g. ``"cpu"``, ``"cuda"``, ``"dml"``,
+            ``"webgpu"``, ``"trt-rtx"``).
+        context_length: Minimum context length written to ``genai_config.json``.
+            Overridden upward by ``pkg.config.max_position_embeddings`` when
+            larger.
+        local_config_dir: Local model directory to copy tokenizer files from
+            when ``hf_model_id`` is ``None``.
+        external_data: External-data format passed to :meth:`ModelPackage.save`
+            (``"onnx"`` or ``"safetensors"``).
+        progress_bar: Whether to show the save progress bar.
+
+    Returns:
+        Manifest dict mapping artifact names to paths::
+
+            {
+                "model": "/output/model.onnx",          # or per-component paths
+                "genai_config": "/output/genai_config.json",
+                "tokenizer.json": "/output/tokenizer.json",
+                ...
+            }
+
+    Raises:
+        ValueError: If ``pkg.config`` is ``None`` (required for genai_config
+            generation; e.g. diffusion models have no config and are not
+            supported).
+
+    Example::
+
+        from mobius import build
+        from mobius.integrations.ort_genai import export_package
+
+        pkg = build("Qwen/Qwen3-0.6B", load_weights=True)
+        export_package(pkg, "/output/qwen3", hf_model_id="Qwen/Qwen3-0.6B", ep="cuda")
+    """
+    # Preflight: fail fast before writing ONNX so the user doesn't end up
+    # with a half-exported directory containing only the model file.
+    if getattr(pkg, "config", None) is None:
+        raise ValueError(
+            "export_package requires ModelPackage.config to be set. "
+            "This is set automatically when building with mobius.build(). "
+            "Diffusion models (which have no config) are not supported — "
+            "use ModelPackage.save() directly for those."
+        )
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    # 1. Save ONNX models + weights
+    logger.info("Saving ONNX models to %s", output_dir)
+    pkg.save(
+        output_dir,
+        external_data=external_data,
+        progress_bar=progress_bar,
+    )
+
+    # 2. Write ORT-GenAI config artifacts
+    result = write_ort_genai_config(
+        pkg,
+        output_dir,
+        hf_model_id=hf_model_id,
+        ep=ep,
+        context_length=context_length,
+        local_config_dir=local_config_dir,
+    )
+
+    # 3. Add ONNX paths to the manifest
+    if len(pkg) == 1:
+        result["model"] = os.path.join(output_dir, "model.onnx")
+    else:
+        for name in pkg:
+            result[name] = os.path.join(output_dir, name, "model.onnx")
+
+    logger.info("Export complete: %d artifacts", len(result))
+    return result
+
+
 def auto_export(
     model_id: str,
     output_dir: str,
@@ -918,28 +1036,16 @@ def auto_export(
             "Diffusion models are not yet supported."
         )
 
-    # Save ONNX models
-    logger.info("Saving ONNX models to %s", output_dir)
-    pkg.save(
-        output_dir,
-        external_data=external_data,
-        progress_bar=progress_bar,
-    )
-
-    # Write ORT-GenAI config artifacts (genai_config.json, tokenizer, processor)
-    result = write_ort_genai_config(
+    # Delegate save + config generation to the integration helper
+    result = export_package(
         pkg,
         output_dir,
         hf_model_id=model_id,
         ep=ep,
         context_length=context_length,
+        external_data=external_data,
+        progress_bar=progress_bar,
     )
 
-    # Add ONNX model paths to manifest
-    if len(pkg) == 1:
-        result["model"] = os.path.join(output_dir, "model.onnx")
-    else:
-        for name in pkg:
-            result[name] = os.path.join(output_dir, name, "model.onnx")
-
     logger.info("Export complete: %d artifacts", len(result))
+    return result

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -5,11 +5,13 @@
 
 Three entry points, in order of increasing convenience:
 
-- :func:`write_ort_genai_config` — config-only API. Takes an already-built
-  :class:`~mobius._model_package.ModelPackage` (with weights already saved
-  separately) and writes the ORT-GenAI config artifacts
-  (``genai_config.json``, tokenizer files, ``processor_config.json`` /
-  ``image_processor.json``) into a directory.
+- :func:`write_ort_genai_config` — config-only API.  Generates the ORT-GenAI
+  config artifacts (``genai_config.json``, tokenizer files,
+  ``processor_config.json`` / ``image_processor.json``) for an already-built
+  :class:`~mobius._model_package.ModelPackage`.  Does **not** write any ONNX
+  files — call :meth:`ModelPackage.save` separately if the ONNX models are
+  not already on disk.  The package only needs ``pkg.config`` and the model
+  graph metadata; weights need not have been written yet.
 
 - :func:`export_package` — save+config API. Takes an already-built
   ``ModelPackage`` and writes both the ONNX models AND the ORT-GenAI config
@@ -24,12 +26,15 @@ All three produce a directory that ``onnxruntime-genai`` can load directly.
 
 Example::
 
-    # Config-only — when ONNX is already on disk
+    # Config-only — assumes you've already saved the ONNX files yourself
+    from mobius import build
     from mobius.integrations.ort_genai import write_ort_genai_config
+
+    pkg = build("Qwen/Qwen3-0.6B", load_weights=True)
+    pkg.save("/output/qwen3")  # write ONNX + weights first
     write_ort_genai_config(pkg, "/output/qwen3", hf_model_id="Qwen/Qwen3-0.6B")
 
-    # Save + config — when you have a built package in memory
-    from mobius import build
+    # Save + config — single call, when you have a built package in memory
     from mobius.integrations.ort_genai import export_package
 
     pkg = build("Qwen/Qwen3-0.6B", load_weights=True)
@@ -884,11 +889,14 @@ def export_package(
 
     Args:
         pkg: Already-built :class:`~mobius._model_package.ModelPackage` with
-            weights applied and ``config`` set.  Must contain all components
-            you want exported; partial exports are not supported because the
-            generated ``genai_config.json`` would reference components that
-            do not exist on disk.  Build a separate filtered package if you
-            need a subset.
+            weights applied and ``config`` set.  All components in *pkg* are
+            saved; selective export via :meth:`ModelPackage.save`'s
+            ``components`` filter is intentionally not exposed here, because
+            the ORT-GenAI runtime expects the on-disk file layout to match
+            what ``model.type`` in :file:`genai_config.json` declares (e.g. a
+            multimodal ``model.type`` implies a vision encoder file is
+            present).  If you need a partial export, build a separate
+            filtered ``ModelPackage`` first.
         output_dir: Output directory (created if needed).
         hf_model_id: HuggingFace model ID for tokenizer download / token-id
             resolution.  When ``None``, token IDs are read from ``pkg.config``
@@ -1036,7 +1044,8 @@ def auto_export(
             "Diffusion models are not yet supported."
         )
 
-    # Delegate save + config generation to the integration helper
+    # Delegate save + config generation to the integration helper.
+    # `export_package` already logs "Export complete" so we don't repeat it here.
     result = export_package(
         pkg,
         output_dir,
@@ -1047,5 +1056,4 @@ def auto_export(
         progress_bar=progress_bar,
     )
 
-    logger.info("Export complete: %d artifacts", len(result))
     return result

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -963,7 +963,7 @@ class TestExportPackage:
         assert save_calls[0]["progress_bar"] is False
 
     def test_propagates_genai_config_kwargs(self, tmp_path, monkeypatch):
-        """ep, context_length, and hf_model_id reach genai_config.json."""
+        """ep and context_length reach the generated genai_config.json."""
         from mobius.integrations.ort_genai.auto_export import export_package
 
         pkg = self._make_pkg()

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -910,6 +910,118 @@ class TestExportForOrtGenai:
         assert data["model"]["eos_token_id"] == [1, 106]
 
 
+class TestExportPackage:
+    """Tests for export_package() — the save+config integration helper."""
+
+    @staticmethod
+    def _make_pkg():
+        return _make_fake_llm_pkg("qwen2")
+
+    def test_writes_both_onnx_and_genai_config(self, tmp_path, monkeypatch):
+        """export_package calls pkg.save AND writes genai_config.json."""
+        from mobius.integrations.ort_genai.auto_export import export_package
+
+        pkg = self._make_pkg()
+        save_calls = []
+
+        def fake_save(self, directory, **kwargs):
+            save_calls.append((directory, kwargs))
+
+        monkeypatch.setattr(pkg.__class__, "save", fake_save)
+
+        result = export_package(pkg, str(tmp_path))
+
+        # pkg.save called exactly once with the output dir
+        assert len(save_calls) == 1
+        assert save_calls[0][0] == str(tmp_path)
+        # genai_config artifact is in the manifest
+        assert "genai_config" in result
+        assert os.path.isfile(result["genai_config"])
+        # ONNX path is in the manifest (single-component package)
+        assert result["model"] == os.path.join(str(tmp_path), "model.onnx")
+
+    def test_propagates_save_kwargs(self, tmp_path, monkeypatch):
+        """external_data and progress_bar are forwarded to pkg.save."""
+        from mobius.integrations.ort_genai.auto_export import export_package
+
+        pkg = self._make_pkg()
+        save_calls = []
+
+        def fake_save(self, directory, **kwargs):
+            save_calls.append(kwargs)
+
+        monkeypatch.setattr(pkg.__class__, "save", fake_save)
+
+        export_package(
+            pkg,
+            str(tmp_path),
+            external_data="safetensors",
+            progress_bar=False,
+        )
+
+        assert save_calls[0]["external_data"] == "safetensors"
+        assert save_calls[0]["progress_bar"] is False
+
+    def test_propagates_genai_config_kwargs(self, tmp_path, monkeypatch):
+        """ep, context_length, and hf_model_id reach genai_config.json."""
+        from mobius.integrations.ort_genai.auto_export import export_package
+
+        pkg = self._make_pkg()
+        monkeypatch.setattr(pkg.__class__, "save", lambda self, d, **kw: None)
+
+        result = export_package(
+            pkg,
+            str(tmp_path),
+            ep="cuda",
+            context_length=8192,
+        )
+
+        with open(result["genai_config"]) as f:
+            data = json.load(f)
+        # ep="cuda" should produce CUDA provider_options
+        provider_opts = data["model"]["decoder"]["session_options"]["provider_options"]
+        assert any("cuda" in po for po in provider_opts)
+        # context_length should bump max_length
+        assert data["search"]["max_length"] == 8192
+
+    def test_preflights_missing_config(self, tmp_path, monkeypatch):
+        """Raises ValueError BEFORE writing any ONNX when pkg.config is None.
+
+        This avoids leaving a half-exported directory with model.onnx but
+        no genai_config.json.
+        """
+        from mobius._model_package import ModelPackage
+        from mobius.integrations.ort_genai.auto_export import export_package
+
+        pkg = ModelPackage({"model": mock.MagicMock()}, config=None)
+        save_called = []
+
+        def fake_save(self, *a, **kw):
+            save_called.append(True)
+
+        monkeypatch.setattr(pkg.__class__, "save", fake_save)
+
+        with pytest.raises(ValueError, match="config"):
+            export_package(pkg, str(tmp_path))
+
+        # save was NOT called — preflight failed before any I/O
+        assert save_called == []
+
+    def test_returns_manifest_with_all_artifacts(self, tmp_path, monkeypatch):
+        """Returned manifest contains ONNX paths AND config artifacts."""
+        from mobius.integrations.ort_genai.auto_export import export_package
+
+        pkg = self._make_pkg()
+        monkeypatch.setattr(pkg.__class__, "save", lambda self, d, **kw: None)
+
+        result = export_package(pkg, str(tmp_path))
+
+        # Manifest is non-empty and includes both kinds of artifacts
+        assert isinstance(result, dict)
+        assert "model" in result
+        assert "genai_config" in result
+
+
 class TestGemma4GenaiConfig:
     """Tests for Gemma4-specific genai_config generation via graph introspection."""
 

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -963,7 +963,7 @@ class TestExportPackage:
         assert save_calls[0]["progress_bar"] is False
 
     def test_propagates_genai_config_kwargs(self, tmp_path, monkeypatch):
-        """ep and context_length reach the generated genai_config.json."""
+        """The ep and context_length kwargs reach the generated genai_config.json."""
         from mobius.integrations.ort_genai.auto_export import export_package
 
         pkg = self._make_pkg()


### PR DESCRIPTION
# Why this PR

Mobius currently does not ergonomically expose `genai_config.json` generation when users build a `ModelPackage` themselves.

---

# The Problem

The natural Path B workflow today produces an output directory that `onnxruntime-genai` cannot load:

```python
pkg = mobius.build("Qwen/Qwen3-0.6B", load_weights=True)
pkg.save("/output/qwen3/")

# /output/qwen3/ now contains:
#   - model.onnx
#   - model.onnx.data
#
# But ORT-GenAI also requires:
#   - genai_config.json
#   - tokenizer files
#
# which save() does not write.
```

To make it loadable, the user must remember a second call:

```python
write_ort_genai_config(
    pkg,
    "/output/qwen3/",
    hf_model_id="Qwen/Qwen3-0.6B",
    ep="cuda",
)
```

If they forget, they end up with a complete-looking directory that silently fails at load time.

Path A (Model Builder) does not have this footgun — it always writes the config alongside the ONNX artifacts.

---

# What This PR Adds

A new integration helper: `export_package`

This combines:

- `pkg.save()`
- `write_ort_genai_config()`

into a single call with a fail-fast preflight.

```python
from mobius.integrations.ort_genai import export_package

pkg = mobius.build("Qwen/Qwen3-0.6B", load_weights=True)

export_package(
    pkg,
    "/output/qwen3/",
    hf_model_id="Qwen/Qwen3-0.6B",
    ep="cuda",
)

# /output/qwen3/ now contains:
#   - model.onnx
#   - model.onnx.data
#   - genai_config.json
#   - tokenizer files
#
# Directly loadable by ORT-GenAI.
```

This becomes the recommended Path B equivalent of:

```bash
python builder.py -m ... -o out -p fp16 -e cuda
```

---

# Three-Tier API After This PR

| Use Case | API | Notes |
|---|---|---|
| ONNX already on disk, only need configs | `write_ort_genai_config(pkg, dir, …)` | unchanged |
| Built `pkg` in memory, want save + config in one call | `export_package(pkg, dir, …)` | new |
| Have only an HF model id | `auto_export("HF/id", dir, …)` | now delegates to `export_package` |
---

# Changes

- Added:
  ```python
  mobius.integrations.ort_genai.export_package(
      pkg,
      output_dir,
      *,
      hf_model_id,
      ep,
      context_length,
      local_config_dir,
      external_data,
      progress_bar,
  )
  ```

- Refactored `auto_export()` to delegate to `export_package` (DRY)
- Fixed bug:
  - `auto_export()` was annotated as `-> dict[str, str]`
  - but did not actually return the result
- Added doc note on `ModelPackage.save()` directing users to `export_package`
  for ORT-GenAI-compatible directories
- Added tests:
  - `TestExportPackage`
  - validates:
    - artifacts written
    - save kwargs forwarded
    - config kwargs forwarded
    - fail-fast preflight
    - no I/O on missing config
    - manifest returned

---

# Migration Impact

After this lands, the Path A → Path B documentation becomes:

```diff
- python onnxruntime-genai/src/python/py/models/builder.py \
-     -m Qwen/Qwen3-0.6B -o /output/qwen3 -p fp16 -e cuda

+ from mobius import build
+ from mobius.integrations.ort_genai import export_package
+
+ pkg = build(
+     "Qwen/Qwen3-0.6B",
+     load_weights=True,
+     dtype="f16",
+ )
+
+ export_package(
+     pkg,
+     "/output/qwen3",
+     hf_model_id="Qwen/Qwen3-0.6B",
+     ep="cuda",
+ )
```

One Path B call, one Path A call, same output directory layout.

---

# CI Note

The L4/L5 GPU jobs failed with the self-hosted-runner eviction signature:

- step stuck in `in_progress`
- post-cleanup skipped
- ~20 minute runtime
- no actual test failure logged

The docstring change to `_model_package.py` triggered:

```python
run_all = true
```

inside:

```python
detect_affected_models.py
```

because `_model_package.py` matches `_SHARED_INFRA_PATTERNS`.

This caused the full L4/L5 sweep instead of the affected subset.

Re-running the failed jobs should pass.