### PR TITLE
docs: refresh skills for latest Gemma4 state and references

### DIFF
--- a/.agents/skills/multimodal-models/SKILL.md
+++ b/.agents/skills/multimodal-models/SKILL.md
@@ -291,7 +291,7 @@ earlier source layers instead of projecting their own. With GQA
 - `value=None` (empty)
 - `past_key=source_layer_present_key` (borrowed from source)
 - `past_value=source_layer_present_value` (borrowed from source)
-- `do_rotary=0` (RoPE already applied by source layer)
+- `do_rotary=1` (RoPE applied to queries; source K already has RoPE)
 
 This eliminates ~40 Transpose/Reshape ops per shared layer that
 were previously needed to convert the source KV from BNSH

--- a/.agents/skills/multimodal-models/SKILL.md
+++ b/.agents/skills/multimodal-models/SKILL.md
@@ -281,6 +281,33 @@ If you're adding a new multimodal model, you don't need to handle this
 manually — mobius inserts the Cast automatically for all encoder graphs.
 If the model dtype is already f32, no Cast is needed.
 
+## GQA for KV-shared layers (Gemma4)
+
+Models with KV-shared layers (e.g. Gemma4) borrow key/value from
+earlier source layers instead of projecting their own. With GQA
+(PR #279), shared layers use `GroupQueryAttention` with:
+
+- `key=None` (empty, `kv_sequence_length=0`)
+- `value=None` (empty)
+- `past_key=source_layer_present_key` (borrowed from source)
+- `past_value=source_layer_present_value` (borrowed from source)
+- `do_rotary=0` (RoPE already applied by source layer)
+
+This eliminates ~40 Transpose/Reshape ops per shared layer that
+were previously needed to convert the source KV from BNSH
+`[B, kv_heads, seq, head_dim]` to 3D `[B, seq, kv_hidden]` format.
+
+**Caveat:** Requires ORT to support `kv_sequence_length=0` in the
+GQA op. Tracked in microsoft/onnxruntime#28318.
+
+## Vision preprocessing: float-domain bicubic resize
+
+For HF parity in vision preprocessing, ort-extensions provides a
+float-domain bicubic resize (PR #1056) that avoids uint8 clamping
+artifacts. This eliminates 0.03-0.13 pixel differences that can
+cause token divergence in vision encoders. The utility operates in
+packed RGB with fused uint8→float rescale.
+
 ## Cross-references
 
 - **Multimodal debugging:** `.agents/skills/debugging-multimodal/SKILL.md`

--- a/.agents/skills/multimodal-models/SKILL.md
+++ b/.agents/skills/multimodal-models/SKILL.md
@@ -285,25 +285,26 @@ If the model dtype is already f32, no Cast is needed.
 
 Models with KV-shared layers (e.g. Gemma4) borrow key/value from
 earlier source layers instead of projecting their own. With GQA
-(PR #279), shared layers use `GroupQueryAttention` with:
+(`onnxruntime/mobius#279`), shared layers use `GroupQueryAttention` with:
 
-- `key=None` (empty, `kv_sequence_length=0`)
+- `key=None` (empty current K, i.e. `new_kv_length=0`)
 - `value=None` (empty)
 - `past_key=source_layer_present_key` (borrowed from source)
 - `past_value=source_layer_present_value` (borrowed from source)
-- `do_rotary=1` (RoPE applied to queries; source K already has RoPE)
+- `do_rotary=1` (RoPE applied to queries; borrowed source K is already RoPE-rotated)
 
 This eliminates ~40 Transpose/Reshape ops per shared layer that
 were previously needed to convert the source KV from BNSH
 `[B, kv_heads, seq, head_dim]` to 3D `[B, seq, kv_hidden]` format.
 
-**Caveat:** Requires ORT to support `kv_sequence_length=0` in the
-GQA op. Tracked in microsoft/onnxruntime#28318.
+This relies on ORT GQA support for empty current K/V (`new_kv_length=0`,
+represented in graph wiring as empty key/value tensors with
+`kv_sequence_length=0`).
 
 ## Vision preprocessing: float-domain bicubic resize
 
-For HF parity in vision preprocessing, ort-extensions provides a
-float-domain bicubic resize (PR #1056) that avoids uint8 clamping
+For HF parity in vision preprocessing, `microsoft/onnxruntime-extensions#1056`
+provides a float-domain bicubic resize that avoids uint8 clamping
 artifacts. This eliminates 0.03-0.13 pixel differences that can
 cause token divergence in vision encoders. The utility operates in
 packed RGB with fused uint8→float rescale.

--- a/.agents/skills/onnx-export-quantization/SKILL.md
+++ b/.agents/skills/onnx-export-quantization/SKILL.md
@@ -389,18 +389,14 @@ than requiring exact numerical matches.
 
 ## Inference speed: Q4_K_M vs NF4
 
-Benchmark with Gemma4 E2B-IT on GenAI (text-only, 50+ token decode):
-
-| Dtype | CUDA tok/s | CPU tok/s | Notes |
-|-------|-----------|----------|-------|
-| F16 | 104 | 6.8 | Baseline |
-| Q4_K_M | 111 (+8%) | 16.2 (+138%) | **Recommended** |
-| NF4 | 93 (-10%) | 4.0 (-41%) | Slower than F16 |
+For the benchmark table, use the canonical reference in
+`.agents/skills/profiling-onnx-models/SKILL.md` ("Quantization benchmark
+reference (Gemma4 E2B-IT)").
 
 **Q4_K_M is recommended over NF4** for both speed and quality:
-- Faster on both CPU (+138% vs F16) and CUDA (+8% vs F16)
-- NF4 is paradoxically *slower* than F16 on both EPs
-- Quality is comparable between Q4_K_M and NF4
+- Faster on both CPU and CUDA than F16 in the referenced measurement
+- NF4 is slower than F16 in the same measurement
+- Quality is comparable between Q4_K_M and NF4 in spot checks
 - Q4_K_M uses less memory than F16 (~4x compression)
 
 ## Cross-references

--- a/.agents/skills/onnx-export-quantization/SKILL.md
+++ b/.agents/skills/onnx-export-quantization/SKILL.md
@@ -387,6 +387,22 @@ full-precision model. Expected tolerances:
 Verify that generated text is coherent and semantically correct rather
 than requiring exact numerical matches.
 
+## Inference speed: Q4_K_M vs NF4
+
+Benchmark with Gemma4 E2B-IT on GenAI (text-only, 50+ token decode):
+
+| Dtype | CUDA tok/s | CPU tok/s | Notes |
+|-------|-----------|----------|-------|
+| F16 | 104 | 6.8 | Baseline |
+| Q4_K_M | 111 (+8%) | 16.2 (+138%) | **Recommended** |
+| NF4 | 93 (-10%) | 4.0 (-41%) | Slower than F16 |
+
+**Q4_K_M is recommended over NF4** for both speed and quality:
+- Faster on both CPU (+138% vs F16) and CUDA (+8% vs F16)
+- NF4 is paradoxically *slower* than F16 on both EPs
+- Quality is comparable between Q4_K_M and NF4
+- Q4_K_M uses less memory than F16 (~4x compression)
+
 ## Cross-references
 
 - **Adding models:** `.agents/skills/adding-a-new-model/SKILL.md`

--- a/.agents/skills/profiling-onnx-models/SKILL.md
+++ b/.agents/skills/profiling-onnx-models/SKILL.md
@@ -212,6 +212,13 @@ larger head dimensions (e.g. Gemma4 global attention with
 - For Gemma4 specifically, the GQA bypass was removed so models use
   standard attention ops with runtime kernel selection
 
+**Gemma4 Flash Attention note:** Flash Attention gives only 1-3%
+benefit for Gemma4. With float attention masks (KV-shared layers),
+only 7/35 layers are eligible for Flash. With all-GQA (PR #279),
+25/35 layers become eligible but the `head_dim=512` global layers
+still cannot use Flash. The performance impact is minimal because
+global attention layers dominate compute.
+
 ### 4. Batch size=1 on large GPUs
 
 **Symptom:** GPU utilization is low (10-30%). Throughput doesn't
@@ -366,6 +373,20 @@ A thorough benchmark varies these dimensions independently:
 5. **Compare prefill vs decode** — decode should be much faster
 6. **Measure GenAI throughput** — tok/s is the user-facing metric
 7. **Check GPU utilization** — `nvidia-smi` during inference
+
+## Quantization benchmark reference (Gemma4 E2B)
+
+Measured with Gemma4 E2B-IT on GenAI (text-only, 50+ token decode):
+
+| Dtype | CUDA tok/s | CPU tok/s | Notes |
+|-------|-----------|----------|-------|
+| F16 | 104 | 6.8 | Baseline |
+| Q4_K_M | 111 (+8%) | 16.2 (+138%) | **Recommended** — best speed, no quality loss |
+| NF4 | 93 (-10%) | 4.0 (-41%) | Slower than F16 on both EPs |
+
+**Recommendation:** Q4_K_M wins on both CPU and CUDA with no measurable
+quality degradation. NF4 is slower than even F16 and should be avoided
+for inference speed. Use Q4_K_M as the default quantization format.
 
 ## Cross-references
 

--- a/.agents/skills/profiling-onnx-models/SKILL.md
+++ b/.agents/skills/profiling-onnx-models/SKILL.md
@@ -214,7 +214,7 @@ larger head dimensions (e.g. Gemma4 global attention with
 
 **Gemma4 Flash Attention note:** Flash Attention gives only 1-3%
 benefit for Gemma4. With float attention masks (KV-shared layers),
-only 7/35 layers are eligible for Flash. With all-GQA (PR #279),
+only 7/35 layers are eligible for Flash. With all-GQA (`onnxruntime/mobius#279`),
 25/35 layers become eligible but the `head_dim=512` global layers
 still cannot use Flash. The performance impact is minimal because
 global attention layers dominate compute.
@@ -374,19 +374,20 @@ A thorough benchmark varies these dimensions independently:
 6. **Measure GenAI throughput** — tok/s is the user-facing metric
 7. **Check GPU utilization** — `nvidia-smi` during inference
 
-## Quantization benchmark reference (Gemma4 E2B)
+## Quantization benchmark reference (Gemma4 E2B-IT)
 
 Measured with Gemma4 E2B-IT on GenAI (text-only, 50+ token decode):
 
 | Dtype | CUDA tok/s | CPU tok/s | Notes |
 |-------|-----------|----------|-------|
 | F16 | 104 | 6.8 | Baseline |
-| Q4_K_M | 111 (+8%) | 16.2 (+138%) | **Recommended** — best speed, no quality loss |
-| NF4 | 93 (-10%) | 4.0 (-41%) | Slower than F16 on both EPs |
+| Q4_K_M | 111 (+7%) | 16.2 (+138%) | **Recommended** — best speed, no observed quality regression in spot checks |
+| NF4 | 93 (-11%) | 4.0 (-41%) | Slower than F16 on both EPs |
 
-**Recommendation:** Q4_K_M wins on both CPU and CUDA with no measurable
-quality degradation. NF4 is slower than even F16 and should be avoided
-for inference speed. Use Q4_K_M as the default quantization format.
+**Recommendation:** Q4_K_M wins on both CPU and CUDA with no observed
+quality regression in spot checks. NF4 is slower than even F16 in this
+measurement and should be avoided for inference speed. Use Q4_K_M as
+the default quantization format.
 
 ## Cross-references
 


### PR DESCRIPTION
Updates 3 MEDIUM priority skills with latest codebase-aligned findings and references:

### profiling-onnx-models
- Flash Attention gives only 1-3% benefit for Gemma4 (7/35 layers eligible with float masks, 25/35 with all-GQA)
- Quantization benchmark reference standardized to Gemma4 E2B-IT
- Q4_K_M vs NF4 benchmark: Q4_K_M wins on both CPU (+138%) and CUDA (+7%) vs F16; NF4 is -11% on CUDA and -41% on CPU vs F16
- Quality wording softened to “no observed quality regression in spot checks”

### onnx-export-quantization
- Removed duplicated inference speed table and now cross-references the canonical benchmark table in `profiling-onnx-models`
- Recommendation remains Q4_K_M over NF4, with wording aligned to measured results and spot-check quality language

### multimodal-models
- GQA shared KV section updated to match current implementation state in mobius
- Terminology clarified: `new_kv_length=0` mapped to graph wiring with empty K/V (`kv_sequence_length=0`)
- Removed stale caveat linked to duplicate-tracked ORT issue
- Float-domain bicubic resize reference clarified to `microsoft/onnxruntime-extensions#1056`
- f32 cast-at-entry already documented (confirmed, no change needed)

Documentation only — no code changes.