### PR TITLE
Replace onnxscript._internal.builder imports with public API

### DIFF
--- a/.agents/skills/reusable-components/SKILL.md
+++ b/.agents/skills/reusable-components/SKILL.md
@@ -60,7 +60,7 @@ Model-specific compound blocks (e.g. `_TimestepEmbedding`, `_DiTBlock`,
 
 ```python
 from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder
 
 
 class MyComponent(nn.Module):
@@ -68,7 +68,7 @@ class MyComponent(nn.Module):
         super().__init__()
         self.weight = nn.Parameter([hidden_size])
 
-    def forward(self, op: builder.OpBuilder, hidden_states):
+    def forward(self, op: OpBuilder, hidden_states):
         return op.Mul(hidden_states, self.weight)
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,14 +34,13 @@ pytest tests/integration_test.py -m integration -k "qwen2.5-0.5b"
 
 ```python
 # Good
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import nn, OpBuilder
 
 class MyLayer(nn.Module):
     def __init__(self):
         self.param = nn.Parameter([64], name="weight")
 
-    def forward(self, op: builder.OpBuilder, x):
+    def forward(self, op: OpBuilder, x):
         ...
 
 # Bad

--- a/docs/module-architecture.md
+++ b/docs/module-architecture.md
@@ -137,7 +137,7 @@ same `forward()` signature as `DecoderLayer`:
 ```python
 # In models/my_arch.py
 from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder
 from mobius._configs import ArchitectureConfig
 from mobius.components import Attention, MLP, RMSNorm
 
@@ -156,7 +156,7 @@ class MyDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states,
         attention_bias,
         position_embeddings: tuple,
@@ -220,7 +220,7 @@ All decoder layers **must** use the explicit typed signature:
 ```python
 def forward(
     self,
-    op: builder.OpBuilder,
+    op: OpBuilder,
     hidden_states,           # [batch, seq_len, hidden_size]
     attention_bias,          # attention mask/bias tensor
     position_embeddings: tuple,  # (cos, sin) from RoPE

--- a/src/mobius/_testing/__init__.py
+++ b/src/mobius/_testing/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import onnx_ir as ir
-from onnxscript._internal.builder import GraphBuilder
+from onnxscript import GraphBuilder
 
 from mobius._configs import ArchitectureConfig
 from mobius._constants import OPSET_VERSION

--- a/src/mobius/components/_activations.py
+++ b/src/mobius/components/_activations.py
@@ -6,67 +6,66 @@ from __future__ import annotations
 from collections import OrderedDict
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 if TYPE_CHECKING:
     import onnx_ir as ir
 
 
-def silu(op: builder.OpBuilder, x):
+def silu(op: OpBuilder, x):
     """SiLU (Swish) activation: x * sigmoid(x)."""
     return op.Mul(x, op.Sigmoid(x))
 
 
-def gelu(op: builder.OpBuilder, x):
+def gelu(op: OpBuilder, x):
     """GELU activation using the 'none' approximation."""
     return op.Gelu(x)
 
 
-def gelu_tanh(op: builder.OpBuilder, x):
+def gelu_tanh(op: OpBuilder, x):
     """GELU activation using the tanh approximation."""
     return op.Gelu(x, approximate="tanh")
 
 
-def relu(op: builder.OpBuilder, x):
+def relu(op: OpBuilder, x):
     """ReLU activation."""
     return op.Relu(x)
 
 
-def relu2(op: builder.OpBuilder, x):
+def relu2(op: OpBuilder, x):
     """Squared ReLU activation: relu(x)^2."""
     r = op.Relu(x)
     return op.Mul(r, r)
 
 
-def quick_gelu(op: builder.OpBuilder, x):
+def quick_gelu(op: OpBuilder, x):
     """QuickGELU activation: x * sigmoid(1.702 * x)."""
     return op.Mul(x, op.Sigmoid(op.Mul(1.702, x)))
 
 
-def mish(op: builder.OpBuilder, x):
+def mish(op: OpBuilder, x):
     """Mish activation: x * tanh(softplus(x))."""
     softplus = op.Softplus(x)
     return op.Mul(x, op.Tanh(softplus))
 
 
-def sigmoid(op: builder.OpBuilder, x):
+def sigmoid(op: OpBuilder, x):
     """Sigmoid activation."""
     return op.Sigmoid(x)
 
 
-def tanh(op: builder.OpBuilder, x):
+def tanh(op: OpBuilder, x):
     """Tanh activation."""
     return op.Tanh(x)
 
 
-def linear(op: builder.OpBuilder, x):
+def linear(op: OpBuilder, x):
     """Linear (identity) activation."""
     return x
 
 
 # Mapping from activation string names to functions.
-# Each function takes (op: builder.OpBuilder, x) and returns the activated tensor.
+# Each function takes (op: OpBuilder, x) and returns the activated tensor.
 ACT2FN: OrderedDict[str, callable] = OrderedDict(
     {
         "gegelu": gelu,
@@ -96,7 +95,7 @@ ACT2FN: OrderedDict[str, callable] = OrderedDict(
 def get_activation(activation_string: str | None):
     """Get an activation function by name.
 
-    Returns a callable with signature (op: builder.OpBuilder, x) -> result.
+    Returns a callable with signature (op: OpBuilder, x) -> result.
 
     Raises:
         ValueError: If *activation_string* is ``None``.
@@ -119,5 +118,5 @@ class SiLU(nn.Module):
     Useful as a child in ``nn.Sequential`` where a Module is needed.
     """
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return silu(op, x)

--- a/src/mobius/components/_attention.py
+++ b/src/mobius/components/_attention.py
@@ -7,8 +7,7 @@ import math
 from typing import NamedTuple
 
 import onnx_ir as ir
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._common import Linear
@@ -76,7 +75,7 @@ class StaticCacheState(NamedTuple):
 
 
 def _apply_attention(
-    op: builder.OpBuilder,
+    op: OpBuilder,
     query: ir.Value,
     key: ir.Value,
     value: ir.Value,
@@ -281,7 +280,7 @@ class Attention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | GQAContext | None,
         position_embeddings: tuple | None = None,
@@ -367,7 +366,7 @@ class Attention(nn.Module):
 
     def _forward_gqa(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         query_states: ir.Value,
         key_states: ir.Value,
         value_states: ir.Value,
@@ -478,7 +477,7 @@ class Qwen35Attention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None,
         position_embeddings: tuple,

--- a/src/mobius/components/_audio.py
+++ b/src/mobius/components/_audio.py
@@ -18,8 +18,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components._common import Embedding, LayerNorm, Linear
 
@@ -27,7 +26,7 @@ if TYPE_CHECKING:
     import onnx_ir as ir
 
 
-def _swish(op: builder.OpBuilder, x):
+def _swish(op: OpBuilder, x):
     """Swish activation: x * sigmoid(x)."""
     return op.Mul(x, op.Sigmoid(x))
 
@@ -40,21 +39,21 @@ def _swish(op: builder.OpBuilder, x):
 class _SwishModule(nn.Module):
     """Swish activation as an nn.Module (no parameters)."""
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return op.Mul(x, op.Sigmoid(x))
 
 
 class _ReLUModule(nn.Module):
     """ReLU activation as an nn.Module (no parameters)."""
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return op.Relu(x)
 
 
 class _IdentityModule(nn.Module):
     """Identity (no-op) module, placeholder for dropout layers."""
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return x
 
 
@@ -80,7 +79,7 @@ class _Conv2d(nn.Module):
         self._pads = [padding, padding, padding, padding]
         self._groups = groups
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return op.Conv(
             x,
             self.weight,
@@ -112,7 +111,7 @@ class _ConvWeight(nn.Module):
         self._pads = pads or [0, 0]
         self._groups = groups
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return op.Conv(
             x,
             self.weight,
@@ -131,7 +130,7 @@ class _GLULinear(nn.Module):
         super().__init__()
         self.linear = Linear(input_dim, output_dim * 2)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         x = self.linear(op, x)  # [B, T, output_dim * 2]
         first, second = op.Split(x, axis=-1, num_outputs=2, _outputs=2)
         return op.Mul(first, _swish(op, second))
@@ -150,7 +149,7 @@ class _GLUPointWiseConv(nn.Module):
         self.b1 = nn.Parameter([1, channels, 1])
         self.b2 = nn.Parameter([1, channels, 1])
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         # [B, C, T] → [B, 2C, T] → split → GLU gate
         glu_out = self.ext_pw_conv_1d(op, x)  # [B, 2C, T]
         first, second = op.Split(glu_out, axis=1, num_outputs=2, _outputs=2)
@@ -178,7 +177,7 @@ class _DepthwiseSepConv(nn.Module):
         )
         self.pw_conv = _ConvWeight([channels, channels, 1])
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         x = self.dw_conv(op, x)
         return self.pw_conv(op, x)
 
@@ -228,7 +227,7 @@ class NeMoConvSubsampling(nn.Module):
         )
         self.out = Linear(conv_channels * freq, feat_out)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         # x: [B, T, input_size]
         x = op.Unsqueeze(x, [1])  # [B, 1, T, F]
 
@@ -254,7 +253,7 @@ class MeanVarianceNorm(nn.Module):
         self.global_mean = nn.Parameter([input_size])
         self.global_invstd = nn.Parameter([input_size])
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         x = op.Sub(x, self.global_mean)
         return op.Mul(x, self.global_invstd)
 
@@ -274,7 +273,7 @@ class T5RelativeAttentionBias(nn.Module):
         self._max_distance = max_distance
         self._num_buckets = num_buckets
 
-    def forward(self, op: builder.OpBuilder, seq_length: ir.Value):
+    def forward(self, op: OpBuilder, seq_length: ir.Value):
         # seq_length: scalar tensor (int64)
         zero = op.Constant(value_int=0)
         one = op.Constant(value_int=1)
@@ -321,7 +320,7 @@ class ConformerFeedForward(nn.Module):
             ]
         )
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         x = self.layer_norm(op, x)
         for layer in self.net:
             x = layer(op, x)
@@ -344,7 +343,7 @@ class ConformerConvModule(nn.Module):
         self.dw_sep_conv_1d = _DepthwiseSepConv(channels, kernel_size)
         self.ext_pw_conv_1d = _ConvWeight([channels, channels, 1])
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         # x: [B, T, C]
         x = self.layer_norm(op, x)
         x = op.Transpose(x, perm=[0, 2, 1])  # [B, C, T]
@@ -382,7 +381,7 @@ class ConformerAttention(nn.Module):
         self.linear_v = Linear(d_model, d_model)
         self.linear_out = Linear(d_model, d_model)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value, relative_attention_bias: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value, relative_attention_bias: ir.Value):
         # x: [B, T, D], relative_attention_bias: [1, H, T, T]
         q = self.linear_q(op, x)  # [B, T, H*D_h]
         k = self.linear_k(op, x)
@@ -430,7 +429,7 @@ class ConformerEncoderLayer(nn.Module):
         self.layer_norm_att = LayerNorm(d_model)
         self.layer_norm = LayerNorm(d_model)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value, relative_attention_bias: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value, relative_attention_bias: ir.Value):
         # Macaron feed-forward in
         x = op.Add(x, op.Mul(self.feed_forward_in(op, x), 0.5))
 
@@ -491,7 +490,7 @@ class ConformerEncoder(nn.Module):
             ]
         )
 
-    def forward(self, op: builder.OpBuilder, audio_features: ir.Value):
+    def forward(self, op: OpBuilder, audio_features: ir.Value):
         # audio_features: [B, T, input_size]
         x = self.encoder_embedding(op, audio_features)
         x = self.embed(op, x)  # [B, T', attention_dim]

--- a/src/mobius/components/_codec_conv.py
+++ b/src/mobius/components/_codec_conv.py
@@ -15,8 +15,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components._common import LayerNorm, Linear
 
@@ -65,7 +64,7 @@ class CausalConv1d(nn.Module):
             dilation=dilation,
         )
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         """Forward pass.
 
         Args:
@@ -139,7 +138,7 @@ class CausalConvNd(nn.Module):
         self.weight = nn.Parameter(weight_shape)
         self.bias = nn.Parameter([out_channels]) if bias else None
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         """Apply N-d causal convolution.
 
         Args:
@@ -225,7 +224,7 @@ class CausalTransConv1d(nn.Module):
         # Named 'conv' to match HF MimiConvTranspose1d.conv weight names
         self.conv = _TransConv1dParams(in_channels, out_channels, kernel_size, stride, bias)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         """Upsample input.
 
         Args:
@@ -277,7 +276,7 @@ class _Conv1dParams(nn.Module):
         self.weight = nn.Parameter([out_ch, in_ch, kernel])
         self.bias = nn.Parameter([out_ch]) if bias else None
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         if self.bias is not None:
             return op.Conv(
                 x,
@@ -321,7 +320,7 @@ class _TransConv1dParams(nn.Module):
         self.weight = nn.Parameter([in_ch, out_ch, kernel])
         self.bias = nn.Parameter([out_ch]) if bias else None
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         if self.bias is not None:
             return op.ConvTranspose(
                 x,
@@ -360,7 +359,7 @@ class SnakeBeta(nn.Module):
         self.alpha = nn.Parameter([channels])
         self.beta = nn.Parameter([channels])
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         """Apply SnakeBeta activation.
 
         Args:
@@ -402,7 +401,7 @@ class LayerScale(nn.Module):
         super().__init__()
         self.scale = nn.Parameter([dim])
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         """Apply learned scale.
 
         Args:
@@ -445,7 +444,7 @@ class ConvNeXtBlock(nn.Module):
         # Gamma scale
         self.gamma = nn.Parameter([dim])
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         """Forward pass with residual connection.
 
         Args:
@@ -496,7 +495,7 @@ class _DepthwiseConv1dParams(nn.Module):
             group=dim,
         )
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         """Apply depthwise convolution (no padding — caller pads)."""
         return self.conv(op, x)
 
@@ -523,7 +522,7 @@ class DecoderResidualUnit(nn.Module):
         self.act2 = SnakeBeta(dim)
         self.conv2 = CausalConv1d(dim, dim, kernel_size=1)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         """Forward with residual.
 
         Args:
@@ -576,7 +575,7 @@ class DecoderBlock(nn.Module):
             DecoderResidualUnit(out_dim, dilation=9),
         )
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         """Upsample and refine.
 
         Args:

--- a/src/mobius/components/_codec_transformer.py
+++ b/src/mobius/components/_codec_transformer.py
@@ -16,8 +16,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components._codec_conv import LayerScale
 from mobius.components._common import (
@@ -83,7 +82,7 @@ class CodecDecoderTransformerLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         position_embeddings: tuple,
         attention_mask: ir.Value | None = None,
@@ -149,7 +148,7 @@ class _CodecDecoderAttention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         position_embeddings: tuple,
         attention_mask: ir.Value | None = None,
@@ -259,7 +258,7 @@ class CodecDecoderTransformerModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         position_ids: ir.Value,
         attention_mask: ir.Value | None = None,
@@ -332,7 +331,7 @@ class CodecEncoderTransformerLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         position_embeddings: tuple,
         attention_mask: ir.Value | None = None,
@@ -416,7 +415,7 @@ class CodecEncoderTransformerModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         position_ids: ir.Value,
         attention_mask: ir.Value | None = None,

--- a/src/mobius/components/_codec_vq.py
+++ b/src/mobius/components/_codec_vq.py
@@ -16,8 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components._common import INT64_MAX, Embedding
 
@@ -43,7 +42,7 @@ class EuclideanCodebook(nn.Module):
         # After precomputation this holds the actual embeddings
         self.embedding = Embedding(codebook_size, dim)
 
-    def forward(self, op: builder.OpBuilder, codes: ir.Value):
+    def forward(self, op: OpBuilder, codes: ir.Value):
         """Lookup codebook entries.
 
         Args:
@@ -69,7 +68,7 @@ class VectorQuantization(nn.Module):
         super().__init__()
         self._codebook = EuclideanCodebook(codebook_size, dim)
 
-    def forward(self, op: builder.OpBuilder, codes: ir.Value):
+    def forward(self, op: OpBuilder, codes: ir.Value):
         """Decode codes through one VQ layer.
 
         Args:
@@ -101,7 +100,7 @@ class ResidualVectorQuantization(nn.Module):
             [VectorQuantization(codebook_size, dim) for _ in range(num_layers)]
         )
 
-    def forward(self, op: builder.OpBuilder, codes: ir.Value):
+    def forward(self, op: OpBuilder, codes: ir.Value):
         """Decode and sum across quantizer layers.
 
         Args:
@@ -154,7 +153,7 @@ class ResidualVectorQuantizer(nn.Module):
         self.output_proj = _Conv1dProjParams(dim, output_dim)
         self.vq = ResidualVectorQuantization(num_quantizers, codebook_size, dim)
 
-    def forward(self, op: builder.OpBuilder, codes: ir.Value):
+    def forward(self, op: OpBuilder, codes: ir.Value):
         """Decode codes through projected RVQ.
 
         Args:
@@ -181,7 +180,7 @@ class _Conv1dProjParams(nn.Module):
         super().__init__()
         self.weight = nn.Parameter([out_dim, in_dim, 1])
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return op.Conv(
             x,
             self.weight,
@@ -229,7 +228,7 @@ class SplitResidualVectorQuantizer(nn.Module):
             output_dim=codebook_dim,
         )
 
-    def forward(self, op: builder.OpBuilder, codes: ir.Value):
+    def forward(self, op: OpBuilder, codes: ir.Value):
         """Decode all code groups and sum.
 
         Args:

--- a/src/mobius/components/_common.py
+++ b/src/mobius/components/_common.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 
 import numpy as np
 import onnx_ir as ir
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 # Used as Slice "end" to mean "all remaining elements along this axis".
 INT64_MAX = 9223372036854775807
@@ -25,7 +24,7 @@ class Linear(nn.Module):
         self.weight = nn.Parameter([out_features, in_features])
         self.bias = nn.Parameter([out_features]) if bias else None
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         # Transpose weight from [out_features, in_features] → [in_features, out_features]
         # so MatMul(x, w_t) computes x @ weight.T.
         # FoldTransposedInitializerPass (applied after weight loading) will
@@ -50,7 +49,7 @@ class Embedding(nn.Module):
         self.weight = nn.Parameter([num_embeddings, embedding_dim])
         self.padding_idx = padding_idx
 
-    def forward(self, op: builder.OpBuilder, input_ids: ir.Value):
+    def forward(self, op: OpBuilder, input_ids: ir.Value):
         return op.Gather(self.weight, input_ids)
 
 
@@ -63,7 +62,7 @@ class LayerNorm(nn.Module):
         self.bias = nn.Parameter([hidden_size])
         self.eps = eps
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         return op.LayerNormalization(
             hidden_states,
             self.weight,
@@ -87,7 +86,7 @@ class OffsetLayerNorm(nn.Module):
         self.bias = nn.Parameter([hidden_size])
         self.eps = eps
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         effective_weight = op.Add(self.weight, 1.0)
         return op.LayerNormalization(
             hidden_states,
@@ -110,7 +109,7 @@ class LayerNormNoBias(nn.Module):
         self.weight = nn.Parameter([hidden_size])
         self.eps = eps
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         return op.LayerNormalization(
             hidden_states,
             self.weight,
@@ -131,7 +130,7 @@ class LayerNormNoAffine(nn.Module):
         self._hidden_size = hidden_size
         self._eps = eps
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # ONNX LayerNormalization requires a Scale input; use all-ones
         # since this is the no-affine variant (scale/shift come externally).
         # CastLike ensures Scale matches the input dtype (fp16/bf16/fp32).
@@ -150,14 +149,14 @@ class GroupNorm(nn.Module):
         self._num_groups = num_groups
         self._eps = eps
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return op.GroupNormalization(
             x, self.weight, self.bias, num_groups=self._num_groups, epsilon=self._eps
         )
 
 
 def create_attention_bias(
-    op: builder.OpBuilder,
+    op: OpBuilder,
     input_ids,
     attention_mask,
     sliding_window: int | None = None,
@@ -225,7 +224,7 @@ def create_attention_bias(
 
 
 def create_padding_mask(
-    op: builder.OpBuilder,
+    op: OpBuilder,
     input_ids,
     attention_mask,
 ):
@@ -276,7 +275,7 @@ def create_padding_mask(
 
 
 def create_sliding_window_mask(
-    op: builder.OpBuilder,
+    op: OpBuilder,
     input_ids: ir.Value,
     attention_mask: ir.Value,
     window_size: int,

--- a/src/mobius/components/_conv.py
+++ b/src/mobius/components/_conv.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import onnx_ir as ir
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 if TYPE_CHECKING:
     pass
@@ -41,7 +40,7 @@ class Conv2d(nn.Module):
         self._padding = padding
         self._groups = groups
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         p = self._padding
         return op.Conv(
             x,
@@ -75,7 +74,7 @@ class Conv2dNoBias(nn.Module):
         self._padding = padding
         self._groups = groups
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         p = self._padding
         return op.Conv(
             x,
@@ -102,7 +101,7 @@ class BatchNorm2d(nn.Module):
         self.running_var = nn.Parameter((num_features,))
         self._eps = eps
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return op.BatchNormalization(
             x,
             self.weight,
@@ -131,7 +130,7 @@ class ConvTranspose2d(nn.Module):
         self._stride = stride
         self._padding = padding
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         p = self._padding
         return op.ConvTranspose(
             x,
@@ -164,7 +163,7 @@ class CausalDepthwiseConv1d(nn.Module):
         self._channels = channels
         self._kernel_size = kernel_size
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, x: ir.Value) -> ir.Value:
         # x: [B, C, T]
         left_pad = self._kernel_size - 1
         return op.Conv(

--- a/src/mobius/components/_decoder.py
+++ b/src/mobius/components/_decoder.py
@@ -6,8 +6,7 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._attention import Attention, StaticCacheState
@@ -90,7 +89,7 @@ class DecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None,
         position_embeddings: tuple,
@@ -124,7 +123,7 @@ class DecoderLayer(nn.Module):
 
     def _forward_pre_norm(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None,
         position_embeddings: tuple,
@@ -159,7 +158,7 @@ class DecoderLayer(nn.Module):
 
     def _forward_post_norm(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None,
         position_embeddings: tuple,

--- a/src/mobius/components/_deepseek_mla.py
+++ b/src/mobius/components/_deepseek_mla.py
@@ -13,8 +13,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._common import Linear
@@ -104,7 +103,7 @@ class DeepSeekMLA(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,

--- a/src/mobius/components/_diffusion.py
+++ b/src/mobius/components/_diffusion.py
@@ -12,8 +12,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components._activations import SiLU
 from mobius.components._common import LayerNorm, Linear
@@ -41,7 +40,7 @@ class AdaLayerNormZero(nn.Module):
         self.linear = Linear(hidden_size, hidden_size * 6)
         self._silu = SiLU()
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value, timestep_emb: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value, timestep_emb: ir.Value):
         emb = self._silu(op, timestep_emb)
         emb = self.linear(op, emb)
         # [B, 6*C] → 6 x [B, C]
@@ -79,7 +78,7 @@ class AdaLayerNormOutput(nn.Module):
         self.linear = Linear(hidden_size, hidden_size * 2)
         self._silu = SiLU()
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value, timestep_emb: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value, timestep_emb: ir.Value):
         emb = self._silu(op, timestep_emb)
         emb = self.linear(op, emb)
         shift, scale = op.Split(emb, num_outputs=2, axis=-1, _outputs=2)
@@ -106,7 +105,7 @@ class PatchEmbed(nn.Module):
             padding=0,
         )
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         # [B, C, H, W] → [B, hidden, H/p, W/p]
         x = self.proj(op, x)
         batch = op.Shape(x, start=0, end=1)
@@ -134,7 +133,7 @@ class TimestepEmbedding(nn.Module):
         self.linear_2 = Linear(time_embed_dim, time_embed_dim)
         self._silu = SiLU()
 
-    def forward(self, op: builder.OpBuilder, sample: ir.Value):
+    def forward(self, op: OpBuilder, sample: ir.Value):
         sample = self.linear_1(op, sample)
         sample = self._silu(op, sample)
         sample = self.linear_2(op, sample)
@@ -154,7 +153,7 @@ class DiffusionFFN(nn.Module):
         self.linear_1 = Linear(hidden_size, intermediate_size)
         self.linear_2 = Linear(intermediate_size, hidden_size)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         hidden_states = self.linear_1(op, hidden_states)
         # GELU with tanh approximation
         hidden_states = op.Gelu(hidden_states)
@@ -180,7 +179,7 @@ class DiffusionSelfAttention(nn.Module):
         self._num_heads = num_heads
         self._head_dim = hidden_size // num_heads
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         q = self.to_q(op, hidden_states)
         k = self.to_k(op, hidden_states)
         v = self.to_v(op, hidden_states)

--- a/src/mobius/components/_ecapa_tdnn.py
+++ b/src/mobius/components/_ecapa_tdnn.py
@@ -22,8 +22,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 
@@ -31,7 +30,7 @@ if TYPE_CHECKING:
     import onnx_ir as ir
 
 
-def _reflect_pad_1d(op: builder.OpBuilder, x, padding: int):
+def _reflect_pad_1d(op: OpBuilder, x, padding: int):
     """Apply reflect padding along the last dimension (time axis).
 
     ONNX Conv does not support reflect padding natively, so we use
@@ -73,7 +72,7 @@ class TimeDelayNetBlock(nn.Module):
         self._padding = (kernel_size - 1) * dilation // 2
         self.conv = _TDNNConv1d(in_channels, out_channels, kernel_size, dilation)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # hidden_states: (batch, channels, time)
         hidden_states = _reflect_pad_1d(op, hidden_states, self._padding)
         hidden_states = self.conv(op, hidden_states)
@@ -96,7 +95,7 @@ class _TDNNConv1d(nn.Module):
         self._kernel_size = kernel_size
         self._dilation = dilation
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         # x is already padded by reflect_pad_1d
         return op.Conv(
             x,
@@ -147,7 +146,7 @@ class Res2NetBlock(nn.Module):
         self._scale = scale
         self._in_channel = in_channel
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # hidden_states: (batch, channels, time)
         # Split into scale chunks along channel dim
         # Use Slice instead of Split since scale varies dynamically
@@ -198,7 +197,7 @@ class SqueezeExcitationBlock(nn.Module):
         self.conv1 = _SEConv1d(in_channels, se_channels)
         self.conv2 = _SEConv1d(se_channels, out_channels)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # hidden_states: (batch, channels, time)
         # Global mean pooling over time dimension → (batch, channels, 1)
         hidden_states_mean = op.ReduceMean(hidden_states, [2], keepdims=True)
@@ -219,7 +218,7 @@ class _SEConv1d(nn.Module):
         self.weight = nn.Parameter([out_channels, in_channels, 1])
         self.bias = nn.Parameter([out_channels])
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return op.Conv(
             x,
             self.weight,
@@ -261,7 +260,7 @@ class SqueezeExcitationRes2NetBlock(nn.Module):
         self.tdnn2 = TimeDelayNetBlock(out_channels, out_channels, kernel_size=1, dilation=1)
         self.se_block = SqueezeExcitationBlock(out_channels, se_channels, out_channels)
 
-    def forward(self, op: builder.OpBuilder, hidden_state: ir.Value):
+    def forward(self, op: OpBuilder, hidden_state: ir.Value):
         # hidden_state: (batch, channels, time)
         residual = hidden_state
 
@@ -297,7 +296,7 @@ class AttentiveStatisticsPooling(nn.Module):
         # Conv1d to produce per-channel attention weights
         self.conv = _SEConv1d(attention_channels, channels)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # hidden_states: (batch, channels, time)
         seq_length = op.Shape(hidden_states, start=2, end=3)  # (1,)
         seq_length_float = op.Cast(seq_length, to=1)  # float32
@@ -432,7 +431,7 @@ class SpeakerEncoder(nn.Module):
         # Final projection: (2 * enc_channels[-1]) → enc_dim
         self.fc = _SEConv1d(enc_channels[-1] * 2, enc_dim)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # hidden_states: (batch, time, mel_dim) — mel spectrogram
         # Transpose to (batch, mel_dim, time) for Conv1d processing
         hidden_states = op.Transpose(hidden_states, perm=[0, 2, 1])

--- a/src/mobius/components/_encoder.py
+++ b/src/mobius/components/_encoder.py
@@ -7,8 +7,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components._common import Embedding, LayerNorm, Linear
 from mobius.components._mlp import FCMLP
@@ -42,7 +41,7 @@ class EncoderAttention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_mask: ir.Value | None = None,
     ):
@@ -96,7 +95,7 @@ class EncoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_mask: ir.Value | None = None,
     ):
@@ -131,7 +130,7 @@ class BertEmbeddings(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         token_type_ids: ir.Value,
     ):

--- a/src/mobius/components/_encoder_decoder_attention.py
+++ b/src/mobius/components/_encoder_decoder_attention.py
@@ -7,8 +7,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._common import Embedding, Linear
@@ -68,7 +67,7 @@ class EncoderDecoderAttention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         key_value_states: ir.Value | None = None,
         attention_bias: ir.Value | None = None,

--- a/src/mobius/components/_gated_deltanet.py
+++ b/src/mobius/components/_gated_deltanet.py
@@ -30,8 +30,7 @@ the model by the task layer.
 from __future__ import annotations
 
 import onnx_ir as ir
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._common import Linear
@@ -62,7 +61,7 @@ class _DepthwiseConv1d(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_val: ir.Value,
         conv_state: ir.Value,
     ):
@@ -146,7 +145,7 @@ class GatedDeltaNet(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         conv_state: ir.Value,
         recurrent_state: ir.Value,

--- a/src/mobius/components/_gemma4_audio.py
+++ b/src/mobius/components/_gemma4_audio.py
@@ -44,8 +44,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import onnx_ir as ir
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components._common import INT64_MAX, LayerNormNoBias, Linear
 from mobius.components._conv import CausalDepthwiseConv1d, Conv2dNoBias
@@ -60,20 +59,20 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 
-def _gradient_clip(op: builder.OpBuilder, x: ir.Value, clip_val: float = 1e9) -> ir.Value:
+def _gradient_clip(op: OpBuilder, x: ir.Value, clip_val: float = 1e9) -> ir.Value:
     """Clamp activations to ±clip_val (gradient clipping for numerical stability)."""
     lo = op.CastLike(op.Constant(value_float=-clip_val), x)
     hi = op.CastLike(op.Constant(value_float=clip_val), x)
     return op.Clip(x, lo, hi)
 
 
-def _glu(op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+def _glu(op: OpBuilder, x: ir.Value) -> ir.Value:
     """GLU: split last dim in half → a * sigmoid(b)."""
     a, b = op.Split(x, axis=-1, num_outputs=2, _outputs=2)
     return op.Mul(a, op.Sigmoid(b))
 
 
-def _swish(op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+def _swish(op: OpBuilder, x: ir.Value) -> ir.Value:
     """SiLU/Swish activation: x * sigmoid(x)."""
     return op.Mul(x, op.Sigmoid(x))
 
@@ -115,7 +114,7 @@ class ClippableLinear(nn.Module):
         self.output_min = nn.Parameter([])
         self.output_max = nn.Parameter([])
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, x: ir.Value) -> ir.Value:
         # Clamp input activations
         x = op.Clip(x, self.input_min, self.input_max)
         # Linear: x @ weight.T [+ bias]
@@ -178,7 +177,7 @@ class Gemma4ConvSubsampling(nn.Module):
 
     def _conv_norm_relu(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         x: ir.Value,
         conv: Conv2dNoBias,
         norm: LayerNormNoBias,
@@ -193,7 +192,7 @@ class Gemma4ConvSubsampling(nn.Module):
 
     def _mask_and_downsample(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         x: ir.Value,
         mask: ir.Value | None,
     ) -> tuple[ir.Value, ir.Value | None]:
@@ -224,7 +223,7 @@ class Gemma4ConvSubsampling(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         x: ir.Value,
         input_features_mask: ir.Value | None = None,
     ) -> tuple[ir.Value, ir.Value | None]:
@@ -301,7 +300,7 @@ class Gemma4FeedForward(nn.Module):
         self.ffw_layer_2 = ClippableLinear(hidden_size * 4, hidden_size, bias=False)
         self.post_layer_norm = RMSNorm(hidden_size, eps=rms_norm_eps)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         residual = x
         x = _gradient_clip(op, x, self._gradient_clipping)
         x = self.pre_layer_norm(op, x)
@@ -353,7 +352,7 @@ class Gemma4LightConv1d(nn.Module):
         self.conv_norm = RMSNorm(hidden_size, eps=rms_norm_eps)
         self.linear_end = ClippableLinear(hidden_size, hidden_size, bias=False)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         residual = x
         x = self.pre_layer_norm(op, x)  # [B, T, h]
         x = self.linear_start(op, x)  # [B, T, 2h]
@@ -474,7 +473,7 @@ class Gemma4Attention(nn.Module):
             [np.sin(scaled), np.cos(scaled)], axis=-1
         )  # [context_left, hidden_size]
 
-    def _build_causal_window_mask(self, op: builder.OpBuilder, seq_len: ir.Value) -> ir.Value:
+    def _build_causal_window_mask(self, op: OpBuilder, seq_len: ir.Value) -> ir.Value:
         """Build [1, 1, T, T] causal sliding-window attention bias."""
         zero = op.Constant(value_int=0)
         one = op.Constant(value_int=1)
@@ -501,7 +500,7 @@ class Gemma4Attention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         x: ir.Value,
         attention_mask: ir.Value | None = None,
     ) -> ir.Value:
@@ -684,7 +683,7 @@ class Gemma4AudioLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         x: ir.Value,
         attention_mask: ir.Value | None = None,
     ) -> ir.Value:
@@ -789,7 +788,7 @@ class Gemma4AudioEncoder(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_features: ir.Value,
         input_features_mask: ir.Value | None = None,
     ) -> tuple[ir.Value, ir.Value | None]:

--- a/src/mobius/components/_lightning_attention.py
+++ b/src/mobius/components/_lightning_attention.py
@@ -31,8 +31,7 @@ from __future__ import annotations
 import math
 
 import onnx_ir as ir
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._common import Linear
@@ -95,7 +94,7 @@ class LightningAttention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         recurrent_state: ir.Value,
     ):

--- a/src/mobius/components/_lora.py
+++ b/src/mobius/components/_lora.py
@@ -7,8 +7,7 @@ from __future__ import annotations
 
 import numpy
 import onnx_ir as ir
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components._common import Linear
 
@@ -61,7 +60,7 @@ class LoRALinear(Linear):
                 setattr(self, f"_lora_scale_{name}", scale_param)
                 self._adapters.append((name, scale_param))
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         result = super().forward(op, x)
         for name, scale_param in self._adapters:
             lora_a = getattr(self, f"_lora_A_{name}")

--- a/src/mobius/components/_mamba_block.py
+++ b/src/mobius/components/_mamba_block.py
@@ -20,8 +20,7 @@ HuggingFace reference: ``MambaMixer``, ``BambaMixer``,
 from __future__ import annotations
 
 import onnx_ir as ir
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components._common import INT64_MAX, Linear
 from mobius.components._rms_norm import GatedRMSNorm
@@ -42,7 +41,7 @@ class _DepthwiseConv1d(nn.Module):
         self._kernel_size = kernel_size
         self._channels = channels
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         # x: (batch, channels, seq_len)
         result = op.Conv(
             x,
@@ -101,7 +100,7 @@ class MambaBlock(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         conv_state: ir.Value,
         ssm_state: ir.Value,
@@ -196,7 +195,7 @@ class _Mamba2DepthwiseConv1d(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_val: ir.Value,
         conv_state: ir.Value,
     ):
@@ -332,7 +331,7 @@ class Mamba2Block(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         conv_state: ir.Value,
         ssm_state: ir.Value,
@@ -465,7 +464,7 @@ class Mamba2Block(nn.Module):
 
         return output, new_conv_state, new_ssm_state
 
-    def _expand_groups(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+    def _expand_groups(self, op: OpBuilder, x: ir.Value) -> ir.Value:
         """Expand grouped B or C from n_groups to num_heads.
 
         Args:

--- a/src/mobius/components/_mlp.py
+++ b/src/mobius/components/_mlp.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._activations import get_activation
@@ -43,7 +42,7 @@ class MLP(nn.Module):
         )
         self.act_fn = get_activation(config.hidden_act)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         gate = self.act_fn(op, self.gate_proj(op, x))
         up = self.up_proj(op, x)
         return self.down_proj(op, op.Mul(gate, up))
@@ -93,7 +92,7 @@ class GatedMLP(nn.Module):
         self.down_proj = linear_class(intermediate_size, hidden_size, bias=bias)
         self.act_fn = get_activation(activation)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, x: ir.Value) -> ir.Value:
         gate = self.act_fn(op, self.gate_proj(op, x))
         return self.down_proj(op, op.Mul(gate, self.up_proj(op, x)))
 
@@ -136,7 +135,7 @@ class FusedGateUpMLP(nn.Module):
         )
         self.act_fn = get_activation(config.hidden_act)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, x: ir.Value) -> ir.Value:
         # Fused matmul → [*, 2 * intermediate_size]
         gate_up = self.gate_up_proj(op, x)
         # Split activations at intermediate_size boundary
@@ -188,7 +187,7 @@ class FCMLP(nn.Module):
         self.down_proj = linear_class(intermediate_size, hidden_size, bias=bias)
         self.act_fn = get_activation(activation)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, x: ir.Value) -> ir.Value:
         x = self.up_proj(op, x)
         x = self.act_fn(op, x)
         return self.down_proj(op, x)

--- a/src/mobius/components/_moe.py
+++ b/src/mobius/components/_moe.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 import dataclasses
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._mlp import MLP
@@ -31,7 +30,7 @@ class TopKGate(nn.Module):
         self.top_k = top_k
         self.weight = nn.Parameter([num_experts, hidden_size])
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         weight_t = op.Transpose(self.weight, perm=[1, 0])
         router_logits = op.MatMul(hidden_states, weight_t)
         k = op.Constant(value_ints=[self.top_k])
@@ -56,7 +55,7 @@ class SoftmaxTopKGate(nn.Module):
         self.norm_topk_prob = norm_topk_prob
         self.weight = nn.Parameter([num_experts, hidden_size])
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         weight_t = op.Transpose(self.weight, perm=[1, 0])
         router_logits = op.MatMul(hidden_states, weight_t)
         # Softmax over all experts first
@@ -95,7 +94,7 @@ class SigmoidTopKGate(nn.Module):
         self.routed_scaling_factor = routed_scaling_factor
         self.weight = nn.Parameter([num_experts, hidden_size])
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         weight_t = op.Transpose(self.weight, perm=[1, 0])
         router_logits = op.MatMul(hidden_states, weight_t)
         # Sigmoid instead of softmax: each expert scored independently
@@ -154,7 +153,7 @@ class SparseMixerGate(nn.Module):
         expert_weight = op.GatherElements(weights, expert_idx, axis=-1)
         return expert_weight, expert_idx
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         weight_t = op.Transpose(self.weight, perm=[1, 0])
         router_logits = op.MatMul(hidden_states, weight_t)
 
@@ -209,7 +208,7 @@ class MoELayer(nn.Module):
         )
         self.experts = nn.ModuleList([MLP(expert_config) for _ in range(self.num_experts)])
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         routing_weights, selected_experts = self.gate(op, hidden_states)
 
         result = None

--- a/src/mobius/components/_multimodal.py
+++ b/src/mobius/components/_multimodal.py
@@ -19,8 +19,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components._common import Linear
 from mobius.components._rms_norm import RMSNorm
@@ -56,7 +55,7 @@ class Gemma3MultiModalProjector(nn.Module):
         self.pool_kernel = patches_per_image // tokens_per_side
         self.mm_input_projection_weight = nn.Parameter([vision_hidden_size, text_hidden_size])
 
-    def forward(self, op: builder.OpBuilder, vision_features: ir.Value):
+    def forward(self, op: OpBuilder, vision_features: ir.Value):
         # vision_features: [batch, num_patches, vision_hidden_size]
         batch_size = op.Shape(vision_features, start=0, end=1)
         hidden_size = op.Shape(vision_features, start=2, end=3)
@@ -110,7 +109,7 @@ class MLPMultiModalProjector(nn.Module):
         self.linear_1 = Linear(vision_hidden_size, text_hidden_size, bias=bias)
         self.linear_2 = Linear(text_hidden_size, text_hidden_size, bias=bias)
 
-    def forward(self, op: builder.OpBuilder, vision_features: ir.Value):
+    def forward(self, op: OpBuilder, vision_features: ir.Value):
         # vision_features: [batch, num_patches, vision_hidden_size]
         hidden = self.linear_1(op, vision_features)
         hidden = op.Gelu(hidden)
@@ -137,7 +136,7 @@ class LinearMultiModalProjector(nn.Module):
         super().__init__()
         self.linear = Linear(vision_hidden_size, text_hidden_size, bias=bias)
 
-    def forward(self, op: builder.OpBuilder, vision_features: ir.Value):
+    def forward(self, op: OpBuilder, vision_features: ir.Value):
         return self.linear(op, vision_features)
 
 
@@ -154,7 +153,7 @@ class InputMixer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         text_embeddings: ir.Value,
         vision_embeddings: ir.Value,
         input_ids: ir.Value,

--- a/src/mobius/components/_pixtral_vision.py
+++ b/src/mobius/components/_pixtral_vision.py
@@ -21,8 +21,7 @@ from __future__ import annotations
 
 import numpy as np
 import onnx_ir as ir
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._build_context import ep_capabilities
 from mobius._configs import ArchitectureConfig
@@ -94,7 +93,7 @@ class PixtralRoPE2D(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         position_ids: ir.Value,
     ) -> tuple[ir.Value, ir.Value]:
         """Look up 2D RoPE cos/sin by flattened grid position IDs.
@@ -147,7 +146,7 @@ class PixtralAttention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         position_embeddings: tuple[ir.Value, ir.Value],
     ) -> ir.Value:
@@ -232,7 +231,7 @@ class PixtralTransformerLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         position_embeddings: tuple[ir.Value, ir.Value],
     ) -> ir.Value:
@@ -284,7 +283,7 @@ class PixtralTransformerEncoder(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         position_embeddings: tuple[ir.Value, ir.Value],
     ) -> ir.Value:
@@ -326,7 +325,7 @@ class Mistral3PatchMerger(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         grid_h: ir.Value,
         grid_w: ir.Value,
@@ -425,7 +424,7 @@ class Mistral3MultiModalProjector(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         vision_features: ir.Value,
         grid_h: ir.Value,
         grid_w: ir.Value,
@@ -505,7 +504,7 @@ class PixtralVisionTower(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         pixel_values: ir.Value,
     ) -> tuple[ir.Value, ir.Value, ir.Value]:
         """Encode pixel values to patch features.

--- a/src/mobius/components/_pixtral_vision_test.py
+++ b/src/mobius/components/_pixtral_vision_test.py
@@ -117,7 +117,7 @@ def test_patch_merger_matches_hf_unfold_ordering():
     ordering so the learned ``merging_layer`` projection is correct.
     """
     import torch
-    from onnxscript._internal.builder import GraphBuilder
+    from onnxscript import GraphBuilder
 
     hidden_size = 8
     ms = 2

--- a/src/mobius/components/_qformer.py
+++ b/src/mobius/components/_qformer.py
@@ -21,8 +21,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components._common import LayerNorm, Linear
 from mobius.components._mlp import FCMLP
@@ -68,7 +67,7 @@ class QFormerAttention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         key_value_states: ir.Value | None = None,
     ):
@@ -168,7 +167,7 @@ class QFormerLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         encoder_hidden_states: ir.Value,
     ):
@@ -259,7 +258,7 @@ class QFormer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         encoder_hidden_states: ir.Value,
     ):
         """Forward pass.

--- a/src/mobius/components/_quantized_linear.py
+++ b/src/mobius/components/_quantized_linear.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 import math
 
 import onnx_ir as ir
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 # MatMulNBits packs weights into uint8 blobs.  The packed shape depends
 # on bits and block_size:
@@ -85,7 +84,7 @@ class QuantizedLinear(nn.Module):
         )
         self.bias = nn.Parameter([out_features]) if bias else None
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, x: ir.Value) -> ir.Value:
         """Compute quantized matmul: y = x @ dequant(W).
 
         Args:

--- a/src/mobius/components/_qwen25_vl_vision.py
+++ b/src/mobius/components/_qwen25_vl_vision.py
@@ -24,8 +24,7 @@ import math
 
 import numpy as np
 import onnx_ir as ir
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._build_context import ep_capabilities
 from mobius.components._common import LayerNorm, Linear
@@ -66,7 +65,7 @@ class Qwen25VLPatchEmbed(nn.Module):
             name="proj.weight",
         )
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         x = op.Reshape(
             hidden_states,
             [-1, self.in_channels, self.temporal_patch_size, self.patch_size, self.patch_size],
@@ -103,7 +102,7 @@ class Qwen25VLVisionRotaryEmbedding(nn.Module):
             data=ir.tensor(freqs),
         )
 
-    def forward(self, op: builder.OpBuilder, rotary_pos_ids: ir.Value):
+    def forward(self, op: OpBuilder, rotary_pos_ids: ir.Value):
         """Compute cos/sin position embeddings.
 
         Args:
@@ -145,7 +144,7 @@ class Qwen25VLVisionAttention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         cu_seqlens: ir.Value,
         cos: ir.Value,
@@ -362,7 +361,7 @@ class Qwen25VLVisionBlock(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         cu_seqlens: ir.Value,
         cos: ir.Value,
@@ -403,7 +402,7 @@ class Qwen2VLVisionBlock(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         cu_seqlens: ir.Value,
         cos: ir.Value,
@@ -449,7 +448,7 @@ class Qwen25VLPatchMerger(nn.Module):
         self.mlp_0 = Linear(merged_dim, merged_dim, bias=True)
         self.mlp_2 = Linear(merged_dim, out_hidden_size, bias=True)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # hidden_states: (N, hidden_size) where N = total_patches after blocks
         # Apply RMSNorm per-token
         hidden_states = self.ln_q(op, hidden_states)
@@ -1020,7 +1019,7 @@ class Qwen25VLVisionModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         pixel_values: ir.Value,
         image_grid_thw: ir.Value,
     ):
@@ -1176,7 +1175,7 @@ class Qwen2VLVisionModel(Qwen25VLVisionModel):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         pixel_values: ir.Value,
         image_grid_thw: ir.Value,
     ) -> ir.Value:

--- a/src/mobius/components/_qwen3_asr_audio.py
+++ b/src/mobius/components/_qwen3_asr_audio.py
@@ -14,8 +14,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components._common import LayerNorm, Linear
 
@@ -41,7 +40,7 @@ class Qwen3ASRAudioAttention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_mask: ir.Value | None = None,
     ):
@@ -100,7 +99,7 @@ class Qwen3ASRAudioEncoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_mask: ir.Value | None = None,
     ):

--- a/src/mobius/components/_qwen3_vl_vision.py
+++ b/src/mobius/components/_qwen3_vl_vision.py
@@ -23,8 +23,7 @@ import math
 
 import numpy as np
 import onnx_ir as ir
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._build_context import ep_capabilities
 from mobius.components._common import LayerNorm, Linear
@@ -64,7 +63,7 @@ class Qwen3VLPatchEmbed(nn.Module):
         )
         self.bias = nn.Parameter([hidden_size], name="proj.bias")
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # hidden_states: (total_patches, C * T_p * P * P)
         # Reshape to (total_patches, C, T_p, P, P) for Conv3d
         x = op.Reshape(
@@ -112,7 +111,7 @@ class Qwen3VLVisionRotaryEmbedding(nn.Module):
             data=ir.tensor(sin_table),
         )
 
-    def forward(self, op: builder.OpBuilder, position_ids: ir.Value):
+    def forward(self, op: OpBuilder, position_ids: ir.Value):
         """Look up cos/sin for 2D position IDs.
 
         Args:
@@ -160,7 +159,7 @@ class Qwen3VLVisionAttention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         cu_seqlens: ir.Value,
         position_embeddings: tuple,
@@ -336,7 +335,7 @@ class Qwen3VLVisionBlock(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         cu_seqlens: ir.Value,
         position_embeddings: tuple,
@@ -377,7 +376,7 @@ class Qwen3VLPatchMerger(nn.Module):
         self.linear_fc1 = Linear(self.merged_size, self.merged_size, bias=True)
         self.linear_fc2 = Linear(self.merged_size, out_hidden_size, bias=True)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         if self.use_postshuffle_norm:
             # Reshape to merged dim, then normalise
             x = op.Reshape(hidden_states, [-1, self.merged_size])
@@ -834,7 +833,7 @@ class Qwen3VLVisionModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         grid_thw: ir.Value,
     ):

--- a/src/mobius/components/_rms_norm.py
+++ b/src/mobius/components/_rms_norm.py
@@ -4,8 +4,7 @@
 from __future__ import annotations
 
 import onnx_ir as ir
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._flags import flags
 
@@ -18,7 +17,7 @@ class RMSNorm(nn.Module):
         self.weight = nn.Parameter([hidden_size])
         self.variance_epsilon = eps
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         return apply_rms_norm(op, hidden_states, self.weight, self.variance_epsilon)
 
 
@@ -36,7 +35,7 @@ class OffsetRMSNorm(nn.Module):
         self.weight = nn.Parameter([hidden_size])
         self.variance_epsilon = eps
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         effective_weight = op.Add(self.weight, 1.0)
         return op.RMSNormalization(
             hidden_states,
@@ -73,7 +72,7 @@ class GatedRMSNorm(nn.Module):
         self.variance_epsilon = eps
         self.group_size = group_size
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value, gate: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value, gate: ir.Value):
         # SiLU gating in fp32 for precision, matching HF.
         h_f32 = op.Cast(hidden_states, to=ir.DataType.FLOAT)
         g_f32 = op.Cast(gate, to=ir.DataType.FLOAT)
@@ -160,7 +159,7 @@ class PostGatedRMSNorm(nn.Module):
         self.weight = nn.Parameter([hidden_size])
         self.variance_epsilon = eps
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value, gate: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value, gate: ir.Value):
         # RMSNorm uses stash_type=1 internally for fp32 variance.
         normed = op.RMSNormalization(
             hidden_states,
@@ -177,7 +176,7 @@ class PostGatedRMSNorm(nn.Module):
         return op.CastLike(result, hidden_states)
 
 
-def apply_rms_norm(op: builder.OpBuilder, x, weight, eps):
+def apply_rms_norm(op: OpBuilder, x, weight, eps):
     """Apply RMS normalization using the ONNX RMSNormalization op.
 
     Args:

--- a/src/mobius/components/_rotary_embedding.py
+++ b/src/mobius/components/_rotary_embedding.py
@@ -7,8 +7,7 @@ import math
 
 import numpy as np
 import onnx_ir as ir
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._common import INT64_MAX
@@ -35,7 +34,7 @@ def _get_cos_sin_cache(
     )
 
 
-def get_rotary_pos_emb(op: builder.OpBuilder, position_ids, cos_cache, sin_cache):
+def get_rotary_pos_emb(op: OpBuilder, position_ids, cos_cache, sin_cache):
     """Retrieve cos/sin positional embeddings based on position IDs.
 
     Uses Gather to look up the embeddings for the given position IDs.
@@ -55,7 +54,7 @@ def get_rotary_pos_emb(op: builder.OpBuilder, position_ids, cos_cache, sin_cache
 
 
 def apply_rotary_pos_emb(
-    op: builder.OpBuilder,
+    op: OpBuilder,
     x,
     position_embeddings: tuple,
     num_heads: int,
@@ -134,7 +133,7 @@ class BaseRope(nn.Module):
 
     def _cast_embeddings(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         cos: ir.Value,
         sin: ir.Value,
     ) -> tuple[ir.Value, ir.Value]:
@@ -149,7 +148,7 @@ class BaseRope(nn.Module):
             sin = op.Cast(sin, to=self._dtype)
         return cos, sin
 
-    def forward(self, op: builder.OpBuilder, position_ids: ir.Value):
+    def forward(self, op: OpBuilder, position_ids: ir.Value):
         cos, sin = get_rotary_pos_emb(op, position_ids, self.cos_cache, self.sin_cache)
         return self._cast_embeddings(op, cos, sin)
 
@@ -295,7 +294,7 @@ class LongRope(BaseRope):
         sin_cache = np.concatenate([short_sin, long_sin], axis=0)
         super().__init__(cos_cache, sin_cache, dtype=config.dtype)
 
-    def forward(self, op: builder.OpBuilder, position_ids: ir.Value):
+    def forward(self, op: OpBuilder, position_ids: ir.Value):
         if self.has_long_cache:
             max_pos = op.ReduceMax(position_ids, keepdims=False)
             use_long = op.Cast(
@@ -389,7 +388,7 @@ class YarnRope(BaseRope):
         self._llama4_beta = rope_scaling.get("llama_4_scaling_beta")
         self._llama4_original_max_pos = float(original_max_pos)
 
-    def forward(self, op: builder.OpBuilder, position_ids: ir.Value):
+    def forward(self, op: OpBuilder, position_ids: ir.Value):
         cos, sin = get_rotary_pos_emb(op, position_ids, self.cos_cache, self.sin_cache)
         cos, sin = self._cast_embeddings(op, cos, sin)
         if self._llama4_beta is None:
@@ -444,7 +443,7 @@ class _MRopeBase(BaseRope):
             data=ir.tensor(w_mask),
         )
 
-    def forward(self, op: builder.OpBuilder, position_ids: ir.Value):
+    def forward(self, op: OpBuilder, position_ids: ir.Value):
         """Compute MRoPE cos/sin embeddings.
 
         Args:

--- a/src/mobius/components/_sam_vision.py
+++ b/src/mobius/components/_sam_vision.py
@@ -21,8 +21,7 @@ from __future__ import annotations
 
 import numpy as np
 import onnx_ir as ir
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components._common import Linear
 from mobius.components._mlp import FCMLP
@@ -51,7 +50,7 @@ class _SAMPatchEmbed(nn.Module):
         self.bias = nn.Parameter((embed_dim,), name="proj.bias")
         self._kernel_size = kernel_size
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         # (B, 3, H, W) → (B, embed_dim, H/16, W/16)
         x = op.Conv(
             x,
@@ -79,7 +78,7 @@ class _SAMLayerNorm2d(nn.Module):
         self._eps = eps
         self._num_channels = num_channels
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         # x: (B, C, H, W) — normalize over C dimension
         # Reshape to (B, C, H*W), normalize, reshape back
         # Or use InstanceNormalization which normalizes per-channel
@@ -139,7 +138,7 @@ class _SAMAttention(nn.Module):
         relative_coords = q_coords - k_coords + (k_size - 1)
         return relative_coords.astype(np.int64)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         # x: (B, H, W, C)
         # Flatten spatial dims for attention
         B = op.Shape(x, start=0, end=1)  # noqa: N806
@@ -289,7 +288,7 @@ class _SAMBlock(nn.Module):
             self._Hp = H + self._pad_h
             self._Wp = W + self._pad_w
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         # x: (B, H, W, C)
         shortcut = x
         x = self.norm1(op, x)
@@ -366,7 +365,7 @@ class _SAMLayerNorm(nn.Module):
         self.bias = nn.Parameter([hidden_size])
         self._eps = eps
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return op.LayerNormalization(x, self.weight, self.bias, epsilon=self._eps, axis=-1)
 
 
@@ -387,7 +386,7 @@ class _SAMConv2dNoBias(nn.Module):
         self._stride = stride
         self._padding = padding
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         p = self._padding
         return op.Conv(
             x,
@@ -487,7 +486,7 @@ class SAMVisionEncoder(nn.Module):
                 padding=1,
             )
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         # pixel_values: (B, 3, 1024, 1024)
         # → (B, 64, 64, 768)
         x = self.patch_embed(op, pixel_values)

--- a/src/mobius/components/_sanm_attention.py
+++ b/src/mobius/components/_sanm_attention.py
@@ -24,8 +24,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components._common import LayerNorm, Linear
 
@@ -50,7 +49,7 @@ class _FSMNBlock(nn.Module):
         self._n_feat = n_feat
         self._kernel_size = kernel_size
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, x: ir.Value) -> ir.Value:
         """Apply depthwise Conv1d.
 
         Args:
@@ -111,7 +110,7 @@ class SANMAttention(nn.Module):
         self._n_heads = n_heads
         self._head_dim = out_size // n_heads
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, hidden_states: ir.Value) -> ir.Value:
         # hidden_states: [B, T, in_size]
 
         # Fused QKV → [B, T, 3 * out_size]
@@ -157,7 +156,7 @@ class SANMFFN(nn.Module):
         self.w_1 = Linear(hidden_size, ffn_dim, bias=True)
         self.w_2 = Linear(ffn_dim, hidden_size, bias=True)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, x: ir.Value) -> ir.Value:
         # x: [B, T, hidden_size]
         return self.w_2(op, op.Relu(self.w_1(op, x)))  # [B, T, hidden_size]
 
@@ -198,7 +197,7 @@ class SANMEncoderLayer(nn.Module):
         # so the residual around the attention block must be skipped.
         self._has_residual = in_size == out_size
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, hidden_states: ir.Value) -> ir.Value:
         # hidden_states: [B, T, in_size]
 
         # Pre-norm attention with optional residual

--- a/src/mobius/components/_scan_utils.py
+++ b/src/mobius/components/_scan_utils.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import onnx_ir as ir
-from onnxscript._internal import builder
+from onnxscript import GraphBuilder
 
 from mobius._constants import OPSET_VERSION
 
@@ -25,7 +25,7 @@ def create_body_graph(
     state_inputs: Sequence[ir.Value],
     scan_inputs: Sequence[ir.Value],
     name: str = "scan_body",
-) -> tuple[ir.Graph, builder.GraphBuilder]:
+) -> tuple[ir.Graph, GraphBuilder]:
     """Create a Scan body graph and its builder.
 
     Args:
@@ -45,7 +45,7 @@ def create_body_graph(
         name=name,
         opset_imports={"": OPSET_VERSION},
     )
-    body_builder = builder.GraphBuilder(body_graph)
+    body_builder = GraphBuilder(body_graph)
     return body_graph, body_builder
 
 

--- a/src/mobius/components/_ssm.py
+++ b/src/mobius/components/_ssm.py
@@ -29,8 +29,7 @@ HuggingFace reference: ``MambaMixer`` (SSM portion).
 from __future__ import annotations
 
 import onnx_ir as ir
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components._common import Linear
 
@@ -60,7 +59,7 @@ class SelectiveScan(nn.Module):
         # D: (d_inner,) — skip connection / feedthrough
         self.D = nn.Parameter([d_inner])
 
-    def _project_ssm_params(self, op: builder.OpBuilder, x_db):
+    def _project_ssm_params(self, op: OpBuilder, x_db):
         """Split x_proj output into dt_raw, B, C.
 
         Subclasses can override to apply extra transformations (e.g.
@@ -83,7 +82,7 @@ class SelectiveScan(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         x: ir.Value,
         ssm_state: ir.Value,
     ):
@@ -230,7 +229,7 @@ class Mamba2Scan(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         dt_input: ir.Value,
         b_mat: ir.Value,
@@ -327,7 +326,7 @@ class _RMSNorm(nn.Module):
         self.weight = nn.Parameter([size])
         self._eps = eps
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         # Upcast to fp32 for variance computation (matching HF RMSNorm).
         x_f32 = op.Cast(x, to=ir.DataType.FLOAT)
         variance = op.ReduceMean(op.Mul(x_f32, x_f32), [-1], keepdims=True)

--- a/src/mobius/components/_vision.py
+++ b/src/mobius/components/_vision.py
@@ -16,8 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._mlp import FCMLP
@@ -56,7 +55,7 @@ class PatchEmbedding(nn.Module):
             name="position_embedding.weight",
         )
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         # pixel_values: [batch, channels, height, width]
         # Conv2d: extract patches
         patches = op.Conv(
@@ -103,7 +102,7 @@ class VisionAttention(nn.Module):
         self.v_proj = _VisionLinear(hidden_size, hidden_size)
         self.out_proj = _VisionLinear(hidden_size, hidden_size)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # hidden_states: [batch, seq_len, hidden_size]
         q = self.q_proj(op, hidden_states)
         k = self.k_proj(op, hidden_states)
@@ -136,7 +135,7 @@ class _VisionLinear(nn.Module):
         self.weight = nn.Parameter([out_features, in_features])
         self.bias = nn.Parameter([out_features])
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         weight_t = op.Transpose(self.weight, perm=[1, 0])
         result = op.MatMul(x, weight_t)
         return op.Add(result, self.bias)
@@ -151,7 +150,7 @@ class VisionLayerNorm(nn.Module):
         self.bias = nn.Parameter([hidden_size])
         self.eps = eps
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         return op.LayerNormalization(
             hidden_states,
             self.weight,
@@ -190,7 +189,7 @@ class VisionEncoderLayer(nn.Module):
             linear_class=_VisionLinear,
         )
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         residual = hidden_states
         hidden_states = self.layer_norm1(op, hidden_states)
         hidden_states = self.self_attn(op, hidden_states)
@@ -222,7 +221,7 @@ class VisionEncoder(nn.Module):
             ]
         )
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         for layer in self.layers:
             hidden_states = layer(op, hidden_states)
         return hidden_states
@@ -261,7 +260,7 @@ class _VisionModelInner(nn.Module):
         )
         self.post_layernorm = VisionLayerNorm(vc.hidden_size, eps=vc.norm_eps)
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         hidden_states = self.embeddings(op, pixel_values)
         hidden_states = self.encoder(op, hidden_states)
         hidden_states = self.post_layernorm(op, hidden_states)
@@ -282,5 +281,5 @@ class VisionModel(nn.Module):
         super().__init__()
         self.vision_model = _VisionModelInner(config)
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         return self.vision_model(op, pixel_values)

--- a/src/mobius/components/_whisper.py
+++ b/src/mobius/components/_whisper.py
@@ -14,8 +14,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components._common import LayerNorm, Linear
 
@@ -41,7 +40,7 @@ class Conv1d(nn.Module):
         self._strides = [stride]
         self._pads = [padding, padding]
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         # x: [batch, in_channels, seq_len]
         return op.Conv(
             x,
@@ -77,7 +76,7 @@ class WhisperAttention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         key_value_states: ir.Value | None = None,
         past_key_value: tuple | None = None,
@@ -141,7 +140,7 @@ class WhisperEncoderLayer(nn.Module):
         self.final_layer_norm = LayerNorm(d_model, eps=eps)
         self._activation = activation
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         residual = hidden_states
         hidden_states = self.self_attn_layer_norm(op, hidden_states)
         hidden_states, _ = self.self_attn(op, hidden_states)
@@ -186,7 +185,7 @@ class WhisperDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         encoder_hidden_states: ir.Value,
         past_key_value: tuple | None = None,

--- a/src/mobius/functions/causal_conv.py
+++ b/src/mobius/functions/causal_conv.py
@@ -13,7 +13,7 @@ Op spec: https://github.com/onnx/onnx/issues/7689
 from __future__ import annotations
 
 import onnx_ir as ir
-from onnxscript._internal import builder
+from onnxscript._internal.builder import build_function
 
 from mobius._constants import OPSET_VERSION
 
@@ -142,7 +142,7 @@ def causal_conv_nd_with_state(
     # NOTE: Do not set ``overload`` here — call sites (op.CausalConvWithState)
     # do not set an overload, so setting one on the function would prevent the
     # serializer from matching nodes to this function definition.
-    return builder.build_function(
+    return build_function(
         body,
         [
             ir.Value(name="input"),

--- a/src/mobius/functions/linear_attention.py
+++ b/src/mobius/functions/linear_attention.py
@@ -32,7 +32,7 @@ Op spec: https://github.com/onnx/onnx/issues/7689
 from __future__ import annotations
 
 import onnx_ir as ir
-from onnxscript._internal import builder
+from onnxscript._internal.builder import build_function
 
 from mobius._constants import OPSET_VERSION
 from mobius.components._scan_utils import (
@@ -224,7 +224,7 @@ def linear_attention(
         return output, present_state_v
 
     # --- Build the ir.Function ---
-    return builder.build_function(
+    return build_function(
         body,
         inputs,
         domain=DOMAIN,

--- a/src/mobius/functions/packed_multi_head_attention.py
+++ b/src/mobius/functions/packed_multi_head_attention.py
@@ -36,7 +36,7 @@ Attributes:
 from __future__ import annotations
 
 import onnx_ir as ir
-from onnxscript._internal import builder
+from onnxscript._internal.builder import build_function
 
 from mobius._constants import OPSET_VERSION
 
@@ -153,7 +153,7 @@ def packed_multi_head_attention() -> ir.Function:
         # (1, token_count, v_hidden) → (token_count, v_hidden)
         return op.Squeeze(attention_output, [0])
 
-    return builder.build_function(
+    return build_function(
         body,
         [
             ir.Value(name="query"),

--- a/src/mobius/functions/skip_layer_normalization.py
+++ b/src/mobius/functions/skip_layer_normalization.py
@@ -20,7 +20,7 @@ Naming convention:
 from __future__ import annotations
 
 import onnx_ir as ir
-from onnxscript._internal import builder
+from onnxscript._internal.builder import build_function
 
 from mobius._constants import OPSET_VERSION
 
@@ -68,7 +68,7 @@ def skip_layer_normalization() -> ir.Function:
         add_out.name = "add_out"
         return norm_out, mean_out, inv_std_out, add_out
 
-    return builder.build_function(
+    return build_function(
         body,
         [
             ir.Value(name="input"),
@@ -114,7 +114,7 @@ def skip_simplified_layer_normalization() -> ir.Function:
         add_out.name = "add_out"
         return norm_out, add_out
 
-    return builder.build_function(
+    return build_function(
         body,
         [
             ir.Value(name="input"),

--- a/src/mobius/models/adapters.py
+++ b/src/mobius/models/adapters.py
@@ -13,8 +13,7 @@ import dataclasses
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components import Conv2d as _Conv2d
 from mobius.components import GroupNorm as _GroupNorm
@@ -57,7 +56,7 @@ class _T2IAdapterBlock(nn.Module):
         for _ in range(num_res_blocks):
             self.resnets.append(_SimpleResBlock(out_channels))
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         if self.downsample is not None:
             hidden_states = self.downsample(op, hidden_states)
         for resnet in self.resnets:
@@ -76,7 +75,7 @@ class _SimpleResBlock(nn.Module):
         self.conv2 = _Conv2d(channels, channels)
         self._silu = _SiLU()
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         residual = hidden_states
         hidden_states = self.norm1(op, hidden_states)
         hidden_states = self._silu(op, hidden_states)
@@ -121,7 +120,7 @@ class T2IAdapterModel(nn.Module):
                 _Conv2d(channels[i], channels[i], kernel_size=3, stride=2, padding=1)
             )
 
-    def forward(self, op: builder.OpBuilder, condition: ir.Value):
+    def forward(self, op: OpBuilder, condition: ir.Value):
         """Forward pass: conditioning image → multi-scale features.
 
         Args:
@@ -189,7 +188,7 @@ class IPAdapterModel(nn.Module):
             config.num_tokens,
         )
 
-    def forward(self, op: builder.OpBuilder, image_embeds: ir.Value):
+    def forward(self, op: OpBuilder, image_embeds: ir.Value):
         """Project image embeddings to cross-attention tokens.
 
         Args:
@@ -217,7 +216,7 @@ class _ImageProjection(nn.Module):
         self._num_tokens = num_tokens
         self._cross_dim = cross_attention_dim
 
-    def forward(self, op: builder.OpBuilder, image_embeds: ir.Value):
+    def forward(self, op: OpBuilder, image_embeds: ir.Value):
         # [B, image_dim] → [B, num_tokens * cross_dim] → [B, num_tokens, cross_dim]
         hidden = self.proj(op, image_embeds)
         batch = op.Shape(hidden, start=0, end=1)
@@ -239,5 +238,5 @@ class _LayerNorm1D(nn.Module):
         self.bias = nn.Parameter((dim,))
         self._eps = eps
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return op.LayerNormalization(x, self.weight, self.bias, axis=-1, epsilon=self._eps)

--- a/src/mobius/models/apertus.py
+++ b/src/mobius/models/apertus.py
@@ -15,8 +15,7 @@ import dataclasses
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._common import Linear
@@ -44,7 +43,7 @@ class XIELUActivation(nn.Module):
         self.beta = nn.Parameter([1])
         self.eps = nn.Parameter([1])
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, x: ir.Value) -> ir.Value:
         # Learnable activation scales
         alpha_p_act = op.Softplus(self.alpha_p)
         alpha_n_act = op.Add(op.Softplus(self.alpha_n), self.beta)
@@ -76,7 +75,7 @@ class ApertusFCMLP(nn.Module):
         self.down_proj = Linear(config.intermediate_size, config.hidden_size, bias=False)
         self.act_fn = XIELUActivation()
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, x: ir.Value) -> ir.Value:
         x = self.up_proj(op, x)
         x = self.act_fn(op, x)
         return self.down_proj(op, x)

--- a/src/mobius/models/bamba.py
+++ b/src/mobius/models/bamba.py
@@ -31,8 +31,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import BambaConfig
 from mobius.components import (
@@ -85,7 +84,7 @@ class BambaMambaDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -135,7 +134,7 @@ class BambaAttentionDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -196,7 +195,7 @@ class _BambaTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -251,7 +250,7 @@ class BambaCausalLMModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/bart.py
+++ b/src/mobius/models/bart.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._activations import ACT2FN
@@ -38,7 +37,7 @@ class _BartEncoderBlock(nn.Module):
         self.final_layer_norm = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
         self._act_fn = ACT2FN[config.hidden_act]
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         residual = hidden_states
         hidden_states, _ = self.self_attn(op, hidden_states)
         hidden_states = op.Add(residual, hidden_states)
@@ -70,7 +69,7 @@ class _BartDecoderBlock(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         encoder_hidden_states: ir.Value,
         past_key_value: tuple | None = None,
@@ -128,7 +127,7 @@ class _BartEncoder(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value | None = None,
     ):
@@ -172,7 +171,7 @@ class _BartDecoder(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         encoder_hidden_states: ir.Value,
         position_ids: ir.Value | None = None,

--- a/src/mobius/models/base.py
+++ b/src/mobius/models/base.py
@@ -15,8 +15,7 @@ from __future__ import annotations
 
 import onnx_ir as ir
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._build_context import ep_capabilities, get_build_dtype
 from mobius._configs import ArchitectureConfig, CausalLMConfig
@@ -72,7 +71,7 @@ class TextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value | None,
         position_ids: ir.Value,
@@ -210,7 +209,7 @@ class CausalLMModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value | None,
         position_ids: ir.Value,

--- a/src/mobius/models/bert.py
+++ b/src/mobius/models/bert.py
@@ -20,8 +20,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._activations import ACT2FN
@@ -73,9 +72,7 @@ class _BertAttention(nn.Module):
         self.self = self_attn
         self.output = _BertAttentionOutput(hidden_size, eps, bias)
 
-    def forward(
-        self, op: builder.OpBuilder, hidden_states: ir.Value, attention_mask: ir.Value
-    ):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value, attention_mask: ir.Value):
         self_attn = self.self
         query = self_attn.query(op, hidden_states)
         key = self_attn.key(op, hidden_states)
@@ -109,7 +106,7 @@ class _BertIntermediate(nn.Module):
         self.dense = Linear(hidden_size, intermediate_size, bias=bias)
         self._act_fn = ACT2FN[hidden_act]
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         return self._act_fn(op, self.dense(op, hidden_states))
 
 
@@ -149,7 +146,7 @@ class _BertEncoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_mask: ir.Value | None = None,
     ):
@@ -181,7 +178,7 @@ class _BertEmbeddings(nn.Module):
         # Capital 'LayerNorm' matches HF BERT naming
         self.LayerNorm = LayerNorm(hidden_size, eps=layer_norm_eps)
 
-    def forward(self, op: builder.OpBuilder, input_ids: ir.Value, token_type_ids: ir.Value):
+    def forward(self, op: OpBuilder, input_ids: ir.Value, token_type_ids: ir.Value):
         word_embeds = self.word_embeddings(op, input_ids)
         seq_len = op.Shape(input_ids, start=1, end=2)
         position_ids = op.Range(
@@ -232,7 +229,7 @@ class BertModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         token_type_ids: ir.Value,
@@ -276,9 +273,7 @@ class _BertEncoder(nn.Module):
             ]
         )
 
-    def forward(
-        self, op: builder.OpBuilder, hidden_states: ir.Value, attention_mask: ir.Value
-    ):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value, attention_mask: ir.Value):
         for layer in self.layer:
             hidden_states = layer(op, hidden_states, attention_mask)
         return hidden_states

--- a/src/mobius/models/blip2.py
+++ b/src/mobius/models/blip2.py
@@ -34,8 +34,7 @@ import re
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius._weight_utils import vlm_decoder_weights, vlm_embedding_weights
@@ -62,7 +61,7 @@ class _Blip2DecoderModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         inputs_embeds: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -111,7 +110,7 @@ class _Blip2VisionEncoderModel(nn.Module):
         # Project Q-Former output to text embedding dimension
         self.language_projection = Linear(qformer_hidden, config.hidden_size)
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         # ViT: [batch, C, H, W] → [batch, num_patches, vision_hidden_size]
         vision_features = self.vision_model(op, pixel_values)
         # Q-Former: cross-attend → [batch, num_query_tokens, qformer_hidden_size]
@@ -155,7 +154,7 @@ class _Blip2EmbeddingModel(nn.Module):
         )
         self.image_token_id = config.image_token_id or 0
 
-    def forward(self, op: builder.OpBuilder, input_ids: ir.Value, image_features: ir.Value):
+    def forward(self, op: OpBuilder, input_ids: ir.Value, image_features: ir.Value):
         text_embeds = self.embed_tokens(op, input_ids)
 
         image_mask = op.Equal(
@@ -200,7 +199,7 @@ class Blip2Model(nn.Module):
         self.vision_encoder = _Blip2VisionEncoderModel(config)
         self.embedding = _Blip2EmbeddingModel(config)
 
-    def forward(self, op: builder.OpBuilder, **kwargs):
+    def forward(self, op: OpBuilder, **kwargs):
         raise NotImplementedError(
             "Blip2Model uses VisionLanguageTask which calls "
             "each sub-module (decoder, vision_encoder, embedding) separately."

--- a/src/mobius/models/clip.py
+++ b/src/mobius/models/clip.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components import FCMLP
@@ -40,7 +39,7 @@ class _CLIPVisionEmbeddings(nn.Module):
         num_patches = (image_size // patch_size) ** 2
         self.position_embedding = Embedding(num_patches + 1, hidden_size)
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         patch_embeds = self.patch_embedding(op, pixel_values)
         batch_size = op.Shape(pixel_values, start=0, end=1)
 
@@ -71,7 +70,7 @@ class _Conv2dPatchEmbed(nn.Module):
         super().__init__()
         self.projection = Conv2d(in_channels, out_channels, kernel_size, stride)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         # Conv2d: [batch, channels, H, W] -> [batch, out_channels, H', W']
         conv_out = self.projection(op, x)
         # Reshape [batch, out_channels, H', W'] -> [batch, num_patches, out_channels]
@@ -98,7 +97,7 @@ class _CLIPVisionEncoderLayer(nn.Module):
         )
         self.layer_norm2 = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         residual = hidden_states
         hidden_states = self.layer_norm1(op, hidden_states)
         hidden_states = self.self_attn(op, hidden_states)
@@ -129,7 +128,7 @@ class CLIPVisionModel(nn.Module):
         self.pre_layrnorm = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_layernorm = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         hidden_states = self.embeddings(op, pixel_values)
         hidden_states = self.pre_layrnorm(op, hidden_states)
 
@@ -230,7 +229,7 @@ class _SigLIPVisionEmbeddings(nn.Module):
         num_patches = (image_size // patch_size) ** 2
         self.position_embedding = Embedding(num_patches, hidden_size)
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         patch_embeds = self.patch_embedding(op, pixel_values)
         # Position IDs: [0, 1, ..., num_patches-1]
         seq_len = op.Shape(patch_embeds, start=1, end=2)
@@ -260,7 +259,7 @@ class SigLIPVisionModel(nn.Module):
         )
         self.post_layernorm = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         hidden_states = self.embeddings(op, pixel_values)
 
         for layer in self.encoder:
@@ -344,7 +343,7 @@ class _CLIPTextEmbeddings(nn.Module):
         self.word_embeddings = Embedding(config.vocab_size, config.hidden_size)
         self.position_embedding = Embedding(config.max_position_embeddings, config.hidden_size)
 
-    def forward(self, op: builder.OpBuilder, input_ids: ir.Value):
+    def forward(self, op: OpBuilder, input_ids: ir.Value):
         token_embeds = self.word_embeddings(op, input_ids)
         seq_len = op.Shape(input_ids, start=1, end=2)
         position_ids = op.Range(
@@ -374,7 +373,7 @@ class _CLIPTextEncoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_mask: ir.Value | None = None,
     ):
@@ -410,7 +409,7 @@ class CLIPTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         token_type_ids: ir.Value,  # Unused but required by FeatureExtractionTask interface

--- a/src/mobius/models/cogvideox.py
+++ b/src/mobius/models/cogvideox.py
@@ -25,8 +25,7 @@ import math
 import numpy as np
 import onnx_ir as ir
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._diffusers_configs import CogVideoXConfig
 from mobius.components import LayerNorm as _LayerNorm
@@ -144,7 +143,7 @@ class _CogVideoXLayerNormZero(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         encoder_hidden_states: ir.Value,
         temb: ir.Value,
@@ -192,7 +191,7 @@ class _CogVideoXOutputNorm(nn.Module):
         self.linear = _Linear(conditioning_dim, output_dim * 2, bias=True)
         self._silu = _SiLU()
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value, temb: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value, temb: ir.Value):
         emb = self._silu(op, temb)
         emb = self.linear(op, emb)
         # CogVideoX shift-first order
@@ -227,9 +226,7 @@ class _CogVideoXAttention(nn.Module):
         self._num_heads = num_heads
         self._head_dim = head_dim
 
-    def forward(
-        self, op: builder.OpBuilder, hidden_states: ir.Value, encoder_hidden_states: ir.Value
-    ):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value, encoder_hidden_states: ir.Value):
         text_seq_len = op.Shape(encoder_hidden_states, start=1, end=2)
 
         # Concatenate text + video for shared projection
@@ -301,7 +298,7 @@ class _CogVideoXFFN(nn.Module):
         self.gelu_proj = _Linear(hidden_size, intermediate_size)
         self.linear_out = _Linear(intermediate_size, hidden_size)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         hidden_states = self.gelu_proj(op, hidden_states)
         hidden_states = op.Gelu(hidden_states)
         hidden_states = self.linear_out(op, hidden_states)
@@ -337,7 +334,7 @@ class _CogVideoXBlock(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         encoder_hidden_states: ir.Value,
         temb: ir.Value,
@@ -426,7 +423,7 @@ class _CogVideoXPatchEmbed(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         text_embeds: ir.Value,
         video: ir.Value,
     ):
@@ -545,7 +542,7 @@ class CogVideoXTransformer3DModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         sample: ir.Value,
         timestep: ir.Value,
         encoder_hidden_states: ir.Value,
@@ -595,7 +592,7 @@ class CogVideoXTransformer3DModel(nn.Module):
 
         return hidden_states
 
-    def _unpatchify(self, op: builder.OpBuilder, x, batch, num_frames, height, width):
+    def _unpatchify(self, op: OpBuilder, x, batch, num_frames, height, width):
         """Reshape patch tokens back to video: [B, T, C, H, W]."""
         p = self.config.patch_size
         c = self.config.out_channels
@@ -630,7 +627,7 @@ class CogVideoXTransformer3DModel(nn.Module):
         )
         return x
 
-    def _get_timestep_embedding(self, op: builder.OpBuilder, timestep):
+    def _get_timestep_embedding(self, op: OpBuilder, timestep):
         """Sinusoidal timestep embedding (flip_sin_to_cos=True)."""
         half_dim = self._time_proj_dim // 2
         exponent = -math.log(10000.0) / half_dim

--- a/src/mobius/models/cohere.py
+++ b/src/mobius/models/cohere.py
@@ -22,8 +22,7 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components import MLP, Attention, LayerNorm, LayerNormNoBias, StaticCacheState
@@ -49,7 +48,7 @@ class _CohereDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None,
         position_embeddings: tuple,
@@ -114,7 +113,7 @@ class CohereCausalLMModel(LayerNormCausalLMModel):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value | None,
         position_ids: ir.Value,

--- a/src/mobius/models/controlnet.py
+++ b/src/mobius/models/controlnet.py
@@ -23,8 +23,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components import Conv2d as _BaseConv2d
 from mobius.components import SiLU as _SiLU
@@ -86,7 +85,7 @@ class _ControlNetConditioningEmbedding(nn.Module):
         )
         self._silu = _SiLU()
 
-    def forward(self, op: builder.OpBuilder, conditioning: ir.Value):
+    def forward(self, op: OpBuilder, conditioning: ir.Value):
         hidden = self.conv_in(op, conditioning)
         hidden = self._silu(op, hidden)
         for block in self.blocks:
@@ -180,7 +179,7 @@ class ControlNetModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         sample: ir.Value,
         timestep: ir.Value,
         encoder_hidden_states: ir.Value,

--- a/src/mobius/models/deepseek.py
+++ b/src/mobius/models/deepseek.py
@@ -12,8 +12,7 @@ import dataclasses
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components import (
@@ -64,7 +63,7 @@ class DeepSeekMoEGate(nn.Module):
         if self.scoring_func == "sigmoid":
             self.e_score_correction_bias = nn.Parameter([self.num_experts])
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # Compute routing logits: hidden @ weight^T
         weight_t = op.Transpose(self.weight, perm=[1, 0])
         router_logits = op.MatMul(
@@ -164,7 +163,7 @@ class DeepSeekMLADecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -211,7 +210,7 @@ class _DeepSeekStandardDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -255,7 +254,7 @@ class _DeepSeekMoEFFN(nn.Module):
         shared_intermediate = config.moe_intermediate_size * n_shared
         self.shared_experts = _SharedExpertMLP(config, shared_intermediate)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         moe_output = self.moe(op, hidden_states)
         shared_output = self.shared_experts(op, hidden_states)
         return op.Add(moe_output, shared_output)
@@ -270,7 +269,7 @@ class _SharedExpertMLP(nn.Module):
         self.up_proj = Linear(config.hidden_size, intermediate_size, bias=False)
         self.down_proj = Linear(intermediate_size, config.hidden_size, bias=False)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         gate_out = self.gate_proj(op, hidden_states)
         # SiLU = x * sigmoid(x)
         gate = op.Mul(gate_out, op.Sigmoid(gate_out))
@@ -322,7 +321,7 @@ class DeepSeekV3TextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/deepseek_ocr2.py
+++ b/src/mobius/models/deepseek_ocr2.py
@@ -21,8 +21,7 @@ from __future__ import annotations
 import numpy as np
 import onnx_ir as ir
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components import (
@@ -79,7 +78,7 @@ class _Qwen2EncoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -173,7 +172,7 @@ class _Qwen2DecoderAsEncoder(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         sam_features: ir.Value,
     ):
         # sam_features: (B, 896, H_sam, W_sam) — e.g., (B, 896, 16, 16)
@@ -313,7 +312,7 @@ class DeepSeekOCR2VisionEncoderModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         pixel_values: ir.Value,
     ):
         # SAM: (B, 3, 1024, 1024) → (B, 896, 16, 16)
@@ -384,7 +383,7 @@ class DeepSeekOCR2EmbeddingModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         image_features: ir.Value,
     ):
@@ -456,7 +455,7 @@ class DeepSeekOCR2DecoderModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         inputs_embeds: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/depth_anything.py
+++ b/src/mobius/models/depth_anything.py
@@ -16,8 +16,7 @@ import re
 import numpy as np
 import onnx_ir as ir
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig, DepthAnythingConfig
 from mobius.components import (
@@ -61,7 +60,7 @@ class _ViTBackbone(nn.Module):
         # 1-indexed out_indices (layer 1 = after first layer)
         self.out_indices = config.backbone_out_indices or []
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         patch_embeds = self.patch_embeddings(op, pixel_values)
         batch_size = op.Shape(patch_embeds, start=0, end=1)
 
@@ -90,7 +89,7 @@ class _Conv2dPatchEmbed(nn.Module):
         super().__init__()
         self.projection = Conv2d(in_channels, hidden_size, patch_size, patch_size)
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         x = self.projection(op, pixel_values)
         batch = op.Shape(x, start=0, end=1)
         hidden = op.Shape(x, start=1, end=2)
@@ -117,7 +116,7 @@ class _ViTEncoderLayer(nn.Module):
             activation=config.hidden_act,
         )
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         residual = hidden_states
         hidden_states = self.layernorm_before(op, hidden_states)
         hidden_states = self.self_attn(op, hidden_states)
@@ -153,7 +152,7 @@ class _ReassembleLayer(nn.Module):
         else:
             self.resize = None  # Identity
 
-    def forward(self, op: builder.OpBuilder, hidden_state: ir.Value):
+    def forward(self, op: OpBuilder, hidden_state: ir.Value):
         hidden_state = self.projection(op, hidden_state)
         if self.resize is not None:
             hidden_state = self.resize(op, hidden_state)
@@ -168,7 +167,7 @@ class _PreActResidualLayer(nn.Module):
         self.convolution1 = Conv2d(channels, channels, kernel_size=3, padding=1)
         self.convolution2 = Conv2d(channels, channels, kernel_size=3, padding=1)
 
-    def forward(self, op: builder.OpBuilder, hidden_state: ir.Value):
+    def forward(self, op: OpBuilder, hidden_state: ir.Value):
         residual = hidden_state
         hidden_state = op.Relu(hidden_state)
         hidden_state = self.convolution1(op, hidden_state)
@@ -188,7 +187,7 @@ class _FeatureFusionLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_state: ir.Value,
         residual: ir.Value | None = None,
         scale_factor: int = 2,
@@ -247,7 +246,7 @@ class _DepthAnythingNeck(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         patch_height: ir.Value,
         patch_width: ir.Value,
@@ -303,7 +302,7 @@ class _DepthEstimationHead(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         patch_height: ir.Value,
         patch_width: ir.Value,
@@ -360,7 +359,7 @@ class DepthAnythingForDepthEstimation(nn.Module):
         self.neck = _DepthAnythingNeck(config)
         self.head = _DepthEstimationHead(config)
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         feature_maps = self.backbone(op, pixel_values)
 
         patch_height = op.Constant(value_int=self.config.image_size // self._patch_size)

--- a/src/mobius/models/diffllama.py
+++ b/src/mobius/models/diffllama.py
@@ -7,8 +7,7 @@ import math
 
 import numpy as np
 import onnx_ir as ir
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._common import Linear
@@ -79,7 +78,7 @@ class DiffLlamaAttention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None,
         position_embeddings: tuple | None = None,

--- a/src/mobius/models/distilbert.py
+++ b/src/mobius/models/distilbert.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components import FCMLP
@@ -31,7 +30,7 @@ class _DistilBertEmbeddings(nn.Module):
         )
         self.LayerNorm = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
 
-    def forward(self, op: builder.OpBuilder, input_ids: ir.Value):
+    def forward(self, op: OpBuilder, input_ids: ir.Value):
         word_embeds = self.word_embeddings(op, input_ids)
 
         seq_len = op.Shape(input_ids, start=1, end=2)
@@ -62,7 +61,7 @@ class _DistilBertEncoderLayer(nn.Module):
         )
         self.output_layer_norm = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # Self-attention with post-norm
         attn_output = self.attention(op, hidden_states)
         hidden_states = self.sa_layer_norm(op, op.Add(hidden_states, attn_output))
@@ -93,7 +92,7 @@ class DistilBertModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value | None = None,
         token_type_ids: ir.Value | None = None,
@@ -122,7 +121,7 @@ class _DistilBertEncoder(nn.Module):
             [_DistilBertEncoderLayer(config) for _ in range(config.num_hidden_layers)]
         )
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         for layer in self.layer:
             hidden_states = layer(op, hidden_states)
         return hidden_states

--- a/src/mobius/models/dit.py
+++ b/src/mobius/models/dit.py
@@ -22,8 +22,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components import LayerNorm as _LayerNorm
 from mobius.components import Linear as _Linear
@@ -102,9 +101,7 @@ class _DiTCrossAttention(nn.Module):
         self._num_heads = num_heads
         self._head_dim = hidden_size // num_heads
 
-    def forward(
-        self, op: builder.OpBuilder, hidden_states: ir.Value, encoder_hidden_states: ir.Value
-    ):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value, encoder_hidden_states: ir.Value):
         normed = self.norm(op, hidden_states)
         q = self.to_q(op, normed)
         k = self.to_k(op, encoder_hidden_states)
@@ -135,7 +132,7 @@ class _DiTBlock(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         encoder_hidden_states: ir.Value,
         temb: ir.Value,
@@ -230,7 +227,7 @@ class DiTTransformer2DModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         sample: ir.Value,
         timestep: ir.Value,
         encoder_hidden_states: ir.Value,
@@ -269,7 +266,7 @@ class DiTTransformer2DModel(nn.Module):
 
         return hidden_states
 
-    def _get_timestep_embedding(self, op: builder.OpBuilder, timestep):
+    def _get_timestep_embedding(self, op: OpBuilder, timestep):
         """Sinusoidal timestep embedding."""
         half_dim = self.time_proj_dim // 2
         exponent = -math.log(10000.0) / half_dim
@@ -280,7 +277,7 @@ class DiTTransformer2DModel(nn.Module):
         args = op.Mul(t, op.Unsqueeze(freq_const, [0]))
         return op.Concat(op.Cos(args), op.Sin(args), axis=-1)
 
-    def _unpatchify(self, op: builder.OpBuilder, hidden_states, original_input):
+    def _unpatchify(self, op: OpBuilder, hidden_states, original_input):
         """Reshape patches back to spatial dimensions."""
         p = self.config.patch_size
         c = self.config.out_channels

--- a/src/mobius/models/doge.py
+++ b/src/mobius/models/doge.py
@@ -24,8 +24,7 @@ import dataclasses
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._attention import Attention, StaticCacheState
@@ -62,7 +61,7 @@ class DogeAttention(Attention):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None,
         position_embeddings: tuple | None = None,
@@ -174,7 +173,7 @@ class DogeDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None,
         position_ids: ir.Value | None = None,
@@ -220,7 +219,7 @@ class DogeTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -270,7 +269,7 @@ class DogeCausalLMModel(CausalLMModel):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/falcon.py
+++ b/src/mobius/models/falcon.py
@@ -38,7 +38,7 @@ from mobius.components._common import Embedding, LayerNorm, Linear
 
 if TYPE_CHECKING:
     import onnx_ir as ir
-    from onnxscript._internal import builder
+    from onnxscript import OpBuilder
 
 
 class _ALiBiAttention(nn.Module):
@@ -72,7 +72,7 @@ class _ALiBiAttention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         past_key_value: tuple | None = None,
@@ -130,7 +130,7 @@ class _ALiBiDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         past_key_value: tuple | None = None,
@@ -195,7 +195,7 @@ class _FalconDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -333,7 +333,7 @@ class _FalconTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -401,7 +401,7 @@ class _BloomTextModel(_FalconTextModel):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -521,7 +521,7 @@ class FalconCausalLMModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/flux_sd3.py
+++ b/src/mobius/models/flux_sd3.py
@@ -17,8 +17,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components import LayerNorm as _LayerNorm
 from mobius.components import Linear as _Linear
@@ -108,7 +107,7 @@ class _JointAttentionBlock(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         encoder_hidden_states: ir.Value,
         temb: ir.Value,
@@ -203,7 +202,7 @@ class SD3Transformer2DModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         sample: ir.Value,
         timestep: ir.Value,
         encoder_hidden_states: ir.Value,
@@ -251,7 +250,7 @@ class SD3Transformer2DModel(nn.Module):
         )
         return hidden_states
 
-    def _get_timestep_embedding(self, op: builder.OpBuilder, timestep):
+    def _get_timestep_embedding(self, op: OpBuilder, timestep):
         half_dim = self.time_proj_dim // 2
         exponent = -math.log(10000.0) / half_dim
         freqs = np.exp(np.arange(half_dim) * exponent).astype(np.float32)
@@ -318,7 +317,7 @@ class _FluxSingleBlock(nn.Module):
         self.attn = _DiTSelfAttention(hidden_size, num_heads)
         self.ff = _DiTFFN(hidden_size)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value, temb: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value, temb: ir.Value):
         normed, shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.norm(
             op,
             hidden_states,
@@ -387,7 +386,7 @@ class FluxTransformer2DModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         sample: ir.Value,
         timestep: ir.Value,
         encoder_hidden_states: ir.Value,
@@ -455,7 +454,7 @@ class FluxTransformer2DModel(nn.Module):
         )
         return hidden_states
 
-    def _get_timestep_embedding(self, op: builder.OpBuilder, timestep):
+    def _get_timestep_embedding(self, op: OpBuilder, timestep):
         half_dim = self.time_proj_dim // 2
         exponent = -math.log(10000.0) / half_dim
         freqs = np.exp(np.arange(half_dim) * exponent).astype(np.float32)

--- a/src/mobius/models/fun_asr.py
+++ b/src/mobius/models/fun_asr.py
@@ -24,8 +24,7 @@ from __future__ import annotations
 import numpy as np
 import onnx_ir as ir
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._common import (
@@ -130,7 +129,7 @@ class FunASRAudioEncoder(nn.Module):
         # Adaptor: projects encoder hidden_dim (512) → LLM hidden_size (1024)
         self.adaptor = FunASRAudioAdaptor(config)
 
-    def forward(self, op: builder.OpBuilder, input_features: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, input_features: ir.Value) -> ir.Value:
         """Encode LFR-processed fbank features to LLM-dimension audio embeddings.
 
         Args:
@@ -202,7 +201,7 @@ class AdaptorAttention(nn.Module):
         self._n_heads = n_heads
         self._head_dim = hidden_size // n_heads
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, hidden_states: ir.Value) -> ir.Value:
         """Multi-head self-attention.
 
         Args:
@@ -251,7 +250,7 @@ class FunASRAdaptorBlock(nn.Module):
         self.norm2 = LayerNorm(hidden_size)
         self.feed_forward = SANMFFN(hidden_size, ffn_dim)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, hidden_states: ir.Value) -> ir.Value:
         # Pre-norm attention with residual
         residual = hidden_states
         hidden_states = self.norm1(op, hidden_states)
@@ -301,7 +300,7 @@ class FunASRAudioAdaptor(nn.Module):
             [FunASRAdaptorBlock(llm_hidden, ffn_dim, n_heads) for _ in range(num_blocks)]
         )
 
-    def forward(self, op: builder.OpBuilder, audio_features: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, audio_features: ir.Value) -> ir.Value:
         """Project audio features from encoder dim to LLM hidden dim.
 
         Args:
@@ -366,7 +365,7 @@ class FunASREmbeddingModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         audio_features: ir.Value,
     ) -> ir.Value:
@@ -438,7 +437,7 @@ class FunASRDecoderModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         inputs_embeds: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -514,7 +513,7 @@ class FunASRForConditionalGeneration(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/gemma.py
+++ b/src/mobius/models/gemma.py
@@ -15,8 +15,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig, Gemma2Config
 from mobius.components import (
@@ -48,7 +47,7 @@ class GemmaScaledWordEmbedding(Embedding):
         super().__init__(num_embeddings, embedding_dim, padding_idx)
         self.embed_scale = embed_scale
 
-    def forward(self, op: builder.OpBuilder, input_ids: ir.Value):
+    def forward(self, op: OpBuilder, input_ids: ir.Value):
         embeddings = super().forward(op, input_ids)
         return op.Mul(embeddings, self.embed_scale)
 
@@ -77,7 +76,7 @@ class GemmaTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -145,7 +144,7 @@ class Gemma2Attention(Attention):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple | None = None,
@@ -224,7 +223,7 @@ class Gemma2DecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -278,7 +277,7 @@ class Gemma2TextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -336,7 +335,7 @@ class Gemma2CausalLMModel(CausalLMModel):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/gemma3.py
+++ b/src/mobius/models/gemma3.py
@@ -15,8 +15,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius._weight_utils import vlm_decoder_weights, vlm_embedding_weights
@@ -46,7 +45,7 @@ class _Gemma3DecoderModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         inputs_embeds: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -87,7 +86,7 @@ class _Gemma3VisionEncoderModel(nn.Module):
             ),
         )
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         vision_features = self.vision_tower(op, pixel_values)
         return self.multi_modal_projector(op, vision_features)
 
@@ -125,7 +124,7 @@ class _Gemma3EmbeddingModel(nn.Module):
         )
         self.image_token_id = config.image_token_id or 0
 
-    def forward(self, op: builder.OpBuilder, input_ids: ir.Value, image_features: ir.Value):
+    def forward(self, op: OpBuilder, input_ids: ir.Value, image_features: ir.Value):
         text_embeds = self.embed_tokens(op, input_ids)
 
         image_mask = op.Equal(
@@ -167,7 +166,7 @@ class Gemma3MultiModalModel(nn.Module):
         self.vision_encoder = _Gemma3VisionEncoderModel(config)
         self.embedding = _Gemma3EmbeddingModel(config)
 
-    def forward(self, op: builder.OpBuilder, **kwargs):
+    def forward(self, op: OpBuilder, **kwargs):
         raise NotImplementedError(
             "Gemma3MultiModalModel uses VisionLanguageTask which calls "
             "each sub-module (decoder, vision_encoder, embedding) separately."

--- a/src/mobius/models/gemma3_text.py
+++ b/src/mobius/models/gemma3_text.py
@@ -8,8 +8,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components import (
@@ -39,7 +38,7 @@ class Gemma3TextScaledWordEmbedding(Embedding):
         super().__init__(num_embeddings, embedding_dim, padding_idx)
         self.embed_scale = embed_scale
 
-    def forward(self, op: builder.OpBuilder, input_ids: ir.Value):
+    def forward(self, op: OpBuilder, input_ids: ir.Value):
         embeddings = super().forward(op, input_ids)
         return op.Mul(embeddings, self.embed_scale)
 
@@ -64,7 +63,7 @@ class Gemma3DecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -124,7 +123,7 @@ class Gemma3TextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/gemma3n.py
+++ b/src/mobius/models/gemma3n.py
@@ -23,8 +23,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import Gemma3nConfig
 from mobius.components import (
@@ -60,7 +59,7 @@ class Gemma3nAttention(Attention):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states,
         attention_bias,
         position_embeddings=None,
@@ -142,7 +141,7 @@ class Gemma3nScaledWordEmbedding(Embedding):
         super().__init__(num_embeddings, embedding_dim, padding_idx)
         self.embed_scale = embed_scale
 
-    def forward(self, op: builder.OpBuilder, input_ids: ir.Value):
+    def forward(self, op: OpBuilder, input_ids: ir.Value):
         embeddings = super().forward(op, input_ids)
         return op.Mul(embeddings, self.embed_scale)
 
@@ -159,7 +158,7 @@ class Gemma3nLaurelBlock(nn.Module):
         self.linear_right = Linear(laurel_rank, hidden_size, bias=False)
         self.post_laurel_norm = RMSNorm(hidden_size, eps=eps)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         laurel_hidden = self.linear_left(op, hidden_states)
         laurel_hidden = self.linear_right(op, laurel_hidden)
         normed = self.post_laurel_norm(op, laurel_hidden)
@@ -193,14 +192,14 @@ class Gemma3nAltUp(nn.Module):
         self.router_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.router_input_scale = float(config.hidden_size**-1.0)
 
-    def _compute_router_modalities(self, op: builder.OpBuilder, x):
+    def _compute_router_modalities(self, op: OpBuilder, x):
         """Compute router modalities: tanh(router(norm(x) * scale))."""
         router_input = self.router_norm(op, x)
         router_input = op.Mul(router_input, self.router_input_scale)
         routed = self.modality_router(op, router_input)
         return op.Tanh(routed)
 
-    def predict(self, op: builder.OpBuilder, hidden_states_list: list):
+    def predict(self, op: OpBuilder, hidden_states_list: list):
         """Predict step: modify inputs using learned prediction coefficients.
 
         Args:
@@ -240,7 +239,7 @@ class Gemma3nAltUp(nn.Module):
             predictions.append(pred_i)
         return predictions
 
-    def correct(self, op: builder.OpBuilder, predictions: list, activated):
+    def correct(self, op: OpBuilder, predictions: list, activated):
         """Correct step: propagate transformer output to all predictions.
 
         Args:
@@ -266,7 +265,7 @@ class Gemma3nAltUp(nn.Module):
             corrected.append(corrected_i)
         return corrected
 
-    def scale_corrected_output(self, op: builder.OpBuilder, corrected, scale):
+    def scale_corrected_output(self, op: OpBuilder, corrected, scale):
         """Apply per-dimension scaling to the corrected output."""
         return op.Mul(corrected, scale)
 
@@ -306,7 +305,7 @@ class Gemma3nDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states_list: list,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -438,7 +437,7 @@ class Gemma3nTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -30,8 +30,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import onnx_ir as ir
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._build_context import ep_capabilities
 from mobius._configs import ArchitectureConfig, Gemma4Config
@@ -109,7 +108,7 @@ class _Gemma4ScaleFreeRMSNorm(nn.Module):
         # Constant all-ones scale (not a learnable parameter from HF).
         self.weight = nn.Parameter([dim], data=ir.Tensor(np.ones(dim, dtype=np.float32)))
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, hidden_states: ir.Value) -> ir.Value:
         # stash_type=1 means accumulate variance in float32, avoiding
         # FP16 overflow when squaring large values.
         # CastLike ensures the weight matches the input dtype.
@@ -194,7 +193,7 @@ class Gemma4VisionSelfAttention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None = None,
         pixel_position_ids: ir.Value | None = None,
@@ -349,7 +348,7 @@ class Gemma4VisionEncoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None = None,
         pixel_position_ids: ir.Value | None = None,
@@ -395,7 +394,7 @@ class Gemma4VisionPooler(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         vision_features: ir.Value,
         pixel_position_ids: ir.Value,
     ) -> ir.Value:
@@ -493,7 +492,7 @@ class _Gemma4VisionPatchEmbedder(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         pixel_values: ir.Value,
         pixel_position_ids: ir.Value,
     ) -> tuple[ir.Value, ir.Value]:
@@ -573,7 +572,7 @@ class _Gemma4VisionEncoderCore(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         pixel_values: ir.Value,
         pixel_position_ids: ir.Value,
     ) -> ir.Value:
@@ -702,7 +701,7 @@ class Gemma4TextAttention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | GQAContext,
         position_embeddings: tuple | None = None,
@@ -978,7 +977,7 @@ class _Gemma4MoeRouter(nn.Module):
         self.proj = Linear(hidden_size, num_experts, bias=False)
         self.per_expert_scale = nn.Parameter([num_experts])
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, hidden_states: ir.Value) -> ir.Value:
         """Compute router probabilities over all experts.
 
         Args:
@@ -1128,7 +1127,7 @@ class Gemma4DecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | GQAContext,
         position_embeddings: tuple | None,
@@ -1225,7 +1224,7 @@ class Gemma4DecoderLayer(nn.Module):
 
     def _dispatch_moe_fallback(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         normed_flat: ir.Value,
         router_probs: ir.Value,
     ) -> ir.Value:
@@ -1424,7 +1423,7 @@ class Gemma4TextModel(nn.Module):
 
     def _compute_per_layer_inputs(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value | None,
         inputs_embeds: ir.Value,
     ) -> list[ir.Value] | None:
@@ -1483,7 +1482,7 @@ class Gemma4TextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value | None,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -1666,7 +1665,7 @@ class Gemma4CausalLMModel(CausalLMModel):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -1741,7 +1740,7 @@ class _Gemma4DecoderModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         inputs_embeds: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -1801,7 +1800,7 @@ class _Gemma4VisionEncoderModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         pixel_values: ir.Value,
         pixel_position_ids: ir.Value,
     ) -> ir.Value:
@@ -1886,7 +1885,7 @@ class Gemma4EmbeddingModel(nn.Module):
 
     def _scatter_features(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden: ir.Value,
         input_ids: ir.Value,
         token_id: int,
@@ -1922,7 +1921,7 @@ class Gemma4EmbeddingModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         image_features: ir.Value,
         audio_features: ir.Value | None = None,
@@ -2009,7 +2008,7 @@ class _Gemma4AudioEncoderModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_features: ir.Value,
         input_features_mask: ir.Value | None = None,
     ) -> tuple[ir.Value, ir.Value | None]:
@@ -2071,7 +2070,7 @@ class Gemma4Model(nn.Module):
             _Gemma4AudioEncoderModel(config) if config.audio is not None else None
         )
 
-    def forward(self, op: builder.OpBuilder, **kwargs):
+    def forward(self, op: OpBuilder, **kwargs):
         raise NotImplementedError(
             "Gemma4Model is a multi-model split; Gemma4Task builds each sub-module "
             "(decoder, vision_encoder, embedding, and optionally audio_encoder) separately."

--- a/src/mobius/models/glm.py
+++ b/src/mobius/models/glm.py
@@ -24,8 +24,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._attention import StaticCacheState
@@ -83,7 +82,7 @@ class Glm4DecoderLayer(DecoderLayer):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None,
         position_embeddings: tuple,

--- a/src/mobius/models/gpt2.py
+++ b/src/mobius/models/gpt2.py
@@ -12,8 +12,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components import (
@@ -58,7 +57,7 @@ class GPT2CausalLMModel(CausalLMModel):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -330,7 +329,7 @@ class _GPT2TextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -415,7 +414,7 @@ class _GPT2DecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         past_key_value: tuple | None = None,

--- a/src/mobius/models/gpt_neox.py
+++ b/src/mobius/models/gpt_neox.py
@@ -18,8 +18,7 @@ import dataclasses
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius._weight_utils import rename_mlp_projections, split_interleaved_qkv_weights
@@ -67,7 +66,7 @@ class _GPTNeoXDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None,
         position_embeddings: tuple,
@@ -110,7 +109,7 @@ class _GPTNeoXTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -169,7 +168,7 @@ class GPTNeoXCausalLMModel(CausalLMModel):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -249,7 +248,7 @@ class _GPTNeoXJapaneseDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None,
         position_embeddings: tuple,
@@ -292,7 +291,7 @@ class _GPTNeoXJapaneseTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/gptj_codegen.py
+++ b/src/mobius/models/gptj_codegen.py
@@ -24,8 +24,7 @@ import dataclasses
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius._weight_utils import rename_mlp_projections, split_codegen_qkv
@@ -70,7 +69,7 @@ class _GPTJDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None,
         position_embeddings: tuple,
@@ -111,7 +110,7 @@ class _GPTJTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -171,7 +170,7 @@ class GPTJCausalLMModel(CausalLMModel):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -245,7 +244,7 @@ class CodeGenCausalLMModel(CausalLMModel):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/gptoss.py
+++ b/src/mobius/models/gptoss.py
@@ -22,8 +22,7 @@ import math
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components import (
@@ -54,7 +53,7 @@ class _GptOssGate(nn.Module):
         self.weight = nn.Parameter([num_experts, hidden_size])
         self.bias = nn.Parameter([num_experts])
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # router_logits: [B, S, N_exp] = [B, S, H] @ [H, N_exp] + [N_exp]
         weight_t = op.Transpose(self.weight, perm=[1, 0])
         router_logits = op.MatMul(hidden_states, weight_t)
@@ -92,7 +91,7 @@ class _GptOssExpertMLP(nn.Module):
         self.up_proj = Linear(hidden_size, intermediate_size, bias=True)
         self.down_proj = Linear(intermediate_size, hidden_size, bias=True)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         gate = self.gate_proj(op, hidden_states)  # [B, S, inter]
         up = self.up_proj(op, hidden_states)  # [B, S, inter]
 
@@ -126,7 +125,7 @@ class _GptOssMoELayer(nn.Module):
             ]
         )
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         routing_weights, selected_experts = self.gate(op, hidden_states)
 
         # Loop over experts: mask-and-accumulate dispatch
@@ -204,7 +203,7 @@ class _GptOssAttention(nn.Module):
 
     def _expand_kv_for_gqa(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         kv: ir.Value,
         batch_1d: ir.Value,
         kv_len_1d: ir.Value,
@@ -237,7 +236,7 @@ class _GptOssAttention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None,
         position_embeddings: tuple | None = None,
@@ -363,7 +362,7 @@ class _GptOssDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None,
         position_embeddings: tuple,
@@ -405,7 +404,7 @@ class _GptOssTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value | None,
         position_ids: ir.Value,

--- a/src/mobius/models/granite.py
+++ b/src/mobius/models/granite.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components import (
@@ -41,7 +40,7 @@ class GraniteTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -97,7 +96,7 @@ class GraniteCausalLMModel(CausalLMModel):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -147,7 +146,7 @@ class GraniteMoETextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value | None,
         position_ids: ir.Value,
@@ -209,7 +208,7 @@ class GraniteMoECausalLMModel(CausalLMModel):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value | None,
         position_ids: ir.Value,

--- a/src/mobius/models/granitemoehybrid.py
+++ b/src/mobius/models/granitemoehybrid.py
@@ -27,8 +27,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import GraniteMoeHybridConfig
 from mobius.components import (
@@ -62,7 +61,7 @@ class _Linear3D(nn.Module):
         super().__init__()
         self.weight = nn.Parameter([n_experts, out_features, in_features])
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value, expert_index: int) -> ir.Value:
+    def forward(self, op: OpBuilder, x: ir.Value, expert_index: int) -> ir.Value:
         """Select expert *expert_index* and compute ``x @ W[expert_index].T``."""
         # W[e]: [out_features, in_features]
         w_e = op.Squeeze(op.Gather(self.weight, [expert_index], axis=0), [0])
@@ -113,7 +112,7 @@ class _FusedMoEBlock(nn.Module):
             config.intermediate_size,
         )
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         """Route tokens to experts and accumulate weighted outputs."""
         # routing_weights: [batch*seq, top_k], selected_experts: [batch*seq, top_k]
         routing_weights, selected_experts = self.gate(op, hidden_states)
@@ -173,7 +172,7 @@ class _FusedSharedMLP(nn.Module):
         )
         self.act_fn = get_activation(config.hidden_act)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, x: ir.Value) -> ir.Value:
         gate_up = self.input_linear(op, x)  # [*, 2*shared_intermediate]
         gate, up = op.Split(gate_up, axis=-1, num_outputs=2, _outputs=2)
         return self.output_linear(op, op.Mul(self.act_fn(op, gate), up))
@@ -223,7 +222,7 @@ class _GraniteMoeHybridMambaDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -289,7 +288,7 @@ class _GraniteMoeHybridAttentionDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -357,7 +356,7 @@ class _GraniteMoeHybridTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -417,7 +416,7 @@ class GraniteMoeHybridCausalLMModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/hunyuan_dit.py
+++ b/src/mobius/models/hunyuan_dit.py
@@ -30,8 +30,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components import LayerNorm as _LayerNorm
 from mobius.components import Linear as _Linear
@@ -104,7 +103,7 @@ class _LayerNormNoAffine(nn.Module):
         self._dim = dim
         self._eps = eps
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         # Use ReduceMean + variance computation for norm without params
         mean = op.ReduceMean(x, [-1], keepdims=True)
         diff = op.Sub(x, mean)
@@ -128,7 +127,7 @@ class _AdaLayerNormShift(nn.Module):
         self.linear = _Linear(hidden_size, hidden_size)
         self._silu = _SiLU()
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value, temb: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value, temb: ir.Value):
         # shift = Linear(SiLU(temb))
         shift = self._silu(op, temb)
         shift = self.linear(op, shift)
@@ -156,7 +155,7 @@ class _HunyuanSelfAttention(nn.Module):
             self.norm_q = _LayerNorm(self._head_dim, eps=1e-6)
             self.norm_k = _LayerNorm(self._head_dim, eps=1e-6)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         q = self.to_q(op, hidden_states)
         k = self.to_k(op, hidden_states)
         v = self.to_v(op, hidden_states)
@@ -215,9 +214,7 @@ class _HunyuanCrossAttention(nn.Module):
             self.norm_q = _LayerNorm(self._head_dim, eps=1e-6)
             self.norm_k = _LayerNorm(self._head_dim, eps=1e-6)
 
-    def forward(
-        self, op: builder.OpBuilder, hidden_states: ir.Value, encoder_hidden_states: ir.Value
-    ):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value, encoder_hidden_states: ir.Value):
         q = self.to_q(op, hidden_states)
         k = self.to_k(op, encoder_hidden_states)
         v = self.to_v(op, encoder_hidden_states)
@@ -259,7 +256,7 @@ class _GEGLU(nn.Module):
         super().__init__()
         self.proj = _Linear(hidden_size, intermediate_size * 2)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         projected = self.proj(op, hidden_states)
         # Split into gate and value: [B, seq, 2*inter] → 2x [B, seq, inter]
         hidden, gate = op.Split(projected, num_outputs=2, axis=-1, _outputs=2)
@@ -278,7 +275,7 @@ class _HunyuanFFN(nn.Module):
         self.geglu = _GEGLU(hidden_size, intermediate_size)
         self.linear_out = _Linear(intermediate_size, hidden_size)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         hidden_states = self.geglu(op, hidden_states)
         return self.linear_out(op, hidden_states)
 
@@ -326,7 +323,7 @@ class _HunyuanDiTBlock(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         encoder_hidden_states: ir.Value,
         temb: ir.Value,
@@ -376,7 +373,7 @@ class _AdaLayerNormContinuous(nn.Module):
         self.linear = _Linear(hidden_size, hidden_size * 2)
         self._silu = _SiLU()
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value, temb: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value, temb: ir.Value):
         emb = self._silu(op, temb)
         emb = self.linear(op, emb)
         # Split into scale and shift
@@ -463,7 +460,7 @@ class HunyuanDiT2DModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         sample: ir.Value,
         timestep: ir.Value,
         encoder_hidden_states: ir.Value,
@@ -523,7 +520,7 @@ class HunyuanDiT2DModel(nn.Module):
 
         return hidden_states
 
-    def _get_timestep_embedding(self, op: builder.OpBuilder, timestep):
+    def _get_timestep_embedding(self, op: OpBuilder, timestep):
         """Sinusoidal timestep embedding."""
         half_dim = self._time_proj_dim // 2
         exponent = -math.log(10000.0) / half_dim
@@ -534,7 +531,7 @@ class HunyuanDiT2DModel(nn.Module):
         args = op.Mul(t, op.Unsqueeze(freq_const, [0]))
         return op.Concat(op.Cos(args), op.Sin(args), axis=-1)
 
-    def _unpatchify(self, op: builder.OpBuilder, hidden_states, original):
+    def _unpatchify(self, op: OpBuilder, hidden_states, original):
         """Reshape patches back to spatial dimensions."""
         p = self.config.patch_size
         c = self._out_channels

--- a/src/mobius/models/internlm.py
+++ b/src/mobius/models/internlm.py
@@ -20,8 +20,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components import (
@@ -48,7 +47,7 @@ class _InternLMMLP(nn.Module):
         self.w3 = Linear(config.hidden_size, config.intermediate_size, bias=config.mlp_bias)
         self._act_fn = get_activation(config.hidden_act)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         gate = self._act_fn(op, self.w1(op, hidden_states))
         up = self.w3(op, hidden_states)
         return self.w2(op, op.Mul(gate, up))
@@ -70,7 +69,7 @@ class _InternLMDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -116,7 +115,7 @@ class _InternLMTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -171,7 +170,7 @@ class InternLM2CausalLMModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/internvl.py
+++ b/src/mobius/models/internvl.py
@@ -30,8 +30,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius._weight_utils import (
@@ -63,7 +62,7 @@ class _InternVisionLinear(nn.Module):
         self.weight = nn.Parameter([out_features, in_features])
         self.bias = nn.Parameter([out_features])
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         weight_t = op.Transpose(self.weight, perm=[1, 0])
         result = op.MatMul(x, weight_t)
         return op.Add(result, self.bias)
@@ -99,7 +98,7 @@ class _InternVisionEmbeddings(nn.Module):
         # Position embedding includes CLS position — bare parameter
         self.position_embedding = nn.Parameter([1, self.num_patches + 1, hidden_size])
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         # pixel_values: [batch, channels, height, width]
         patch_embeds = self.patch_embedding(op, pixel_values)
         # patch_embeds: [batch, hidden_size, grid_h, grid_w]
@@ -145,7 +144,7 @@ class _InternVisionAttention(nn.Module):
         self.qkv = _InternVisionLinear(hidden_size, 3 * hidden_size)
         self.proj = _InternVisionLinear(hidden_size, hidden_size)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # hidden_states: [batch, seq_len, hidden_size]
         qkv = self.qkv(op, hidden_states)  # [batch, seq, 3*hidden]
         # Split into Q, K, V along last dimension
@@ -175,7 +174,7 @@ class _InternVisionMLP(nn.Module):
         self.fc1 = _InternVisionLinear(hidden_size, intermediate_size)
         self.fc2 = _InternVisionLinear(intermediate_size, hidden_size)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         hidden_states = self.fc1(op, hidden_states)
         hidden_states = op.Gelu(hidden_states)
         return self.fc2(op, hidden_states)
@@ -209,7 +208,7 @@ class _InternVisionEncoderLayer(nn.Module):
         self.ls1 = nn.Parameter([hidden_size])
         self.ls2 = nn.Parameter([hidden_size])
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # Pre-norm attention with layer scale
         residual = hidden_states
         hidden_states = self.norm1(op, hidden_states)
@@ -248,7 +247,7 @@ class _InternVisionEncoder(nn.Module):
             ]
         )
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         for layer in self.layers:
             hidden_states = layer(op, hidden_states)
         return hidden_states
@@ -281,7 +280,7 @@ class _InternVisionModel(nn.Module):
             norm_eps=vc.norm_eps,
         )
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         hidden_states = self.embeddings(op, pixel_values)
         hidden_states = self.encoder(op, hidden_states)
         return hidden_states
@@ -301,7 +300,7 @@ class _GELUPlaceholder(nn.Module):
     weight names ``mlp1.1.*`` and ``mlp1.3.*`` match HuggingFace.
     """
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return op.Gelu(x)
 
 
@@ -325,7 +324,7 @@ class _InternVL2DecoderModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         inputs_embeds: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -381,7 +380,7 @@ class _InternVL2VisionEncoderModel(nn.Module):
             Linear(llm_hidden, llm_hidden, bias=True),
         )
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         # Run InternViT encoder
         vit_embeds = self.vision_model(op, pixel_values)
         # vit_embeds: [batch, num_patches+1, hidden_size] (includes CLS)
@@ -506,7 +505,7 @@ class _InternVL2EmbeddingModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         image_features: ir.Value,
     ):
@@ -555,7 +554,7 @@ class InternVL2Model(nn.Module):
         self.vision_encoder = _InternVL2VisionEncoderModel(config)
         self.embedding = _InternVL2EmbeddingModel(config)
 
-    def forward(self, op: builder.OpBuilder, **kwargs):
+    def forward(self, op: OpBuilder, **kwargs):
         raise NotImplementedError(
             "InternVL2Model uses VisionLanguageTask which calls "
             "each sub-module (decoder, vision_encoder, embedding) "

--- a/src/mobius/models/jamba.py
+++ b/src/mobius/models/jamba.py
@@ -25,8 +25,7 @@ import math
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import JambaConfig
 from mobius.components import (
@@ -93,7 +92,7 @@ class JambaMambaDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -154,7 +153,7 @@ class JambaAttentionDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -223,7 +222,7 @@ class _JambaTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -278,7 +277,7 @@ class JambaCausalLMModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/jetmoe.py
+++ b/src/mobius/models/jetmoe.py
@@ -20,8 +20,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components import (
@@ -56,7 +55,7 @@ class _JetMoARouter(nn.Module):
         self.top_k = top_k
         self.weight = nn.Parameter([num_experts, hidden_size])
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # routing logits: [bsz, seq, n_experts]
         weight_t = op.Transpose(self.weight, perm=[1, 0])
         logits = op.MatMul(hidden_states, weight_t)
@@ -126,7 +125,7 @@ class _JetMoeAttention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None,
         position_embeddings: tuple,
@@ -282,7 +281,7 @@ class _JetMoeMLP(nn.Module):
         # Additive output bias: [hidden]
         self.bias = nn.Parameter([config.hidden_size])
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         return op.Add(self.moe(op, hidden_states), self.bias)
 
 
@@ -312,7 +311,7 @@ class JetMoeDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None,
         position_embeddings: tuple,
@@ -365,7 +364,7 @@ class _JetMoeTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value | None,
         position_ids: ir.Value,

--- a/src/mobius/models/llava.py
+++ b/src/mobius/models/llava.py
@@ -24,8 +24,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius._weight_utils import vlm_decoder_weights, vlm_embedding_weights
@@ -52,7 +51,7 @@ class _LLaVADecoderModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         inputs_embeds: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -86,7 +85,7 @@ class _LLaVAVisionEncoderModel(nn.Module):
             text_hidden_size=config.hidden_size,
         )
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         vision_features = self.vision_tower(op, pixel_values)
         return self.multi_modal_projector(op, vision_features)
 
@@ -115,7 +114,7 @@ class _LLaVAEmbeddingModel(nn.Module):
         )
         self.image_token_id = config.image_token_id or 0
 
-    def forward(self, op: builder.OpBuilder, input_ids: ir.Value, image_features: ir.Value):
+    def forward(self, op: OpBuilder, input_ids: ir.Value, image_features: ir.Value):
         text_embeds = self.embed_tokens(op, input_ids)
 
         image_mask = op.Equal(
@@ -173,7 +172,7 @@ class _PixtralVisionEncoderModel(nn.Module):
             norm_eps=config.rms_norm_eps,
         )
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         hidden_states, grid_h, grid_w = self.vision_tower(op, pixel_values)
         return self.multi_modal_projector(op, hidden_states, grid_h, grid_w)
 
@@ -214,7 +213,7 @@ class LLaVAModel(nn.Module):
             self.vision_encoder = _LLaVAVisionEncoderModel(config)
         self.embedding = _LLaVAEmbeddingModel(config)
 
-    def forward(self, op: builder.OpBuilder, **kwargs):
+    def forward(self, op: OpBuilder, **kwargs):
         raise NotImplementedError(
             "LLaVAModel uses VisionLanguageTask which calls "
             "each sub-module (decoder, vision_encoder, embedding) separately."

--- a/src/mobius/models/longcat_flash.py
+++ b/src/mobius/models/longcat_flash.py
@@ -15,8 +15,7 @@ import dataclasses
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig, LongcatFlashConfig
 from mobius.components import (
@@ -88,7 +87,7 @@ class _LongcatFlashMLA(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -197,7 +196,7 @@ class _LongcatFlashRouter(nn.Module):
         self.top_k = config.num_experts_per_tok
         self.routed_scaling_factor = config.routed_scaling_factor
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # Compute routing logits: (B*S, total_experts)
         router_logits = self.classifier(op, hidden_states)
         # Softmax over all experts
@@ -244,7 +243,7 @@ class _LongcatFlashMoE(nn.Module):
             [MLP(expert_config) for _ in range(self.n_routed_experts)]
         )
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         routing_weights, selected_experts = self.router(op, hidden_states)
         # routing_weights: (B*S, top_k), selected_experts: (B*S, top_k)
 
@@ -305,7 +304,7 @@ class LongcatFlashDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -385,7 +384,7 @@ class LongcatFlashTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/mamba.py
+++ b/src/mobius/models/mamba.py
@@ -30,8 +30,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import Mamba2Config, MambaConfig
 from mobius.components import (
@@ -74,7 +73,7 @@ class MambaBackbone(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         past_states: list[tuple] | None = None,
     ):
@@ -130,7 +129,7 @@ class _MambaResidualBlock(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         past_state: tuple | None = None,
     ):
@@ -189,7 +188,7 @@ class MambaCausalLMModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         past_states: list[tuple] | None = None,
     ):
@@ -295,7 +294,7 @@ class _Mamba2ResidualBlock(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         past_state: tuple | None = None,
     ):
@@ -358,7 +357,7 @@ class Mamba2Backbone(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         past_states: list[tuple] | None = None,
     ):
@@ -413,7 +412,7 @@ class Mamba2CausalLMModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         past_states: list[tuple] | None = None,
     ):

--- a/src/mobius/models/minimax.py
+++ b/src/mobius/models/minimax.py
@@ -22,8 +22,7 @@ import math
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components import (
@@ -89,7 +88,7 @@ class MiniMaxDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None,
         position_embeddings: tuple[ir.Value, ir.Value],
@@ -145,7 +144,7 @@ class MiniMaxTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -209,7 +208,7 @@ class MiniMaxCausalLMModel(CausalLMModel):
 
 
 def _scaled_add(
-    op: builder.OpBuilder,
+    op: OpBuilder,
     residual: ir.Value,
     sub_layer_out: ir.Value,
     alpha: float,

--- a/src/mobius/models/mllama.py
+++ b/src/mobius/models/mllama.py
@@ -20,8 +20,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig, MllamaConfig
 from mobius._weight_utils import vlm_decoder_weights, vlm_embedding_weights
@@ -81,7 +80,7 @@ class MllamaCrossAttention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         cross_attention_states: ir.Value,
         past_key_value: tuple | None = None,
@@ -158,7 +157,7 @@ class MllamaCrossAttentionDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         cross_attention_states: ir.Value,
         past_key_value: tuple | None = None,
@@ -221,7 +220,7 @@ class MllamaTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value | None,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -280,7 +279,7 @@ class _MllamaDecoderModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         inputs_embeds: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -312,7 +311,7 @@ class _MllamaVisionEncoderModel(nn.Module):
         super().__init__()
         self.vision_model = VisionModel(config)
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         return self.vision_model(op, pixel_values)
 
     def preprocess_weights(
@@ -338,7 +337,7 @@ class _MllamaEmbeddingModel(nn.Module):
             config.vocab_size, config.hidden_size, config.pad_token_id
         )
 
-    def forward(self, op: builder.OpBuilder, input_ids: ir.Value, image_features: ir.Value):
+    def forward(self, op: OpBuilder, input_ids: ir.Value, image_features: ir.Value):
         text_embeds = self.embed_tokens(op, input_ids)
         # For Mllama, vision features are injected via cross-attention
         # (not concatenated). The embedding model just returns text embeds.
@@ -371,7 +370,7 @@ class MllamaCausalLMModel(nn.Module):
         self.vision_encoder = _MllamaVisionEncoderModel(config)
         self.embedding = _MllamaEmbeddingModel(config)
 
-    def forward(self, op: builder.OpBuilder, **kwargs):
+    def forward(self, op: OpBuilder, **kwargs):
         raise NotImplementedError(
             "MllamaCausalLMModel uses VisionLanguageTask which calls "
             "each sub-module (decoder, vision_encoder, embedding) separately."

--- a/src/mobius/models/modernbert.py
+++ b/src/mobius/models/modernbert.py
@@ -22,8 +22,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._activations import ACT2FN
@@ -61,7 +60,7 @@ class _ModernBertAttention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_mask: ir.Value,
         position_embeddings: tuple,
@@ -117,7 +116,7 @@ class _ModernBertMLP(nn.Module):
         self.Wo = Linear(config.intermediate_size, config.hidden_size, bias=config.mlp_bias)
         self._act_fn = ACT2FN[config.hidden_act]
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         gate = self._act_fn(op, self.gate_proj(op, hidden_states))
         up = self.up_proj(op, hidden_states)
         return self.Wo(op, op.Mul(gate, up))
@@ -142,7 +141,7 @@ class _ModernBertLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_mask: ir.Value,
         position_embeddings: tuple,
@@ -194,7 +193,7 @@ class ModernBertModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         token_type_ids: ir.Value,  # Unused but required by feature-extraction task
@@ -331,7 +330,7 @@ class _ModernBertDecoderTextModel(_TextModel):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value | None,
         position_ids: ir.Value,
@@ -366,7 +365,7 @@ class _ModernBertDecoderLMHead(nn.Module):
         self.norm = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.decoder = Linear(config.hidden_size, config.vocab_size, bias=True)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, hidden_states: ir.Value) -> ir.Value:
         # dense → norm → decoder projection with vocab bias
         hidden_states = self.dense(op, hidden_states)
         hidden_states = self.norm(op, hidden_states)

--- a/src/mobius/models/moe.py
+++ b/src/mobius/models/moe.py
@@ -9,8 +9,7 @@ import math
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components import (
@@ -73,7 +72,7 @@ class MoEDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None,
         position_embeddings: tuple,
@@ -185,7 +184,7 @@ class MoETextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value | None,
         position_ids: ir.Value,
@@ -290,7 +289,7 @@ class Qwen2MoELayer(MoELayer):
         self.shared_expert = MLP(shared_config)
         self.shared_expert_gate = Linear(config.hidden_size, 1, bias=False)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # Routing expert output: top-k weighted sum  [B, S, H]
         expert_output = super().forward(op, hidden_states)
         # Shared expert always runs on every token
@@ -360,7 +359,7 @@ class UngatedSharedMoELayer(MoELayer):
         )
         self.shared_expert = MLP(shared_config)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # Routed expert output: top-k weighted sum  [B, S, H]
         routing_output = super().forward(op, hidden_states)
         # Shared expert always runs on every token, no gate scaling

--- a/src/mobius/models/nanochat.py
+++ b/src/mobius/models/nanochat.py
@@ -28,7 +28,7 @@ import dataclasses
 
 import onnx_ir as ir
 import torch
-from onnxscript._internal import builder
+from onnxscript import OpBuilder
 
 from mobius._configs import NanoChatConfig
 from mobius._weight_utils import rename_mlp_projections
@@ -52,7 +52,7 @@ class NanoChatAttention(Attention):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None,
         position_embeddings: tuple | None = None,
@@ -119,7 +119,7 @@ class NanoChatTextModel(TextModel):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value | None,
         position_ids: ir.Value,
@@ -203,7 +203,7 @@ class NanoChatCausalLMModel(CausalLMModel):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/nemotron_h.py
+++ b/src/mobius/models/nemotron_h.py
@@ -33,8 +33,7 @@ import re
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import NemotronHConfig
 from mobius._weight_utils import tie_word_embeddings
@@ -90,7 +89,7 @@ class NemotronHMambaLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -132,7 +131,7 @@ class NemotronHAttentionLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -175,7 +174,7 @@ class NemotronHMLPLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -235,7 +234,7 @@ class NemotronHMoEGate(nn.Module):
         # Correction bias for expert selection (loaded from checkpoint)
         self.e_score_correction_bias = nn.Parameter([num_experts])
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # Cast to float32 for numerical stability (eps=1e-20 underflows
         # in fp16/bf16).  HF does the same: hidden_states.type(torch.float32)
         # in NemotronHTopkRouter.forward and never casts back.
@@ -353,7 +352,7 @@ class NemotronHMoEBlock(nn.Module):
                 bias=config.mlp_bias,
             )
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         residual = hidden_states
 
         # Gate routes on original hidden states
@@ -407,7 +406,7 @@ class NemotronHMoELayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -467,7 +466,7 @@ class _NemotronHTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -523,7 +522,7 @@ class NemotronHCausalLMModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/olmo.py
+++ b/src/mobius/models/olmo.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 
 import numpy as np
 import onnx_ir as ir
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components import (
@@ -38,7 +37,7 @@ class _WeightFreeLayerNorm(nn.Module):
         )
         self.eps = eps
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         return op.LayerNormalization(
             hidden_states, self.scale, self.bias, epsilon=self.eps, axis=-1
         )
@@ -56,7 +55,7 @@ class _OlmoDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -99,7 +98,7 @@ class _OlmoTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -167,7 +166,7 @@ class _PostNormTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/opt.py
+++ b/src/mobius/models/opt.py
@@ -16,7 +16,7 @@ from mobius.models.gpt2 import GPT2CausalLMModel, _GPT2TextModel
 
 if TYPE_CHECKING:
     import onnx_ir as ir
-    from onnxscript._internal import builder
+    from onnxscript import OpBuilder
 
 
 class OPTCausalLMModel(GPT2CausalLMModel):
@@ -37,7 +37,7 @@ class OPTCausalLMModel(GPT2CausalLMModel):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/persimmon.py
+++ b/src/mobius/models/persimmon.py
@@ -21,8 +21,7 @@ import dataclasses
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius._weight_utils import rename_mlp_projections, split_interleaved_qkv_weights
@@ -70,7 +69,7 @@ class _PersimmonDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None,
         position_embeddings: tuple,
@@ -117,7 +116,7 @@ class _PersimmonTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -175,7 +174,7 @@ class PersimmonCausalLMModel(CausalLMModel):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/phi.py
+++ b/src/mobius/models/phi.py
@@ -13,8 +13,7 @@ from __future__ import annotations
 
 import onnx_ir as ir
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius._weight_utils import split_fused_qkv
@@ -73,7 +72,7 @@ class _PhiDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None,
         position_embeddings: tuple,
@@ -117,7 +116,7 @@ class _PhiTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -169,7 +168,7 @@ class PhiCausalLMModel(CausalLMModel):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -399,7 +398,7 @@ class _Phi4MMSigLIPEncoder(nn.Module):
             norm_eps=norm_eps,
         )
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         hidden_states = self.embeddings(op, pixel_values)
         return self.encoder(op, hidden_states)
 
@@ -407,7 +406,7 @@ class _Phi4MMSigLIPEncoder(nn.Module):
 class _GELUModule(nn.Module):
     """GELU activation as an nn.Module (no parameters)."""
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return op.Gelu(x)
 
 
@@ -431,7 +430,7 @@ class _Phi4MMProjectionMLP(nn.Module):
             setattr(self, str(i), layer)
         self._layers = layers
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         for layer in self._layers:
             x = layer(op, x)
         return x
@@ -451,7 +450,7 @@ class _Phi4MMImageEmbedding(nn.Module):
         self.glb_GN = nn.Parameter([1, 1, vision_hidden_size])
         self.sub_GN = nn.Parameter([1, 1, 1, vision_hidden_size])
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         vision_features = self.img_processor(op, pixel_values)
         return self.img_projection(op, vision_features)
 
@@ -482,7 +481,7 @@ class _Phi4MMAudioEmbedding(nn.Module):
         self.speech = _Phi4MMProjectionMLP(audio_dim, text_hidden_size)
         self.vision = _Phi4MMProjectionMLP(audio_dim, text_hidden_size)
 
-    def forward(self, op: builder.OpBuilder, audio_features: ir.Value):
+    def forward(self, op: OpBuilder, audio_features: ir.Value):
         audio_hidden = self.encoder(op, audio_features)
         return self.speech(op, audio_hidden)
 
@@ -497,7 +496,7 @@ class _Phi4MMImageAudioEmbedding(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         pixel_values: ir.Value | None = None,
         audio_features: ir.Value | None = None,
     ):
@@ -540,7 +539,7 @@ class _Phi4MMMultiModalTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -641,7 +640,7 @@ class _Phi4MMVisionModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         pixel_values: ir.Value,
         image_sizes: ir.Value,
     ):
@@ -828,7 +827,7 @@ class _Phi4MMSpeechModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         audio_embeds: ir.Value,
         audio_sizes: ir.Value,
         audio_projection_mode: ir.Value,
@@ -875,7 +874,7 @@ class _Phi4MMEmbeddingModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         image_features: ir.Value,
         audio_features: ir.Value,
@@ -925,7 +924,7 @@ class _Phi4MMDecoderModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         inputs_embeds: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -982,7 +981,7 @@ class Phi4MMMultiModalModel(nn.Module):
         self.embedding = _Phi4MMEmbeddingModel(config)
         self.decoder = _Phi4MMDecoderModel(config)
 
-    def forward(self, op: builder.OpBuilder, **kwargs):
+    def forward(self, op: OpBuilder, **kwargs):
         raise NotImplementedError(
             "Phi4MMMultiModalModel uses Phi4MMMultiModalTask "
             "which calls each sub-module (vision_encoder, "

--- a/src/mobius/models/qwen35.py
+++ b/src/mobius/models/qwen35.py
@@ -7,8 +7,7 @@ import dataclasses
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._attention import Qwen35Attention
@@ -68,7 +67,7 @@ class Qwen35DecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple[ir.Value, ir.Value],
@@ -128,7 +127,7 @@ class Qwen35TextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value | None,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -252,7 +251,7 @@ class Qwen35MoEBlock(nn.Module):
         self.shared_expert = MLP(shared_config)
         self.shared_expert_gate = Linear(config.hidden_size, 1, bias=False)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         routing_weights, selected_experts = self.gate(op, hidden_states)
 
         # Loop-over-experts dispatch (same pattern as MoELayer)
@@ -320,7 +319,7 @@ class Qwen35MoETextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -467,7 +466,7 @@ class Qwen35VL3ModelCausalLMModel(nn.Module):
         self.vision_encoder = Qwen3VLVisionEncoderModel(config)
         self.embedding = Qwen3VLEmbeddingModel(config)
 
-    def forward(self, op: builder.OpBuilder, **kwargs):
+    def forward(self, op: OpBuilder, **kwargs):
         raise NotImplementedError(
             "Qwen35VL3ModelCausalLMModel uses QwenVLTask "
             "which calls each sub-module separately."
@@ -531,7 +530,7 @@ class Qwen35VLDecoderModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         inputs_embeds: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/qwen3_asr.py
+++ b/src/mobius/models/qwen3_asr.py
@@ -22,8 +22,7 @@ import dataclasses
 import numpy as np
 import onnx_ir as ir
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._common import (
@@ -177,7 +176,7 @@ class Qwen3ASRAudioEncoder(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_features: ir.Value,
         feature_attention_mask: ir.Value,
     ):
@@ -418,7 +417,7 @@ class Qwen3ASREmbeddingModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         audio_features: ir.Value,
     ):
@@ -483,7 +482,7 @@ class Qwen3ASRDecoderModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         inputs_embeds: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -555,7 +554,7 @@ class Qwen3ASRForConditionalGeneration(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/qwen3_next.py
+++ b/src/mobius/models/qwen3_next.py
@@ -23,8 +23,7 @@ import dataclasses
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._attention import Qwen35Attention
@@ -85,7 +84,7 @@ class Qwen3NextMoEBlock(nn.Module):
         self.shared_expert = MLP(shared_config)
         self.shared_expert_gate = Linear(config.hidden_size, 1, bias=False)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # Route tokens to experts via softmax top-k gating
         # routing_weights: (B, T, top_k) — gating weights per selected expert
         # selected_experts: (B, T, top_k) — indices of selected experts
@@ -152,7 +151,7 @@ class Qwen3NextDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -217,7 +216,7 @@ class Qwen3NextTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/qwen3_tts.py
+++ b/src/mobius/models/qwen3_tts.py
@@ -28,8 +28,7 @@ import dataclasses
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components import (
@@ -74,7 +73,7 @@ class Qwen3TTSTalkerDecoderModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         inputs_embeds: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -214,7 +213,7 @@ class Qwen3TTSCodePredictorModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         inputs_embeds: ir.Value,
         step_index: ir.Value,
         attention_mask: ir.Value,
@@ -330,7 +329,7 @@ class Qwen3TTSEmbeddingModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         text_ids: ir.Value,
         codec_ids: ir.Value,
     ):
@@ -386,7 +385,7 @@ class Qwen3TTSSpeakerEncoderModel(nn.Module):
             enc_se_channels=se.enc_se_channels if se else 128,
         )
 
-    def forward(self, op: builder.OpBuilder, mel_input: ir.Value):
+    def forward(self, op: OpBuilder, mel_input: ir.Value):
         """Extract speaker embedding from mel spectrogram.
 
         Args:
@@ -434,7 +433,7 @@ class Qwen3TTSForConditionalGeneration(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/qwen3_tts_tokenizer.py
+++ b/src/mobius/models/qwen3_tts_tokenizer.py
@@ -20,8 +20,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components._codec_conv import (
     CausalConv1d,
@@ -145,7 +144,7 @@ class Qwen3TTSCodecDecoderModel(nn.Module):
         )
         self.decoder = nn.Sequential(*decoder_modules)
 
-    def forward(self, op: builder.OpBuilder, codes: ir.Value):
+    def forward(self, op: OpBuilder, codes: ir.Value):
         """Decode audio codes to waveform.
 
         Args:
@@ -256,7 +255,7 @@ class Qwen3TTSCodecEncoderModel(nn.Module):
         # We reuse the same SplitRVQ structure but add encode logic
         self.quantizer = _EncoderSplitRVQ(config)
 
-    def forward(self, op: builder.OpBuilder, waveform: ir.Value):
+    def forward(self, op: OpBuilder, waveform: ir.Value):
         """Encode waveform to audio codes.
 
         Args:
@@ -333,7 +332,7 @@ class _MimiConvEncoder(nn.Module):
             _EncoderConvLayer(1024, 512, 3, 1),  # 14
         )
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         """Encode waveform through conv layers.
 
         Args:
@@ -353,7 +352,7 @@ class _ELUModule(nn.Module):
     that must be computed (not skipped).
     """
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return op.Elu(x, alpha=1.0)
 
 
@@ -381,7 +380,7 @@ class _EncoderConvLayer(nn.Module):
             stride=stride,
         )
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         # Causal padding: left-pad by (kernel - 1)
         pad_left = self._kernel - 1
         if pad_left > 0:
@@ -410,7 +409,7 @@ class _EncoderResBlock(nn.Module):
             _EncoderConvLayer(half, dim, 1, 1),  # 3: pointwise conv
         )
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         residual = x
         return op.Add(residual, self.block(op, x))
 
@@ -433,7 +432,7 @@ class _DownsampleConv(nn.Module):
             stride=stride,
         )
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         # Causal left-pad: (B, C, T) -> (B, C, T + kernel-1)
         pad_left = self._kernel - 1
         if pad_left > 0:
@@ -483,7 +482,7 @@ class _EncoderSplitRVQ(nn.Module):
         self._num_semantic = num_semantic
         self._num_valid = config.num_quantizers if hasattr(config, "num_quantizers") else 16
 
-    def forward(self, op: builder.OpBuilder, hidden: ir.Value):
+    def forward(self, op: OpBuilder, hidden: ir.Value):
         """Encode features to discrete codes.
 
         Args:
@@ -530,7 +529,7 @@ class _EncoderRVQ(nn.Module):
             [_EncoderVQ(codebook_size, dim) for _ in range(num_quantizers)]
         )
 
-    def forward(self, op: builder.OpBuilder, hidden: ir.Value):
+    def forward(self, op: OpBuilder, hidden: ir.Value):
         """Encode to codes with residual quantization.
 
         Args:
@@ -575,7 +574,7 @@ class _EncoderVQ(nn.Module):
         # codebook.embed_sum -> precomputed to codebook.embedding
         self.codebook = _EncoderCodebook(codebook_size, dim)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         """Find nearest codebook entry.
 
         Args:
@@ -620,7 +619,7 @@ class _EncoderCodebook(nn.Module):
         super().__init__()
         self.embedding = nn.Parameter([codebook_size, dim])
 
-    def forward(self, op: builder.OpBuilder):
+    def forward(self, op: OpBuilder):
         """Return the embedding table as an identity op.
 
         This ensures onnxscript registers the parameter.

--- a/src/mobius/models/qwen_image.py
+++ b/src/mobius/models/qwen_image.py
@@ -17,8 +17,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._diffusers_configs import QwenImageConfig
 from mobius.components import (
@@ -50,7 +49,7 @@ class _TimestepMLP(nn.Module):
         self.linear_1 = _Linear(in_channels, time_embed_dim)
         self.linear_2 = _Linear(time_embed_dim, time_embed_dim)
 
-    def forward(self, op: builder.OpBuilder, sample: ir.Value):
+    def forward(self, op: OpBuilder, sample: ir.Value):
         sample = self.linear_1(op, sample)
         sample = op.Mul(sample, op.Sigmoid(sample))  # SiLU
         sample = self.linear_2(op, sample)
@@ -67,7 +66,7 @@ class _TimestepEmbedding(nn.Module):
         super().__init__()
         self.timestep_embedder = _TimestepMLP(in_channels, time_embed_dim)
 
-    def forward(self, op: builder.OpBuilder, sample: ir.Value):
+    def forward(self, op: OpBuilder, sample: ir.Value):
         return self.timestep_embedder(op, sample)
 
 
@@ -82,7 +81,7 @@ class _AdaLayerNormOutput(nn.Module):
         self.norm = _LayerNormNoAffine(hidden_size, eps=eps)
         self.linear = _Linear(hidden_size, hidden_size * 2)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value, timestep_emb: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value, timestep_emb: ir.Value):
         emb = op.Mul(timestep_emb, op.Sigmoid(timestep_emb))  # SiLU
         emb = self.linear(op, emb)
         shift, scale = op.Split(emb, num_outputs=2, axis=-1, _outputs=2)
@@ -101,7 +100,7 @@ class _RMSNormQK(nn.Module):
         self.weight = nn.Parameter((dim,))
         self._eps = eps
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return op.RMSNormalization(x, self.weight, axis=-1, epsilon=self._eps, stash_type=1)
 
 
@@ -113,7 +112,7 @@ class _RMSNorm(nn.Module):
         self.weight = nn.Parameter((dim,))
         self._eps = eps
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return op.RMSNormalization(x, self.weight, axis=-1, epsilon=self._eps, stash_type=1)
 
 
@@ -124,14 +123,14 @@ class _GELUGate(nn.Module):
         super().__init__()
         self.proj = _Linear(in_features, out_features)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return op.Gelu(self.proj(op, x), approximate="tanh")
 
 
 class _NoOpModule(nn.Module):
     """Placeholder for HF nn.Dropout (no parameters, identity at inference)."""
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return x
 
 
@@ -154,7 +153,7 @@ class _GeluApproxFFN(nn.Module):
             _Linear(inner_dim, dim_out),
         )
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         # Sequential chains: GELUGate → NoOp → Linear
         return self.net(op, x)
 
@@ -190,7 +189,7 @@ class _QwenImageJointAttention(nn.Module):
         self.norm_added_q = _RMSNormQK(head_dim, eps=eps)
         self.norm_added_k = _RMSNormQK(head_dim, eps=eps)
 
-    def forward(self, op: builder.OpBuilder, img_hidden: ir.Value, txt_hidden: ir.Value):
+    def forward(self, op: OpBuilder, img_hidden: ir.Value, txt_hidden: ir.Value):
         batch = op.Shape(img_hidden, start=0, end=1)
 
         # Image stream QKV
@@ -301,7 +300,7 @@ class _QwenImageTransformerBlock(nn.Module):
         self.txt_mlp = _GeluApproxFFN(dim)
 
     def forward(
-        self, op: builder.OpBuilder, img_hidden: ir.Value, txt_hidden: ir.Value, temb: ir.Value
+        self, op: OpBuilder, img_hidden: ir.Value, txt_hidden: ir.Value, temb: ir.Value
     ):
         one = 1.0
 
@@ -411,7 +410,7 @@ class QwenImageTransformer2DModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         sample: ir.Value,
         timestep: ir.Value,
         encoder_hidden_states: ir.Value,
@@ -440,7 +439,7 @@ class QwenImageTransformer2DModel(nn.Module):
 
         return output
 
-    def _get_timestep_embedding(self, op: builder.OpBuilder, timestep, dim):
+    def _get_timestep_embedding(self, op: OpBuilder, timestep, dim):
         """Compute sinusoidal timestep embedding."""
         half_dim = 256 // 2
         exponent = -math.log(10000.0) / half_dim

--- a/src/mobius/models/qwen_image_vae.py
+++ b/src/mobius/models/qwen_image_vae.py
@@ -15,8 +15,7 @@ from __future__ import annotations
 import itertools
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._diffusers_configs import QwenImageVAEConfig
 from mobius.components import Conv2d as _Conv2d
@@ -78,7 +77,7 @@ class _CausalConv3d(nn.Module):
         ]
         self._needs_pad = any(p > 0 for p in self._onnx_pads)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         if self._needs_pad:
             x = op.Pad(
                 x,
@@ -109,7 +108,7 @@ class _RMSNorm3d(nn.Module):
         self.gamma = nn.Parameter((dim, 1, 1, 1))
         self._scale = dim**0.5
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         # F.normalize(x, dim=1) * scale * gamma
         # L2 normalize along channel dimension
         norm = op.ReduceL2(x, [1], keepdims=True)
@@ -135,7 +134,7 @@ class _ResidualBlock(nn.Module):
         self.conv_shortcut = _CausalConv3d(in_dim, out_dim, 1) if in_dim != out_dim else None
         self._silu = _SiLU()
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         h = x if self.conv_shortcut is None else self.conv_shortcut(op, x)
         x = self.norm1(op, x)
         x = self._silu(op, x)
@@ -161,7 +160,7 @@ class _AttentionBlock(nn.Module):
         self.proj = _Conv2d(dim, dim, kernel_size=1)
         self._dim = dim
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         identity = x
         # x: (B, C, T, H, W)
         b_shape = op.Shape(x, start=0, end=1)
@@ -225,7 +224,7 @@ class _MidBlock(nn.Module):
             self.attentions.append(_AttentionBlock(dim))
             self.resnets.append(_ResidualBlock(dim, dim))
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         x = self.resnets[0](op, x)
         for i in range(len(self.attentions)):
             x = self.attentions[i](op, x)
@@ -252,7 +251,7 @@ class _SequentialConv2d(nn.Module):
         setattr(self, "1", conv)
         self._asymmetric_pad = asymmetric_pad
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         if self._asymmetric_pad:
             # Asymmetric pad (0,1,0,1) on H,W — equivalent to ZeroPad2d
             x = op.Pad(
@@ -297,7 +296,7 @@ class _Resample(nn.Module):
             )
             self.time_conv = _CausalConv3d(dim, dim * 2, (3, 1, 1), padding=(1, 0, 0))
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         # x: (B, C, T, H, W)
         b_shape = op.Shape(x, start=0, end=1)
         c_shape = op.Shape(x, start=1, end=2)
@@ -405,7 +404,7 @@ class _Encoder3d(nn.Module):
         self.conv_out = _CausalConv3d(dims[-1], z_dim * 2, 3, padding=1)
         self._silu = _SiLU()
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         x = self.conv_in(op, x)
         x = self.down_blocks(op, x)
         x = self.mid_block(op, x)
@@ -435,7 +434,7 @@ class _UpBlock(nn.Module):
         if upsample_mode is not None:
             self.upsamplers = nn.ModuleList([_Resample(out_dim, mode=upsample_mode)])
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         x = self.resnets(op, x)
         if self.upsamplers is not None:
             x = self.upsamplers[0](op, x)
@@ -475,7 +474,7 @@ class _Decoder3d(nn.Module):
         self.conv_out = _CausalConv3d(dims[-1], 3, 3, padding=1)
         self._silu = _SiLU()
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         x = self.conv_in(op, x)
         x = self.mid_block(op, x)
         x = self.up_blocks(op, x)

--- a/src/mobius/models/qwen_vl.py
+++ b/src/mobius/models/qwen_vl.py
@@ -6,8 +6,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components import (
@@ -93,7 +92,7 @@ class Qwen25VLCausalLMModel(nn.Module):
         self.vision_encoder = Qwen25VLVisionEncoderModel(config)
         self.embedding = Qwen25VLEmbeddingModel(config)
 
-    def forward(self, op: builder.OpBuilder, **kwargs):
+    def forward(self, op: OpBuilder, **kwargs):
         raise NotImplementedError(
             "Qwen25VLCausalLMModel uses Qwen25VL3ModelTask which calls "
             "each sub-module (decoder, vision_encoder, embedding) separately."
@@ -150,7 +149,7 @@ class Qwen25VLDecoderModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         inputs_embeds: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -226,7 +225,7 @@ class Qwen25VLVisionEncoderModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         pixel_values: ir.Value,
         image_grid_thw: ir.Value,
     ):
@@ -275,7 +274,7 @@ class Qwen25VLEmbeddingModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         image_features: ir.Value,
     ):
@@ -399,7 +398,7 @@ class Qwen2VLCausalLMModel(nn.Module):
         self.vision_encoder = Qwen2VLVisionEncoderModel(config)
         self.embedding = Qwen25VLEmbeddingModel(config)
 
-    def forward(self, op: builder.OpBuilder, **kwargs):
+    def forward(self, op: OpBuilder, **kwargs):
         raise NotImplementedError(
             "Qwen2VLCausalLMModel uses Qwen25VL3ModelTask which calls "
             "each sub-module (decoder, vision_encoder, embedding) "
@@ -460,7 +459,7 @@ class _Qwen3VLTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -566,7 +565,7 @@ class _Qwen3VLForMultimodalLM(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -634,7 +633,7 @@ class Qwen3VLCausalLMModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -748,7 +747,7 @@ class Qwen3VL3ModelCausalLMModel(nn.Module):
         self.vision_encoder = Qwen3VLVisionEncoderModel(config)
         self.embedding = Qwen3VLEmbeddingModel(config)
 
-    def forward(self, op: builder.OpBuilder, **kwargs):
+    def forward(self, op: OpBuilder, **kwargs):
         raise NotImplementedError(
             "Qwen3VL3ModelCausalLMModel uses QwenVLTask "
             "which calls each sub-module separately."
@@ -808,7 +807,7 @@ class Qwen3VLDecoderModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         inputs_embeds: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -882,7 +881,7 @@ class Qwen3VLVisionEncoderModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         pixel_values: ir.Value,
         image_grid_thw: ir.Value,
     ):

--- a/src/mobius/models/sam2.py
+++ b/src/mobius/models/sam2.py
@@ -18,8 +18,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import Sam2Config
 from mobius.components._activations import ACT2FN
@@ -65,7 +64,7 @@ class _Sam2HieraBlock(nn.Module):
         if self._has_dim_proj:
             self.proj = Linear(dim_in, dim_out)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # hidden_states: [B, S, dim_in]
         residual = hidden_states
         hidden_states = self.layer_norm1(op, hidden_states)
@@ -186,7 +185,7 @@ class Sam2VisionModel(nn.Module):
                 Conv2dNoBias(dim, fpn_hidden_size, kernel_size=1, stride=1, padding=0)
             )
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         # Patch embedding: [B, 3, H, W] → [B, C, H', W']
         x = self.patch_embed(op, pixel_values)
         # Flatten spatial dims: [B, C, H', W'] → [B, H'*W', C]

--- a/src/mobius/models/segformer.py
+++ b/src/mobius/models/segformer.py
@@ -15,8 +15,7 @@ import re
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import SegformerConfig
 from mobius.components._activations import ACT2FN
@@ -45,7 +44,7 @@ class _OverlapPatchEmbeddings(nn.Module):
         )
         self.layer_norm = LayerNorm(hidden_size)
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         embeddings = self.proj(op, pixel_values)
         # Save spatial dims for later reshape
         height = op.Shape(embeddings, start=2, end=3)
@@ -85,7 +84,7 @@ class _EfficientSelfAttention(nn.Module):
             self.sr_layer_norm = LayerNorm(hidden_size)
 
     def forward(
-        self, op: builder.OpBuilder, hidden_states: ir.Value, height: ir.Value, width: ir.Value
+        self, op: OpBuilder, hidden_states: ir.Value, height: ir.Value, width: ir.Value
     ):
         query = self.query(op, hidden_states)
 
@@ -137,7 +136,7 @@ class _DWConv(nn.Module):
         self.dwconv = Conv2d(dim, dim, kernel_size=3, padding=1, groups=dim)
 
     def forward(
-        self, op: builder.OpBuilder, hidden_states: ir.Value, height: ir.Value, width: ir.Value
+        self, op: OpBuilder, hidden_states: ir.Value, height: ir.Value, width: ir.Value
     ):
         # [B, S, C] → [B, C, H, W]
         batch = op.Shape(hidden_states, start=0, end=1)
@@ -165,7 +164,7 @@ class _MixFFN(nn.Module):
         self._act_fn = ACT2FN[hidden_act]
 
     def forward(
-        self, op: builder.OpBuilder, hidden_states: ir.Value, height: ir.Value, width: ir.Value
+        self, op: OpBuilder, hidden_states: ir.Value, height: ir.Value, width: ir.Value
     ):
         hidden_states = self.dense1(op, hidden_states)
         hidden_states = self.dwconv(op, hidden_states, height, width)
@@ -194,7 +193,7 @@ class _SegformerLayer(nn.Module):
         self.mlp = _MixFFN(hidden_size, mlp_ratio, hidden_act)
 
     def forward(
-        self, op: builder.OpBuilder, hidden_states: ir.Value, height: ir.Value, width: ir.Value
+        self, op: OpBuilder, hidden_states: ir.Value, height: ir.Value, width: ir.Value
     ):
         # Attention block
         normed = self.layer_norm_1(op, hidden_states)
@@ -263,7 +262,7 @@ class _SegformerEncoder(nn.Module):
         self._num_stages = num_stages
         self._hidden_sizes = hidden_sizes
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         hidden_states = pixel_values
         all_hidden_states = []
 
@@ -302,7 +301,7 @@ class _LinearCStage(nn.Module):
         super().__init__()
         self.proj = Linear(in_features, out_features)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return self.proj(op, x)
 
 
@@ -330,7 +329,7 @@ class _SegformerDecodeHead(nn.Module):
         # Classifier
         self.classifier = Conv2d(dec_hidden, num_labels, kernel_size=1, padding=0)
 
-    def forward(self, op: builder.OpBuilder, encoder_hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, encoder_hidden_states: ir.Value):
         # Target spatial size = first stage output (largest resolution)
         target_h = op.Shape(encoder_hidden_states[0], start=2, end=3)
         target_w = op.Shape(encoder_hidden_states[0], start=3, end=4)
@@ -392,7 +391,7 @@ class SegformerForSemanticSegmentation(nn.Module):
         self.encoder = _SegformerEncoder(config)
         self.decode_head = _SegformerDecodeHead(config)
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         encoder_hidden_states = self.encoder(op, pixel_values)
         logits = self.decode_head(op, encoder_hidden_states)
         return logits

--- a/src/mobius/models/sensevoice_small.py
+++ b/src/mobius/models/sensevoice_small.py
@@ -23,8 +23,7 @@ from __future__ import annotations
 import numpy as np
 import onnx_ir as ir
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._common import (
@@ -131,7 +130,7 @@ class SenseVoiceSmallModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_features: ir.Value,
         language_id: ir.Value,
     ) -> ir.Value:
@@ -288,7 +287,7 @@ class _SenseVoiceEncoder(nn.Module):
         )
         self.tp_norm = LayerNorm(hidden_size)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, hidden_states: ir.Value) -> ir.Value:
         """Encode through all 3 stacks.
 
         Args:

--- a/src/mobius/models/smollm.py
+++ b/src/mobius/models/smollm.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components import (
@@ -48,7 +47,7 @@ class SmolLM3TextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/t5.py
+++ b/src/mobius/models/t5.py
@@ -9,8 +9,7 @@ import math
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components._activations import ACT2FN
@@ -29,7 +28,7 @@ if TYPE_CHECKING:
 
 
 def _relative_position_bucket(
-    op: builder.OpBuilder,
+    op: OpBuilder,
     relative_position,
     *,
     bidirectional: bool,
@@ -97,7 +96,7 @@ def _relative_position_bucket(
 
 
 def _compute_position_bias(
-    op: builder.OpBuilder,
+    op: OpBuilder,
     embedding: Embedding,
     query_length,
     key_length,
@@ -182,7 +181,7 @@ class T5EncoderBlock(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value | None = None,
     ):
@@ -223,7 +222,7 @@ class T5DecoderBlock(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         encoder_hidden_states: ir.Value,
         attention_bias: ir.Value | None = None,
@@ -278,7 +277,7 @@ class _T5FFN(nn.Module):
         self.wo = Linear(config.intermediate_size, config.hidden_size, bias=False)
         self._act_fn = ACT2FN[config.hidden_act]
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         if self._is_gated:
             gate = self._act_fn(op, self.wi_0(op, hidden_states))
             hidden_states = op.Mul(gate, self.wi_1(op, hidden_states))
@@ -315,7 +314,7 @@ class T5Encoder(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value | None = None,
     ):
@@ -364,7 +363,7 @@ class T5Decoder(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         encoder_hidden_states: ir.Value,
         attention_mask: ir.Value | None = None,

--- a/src/mobius/models/unet.py
+++ b/src/mobius/models/unet.py
@@ -21,8 +21,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._diffusers_configs import UNet2DConfig
 from mobius.components import Conv2d as _Conv2d
@@ -47,7 +46,7 @@ class _TimestepEmbedding(nn.Module):
         self.linear_2 = _Linear(time_embed_dim, time_embed_dim)
         self._silu = _SiLU()
 
-    def forward(self, op: builder.OpBuilder, sample: ir.Value):
+    def forward(self, op: OpBuilder, sample: ir.Value):
         sample = self.linear_1(op, sample)
         sample = self._silu(op, sample)
         sample = self.linear_2(op, sample)
@@ -85,7 +84,7 @@ class _ResNetBlock2DWithTime(nn.Module):
         else:
             self.conv_shortcut = None
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value, temb: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value, temb: ir.Value):
         residual = hidden_states
 
         hidden_states = self.norm1(op, hidden_states)
@@ -140,7 +139,7 @@ class _CrossAttentionBlock(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         encoder_hidden_states: ir.Value | None = None,
     ):
@@ -191,7 +190,7 @@ class _BasicAttention(nn.Module):
         self._num_heads = num_heads
         self._head_dim = query_dim // num_heads
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value, context: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value, context: ir.Value):
         q = self.to_q(op, hidden_states)
         k = self.to_k(op, context)
         v = self.to_v(op, context)
@@ -217,7 +216,7 @@ class _LayerNorm1D(nn.Module):
         self.bias = nn.Parameter((dim,))
         self._eps = eps
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return op.LayerNormalization(x, self.weight, self.bias, axis=-1, epsilon=self._eps)
 
 
@@ -230,7 +229,7 @@ class _FeedForward(nn.Module):
         self.proj_in = _Linear(dim, inner_dim * 2)
         self.proj_out = _Linear(inner_dim, dim)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         projected = self.proj_in(op, x)
         # Split into value and gate
         x1, gate = op.Split(projected, num_outputs=2, axis=-1, _outputs=2)
@@ -283,7 +282,7 @@ class _DownBlock2D(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         temb: ir.Value,
         encoder_hidden_states: ir.Value | None = None,
@@ -344,7 +343,7 @@ class _UpBlock2D(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         temb: ir.Value,
         skip_connections: ir.Value,
@@ -371,7 +370,7 @@ class _Downsample2D(nn.Module):
         super().__init__()
         self.conv = _Conv2d(channels, channels, kernel_size=3, stride=2, padding=1)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         return self.conv(op, x)
 
 
@@ -382,7 +381,7 @@ class _Upsample2D(nn.Module):
         super().__init__()
         self.conv = _Conv2d(channels, channels, kernel_size=3, padding=1)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # Upsample 2x using nearest neighbor
         hidden_states = op.Resize(
             hidden_states,
@@ -426,7 +425,7 @@ class _UNetMidBlock2DCrossAttn(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         temb: ir.Value,
         encoder_hidden_states: ir.Value | None = None,
@@ -528,7 +527,7 @@ class UNet2DConditionModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         sample: ir.Value,
         timestep: ir.Value,
         encoder_hidden_states: ir.Value,
@@ -572,7 +571,7 @@ class UNet2DConditionModel(nn.Module):
 
         return sample
 
-    def _get_timestep_embedding(self, op: builder.OpBuilder, timestep):
+    def _get_timestep_embedding(self, op: OpBuilder, timestep):
         """Sinusoidal timestep embedding."""
         half_dim = self.time_proj_dim // 2
         exponent = -math.log(10000.0) / half_dim

--- a/src/mobius/models/vae.py
+++ b/src/mobius/models/vae.py
@@ -11,8 +11,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._diffusers_configs import VAEConfig
 from mobius.components import Conv2d as _Conv2d
@@ -50,7 +49,7 @@ class _ResNetBlock2D(nn.Module):
         else:
             self.conv_shortcut = None
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         residual = hidden_states
 
         hidden_states = self.norm1(op, hidden_states)
@@ -85,7 +84,7 @@ class _AttentionBlock(nn.Module):
         self._channels = channels
         self._num_heads = max(1, channels // num_head_channels) if num_head_channels > 0 else 1
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         residual = hidden_states
         batch = op.Shape(hidden_states, start=0, end=1)
         channels = op.Shape(hidden_states, start=1, end=2)
@@ -148,7 +147,7 @@ class _DownEncoderBlock2D(nn.Module):
         else:
             self.downsamplers = None
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         for resnet in self.resnets:
             hidden_states = resnet(op, hidden_states)
 
@@ -166,7 +165,7 @@ class _Downsample2D(nn.Module):
         super().__init__()
         self.conv = _Conv2d(channels, channels, kernel_size=3, stride=2, padding=1)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         return self.conv(op, hidden_states)
 
 
@@ -197,7 +196,7 @@ class _UpDecoderBlock2D(nn.Module):
         else:
             self.upsamplers = None
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         for resnet in self.resnets:
             hidden_states = resnet(op, hidden_states)
 
@@ -215,7 +214,7 @@ class _Upsample2D(nn.Module):
         super().__init__()
         self.conv = _Conv2d(channels, channels, kernel_size=3, padding=1)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         hidden_states = op.Resize(
             hidden_states,
             None,
@@ -249,7 +248,7 @@ class _MidBlock2D(nn.Module):
         else:
             self.attentions = None
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         hidden_states = self.resnets[0](op, hidden_states)
 
         if self.attentions is not None:
@@ -302,7 +301,7 @@ class _VAEEncoder(nn.Module):
         )
         self._silu = _SiLU()
 
-    def forward(self, op: builder.OpBuilder, sample: ir.Value):
+    def forward(self, op: OpBuilder, sample: ir.Value):
         hidden_states = self.conv_in(op, sample)
 
         for down_block in self.down_blocks:
@@ -356,7 +355,7 @@ class _VAEDecoder(nn.Module):
         )
         self._silu = _SiLU()
 
-    def forward(self, op: builder.OpBuilder, latent_sample: ir.Value):
+    def forward(self, op: OpBuilder, latent_sample: ir.Value):
         hidden_states = self.conv_in(op, latent_sample)
 
         hidden_states = self.mid_block(op, hidden_states)

--- a/src/mobius/models/video_vae.py
+++ b/src/mobius/models/video_vae.py
@@ -18,8 +18,7 @@ import dataclasses
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius.components import GroupNorm as _GroupNorm
 from mobius.components import SiLU as _SiLU
@@ -79,7 +78,7 @@ class _Conv3d(nn.Module):
         self._stride = list(stride)
         self._padding = list(padding)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         pads = [
             p for p in self._padding for _ in range(2)
         ]  # [d_begin, h_begin, w_begin, d_end, h_end, w_end]
@@ -115,7 +114,7 @@ class _ResNetBlock3D(nn.Module):
         else:
             self.conv_shortcut = None
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         residual = hidden_states
         hidden_states = self.norm1(op, hidden_states)
         hidden_states = self._silu(op, hidden_states)
@@ -162,7 +161,7 @@ class _DownBlock3D(nn.Module):
                 )
             )
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         for resnet in self.resnets:
             hidden_states = resnet(op, hidden_states)
         if self.downsamplers is not None:
@@ -195,7 +194,7 @@ class _UpBlock3D(nn.Module):
                 _Conv3d(out_channels, out_channels, kernel_size=(1, 3, 3), padding=(0, 1, 1))
             )
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         for resnet in self.resnets:
             hidden_states = resnet(op, hidden_states)
         if self.upsamplers is not None:
@@ -221,7 +220,7 @@ class _MidBlock3D(nn.Module):
         self.resnets.append(_ResNetBlock3D(channels, channels, norm_num_groups))
         self.resnets.append(_ResNetBlock3D(channels, channels, norm_num_groups))
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         for resnet in self.resnets:
             hidden_states = resnet(op, hidden_states)
         return hidden_states
@@ -267,7 +266,7 @@ class _VideoEncoder(nn.Module):
         )
         self._silu = _SiLU()
 
-    def forward(self, op: builder.OpBuilder, sample: ir.Value):
+    def forward(self, op: OpBuilder, sample: ir.Value):
         hidden_states = self.conv_in(op, sample)
         for down_block in self.down_blocks:
             hidden_states = down_block(op, hidden_states)
@@ -315,7 +314,7 @@ class _VideoDecoder(nn.Module):
         )
         self._silu = _SiLU()
 
-    def forward(self, op: builder.OpBuilder, latent_sample: ir.Value):
+    def forward(self, op: OpBuilder, latent_sample: ir.Value):
         hidden_states = self.conv_in(op, latent_sample)
         hidden_states = self.mid_block(op, hidden_states)
         for up_block in self.up_blocks:
@@ -349,7 +348,7 @@ class VideoAutoencoderModel(nn.Module):
         self.quant_conv = None
         self.post_quant_conv = None
 
-    def forward(self, op: builder.OpBuilder, latent_sample: ir.Value):
+    def forward(self, op: OpBuilder, latent_sample: ir.Value):
         """Decoder forward pass."""
         return self.decoder(op, latent_sample)
 

--- a/src/mobius/models/vit.py
+++ b/src/mobius/models/vit.py
@@ -10,8 +10,7 @@ import re
 import numpy as np
 import onnx_ir as ir
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components import (
@@ -47,7 +46,7 @@ class ViTModel(nn.Module):
         self.encoder = _ViTEncoder(config)
         self.layernorm = LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         hidden_states = self.embeddings(op, pixel_values)
         hidden_states = self.encoder(op, hidden_states)
         hidden_states = self.layernorm(op, hidden_states)
@@ -82,7 +81,7 @@ class _ViTEmbeddings(nn.Module):
             ),
         )
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         patch_embeds = self.patch_embeddings(op, pixel_values)
         batch_size = op.Shape(patch_embeds, start=0, end=1)
 
@@ -105,7 +104,7 @@ class _Conv2dPatchEmbed(nn.Module):
         super().__init__()
         self.projection = _Conv2d(in_channels, hidden_size, patch_size, patch_size)
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         # Conv2d: [batch, channels, H, W] -> [batch, hidden, H/patch, W/patch]
         x = self.projection(op, pixel_values)
         # Flatten spatial dims and transpose: [batch, hidden, num_patches] -> [batch, num_patches, hidden]
@@ -125,7 +124,7 @@ class _ViTEncoder(nn.Module):
             [_ViTEncoderLayer(config) for _ in range(config.num_hidden_layers)]
         )
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         for layer in self.layer:
             hidden_states = layer(op, hidden_states)
         return hidden_states
@@ -149,7 +148,7 @@ class _ViTEncoderLayer(nn.Module):
             activation=config.hidden_act,
         )
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         residual = hidden_states
         hidden_states = self.layernorm_before(op, hidden_states)
         hidden_states = self.self_attn(op, hidden_states)

--- a/src/mobius/models/wav2vec2.py
+++ b/src/mobius/models/wav2vec2.py
@@ -21,8 +21,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius.components import FCMLP
@@ -45,7 +44,7 @@ class _Conv1dFeatureExtractor(nn.Module):
             layer = _ConvLayerBlock(in_ch, out_ch, kernel, use_group_norm=(i == 0))
             self.conv_layers.append(layer)
 
-    def forward(self, op: builder.OpBuilder, input_values: ir.Value):
+    def forward(self, op: OpBuilder, input_values: ir.Value):
         # input_values: [batch, time] → [batch, 1, time]
         hidden_states = op.Unsqueeze(input_values, [1])
         for layer in self.conv_layers:
@@ -74,7 +73,7 @@ class _ConvLayerBlock(nn.Module):
             self.layer_norm = nn.Parameter((out_channels,))
             self.layer_norm_bias = nn.Parameter((out_channels,))
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         hidden_states = op.Conv(hidden_states, self.conv, self.conv_bias)
         if self.use_group_norm:
             hidden_states = op.GroupNormalization(
@@ -95,7 +94,7 @@ class _FeatureProjection(nn.Module):
         self.layer_norm = LayerNorm(conv_dim, eps=eps)
         self.projection = Linear(conv_dim, hidden_size)
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         hidden_states = self.layer_norm(op, hidden_states)
         hidden_states = self.projection(op, hidden_states)
         return hidden_states
@@ -116,7 +115,7 @@ class _Wav2Vec2EncoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_mask: ir.Value | None = None,
     ):
@@ -146,7 +145,7 @@ class _Wav2Vec2Attention(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_mask: ir.Value | None = None,
     ):
@@ -182,7 +181,7 @@ class _Wav2Vec2Encoder(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_mask: ir.Value | None = None,
     ):
@@ -233,7 +232,7 @@ class Wav2Vec2Model(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_values: ir.Value,
         attention_mask: ir.Value | None = None,
     ):

--- a/src/mobius/models/whisper.py
+++ b/src/mobius/models/whisper.py
@@ -17,8 +17,7 @@ import math
 import numpy as np
 import onnx_ir as ir
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import WhisperConfig
 from mobius.components import (
@@ -88,7 +87,7 @@ class WhisperEncoderModel(nn.Module):
         )
         self.layer_norm = LayerNorm(d_model, eps=eps)
 
-    def forward(self, op: builder.OpBuilder, input_features: ir.Value):
+    def forward(self, op: OpBuilder, input_features: ir.Value):
         # input_features: [batch, num_mel_bins, audio_seq_len]
         hidden_states = op.Gelu(self.conv1(op, input_features))
         hidden_states = op.Gelu(self.conv2(op, hidden_states))
@@ -143,7 +142,7 @@ class WhisperDecoderModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         decoder_input_ids: ir.Value,
         encoder_hidden_states: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/xlm.py
+++ b/src/mobius/models/xlm.py
@@ -16,8 +16,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
 from mobius._weight_utils import tie_word_embeddings
@@ -54,7 +53,7 @@ class _XLMTextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -109,7 +108,7 @@ class XLMCausalLMModel(GPT2CausalLMModel):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/src/mobius/models/yolos.py
+++ b/src/mobius/models/yolos.py
@@ -16,8 +16,7 @@ import re
 import numpy as np
 import onnx_ir as ir
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig, YolosConfig
 from mobius.components import (
@@ -59,7 +58,7 @@ class _YolosEmbeddings(nn.Module):
             data=ir.tensor(np.zeros((1, num_positions, hidden_size), dtype=np.float32)),
         )
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         patch_embeds = self.patch_embeddings(op, pixel_values)
         batch_size = op.Shape(patch_embeds, start=0, end=1)
 
@@ -90,7 +89,7 @@ class _Conv2dPatchEmbed(nn.Module):
         super().__init__()
         self.projection = _Conv2d(in_channels, hidden_size, patch_size, patch_size)
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         x = self.projection(op, pixel_values)
         batch = op.Shape(x, start=0, end=1)
         hidden = op.Shape(x, start=1, end=2)
@@ -118,7 +117,7 @@ class _YolosEncoderLayer(nn.Module):
             bias=True,
         )
 
-    def forward(self, op: builder.OpBuilder, hidden_states: ir.Value):
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
         residual = hidden_states
         hidden_states = self.layernorm_before(op, hidden_states)
         hidden_states = self.self_attn(op, hidden_states)
@@ -142,7 +141,7 @@ class _MLPPredictionHead(nn.Module):
         )
         self.num_layers = num_layers
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value):
+    def forward(self, op: OpBuilder, x: ir.Value):
         for i, layer in enumerate(self.layers):
             x = layer(op, x)
             if i < self.num_layers - 1:
@@ -196,7 +195,7 @@ class YolosForObjectDetection(nn.Module):
             config.hidden_size, config.hidden_size, 4, num_layers=3
         )
 
-    def forward(self, op: builder.OpBuilder, pixel_values: ir.Value):
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
         hidden_states = self.embeddings(op, pixel_values)
 
         for i, layer in enumerate(self.encoder):

--- a/src/mobius/models/zamba2.py
+++ b/src/mobius/models/zamba2.py
@@ -42,8 +42,7 @@ import re
 from typing import TYPE_CHECKING
 
 import torch
-from onnxscript import nn
-from onnxscript._internal import builder
+from onnxscript import OpBuilder, nn
 
 from mobius._configs import Zamba2Config
 from mobius._weight_utils import tie_word_embeddings
@@ -97,7 +96,7 @@ class Zamba2MambaDecoderLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple,
@@ -135,7 +134,7 @@ class _Adapter(nn.Module):
         self.down = Linear(in_features, rank, bias=False)
         self.up = Linear(rank, out_features, bias=False)
 
-    def forward(self, op: builder.OpBuilder, x: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, x: ir.Value) -> ir.Value:
         return self.up(op, self.down(op, x))
 
 
@@ -157,7 +156,7 @@ class _Zamba2QKVAdapters(nn.Module):
         self.k_adapter = _Adapter(attn_hidden, config.num_key_value_heads * head_dim, rank)
         self.v_adapter = _Adapter(attn_hidden, config.num_key_value_heads * head_dim, rank)
 
-    def forward(self, op: builder.OpBuilder, attn_input: ir.Value) -> tuple:
+    def forward(self, op: OpBuilder, attn_input: ir.Value) -> tuple:
         """Compute Q/K/V adapter outputs from layer-normed concat hidden."""
         return (
             self.q_adapter(op, attn_input),
@@ -178,7 +177,7 @@ class _Zamba2MLPAdapter(nn.Module):
         rank = config.adapter_rank
         self.mlp_adapter = _Adapter(config.hidden_size, 2 * config.intermediate_size, rank)
 
-    def forward(self, op: builder.OpBuilder, mlp_input: ir.Value) -> ir.Value:
+    def forward(self, op: OpBuilder, mlp_input: ir.Value) -> ir.Value:
         """Compute MLP adapter output from pre-FFN hidden states."""
         return self.mlp_adapter(op, mlp_input)
 
@@ -203,7 +202,7 @@ class _Zamba2AttentionProjections(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         attn_output: ir.Value | None = None,
     ):
@@ -254,7 +253,7 @@ class Zamba2SharedTransformerLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         concat_hidden: ir.Value,
         attention_bias: ir.Value,
         position_embeddings: tuple | None,
@@ -377,7 +376,7 @@ class Zamba2InjectedMambaLayer(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         hidden_states: ir.Value,
         transformer_hidden_states: ir.Value,
         past_key_value: tuple | None,
@@ -494,7 +493,7 @@ class _Zamba2TextModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,
@@ -618,7 +617,7 @@ class Zamba2CausalLMModel(nn.Module):
 
     def forward(
         self,
-        op: builder.OpBuilder,
+        op: OpBuilder,
         input_ids: ir.Value,
         attention_mask: ir.Value,
         position_ids: ir.Value,

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -3796,7 +3796,7 @@ def test_qwen35_deltanet_single_layer_parity():
     - recurrent_state carry matches HF
     """
     import onnx_ir as ir
-    from onnxscript._internal import builder as onnx_builder
+    from onnxscript import GraphBuilder
 
     try:
         from transformers.models.qwen3_5.modeling_qwen3_5 import (
@@ -3858,7 +3858,7 @@ def test_qwen35_deltanet_single_layer_parity():
         name="deltanet_test",
         opset_imports={"": OPSET_VERSION, "com.microsoft": 1},
     )
-    graph_builder = onnx_builder.GraphBuilder(graph)
+    graph_builder = GraphBuilder(graph)
     op = graph_builder.op
 
     output, new_conv, new_rec = onnx_dn(

--- a/tests/parity/phi3_rms_norm_parity_test.py
+++ b/tests/parity/phi3_rms_norm_parity_test.py
@@ -56,7 +56,7 @@ def _get_cached_rms_norm_session(
         ``"weight"`` (shape ``[hidden_size]``), both float32.
     """
     import onnx_ir as ir
-    from onnxscript._internal.builder import GraphBuilder
+    from onnxscript import GraphBuilder
 
     from mobius.components._rms_norm import apply_rms_norm
 


### PR DESCRIPTION
Import OpBuilder and GraphBuilder directly from onnxscript instead of from the private onnxscript._internal.builder module. The builder module was only used for these two classes (type annotations) across ~105 source files plus docs and skills.

Four files in src/mobius/functions/ still import build_function from onnxscript._internal.builder since it is not yet part of the public API.