### PR TITLE
Migrate op_multi_out to __getattr__ dispatch with _outputs

### DIFF
--- a/src/mobius/rewrite_rules/_group_query_attention.py
+++ b/src/mobius/rewrite_rules/_group_query_attention.py
@@ -647,7 +647,13 @@ class AttentionToGQA(RewriteRuleClassBase):
             gqa_attrs["softcap"] = softcap
 
         outputs = op.GroupQueryAttention(
-            q, k, v, past_key, past_value, self._seqlens_k, self._total_seq_len,
+            q,
+            k,
+            v,
+            past_key,
+            past_value,
+            self._seqlens_k,
+            self._total_seq_len,
             _domain="com.microsoft",
             _outputs=3,
             **gqa_attrs,

--- a/src/mobius/rewrite_rules/_group_query_attention.py
+++ b/src/mobius/rewrite_rules/_group_query_attention.py
@@ -244,22 +244,19 @@ class RotaryAttentionToGQA(RewriteRuleClassBase):
         }
         if softcap:
             gqa_attrs["softcap"] = softcap
-        outputs = op.op_multi_out(
-            "GroupQueryAttention",
-            inputs=[
-                q_pre,
-                k_pre,
-                v,
-                past_key,
-                past_value,
-                self._seqlens_k,
-                self._total_seq_len,
-                self._cos_cache,
-                self._sin_cache,
-            ],
-            domain="com.microsoft",
-            attributes=gqa_attrs,
-            num_outputs=3,
+        outputs = op.GroupQueryAttention(
+            q_pre,
+            k_pre,
+            v,
+            past_key,
+            past_value,
+            self._seqlens_k,
+            self._total_seq_len,
+            self._cos_cache,
+            self._sin_cache,
+            _domain="com.microsoft",
+            _outputs=3,
+            **gqa_attrs,
         )
 
         return outputs[0], outputs[1], outputs[2]
@@ -377,17 +374,14 @@ class PackQKVForGQA(RewriteRuleClassBase):
         gqa_node = gqa_out.producer()
         attrs = {key: gqa_node.attributes[key].value for key in gqa_node.attributes}
 
-        outputs = op.op_multi_out(
-            "GroupQueryAttention",
-            inputs=[
-                packed_qkv,
-                None,
-                None,
-                *gqa_node.inputs[3:],
-            ],
-            domain="com.microsoft",
-            attributes=attrs,
-            num_outputs=3,
+        outputs = op.GroupQueryAttention(
+            packed_qkv,
+            None,
+            None,
+            *gqa_node.inputs[3:],
+            _domain="com.microsoft",
+            _outputs=3,
+            **attrs,
         )
 
         return outputs[0], outputs[1], outputs[2]
@@ -507,17 +501,14 @@ class PackQKVWithBiasForGQA(RewriteRuleClassBase):
         gqa_node = gqa_out.producer()
         attrs = {key: gqa_node.attributes[key].value for key in gqa_node.attributes}
 
-        outputs = op.op_multi_out(
-            "GroupQueryAttention",
-            inputs=[
-                packed_qkv,
-                None,
-                None,
-                *gqa_node.inputs[3:],
-            ],
-            domain="com.microsoft",
-            attributes=attrs,
-            num_outputs=3,
+        outputs = op.GroupQueryAttention(
+            packed_qkv,
+            None,
+            None,
+            *gqa_node.inputs[3:],
+            _domain="com.microsoft",
+            _outputs=3,
+            **attrs,
         )
 
         return outputs[0], outputs[1], outputs[2]
@@ -655,12 +646,11 @@ class AttentionToGQA(RewriteRuleClassBase):
         if softcap:
             gqa_attrs["softcap"] = softcap
 
-        outputs = op.op_multi_out(
-            "GroupQueryAttention",
-            inputs=[q, k, v, past_key, past_value, self._seqlens_k, self._total_seq_len],
-            domain="com.microsoft",
-            attributes=gqa_attrs,
-            num_outputs=3,
+        outputs = op.GroupQueryAttention(
+            q, k, v, past_key, past_value, self._seqlens_k, self._total_seq_len,
+            _domain="com.microsoft",
+            _outputs=3,
+            **gqa_attrs,
         )
         return outputs[0], outputs[1], outputs[2]
 

--- a/src/mobius/rewrite_rules/_separate_rope.py
+++ b/src/mobius/rewrite_rules/_separate_rope.py
@@ -134,7 +134,10 @@ class GQASeparateRoPE(RewriteRuleClassBase):
         remaining = list(gqa_node.inputs[3:7])
 
         outputs = op.GroupQueryAttention(
-            q_rot, k_rot, v, *remaining,
+            q_rot,
+            k_rot,
+            v,
+            *remaining,
             _domain="com.microsoft",
             _outputs=3,
             **attrs,

--- a/src/mobius/rewrite_rules/_separate_rope.py
+++ b/src/mobius/rewrite_rules/_separate_rope.py
@@ -133,12 +133,11 @@ class GQASeparateRoPE(RewriteRuleClassBase):
         # past_key, past_value, seqlens_k, total_sequence_length.
         remaining = list(gqa_node.inputs[3:7])
 
-        outputs = op.op_multi_out(
-            "GroupQueryAttention",
-            inputs=[q_rot, k_rot, v, *remaining],
-            domain="com.microsoft",
-            attributes=attrs,
-            num_outputs=3,
+        outputs = op.GroupQueryAttention(
+            q_rot, k_rot, v, *remaining,
+            _domain="com.microsoft",
+            _outputs=3,
+            **attrs,
         )
         return outputs[0], outputs[1], outputs[2]
 

--- a/src/mobius/rewrite_rules/_skip_layer_norm.py
+++ b/src/mobius/rewrite_rules/_skip_layer_norm.py
@@ -114,12 +114,14 @@ class AddLayerNormToSkipLayerNorm(RewriteRuleClassBase):
         input_a = add_node.inputs[0]
         input_b = add_node.inputs[1]
 
-        outputs = op.op_multi_out(
-            "SkipLayerNormalization",
-            inputs=[input_a, input_b, weight, bias],
-            domain="com.microsoft",
-            attributes={"epsilon": epsilon},
-            num_outputs=4,
+        outputs = op.SkipLayerNormalization(
+            input_a,
+            input_b,
+            weight,
+            bias,
+            _domain="com.microsoft",
+            epsilon=epsilon,
+            _outputs=4,
         )
         new_norm_out = outputs[0]
         skip_out = outputs[3]
@@ -200,12 +202,13 @@ class AddLayerNormNoBiasToSkipLayerNorm(RewriteRuleClassBase):
         input_b = add_node.inputs[1]
 
         # SkipLayerNormalization with gamma only (no beta)
-        outputs = op.op_multi_out(
-            "SkipLayerNormalization",
-            inputs=[input_a, input_b, weight],
-            domain="com.microsoft",
-            attributes={"epsilon": epsilon},
-            num_outputs=4,
+        outputs = op.SkipLayerNormalization(
+            input_a,
+            input_b,
+            weight,
+            _domain="com.microsoft",
+            epsilon=epsilon,
+            _outputs=4,
         )
         new_norm_out = outputs[0]
         skip_out = outputs[3]

--- a/src/mobius/rewrite_rules/_skip_norm.py
+++ b/src/mobius/rewrite_rules/_skip_norm.py
@@ -102,12 +102,13 @@ class AddRMSNormToSkipNorm(RewriteRuleClassBase):
         input_a = add_node.inputs[0]
         input_b = add_node.inputs[1]
 
-        outputs = op.op_multi_out(
-            "SkipSimplifiedLayerNormalization",
-            inputs=[input_a, input_b, weight],
-            domain="com.microsoft",
-            attributes={"epsilon": epsilon},
-            num_outputs=4,
+        outputs = op.SkipSimplifiedLayerNormalization(
+            input_a,
+            input_b,
+            weight,
+            _domain="com.microsoft",
+            epsilon=epsilon,
+            _outputs=4,
         )
         new_norm_out = outputs[0]
         skip_out = outputs[3]

--- a/src/mobius/rewrite_rules/_unpack_qkv.py
+++ b/src/mobius/rewrite_rules/_unpack_qkv.py
@@ -286,7 +286,10 @@ class GQAUnpackQKV(RewriteRuleClassBase):
         remaining = list(gqa_node.inputs[3:])  # everything after the packed slot
 
         outputs = op.GroupQueryAttention(
-            q, k, v, *remaining,
+            q,
+            k,
+            v,
+            *remaining,
             _domain="com.microsoft",
             _outputs=3,
             **attrs,

--- a/src/mobius/rewrite_rules/_unpack_qkv.py
+++ b/src/mobius/rewrite_rules/_unpack_qkv.py
@@ -285,12 +285,11 @@ class GQAUnpackQKV(RewriteRuleClassBase):
         attrs = {key: gqa_node.attributes[key].value for key in gqa_node.attributes}
         remaining = list(gqa_node.inputs[3:])  # everything after the packed slot
 
-        outputs = op.op_multi_out(
-            "GroupQueryAttention",
-            inputs=[q, k, v, *remaining],
-            domain="com.microsoft",
-            attributes=attrs,
-            num_outputs=3,
+        outputs = op.GroupQueryAttention(
+            q, k, v, *remaining,
+            _domain="com.microsoft",
+            _outputs=3,
+            **attrs,
         )
         return outputs[0], outputs[1], outputs[2]
 


### PR DESCRIPTION
## Problem

`op.op_multi_out()` is being removed from onnxscript/onnx_ir. 9 call sites across 5 rewrite rule files use this API.

## Fix

Replace all `op.op_multi_out()` calls with the standard `__getattr__` dispatch pattern using `_outputs=N`:

```python
# Before
outputs = op.op_multi_out(
    'GroupQueryAttention',
    inputs=[q, k, v, past_k, past_v, seqlens, total_seq, cos, sin],
    domain='com.microsoft',
    attributes=gqa_attrs,
    num_outputs=3,
)

# After
outputs = op.GroupQueryAttention(
    q, k, v, past_k, past_v, seqlens, total_seq, cos, sin,
    _domain='com.microsoft',
    _outputs=3,
    **gqa_attrs,
)
```

## Files Changed (5 files, 9 calls)
- `_group_query_attention.py`: 4 calls
- `_skip_layer_norm.py`: 2 calls
- `_skip_norm.py`: 1 call
- `_unpack_qkv.py`: 1 call
- `_separate_rope.py`: 1 call

## Testing
- ✅ All 2718 tests pass
- ✅ Verified GQA (24 ops), SkipNorm (48 ops), RoPE separation all produce correct output on Qwen2.5-0.5B with CUDA EP