### PR TITLE
Add explicit stash_type=1 to RMSNorm and guard skip norm fusion

### DIFF
--- a/src/mobius/components/_rms_norm.py
+++ b/src/mobius/components/_rms_norm.py
@@ -41,6 +41,7 @@ class OffsetRMSNorm(nn.Module):
             hidden_states,
             effective_weight,
             epsilon=self.variance_epsilon,
+            stash_type=1,
             axis=-1,
         )
 
@@ -123,6 +124,7 @@ class GatedRMSNorm(nn.Module):
                     grouped,
                     weight_grouped,
                     epsilon=self.variance_epsilon,
+                    stash_type=1,
                     axis=-1,
                 )
                 normed = op.Reshape(normed, orig_shape)
@@ -134,6 +136,7 @@ class GatedRMSNorm(nn.Module):
                 gated,
                 self.weight,
                 epsilon=self.variance_epsilon,
+                stash_type=1,
                 axis=-1,
             )
         return op.CastLike(normed, hidden_states)
@@ -188,4 +191,7 @@ def apply_rms_norm(op: OpBuilder, x, weight, eps):
     Returns:
         Normalized tensor with the same shape as input.
     """
-    return op.RMSNormalization(x, weight, epsilon=eps, axis=-1)
+    # stash_type=1 forces internal variance computation in float32,
+    # preventing overflow/underflow in f16/bf16.  This is the ONNX
+    # default but is stated explicitly for clarity.
+    return op.RMSNormalization(x, weight, epsilon=eps, stash_type=1, axis=-1)

--- a/src/mobius/rewrite_rules/_skip_layer_norm.py
+++ b/src/mobius/rewrite_rules/_skip_layer_norm.py
@@ -103,6 +103,16 @@ class AddLayerNormToSkipLayerNorm(RewriteRuleClassBase):
                 f"LayerNorm axis={axis}, expected -1 for SkipLayerNormalization compatibility"
             )
 
+        # SkipLayerNormalization does not expose a stash_type attribute
+        # — its ORT kernel always uses float32 accumulation, matching
+        # the ONNX default stash_type=1.  Refuse fusion if the source
+        # LayerNorm requests a different stash_type.
+        stash = ln.attributes.get_int("stash_type", 1)
+        if stash != 1:
+            return result.fail(
+                f"LayerNorm has stash_type={stash}; fused op always uses fp32 accumulation"
+            )
+
         return result
 
     def rewrite(self, op, add_out, weight, bias, norm_out, **_):
@@ -185,6 +195,13 @@ class AddLayerNormNoBiasToSkipLayerNorm(RewriteRuleClassBase):
         if axis != -1:
             return result.fail(
                 f"LayerNorm axis={axis}, expected -1 for SkipLayerNormalization compatibility"
+            )
+
+        # SkipLayerNormalization does not expose a stash_type attribute.
+        stash = ln.attributes.get_int("stash_type", 1)
+        if stash != 1:
+            return result.fail(
+                f"LayerNorm has stash_type={stash}; fused op always uses fp32 accumulation"
             )
 
         # Ensure this is truly bias-free (2 inputs, not 3)

--- a/src/mobius/rewrite_rules/_skip_norm.py
+++ b/src/mobius/rewrite_rules/_skip_norm.py
@@ -91,6 +91,17 @@ class AddRMSNormToSkipNorm(RewriteRuleClassBase):
         if rmsnorm.attributes.get_float("epsilon", None) is None:
             return result.fail("Missing epsilon attribute on RMSNormalization")
 
+        # SkipSimplifiedLayerNormalization does not expose a stash_type
+        # attribute — its ORT kernel always uses float32 accumulation,
+        # matching the ONNX default stash_type=1.  Refuse fusion if the
+        # source RMSNorm requests a different stash_type so we don't
+        # silently change precision semantics.
+        stash = rmsnorm.attributes.get_int("stash_type", 1)
+        if stash != 1:
+            return result.fail(
+                f"RMSNorm has stash_type={stash}; fused op always uses fp32 accumulation"
+            )
+
         return result
 
     def rewrite(self, op, add_out, weight, norm_out, **_):


### PR DESCRIPTION
## Summary

Two changes to improve f16/bf16 precision safety:

### 1. Explicit stash_type=1 on all RMSNormalization call sites

While `stash_type=1` (float32 variance accumulation) is already the ONNX spec default, stating it explicitly makes the precision guarantee visible and prevents accidental removal. Sites updated:
- `apply_rms_norm()` — used by the base `RMSNorm` component
- `OffsetRMSNorm` — used by Qwen3.5
- `GatedRMSNorm` — grouped and standard paths (used by Mamba2/Bamba/NemotronH)

### 2. Guard skip norm rewrite rules against non-default stash_type

`SkipSimplifiedLayerNormalization` and `SkipLayerNormalization` (com.microsoft custom ops) do not expose a `stash_type` attribute — their ORT kernels always use float32 accumulation. If a source norm has `stash_type != 1`, the fusion is now refused to avoid silently changing precision semantics.

Affected rules:
- `AddRMSNormToSkipNorm` (`_skip_norm.py`)
- `AddLayerNormToSkipLayerNorm` (`_skip_layer_norm.py`)
- `AddLayerNormNoBiasToSkipLayerNorm` (`_skip_layer_norm.py`)

### Tests
All 2748 tests pass, 41 skipped. Lint clean.