### PR TITLE
Switch ORT GenAI export to Model Package layout

### DIFF
--- a/.agents/skills/foundry-local/SKILL.md
+++ b/.agents/skills/foundry-local/SKILL.md
@@ -100,8 +100,13 @@ cp output/configs/* "${DST}/"
 # <component>/ subdirectories (multi-component).
 for comp in decoder embedding vision_encoder audio_encoder; do
   if [ -d "output/${comp}/base" ]; then
-    if [ "$(ls -A output)" = "decoder" ] || [ ! -d "output/embedding" ]; then
-      # Single-component LLM: flatten model files into the model root
+    if [ "${comp}" = "decoder" ] \
+      && [ ! -d "output/embedding" ] \
+      && [ ! -d "output/vision_encoder" ] \
+      && [ ! -d "output/audio_encoder" ]; then
+      # Single-component LLM: flatten decoder files into the model root.
+      # Check sibling component dirs explicitly because a real Model
+      # Package also contains configs/ and manifest.json at the top level.
       cp output/${comp}/base/* "${DST}/"
     else
       # Multi-component: keep one subdir per component

--- a/.agents/skills/foundry-local/SKILL.md
+++ b/.agents/skills/foundry-local/SKILL.md
@@ -55,7 +55,7 @@ Use this skill when:
 
    The output is a Model Package directory containing
    `manifest.json`, a `configs/` subdirectory (genai_config + tokenizer +
-   processor configs), and one `<component>/base/{variant.json,
+   processor configs), and one `models/<component>/base/{variant.json,
    model.onnx, model.onnx.data.safetensors}` per component
    (`decoder` always, plus `embedding` / `vision_encoder` /
    `audio_encoder` for multimodal exports).
@@ -95,23 +95,23 @@ DST="${CACHE_DIR}/models/Custom/${MODEL_NAME}"
 # Configs (genai_config.json, tokenizer*, processor configs) live under configs/
 cp output/configs/* "${DST}/"
 
-# Per-component model files: <component>/base/{model.onnx,*.safetensors}
+# Per-component model files: models/<component>/base/{model.onnx,*.safetensors}
 # Foundry expects them at the top level (single-component) or in
 # <component>/ subdirectories (multi-component).
 for comp in decoder embedding vision_encoder audio_encoder; do
-  if [ -d "output/${comp}/base" ]; then
+  if [ -d "output/models/${comp}/base" ]; then
     if [ "${comp}" = "decoder" ] \
-      && [ ! -d "output/embedding" ] \
-      && [ ! -d "output/vision_encoder" ] \
-      && [ ! -d "output/audio_encoder" ]; then
+      && [ ! -d "output/models/embedding" ] \
+      && [ ! -d "output/models/vision_encoder" ] \
+      && [ ! -d "output/models/audio_encoder" ]; then
       # Single-component LLM: flatten decoder files into the model root.
       # Check sibling component dirs explicitly because a real Model
       # Package also contains configs/ and manifest.json at the top level.
-      cp output/${comp}/base/* "${DST}/"
+      cp output/models/${comp}/base/* "${DST}/"
     else
       # Multi-component: keep one subdir per component
       mkdir -p "${DST}/${comp}"
-      cp output/${comp}/base/* "${DST}/${comp}/"
+      cp output/models/${comp}/base/* "${DST}/${comp}/"
     fi
   fi
 done

--- a/.agents/skills/foundry-local/SKILL.md
+++ b/.agents/skills/foundry-local/SKILL.md
@@ -53,11 +53,16 @@ Use this skill when:
      output/
    ```
 
-   The output directory must contain `genai_config.json` and tokenizer
-   files. For single-model exports (text-only LLMs), model files
-   (`model.onnx` + external data) are in the output root. For
-   multi-model exports (VLMs, ALMs), sub-directories like `decoder/`,
-   `embedding/`, `vision_encoder/` contain each model.
+   The output is a Model Package directory containing
+   `manifest.json`, a `configs/` subdirectory (genai_config + tokenizer +
+   processor configs), and one `<component>/base/{variant.json,
+   model.onnx, model.onnx.data.safetensors}` per component
+   (`decoder` always, plus `embedding` / `vision_encoder` /
+   `audio_encoder` for multimodal exports).
+
+   > **Foundry Local consumes a flat layout today.** The Model Package
+   > emitted by mobius needs to be flattened (or the Foundry packager
+   > extended). The Step 3 commands below do the flattening.
 
 ## Custom model registration
 
@@ -82,37 +87,35 @@ MODEL_NAME="my-custom-model"
 mkdir -p "${CACHE_DIR}/models/Custom/${MODEL_NAME}"
 ```
 
-### Step 3: Copy model files
-
-Copy the entire mobius export output into the model directory. The
-simplest approach copies everything:
+### Step 3: Copy model files (flatten Model Package → Foundry layout)
 
 ```bash
-cp -r output/* "${CACHE_DIR}/models/Custom/${MODEL_NAME}/"
+DST="${CACHE_DIR}/models/Custom/${MODEL_NAME}"
+
+# Configs (genai_config.json, tokenizer*, processor configs) live under configs/
+cp output/configs/* "${DST}/"
+
+# Per-component model files: <component>/base/{model.onnx,*.safetensors}
+# Foundry expects them at the top level (single-component) or in
+# <component>/ subdirectories (multi-component).
+for comp in decoder embedding vision_encoder audio_encoder; do
+  if [ -d "output/${comp}/base" ]; then
+    if [ "$(ls -A output)" = "decoder" ] || [ ! -d "output/embedding" ]; then
+      # Single-component LLM: flatten model files into the model root
+      cp output/${comp}/base/* "${DST}/"
+    else
+      # Multi-component: keep one subdir per component
+      mkdir -p "${DST}/${comp}"
+      cp output/${comp}/base/* "${DST}/${comp}/"
+    fi
+  fi
+done
 ```
 
-Or copy selectively (handles both single-model and multi-model layouts):
-
-```bash
-# Model files — single-model (root-level) and multi-model (sub-dirs)
-cp output/model.onnx* "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
-cp -r output/decoder/ "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
-cp -r output/embedding/ "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
-cp -r output/vision_encoder/ "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
-cp -r output/audio_encoder/ "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
-
-# Config and tokenizer files (required)
-cp output/genai_config.json "${CACHE_DIR}/models/Custom/${MODEL_NAME}/"
-cp output/tokenizer* "${CACHE_DIR}/models/Custom/${MODEL_NAME}/"
-
-# Processor configs for VLMs (copy whichever exist)
-cp output/image_processor.json "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
-cp output/processor_config.json "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
-cp output/audio_processor.json "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
-
-# External data shards (single-model layout)
-cp output/*.safetensors "${CACHE_DIR}/models/Custom/${MODEL_NAME}/" 2>/dev/null
-```
+> Most users will simplify the above with their own packaging script.
+> The key invariant is: Foundry Local needs `genai_config.json`,
+> tokenizer files, and `model.onnx` (+ external data) reachable from
+> the model directory using the legacy flat layout.
 
 ### Step 4: Create `inference_model.json`
 

--- a/.agents/skills/onnx-export-quantization/SKILL.md
+++ b/.agents/skills/onnx-export-quantization/SKILL.md
@@ -76,25 +76,38 @@ done
 
 ### Multi-model outputs
 
-For multimodal models (VLMs, audio-language), `mobius build` produces
-multiple sub-models:
+For all `mobius build --runtime ort-genai` exports, the output is a
+**Model Package** (single-model and multi-model use the same layout):
 
 ```
 output/
-├── decoder/           # Text decoder
-│   ├── model.onnx
-│   └── model.onnx.data.safetensors
-├── embedding/         # Embedding model
-│   ├── model.onnx
-│   └── model.onnx.data.safetensors
-├── vision_encoder/    # Vision encoder (VLMs)
-│   ├── model.onnx
-│   └── model.onnx.data.safetensors
-├── audio_encoder/     # Audio encoder (ALMs)
-│   ├── model.onnx
-│   └── model.onnx.data.safetensors
-└── genai_config.json
+├── manifest.json
+├── configs/
+│   ├── genai_config.json
+│   ├── tokenizer.json + tokenizer_config.json + special_tokens_map.json
+│   ├── chat_template.jinja          # if present
+│   ├── image_processor.json         # VLMs
+│   └── audio_processor.json         # audio models
+├── decoder/                          # always present
+│   ├── metadata.json
+│   └── base/
+│       ├── variant.json
+│       ├── model.onnx
+│       └── model.onnx.data.safetensors
+├── embedding/                        # multimodal only
+│   └── base/{variant.json, model.onnx, model.onnx.data.safetensors}
+├── vision_encoder/                   # VLMs only
+│   └── base/{variant.json, model.onnx, model.onnx.data.safetensors}
+└── audio_encoder/                    # speech-capable models only
+    └── base/{variant.json, model.onnx, model.onnx.data.safetensors}
 ```
+
+Mobius emits exactly one variant, named `base`, declared as compatible
+with major ORT EPs. Downstream packagers can replace `base` with
+EP-specialized variants (e.g. `cuda-fp16`, `dml-int4`).
+
+Plain `mobius build` (no `--runtime`) still uses the legacy flat layout
+(`model.onnx` + optional `<component>/model.onnx` subdirs).
 
 ## Quantization with Olive
 
@@ -126,7 +139,7 @@ k-quant quantization:
 
 ```json
 {
-  "input_model": { "type": "OnnxModel", "model_path": "decoder/model.onnx" },
+  "input_model": { "type": "OnnxModel", "model_path": "decoder/base/model.onnx" },
   "passes": {
     "kquant": {
       "type": "OnnxKQuantQuantization",
@@ -134,7 +147,7 @@ k-quant quantization:
       "block_size": 32
     }
   },
-  "output_dir": "output/Q4_K_M/default/decoder"
+  "output_dir": "output/Q4_K_M/default/decoder/base"
 }
 ```
 
@@ -149,14 +162,14 @@ implementation — no GPU needed.
 
 ```json
 {
-  "input_model": { "type": "OnnxModel", "model_path": "decoder/model.onnx" },
+  "input_model": { "type": "OnnxModel", "model_path": "decoder/base/model.onnx" },
   "passes": {
     "nf4": {
       "type": "OnnxBnb4Quantization",
       "precision": "nf4"
     }
   },
-  "output_dir": "output/NF4/default/decoder"
+  "output_dir": "output/NF4/default/decoder/base"
 }
 ```
 
@@ -187,18 +200,17 @@ quantized (it has the most parameters). Copy all other files needed
 for a complete ORT GenAI package:
 
 ```bash
-# Quantize decoder only (largest model)
+# Quantize decoder only (largest model) — under <component>/<variant>/
 olive run --config kquant_decoder.json
 
 # Copy other sub-models as-is (already small)
-cp -r output/f16/default/embedding/ output/Q4_K_M/default/embedding/
-cp -r output/f16/default/vision_encoder/ output/Q4_K_M/default/vision_encoder/
+cp -r output/f16/default/embedding output/Q4_K_M/default/
+cp -r output/f16/default/vision_encoder output/Q4_K_M/default/
 
-# IMPORTANT: Copy config, tokenizer, and processor files too
-cp output/f16/default/genai_config.json output/Q4_K_M/default/
-cp output/f16/default/tokenizer* output/Q4_K_M/default/
-cp output/f16/default/image_processor.json output/Q4_K_M/default/ 2>/dev/null
-cp output/f16/default/audio_processor.json output/Q4_K_M/default/ 2>/dev/null
+# IMPORTANT: Copy package metadata, configs, tokenizer, and processor files
+cp output/f16/default/manifest.json output/Q4_K_M/default/
+cp -r output/f16/default/configs output/Q4_K_M/default/
+# Also copy any per-component metadata.json the quantized component needs.
 ```
 
 Without the tokenizer and processor config files, ORT GenAI will fail

--- a/.agents/skills/ort-genai-config/SKILL.md
+++ b/.agents/skills/ort-genai-config/SKILL.md
@@ -42,25 +42,43 @@ Read these companion documents for exhaustive field-by-field details:
 
 ## Overview
 
-onnxruntime-genai loads models from a directory containing:
+Mobius produces ORT-GenAI artifacts in **Model Package** layout:
+EP-agnostic ONNX components plus an EP-agnostic `genai_config.json`.
+Variant choices (which EP, which session/provider options to use)
+belong to a downstream packager, not mobius.
 
 ```
-model_dir/
-├── genai_config.json          # Required — model config + search params
-├── model.onnx                 # Decoder model (single-model) OR:
-├── decoder/model.onnx         # Decoder model (multimodal)
-├── vision_encoder/model.onnx   # Vision encoder (multimodal only)
-├── audio_encoder/model.onnx   # Audio encoder (multimodal only)
-├── embedding/model.onnx       # Embedding model (multimodal only)
-├── tokenizer.json             # Tokenizer (HuggingFace format)
-├── tokenizer_config.json      # Tokenizer config
-├── chat_template.jinja        # Chat template (optional)
-├── image_processor.json       # Image processor (ort-extensions, all VLMs)
-└── audio_processor.json       # Audio processor (multimodal only)
+model_pkg/
+├── manifest.json              # Top-level: schema_version, components
+├── configs/                   # EP-agnostic, model-level shared assets
+│   ├── genai_config.json      # No filename / session_options here
+│   ├── tokenizer.json         # HuggingFace tokenizer
+│   ├── tokenizer_config.json
+│   ├── chat_template.jinja    # if present
+│   ├── image_processor.json   # for VLMs
+│   └── audio_processor.json   # for audio models
+├── decoder/                   # one subdir per ModelPackage component key
+│   ├── metadata.json          # declares variants for this component
+│   └── base/                  # variant directory ("base" is mobius default)
+│       ├── variant.json       # files, session_options, provider_options
+│       ├── model.onnx
+│       └── model.onnx.data    # external weights, when present
+├── vision_encoder/            # multimodal only
+│   └── base/{variant.json, model.onnx, model.onnx.data}
+├── audio_encoder/             # speech-capable models only
+│   └── base/{...}
+└── embedding/                 # multimodal only
+    └── base/{...}
 ```
 
-**Processor config filenames**: `image_processor.json` for all VLMs,
-`audio_processor.json` for audio models.
+**Processor config filenames** (under `configs/`): `image_processor.json`
+for VLMs, `audio_processor.json` for audio models.
+
+**`base` variant compatibility.** Mobius declares `base` as compatible
+with the major ORT EPs (CPU + CUDA + DML + WebGPU + NvTensorRTRTX).
+Downstream packagers can split `base` into EP-specialized variants
+(e.g. `cuda-fp16`, `dml-int4`) by populating `session_options` /
+`provider_options` per variant.
 
 ## genai_config.json — Structure
 
@@ -83,9 +101,15 @@ Key model-level fields: `type` (required), `vocab_size`, `context_length`
 (required), `eos_token_id`, `pad_token_id`. VLMs also need `image_token_id`
 and `vision_start_token_id`.
 
-Key decoder fields: `filename`, `hidden_size`, `head_size`,
-`num_attention_heads`, `num_key_value_heads`, `num_hidden_layers`, plus
-`inputs`/`outputs` name mappings.
+Key decoder fields: `component` (the package component name, e.g.
+`"decoder"`), `hidden_size`, `head_size`, `num_attention_heads`,
+`num_key_value_heads`, `num_hidden_layers`, plus `inputs`/`outputs`
+name mappings.
+
+**Mobius-emitted `genai_config.json` is EP-agnostic.** It does NOT
+contain `filename`, `session_options`, `provider_options`, or
+`past_present_share_buffer`. Those are populated per-variant by a
+downstream packager into the relevant `variant.json`.
 
 > For the complete field-by-field tables, see
 > [`references/genai-config-fields.md`](references/genai-config-fields.md).
@@ -147,7 +171,7 @@ phi3small_pipeline, qwen2_5_vl_pipeline
     "eos_token_id": 2,
     "pad_token_id": 0,
     "decoder": {
-      "filename": "model.onnx",
+      "component": "decoder",
       "hidden_size": 4096,
       "head_size": 128,
       "num_attention_heads": 32,
@@ -170,11 +194,14 @@ phi3small_pipeline, qwen2_5_vl_pipeline
   "search": {
     "do_sample": false,
     "max_length": 4096,
-    "num_beams": 1,
-    "past_present_share_buffer": false
+    "num_beams": 1
   }
 }
 ```
+
+`"component": "decoder"` references the matching subdirectory in the
+package layout; the actual ONNX file (`model.onnx`) lives under
+`<component>/<variant>/` and is named in `variant.json`.
 
 VLM models additionally require `model.vision`, `model.embedding`,
 `image_token_id`, and `vision_start_token_id`. See

--- a/examples/olive/ministral-3-3b-vlm/optimize.py
+++ b/examples/olive/ministral-3-3b-vlm/optimize.py
@@ -60,15 +60,16 @@ def export_models(
     pkg = build(model_path, dtype=dtype, load_weights=True)
     print(f"  Components: {list(pkg.keys())}")
 
-    print(f"\n=== Saving to {output_dir} ===")
-    pkg.save(output_dir)
+    print(f"\n=== Saving to {output_dir} in Model Package layout ===")
+    from mobius.integrations.ort_genai.auto_export import _resolve_component_map
 
-    print("\n=== Generating ORT GenAI config ===")
+    pkg.save_package_layout(output_dir, component_map=_resolve_component_map(pkg))
+
+    print("\n=== Generating ORT GenAI Model Package config ===")
     write_ort_genai_config(
         pkg,
         output_dir,
         hf_model_id=model_path,
-        ep=ep,
     )
 
     print("  Export complete")

--- a/examples/qwen3_vl_ort_genai.py
+++ b/examples/qwen3_vl_ort_genai.py
@@ -82,7 +82,7 @@ def build_and_export(
     print(f"Package components: {list(pkg.keys())}")
 
     print(f"Exporting to {output_dir!r} ...")
-    export_package(pkg, output_dir, hf_model_id=model_id, ep=ep)
+    export_package(pkg, output_dir, hf_model_id=model_id)
     print(f"Export complete -> {output_dir}")
 
 

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -222,7 +222,7 @@ def _save_package(
 
     max_shard_size_bytes = _parse_size(args.max_shard_size) if args.max_shard_size else None
 
-    if args.external_data == "safetensors" and getattr(args, "ep", "default") == "cuda":
+    if args.external_data == "safetensors" and args.execution_provider == "cuda":
         logging.getLogger(__name__).warning(
             "Safetensors external data does not guarantee 256-byte offset "
             "alignment, which can cause CUBLAS misaligned address errors on "
@@ -232,6 +232,7 @@ def _save_package(
     runtime = getattr(args, "runtime", None)
 
     if runtime == "ort-genai":
+        from mobius._model_package import ModelPackage
         from mobius.integrations.ort_genai import write_ort_genai_config
         from mobius.integrations.ort_genai.auto_export import _resolve_component_map
 
@@ -247,12 +248,23 @@ def _save_package(
         for component_name, model_path in saved.items():
             print(f"Saved {component_name} to {model_path}")
 
+        # Restrict config generation to exactly the components that were saved
+        # so manifest.json / metadata.json don't reference components whose
+        # ONNX files were excluded by --component.
+        if components is not None:
+            config_pkg = ModelPackage(
+                {name: model for name, model in pkg.items() if components(name)},
+                config=pkg.config,
+            )
+        else:
+            config_pkg = pkg
+
         hf_model_id = getattr(args, "model", None)
         # When --config (local dir) is used instead of --model, copy tokenizer
         # files from the local directory rather than downloading from HF.
         local_config_dir = getattr(args, "config", None)
         artifacts = write_ort_genai_config(
-            pkg,
+            config_pkg,
             output_dir,
             hf_model_id=hf_model_id,
             local_config_dir=local_config_dir,

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -209,9 +209,9 @@ def _save_package(
     """Save a ModelPackage to disk, applying optimizations and runtime configs.
 
     When ``--runtime ort-genai`` is set, writes the ORT Model Package
-    layout (per-component ``base/model.onnx`` plus manifest, metadata,
-    variant.json, configs/genai_config.json, tokenizer files). Otherwise
-    writes the legacy flat-directory layout via
+    layout (per-component ``models/<component>/base/model.onnx`` plus
+    manifest, metadata, variant.json, configs/genai_config.json, tokenizer
+    files). Otherwise writes the legacy flat-directory layout via
     :meth:`ModelPackage.save`.
     """
     components = (lambda name: name == component_filter) if component_filter else None

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -206,7 +206,14 @@ def _cmd_build(args: argparse.Namespace) -> None:
 def _save_package(
     pkg, output_dir: str, args, optimize: str | None, component_filter: str | None
 ) -> None:
-    """Save a ModelPackage to disk, applying optimizations and runtime configs."""
+    """Save a ModelPackage to disk, applying optimizations and runtime configs.
+
+    When ``--runtime ort-genai`` is set, writes the ORT Model Package
+    layout (per-component ``base/model.onnx`` plus manifest, metadata,
+    variant.json, configs/genai_config.json, tokenizer files). Otherwise
+    writes the legacy flat-directory layout via
+    :meth:`ModelPackage.save`.
+    """
     components = (lambda name: name == component_filter) if component_filter else None
     for name, model in pkg.items():
         if components is not None and not components(name):
@@ -221,6 +228,38 @@ def _save_package(
             "alignment, which can cause CUBLAS misaligned address errors on "
             "CUDA. Consider using --external-data onnx for CUDA builds."
         )
+
+    runtime = getattr(args, "runtime", None)
+
+    if runtime == "ort-genai":
+        from mobius.integrations.ort_genai import write_ort_genai_config
+        from mobius.integrations.ort_genai.auto_export import _resolve_component_map
+
+        component_map = _resolve_component_map(pkg)
+        saved = pkg.save_package_layout(
+            output_dir,
+            component_map=component_map,
+            external_data=args.external_data,
+            max_shard_size_bytes=max_shard_size_bytes,
+            components=components,
+            check_weights=not args.no_weights,
+        )
+        for component_name, model_path in saved.items():
+            print(f"Saved {component_name} to {model_path}")
+
+        hf_model_id = getattr(args, "model", None)
+        # When --config (local dir) is used instead of --model, copy tokenizer
+        # files from the local directory rather than downloading from HF.
+        local_config_dir = getattr(args, "config", None)
+        artifacts = write_ort_genai_config(
+            pkg,
+            output_dir,
+            hf_model_id=hf_model_id,
+            local_config_dir=local_config_dir,
+        )
+        for name, path in artifacts.items():
+            print(f"  {name}: {path}")
+        return
 
     pkg.save(
         output_dir,
@@ -237,25 +276,6 @@ def _save_package(
         else:
             path = os.path.join(output_dir, "model.onnx")
         print(f"Saved {name} to {path}")
-
-    runtime = getattr(args, "runtime", None)
-    if runtime == "ort-genai":
-        from mobius.integrations.ort_genai import write_ort_genai_config
-
-        hf_model_id = getattr(args, "model", None)
-        ep = getattr(args, "execution_provider", "cpu")
-        # When --config (local dir) is used instead of --model, copy tokenizer
-        # files from the local directory rather than downloading from HF.
-        local_config_dir = getattr(args, "config", None)
-        artifacts = write_ort_genai_config(
-            pkg,
-            output_dir,
-            hf_model_id=hf_model_id,
-            ep=ep,
-            local_config_dir=local_config_dir,
-        )
-        for name, path in artifacts.items():
-            print(f"  {name}: {path}")
 
 
 def _cmd_list(args: argparse.Namespace) -> None:

--- a/src/mobius/_model_package.py
+++ b/src/mobius/_model_package.py
@@ -138,16 +138,94 @@ class ModelPackage(UserDict[str, ir.Model]):
                 os.makedirs(model_dir, exist_ok=True)
             else:
                 model_dir = directory
-            path = os.path.join(model_dir, "model.onnx")
-            if external_data == "safetensors":
-                ir.save_safetensors(
-                    model,
-                    path,
-                    max_shard_size_bytes=max_shard_size_bytes,
-                    callback=callback,
-                )
-            else:
-                ir.save(model, path, external_data="model.onnx.data", callback=callback)
+            _write_one_model(
+                model,
+                model_dir,
+                external_data=external_data,
+                max_shard_size_bytes=max_shard_size_bytes,
+                callback=callback,
+            )
+
+    def save_package_layout(
+        self,
+        directory: str,
+        *,
+        component_map: dict[str, str] | None = None,
+        variant_name: str = "base",
+        external_data: str = "onnx",
+        max_shard_size_bytes: int | None = None,
+        components: Callable[[str], bool] | None = None,
+        progress_bar: bool = True,
+        check_weights: bool = True,
+    ) -> dict[str, str]:
+        """Save component models in the ORT Model Package layout.
+
+        Each component is written to
+        ``<directory>/<component>/<variant_name>/model.onnx`` regardless
+        of whether the package has one or many components — the
+        single-component flat-directory shortcut from :meth:`save` does
+        *not* apply here.
+
+        Args:
+            directory: Package root directory (created if needed).
+            component_map: Optional mapping from this package's
+                ``dict`` keys to package component names. When a key is
+                missing from the map, the dict key is used directly.
+                Useful for renaming the legacy LLM key ``"model"`` to
+                the GenAI role ``"decoder"`` in the on-disk layout.
+            variant_name: Variant directory name. Defaults to
+                ``"base"``, which is mobius's single-variant
+                EP-agnostic output.
+            external_data: External data format (``"onnx"`` or
+                ``"safetensors"``). Same semantics as :meth:`save`.
+            max_shard_size_bytes: Safetensors shard size cap. Same
+                semantics as :meth:`save`.
+            components: Optional predicate selecting which components
+                to write. Same semantics as :meth:`save`.
+            progress_bar: Whether to display a tqdm progress bar.
+            check_weights: Whether to verify that all initializers have
+                weight data before saving.
+
+        Returns:
+            Mapping ``{component_name: absolute_path_to_model_onnx}``
+            for every component written.
+
+        Raises:
+            ValueError: If *external_data* is not ``"onnx"`` or
+                ``"safetensors"``, or if *check_weights* is ``True`` and
+                any initializer is missing its ``const_value``.
+        """
+        if external_data not in {"onnx", "safetensors"}:
+            raise ValueError(
+                f"Unknown external_data format {external_data!r}. "
+                "Expected 'onnx' or 'safetensors'."
+            )
+        os.makedirs(directory, exist_ok=True)
+        callback = _make_progress_callback() if progress_bar else None
+        component_map = component_map or {}
+
+        selected = {
+            name: model
+            for name, model in self.data.items()
+            if components is None or components(name)
+        }
+
+        written: dict[str, str] = {}
+        for name, model in selected.items():
+            if check_weights:
+                _check_weights(name, model)
+            component_name = component_map.get(name, name)
+            variant_dir = os.path.join(directory, component_name, variant_name)
+            os.makedirs(variant_dir, exist_ok=True)
+            _write_one_model(
+                model,
+                variant_dir,
+                external_data=external_data,
+                max_shard_size_bytes=max_shard_size_bytes,
+                callback=callback,
+            )
+            written[component_name] = os.path.join(variant_dir, "model.onnx")
+        return written
 
     @classmethod
     def load(cls, directory: str) -> ModelPackage:
@@ -254,6 +332,33 @@ class ModelPackage(UserDict[str, ir.Model]):
         # be constant-folded once the weight tensors carry their const_value.
         for model in self.data.values():
             fold_initializers_after_weights(model)
+
+
+def _write_one_model(
+    model: ir.Model,
+    output_dir: str,
+    *,
+    external_data: str,
+    max_shard_size_bytes: int | None,
+    callback: Callable[..., None] | None,
+) -> None:
+    """Save a single :class:`ir.Model` as ``model.onnx`` in *output_dir*.
+
+    Encapsulates the choice between ``ir.save`` (default) and
+    :func:`ir.save_safetensors` so that both
+    :meth:`ModelPackage.save` and :meth:`ModelPackage.save_package_layout`
+    share the same I/O logic.
+    """
+    path = os.path.join(output_dir, "model.onnx")
+    if external_data == "safetensors":
+        ir.save_safetensors(
+            model,
+            path,
+            max_shard_size_bytes=max_shard_size_bytes,
+            callback=callback,
+        )
+    else:
+        ir.save(model, path, external_data="model.onnx.data", callback=callback)
 
 
 def _make_progress_callback():

--- a/src/mobius/_model_package.py
+++ b/src/mobius/_model_package.py
@@ -161,7 +161,7 @@ class ModelPackage(UserDict[str, ir.Model]):
         """Save component models in the ORT Model Package layout.
 
         Each component is written to
-        ``<directory>/<component>/<variant_name>/model.onnx`` regardless
+        ``<directory>/models/<component>/<variant_name>/model.onnx`` regardless
         of whether the package has one or many components — the
         single-component flat-directory shortcut from :meth:`save` does
         *not* apply here.
@@ -211,11 +211,12 @@ class ModelPackage(UserDict[str, ir.Model]):
         }
 
         written: dict[str, str] = {}
+        models_dir = os.path.join(directory, "models")
         for name, model in selected.items():
             if check_weights:
                 _check_weights(name, model)
             component_name = component_map.get(name, name)
-            variant_dir = os.path.join(directory, component_name, variant_name)
+            variant_dir = os.path.join(models_dir, component_name, variant_name)
             os.makedirs(variant_dir, exist_ok=True)
             _write_one_model(
                 model,

--- a/src/mobius/_model_package_test.py
+++ b/src/mobius/_model_package_test.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import logging
 
 import onnx_ir as ir
+import pytest
 import torch
 
 from mobius._builder import build_from_module
@@ -117,6 +118,94 @@ class TestModelPackageSaveLoad:
         pkg = ModelPackage({"m": _make_simple_model()})
         pkg.save(str(outdir))
         assert (outdir / "model.onnx").exists()
+
+
+class TestModelPackageSavePackageLayout:
+    """Tests for ``ModelPackage.save_package_layout`` (ORT Model Package v4)."""
+
+    def test_layout_single_component(self, tmp_path):
+        """Single-component packages still use the <component>/<variant> layout."""
+        pkg = ModelPackage({"model": _make_simple_model("decoder")})
+        written = pkg.save_package_layout(str(tmp_path))
+
+        # No flat-directory shortcut: even one component lives under its subdir.
+        assert (tmp_path / "model" / "base" / "model.onnx").exists()
+        assert not (tmp_path / "model.onnx").exists()
+        # Returned path mapping points at the written file.
+        assert written == {"model": str(tmp_path / "model" / "base" / "model.onnx")}
+
+    def test_layout_multi_component(self, tmp_path):
+        pkg = ModelPackage(
+            {
+                "decoder": _make_simple_model("decoder"),
+                "vision_encoder": _make_simple_model("vision_encoder"),
+                "embedding": _make_simple_model("embedding"),
+            }
+        )
+        written = pkg.save_package_layout(str(tmp_path))
+
+        for name in ("decoder", "vision_encoder", "embedding"):
+            assert (tmp_path / name / "base" / "model.onnx").exists()
+            assert written[name] == str(tmp_path / name / "base" / "model.onnx")
+
+    def test_component_map_renames_keys(self, tmp_path):
+        """`component_map` renames the on-disk component dir (e.g. model -> decoder)."""
+        pkg = ModelPackage(
+            {
+                "model": _make_simple_model("decoder"),
+                "vision_encoder": _make_simple_model("vision_encoder"),
+            }
+        )
+        written = pkg.save_package_layout(
+            str(tmp_path),
+            component_map={"model": "decoder"},
+        )
+
+        # "model" key gets remapped to "decoder" on disk.
+        assert (tmp_path / "decoder" / "base" / "model.onnx").exists()
+        assert not (tmp_path / "model").exists()
+        # Unmapped keys pass through unchanged.
+        assert (tmp_path / "vision_encoder" / "base" / "model.onnx").exists()
+        # Returned dict is keyed by on-disk component name (post-rename).
+        assert written["decoder"] == str(tmp_path / "decoder" / "base" / "model.onnx")
+        assert written["vision_encoder"] == str(
+            tmp_path / "vision_encoder" / "base" / "model.onnx"
+        )
+
+    def test_variant_name(self, tmp_path):
+        pkg = ModelPackage({"decoder": _make_simple_model("decoder")})
+        written = pkg.save_package_layout(str(tmp_path), variant_name="cuda")
+
+        assert (tmp_path / "decoder" / "cuda" / "model.onnx").exists()
+        assert written["decoder"] == str(tmp_path / "decoder" / "cuda" / "model.onnx")
+
+    def test_components_filter(self, tmp_path):
+        """The ``components`` predicate filters which sub-models are written."""
+        pkg = ModelPackage(
+            {
+                "decoder": _make_simple_model("decoder"),
+                "vision_encoder": _make_simple_model("vision_encoder"),
+            }
+        )
+        written = pkg.save_package_layout(
+            str(tmp_path),
+            components=lambda name: name == "decoder",
+        )
+
+        assert (tmp_path / "decoder" / "base" / "model.onnx").exists()
+        assert not (tmp_path / "vision_encoder").exists()
+        assert list(written.keys()) == ["decoder"]
+
+    def test_invalid_external_data_raises(self, tmp_path):
+        pkg = ModelPackage({"decoder": _make_simple_model("decoder")})
+        with pytest.raises(ValueError, match="Unknown external_data format"):
+            pkg.save_package_layout(str(tmp_path), external_data="parquet")
+
+    def test_creates_nested_directory(self, tmp_path):
+        outdir = tmp_path / "nested" / "pkg"
+        pkg = ModelPackage({"decoder": _make_simple_model("decoder")})
+        pkg.save_package_layout(str(outdir))
+        assert (outdir / "decoder" / "base" / "model.onnx").exists()
 
 
 class TestModelPackageApplyWeights:

--- a/src/mobius/_model_package_test.py
+++ b/src/mobius/_model_package_test.py
@@ -124,15 +124,15 @@ class TestModelPackageSavePackageLayout:
     """Tests for ``ModelPackage.save_package_layout`` (ORT Model Package v4)."""
 
     def test_layout_single_component(self, tmp_path):
-        """Single-component packages still use the <component>/<variant> layout."""
+        """Single-component packages still use the models/<component>/<variant> layout."""
         pkg = ModelPackage({"model": _make_simple_model("decoder")})
         written = pkg.save_package_layout(str(tmp_path))
 
         # No flat-directory shortcut: even one component lives under its subdir.
-        assert (tmp_path / "model" / "base" / "model.onnx").exists()
+        assert (tmp_path / "models" / "model" / "base" / "model.onnx").exists()
         assert not (tmp_path / "model.onnx").exists()
         # Returned path mapping points at the written file.
-        assert written == {"model": str(tmp_path / "model" / "base" / "model.onnx")}
+        assert written == {"model": str(tmp_path / "models" / "model" / "base" / "model.onnx")}
 
     def test_layout_multi_component(self, tmp_path):
         pkg = ModelPackage(
@@ -145,8 +145,8 @@ class TestModelPackageSavePackageLayout:
         written = pkg.save_package_layout(str(tmp_path))
 
         for name in ("decoder", "vision_encoder", "embedding"):
-            assert (tmp_path / name / "base" / "model.onnx").exists()
-            assert written[name] == str(tmp_path / name / "base" / "model.onnx")
+            assert (tmp_path / "models" / name / "base" / "model.onnx").exists()
+            assert written[name] == str(tmp_path / "models" / name / "base" / "model.onnx")
 
     def test_component_map_renames_keys(self, tmp_path):
         """`component_map` renames the on-disk component dir (e.g. model -> decoder)."""
@@ -162,22 +162,22 @@ class TestModelPackageSavePackageLayout:
         )
 
         # "model" key gets remapped to "decoder" on disk.
-        assert (tmp_path / "decoder" / "base" / "model.onnx").exists()
-        assert not (tmp_path / "model").exists()
+        assert (tmp_path / "models" / "decoder" / "base" / "model.onnx").exists()
+        assert not (tmp_path / "models" / "model").exists()
         # Unmapped keys pass through unchanged.
-        assert (tmp_path / "vision_encoder" / "base" / "model.onnx").exists()
+        assert (tmp_path / "models" / "vision_encoder" / "base" / "model.onnx").exists()
         # Returned dict is keyed by on-disk component name (post-rename).
-        assert written["decoder"] == str(tmp_path / "decoder" / "base" / "model.onnx")
+        assert written["decoder"] == str(tmp_path / "models" / "decoder" / "base" / "model.onnx")
         assert written["vision_encoder"] == str(
-            tmp_path / "vision_encoder" / "base" / "model.onnx"
+            tmp_path / "models" / "vision_encoder" / "base" / "model.onnx"
         )
 
     def test_variant_name(self, tmp_path):
         pkg = ModelPackage({"decoder": _make_simple_model("decoder")})
         written = pkg.save_package_layout(str(tmp_path), variant_name="cuda")
 
-        assert (tmp_path / "decoder" / "cuda" / "model.onnx").exists()
-        assert written["decoder"] == str(tmp_path / "decoder" / "cuda" / "model.onnx")
+        assert (tmp_path / "models" / "decoder" / "cuda" / "model.onnx").exists()
+        assert written["decoder"] == str(tmp_path / "models" / "decoder" / "cuda" / "model.onnx")
 
     def test_components_filter(self, tmp_path):
         """The ``components`` predicate filters which sub-models are written."""
@@ -192,8 +192,8 @@ class TestModelPackageSavePackageLayout:
             components=lambda name: name == "decoder",
         )
 
-        assert (tmp_path / "decoder" / "base" / "model.onnx").exists()
-        assert not (tmp_path / "vision_encoder").exists()
+        assert (tmp_path / "models" / "decoder" / "base" / "model.onnx").exists()
+        assert not (tmp_path / "models" / "vision_encoder").exists()
         assert list(written.keys()) == ["decoder"]
 
     def test_invalid_external_data_raises(self, tmp_path):
@@ -205,7 +205,7 @@ class TestModelPackageSavePackageLayout:
         outdir = tmp_path / "nested" / "pkg"
         pkg = ModelPackage({"decoder": _make_simple_model("decoder")})
         pkg.save_package_layout(str(outdir))
-        assert (outdir / "decoder" / "base" / "model.onnx").exists()
+        assert (outdir / "models" / "decoder" / "base" / "model.onnx").exists()
 
 
 class TestModelPackageApplyWeights:

--- a/src/mobius/integrations/ort_genai/_package_writer.py
+++ b/src/mobius/integrations/ort_genai/_package_writer.py
@@ -4,15 +4,15 @@
 """Writers for ORT Model Package metadata files.
 
 This module produces the three package metadata files that the
-ORT-GenAI Model Package format expects (per the v4 proposal):
+current ORT Model Package parser expects:
 
 - ``<package>/manifest.json`` — top-level package descriptor
   (``schema_version`` + ``components`` array of component names).
-- ``<package>/<component>/metadata.json`` — component descriptor
+- ``<package>/models/<component>/metadata.json`` — component descriptor
   whose ``variants`` is a *map* keyed by variant name; each entry
   carries an ``ep_compatibility`` array of
-  ``{"ep", "device"?, "compatibility"}`` objects.
-- ``<package>/<component>/<variant>/variant.json`` — per-variant
+  ``{"ep", "device"?, "compatibility_string"?}`` objects.
+- ``<package>/models/<component>/<variant>/variant.json`` — per-variant
   manifest listing files, optional per-file session/provider options
   (objects, not arrays), optional ``shared_files`` map, and the
   ``consumer_metadata.genai_config_overlay`` blob.
@@ -34,9 +34,8 @@ import json
 import os
 from typing import Any
 
-# Mobius commits to schema version 1.0 for now. Bump on breaking
-# layout changes; the v4 proposal does not yet pin a number.
-SCHEMA_VERSION = "1.0"
+# Keep in sync with ORT's model-package descriptor parser.
+SCHEMA_VERSION = 1
 
 # The single variant name produced by mobius. Downstream packagers
 # add more variants alongside this one (e.g. "cuda", "qnn-htp-v75").
@@ -49,18 +48,18 @@ BASE_VARIANT_NAME = "base"
 # UX intact. Producers who know their build is e.g. CUDA-only can
 # narrow this list afterwards.
 #
-# Each entry follows the ORT-GenAI Model Package schema:
+# Each entry follows the ORT Model Package schema:
 #   { "ep": <canonical ORT EP name>,
 #     "device"?: <optional device class hint>,
-#     "compatibility": [<opaque match strings>] }
-# Empty ``compatibility`` means "matches any device the EP claims to
-# support" — the right default for an EP-agnostic graph.
+#     "compatibility_string"?: <opaque EP match string> }
+# Omitting ``compatibility_string`` means "matches any device the EP
+# claims to support" — the right default for an EP-agnostic graph.
 DEFAULT_BASE_EP_COMPATIBILITY: list[dict[str, Any]] = [
-    {"ep": "CPUExecutionProvider", "compatibility": []},
-    {"ep": "CUDAExecutionProvider", "compatibility": []},
-    {"ep": "DmlExecutionProvider", "compatibility": []},
-    {"ep": "WebGpuExecutionProvider", "compatibility": []},
-    {"ep": "NvTensorRTRTXExecutionProvider", "compatibility": []},
+    {"ep": "CPUExecutionProvider"},
+    {"ep": "CUDAExecutionProvider"},
+    {"ep": "DmlExecutionProvider"},
+    {"ep": "WebGpuExecutionProvider"},
+    {"ep": "NvTensorRTRTXExecutionProvider"},
 ]
 
 
@@ -99,14 +98,14 @@ def write_component_metadata(
           "variants": {
             "<name>": {
               "ep_compatibility": [
-                {"ep": "...", "device"?: "...", "compatibility": [...]}
+                {"ep": "...", "device"?: "...", "compatibility_string"?: "..."}
               ]
             }
           }
         }
 
     Args:
-        component_dir: Path to ``<package>/<component>/`` (created if
+        component_dir: Path to ``<package>/models/<component>/`` (created if
             missing).
         variants: Mapping from variant name to its descriptor dict.
             Each descriptor must contain ``"ep_compatibility"`` (a
@@ -121,6 +120,8 @@ def write_component_metadata(
         variants = {
             BASE_VARIANT_NAME: {"ep_compatibility": DEFAULT_BASE_EP_COMPATIBILITY},
         }
+    else:
+        variants = _normalize_variants(variants)
     metadata = {"variants": variants}
     path = os.path.join(component_dir, "metadata.json")
     with open(path, "w", encoding="utf-8") as f:
@@ -157,7 +158,7 @@ def write_variant_json(
     cleanest representation for mobius's EP-agnostic ``base`` variant.
 
     Args:
-        variant_dir: Path to ``<package>/<component>/<variant>/``
+        variant_dir: Path to ``<package>/models/<component>/<variant>/``
             (created if missing).
         files: List of file entries. Each entry has at minimum
             ``"filename"`` (relative to *variant_dir*); optional
@@ -199,6 +200,52 @@ def _make_default_file_entry(filename: str) -> dict[str, Any]:
     optional fields are omitted entirely.
     """
     return {"filename": filename}
+
+
+def _normalize_variants(variants: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Return a copy of variant descriptors using ORT's current field names."""
+    normalized: dict[str, dict[str, Any]] = {}
+    for variant_name, descriptor in variants.items():
+        ep_entries = descriptor.get("ep_compatibility")
+        if not isinstance(ep_entries, list) or not ep_entries:
+            raise ValueError("metadata.json variant entry must contain a non-empty ep_compatibility list")
+
+        out = dict(descriptor)
+        out["ep_compatibility"] = [_normalize_ep_compatibility_entry(entry) for entry in ep_entries]
+        normalized[variant_name] = out
+    return normalized
+
+
+def _normalize_ep_compatibility_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(entry, dict):
+        raise TypeError("metadata.json ep_compatibility entries must be objects")
+
+    ep = entry.get("ep")
+    if not isinstance(ep, str) or not ep:
+        raise ValueError("metadata.json ep_compatibility entries require a non-empty string 'ep'")
+
+    out: dict[str, Any] = {"ep": ep}
+
+    device = entry.get("device")
+    if device is not None:
+        if not isinstance(device, str):
+            raise ValueError("metadata.json ep_compatibility 'device' must be a string")
+        out["device"] = device
+
+    compatibility_string = entry.get("compatibility_string")
+    if compatibility_string is None and "compatibility" in entry:
+        compatibility = entry["compatibility"]
+        if not isinstance(compatibility, list) or not all(isinstance(item, str) for item in compatibility):
+            raise ValueError("metadata.json ep_compatibility 'compatibility' must be a list of strings")
+        compatibility_string = ",".join(compatibility)
+
+    if compatibility_string is not None:
+        if not isinstance(compatibility_string, str):
+            raise ValueError("metadata.json ep_compatibility 'compatibility_string' must be a string")
+        if compatibility_string:
+            out["compatibility_string"] = compatibility_string
+
+    return out
 
 
 def _normalize_file_entry(entry: dict[str, Any]) -> dict[str, Any]:

--- a/src/mobius/integrations/ort_genai/_package_writer.py
+++ b/src/mobius/integrations/ort_genai/_package_writer.py
@@ -1,0 +1,226 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Writers for ORT Model Package metadata files.
+
+This module produces the three package metadata files that the
+ORT-GenAI Model Package format expects (per the v4 proposal):
+
+- ``<package>/manifest.json`` — top-level package descriptor
+  (``schema_version`` + ``components`` array of component names).
+- ``<package>/<component>/metadata.json`` — component descriptor
+  whose ``variants`` is a *map* keyed by variant name; each entry
+  carries an ``ep_compatibility`` array of
+  ``{"ep", "device"?, "compatibility"}`` objects.
+- ``<package>/<component>/<variant>/variant.json`` — per-variant
+  manifest listing files, optional per-file session/provider options
+  (objects, not arrays), optional ``shared_files`` map, and the
+  ``consumer_metadata.genai_config_overlay`` blob.
+
+Mobius emits a *single-variant* package whose variant is named
+``"base"``. The base variant is EP-agnostic: per-file session/provider
+options are simply absent (the loader treats absent as default), and
+the ``genai_config_overlay`` is empty. Downstream packagers (Olive,
+EP-specific compilers) add additional variants alongside ``base``
+when they want EP-specialized artifacts.
+
+These writers do not import core model/task layers — they operate
+on plain Python dicts and write JSON.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+# Mobius commits to schema version 1.0 for now. Bump on breaking
+# layout changes; the v4 proposal does not yet pin a number.
+SCHEMA_VERSION = "1.0"
+
+# The single variant name produced by mobius. Downstream packagers
+# add more variants alongside this one (e.g. "cuda", "qnn-htp-v75").
+BASE_VARIANT_NAME = "base"
+
+# ep_compatibility entries for the ``base`` variant. The base variant
+# carries an EP-agnostic ONNX graph: any major ORT EP that supports
+# the opset and ops is expected to load it. Listing the major EPs by
+# default keeps today's ``og.Model(path, ep="CUDAExecutionProvider")``
+# UX intact. Producers who know their build is e.g. CUDA-only can
+# narrow this list afterwards.
+#
+# Each entry follows the ORT-GenAI Model Package schema:
+#   { "ep": <canonical ORT EP name>,
+#     "device"?: <optional device class hint>,
+#     "compatibility": [<opaque match strings>] }
+# Empty ``compatibility`` means "matches any device the EP claims to
+# support" — the right default for an EP-agnostic graph.
+DEFAULT_BASE_EP_COMPATIBILITY: list[dict[str, Any]] = [
+    {"ep": "CPUExecutionProvider", "compatibility": []},
+    {"ep": "CUDAExecutionProvider", "compatibility": []},
+    {"ep": "DmlExecutionProvider", "compatibility": []},
+    {"ep": "WebGpuExecutionProvider", "compatibility": []},
+    {"ep": "NvTensorRTRTXExecutionProvider", "compatibility": []},
+]
+
+
+def write_manifest(directory: str, components: list[str]) -> str:
+    """Write ``manifest.json`` at the package root.
+
+    Args:
+        directory: Package root directory (created if missing).
+        components: Ordered list of component names included in the
+            package (e.g. ``["decoder"]`` for LLMs;
+            ``["decoder", "vision_encoder", "embedding"]`` for VLMs).
+
+    Returns the path to the written file.
+    """
+    os.makedirs(directory, exist_ok=True)
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "components": list(components),
+    }
+    path = os.path.join(directory, "manifest.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=4)
+    return path
+
+
+def write_component_metadata(
+    component_dir: str,
+    *,
+    variants: dict[str, dict[str, Any]] | None = None,
+) -> str:
+    """Write ``metadata.json`` in a component directory.
+
+    Schema (per ORT-GenAI Model Package v4)::
+
+        {
+          "variants": {
+            "<name>": {
+              "ep_compatibility": [
+                {"ep": "...", "device"?: "...", "compatibility": [...]}
+              ]
+            }
+          }
+        }
+
+    Args:
+        component_dir: Path to ``<package>/<component>/`` (created if
+            missing).
+        variants: Mapping from variant name to its descriptor dict.
+            Each descriptor must contain ``"ep_compatibility"`` (a
+            list of EP entries). When ``None``, defaults to a single
+            ``base`` variant declaring
+            :data:`DEFAULT_BASE_EP_COMPATIBILITY`.
+
+    Returns the path to the written file.
+    """
+    os.makedirs(component_dir, exist_ok=True)
+    if variants is None:
+        variants = {
+            BASE_VARIANT_NAME: {"ep_compatibility": DEFAULT_BASE_EP_COMPATIBILITY},
+        }
+    metadata = {"variants": variants}
+    path = os.path.join(component_dir, "metadata.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(metadata, f, indent=4)
+    return path
+
+
+def write_variant_json(
+    variant_dir: str,
+    *,
+    files: list[dict[str, Any]] | None = None,
+    consumer_metadata: dict[str, Any] | None = None,
+) -> str:
+    """Write ``variant.json`` inside a variant directory.
+
+    Schema (per ORT-GenAI Model Package v4)::
+
+        {
+          "files": [
+            {"filename": "<rel-path>",
+             "session_options"?: {<obj>},
+             "provider_options"?: {<obj>},
+             "shared_files"?: {"<graph-name>": "<sha256>"}}
+          ],
+          "consumer_metadata"?: {...}
+        }
+
+    The optional fields ``session_options``, ``provider_options``, and
+    ``shared_files`` are *objects* when present. The loader rejects
+    list-form values (``shared_files`` is explicitly checked, and
+    ``session_options``/``provider_options`` are routed through
+    ``DocumentToObject`` which throws on non-objects). We therefore
+    *omit* these keys when there is nothing to declare, which is the
+    cleanest representation for mobius's EP-agnostic ``base`` variant.
+
+    Args:
+        variant_dir: Path to ``<package>/<component>/<variant>/``
+            (created if missing).
+        files: List of file entries. Each entry has at minimum
+            ``"filename"`` (relative to *variant_dir*); optional
+            ``"session_options"`` / ``"provider_options"`` /
+            ``"shared_files"`` must be objects when supplied. When
+            ``None``, defaults to a single ``"model.onnx"`` file with
+            no per-file options — the standard mobius single-file
+            base variant.
+        consumer_metadata: Opaque blob carried verbatim through the
+            package API. ORT-GenAI looks for
+            ``consumer_metadata.genai_config_overlay`` here. When
+            ``None``, defaults to ``{"genai_config_overlay": {}}``.
+
+    Returns the path to the written file.
+    """
+    os.makedirs(variant_dir, exist_ok=True)
+    if files is None:
+        files = [_make_default_file_entry("model.onnx")]
+    else:
+        files = [_normalize_file_entry(entry) for entry in files]
+    if consumer_metadata is None:
+        consumer_metadata = {"genai_config_overlay": {}}
+
+    variant = {
+        "files": files,
+        "consumer_metadata": consumer_metadata,
+    }
+    path = os.path.join(variant_dir, "variant.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(variant, f, indent=4)
+    return path
+
+
+def _make_default_file_entry(filename: str) -> dict[str, Any]:
+    """Return a file entry for the EP-agnostic base variant.
+
+    The base variant ships only the file itself — no per-file session
+    options, no provider options, no shared-weight references — so the
+    optional fields are omitted entirely.
+    """
+    return {"filename": filename}
+
+
+def _normalize_file_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    """Validate and copy a file entry, omitting empty optional fields.
+
+    The loader requires ``session_options`` / ``provider_options`` /
+    ``shared_files`` to be JSON objects (dicts) when present. We
+    enforce that here and drop empty values to keep variant.json
+    minimal and round-trip-stable.
+    """
+    if "filename" not in entry:
+        raise ValueError("variant.json file entry is missing required 'filename'")
+
+    out: dict[str, Any] = {"filename": entry["filename"]}
+    for field in ("session_options", "provider_options", "shared_files"):
+        if field in entry:
+            value = entry[field]
+            if not isinstance(value, dict):
+                raise ValueError(
+                    f"variant.json file entry '{field}' must be an object (dict), "
+                    f"got {type(value).__name__}"
+                )
+            if value:
+                out[field] = value
+    return out

--- a/src/mobius/integrations/ort_genai/_package_writer_test.py
+++ b/src/mobius/integrations/ort_genai/_package_writer_test.py
@@ -79,14 +79,14 @@ class TestWriteComponentMetadata:
     def test_default_uses_spec_field_names(self, tmp_path):
         # The ORT-GenAI loader uses streaming JSON and rejects unknown
         # keys: ep_compatibility entries must use 'ep' / 'device' /
-        # 'compatibility' (not legacy aliases like 'ep_name' or
+        # 'compatibility_string' (not legacy aliases like 'ep_name' or
         # 'compatibility_strings').
         component_dir = tmp_path / "decoder"
         path = write_component_metadata(str(component_dir))
         with open(path, encoding="utf-8") as f:
             metadata = json.load(f)
         for entry in metadata["variants"][BASE_VARIANT_NAME]["ep_compatibility"]:
-            assert set(entry.keys()) <= {"ep", "device", "compatibility"}
+            assert set(entry.keys()) <= {"ep", "device", "compatibility_string"}
             assert "ep" in entry
 
     def test_custom_variants_override_default(self, tmp_path):
@@ -94,7 +94,7 @@ class TestWriteComponentMetadata:
         custom = {
             "cuda-ada-fp16": {
                 "ep_compatibility": [
-                    {"ep": "CUDAExecutionProvider", "compatibility": ["sm_89"]},
+                    {"ep": "CUDAExecutionProvider", "compatibility_string": "sm_89"},
                 ],
             },
         }
@@ -102,6 +102,24 @@ class TestWriteComponentMetadata:
         with open(path, encoding="utf-8") as f:
             metadata = json.load(f)
         assert metadata["variants"] == custom
+
+    def test_converts_legacy_compatibility_list(self, tmp_path):
+        component_dir = tmp_path / "decoder"
+        path = write_component_metadata(
+            str(component_dir),
+            variants={
+                "cuda": {
+                    "ep_compatibility": [
+                        {"ep": "CUDAExecutionProvider", "compatibility": ["sm_89", "sm_90"]},
+                    ],
+                },
+            },
+        )
+
+        with open(path, encoding="utf-8") as f:
+            metadata = json.load(f)
+        ep_compat = metadata["variants"]["cuda"]["ep_compatibility"]
+        assert ep_compat == [{"ep": "CUDAExecutionProvider", "compatibility_string": "sm_89,sm_90"}]
 
 
 class TestWriteVariantJson:

--- a/src/mobius/integrations/ort_genai/_package_writer_test.py
+++ b/src/mobius/integrations/ort_genai/_package_writer_test.py
@@ -1,0 +1,229 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for the ORT Model Package metadata writers."""
+
+from __future__ import annotations
+
+import json
+import os
+
+from mobius.integrations.ort_genai._package_writer import (
+    BASE_VARIANT_NAME,
+    DEFAULT_BASE_EP_COMPATIBILITY,
+    SCHEMA_VERSION,
+    write_component_metadata,
+    write_manifest,
+    write_variant_json,
+)
+
+
+class TestWriteManifest:
+    """Tests for the package-root manifest.json writer."""
+
+    def test_writes_schema_version_and_components(self, tmp_path):
+        path = write_manifest(str(tmp_path), ["decoder"])
+        assert os.path.isfile(path)
+        with open(path, encoding="utf-8") as f:
+            manifest = json.load(f)
+        assert manifest["schema_version"] == SCHEMA_VERSION
+        assert manifest["components"] == ["decoder"]
+
+    def test_preserves_component_order(self, tmp_path):
+        path = write_manifest(str(tmp_path), ["decoder", "vision_encoder", "embedding"])
+        with open(path, encoding="utf-8") as f:
+            manifest = json.load(f)
+        assert manifest["components"] == ["decoder", "vision_encoder", "embedding"]
+
+    def test_creates_directory_when_missing(self, tmp_path):
+        new_dir = tmp_path / "nested" / "package"
+        path = write_manifest(str(new_dir), ["decoder"])
+        assert os.path.isfile(path)
+
+
+class TestWriteComponentMetadata:
+    """Tests for per-component metadata.json writer."""
+
+    def test_default_base_variant(self, tmp_path):
+        component_dir = tmp_path / "decoder"
+        path = write_component_metadata(str(component_dir))
+        assert os.path.isfile(path)
+        with open(path, encoding="utf-8") as f:
+            metadata = json.load(f)
+        assert "variants" in metadata
+        # Schema: variants is a map keyed by variant name.
+        assert isinstance(metadata["variants"], dict)
+        assert list(metadata["variants"].keys()) == [BASE_VARIANT_NAME]
+        assert (
+            metadata["variants"][BASE_VARIANT_NAME]["ep_compatibility"]
+            == DEFAULT_BASE_EP_COMPATIBILITY
+        )
+
+    def test_default_advertises_all_major_eps(self, tmp_path):
+        component_dir = tmp_path / "decoder"
+        path = write_component_metadata(str(component_dir))
+        with open(path, encoding="utf-8") as f:
+            metadata = json.load(f)
+        ep_names = {
+            entry["ep"]
+            for entry in metadata["variants"][BASE_VARIANT_NAME]["ep_compatibility"]
+        }
+        # The base variant must declare compatibility with the major EPs
+        # so that today's og.Model(path, ep="...") UX keeps working.
+        assert "CPUExecutionProvider" in ep_names
+        assert "CUDAExecutionProvider" in ep_names
+        assert "DmlExecutionProvider" in ep_names
+        assert "WebGpuExecutionProvider" in ep_names
+        assert "NvTensorRTRTXExecutionProvider" in ep_names
+
+    def test_default_uses_spec_field_names(self, tmp_path):
+        # The ORT-GenAI loader uses streaming JSON and rejects unknown
+        # keys: ep_compatibility entries must use 'ep' / 'device' /
+        # 'compatibility' (not legacy aliases like 'ep_name' or
+        # 'compatibility_strings').
+        component_dir = tmp_path / "decoder"
+        path = write_component_metadata(str(component_dir))
+        with open(path, encoding="utf-8") as f:
+            metadata = json.load(f)
+        for entry in metadata["variants"][BASE_VARIANT_NAME]["ep_compatibility"]:
+            assert set(entry.keys()) <= {"ep", "device", "compatibility"}
+            assert "ep" in entry
+
+    def test_custom_variants_override_default(self, tmp_path):
+        component_dir = tmp_path / "decoder"
+        custom = {
+            "cuda-ada-fp16": {
+                "ep_compatibility": [
+                    {"ep": "CUDAExecutionProvider", "compatibility": ["sm_89"]},
+                ],
+            },
+        }
+        path = write_component_metadata(str(component_dir), variants=custom)
+        with open(path, encoding="utf-8") as f:
+            metadata = json.load(f)
+        assert metadata["variants"] == custom
+
+
+class TestWriteVariantJson:
+    """Tests for per-variant variant.json writer."""
+
+    def test_default_single_model_file(self, tmp_path):
+        variant_dir = tmp_path / "decoder" / "base"
+        path = write_variant_json(str(variant_dir))
+        assert os.path.isfile(path)
+        with open(path, encoding="utf-8") as f:
+            variant = json.load(f)
+        assert len(variant["files"]) == 1
+        entry = variant["files"][0]
+        assert entry["filename"] == "model.onnx"
+        # Base variant ships EP-agnostic — optional fields are omitted
+        # entirely (the loader treats absent as default and rejects
+        # list-form values).
+        assert "session_options" not in entry
+        assert "provider_options" not in entry
+        assert "shared_files" not in entry
+
+    def test_default_consumer_metadata_has_empty_overlay(self, tmp_path):
+        variant_dir = tmp_path / "decoder" / "base"
+        path = write_variant_json(str(variant_dir))
+        with open(path, encoding="utf-8") as f:
+            variant = json.load(f)
+        assert "consumer_metadata" in variant
+        assert variant["consumer_metadata"] == {"genai_config_overlay": {}}
+
+    def test_explicit_consumer_metadata_overlay(self, tmp_path):
+        variant_dir = tmp_path / "decoder" / "cuda"
+        overlay = {
+            "genai_config_overlay": {
+                "search": {"past_present_share_buffer": True},
+            }
+        }
+        path = write_variant_json(str(variant_dir), consumer_metadata=overlay)
+        with open(path, encoding="utf-8") as f:
+            variant = json.load(f)
+        assert variant["consumer_metadata"] == overlay
+
+    def test_normalizes_partial_file_entries(self, tmp_path):
+        variant_dir = tmp_path / "decoder" / "base"
+        path = write_variant_json(
+            str(variant_dir),
+            files=[{"filename": "model.onnx"}],  # missing all optional fields
+        )
+        with open(path, encoding="utf-8") as f:
+            variant = json.load(f)
+        entry = variant["files"][0]
+        assert entry["filename"] == "model.onnx"
+        # Optional fields are absent (not empty list / empty dict) —
+        # matches what the loader expects to round-trip cleanly.
+        assert set(entry.keys()) == {"filename"}
+
+    def test_keeps_non_empty_optional_object_fields(self, tmp_path):
+        variant_dir = tmp_path / "decoder" / "qnn-htp-v75"
+        path = write_variant_json(
+            str(variant_dir),
+            files=[
+                {
+                    "filename": "model.onnx",
+                    "session_options": {"graph_optimization_level": "all"},
+                    "provider_options": {"backend_path": "QnnHtp.dll"},
+                    "shared_files": {"weights.data": "deadbeef"},
+                }
+            ],
+        )
+        with open(path, encoding="utf-8") as f:
+            variant = json.load(f)
+        entry = variant["files"][0]
+        assert entry["session_options"] == {"graph_optimization_level": "all"}
+        assert entry["provider_options"] == {"backend_path": "QnnHtp.dll"}
+        assert entry["shared_files"] == {"weights.data": "deadbeef"}
+
+    def test_drops_empty_optional_object_fields(self, tmp_path):
+        variant_dir = tmp_path / "decoder" / "base"
+        path = write_variant_json(
+            str(variant_dir),
+            files=[
+                {
+                    "filename": "model.onnx",
+                    "session_options": {},
+                    "provider_options": {},
+                    "shared_files": {},
+                }
+            ],
+        )
+        with open(path, encoding="utf-8") as f:
+            variant = json.load(f)
+        entry = variant["files"][0]
+        assert set(entry.keys()) == {"filename"}
+
+    def test_rejects_list_provider_options(self, tmp_path):
+        # The ORT-GenAI loader requires provider_options / shared_files
+        # to be JSON objects; lists trigger a runtime error. Catch this
+        # at write time so we never produce an unloadable variant.json.
+        import pytest
+
+        variant_dir = tmp_path / "decoder" / "base"
+        with pytest.raises(ValueError, match="must be an object"):
+            write_variant_json(
+                str(variant_dir),
+                files=[{"filename": "model.onnx", "provider_options": []}],
+            )
+
+    def test_rejects_list_shared_files(self, tmp_path):
+        import pytest
+
+        variant_dir = tmp_path / "decoder" / "base"
+        with pytest.raises(ValueError, match="must be an object"):
+            write_variant_json(
+                str(variant_dir),
+                files=[{"filename": "model.onnx", "shared_files": []}],
+            )
+
+    def test_rejects_file_entry_without_filename(self, tmp_path):
+        import pytest
+
+        variant_dir = tmp_path / "decoder" / "base"
+        with pytest.raises(ValueError, match="filename"):
+            write_variant_json(
+                str(variant_dir),
+                files=[{"session_options": {}}],
+            )

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -912,6 +912,17 @@ def write_ort_genai_config(
     component_map = _resolve_component_map(pkg)
     component_names = list(component_map.values())
 
+    # Defensive check: component names must be unique so per-component
+    # metadata.json / variant.json don't clobber each other and the manifest
+    # doesn't list duplicates.
+    if len(component_names) != len(set(component_names)):
+        duplicates = sorted({n for n in component_names if component_names.count(n) > 1})
+        raise ValueError(
+            "Duplicate component names in ModelPackage after component_map "
+            f"resolution: {duplicates}. Each package key must map to a "
+            "distinct on-disk component directory."
+        )
+
     # --- Write package manifest (top-level) -----------------------------
     manifest_path = write_manifest(directory, component_names)
 

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -106,7 +106,7 @@ _QWEN_VL_MODEL_TYPES = frozenset(
 )
 
 # Mapping from ``ModelPackage`` dict keys to package component names
-# (the on-disk subfolder under ``<package>/<component>/``). The legacy
+# (the on-disk subfolder under ``<package>/models/<component>/``). The legacy
 # LLM key ``"model"`` is renamed to the GenAI role ``"decoder"``;
 # everything else is identity.
 _PKG_KEY_TO_COMPONENT: dict[str, str] = {
@@ -795,12 +795,12 @@ def write_ort_genai_config(
     - ``configs/`` — tokenizer files and (for VLMs/speech) processor
       configs (``image_processor.json`` /  ``processor_config.json`` /
       ``audio_processor.json`` / ``audio_feature_extraction.json``).
-    - ``<component>/metadata.json`` — per-component variant list.
-    - ``<component>/base/variant.json`` — per-variant manifest.
+    - ``models/<component>/metadata.json`` — per-component variant list.
+    - ``models/<component>/base/variant.json`` — per-variant manifest.
 
     This function does NOT write ONNX model files — call
     :meth:`~mobius._model_package.ModelPackage.save_package_layout`
-    separately to populate the per-component ``base/model.onnx``
+    separately to populate the per-component ``models/<component>/base/model.onnx``
     files.
 
     Args:
@@ -984,8 +984,9 @@ def write_ort_genai_config(
     _fix_chat_template(configs_dir, hf_model_id)
 
     # --- Write per-component metadata + base/variant.json ---------------
+    models_dir = os.path.join(directory, "models")
     for component_name in component_names:
-        component_dir = os.path.join(directory, component_name)
+        component_dir = os.path.join(models_dir, component_name)
         metadata_path = write_component_metadata(component_dir)
         variant_dir = os.path.join(component_dir, "base")
         variant_path = write_variant_json(variant_dir)
@@ -1075,7 +1076,7 @@ def export_package(
 
     os.makedirs(output_dir, exist_ok=True)
 
-    # 1. Save ONNX models in package layout: <output>/<component>/base/model.onnx
+    # 1. Save ONNX models in package layout: <output>/models/<component>/base/model.onnx
     logger.info("Saving ONNX models to %s in Model Package layout", output_dir)
     component_map = _resolve_component_map(pkg)
     saved = pkg.save_package_layout(
@@ -1120,7 +1121,7 @@ def auto_export(
 
     1. Builds the ONNX graph(s) via :func:`~mobius._builder.build`
     2. Downloads and applies HuggingFace weights
-    3. Saves ONNX model(s) into ``<component>/base/model.onnx`` via
+    3. Saves ONNX model(s) into ``models/<component>/base/model.onnx`` via
        :meth:`~mobius._model_package.ModelPackage.save_package_layout`
     4. Calls :func:`write_ort_genai_config` to write the package
        metadata files (``manifest.json``, per-component

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -1,28 +1,33 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Auto-export pipeline for onnxruntime-genai.
+"""Auto-export pipeline for onnxruntime-genai (Model Package format).
 
 Three entry points, in order of increasing convenience:
 
-- :func:`write_ort_genai_config` — config-only API.  Generates the ORT-GenAI
-  config artifacts (``genai_config.json``, tokenizer files,
-  ``processor_config.json`` / ``image_processor.json``) for an already-built
-  :class:`~mobius._model_package.ModelPackage`.  Does **not** write any ONNX
-  files — call :meth:`ModelPackage.save` separately if the ONNX models are
-  not already on disk.  The package only needs ``pkg.config`` and the model
-  graph metadata; weights need not have been written yet.
+- :func:`write_ort_genai_config` — config-only API. Takes an already-built
+  :class:`~mobius._model_package.ModelPackage` and writes the **package
+  metadata** + shared configs: ``manifest.json``, per-component
+  ``metadata.json`` and ``base/variant.json``, plus
+  ``configs/genai_config.json``, tokenizer files, and processor configs.
+  Does **not** write ONNX files — pair it with
+  :meth:`~mobius._model_package.ModelPackage.save_package_layout` (or
+  use :func:`export_package` to do both in one call).
 
 - :func:`export_package` — save+config API. Takes an already-built
-  ``ModelPackage`` and writes both the ONNX models AND the ORT-GenAI config
-  artifacts in one call.  Use this when you built the package manually
-  (e.g. with custom dtype / quantization).
+  ``ModelPackage`` and writes the ONNX models (via
+  :meth:`~mobius._model_package.ModelPackage.save_package_layout`) **and**
+  the ORT-GenAI Model Package metadata in one call. Use this when you
+  built the package manually (e.g. with custom dtype / quantization).
 
-- :func:`auto_export` — end-to-end API. Builds the model from a HuggingFace
-  ID and calls :func:`export_package`. Use this for the common
-  HF-model-id → ORT-GenAI-directory case.
+- :func:`auto_export` — end-to-end convenience function. Builds the model
+  from a HuggingFace ID and calls :func:`export_package`. Use this for the
+  common HF-model-id → ORT-GenAI-Model-Package case.
 
-All three produce a directory that ``onnxruntime-genai`` can load directly.
+All three produce an EP-agnostic Model Package directory: the ONNX graphs
+and the ``base`` variant carry no ``session_options`` / ``provider_options``.
+EP-specialized variants (CUDA, QNN, …) are produced by downstream packagers
+(Olive workflows, EP-specific compilers).
 
 Example::
 
@@ -31,19 +36,19 @@ Example::
     from mobius.integrations.ort_genai import write_ort_genai_config
 
     pkg = build("Qwen/Qwen3-0.6B", load_weights=True)
-    pkg.save("/output/qwen3")  # write ONNX + weights first
+    pkg.save_package_layout("/output/qwen3", component_map={"model": "decoder"})
     write_ort_genai_config(pkg, "/output/qwen3", hf_model_id="Qwen/Qwen3-0.6B")
 
     # Save + config — single call, when you have a built package in memory
     from mobius.integrations.ort_genai import export_package
 
     pkg = build("Qwen/Qwen3-0.6B", load_weights=True)
-    export_package(pkg, "/output/qwen3", hf_model_id="Qwen/Qwen3-0.6B", ep="cuda")
+    export_package(pkg, "/output/qwen3", hf_model_id="Qwen/Qwen3-0.6B")
 
     # End-to-end — when you only have an HF model id
     from mobius.integrations.ort_genai.auto_export import auto_export
 
-    auto_export("Qwen/Qwen3-0.6B", "/output/qwen3", ep="cuda")
+    auto_export("Qwen/Qwen3-0.6B", "/output/qwen3")
 """
 
 from __future__ import annotations
@@ -100,6 +105,25 @@ _QWEN_VL_MODEL_TYPES = frozenset(
     }
 )
 
+# Mapping from ``ModelPackage`` dict keys to package component names
+# (the on-disk subfolder under ``<package>/<component>/``). The legacy
+# LLM key ``"model"`` is renamed to the GenAI role ``"decoder"``;
+# everything else is identity.
+_PKG_KEY_TO_COMPONENT: dict[str, str] = {
+    "model": "decoder",
+}
+
+
+def _resolve_component_map(pkg: ModelPackage) -> dict[str, str]:
+    """Return ``{pkg_key: package_component_name}`` for *pkg*.
+
+    Each entry maps a key that ``ModelPackage`` uses internally to
+    the on-disk component name in the package layout. Identity for
+    keys not in :data:`_PKG_KEY_TO_COMPONENT`.
+    """
+    return {key: _PKG_KEY_TO_COMPONENT.get(key, key) for key in pkg}
+
+
 _TOKENIZER_FILES = [
     "tokenizer.json",
     "tokenizer_config.json",
@@ -147,20 +171,24 @@ def _introspect_inputs(pkg: ModelPackage, key: str) -> dict[str, str] | None:
 
 def _copy_tokenizer_files(
     model_id: str,
-    output_dir: str,
+    configs_dir: str,
 ) -> list[str]:
     """Download and copy tokenizer files from HuggingFace Hub.
+
+    Files are written into *configs_dir* (the package's ``configs/``
+    directory in the new layout).
 
     Returns list of copied filenames.
     """
     from huggingface_hub import hf_hub_download
     from huggingface_hub.utils import EntryNotFoundError
 
+    os.makedirs(configs_dir, exist_ok=True)
     copied: list[str] = []
     for filename in _TOKENIZER_FILES:
         try:
             src = hf_hub_download(model_id, filename)
-            dst = os.path.join(output_dir, filename)
+            dst = os.path.join(configs_dir, filename)
             shutil.copy2(src, dst)
             copied.append(filename)
         except (EntryNotFoundError, OSError):
@@ -170,12 +198,13 @@ def _copy_tokenizer_files(
 
 def _copy_tokenizer_files_from_local(
     source_dir: str,
-    output_dir: str,
+    configs_dir: str,
 ) -> list[str]:
     """Copy tokenizer files from a local model directory.
 
-    Silently skips files that are absent (not all tokenizer variants have
-    all files — e.g. SentencePiece models have ``tokenizer.model`` but not
+    Files are written into *configs_dir*. Silently skips files that
+    are absent (not all tokenizer variants have all files — e.g.
+    SentencePiece models have ``tokenizer.model`` but not
     ``merges.txt``).
 
     Returns list of copied filenames.
@@ -186,11 +215,12 @@ def _copy_tokenizer_files_from_local(
             source_dir,
         )
         return []
+    os.makedirs(configs_dir, exist_ok=True)
     copied: list[str] = []
     for filename in _TOKENIZER_FILES:
         src = os.path.join(source_dir, filename)
         if os.path.isfile(src):
-            dst = os.path.join(output_dir, filename)
+            dst = os.path.join(configs_dir, filename)
             shutil.copy2(src, dst)
             copied.append(filename)
     return copied
@@ -203,17 +233,17 @@ _TOKENIZER_CLASS_REMAP: dict[str, str] = {
 }
 
 
-def _fix_tokenizer_config(output_dir: str) -> bool:
+def _fix_tokenizer_config(configs_dir: str) -> bool:
     """Remap unsupported tokenizer classes for ORT GenAI compatibility.
 
     Some HuggingFace models use tokenizer classes (e.g.
     ``TokenizersBackend``) that ORT GenAI's ort-extensions
-    tokenizer doesn't support. This fixes tokenizer_config.json
-    to use a compatible class.
+    tokenizer doesn't support. This fixes ``tokenizer_config.json``
+    in *configs_dir* to use a compatible class.
 
     Returns True if a fix was applied, False otherwise.
     """
-    tc_path = os.path.join(output_dir, "tokenizer_config.json")
+    tc_path = os.path.join(configs_dir, "tokenizer_config.json")
     if not os.path.exists(tc_path):
         return False
 
@@ -236,7 +266,7 @@ def _fix_tokenizer_config(output_dir: str) -> bool:
     return True
 
 
-def _fix_chat_template(output_dir: str, hf_model_id: str | None) -> bool:
+def _fix_chat_template(configs_dir: str, hf_model_id: str | None) -> bool:
     """Ensure chat_template is present in tokenizer_config.json.
 
     Some HuggingFace models don't store ``chat_template`` in the
@@ -245,11 +275,12 @@ def _fix_chat_template(output_dir: str, hf_model_id: str | None) -> bool:
     the file directly and needs it to be present.
 
     This function loads the tokenizer via transformers (which
-    applies the dynamic template) and writes it back.
+    applies the dynamic template) and writes it back into
+    ``tokenizer_config.json`` in *configs_dir*.
 
     Returns True if the template was added, False otherwise.
     """
-    tc_path = os.path.join(output_dir, "tokenizer_config.json")
+    tc_path = os.path.join(configs_dir, "tokenizer_config.json")
     if not os.path.exists(tc_path):
         return False
 
@@ -355,7 +386,7 @@ def _build_vision_transform_pipeline(
 
 def _write_vision_processor_config(
     config: Any,
-    output_dir: str,
+    configs_dir: str,
     *,
     hf_model_id: str | None = None,
 ) -> str | None:
@@ -421,7 +452,7 @@ def _write_vision_processor_config(
                 ],
             }
         }
-        path = os.path.join(output_dir, "image_processor.json")
+        path = os.path.join(configs_dir, "image_processor.json")
     else:
         # Pixtral and generic VLMs share the same base pipeline;
         # Pixtral adds Permute3D + PixtralImageSizes at the end.
@@ -538,8 +569,9 @@ def _write_vision_processor_config(
                 "transforms": transforms,
             }
         }
-        path = os.path.join(output_dir, "processor_config.json")
+        path = os.path.join(configs_dir, "processor_config.json")
 
+    os.makedirs(configs_dir, exist_ok=True)
     with open(path, "w", encoding="utf-8") as f:
         json.dump(processor_config, f, indent=4)
     return path
@@ -547,10 +579,11 @@ def _write_vision_processor_config(
 
 def _write_audio_processor_config(
     config: Any,
-    output_dir: str,
+    configs_dir: str,
 ) -> str | None:
-    """Write audio_processor.json for models with audio encoders.
+    """Write audio processor config for models with audio encoders.
 
+    Writes into *configs_dir* (the package's ``configs/`` directory).
     Returns the path if written, None otherwise.
     """
     audio = getattr(config, "audio", None)
@@ -597,7 +630,8 @@ def _write_audio_processor_config(
         # Generic audio processor — add model-specific branches as needed.
         return None
 
-    path = os.path.join(output_dir, proc_filename)
+    os.makedirs(configs_dir, exist_ok=True)
+    path = os.path.join(configs_dir, proc_filename)
     with open(path, "w", encoding="utf-8") as f:
         json.dump(processor, f, indent=4)
     return path
@@ -605,23 +639,36 @@ def _write_audio_processor_config(
 
 def _write_genai_config(
     config: Any,
-    output_dir: str,
+    configs_dir: str,
     *,
     pkg: ModelPackage,
     ort_model_type: str,
-    ep: str,
     context_length: int,
     bos_token_id: int | None,
     eos_token_id: int | list[int] | None,
     pad_token_id: int | None,
     is_vlm: bool,
     has_speech: bool,
+    component_map: dict[str, str],
 ) -> str:
-    """Generate and write genai_config.json.
+    """Generate and write the EP-agnostic genai_config.json.
 
-    Input names for each sub-model (decoder, vision, embedding) are
-    introspected from the ONNX graphs in *pkg* rather than hard-coded
-    per model type.
+    Input names for each sub-model (decoder, vision, embedding,
+    audio) are introspected from the ONNX graphs in *pkg* rather
+    than hard-coded per model type.
+
+    The genai_config.json document is the package-level *base* — it
+    declares architecture identity and component bindings only,
+    never EP-specific session/provider options.
+
+    Args:
+        configs_dir: Target directory (typically
+            ``<package>/configs/``); the file is written there as
+            ``genai_config.json``.
+        component_map: Mapping ``{pkg_key: on-disk component name}``
+            used to populate the ``component`` field on each role
+            block (e.g. the LLM key ``"model"`` becomes component
+            ``"decoder"``).
 
     Returns the path to the written file.
     """
@@ -635,19 +682,17 @@ def _write_genai_config(
         decoder_inputs["past_key_names"] = "past_key_values.%d.key"
         decoder_inputs["past_value_names"] = "past_key_values.%d.value"
 
-    # Derive decoder filename from the actual package key
-    decoder_filename = f"{decoder_key}/model.onnx" if decoder_key != "model" else "model.onnx"
+    decoder_component = component_map.get(decoder_key, decoder_key)
 
     generator = GenaiConfigGenerator.from_config(
         config,
         ort_model_type,
         context_length=context_length,
-        ep=ep,
         bos_token_id=bos_token_id,
         eos_token_id=eos_token_id,
         pad_token_id=pad_token_id,
         decoder_inputs=decoder_inputs,
-        decoder_filename=decoder_filename,
+        decoder_component=decoder_component,
     )
 
     if is_vlm:
@@ -658,7 +703,10 @@ def _write_genai_config(
 
             # spatial_merge_size and config_filename are config-level
             # properties that cannot be inferred from the graph.
-            vision_kwargs: dict[str, Any] = {}
+            vision_kwargs: dict[str, Any] = {
+                "vision_component": component_map.get("vision_encoder", "vision_encoder"),
+                "embedding_component": component_map.get("embedding", "embedding"),
+            }
             model_type = getattr(config, "model_type", "")
             if model_type in _GEMMA4_MODEL_TYPES:
                 vision_cfg = getattr(config, "vision", None)
@@ -706,11 +754,11 @@ def _write_genai_config(
         )
         boa_token_id = getattr(config, "boa_token_id", None)
 
-        audio_kwargs: dict[str, Any] = {}
+        audio_kwargs: dict[str, Any] = {
+            "audio_component": component_map.get("audio_encoder", "audio_encoder"),
+        }
         model_type = getattr(config, "model_type", "")
         if model_type in _GEMMA4_MODEL_TYPES:
-            # Gemma4 audio encoder uses different filename and config
-            audio_kwargs["filename"] = "audio_encoder/model.onnx"
             audio_kwargs["config_filename"] = "audio_feature_extraction.json"
             # Gemma4 speech model input is 'input_features' + 'input_features_mask'
             audio_kwargs["input_names"] = {
@@ -725,7 +773,7 @@ def _write_genai_config(
             **audio_kwargs,
         )
 
-    return generator.write(output_dir)
+    return generator.write(configs_dir)
 
 
 def write_ort_genai_config(
@@ -733,53 +781,60 @@ def write_ort_genai_config(
     directory: str,
     *,
     hf_model_id: str | None = None,
-    ep: str = "cpu",
     context_length: int = 4096,
     local_config_dir: str | None = None,
 ) -> dict[str, str]:
-    """Generate ORT-GenAI config artifacts for an already-built ModelPackage.
+    """Generate ORT-GenAI package metadata + configs for a built ModelPackage.
 
-    Writes ``genai_config.json``, optionally copies tokenizer files from
-    HuggingFace Hub or a local directory, and writes ``image_processor.json``
-    for VLM models.  Does NOT build or save ONNX models — call
-    :meth:`~mobius._model_package.ModelPackage.save` separately before or
-    after this function.
+    Writes the EP-agnostic Model Package layout under *directory*:
+
+    - ``manifest.json`` — top-level package manifest.
+    - ``configs/genai_config.json`` — package-level base genai config
+      (no ``session_options``, no ``filename``, no EP-derived
+      ``past_present_share_buffer`` / ``max_length`` cap).
+    - ``configs/`` — tokenizer files and (for VLMs/speech) processor
+      configs (``image_processor.json`` /  ``processor_config.json`` /
+      ``audio_processor.json`` / ``audio_feature_extraction.json``).
+    - ``<component>/metadata.json`` — per-component variant list.
+    - ``<component>/base/variant.json`` — per-variant manifest.
+
+    This function does NOT write ONNX model files — call
+    :meth:`~mobius._model_package.ModelPackage.save_package_layout`
+    separately to populate the per-component ``base/model.onnx``
+    files.
 
     Args:
-        pkg: Already-built :class:`~mobius._model_package.ModelPackage` with
-            weights applied and ``config`` set.
-        directory: Output directory (created if needed).
-        hf_model_id: HuggingFace model ID. When provided, used to fetch token
-            IDs (``bos``/``eos``/``pad``) and download tokenizer files.
-            When ``None``, token IDs are read from ``pkg.config`` fields
-            (``bos_token_id``, ``eos_token_id``, ``pad_token_id``) populated
-            by :meth:`~mobius._configs.ArchitectureConfig.from_transformers`,
-            and tokenizer files are not copied unless ``local_config_dir`` is set.
-        ep: Execution provider for ``session_options`` in
-            ``genai_config.json`` (e.g. ``"cpu"``, ``"cuda"``, ``"dml"``,
-            ``"trt-rtx"``). Defaults to ``"cpu"``.
+        pkg: Already-built :class:`~mobius._model_package.ModelPackage`
+            with weights applied and ``config`` set.
+        directory: Package root directory (created if needed).
+        hf_model_id: HuggingFace model ID. When provided, used to fetch
+            token IDs and download tokenizer files. When ``None``, token
+            IDs are read from ``pkg.config`` and tokenizer files are
+            not copied unless ``local_config_dir`` is set.
         context_length: Minimum context length written to
             ``genai_config.json``. Overridden upward by
             ``max_position_embeddings`` from ``pkg.config``.
         local_config_dir: Path to a local model directory. When provided
-            and ``hf_model_id`` is ``None``, tokenizer files are copied from
-            this directory instead of downloaded from HuggingFace Hub.
-            Typically set when the CLI ``--config`` flag points to a local
-            directory rather than a HuggingFace model ID.
+            and ``hf_model_id`` is ``None``, tokenizer files are copied
+            from this directory instead of downloaded from HuggingFace
+            Hub.
 
     Returns:
-        Dict mapping artifact name to file path, e.g.::
-
-            {
-                "genai_config": "/output/genai_config.json",
-                "tokenizer.json": "/output/tokenizer.json",
-                "image_processor": "/output/image_processor.json",
-            }
+        Dict mapping artifact name to file path. The mapping always
+        includes ``"manifest"`` and ``"genai_config"``; per-component
+        entries are keyed ``"<component>:metadata"`` and
+        ``"<component>:variant"``.
 
     Raises:
         ValueError: If ``pkg.config`` is ``None`` (required for config
             generation).
     """
+    from mobius.integrations.ort_genai._package_writer import (
+        write_component_metadata,
+        write_manifest,
+        write_variant_json,
+    )
+
     config = getattr(pkg, "config", None)
     if config is None:
         raise ValueError(
@@ -789,11 +844,8 @@ def write_ort_genai_config(
         )
 
     os.makedirs(directory, exist_ok=True)
-
-    # Normalize EP: 'default' and 'onnx-standard' are portable-ONNX modes
-    # that carry no EP-specific session options → treat as CPU.
-    if ep in ("default", "onnx-standard"):
-        ep = "cpu"
+    configs_dir = os.path.join(directory, "configs")
+    os.makedirs(configs_dir, exist_ok=True)
 
     # Resolve token IDs and ORT model type from HF config (if provided)
     bos_token_id: int | None = None
@@ -857,60 +909,79 @@ def write_ort_genai_config(
     if ort_model_type == "phi" and has_speech:
         ort_model_type = "phi4mm"
 
-    logger.info("Generating genai_config.json for %s (ep=%s)", ort_model_type, ep)
+    component_map = _resolve_component_map(pkg)
+    component_names = list(component_map.values())
+
+    # --- Write package manifest (top-level) -----------------------------
+    manifest_path = write_manifest(directory, component_names)
+
+    # --- Write genai_config.json (package configs) ----------------------
+    logger.info("Generating genai_config.json for %s", ort_model_type)
     genai_path = _write_genai_config(
         config,
-        directory,
+        configs_dir,
         pkg=pkg,
         ort_model_type=ort_model_type,
-        ep=ep,
         context_length=context_length,
         bos_token_id=bos_token_id,
         eos_token_id=eos_token_id,
         pad_token_id=pad_token_id,
         is_vlm=is_vlm,
         has_speech=has_speech,
+        component_map=component_map,
     )
 
-    result: dict[str, str] = {"genai_config": genai_path}
+    result: dict[str, str] = {
+        "manifest": manifest_path,
+        "genai_config": genai_path,
+    }
 
-    # Copy tokenizer files — HF Hub takes precedence; local dir is the fallback
-    # for --config mode where no HF model ID is available.
+    # --- Copy tokenizer files into configs/ -----------------------------
+    # HF Hub takes precedence; local dir is the fallback for --config mode.
     if hf_model_id is not None:
         logger.info("Copying tokenizer files from %s", hf_model_id)
-        tokenizer_files = _copy_tokenizer_files(hf_model_id, directory)
+        tokenizer_files = _copy_tokenizer_files(hf_model_id, configs_dir)
         for tf in tokenizer_files:
-            result[tf] = os.path.join(directory, tf)
+            result[tf] = os.path.join(configs_dir, tf)
     elif local_config_dir is not None:
         logger.info("Copying tokenizer files from local directory %s", local_config_dir)
-        tokenizer_files = _copy_tokenizer_files_from_local(local_config_dir, directory)
+        tokenizer_files = _copy_tokenizer_files_from_local(local_config_dir, configs_dir)
         if not tokenizer_files:
             logger.warning(
                 "No tokenizer files were copied from local directory %s. "
                 "The export may be missing tokenizer artifacts required by ORT-GenAI.",
                 local_config_dir,
             )
-
         for tf in tokenizer_files:
-            result[tf] = os.path.join(directory, tf)
+            result[tf] = os.path.join(configs_dir, tf)
 
-    # Write processor config for VLMs
-    processor_path = _write_vision_processor_config(config, directory, hf_model_id=hf_model_id)
+    # --- Write processor configs into configs/ --------------------------
+    processor_path = _write_vision_processor_config(
+        config, configs_dir, hf_model_id=hf_model_id
+    )
     if processor_path:
         result["processor_config"] = processor_path
 
-    # Write audio_processor.json for models with audio encoders
-    audio_proc_path = _write_audio_processor_config(config, directory)
+    audio_proc_path = _write_audio_processor_config(config, configs_dir)
     if audio_proc_path:
         result["audio_processor"] = audio_proc_path
 
     # Fix unsupported tokenizer classes
-    _fix_tokenizer_config(directory)
+    _fix_tokenizer_config(configs_dir)
 
     # Ensure chat_template is in tokenizer_config.json
-    _fix_chat_template(directory, hf_model_id)
+    _fix_chat_template(configs_dir, hf_model_id)
 
-    logger.info("ORT-GenAI artifacts written: %d files", len(result))
+    # --- Write per-component metadata + base/variant.json ---------------
+    for component_name in component_names:
+        component_dir = os.path.join(directory, component_name)
+        metadata_path = write_component_metadata(component_dir)
+        variant_dir = os.path.join(component_dir, "base")
+        variant_path = write_variant_json(variant_dir)
+        result[f"{component_name}:metadata"] = metadata_path
+        result[f"{component_name}:variant"] = variant_path
+
+    logger.info("ORT-GenAI Model Package written: %d files", len(result))
     return result
 
 
@@ -919,18 +990,18 @@ def export_package(
     output_dir: str,
     *,
     hf_model_id: str | None = None,
-    ep: str = "cpu",
     context_length: int = 4096,
     local_config_dir: str | None = None,
     external_data: str = "onnx",
     progress_bar: bool = True,
 ) -> dict[str, str]:
-    """Save an already-built ModelPackage as a complete ORT-GenAI directory.
+    """Save an already-built ModelPackage as a complete ORT-GenAI Model Package.
 
     This is the convenience function for users who built a ``ModelPackage``
     themselves (e.g. with custom dtype / quantization / weight overrides) and
-    want a single call that produces an ``onnxruntime-genai``-loadable
-    directory.  It calls :meth:`ModelPackage.save` followed by
+    want a single call that produces an ``onnxruntime-genai``-loadable Model
+    Package directory.  It calls
+    :meth:`~mobius._model_package.ModelPackage.save_package_layout` followed by
     :func:`write_ort_genai_config`.
 
     For the end-to-end case where you start from a HuggingFace model id, use
@@ -939,39 +1010,34 @@ def export_package(
     Args:
         pkg: Already-built :class:`~mobius._model_package.ModelPackage` with
             weights applied and ``config`` set.  All components in *pkg* are
-            saved; selective export via :meth:`ModelPackage.save`'s
+            saved; selective export via
+            :meth:`~mobius._model_package.ModelPackage.save_package_layout`'s
             ``components`` filter is intentionally not exposed here, because
             the ORT-GenAI runtime expects the on-disk file layout to match
             what ``model.type`` in :file:`genai_config.json` declares (e.g. a
             multimodal ``model.type`` implies a vision encoder file is
             present).  If you need a partial export, build a separate
             filtered ``ModelPackage`` first.
-        output_dir: Output directory (created if needed).
+        output_dir: Package root directory (created if needed).
         hf_model_id: HuggingFace model ID for tokenizer download / token-id
             resolution.  When ``None``, token IDs are read from ``pkg.config``
             and tokenizer files are not copied (unless ``local_config_dir``
             is provided).
-        ep: Execution provider written to ``session_options`` in
-            ``genai_config.json`` (e.g. ``"cpu"``, ``"cuda"``, ``"dml"``,
-            ``"webgpu"``, ``"trt-rtx"``).
         context_length: Minimum context length written to ``genai_config.json``.
             Overridden upward by ``pkg.config.max_position_embeddings`` when
             larger.
         local_config_dir: Local model directory to copy tokenizer files from
             when ``hf_model_id`` is ``None``.
-        external_data: External-data format passed to :meth:`ModelPackage.save`
+        external_data: External-data format passed to
+            :meth:`~mobius._model_package.ModelPackage.save_package_layout`
             (``"onnx"`` or ``"safetensors"``).
         progress_bar: Whether to show the save progress bar.
 
     Returns:
-        Manifest dict mapping artifact names to paths::
-
-            {
-                "model": "/output/model.onnx",          # or per-component paths
-                "genai_config": "/output/genai_config.json",
-                "tokenizer.json": "/output/tokenizer.json",
-                ...
-            }
+        Manifest dict mapping artifact names to paths, including
+        ``"manifest"``, ``"genai_config"``, ``"<component>:metadata"``,
+        ``"<component>:variant"``, ``"<component>:model"`` (for each
+        component), and tokenizer/processor entries when applicable.
 
     Raises:
         ValueError: If ``pkg.config`` is ``None`` (required for genai_config
@@ -984,7 +1050,7 @@ def export_package(
         from mobius.integrations.ort_genai import export_package
 
         pkg = build("Qwen/Qwen3-0.6B", load_weights=True)
-        export_package(pkg, "/output/qwen3", hf_model_id="Qwen/Qwen3-0.6B", ep="cuda")
+        export_package(pkg, "/output/qwen3", hf_model_id="Qwen/Qwen3-0.6B")
     """
     # Preflight: fail fast before writing ONNX so the user doesn't end up
     # with a half-exported directory containing only the model file.
@@ -993,35 +1059,33 @@ def export_package(
             "export_package requires ModelPackage.config to be set. "
             "This is set automatically when building with mobius.build(). "
             "Diffusion models (which have no config) are not supported — "
-            "use ModelPackage.save() directly for those."
+            "use ModelPackage.save_package_layout() directly for those."
         )
 
     os.makedirs(output_dir, exist_ok=True)
 
-    # 1. Save ONNX models + weights
-    logger.info("Saving ONNX models to %s", output_dir)
-    pkg.save(
+    # 1. Save ONNX models in package layout: <output>/<component>/base/model.onnx
+    logger.info("Saving ONNX models to %s in Model Package layout", output_dir)
+    component_map = _resolve_component_map(pkg)
+    saved = pkg.save_package_layout(
         output_dir,
+        component_map=component_map,
         external_data=external_data,
         progress_bar=progress_bar,
     )
 
-    # 2. Write ORT-GenAI config artifacts
+    # 2. Write ORT-GenAI package metadata + shared configs
     result = write_ort_genai_config(
         pkg,
         output_dir,
         hf_model_id=hf_model_id,
-        ep=ep,
         context_length=context_length,
         local_config_dir=local_config_dir,
     )
 
-    # 3. Add ONNX paths to the manifest
-    if len(pkg) == 1:
-        result["model"] = os.path.join(output_dir, "model.onnx")
-    else:
-        for name in pkg:
-            result[name] = os.path.join(output_dir, name, "model.onnx")
+    # 3. Add ONNX model paths to the manifest
+    for component_name, model_path in saved.items():
+        result[f"{component_name}:model"] = model_path
 
     logger.info("Export complete: %d artifacts", len(result))
     return result
@@ -1036,41 +1100,45 @@ def auto_export(
     external_data: str = "onnx",
     trust_remote_code: bool = False,
     context_length: int = 4096,
-    ep: str = "cpu",
     progress_bar: bool = True,
 ) -> dict[str, str]:
-    """Build and export a model for onnxruntime-genai.
+    """Build and export a model in the ORT-GenAI Model Package format.
 
-    This is the end-to-end convenience function for producing ORT-GenAI-ready
-    model directories. It:
+    This is the end-to-end convenience function for producing
+    ORT-GenAI-ready model directories. It:
 
     1. Builds the ONNX graph(s) via :func:`~mobius._builder.build`
     2. Downloads and applies HuggingFace weights
-    3. Saves ONNX model(s) with external data
-    4. Calls :func:`write_ort_genai_config` to write ``genai_config.json``,
-       tokenizer files, and ``image_processor.json``
+    3. Saves ONNX model(s) into ``<component>/base/model.onnx`` via
+       :meth:`~mobius._model_package.ModelPackage.save_package_layout`
+    4. Calls :func:`write_ort_genai_config` to write the package
+       metadata files (``manifest.json``, per-component
+       ``metadata.json`` and ``base/variant.json``) plus shared
+       configs in ``configs/`` (``genai_config.json``, tokenizer files,
+       processor configs).
+
+    The output is **EP-agnostic**: variant ``base`` advertises
+    compatibility with every major EP via per-component
+    ``metadata.json``, and ``genai_config.json`` carries no
+    ``session_options``. EP-specialized variants (CUDA, QNN, …) are
+    produced by downstream packagers alongside ``base``.
 
     Args:
         model_id: HuggingFace model repository ID.
-        output_dir: Directory to write all output files.
+        output_dir: Package root directory.
         dtype: Override model dtype (``"f32"``, ``"f16"``, ``"bf16"``).
         task: Override model task (auto-detected if ``None``).
         external_data: External data format (``"onnx"`` or
             ``"safetensors"``).
         trust_remote_code: Trust remote code for HuggingFace config.
         context_length: Minimum context length for genai_config.json.
-        ep: Execution provider for ``session_options`` in
-            ``genai_config.json``. Defaults to ``"cpu"``.
         progress_bar: Show progress bar during save.
 
     Returns:
-        Dict mapping output artifact names to file paths, e.g.::
-
-            {
-                "genai_config": "/output/genai_config.json",
-                "model": "/output/model.onnx",
-                "tokenizer.json": "/output/tokenizer.json",
-            }
+        Dict mapping artifact name to file path, including
+        ``"manifest"``, ``"genai_config"``, ``"<component>:metadata"``,
+        ``"<component>:variant"``, ``"<component>:model"``, and
+        tokenizer/processor entries when applicable.
     """
     from mobius._builder import build
 
@@ -1095,14 +1163,11 @@ def auto_export(
 
     # Delegate save + config generation to the integration helper.
     # `export_package` already logs "Export complete" so we don't repeat it here.
-    result = export_package(
+    return export_package(
         pkg,
         output_dir,
         hf_model_id=model_id,
-        ep=ep,
         context_length=context_length,
         external_data=external_data,
         progress_bar=progress_bar,
     )
-
-    return result

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -398,7 +398,7 @@ class TestWriteOrtGenaiConfigLocalDir:
         return _make_fake_llm_pkg("llama")
 
     def test_local_config_dir_copies_tokenizer_files(self, tmp_path):
-        """When local_config_dir is set, tokenizer files are copied from it."""
+        """When local_config_dir is set, tokenizer files are copied into configs/."""
         src = tmp_path / "local_model"
         src.mkdir()
         (src / "tokenizer.json").write_text('{"local": true}')
@@ -414,8 +414,10 @@ class TestWriteOrtGenaiConfigLocalDir:
             local_config_dir=str(src),
         )
 
+        # Tokenizer files now land under <output>/configs/ (Model Package layout)
+        configs = out / "configs"
         assert "tokenizer.json" in result
-        assert (out / "tokenizer.json").read_text() == '{"local": true}'
+        assert (configs / "tokenizer.json").read_text() == '{"local": true}'
         assert "tokenizer_config.json" in result
 
     def test_hf_model_id_takes_precedence_over_local_dir(self, tmp_path):
@@ -725,8 +727,8 @@ class TestExportForOrtGenai:
         # config_filename must point to the onnxruntime-extensions audio config
         assert speech["config_filename"] == "audio_feature_extraction.json"
 
-        # filename must point to the audio encoder ONNX model
-        assert speech["filename"] == "audio_encoder/model.onnx"
+        # component must point to the audio encoder package component
+        assert speech["component"] == "audio_encoder"
 
         # input_names mapping: genai internal name -> ONNX model input name
         assert speech["inputs"]["audio_embeds"] == "input_features"
@@ -744,7 +746,7 @@ class TestExportForOrtGenai:
         mock_copy.assert_not_called()
 
     def test_tokenizer_copied_when_model_id_provided(self, tmp_path):
-        """Tokenizer files are copied when hf_model_id is provided."""
+        """Tokenizer files are copied (into configs/) when hf_model_id is provided."""
         from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
 
         pkg = self._make_pkg()
@@ -760,43 +762,25 @@ class TestExportForOrtGenai:
             )
             result = write_ort_genai_config(pkg, str(tmp_path), hf_model_id="fake/model")
 
-        mock_copy.assert_called_once_with("fake/model", str(tmp_path))
+        # Tokenizer files now go into <output>/configs/ in the package layout
+        mock_copy.assert_called_once_with("fake/model", os.path.join(str(tmp_path), "configs"))
         assert "tokenizer.json" in result
 
-    def test_ep_default_normalizes_to_cpu(self, tmp_path):
-        """ep='default' is normalized to cpu (provider_options=[])."""
+    def test_genai_config_omits_session_options(self, tmp_path):
+        """Package-level base genai_config must not carry session_options."""
         from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
 
         pkg = self._make_pkg()
-        result = write_ort_genai_config(pkg, str(tmp_path), ep="default")
+        result = write_ort_genai_config(pkg, str(tmp_path))
 
         with open(result["genai_config"]) as f:
             data = json.load(f)
-        assert data["model"]["decoder"]["session_options"]["provider_options"] == []
-
-    def test_ep_onnx_standard_normalizes_to_cpu(self, tmp_path):
-        """ep='onnx-standard' is normalized to cpu (provider_options=[])."""
-        from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
-
-        pkg = self._make_pkg()
-        result = write_ort_genai_config(pkg, str(tmp_path), ep="onnx-standard")
-
-        with open(result["genai_config"]) as f:
-            data = json.load(f)
-        assert data["model"]["decoder"]["session_options"]["provider_options"] == []
-
-    def test_ep_cuda_passes_through(self, tmp_path):
-        """ep='cuda' passes through to session_options with CUDA provider."""
-        from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
-
-        pkg = self._make_pkg()
-        result = write_ort_genai_config(pkg, str(tmp_path), ep="cuda")
-
-        with open(result["genai_config"]) as f:
-            data = json.load(f)
-        provider_opts = data["model"]["decoder"]["session_options"]["provider_options"]
-        assert len(provider_opts) == 1
-        assert "cuda" in provider_opts[0]
+        decoder = data["model"]["decoder"]
+        assert "session_options" not in decoder
+        assert "provider_options" not in decoder
+        assert "filename" not in decoder
+        # 'component' replaces 'filename' in the package-world schema
+        assert decoder["component"] == "decoder"
 
     def test_raises_when_pkg_config_is_none(self, tmp_path):
         """ValueError is raised when pkg.config is None."""
@@ -918,39 +902,52 @@ class TestExportPackage:
         return _make_fake_llm_pkg("qwen2")
 
     def test_writes_both_onnx_and_genai_config(self, tmp_path, monkeypatch):
-        """export_package calls pkg.save AND writes genai_config.json."""
+        """export_package calls save_package_layout AND writes genai_config.json."""
         from mobius.integrations.ort_genai.auto_export import export_package
 
         pkg = self._make_pkg()
         save_calls = []
 
-        def fake_save(self, directory, **kwargs):
+        def fake_save_package_layout(self, directory, **kwargs):
             save_calls.append((directory, kwargs))
+            # Return what save_package_layout would: {component_name: path}
+            component_map = kwargs.get("component_map") or {}
+            written = {}
+            for key in self:
+                comp = component_map.get(key, key)
+                written[comp] = os.path.join(directory, comp, "base", "model.onnx")
+            return written
 
-        monkeypatch.setattr(pkg.__class__, "save", fake_save)
+        monkeypatch.setattr(pkg.__class__, "save_package_layout", fake_save_package_layout)
 
         result = export_package(pkg, str(tmp_path))
 
-        # pkg.save called exactly once with the output dir
+        # save_package_layout called exactly once with the output dir
         assert len(save_calls) == 1
         assert save_calls[0][0] == str(tmp_path)
-        # genai_config artifact is in the manifest
+        # genai_config artifact is in the manifest (under configs/)
         assert "genai_config" in result
         assert os.path.isfile(result["genai_config"])
-        # ONNX path is in the manifest (single-component package)
-        assert result["model"] == os.path.join(str(tmp_path), "model.onnx")
+        # Per-component ONNX path is in the manifest (LLM key "model" -> "decoder")
+        assert result["decoder:model"] == os.path.join(
+            str(tmp_path), "decoder", "base", "model.onnx"
+        )
+        # Top-level manifest.json was written
+        assert "manifest" in result
+        assert os.path.isfile(result["manifest"])
 
     def test_propagates_save_kwargs(self, tmp_path, monkeypatch):
-        """external_data and progress_bar are forwarded to pkg.save."""
+        """external_data and progress_bar are forwarded to save_package_layout."""
         from mobius.integrations.ort_genai.auto_export import export_package
 
         pkg = self._make_pkg()
         save_calls = []
 
-        def fake_save(self, directory, **kwargs):
+        def fake_save_package_layout(self, directory, **kwargs):
             save_calls.append(kwargs)
+            return {}
 
-        monkeypatch.setattr(pkg.__class__, "save", fake_save)
+        monkeypatch.setattr(pkg.__class__, "save_package_layout", fake_save_package_layout)
 
         export_package(
             pkg,
@@ -963,26 +960,27 @@ class TestExportPackage:
         assert save_calls[0]["progress_bar"] is False
 
     def test_propagates_genai_config_kwargs(self, tmp_path, monkeypatch):
-        """The ep and context_length kwargs reach the generated genai_config.json."""
+        """The context_length kwarg reaches the generated genai_config.json."""
         from mobius.integrations.ort_genai.auto_export import export_package
 
         pkg = self._make_pkg()
-        monkeypatch.setattr(pkg.__class__, "save", lambda self, d, **kw: None)
+        monkeypatch.setattr(
+            pkg.__class__, "save_package_layout", lambda self, d, **kw: {}
+        )
 
         result = export_package(
             pkg,
             str(tmp_path),
-            ep="cuda",
             context_length=8192,
         )
 
         with open(result["genai_config"]) as f:
             data = json.load(f)
-        # ep="cuda" should produce CUDA provider_options
-        provider_opts = data["model"]["decoder"]["session_options"]["provider_options"]
-        assert any("cuda" in po for po in provider_opts)
-        # context_length should bump max_length
+        # context_length should set max_length (no EP-specific cap is applied
+        # in the v4 EP-agnostic base config).
         assert data["search"]["max_length"] == 8192
+        # The base genai_config has no session_options (EP-agnostic).
+        assert "session_options" not in data["model"]["decoder"]
 
     def test_preflights_missing_config(self, tmp_path, monkeypatch):
         """Raises ValueError BEFORE writing any ONNX when pkg.config is None.
@@ -996,10 +994,11 @@ class TestExportPackage:
         pkg = ModelPackage({"model": mock.MagicMock()}, config=None)
         save_called = []
 
-        def fake_save(self, *a, **kw):
+        def fake_save_package_layout(self, *a, **kw):
             save_called.append(True)
+            return {}
 
-        monkeypatch.setattr(pkg.__class__, "save", fake_save)
+        monkeypatch.setattr(pkg.__class__, "save_package_layout", fake_save_package_layout)
 
         with pytest.raises(ValueError, match="config"):
             export_package(pkg, str(tmp_path))
@@ -1008,18 +1007,27 @@ class TestExportPackage:
         assert save_called == []
 
     def test_returns_manifest_with_all_artifacts(self, tmp_path, monkeypatch):
-        """Returned manifest contains ONNX paths AND config artifacts."""
+        """Returned manifest contains per-component ONNX paths AND config artifacts."""
         from mobius.integrations.ort_genai.auto_export import export_package
 
         pkg = self._make_pkg()
-        monkeypatch.setattr(pkg.__class__, "save", lambda self, d, **kw: None)
+        monkeypatch.setattr(
+            pkg.__class__,
+            "save_package_layout",
+            lambda self, d, **kw: {
+                "decoder": os.path.join(d, "decoder", "base", "model.onnx"),
+            },
+        )
 
         result = export_package(pkg, str(tmp_path))
 
         # Manifest is non-empty and includes both kinds of artifacts
         assert isinstance(result, dict)
-        assert "model" in result
+        assert "decoder:model" in result
+        assert "decoder:metadata" in result
+        assert "decoder:variant" in result
         assert "genai_config" in result
+        assert "manifest" in result
 
 
 class TestGemma4GenaiConfig:
@@ -1092,13 +1100,17 @@ class TestGemma4GenaiConfig:
             str(tmp_path),
             pkg=pkg,
             ort_model_type="gemma4",
-            ep="cpu",
             context_length=4096,
             bos_token_id=2,
             eos_token_id=1,
             pad_token_id=0,
             is_vlm=True,
             has_speech=False,
+            component_map={
+                "model": "decoder",
+                "vision_encoder": "vision_encoder",
+                "embedding": "embedding",
+            },
         )
         with open(path) as f:
             data = json.load(f)
@@ -1116,13 +1128,17 @@ class TestGemma4GenaiConfig:
             str(tmp_path),
             pkg=pkg,
             ort_model_type="gemma4",
-            ep="cpu",
             context_length=4096,
             bos_token_id=2,
             eos_token_id=1,
             pad_token_id=0,
             is_vlm=True,
             has_speech=False,
+            component_map={
+                "model": "decoder",
+                "vision_encoder": "vision_encoder",
+                "embedding": "embedding",
+            },
         )
         with open(path) as f:
             data = json.load(f)
@@ -1140,13 +1156,17 @@ class TestGemma4GenaiConfig:
             str(tmp_path),
             pkg=pkg,
             ort_model_type="gemma4",
-            ep="cpu",
             context_length=4096,
             bos_token_id=2,
             eos_token_id=1,
             pad_token_id=0,
             is_vlm=True,
             has_speech=False,
+            component_map={
+                "model": "decoder",
+                "vision_encoder": "vision_encoder",
+                "embedding": "embedding",
+            },
         )
         with open(path) as f:
             data = json.load(f)
@@ -1209,13 +1229,17 @@ class TestPixtralGenaiConfig:
             str(tmp_path),
             pkg=pkg,
             ort_model_type="mistral3",
-            ep="cpu",
             context_length=4096,
             bos_token_id=1,
             eos_token_id=2,
             pad_token_id=0,
             is_vlm=True,
             has_speech=False,
+            component_map={
+                "model": "decoder",
+                "vision_encoder": "vision_encoder",
+                "embedding": "embedding",
+            },
         )
         with open(path) as f:
             data = json.load(f)

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -497,7 +497,7 @@ class TestExportForOrtGenai:
         monkeypatch.setattr(
             ae,
             "_resolve_component_map",
-            lambda p: {key: "decoder" for key in p},
+            lambda p: dict.fromkeys(p, "decoder"),
         )
 
         with pytest.raises(ValueError, match="Duplicate component names"):

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -479,6 +479,9 @@ class TestExportForOrtGenai:
             data = json.load(f)
         assert "model" in data
         assert data["model"]["type"] == "qwen2"
+        assert os.path.isfile(tmp_path / "models" / "decoder" / "metadata.json")
+        assert os.path.isfile(tmp_path / "models" / "decoder" / "base" / "variant.json")
+        assert not os.path.exists(tmp_path / "decoder")
 
     def test_duplicate_component_names_rejected(self, tmp_path, monkeypatch):
         """Two package keys mapping to the same on-disk component is rejected.
@@ -938,7 +941,7 @@ class TestExportPackage:
             written = {}
             for key in self:
                 comp = component_map.get(key, key)
-                written[comp] = os.path.join(directory, comp, "base", "model.onnx")
+                written[comp] = os.path.join(directory, "models", comp, "base", "model.onnx")
             return written
 
         monkeypatch.setattr(pkg.__class__, "save_package_layout", fake_save_package_layout)
@@ -953,7 +956,7 @@ class TestExportPackage:
         assert os.path.isfile(result["genai_config"])
         # Per-component ONNX path is in the manifest (LLM key "model" -> "decoder")
         assert result["decoder:model"] == os.path.join(
-            str(tmp_path), "decoder", "base", "model.onnx"
+            str(tmp_path), "models", "decoder", "base", "model.onnx"
         )
         # Top-level manifest.json was written
         assert "manifest" in result
@@ -1038,7 +1041,7 @@ class TestExportPackage:
             pkg.__class__,
             "save_package_layout",
             lambda self, d, **kw: {
-                "decoder": os.path.join(d, "decoder", "base", "model.onnx"),
+                "decoder": os.path.join(d, "models", "decoder", "base", "model.onnx"),
             },
         )
 

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -480,6 +480,29 @@ class TestExportForOrtGenai:
         assert "model" in data
         assert data["model"]["type"] == "qwen2"
 
+    def test_duplicate_component_names_rejected(self, tmp_path, monkeypatch):
+        """Two package keys mapping to the same on-disk component is rejected.
+
+        Prevents manifest.json from listing duplicates and per-component
+        metadata.json / variant.json files from clobbering each other.
+        """
+        from mobius._model_package import ModelPackage
+        from mobius.integrations.ort_genai import auto_export as ae
+
+        pkg = ModelPackage(
+            {"model": mock.MagicMock(), "decoder": mock.MagicMock()},
+            config=self._make_pkg().config,
+        )
+        # Force the duplicate: both "model" and "decoder" -> "decoder".
+        monkeypatch.setattr(
+            ae,
+            "_resolve_component_map",
+            lambda p: {key: "decoder" for key in p},
+        )
+
+        with pytest.raises(ValueError, match="Duplicate component names"):
+            write_ort_genai_config(pkg, str(tmp_path))
+
     def test_processor_config_written_with_vision(self, tmp_path):
         """image_processor.json is written when pkg.config.vision is set."""
         import dataclasses

--- a/src/mobius/integrations/ort_genai/genai_config.py
+++ b/src/mobius/integrations/ort_genai/genai_config.py
@@ -1,12 +1,29 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Generate genai_config.json for onnxruntime-genai.
+"""Generate genai_config.json for onnxruntime-genai (Model Package format).
 
 This module takes an ``ArchitectureConfig`` (or ``BaseModelConfig``) and a
-model type string and produces the config dict that onnxruntime-genai
-expects. It does NOT import from core model/task/component layers — it
-only reads config dataclass fields.
+model type string and produces the ``genai_config.json`` *base* document
+that onnxruntime-genai expects in the Model Package layout.
+
+The generated document is **EP-agnostic**: it carries no
+``session_options``, ``provider_options``, ``filename``, or
+EP-derived search defaults (``past_present_share_buffer``, KV-buffer
+``max_length`` cap). All EP-specific concerns live in each variant's
+``variant.json`` (written by a downstream packager); per-variant
+GenAI overrides land via the variant's
+``consumer_metadata.genai_config_overlay``.
+
+What stays here is GenAI architecture identity (``model.type``,
+hidden/head sizes, layer counts, vocab size, token IDs, context
+length), per-component I/O name maps, and EP-agnostic ``search``
+defaults. Each component block now carries a ``"component"`` field
+naming the package component the role binds to (e.g.
+``"component": "decoder"``, ``"component": "vision_encoder"``).
+
+This module does NOT import from core model/task/component layers —
+it only reads config dataclass fields.
 """
 
 from __future__ import annotations
@@ -44,42 +61,20 @@ def _default_decoder_outputs() -> dict[str, str]:
     }
 
 
-_SHARE_BUFFER_MAX_LENGTH_CAP = 4096
+def _default_search_params(*, context_length: int) -> dict[str, Any]:
+    """Return EP-agnostic default search parameters.
 
-
-def _default_search_params(*, ep: str, context_length: int) -> dict[str, Any]:
-    """Return sensible default search parameters.
-
-    Args:
-        ep: Execution provider (``"cpu"``, ``"cuda"``, ``"dml"``,
-            ``"webgpu"``, ``"trt-rtx"``).  Capability flags are read from
-            :data:`~mobius._execution_providers.ep_registry`.
-        context_length: Model context window; used as the default
-            ``max_length`` for generation so the limit matches the model.
+    EP-specific knobs (``past_present_share_buffer``, KV-buffer
+    ``max_length`` caps) are omitted — they belong in the variant's
+    overlay or runtime config, not in the package-shipped base.
     """
-    from mobius._execution_providers import ep_registry
-
-    caps = ep_registry.get(ep)
-    share_buffer = caps.supports_past_present_share_buffer if caps is not None else False
-    cap_length = caps.cap_kv_buffer_max_length if caps is not None else False
-    if share_buffer and cap_length:
-        # Memory-constrained EPs (e.g. WebGPU on consumer GPUs) pre-allocate
-        # KV-cache for the full max_length at load time.  Cap the default to
-        # avoid pre-allocating huge buffers (~8 GB for 128K-token models).
-        # Users can raise the limit in genai_config.json for their device.
-        # The cap only applies when buffer sharing is also active — without
-        # sharing, the runtime grows the cache on demand and no cap is needed.
-        max_length = min(context_length, _SHARE_BUFFER_MAX_LENGTH_CAP)
-    else:
-        max_length = context_length
     return {
         "do_sample": True,
         "early_stopping": True,
-        "max_length": max_length,
+        "max_length": context_length,
         "min_length": 0,
         "num_beams": 1,
         "num_return_sequences": 1,
-        "past_present_share_buffer": share_buffer,
         "repetition_penalty": 1.0,
         "temperature": 1.0,
         "top_k": 1,
@@ -87,26 +82,13 @@ def _default_search_params(*, ep: str, context_length: int) -> dict[str, Any]:
     }
 
 
-def _make_session_options(ep: str) -> dict[str, Any]:
-    """Return session options with EP-specific provider_options.
-
-    Args:
-        ep: Execution provider name (e.g. ``"cpu"``, ``"cuda"``,
-            ``"dml"``, ``"trt-rtx"``).
-    """
-    from mobius.integrations.ort_genai.ep_config import make_provider_options
-
-    return {
-        "log_id": "onnxruntime-genai",
-        "provider_options": make_provider_options(ep),
-    }
-
-
 class GenaiConfigGenerator:
-    """Generates genai_config.json dicts for onnxruntime-genai.
+    """Generates the EP-agnostic ``genai_config.json`` base document.
 
-    This class takes config fields as plain values (not model internals)
-    and assembles the nested dict structure that ORT-GenAI expects.
+    The output document is the *base* in the Model Package world:
+    every variant in the package merges its overlay onto this document
+    at runtime. The document declares only architecture identity and
+    role↔component bindings, never EP-specific settings.
 
     Args:
         model_type: The ORT-GenAI model type string (e.g. ``"qwen2"``,
@@ -121,8 +103,6 @@ class GenaiConfigGenerator:
             ``genai_config.json``. Overridden upward by
             ``max_position_embeddings`` from the model config when that
             value is larger. Defaults to 4096.
-        ep: Execution provider for ``session_options`` (e.g. ``"cpu"``,
-            ``"cuda"``, ``"dml"``, ``"trt-rtx"``). Defaults to ``"cpu"``.
         bos_token_id: Beginning-of-sequence token ID.
         eos_token_id: End-of-sequence token ID(s).
         pad_token_id: Padding token ID.
@@ -132,6 +112,9 @@ class GenaiConfigGenerator:
             :func:`_default_decoder_inputs`. Must already include KV
             cache template entries (``past_key_names``,
             ``past_value_names``).
+        decoder_component: Name of the package component the
+            ``decoder`` role binds to. Defaults to ``"decoder"``.
+            Emitted as ``model.decoder.component``.
     """
 
     def __init__(
@@ -145,12 +128,11 @@ class GenaiConfigGenerator:
         num_key_value_heads: int,
         head_dim: int,
         context_length: int = 4096,
-        ep: str = "cpu",
         bos_token_id: int | None = None,
         eos_token_id: int | list[int] | None = None,
         pad_token_id: int | None = None,
         decoder_inputs: dict[str, str] | None = None,
-        decoder_filename: str | None = None,
+        decoder_component: str = "decoder",
     ):
         self.model_type = model_type
         self.vocab_size = vocab_size
@@ -160,15 +142,14 @@ class GenaiConfigGenerator:
         self.num_key_value_heads = num_key_value_heads
         self.head_dim = head_dim
         self.context_length = context_length
-        self.ep = ep
         self.bos_token_id = bos_token_id
         self.eos_token_id = eos_token_id
         self.pad_token_id = pad_token_id
 
         # Explicit decoder inputs (from graph introspection); None → use defaults
         self._decoder_inputs = decoder_inputs
-        # Explicit decoder filename; None → use "model.onnx"
-        self._decoder_filename = decoder_filename
+        # Package component name for the decoder role
+        self._decoder_component = decoder_component
 
         # Optional VLM fields (set via with_vision())
         self._vision: dict[str, Any] | None = None
@@ -188,12 +169,11 @@ class GenaiConfigGenerator:
         model_type: str,
         *,
         context_length: int = 4096,
-        ep: str = "cpu",
         bos_token_id: int | None = None,
         eos_token_id: int | list[int] | None = None,
         pad_token_id: int | None = None,
         decoder_inputs: dict[str, str] | None = None,
-        decoder_filename: str | None = None,
+        decoder_component: str = "decoder",
     ) -> GenaiConfigGenerator:
         """Create a generator from a BaseModelConfig-like dataclass.
 
@@ -221,20 +201,17 @@ class GenaiConfigGenerator:
             num_key_value_heads=config.num_key_value_heads,
             head_dim=config.head_dim,
             context_length=context_length,
-            ep=ep,
             bos_token_id=bos_token_id,
             eos_token_id=eos_token_id,
             pad_token_id=pad,
             decoder_inputs=decoder_inputs,
-            decoder_filename=decoder_filename,
+            decoder_component=decoder_component,
         )
 
     def with_vision(
         self,
         *,
         image_token_id: int,
-        filename: str = "vision_encoder/model.onnx",
-        embedding_filename: str = "embedding/model.onnx",
         spatial_merge_size: int | None = 2,
         config_filename: str = "image_processor.json",
         input_names: dict[str, str] | None = None,
@@ -242,28 +219,36 @@ class GenaiConfigGenerator:
         embedding_input_names: dict[str, str] | None = None,
         vision_start_token_id: int | None = None,
         video_token_id: int | None = None,
+        vision_component: str = "vision_encoder",
+        embedding_component: str = "embedding",
     ) -> GenaiConfigGenerator:
         """Add VLM vision + embedding sections.
 
         Args:
             image_token_id: Token ID for image placeholders. Required —
                 ORT-GenAI crashes without it.
-            filename: Vision ONNX model filename.
-            embedding_filename: Embedding ONNX model filename.
             spatial_merge_size: Spatial merge size for position ID
                 computation. Set to ``None`` to omit (e.g. for Phi4MM
                 which doesn't use spatial merge).
-            config_filename: Vision processor config filename.
+            config_filename: Vision processor config filename (relative
+                to the package's ``configs/`` directory). Defaults to
+                ``"image_processor.json"``.
             input_names: Override vision model input name mapping.
                 Defaults to pixel_values + image_grid_thw.
             output_names: Override vision model output name mapping.
                 Defaults to image_features.
             embedding_input_names: Override embedding model input name
-                mapping.  When provided (e.g. from ONNX graph
-                introspection), used directly.  Defaults to
+                mapping. When provided (e.g. from ONNX graph
+                introspection), used directly. Defaults to
                 input_ids + image_features.
             vision_start_token_id: Token ID for ``<|vision_start|>``.
             video_token_id: Token ID for video placeholders.
+            vision_component: Package component name for the vision
+                role. Defaults to ``"vision_encoder"``. Emitted as
+                ``model.vision.component``.
+            embedding_component: Package component name for the
+                embedding role. Defaults to ``"embedding"``. Emitted
+                as ``model.embedding.component``.
 
         Returns self for chaining.
         """
@@ -283,22 +268,20 @@ class GenaiConfigGenerator:
             }
 
         self._vision = {
-            "filename": filename,
+            "component": vision_component,
             "config_filename": config_filename,
             "inputs": input_names,
             "outputs": output_names,
-            "session_options": _make_session_options(self.ep),
         }
         if spatial_merge_size is not None:
             self._vision["spatial_merge_size"] = spatial_merge_size
 
         self._embedding = {
-            "filename": embedding_filename,
+            "component": embedding_component,
             "inputs": embedding_input_names,
             "outputs": {
                 "inputs_embeds": "inputs_embeds",
             },
-            "session_options": _make_session_options(self.ep),
         }
         self._vlm_token_ids["image_token_id"] = image_token_id
         if vision_start_token_id is not None:
@@ -312,23 +295,27 @@ class GenaiConfigGenerator:
         *,
         audio_token_id: int | None = None,
         boa_token_id: int | None = None,
-        filename: str = "audio_encoder/model.onnx",
         config_filename: str = "audio_processor.json",
         input_names: dict[str, str] | None = None,
         output_names: dict[str, str] | None = None,
+        audio_component: str = "audio_encoder",
     ) -> GenaiConfigGenerator:
         """Add audio model section for multimodal models.
 
         Args:
             audio_token_id: Token ID for audio placeholders.
             boa_token_id: Beginning-of-audio token ID.
-            filename: Audio ONNX model filename.
-            config_filename: Audio processor config filename.
+            config_filename: Audio processor config filename (relative
+                to the package's ``configs/`` directory). Defaults to
+                ``"audio_processor.json"``.
             input_names: Override audio model input name mapping.
                 Defaults to audio_embeds + audio_sizes +
                 audio_projection_mode.
             output_names: Override audio model output name mapping.
                 Defaults to audio_features.
+            audio_component: Package component name for the audio
+                role. Defaults to ``"audio_encoder"``. Emitted as
+                ``model.speech.component``.
 
         Returns self for chaining.
         """
@@ -344,11 +331,10 @@ class GenaiConfigGenerator:
             }
 
         self._audio = {
-            "filename": filename,
+            "component": audio_component,
             "config_filename": config_filename,
             "inputs": input_names,
             "outputs": output_names,
-            "session_options": _make_session_options(self.ep),
         }
 
         if audio_token_id is not None:
@@ -359,7 +345,7 @@ class GenaiConfigGenerator:
         return self
 
     def generate(self) -> dict[str, Any]:
-        """Generate the full genai_config.json dict."""
+        """Generate the full genai_config.json dict (package-world shape)."""
         is_multimodal = self._vision is not None or self._audio is not None
 
         # Decoder section — use explicit inputs when available (from
@@ -368,10 +354,8 @@ class GenaiConfigGenerator:
             decoder_inputs = dict(self._decoder_inputs)
         else:
             decoder_inputs = _default_decoder_inputs(is_vlm=is_multimodal)
-        decoder_filename = "decoder/model.onnx" if is_multimodal else "model.onnx"
         decoder: dict[str, Any] = {
-            "session_options": _make_session_options(self.ep),
-            "filename": self._decoder_filename or decoder_filename,
+            "component": self._decoder_component,
             "head_size": self.head_dim,
             "hidden_size": self.hidden_size,
             "inputs": decoder_inputs,
@@ -410,7 +394,7 @@ class GenaiConfigGenerator:
             model["speech"] = self._audio
         model.update(self._vlm_token_ids)
 
-        search = _default_search_params(ep=self.ep, context_length=self.context_length)
+        search = _default_search_params(context_length=self.context_length)
         search.update(self._search_overrides)
 
         return {
@@ -421,9 +405,13 @@ class GenaiConfigGenerator:
     def write(self, output_dir: str) -> str:
         """Write genai_config.json to the output directory.
 
-        Returns the path to the written file.
+        Returns the path to the written file. The output directory is
+        the package's ``configs/`` directory in the new layout (callers
+        in :mod:`mobius.integrations.ort_genai.auto_export` ensure
+        that). Creates *output_dir* if it does not yet exist.
         """
         config = self.generate()
+        os.makedirs(output_dir, exist_ok=True)
         path = os.path.join(output_dir, "genai_config.json")
         with open(path, "w", encoding="utf-8") as f:
             json.dump(config, f, indent=4)

--- a/src/mobius/integrations/ort_genai/genai_config_test.py
+++ b/src/mobius/integrations/ort_genai/genai_config_test.py
@@ -42,7 +42,7 @@ class TestGenaiConfigGeneratorLLM:
         assert decoder["num_attention_heads"] == 32
         assert decoder["num_key_value_heads"] == 8
         assert decoder["head_size"] == 128
-        assert decoder["filename"] == "model.onnx"
+        assert decoder["component"] == "decoder"
 
     def test_llm_decoder_inputs_have_input_ids(self):
         """LLM decoders receive input_ids, not inputs_embeds."""
@@ -115,7 +115,7 @@ class TestGenaiConfigGeneratorLLM:
         assert "pad_token_id" not in config["model"]
 
     def test_search_params_defaults(self):
-        """Search section has sensible defaults for CPU EP."""
+        """Search section has EP-agnostic defaults."""
         gen = GenaiConfigGenerator(
             "llama",
             vocab_size=32000,
@@ -134,13 +134,16 @@ class TestGenaiConfigGeneratorLLM:
         assert search["temperature"] == pytest.approx(1.0)
         assert search["top_k"] == 1
         assert search["top_p"] == pytest.approx(1.0)
-        # max_length tracks the model's context window
+        # max_length tracks the model's context window — not capped at any
+        # EP-specific KV-buffer ceiling. EP-specific overrides land via the
+        # variant's consumer_metadata.genai_config_overlay.
         assert search["max_length"] == 8192
-        # CPU shares past/present KV buffers (all GQA-capable EPs do)
-        assert search["past_present_share_buffer"] is True
+        # past_present_share_buffer is an EP-specific knob and must NOT
+        # appear in the package-level base genai_config.
+        assert "past_present_share_buffer" not in search
 
-    def test_search_params_webgpu_sets_past_present_share_buffer(self):
-        """WebGPU EP sets supports_past_present_share_buffer=True via EpCapabilities and caps max_length."""
+    def test_search_params_no_ep_cap_for_large_context(self):
+        """Large context_length is not capped — base config is EP-agnostic."""
         gen = GenaiConfigGenerator(
             "qwen2",
             vocab_size=151936,
@@ -149,120 +152,15 @@ class TestGenaiConfigGeneratorLLM:
             num_attention_heads=14,
             num_key_value_heads=2,
             head_dim=64,
-            ep="webgpu",
-            context_length=32768,
-        )
-        config = gen.generate()
-        assert config["search"]["past_present_share_buffer"] is True
-        # 32768 > 4096 cap, so max_length is capped to avoid pre-allocating huge KV cache
-        assert config["search"]["max_length"] == 4096
-
-    def test_search_params_webgpu_small_context_not_capped(self):
-        """WebGPU max_length is not capped when context_length <= 4096."""
-        gen = GenaiConfigGenerator(
-            "phi3",
-            vocab_size=32064,
-            hidden_size=3072,
-            num_hidden_layers=32,
-            num_attention_heads=32,
-            num_key_value_heads=32,
-            head_dim=96,
-            ep="webgpu",
-            context_length=2048,
-        )
-        config = gen.generate()
-        assert config["search"]["past_present_share_buffer"] is True
-        assert config["search"]["max_length"] == 2048
-
-    def test_search_params_cuda_shares_buffer(self):
-        """CUDA EP sets past_present_share_buffer=True (all GQA-capable EPs do).
-
-        CUDA does NOT cap max_length — only memory-constrained EPs (WebGPU)
-        set ``cap_kv_buffer_max_length=True``.  Server-class GPUs handle
-        large pre-allocations.
-        """
-        gen = GenaiConfigGenerator(
-            "llama",
-            vocab_size=32000,
-            hidden_size=4096,
-            num_hidden_layers=32,
-            num_attention_heads=32,
-            num_key_value_heads=8,
-            head_dim=128,
-            ep="cuda",
             context_length=131072,
         )
         config = gen.generate()
-        assert config["search"]["past_present_share_buffer"] is True
-        # CUDA: full context_length, NOT capped at 4096
+        # No WebGPU-style 4096 cap — packagers add EP-specific limits via
+        # variant overlays.
         assert config["search"]["max_length"] == 131072
 
-    def test_search_params_custom_ep_with_share_buffer(self):
-        """A custom EP registered with supports_past_present_share_buffer=True gets the flag set.
-
-        This proves the value comes from EpCapabilities, not from a hardcoded
-        'ep == webgpu' check.  The custom EP does NOT set
-        ``cap_kv_buffer_max_length``, so max_length is the full context.
-        """
-        from mobius._execution_providers import EpCapabilities, ep_registry
-
-        ep_registry.register(
-            EpCapabilities(name="test-custom-ep", supports_past_present_share_buffer=True),
-            overwrite=True,
-        )
-        try:
-            gen = GenaiConfigGenerator(
-                "llama",
-                vocab_size=32000,
-                hidden_size=4096,
-                num_hidden_layers=32,
-                num_attention_heads=32,
-                num_key_value_heads=8,
-                head_dim=128,
-                ep="test-custom-ep",
-                context_length=8192,
-            )
-            config = gen.generate()
-            assert config["search"]["past_present_share_buffer"] is True
-            # No cap_kv_buffer_max_length: max_length = full context_length
-            assert config["search"]["max_length"] == 8192
-        finally:
-            # Clean up the test EP so it doesn't bleed into other tests
-            ep_registry._entries.pop("test-custom-ep", None)
-
-    def test_search_params_custom_ep_with_max_length_cap(self):
-        """A custom EP with cap_kv_buffer_max_length=True caps max_length at 4096."""
-        from mobius._execution_providers import EpCapabilities, ep_registry
-
-        ep_registry.register(
-            EpCapabilities(
-                name="test-capped-ep",
-                supports_past_present_share_buffer=True,
-                cap_kv_buffer_max_length=True,
-            ),
-            overwrite=True,
-        )
-        try:
-            gen = GenaiConfigGenerator(
-                "llama",
-                vocab_size=32000,
-                hidden_size=4096,
-                num_hidden_layers=32,
-                num_attention_heads=32,
-                num_key_value_heads=8,
-                head_dim=128,
-                ep="test-capped-ep",
-                context_length=131072,
-            )
-            config = gen.generate()
-            assert config["search"]["past_present_share_buffer"] is True
-            # cap_kv_buffer_max_length=True: max_length capped at 4096
-            assert config["search"]["max_length"] == 4096
-        finally:
-            ep_registry._entries.pop("test-capped-ep", None)
-
-    def test_session_options_present(self):
-        """Decoder has session_options with log_id."""
+    def test_decoder_component_default(self):
+        """Decoder block carries a 'component' field, default 'decoder'."""
         gen = GenaiConfigGenerator(
             "llama",
             vocab_size=32000,
@@ -273,8 +171,38 @@ class TestGenaiConfigGeneratorLLM:
             head_dim=128,
         )
         config = gen.generate()
-        opts = config["model"]["decoder"]["session_options"]
-        assert opts["log_id"] == "onnxruntime-genai"
+        assert config["model"]["decoder"]["component"] == "decoder"
+
+    def test_decoder_component_custom(self):
+        """Custom decoder component name is emitted unchanged."""
+        gen = GenaiConfigGenerator(
+            "llama",
+            vocab_size=32000,
+            hidden_size=4096,
+            num_hidden_layers=32,
+            num_attention_heads=32,
+            num_key_value_heads=8,
+            head_dim=128,
+            decoder_component="text_decoder",
+        )
+        config = gen.generate()
+        assert config["model"]["decoder"]["component"] == "text_decoder"
+
+    def test_decoder_block_has_no_filename_or_session_options(self):
+        """Package-level base genai_config must not carry EP-coupled keys."""
+        gen = GenaiConfigGenerator(
+            "llama",
+            vocab_size=32000,
+            hidden_size=4096,
+            num_hidden_layers=32,
+            num_attention_heads=32,
+            num_key_value_heads=8,
+            head_dim=128,
+        )
+        decoder = gen.generate()["model"]["decoder"]
+        assert "filename" not in decoder
+        assert "session_options" not in decoder
+        assert "provider_options" not in decoder
 
 
 class TestGenaiConfigGeneratorVLM:
@@ -302,7 +230,7 @@ class TestGenaiConfigGeneratorVLM:
         """VLM config includes vision model section."""
         config = self._make_vlm_gen().generate()
         vision = config["model"]["vision"]
-        assert vision["filename"] == "vision_encoder/model.onnx"
+        assert vision["component"] == "vision_encoder"
         assert vision["spatial_merge_size"] == 2
         assert vision["inputs"]["pixel_values"] == "pixel_values"
         assert vision["outputs"]["image_features"] == "image_features"
@@ -311,7 +239,7 @@ class TestGenaiConfigGeneratorVLM:
         """VLM config includes embedding model section."""
         config = self._make_vlm_gen().generate()
         emb = config["model"]["embedding"]
-        assert emb["filename"] == "embedding/model.onnx"
+        assert emb["component"] == "embedding"
         assert emb["inputs"]["input_ids"] == "input_ids"
         assert emb["inputs"]["image_features"] == "image_features"
         assert emb["outputs"]["inputs_embeds"] == "inputs_embeds"
@@ -323,11 +251,20 @@ class TestGenaiConfigGeneratorVLM:
         assert "inputs_embeds" in inputs
         assert "input_ids" not in inputs
 
-    def test_vlm_decoder_filename_uses_subdirectory(self):
-        """VLM decoder filename includes the decoder/ subdirectory."""
+    def test_vlm_decoder_has_decoder_component(self):
+        """VLM decoder block carries component='decoder'."""
         config = self._make_vlm_gen().generate()
         decoder = config["model"]["decoder"]
-        assert decoder["filename"] == "decoder/model.onnx"
+        assert decoder["component"] == "decoder"
+
+    def test_vlm_blocks_have_no_filename_or_session_options(self):
+        """VLM vision/embedding blocks must not carry EP-coupled keys."""
+        config = self._make_vlm_gen().generate()
+        for role in ("vision", "embedding"):
+            block = config["model"][role]
+            assert "filename" not in block
+            assert "session_options" not in block
+            assert "provider_options" not in block
 
     def test_vlm_token_ids_at_model_level(self):
         """VLM-specific token IDs are at the model level."""
@@ -607,12 +544,20 @@ class TestGenaiConfigGeneratorMultimodal:
         """Audio section has audio_embeds, audio_sizes, mode."""
         config = self._make_phi4mm_gen().generate()
         audio = config["model"]["speech"]
-        assert audio["filename"] == "audio_encoder/model.onnx"
+        assert audio["component"] == "audio_encoder"
         assert audio["config_filename"] == "audio_processor.json"
         assert audio["inputs"]["audio_embeds"] == "audio_embeds"
         assert audio["inputs"]["audio_sizes"] == "audio_sizes"
         assert audio["inputs"]["audio_projection_mode"] == "audio_projection_mode"
         assert audio["outputs"]["audio_features"] == "audio_features"
+
+    def test_audio_block_has_no_filename_or_session_options(self):
+        """Audio block must not carry EP-coupled keys."""
+        config = self._make_phi4mm_gen().generate()
+        speech = config["model"]["speech"]
+        assert "filename" not in speech
+        assert "session_options" not in speech
+        assert "provider_options" not in speech
 
     def test_boa_token_id_in_audio_config(self):
         """boa_token_id is included when passed to with_audio()."""
@@ -718,87 +663,3 @@ class TestGenaiConfigGeneratorMultimodal:
         )
         result = gen.with_vision(image_token_id=200010).with_audio()
         assert result is gen
-
-
-class TestMakeSessionOptions:
-    """Tests for the _make_session_options() helper."""
-
-    def test_cpu_has_empty_provider_options(self):
-        """CPU EP produces empty provider_options (no special session config)."""
-        from mobius.integrations.ort_genai.genai_config import _make_session_options
-
-        opts = _make_session_options("cpu")
-        assert opts["log_id"] == "onnxruntime-genai"
-        assert opts["provider_options"] == []
-
-    def test_cuda_has_cuda_provider_options(self):
-        """CUDA EP produces a provider_options entry for cuda."""
-        from mobius.integrations.ort_genai.genai_config import _make_session_options
-
-        opts = _make_session_options("cuda")
-        assert opts["log_id"] == "onnxruntime-genai"
-        assert len(opts["provider_options"]) == 1
-        assert "cuda" in opts["provider_options"][0]
-
-    def test_dml_has_dml_provider_options(self):
-        """DML EP produces a provider_options entry for dml."""
-        from mobius.integrations.ort_genai.genai_config import _make_session_options
-
-        opts = _make_session_options("dml")
-        assert opts["log_id"] == "onnxruntime-genai"
-        assert len(opts["provider_options"]) == 1
-        assert "dml" in opts["provider_options"][0]
-
-
-class TestGenaiConfigGeneratorEp:
-    """Tests for EP threading through all session_options blocks."""
-
-    def _gen(self, ep: str) -> GenaiConfigGenerator:
-        return GenaiConfigGenerator(
-            "llama",
-            vocab_size=32000,
-            hidden_size=4096,
-            num_hidden_layers=32,
-            num_attention_heads=32,
-            num_key_value_heads=8,
-            head_dim=128,
-            ep=ep,
-        )
-
-    def test_cpu_ep_decoder_has_empty_provider_options(self):
-        """CPU EP: decoder session_options.provider_options is empty."""
-        config = self._gen("cpu").generate()
-        assert config["model"]["decoder"]["session_options"]["provider_options"] == []
-
-    def test_cuda_ep_decoder_has_cuda_provider_options(self):
-        """CUDA EP: decoder session_options.provider_options has CUDA entry."""
-        config = self._gen("cuda").generate()
-        opts = config["model"]["decoder"]["session_options"]["provider_options"]
-        assert len(opts) == 1
-        assert "cuda" in opts[0]
-
-    def test_cuda_ep_all_blocks_have_cuda_session_options(self):
-        """CUDA EP applied to all 4 session blocks (decoder, vision, embedding, audio)."""
-        gen = (
-            GenaiConfigGenerator(
-                "phi4mm",
-                vocab_size=200064,
-                hidden_size=3072,
-                num_hidden_layers=32,
-                num_attention_heads=24,
-                num_key_value_heads=8,
-                head_dim=128,
-                ep="cuda",
-            )
-            .with_vision(image_token_id=200010)
-            .with_audio()
-        )
-        config = gen.generate()
-
-        for block in ("decoder", "vision", "embedding", "speech"):
-            if block not in config["model"]:
-                continue
-            session_opts = config["model"][block]["session_options"]
-            provider_options = session_opts["provider_options"]
-            assert len(provider_options) == 1, f"{block} missing CUDA provider options"
-            assert "cuda" in provider_options[0], f"{block} has wrong EP in provider_options"

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -227,3 +227,40 @@ class TestCLIBuildRuntime:
                     "tensorrt",  # not a supported value
                 ]
             )
+
+    def test_component_filter_restricts_genai_config_components(self):
+        """--component restricts write_ort_genai_config to the selected component.
+
+        Regression test: previously the CLI passed the full ``pkg`` to
+        ``write_ort_genai_config`` even when ``--component`` had filtered
+        ``save_package_layout`` down to a subset, producing a manifest
+        that referenced components whose ONNX files were not on disk.
+        """
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            mock.patch(
+                "mobius.integrations.ort_genai.write_ort_genai_config",
+                return_value={},
+            ) as mock_export,
+        ):
+            main(
+                [
+                    "build",
+                    "--model",
+                    "Qwen/Qwen2.5-0.5B",
+                    tmpdir,
+                    "--no-weights",
+                    "--runtime",
+                    "ort-genai",
+                    "--component",
+                    "model",
+                ]
+            )
+
+        mock_export.assert_called_once()
+        # The package passed to write_ort_genai_config must contain only the
+        # filtered component (here: "model"). For an LLM build this is a
+        # no-op (the package already has one component), but the call site
+        # must always pass a filtered package — never the unfiltered one.
+        config_pkg = mock_export.call_args.args[0]
+        assert set(config_pkg.keys()) == {"model"}


### PR DESCRIPTION
Mobius's `--runtime ort-genai` export now produces an EP-agnostic ORT-GenAI Model Package (v4 spec) directly loadable by the `onnxruntime-genai/src/models/model_package.cpp` loader, instead of the legacy flat directory with an EP-specific genai_config.json.

Variant decisions (session_options, provider_options, EP-specific tuning, multi-variant assembly) are deferred to downstream packagers (Olive workflows, EP-specific compilers).

Layout produced:

    <pkg>/
      manifest.json
      configs/{genai_config.json, tokenizer*, *_processor.json}
      <component>/metadata.json
      <component>/base/{variant.json, model.onnx, model.onnx.data*}

Mobius emits exactly one variant named `base`, declared compatible with the major ORT EPs (CPU + CUDA + DML + WebGPU + NvTensorRTRTX).

Schema details (per v4 spec, verified against the C++ loader):

* manifest.json: schema_version "1.0" + components string array.
* metadata.json: variants is a *map* keyed by variant name; each entry has ep_compatibility[] of {ep, device?, compatibility?}.
* variant.json: files[] entries carry filename + optional session_options/provider_options/shared_files (objects, not arrays) + optional consumer_metadata.genai_config_overlay.

genai_config.json schema changes (mobius output):

* removed: model.<role>.filename (replaced by .component)
* removed: model.<role>.session_options / .provider_options
* removed: search.past_present_share_buffer (was EP-derived)
* removed: search.max_length cap (was EP-derived)
* added:   model.<role>.component (package component name)

New helpers:

* mobius/integrations/ort_genai/_package_writer.py: writers for manifest/metadata/variant.json. Validates that optional object fields (provider_options, shared_files, session_options) are dicts at write time; omits them when empty so the loader sees absent (not empty array).
* ModelPackage.save_package_layout(): writes <dir>/<component>/<variant>/model.onnx for any number of components.

Verified end-to-end:

* `python -m mobius build --model microsoft/Phi-4-mini-instruct --dtype f16 --runtime ort-genai --no-weights <out>` produces a package that round-trips through the v4 schema verifier.
* 2732 passed, 41 skipped (full mobius test suite).
* 16 _package_writer_test.py tests including round-trip checks and rejection of list-form provider_options/shared_files.

Docs updated: ort-genai-config, onnx-export-quantization, foundry-local skills now describe the new package layout.