### PR TITLE
Add Q1_0 GGUF support (mainline + Tencent SEQ 2-bit variant)

### DIFF
--- a/examples/hy_mt1_5.py
+++ b/examples/hy_mt1_5.py
@@ -1,0 +1,183 @@
+r"""End-to-end translation example for Hy-MT1.5-1.8B via ORT GenAI.
+
+Demonstrates loading a mobius-built Hy-MT1.5 export with
+``onnxruntime-genai`` (no PyTorch at inference time). The HF model_type
+``hunyuan_v1_dense`` is mapped to ORT GenAI's generic ``decoder`` LLM
+type (see ``onnxruntime-genai/src/models/model_type.h``); this script
+verifies that the resulting ``genai_config.json`` loads and that
+``Generator.generate_next_token()`` produces output end-to-end.
+
+Two model variants are supported, selected by ``--variant``:
+
+* ``bf16``  - full-precision export from the HuggingFace safetensors.
+  Note: BF16 MatMul isn't implemented on the ORT CPU EP, so this
+  variant only runs on CUDA / DML / WebGPU.
+* ``Q1_0``  - 2-bit-quantized export from the AngelSlim GGUF (Tencent
+  SEQ codebook; default mobius packing is ``MatMulNBits bits=4``
+  inflated form for fast CPU decode).
+
+Known caveat: the upstream Hy-MT1.5 BPE vocab uses placeholder special
+tokens and Chinese characters that ort-extensions' tokenizer does not
+fully round-trip today — for example ``"你好"`` tokenizes to an empty
+sequence. The chat template path renders correctly, but tokenization
+of CJK content in the message body is lossy. This is independent of
+the ``model_type=decoder`` fix and tracked downstream.
+
+Usage::
+
+    # Build + run the Q1_0 quantized variant on CPU
+    huggingface-cli download AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF \\
+        Hy-MT1.5-1.8B-2bit.gguf --local-dir ./gguf
+    python examples/hy_mt1_5.py --variant Q1_0 --build \\
+        --gguf ./gguf/Hy-MT1.5-1.8B-2bit.gguf --out ./hy-mt-q1_0-onnx
+
+    # Reuse an existing build (no --build)
+    python examples/hy_mt1_5.py --variant Q1_0 --out ./hy-mt-q1_0-onnx
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+HF_MODEL_ID = "tencent/Hy-MT1.5-1.8B-2bit"
+
+_DEFAULT_PROMPT = "Translate the following Chinese text to English: 你好，世界！"  # noqa: RUF001
+
+
+def _build_bf16(output_dir: Path) -> None:
+    """Build the BF16 ONNX model + ORT-GenAI config in-process."""
+    import mobius
+    from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
+
+    print(f"Building bf16 -> {output_dir}")
+    pkg = mobius.build(HF_MODEL_ID, dtype="bf16", load_weights=True)
+    pkg.save(str(output_dir))
+    write_ort_genai_config(pkg, str(output_dir), hf_model_id=HF_MODEL_ID, ep="cpu")
+    _patch_genai_config(output_dir)
+    print("  genai_config.json + tokenizer files written")
+
+
+def _build_q1_0(gguf_path: Path, output_dir: Path) -> None:
+    """Build the 2-bit Q1_0 ONNX model + ORT-GenAI config in-process."""
+    from mobius.integrations.gguf._builder import build_from_gguf
+    from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
+
+    print(f"Building Q1_0 -> {output_dir}")
+    pkg = build_from_gguf(str(gguf_path), keep_quantized=True, dtype="f32")
+    pkg.save(str(output_dir))
+    write_ort_genai_config(pkg, str(output_dir), hf_model_id=HF_MODEL_ID, ep="cpu")
+    _patch_genai_config(output_dir)
+    print("  genai_config.json + tokenizer files written")
+
+
+def _patch_genai_config(output_dir: Path) -> None:
+    """Disable ``past_present_share_buffer`` for the dynamic-cache export.
+
+    mobius emits a dynamic-shape KV cache (no pre-allocated buffer);
+    ORT GenAI's default of ``past_present_share_buffer = True`` would
+    feed the attention op a mask whose ``total_sequence_length`` doesn't
+    match the dynamic past_key/past_value shapes, producing
+    ``inconsistent total_sequence_length`` at runtime.
+    """
+    import json
+
+    cfg_path = output_dir / "genai_config.json"
+    cfg = json.loads(cfg_path.read_text())
+    cfg.setdefault("search", {})["past_present_share_buffer"] = False
+    cfg_path.write_text(json.dumps(cfg, indent=4))
+
+
+def _ensure_built(args: argparse.Namespace) -> Path:
+    out = Path(args.out).resolve()
+    if args.build:
+        out.mkdir(parents=True, exist_ok=True)
+        if args.variant == "bf16":
+            _build_bf16(out)
+        elif args.variant == "Q1_0":
+            if not args.gguf:
+                sys.exit("--gguf is required for --variant Q1_0 --build")
+            _build_q1_0(Path(args.gguf), out)
+    if not (out / "genai_config.json").exists():
+        sys.exit(
+            f"{out}/genai_config.json missing. Re-run with --build or point --out "
+            "at a directory produced by `mobius build --runtime ort-genai`."
+        )
+    return out
+
+
+def run_translation(model_dir: Path, prompt: str, max_new_tokens: int) -> str:
+    """Run a single greedy generation through ORT GenAI."""
+    import onnxruntime_genai as og
+
+    print(f"\nLoading ORT GenAI model from {model_dir}")
+    model = og.Model(str(model_dir))
+    tokenizer = og.Tokenizer(model)
+    tokenizer_stream = tokenizer.create_stream()
+
+    # Apply the chat template from the model dir if present.
+    chat_template_path = model_dir / "chat_template.jinja"
+    if chat_template_path.exists():
+        from jinja2 import Environment
+
+        template = Environment().from_string(chat_template_path.read_text())
+        full_prompt = template.render(
+            messages=[{"role": "user", "content": prompt}],
+            add_generation_prompt=True,
+        )
+    else:
+        full_prompt = prompt
+
+    print(f"\nPrompt:\n  {prompt!r}")
+    input_tokens = tokenizer.encode(full_prompt)
+
+    params = og.GeneratorParams(model)
+    params.set_search_options(max_length=len(input_tokens) + max_new_tokens, do_sample=False)
+    generator = og.Generator(model, params)
+    generator.append_tokens(input_tokens)
+
+    print("Generating: ", end="", flush=True)
+    response_chunks = []
+    while not generator.is_done():
+        generator.generate_next_token()
+        new_token = generator.get_next_tokens()[0]
+        chunk = tokenizer_stream.decode(new_token)
+        response_chunks.append(chunk)
+        print(chunk, end="", flush=True)
+    print()
+
+    text = "".join(response_chunks)
+    return text
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--variant", choices=("bf16", "Q1_0"), default="bf16")
+    parser.add_argument(
+        "--out", default=None, help="ONNX model directory (will be created with --build)"
+    )
+    parser.add_argument("--build", action="store_true", help="Build the model before running")
+    parser.add_argument(
+        "--gguf",
+        default=None,
+        help="Path to the Tencent SEQ GGUF (required with --variant Q1_0 --build)",
+    )
+    parser.add_argument("--prompt", default=_DEFAULT_PROMPT)
+    parser.add_argument("--max-new-tokens", type=int, default=64)
+    args = parser.parse_args()
+
+    if args.out is None:
+        args.out = f"./hy-mt-{args.variant.lower()}-onnx"
+
+    out = _ensure_built(args)
+    text = run_translation(out, args.prompt, args.max_new_tokens)
+
+    print("\n--- Full response ---")
+    print(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hy_mt1_5.py
+++ b/examples/hy_mt1_5.py
@@ -1,3 +1,4 @@
+# ruff: noqa: RUF002
 r"""End-to-end translation example for Hy-MT1.5-1.8B via ORT GenAI.
 
 Demonstrates loading a mobius-built Hy-MT1.5 export with
@@ -5,7 +6,7 @@ Demonstrates loading a mobius-built Hy-MT1.5 export with
 ``hunyuan_v1_dense`` is mapped to ORT GenAI's generic ``decoder`` LLM
 type (see ``onnxruntime-genai/src/models/model_type.h``); this script
 verifies that the resulting ``genai_config.json`` loads and that
-``Generator.generate_next_token()`` produces output end-to-end.
+``Generator`` produces real translations end-to-end.
 
 Two model variants are supported, selected by ``--variant``:
 
@@ -16,12 +17,28 @@ Two model variants are supported, selected by ``--variant``:
   SEQ codebook; default mobius packing is ``MatMulNBits bits=4``
   inflated form for fast CPU decode).
 
-Known caveat: the upstream Hy-MT1.5 BPE vocab uses placeholder special
-tokens and Chinese characters that ort-extensions' tokenizer does not
-fully round-trip today — for example ``"你好"`` tokenizes to an empty
-sequence. The chat template path renders correctly, but tokenization
-of CJK content in the message body is lossy. This is independent of
-the ``model_type=decoder`` fix and tracked downstream.
+Tokenizer caveat: the Hy-MT1.5 BPE vocab uses a custom regex
+pre-tokenizer that ort-extensions does not currently round-trip
+(``"Hello, world!"`` tokenizes to a single space token, ``"你好"``
+tokenizes to an empty sequence). By default this example tokenizes
+and detokenizes with the HuggingFace tokenizer and feeds raw token
+IDs to ``og.Generator``, which still exercises the full ORT GenAI
+inference path. Pass ``--use-ort-tokenizer`` to force the broken
+``og.Tokenizer`` path for reproduction / debugging.
+
+Expected output (Q1_0 on CPU EP)::
+
+    $ python examples/hy_mt1_5.py --variant Q1_0 --out ./hy-mt-q1_0-onnx \\
+          --prompt 'Translate to Spanish: The cat is sleeping on the chair.'
+    El gato está durmiendo en la silla.
+
+    $ python examples/hy_mt1_5.py --variant Q1_0 --out ./hy-mt-q1_0-onnx \\
+          --prompt 'Translate to French: Knowledge is power.'
+    La connaissance est puissance.
+
+    $ python examples/hy_mt1_5.py --variant Q1_0 --out ./hy-mt-q1_0-onnx
+    # default prompt: Translate the following Chinese text to English: 你好，世界！
+    Hello, world!
 
 Usage::
 
@@ -107,16 +124,19 @@ def _ensure_built(args: argparse.Namespace) -> Path:
     return out
 
 
-def run_translation(model_dir: Path, prompt: str, max_new_tokens: int) -> str:
+def run_translation(
+    model_dir: Path,
+    prompt: str,
+    max_new_tokens: int,
+    use_hf_tokenizer: bool,
+) -> str:
     """Run a single greedy generation through ORT GenAI."""
     import onnxruntime_genai as og
 
     print(f"\nLoading ORT GenAI model from {model_dir}")
     model = og.Model(str(model_dir))
-    tokenizer = og.Tokenizer(model)
-    tokenizer_stream = tokenizer.create_stream()
 
-    # Apply the chat template from the model dir if present.
+    # Apply the chat template from the model dir (works either way).
     chat_template_path = model_dir / "chat_template.jinja"
     if chat_template_path.exists():
         from jinja2 import Environment
@@ -130,6 +150,40 @@ def run_translation(model_dir: Path, prompt: str, max_new_tokens: int) -> str:
         full_prompt = prompt
 
     print(f"\nPrompt:\n  {prompt!r}")
+
+    if use_hf_tokenizer:
+        # Tokenize and detokenize via HuggingFace. ORT-extensions' BPE
+        # tokenizer does not currently round-trip the Hy-MT1.5 vocab's
+        # custom regex pre-tokenizer, so we bypass og.Tokenizer here
+        # while still exercising the ORT GenAI inference path.
+        import transformers
+
+        hf_tok = transformers.AutoTokenizer.from_pretrained(HF_MODEL_ID)
+        input_tokens = hf_tok.encode(full_prompt, add_special_tokens=False)
+
+        params = og.GeneratorParams(model)
+        params.set_search_options(
+            max_length=len(input_tokens) + max_new_tokens, do_sample=False
+        )
+        generator = og.Generator(model, params)
+        generator.append_tokens(input_tokens)
+
+        print("Generating: ", end="", flush=True)
+        generated_ids: list[int] = []
+        while not generator.is_done() and len(generated_ids) < max_new_tokens:
+            generator.generate_next_token()
+            new_token = int(generator.get_next_tokens()[0])
+            generated_ids.append(new_token)
+            # Decode incrementally; some tokens are multi-byte and only
+            # render when combined with neighbours, so we re-decode the
+            # accumulated tail and print the delta.
+            text_so_far = hf_tok.decode(generated_ids, skip_special_tokens=False)
+            print(text_so_far, end="\r", flush=True)
+        print()
+        return hf_tok.decode(generated_ids, skip_special_tokens=False)
+
+    tokenizer = og.Tokenizer(model)
+    tokenizer_stream = tokenizer.create_stream()
     input_tokens = tokenizer.encode(full_prompt)
 
     params = og.GeneratorParams(model)
@@ -138,17 +192,15 @@ def run_translation(model_dir: Path, prompt: str, max_new_tokens: int) -> str:
     generator.append_tokens(input_tokens)
 
     print("Generating: ", end="", flush=True)
-    response_chunks = []
+    chunks: list[str] = []
     while not generator.is_done():
         generator.generate_next_token()
         new_token = generator.get_next_tokens()[0]
         chunk = tokenizer_stream.decode(new_token)
-        response_chunks.append(chunk)
+        chunks.append(chunk)
         print(chunk, end="", flush=True)
     print()
-
-    text = "".join(response_chunks)
-    return text
+    return "".join(chunks)
 
 
 def main() -> None:
@@ -167,13 +219,29 @@ def main() -> None:
     )
     parser.add_argument("--prompt", default=_DEFAULT_PROMPT)
     parser.add_argument("--max-new-tokens", type=int, default=64)
+    parser.add_argument(
+        "--use-ort-tokenizer",
+        action="store_true",
+        help=(
+            "Use ort-extensions' tokenizer (og.Tokenizer) instead of the "
+            "HuggingFace one. The Hy-MT1.5 vocab's custom regex pre-tokenizer "
+            "is not currently round-tripped by ort-extensions, so by default "
+            "we tokenize with HF and feed raw token IDs to og.Generator. "
+            "Enable this flag to exercise the full og.Tokenizer path."
+        ),
+    )
     args = parser.parse_args()
 
     if args.out is None:
         args.out = f"./hy-mt-{args.variant.lower()}-onnx"
 
     out = _ensure_built(args)
-    text = run_translation(out, args.prompt, args.max_new_tokens)
+    text = run_translation(
+        out,
+        args.prompt,
+        args.max_new_tokens,
+        use_hf_tokenizer=not args.use_ort_tokenizer,
+    )
 
     print("\n--- Full response ---")
     print(text)

--- a/examples/hy_mt1_5.py
+++ b/examples/hy_mt1_5.py
@@ -72,7 +72,6 @@ def _build_bf16(output_dir: Path) -> None:
     pkg = mobius.build(HF_MODEL_ID, dtype="bf16", load_weights=True)
     pkg.save(str(output_dir))
     write_ort_genai_config(pkg, str(output_dir), hf_model_id=HF_MODEL_ID, ep="cpu")
-    _patch_genai_config(output_dir)
     print("  genai_config.json + tokenizer files written")
 
 
@@ -82,28 +81,17 @@ def _build_q1_0(gguf_path: Path, output_dir: Path) -> None:
     from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
 
     print(f"Building Q1_0 -> {output_dir}")
-    pkg = build_from_gguf(str(gguf_path), keep_quantized=True, dtype="f32")
+    # ep='cpu' applies the GroupQueryAttention rewrite. With standard
+    # opset 23 Attention (ep='default'), ORT GenAI's
+    # past_present_share_buffer mode cannot be used; mobius's
+    # write_ort_genai_config inspects the resulting graph and turns
+    # share_buffer off automatically when GQA is absent.
+    pkg = build_from_gguf(
+        str(gguf_path), keep_quantized=True, dtype="f32", execution_provider="cpu"
+    )
     pkg.save(str(output_dir))
     write_ort_genai_config(pkg, str(output_dir), hf_model_id=HF_MODEL_ID, ep="cpu")
-    _patch_genai_config(output_dir)
     print("  genai_config.json + tokenizer files written")
-
-
-def _patch_genai_config(output_dir: Path) -> None:
-    """Disable ``past_present_share_buffer`` for the dynamic-cache export.
-
-    mobius emits a dynamic-shape KV cache (no pre-allocated buffer);
-    ORT GenAI's default of ``past_present_share_buffer = True`` would
-    feed the attention op a mask whose ``total_sequence_length`` doesn't
-    match the dynamic past_key/past_value shapes, producing
-    ``inconsistent total_sequence_length`` at runtime.
-    """
-    import json
-
-    cfg_path = output_dir / "genai_config.json"
-    cfg = json.loads(cfg_path.read_text())
-    cfg.setdefault("search", {})["past_present_share_buffer"] = False
-    cfg_path.write_text(json.dumps(cfg, indent=4))
 
 
 def _ensure_built(args: argparse.Namespace) -> Path:

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -324,6 +324,7 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
         gguf_path,
         dtype=args.dtype,
         keep_quantized=args.keep_quantized,
+        execution_provider=args.execution_provider,
     )
 
     pkg.save(
@@ -557,6 +558,18 @@ def main(argv: list[str] | None = None) -> None:
         choices=["onnx", "safetensors"],
         default="onnx",
         help="External data format (default: onnx).",
+    )
+    gguf_parser.add_argument(
+        "--ep",
+        "--execution-provider",
+        dest="execution_provider",
+        default="default",
+        metavar="EP",
+        help=(
+            "Target execution provider for EP-aware graph optimisations "
+            "(e.g. 'cpu' to apply the GroupQueryAttention rewrite). "
+            "Defaults to 'default' (portable ONNX, no vendor fusions)."
+        ),
     )
     gguf_parser.set_defaults(func=_cmd_build_gguf)
 

--- a/src/mobius/_configs.py
+++ b/src/mobius/_configs.py
@@ -798,6 +798,10 @@ class QuantizationConfig:
     group_size: int = 128
     quant_method: str = "none"
     sym: bool = True
+    # When True, zero_points is a per-block float tensor rather than a
+    # bit-packed uint8. Required for codebooks with non-integer offsets
+    # (e.g. Tencent SEQ uses 1.5).
+    float_zero_point: bool = False
 
     @classmethod
     def from_transformers(cls, hf_config) -> QuantizationConfig | None:

--- a/src/mobius/_flags.py
+++ b/src/mobius/_flags.py
@@ -84,6 +84,12 @@ class _Flags:
          - ``False``
          - Lower the ONNX opset declaration to 23 for non-CPU EPs
            (ORT ≤1.24.x workaround). Disabled by default.
+       * - ``tencent_q1_0_use_native_2bit``
+         - ``MOBIUS_TENCENT_Q1_0_USE_NATIVE_2BIT``
+         - ``False``
+         - Use native ``MatMulNBits bits=2`` for Tencent SEQ Q1_0
+           (smaller, semantically faithful, but ~20× slower on CPU EP
+           pending an MLAS fast path).
     """
 
     suppress_dedup_warning: bool = dataclasses.field(
@@ -114,6 +120,34 @@ class _Flags:
     Lowering the import declaration lets the EP find its existing kernels.
     Set ``MOBIUS_ORT_LOWER_OPSET_FOR_EP=1`` to re-enable if running on
     an older ORT build without opset 24 kernel registration.
+    """
+
+    tencent_q1_0_use_native_2bit: bool = dataclasses.field(
+        default_factory=lambda: _env_bool("MOBIUS_TENCENT_Q1_0_USE_NATIVE_2BIT", False)
+    )
+    """Emit Tencent custom Q1_0 (2-bit SEQ) tensors using native
+    ``MatMulNBits bits=2`` + float ``zero_point = 1.5`` instead of the
+    ``bits=4`` inflation that defaults today.
+
+    Pros (when set to ``True``):
+        Halves the on-disk weight bytes (2 bpw vs 4 bpw inflated).
+        Semantically faithful to the source quantization layout.
+
+    Cons (default ``False``):
+        ORT's CPU ``bits=2`` + float-zp dequant path is currently a
+        naive scalar fallback (~20× slower than the ``bits=4`` packed
+        path on the same weights). See
+        `microsoft/onnxruntime#28552
+        <https://github.com/microsoft/onnxruntime/issues/28552>`_.
+        Also requires ORT ≥1.27 (the float-zp path was added in
+        `microsoft/onnxruntime#28354
+        <https://github.com/microsoft/onnxruntime/pull/28354>`_).
+
+    The ``bits=4`` default inflates each 2-bit code ``c ∈ {0..3}`` to
+    a 4-bit slot ``2c ∈ {0,2,4,6}`` paired with integer ``zero_point=3``;
+    dequant gives the same SEQ codebook values, just at twice the
+    weight storage. Set ``MOBIUS_TENCENT_Q1_0_USE_NATIVE_2BIT=1`` to
+    opt in to the smaller native form once kernel performance lands.
     """
 
 

--- a/src/mobius/_flags.py
+++ b/src/mobius/_flags.py
@@ -83,12 +83,12 @@ class _Flags:
          - ``MOBIUS_ORT_LOWER_OPSET_FOR_EP``
          - ``False``
          - Lower the ONNX opset declaration to 23 for non-CPU EPs
-           (ORT ≤1.24.x workaround). Disabled by default.
+           (ORT <=1.24.x workaround). Disabled by default.
        * - ``tencent_q1_0_use_native_2bit``
          - ``MOBIUS_TENCENT_Q1_0_USE_NATIVE_2BIT``
          - ``False``
          - Use native ``MatMulNBits bits=2`` for Tencent SEQ Q1_0
-           (smaller, semantically faithful, but ~20× slower on CPU EP
+           (smaller, semantically faithful, but ~20x slower on CPU EP
            pending an MLAS fast path).
     """
 
@@ -105,7 +105,7 @@ class _Flags:
         default_factory=lambda: _env_bool("MOBIUS_ORT_CUDA_GROUPED_RMSNORM_WORKAROUND", False)
     )
     """Decompose grouped RMSNormalization into basic ops to work around an
-    ORT ≤1.24.4 CUDA kernel bug that produces wrong results when scale is 2D.
+    ORT <=1.24.4 CUDA kernel bug that produces wrong results when scale is 2D.
     Set ``MOBIUS_ORT_CUDA_GROUPED_RMSNORM_WORKAROUND=1`` when targeting CUDA.
     """
 
@@ -115,7 +115,7 @@ class _Flags:
     """Lower the ONNX default-domain opset declaration to 23 when creating
     ORT sessions on non-CPU execution providers (CUDA, TRT, etc.).
 
-    ORT ≤1.24.x EPs didn't register kernels for opset 24 standard ops
+    ORT <=1.24.x EPs didn't register kernels for opset 24 standard ops
     (Squeeze, Reshape, etc.) even though the semantics are unchanged.
     Lowering the import declaration lets the EP find its existing kernels.
     Set ``MOBIUS_ORT_LOWER_OPSET_FOR_EP=1`` to re-enable if running on
@@ -135,16 +135,16 @@ class _Flags:
 
     Cons (default ``False``):
         ORT's CPU ``bits=2`` + float-zp dequant path is currently a
-        naive scalar fallback (~20× slower than the ``bits=4`` packed
+        naive scalar fallback (~20x slower than the ``bits=4`` packed
         path on the same weights). See
         `microsoft/onnxruntime#28552
         <https://github.com/microsoft/onnxruntime/issues/28552>`_.
-        Also requires ORT ≥1.27 (the float-zp path was added in
+        Also requires ORT >=1.27 (the float-zp path was added in
         `microsoft/onnxruntime#28354
         <https://github.com/microsoft/onnxruntime/pull/28354>`_).
 
-    The ``bits=4`` default inflates each 2-bit code ``c ∈ {0..3}`` to
-    a 4-bit slot ``2c ∈ {0,2,4,6}`` paired with integer ``zero_point=3``;
+    The ``bits=4`` default inflates each 2-bit code ``c in {0..3}`` to
+    a 4-bit slot ``2c in {0,2,4,6}`` paired with integer ``zero_point=3``;
     dequant gives the same SEQ codebook values, just at twice the
     weight storage. Set ``MOBIUS_TENCENT_Q1_0_USE_NATIVE_2BIT=1`` to
     opt in to the smaller native form once kernel performance lands.

--- a/src/mobius/components/_quantized_linear.py
+++ b/src/mobius/components/_quantized_linear.py
@@ -37,6 +37,13 @@ class QuantizedLinear(nn.Module):
         bits: Quantization bit-width (2, 4, or 8).
         block_size: Number of elements per quantization group.
         has_zero_point: Whether asymmetric zero-point is used.
+        zero_point_dtype: Dtype for the zero_points parameter when
+            ``has_zero_point`` is true. ``UINT8`` (default) uses ORT's
+            bit-packed integer zero-points (same bit width as the
+            weights). Float dtypes (``FLOAT``/``FLOAT16``/``BFLOAT16``)
+            produce one un-packed float per block — required for
+            codebooks whose offset is not an integer (e.g. Tencent SEQ
+            uses ``1.5``).
         bias: Whether to include a bias term.
     """
 
@@ -47,6 +54,7 @@ class QuantizedLinear(nn.Module):
         bits: int = 4,
         block_size: int = 32,
         has_zero_point: bool = False,
+        zero_point_dtype: ir.DataType = ir.DataType.UINT8,
         bias: bool = False,
     ):
         super().__init__()
@@ -71,20 +79,26 @@ class QuantizedLinear(nn.Module):
         # Per-block scale factors
         self.scales = nn.Parameter([out_features, n_blocks])
         # Optional per-block zero points (asymmetric quantization).
-        # Zero points use the same bit-packing as the weights, so the
-        # packed last dimension is ceil(n_blocks * bits / 8):
+        # UINT8 zero_points use the same bit-packing as the weights, so
+        # the packed last dimension is ceil(n_blocks * bits / 8):
         #   bits=2 → 4 zero-points per byte
         #   bits=4 → 2 zero-points per byte
         #   bits=8 → 1 zero-point per byte (no packing)
-        zp_dim = math.ceil(n_blocks * bits / 8)
-        self.zero_points = (
-            nn.Parameter(
-                [out_features, zp_dim],
-                dtype=ir.DataType.UINT8,
-            )
-            if has_zero_point
-            else None
-        )
+        # Float zero_points are one value per block, dtype as specified.
+        if has_zero_point:
+            if zero_point_dtype == ir.DataType.UINT8:
+                zp_dim = math.ceil(n_blocks * bits / 8)
+                self.zero_points = nn.Parameter(
+                    [out_features, zp_dim],
+                    dtype=ir.DataType.UINT8,
+                )
+            else:
+                self.zero_points = nn.Parameter(
+                    [out_features, n_blocks],
+                    dtype=zero_point_dtype,
+                )
+        else:
+            self.zero_points = None
         self.bias = nn.Parameter([out_features]) if bias else None
 
     def forward(self, op: OpBuilder, x: ir.Value) -> ir.Value:
@@ -118,6 +132,7 @@ def make_quantized_linear_factory(
     bits: int = 4,
     block_size: int = 32,
     has_zero_point: bool = False,
+    zero_point_dtype: ir.DataType = ir.DataType.UINT8,
 ) -> type:
     """Create a QuantizedLinear factory compatible with the linear_class pattern.
 
@@ -129,6 +144,8 @@ def make_quantized_linear_factory(
         bits: Quantization bit-width (typically 4).
         block_size: Number of elements per quantization group.
         has_zero_point: Whether to include zero-point parameters.
+        zero_point_dtype: Dtype for the zero_points parameter (see
+            :class:`QuantizedLinear`).
 
     Returns:
         A class that constructs QuantizedLinear instances.
@@ -148,6 +165,7 @@ def make_quantized_linear_factory(
                 bits=bits,
                 block_size=block_size,
                 has_zero_point=has_zero_point,
+                zero_point_dtype=zero_point_dtype,
             )
 
     _Factory.__name__ = "QuantizedLinear"

--- a/src/mobius/components/_quantized_linear.py
+++ b/src/mobius/components/_quantized_linear.py
@@ -16,7 +16,7 @@ from onnxscript import OpBuilder, nn
 #     where n_blocks = ceil(K / block_size)
 #           blob_size = block_size * bits / 8
 #   scales:         [N, n_blocks]             (float16/float32)
-#   zero_points:    [N, ceil(n_blocks/2)]    (uint8, optional, 4-bit packed)
+#   zero_points:    [N, ceil(n_blocks*bits/8)] (uint8, optional, bit-packed)
 
 _MICROSOFT_DOMAIN = "com.microsoft"
 
@@ -34,7 +34,7 @@ class QuantizedLinear(nn.Module):
     Args:
         in_features: Input dimension (K).
         out_features: Output dimension (N).
-        bits: Quantization bit-width (4 or 8).
+        bits: Quantization bit-width (2, 4, or 8).
         block_size: Number of elements per quantization group.
         has_zero_point: Whether asymmetric zero-point is used.
         bias: Whether to include a bias term.
@@ -50,8 +50,8 @@ class QuantizedLinear(nn.Module):
         bias: bool = False,
     ):
         super().__init__()
-        if bits not in (4, 8):
-            raise ValueError(f"bits must be 4 or 8, got {bits}")
+        if bits not in (2, 4, 8):
+            raise ValueError(f"bits must be 2, 4, or 8, got {bits}")
         if block_size < 16 or (block_size & (block_size - 1)):
             raise ValueError(f"block_size must be a power of 2 >= 16, got {block_size}")
 
@@ -71,9 +71,12 @@ class QuantizedLinear(nn.Module):
         # Per-block scale factors
         self.scales = nn.Parameter([out_features, n_blocks])
         # Optional per-block zero points (asymmetric quantization).
-        # For 4-bit, two zero-point values are packed per byte →
-        # the last dimension is ceil(n_blocks / 2).
-        zp_dim = math.ceil(n_blocks / 2) if bits == 4 else n_blocks
+        # Zero points use the same bit-packing as the weights, so the
+        # packed last dimension is ceil(n_blocks * bits / 8):
+        #   bits=2 → 4 zero-points per byte
+        #   bits=4 → 2 zero-points per byte
+        #   bits=8 → 1 zero-point per byte (no packing)
+        zp_dim = math.ceil(n_blocks * bits / 8)
         self.zero_points = (
             nn.Parameter(
                 [out_features, zp_dim],

--- a/src/mobius/components/_quantized_linear_test.py
+++ b/src/mobius/components/_quantized_linear_test.py
@@ -64,8 +64,22 @@ class TestQuantizedLinearInit:
         assert ql.weight.shape == [OUT_FEATURES, n_blocks, blob_size]
 
     def test_rejects_invalid_bits(self):
-        with pytest.raises(ValueError, match="bits must be 4 or 8"):
+        with pytest.raises(ValueError, match="bits must be 2, 4, or 8"):
             QuantizedLinear(IN_FEATURES, OUT_FEATURES, bits=3)
+
+    def test_2bit_packed_shape(self):
+        ql = QuantizedLinear(IN_FEATURES, OUT_FEATURES, bits=2, block_size=32)
+        n_blocks = math.ceil(IN_FEATURES / 32)
+        blob_size = 32 * 2 // 8  # = 8
+        assert ql.weight.shape == [OUT_FEATURES, n_blocks, blob_size]
+
+    def test_2bit_zero_points_packed_4_per_byte(self):
+        ql = QuantizedLinear(
+            IN_FEATURES, OUT_FEATURES, bits=2, block_size=32, has_zero_point=True
+        )
+        n_blocks = math.ceil(IN_FEATURES / 32)
+        zp_dim = math.ceil(n_blocks * 2 / 8)  # 4 ZPs per byte
+        assert ql.zero_points.shape == [OUT_FEATURES, zp_dim]
 
     def test_rejects_non_power_of_2_block_size(self):
         with pytest.raises(ValueError, match="block_size must be a power of 2 >= 16"):
@@ -163,6 +177,24 @@ class TestQuantizedLinearForward:
                 attrs = {a.name: a.value for a in node.attributes.values()}
                 assert attrs["bits"] == 8
                 break
+
+    def test_2bit_forward_attributes(self):
+        ql = QuantizedLinear(
+            IN_FEATURES, OUT_FEATURES, bits=2, block_size=32, has_zero_point=True
+        )
+        b, op, graph = create_test_builder()
+        x = create_test_input(b, "x", [1, 4, IN_FEATURES])
+        result = ql(op, x)
+        b._adapt_outputs([result])
+        for node in graph:
+            if node.op_type == "MatMulNBits":
+                attrs = {a.name: a.value for a in node.attributes.values()}
+                assert attrs["bits"] == 2
+                assert attrs["block_size"] == 32
+                assert len(node.inputs) == 4  # x, w, scales, zero_points
+                break
+        else:
+            pytest.fail("MatMulNBits node not found")
 
     def test_parameter_names(self):
         ql = QuantizedLinear(IN_FEATURES, OUT_FEATURES, has_zero_point=True, bias=True)

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -279,8 +279,9 @@ def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, int, bool]:
     # Mainline Q1_0 (1-bit binary) is repacked into 2-bit MatMulNBits
     # with zp=1 — see _repack_q1_0. Tencent's custom Q1_0 (2-bit SEQ,
     # 512-elt blocks) is inflated to 4-bit MatMulNBits with zp=3 — see
-    # parse_tencent_q1_0_tensor — because ORT CPU does not yet support
-    # the half-integer zero-point that 2-bit SEQ would otherwise need.
+    # parse_tencent_q1_0_tensor — because the ORT CPU unpacked-float-zp
+    # path is currently only implemented for bits=4, and the half-integer
+    # SEQ offset 1.5 cannot be expressed with integer zp at bits=2.
     type_params: dict = {
         GGMLQuantizationType.Q4_0: (4, 32, True),
         GGMLQuantizationType.Q4_1: (4, 32, False),

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -106,11 +106,15 @@ def build_from_gguf(
     # 3. Quantized path: detect dominant type and set config
     if keep_quantized:
         from mobius._configs import QuantizationConfig
+        from mobius._flags import flags
         from mobius.integrations.gguf._tencent_q1_0 import is_tencent_q1_0_layout
 
         bits, block_size, is_sym = _detect_quant_params(gguf_model, gguf_arch)
-        # Tencent Q1_0 needs a float zero-point (1.5) — see _tencent_q1_0.
-        float_zp = is_tencent_q1_0_layout(gguf_model)
+        # Float zero-point only when actually using Tencent's native 2-bit form.
+        float_zp = (
+            is_tencent_q1_0_layout(gguf_model)
+            and flags.tencent_q1_0_use_native_2bit
+        )
         config = dataclasses.replace(
             config,
             quantization=QuantizationConfig(
@@ -317,9 +321,15 @@ def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, int, bool]:
     # Override the mainline defaults so the resulting QuantizedLinear
     # matches what parse_tencent_q1_0_tensor produces (4-bit packed).
     if dominant == GGMLQuantizationType.Q1_0 and is_tencent_q1_0_layout(gguf_model):
-        # See _tencent_q1_0.py: we emit native 2-bit with float zp=1.5
-        # and replicate scales across 128-elt sub-blocks.
-        bits, block_size, is_sym = 2, 128, False
+        # See _tencent_q1_0.py — the bits/zp flavour depends on a flag:
+        #   default (fast):  bits=4 packed-uint8 zp=3 (inflated codebook)
+        #   opt-in (small):  bits=2 float zp=1.5 (native SEQ layout)
+        from mobius._flags import flags
+
+        if flags.tencent_q1_0_use_native_2bit:
+            bits, block_size, is_sym = 2, 128, False
+        else:
+            bits, block_size, is_sym = 4, 128, False
 
     logger.info(
         "Dominant GGUF quant type: %s (%d tensors, bits=%d, block_size=%d)",

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -106,8 +106,11 @@ def build_from_gguf(
     # 3. Quantized path: detect dominant type and set config
     if keep_quantized:
         from mobius._configs import QuantizationConfig
+        from mobius.integrations.gguf._tencent_q1_0 import is_tencent_q1_0_layout
 
         bits, block_size, is_sym = _detect_quant_params(gguf_model, gguf_arch)
+        # Tencent Q1_0 needs a float zero-point (1.5) — see _tencent_q1_0.
+        float_zp = is_tencent_q1_0_layout(gguf_model)
         config = dataclasses.replace(
             config,
             quantization=QuantizationConfig(
@@ -115,13 +118,15 @@ def build_from_gguf(
                 group_size=block_size,
                 quant_method="gguf",
                 sym=is_sym,
+                float_zero_point=float_zp,
             ),
         )
         logger.info(
-            "Quantized mode: bits=%d, block_size=%d, symmetric=%s",
+            "Quantized mode: bits=%d, block_size=%d, symmetric=%s, float_zp=%s",
             bits,
             block_size,
             is_sym,
+            float_zp,
         )
 
     # 4. Look up module class and resolve task
@@ -312,7 +317,9 @@ def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, int, bool]:
     # Override the mainline defaults so the resulting QuantizedLinear
     # matches what parse_tencent_q1_0_tensor produces (4-bit packed).
     if dominant == GGMLQuantizationType.Q1_0 and is_tencent_q1_0_layout(gguf_model):
-        bits, block_size, is_sym = 4, 128, False
+        # See _tencent_q1_0.py: we emit native 2-bit with float zp=1.5
+        # and replicate scales across 128-elt sub-blocks.
+        bits, block_size, is_sym = 2, 128, False
 
     logger.info(
         "Dominant GGUF quant type: %s (%d tensors, bits=%d, block_size=%d)",

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -107,17 +107,22 @@ def build_from_gguf(
     if keep_quantized:
         from mobius._configs import QuantizationConfig
 
-        bits, is_sym = _detect_quant_params(gguf_model, gguf_arch)
+        bits, block_size, is_sym = _detect_quant_params(gguf_model, gguf_arch)
         config = dataclasses.replace(
             config,
             quantization=QuantizationConfig(
                 bits=bits,
-                group_size=32,
+                group_size=block_size,
                 quant_method="gguf",
                 sym=is_sym,
             ),
         )
-        logger.info("Quantized mode: bits=%d, symmetric=%s", bits, is_sym)
+        logger.info(
+            "Quantized mode: bits=%d, block_size=%d, symmetric=%s",
+            bits,
+            block_size,
+            is_sym,
+        )
 
     # 4. Look up module class and resolve task
     module_class = registry.get(model_type)
@@ -249,14 +254,14 @@ def _normalize_gguf_weights(
     return result
 
 
-def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, bool]:
-    """Detect bits and symmetry from dominant GGUF quant type.
+def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, int, bool]:
+    """Detect bits, block size, and symmetry from dominant GGUF quant type.
 
-    Scans block-level (projection) tensors and returns the
-    bit-width and symmetry flag of the most common repackable type.
+    Scans block-level (projection) tensors and returns the bit-width,
+    block size, and symmetry flag of the most common repackable type.
 
     Returns:
-        ``(bits, is_symmetric)`` tuple.
+        ``(bits, block_size, is_symmetric)`` tuple.
 
     Raises:
         ValueError: If no repackable quantized tensors are found.
@@ -264,17 +269,24 @@ def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, bool]:
     from gguf import GGMLQuantizationType
 
     from mobius.integrations.gguf._repacker import can_repack
+    from mobius.integrations.gguf._tencent_q1_0 import is_tencent_q1_0_layout
     from mobius.integrations.gguf._tensor_mapping import (
         map_gguf_to_hf_names,
     )
 
-    q4_types = {
-        GGMLQuantizationType.Q4_0,
-        GGMLQuantizationType.Q4_1,
-    }
-    symmetric_types = {
-        GGMLQuantizationType.Q4_0,
-        GGMLQuantizationType.Q8_0,
+    # Per-type parameters: (bits, block_size, is_symmetric).
+    #
+    # Mainline Q1_0 (1-bit binary) is repacked into 2-bit MatMulNBits
+    # with zp=1 — see _repack_q1_0. Tencent's custom Q1_0 (2-bit SEQ,
+    # 512-elt blocks) is inflated to 4-bit MatMulNBits with zp=3 — see
+    # parse_tencent_q1_0_tensor — because ORT CPU does not yet support
+    # the half-integer zero-point that 2-bit SEQ would otherwise need.
+    type_params: dict = {
+        GGMLQuantizationType.Q4_0: (4, 32, True),
+        GGMLQuantizationType.Q4_1: (4, 32, False),
+        GGMLQuantizationType.Q4_K: (4, 32, False),
+        GGMLQuantizationType.Q8_0: (8, 32, True),
+        GGMLQuantizationType.Q1_0: (2, 128, False),
     }
 
     counts: Counter = Counter()
@@ -292,15 +304,23 @@ def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, bool]:
         )
 
     dominant = counts.most_common(1)[0][0]
-    bits = 4 if dominant in q4_types else 8
-    is_sym = dominant in symmetric_types
+    bits, block_size, is_sym = type_params[dominant]
+
+    # Tencent Q1_0 files reuse the Q1_0 type id but ship a different
+    # on-disk layout (2-bit SEQ, 512-element blocks, fp16 scale per block).
+    # Override the mainline defaults so the resulting QuantizedLinear
+    # matches what parse_tencent_q1_0_tensor produces (4-bit packed).
+    if dominant == GGMLQuantizationType.Q1_0 and is_tencent_q1_0_layout(gguf_model):
+        bits, block_size, is_sym = 4, 128, False
+
     logger.info(
-        "Dominant GGUF quant type: %s (%d tensors, bits=%d)",
+        "Dominant GGUF quant type: %s (%d tensors, bits=%d, block_size=%d)",
         dominant,
         counts[dominant],
         bits,
+        block_size,
     )
-    return bits, is_sym
+    return bits, block_size, is_sym
 
 
 def _load_dequantized_state_dict(
@@ -358,6 +378,10 @@ def _load_quantized_state_dict(
         can_repack,
         repack_gguf_tensor,
     )
+    from mobius.integrations.gguf._tencent_q1_0 import (
+        is_tencent_q1_0_layout,
+        parse_tencent_q1_0_tensor,
+    )
     from mobius.integrations.gguf._tensor_mapping import (
         map_gguf_to_hf_names,
     )
@@ -374,6 +398,19 @@ def _load_quantized_state_dict(
 
     num_heads = getattr(config, "num_attention_heads", None)
     num_kv_heads = getattr(config, "num_key_value_heads", None)
+
+    # Detect Tencent's non-mainline Q1_0 layout once per file. Reading
+    # such tensors requires a custom parser keyed on the explicit
+    # per-tensor file offset (mainline byte sizes are wrong).
+    tencent_q1_0 = is_tencent_q1_0_layout(gguf_model)
+    if tencent_q1_0:
+        gguf_path = str(gguf_model._path)
+        data_section_offset = gguf_model._reader.data_offset
+        tensors_by_name = {t.name: t for t in gguf_model._reader.tensors}
+        logger.info(
+            "Detected Tencent Q1_0 layout (block_size=512, 2-bit SEQ); "
+            "using custom per-tensor parser"
+        )
 
     state_dict: dict[str, torch.Tensor] = {}
     n_repacked = 0
@@ -394,15 +431,27 @@ def _load_quantized_state_dict(
         # Repack if the tensor is repackable AND its target ONNX
         # parameter is from a QuantizedLinear module.
         stem = hf_name[: -len(".weight")] if hf_name.endswith(".weight") else None
-        should_repack = stem is not None and stem in quantized_stems and can_repack(qtype_val)
+        is_tencent_q1_0_tensor = tencent_q1_0 and qtype == GGMLQuantizationType.Q1_0
+        should_repack = (
+            stem is not None
+            and stem in quantized_stems
+            and (can_repack(qtype_val) or is_tencent_q1_0_tensor)
+        )
 
         if should_repack:
-            shape_2d = (int(np_shape[0]), int(np_shape[1]))
-            repacked = repack_gguf_tensor(
-                raw.ravel().view(np.uint8),
-                qtype_val,
-                shape_2d,
-            )
+            if is_tencent_q1_0_tensor:
+                repacked = parse_tencent_q1_0_tensor(
+                    gguf_path,
+                    data_section_offset,
+                    tensors_by_name[gguf_name],
+                )
+            else:
+                shape_2d = (int(np_shape[0]), int(np_shape[1]))
+                repacked = repack_gguf_tensor(
+                    raw.ravel().view(np.uint8),
+                    qtype_val,
+                    shape_2d,
+                )
             w = torch.from_numpy(repacked.weight)
             s = torch.from_numpy(repacked.scales)
 

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -111,10 +111,7 @@ def build_from_gguf(
 
         bits, block_size, is_sym = _detect_quant_params(gguf_model, gguf_arch)
         # Float zero-point only when actually using Tencent's native 2-bit form.
-        float_zp = (
-            is_tencent_q1_0_layout(gguf_model)
-            and flags.tencent_q1_0_use_native_2bit
-        )
+        float_zp = is_tencent_q1_0_layout(gguf_model) and flags.tencent_q1_0_use_native_2bit
         config = dataclasses.replace(
             config,
             quantization=QuantizationConfig(

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -35,6 +35,7 @@ def build_from_gguf(
     task: str | None = None,
     dtype: str | None = None,
     keep_quantized: bool = False,
+    execution_provider: str = "default",
 ) -> ModelPackage:
     """Build an ONNX :class:`ModelPackage` from a GGUF file.
 
@@ -59,6 +60,10 @@ def build_from_gguf(
         keep_quantized: When ``True``, preserve quantization for
             supported GGUF types (Q4_0, Q4_1, Q8_0) by repacking
             linear-layer weights into MatMulNBits format.
+        execution_provider: Target execution provider for EP-aware
+            optimisations (e.g. ``"cpu"`` to apply the
+            GroupQueryAttention rewrite). Defaults to ``"default"``
+            (portable, no vendor fusions).
 
     Returns:
         A :class:`ModelPackage` containing the built model(s).
@@ -137,7 +142,7 @@ def build_from_gguf(
 
     # 5. Build ONNX graph
     module = module_class(config)
-    pkg = build_from_module(module, config, task)
+    pkg = build_from_module(module, config, task, execution_provider=execution_provider)
     logger.info(
         "Built ONNX graph for %s (%d components)",
         model_type,

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -170,8 +170,9 @@ class TestBuildQuantizedGguf:
         from mobius.integrations.gguf._reader import GGUFModel
 
         gguf_model = GGUFModel(q4_0_gguf)
-        bits, is_sym = _detect_quant_params(gguf_model, gguf_model.architecture)
+        bits, block_size, is_sym = _detect_quant_params(gguf_model, gguf_model.architecture)
         assert bits == 4
+        assert block_size == 32
         assert is_sym is True
 
 

--- a/src/mobius/integrations/gguf/_config_mapping.py
+++ b/src/mobius/integrations/gguf/_config_mapping.py
@@ -269,6 +269,7 @@ def gguf_to_config(
     rope_scaling_type = metadata.get(f"{gguf_arch}.rope.scaling.type")
     rope_freq_base = metadata.get(f"{gguf_arch}.rope.freq_base")
     rope_type: str | None = None
+    rope_scaling: dict | None = None
     if rope_freq_base is not None or rope_scaling_type is not None:
         if rope_scaling_type in (None, "none", ""):
             rope_type = "default"
@@ -285,6 +286,36 @@ def gguf_to_config(
             )
             rope_type = "default"
 
+    # HunYuan-V1-Dense: HF runs dynamic-NTK RoPE with rope_theta=10000 and
+    # alpha=1000. The Tencent quantization pipeline bakes those into a
+    # static rope.freq_base (~1.1e7) and sets rope.scaling.type='none' in
+    # the GGUF. That works for short contexts but diverges for long
+    # prompts (the dynamic exponent changes with position). Restore the
+    # HF dynamic-NTK config so the ONNX model behaves correctly on
+    # long-context inputs.
+    if (
+        gguf_arch == "hunyuan-dense"
+        and rope_type == "default"
+        and rope_freq_base is not None
+        and float(rope_freq_base) > 1e6
+    ):
+        logger.info(
+            "hunyuan-dense GGUF freq_base=%s exceeds 1e6 — restoring HF "
+            "dynamic-NTK RoPE (rope_theta=10000, alpha=1000)",
+            rope_freq_base,
+        )
+        rope_type = "dynamic"
+        rope_scaling = {
+            "alpha": 1000.0,
+            "factor": 1.0,
+            "beta_fast": 32,
+            "beta_slow": 1,
+            "mscale": 1.0,
+            "mscale_all_dim": 1.0,
+            "type": "dynamic",
+        }
+        hf_fields["rope_theta"] = 10000.0
+
     # Build config — required fields validated above, optional fields
     # use safe defaults
     config = ArchitectureConfig(
@@ -298,6 +329,7 @@ def gguf_to_config(
         max_position_embeddings=hf_fields.get("max_position_embeddings", 2048),
         rope_theta=hf_fields.get("rope_theta", 10000.0),
         rope_type=rope_type,
+        rope_scaling=rope_scaling,
         rms_norm_eps=hf_fields.get("rms_norm_eps", 1e-5),
         hidden_act=hidden_act,
         tie_word_embeddings=_infer_tie_embeddings(model),

--- a/src/mobius/integrations/gguf/_config_mapping.py
+++ b/src/mobius/integrations/gguf/_config_mapping.py
@@ -57,6 +57,7 @@ GGUF_ARCH_TO_MODEL_TYPE: dict[str, str] = {
     "stablelm": "stablelm",
     "nemotron": "nemotron",
     "t5": "t5",
+    "hunyuan-dense": "hunyuan_v1_dense",
     "deci": "llama",  # DeciLM uses Llama architecture
 }
 
@@ -259,6 +260,31 @@ def gguf_to_config(
     rope_sections = metadata.get(f"{gguf_arch}.rope.dimension_sections")
     rope_interleave = rope_sections is not None and any(s > 0 for s in rope_sections)
 
+    # Derive rope_type from rope.scaling.type. GGUF stores the scaling
+    # variant under ``<arch>.rope.scaling.type`` (or omits the key for the
+    # plain non-scaled case). ``ArchitectureConfig.rope_type`` defaults to
+    # ``None``, which would disable RoPE entirely — but every GGUF whose
+    # metadata contains ``rope.freq_base`` is a RoPE model, so we promote
+    # the absence/``"none"`` case to the default RoPE variant.
+    rope_scaling_type = metadata.get(f"{gguf_arch}.rope.scaling.type")
+    rope_freq_base = metadata.get(f"{gguf_arch}.rope.freq_base")
+    rope_type: str | None = None
+    if rope_freq_base is not None or rope_scaling_type is not None:
+        if rope_scaling_type in (None, "none", ""):
+            rope_type = "default"
+        elif rope_scaling_type in ("linear", "yarn", "longrope"):
+            rope_type = rope_scaling_type
+        elif rope_scaling_type == "dynamic":
+            rope_type = "dynamic"
+        else:
+            # Unknown scaling type — fall back to default rather than disabling
+            # RoPE so the model at least runs.
+            logger.warning(
+                "Unrecognized GGUF rope.scaling.type=%r; using rope_type='default'",
+                rope_scaling_type,
+            )
+            rope_type = "default"
+
     # Build config — required fields validated above, optional fields
     # use safe defaults
     config = ArchitectureConfig(
@@ -271,6 +297,7 @@ def gguf_to_config(
         vocab_size=hf_fields.get("vocab_size", 32000),
         max_position_embeddings=hf_fields.get("max_position_embeddings", 2048),
         rope_theta=hf_fields.get("rope_theta", 10000.0),
+        rope_type=rope_type,
         rms_norm_eps=hf_fields.get("rms_norm_eps", 1e-5),
         hidden_act=hidden_act,
         tie_word_embeddings=_infer_tie_embeddings(model),

--- a/src/mobius/integrations/gguf/_repacker.py
+++ b/src/mobius/integrations/gguf/_repacker.py
@@ -3,19 +3,22 @@
 
 """Repack GGUF quantized blocks into ORT MatMulNBits format.
 
-Converts raw GGUF block data for Q4_0, Q4_1, and Q8_0 quantization
-types into the (weight, scales, zero_points) tensors expected by the
-``com.microsoft.MatMulNBits`` operator.
+Converts raw GGUF block data for Q4_0, Q4_1, Q8_0, Q4_K, and Q1_0
+quantization types into the (weight, scales, zero_points) tensors
+expected by the ``com.microsoft.MatMulNBits`` operator.
 
-GGUF block layouts (32 elements per block):
-    Q4_0 (18 bytes): [fp16 scale][16B packed nibbles]
-    Q4_1 (20 bytes): [fp16 scale][fp16 min][16B packed nibbles]
-    Q8_0 (34 bytes): [fp16 scale][32B int8 values]
+GGUF block layouts:
+    Q4_0 (18 bytes, 32 elt):  [fp16 scale][16B packed nibbles]
+    Q4_1 (20 bytes, 32 elt):  [fp16 scale][fp16 min][16B packed nibbles]
+    Q8_0 (34 bytes, 32 elt):  [fp16 scale][32B int8 values]
+    Q4_K (144 bytes, 256 elt): [fp16 d][fp16 dmin][12B sub-scales][128B nibbles]
+    Q1_0 (18 bytes, 128 elt): [fp16 scale][16B packed bits, LSB-first]
+        Dequant: ``bit ? +d : -d`` (1-bit binary).
 
 MatMulNBits expects:
     weight:      [N, n_blocks, blob_size] uint8
     scales:      [N, n_blocks]            float16
-    zero_points: [N, zp_dim]             uint8 (nibble-packed for 4-bit)
+    zero_points: [N, ceil(n_blocks*bits/8)] uint8 (bit-packed)
 """
 
 from __future__ import annotations
@@ -35,6 +38,7 @@ _GGUF_Q4_0 = 2
 _GGUF_Q4_1 = 3
 _GGUF_Q8_0 = 8
 _GGUF_Q4_K = 12
+_GGUF_Q1_0 = 41
 
 # Block byte sizes per GGUF type
 _BLOCK_BYTES = {
@@ -42,15 +46,18 @@ _BLOCK_BYTES = {
     _GGUF_Q4_1: 20,  # 2B scale + 2B min + 16B quants
     _GGUF_Q8_0: 34,  # 2B scale + 32B int8 values
     _GGUF_Q4_K: 144,  # 2B d + 2B dmin + 12B scales + 128B quants
+    _GGUF_Q1_0: 18,  # 2B scale + 16B packed bits (128 elements)
 }
 
 # Elements per GGUF block. Q4_K uses 256-element "super-blocks"
-# that decompose into 8 sub-blocks of 32 for MatMulNBits.
+# that decompose into 8 sub-blocks of 32 for MatMulNBits. Q1_0 uses
+# 128-element blocks (QK1_0 from llama.cpp).
 _GGUF_BLOCK_ELEMENTS = {
     _GGUF_Q4_0: 32,
     _GGUF_Q4_1: 32,
     _GGUF_Q8_0: 32,
     _GGUF_Q4_K: 256,
+    _GGUF_Q1_0: 128,
 }
 
 _SUPPORTED_TYPES = frozenset(_BLOCK_BYTES.keys())
@@ -133,6 +140,8 @@ def repack_gguf_tensor(
         return _repack_q4_1(blocks, n_out, n_blocks_per_row)
     elif gguf_type == _GGUF_Q4_K:
         return _repack_q4_k(blocks, n_out, n_blocks_per_row)
+    elif gguf_type == _GGUF_Q1_0:
+        return _repack_q1_0(blocks, n_out, n_blocks_per_row)
     else:
         return _repack_q8_0(blocks, n_out, n_blocks_per_row)
 
@@ -441,4 +450,85 @@ def _repack_q4_k(
         zero_points=zero_points,
         block_size=_BLOCK_SIZE,
         bits=4,
+    )
+
+
+# Lookup table: 4-bit nibble (LSB-first) → 8-bit ORT 2-bit packed byte.
+# Each Q1_0 bit b ∈ {0, 1} maps to MatMulNBits 2-bit code 2*b ∈ {0, 2}
+# (which under zp=1 dequantizes to {-1, +1}).
+#
+# Q1_0 bit packing: bit `j % 8` of `qs[j // 8]` holds element j.
+# MatMulNBits 2-bit packing: code k of byte i = (byte >> (2*k)) & 0x3.
+#
+# nibble layout (LSB-first):    bit0 bit1 bit2 bit3
+# packed 2-bit byte (LSB-first): c0   c1   c2   c3
+#   where c_k = 2 * bit_k, giving byte = (bit3<<7)|(bit2<<5)|(bit1<<3)|(bit0<<1).
+def _build_q1_0_expand_table() -> "np.ndarray":
+    table = np.zeros(16, dtype=np.uint8)
+    for nibble in range(16):
+        byte = 0
+        for k in range(4):
+            bit = (nibble >> k) & 1
+            byte |= (bit * 2) << (2 * k)
+        table[nibble] = byte
+    return table
+
+
+_Q1_0_EXPAND = _build_q1_0_expand_table()
+
+
+def _repack_q1_0(
+    blocks: np.ndarray,
+    n_out: int,
+    n_blocks_per_row: int,
+) -> RepackedTensor:
+    """Repack Q1_0 (1-bit binary) blocks into MatMulNBits 2-bit format.
+
+    Q1_0 block (18 bytes, 128 elements):
+        ``[fp16 scale (2B)][16B packed bits, LSB-first within each byte]``
+    Dequant per llama.cpp: ``bit ? +scale : -scale``.
+
+    MatMulNBits has no native 1-bit format, so we inflate each Q1_0 bit
+    ``b ∈ {0, 1}`` to a 2-bit code ``B ∈ {0, 2}``. With zero-point=1 and
+    scale=d, the op then dequantizes to ``(B - 1) * d = {-d, +d}`` — an
+    exact equivalent of Q1_0 at 2× the on-disk weight bytes but bit-exact
+    in values.
+
+    Each 8-bit Q1_0 byte encodes 8 elements, producing 2 MatMulNBits 2-bit
+    bytes (4 codes per byte).
+    """
+    raw_scales = blocks[:, :2].copy()
+    raw_bits = blocks[:, 2:]  # (total_blocks, 16)
+
+    scales = raw_scales.view(np.float16).reshape(n_out, n_blocks_per_row)
+
+    # Expand each Q1_0 byte (8 bits) into 2 MatMulNBits 2-bit bytes
+    # via the precomputed 4-bit nibble → 8-bit lookup table.
+    low_nibbles = raw_bits & 0x0F  # bits 0..3 of each Q1_0 byte
+    high_nibbles = (raw_bits >> 4) & 0x0F  # bits 4..7
+
+    ort_low = _Q1_0_EXPAND[low_nibbles]  # (total_blocks, 16) — even ORT bytes
+    ort_high = _Q1_0_EXPAND[high_nibbles]  # (total_blocks, 16) — odd ORT bytes
+
+    # Interleave: ORT bytes for elements 0..7 are (ort_low[0], ort_high[0]),
+    # for elements 8..15 are (ort_low[1], ort_high[1]), etc.
+    blob_size = 32  # 128 elements * 2 bits / 8 = 32 bytes per block
+    interleaved = np.empty((raw_bits.shape[0], blob_size), dtype=np.uint8)
+    interleaved[:, 0::2] = ort_low
+    interleaved[:, 1::2] = ort_high
+    weight = interleaved.reshape(n_out, n_blocks_per_row, blob_size)
+
+    # Zero points: all blocks share zp=1 (so dequant maps {0,2} → {-1,+1}).
+    # Packed as 4 ZPs per byte (bits=2): byte = (1<<6) | (1<<4) | (1<<2) | 1 = 0x55.
+    # Tail of the last byte (when n_blocks_per_row % 4 != 0) is unused by ORT;
+    # we still fill it with 0x55 for cleanliness.
+    zp_cols = math.ceil(n_blocks_per_row / 4)
+    zero_points = np.full((n_out, zp_cols), 0x55, dtype=np.uint8)
+
+    return RepackedTensor(
+        weight=weight,
+        scales=scales,
+        zero_points=zero_points,
+        block_size=128,
+        bits=2,
     )

--- a/src/mobius/integrations/gguf/_repacker.py
+++ b/src/mobius/integrations/gguf/_repacker.py
@@ -185,7 +185,7 @@ def _repack_q4_0(
     """Repack Q4_0 blocks.
 
     Q4_0 block (18 bytes): [fp16 scale (2B)][16B packed 4-bit quants]
-    Dequant: (nibble - 8) * scale  →  symmetric with zero_point = 8.
+    Dequant: (nibble - 8) * scale  ->  symmetric with zero_point = 8.
 
     GGUF nibble ordering differs from MatMulNBits — we reorder during
     repacking.  See ``_reorder_nibbles_gguf_to_ort`` for details.
@@ -194,7 +194,7 @@ def _repack_q4_0(
     raw_scales = blocks[:, :2].copy()
     raw_quants = blocks[:, 2:]  # (total_blocks, 16)
 
-    # Scales: view as fp16 → (total_blocks,) → reshape to (N, n_blocks)
+    # Scales: view as fp16 -> (total_blocks,) -> reshape to (N, n_blocks)
     scales = raw_scales.view(np.float16).reshape(n_out, n_blocks_per_row)
 
     # Reorder nibbles from GGUF order to MatMulNBits order
@@ -228,7 +228,7 @@ def _repack_q4_1(
     """Repack Q4_1 blocks.
 
     Q4_1 block (20 bytes): [fp16 scale (2B)][fp16 min (2B)][16B quants]
-    Dequant: nibble * scale + min  →  asymmetric.
+    Dequant: nibble * scale + min  ->  asymmetric.
 
     MatMulNBits dequant: (nibble - zp) * scale
     So: zp = round(-min / scale), clamped to [0, 15].
@@ -283,7 +283,7 @@ def _repack_q8_0(
     """Repack Q8_0 blocks.
 
     Q8_0 block (34 bytes): [fp16 scale (2B)][32 x int8 values (32B)]
-    Dequant: int8_val * scale  →  symmetric around 0.
+    Dequant: int8_val * scale  ->  symmetric around 0.
 
     MatMulNBits dequant: (uint8_val - zp) * scale
     Convert: uint8_val = int8_val + 128, zp = 128.
@@ -293,7 +293,7 @@ def _repack_q8_0(
 
     scales = raw_scales.view(np.float16).reshape(n_out, n_blocks_per_row)
 
-    # Convert signed int8 → unsigned uint8 by adding 128
+    # Convert signed int8 -> unsigned uint8 by adding 128
     quants_int8 = raw_quants.view(np.int8).astype(np.int16)
     quants_uint8 = (quants_int8 + 128).astype(np.uint8)
     weight = quants_uint8.reshape(n_out, n_blocks_per_row, 32)
@@ -319,12 +319,12 @@ def _unpack_q4_k_scales(
     packed into 12 bytes using 6-bit encoding.  The packing layout (from
     llama.cpp) uses three 4-byte groups::
 
-        Bytes 0-3 (d):   low 6 bits → sub_scale[0..3],
-                         high 2 bits → sub_scale[4..7] bits 4-5
-        Bytes 4-7 (m):   low 6 bits → sub_min[0..3],
-                         high 2 bits → sub_min[4..7] bits 4-5
-        Bytes 8-11 (md): low 4 bits → sub_scale[4..7] bits 0-3,
-                         high 4 bits → sub_min[4..7] bits 0-3
+        Bytes 0-3 (d):   low 6 bits -> sub_scale[0..3],
+                         high 2 bits -> sub_scale[4..7] bits 4-5
+        Bytes 4-7 (m):   low 6 bits -> sub_min[0..3],
+                         high 2 bits -> sub_min[4..7] bits 4-5
+        Bytes 8-11 (md): low 4 bits -> sub_scale[4..7] bits 0-3,
+                         high 4 bits -> sub_min[4..7] bits 0-3
 
     Args:
         scales_raw: uint8 array, shape ``(n_super_blocks, 12)``.
@@ -396,7 +396,7 @@ def _repack_q4_k(
     # Effective zero-point: zp = round(dmin * sub_min / eff_scale)
     # GGUF dequant: d * sub_scale * nibble - dmin * sub_min
     # MatMulNBits: (nibble - zp) * eff_scale = eff_scale * nibble - eff_scale * zp
-    # So eff_scale * zp = dmin * sub_min → zp = dmin * sub_min / eff_scale
+    # So eff_scale * zp = dmin * sub_min -> zp = dmin * sub_min / eff_scale
     numerator = dmin[:, None] * sub_mins_f  # (total, 8)
     with np.errstate(divide="ignore", invalid="ignore"):
         zp_float = np.where(
@@ -416,14 +416,14 @@ def _repack_q4_k(
 
     # Unpack 4-bit quants from Q4_K layout.
     # 128 bytes = 4 groups of 32 bytes. Each group encodes two sub-blocks:
-    #   byte[j] low nibble  → even sub-block element j
-    #   byte[j] high nibble → odd sub-block element j
+    #   byte[j] low nibble  -> even sub-block element j
+    #   byte[j] high nibble -> odd sub-block element j
     qs = qs_raw.reshape(total, 4, 1, 32)
     shifts = np.array([0, 4], dtype=np.uint8).reshape(1, 1, 2, 1)
     qs = (qs >> shifts) & np.uint8(0x0F)  # (total, 4, 2, 32)
     qs = qs.reshape(total, 8, 32)  # (total, 8, 32) — 8 sub-blocks
 
-    # Repack each sub-block's 32 nibbles → 16 MatMulNBits bytes.
+    # Repack each sub-block's 32 nibbles -> 16 MatMulNBits bytes.
     # ORT format: byte[j] = (element[2j+1] << 4) | element[2j]
     pairs = qs.reshape(total, 8, 16, 2)
     ort_packed = (pairs[..., 1] << 4) | pairs[..., 0]  # (total, 8, 16)
@@ -453,8 +453,8 @@ def _repack_q4_k(
     )
 
 
-# Lookup table: 4-bit nibble (LSB-first) → 8-bit ORT 2-bit packed byte.
-# Each Q1_0 bit b ∈ {0, 1} maps to MatMulNBits 2-bit code 2*b ∈ {0, 2}
+# Lookup table: 4-bit nibble (LSB-first) -> 8-bit ORT 2-bit packed byte.
+# Each Q1_0 bit b in {0, 1} maps to MatMulNBits 2-bit code 2*b in {0, 2}
 # (which under zp=1 dequantizes to {-1, +1}).
 #
 # Q1_0 bit packing: bit `j % 8` of `qs[j // 8]` holds element j.
@@ -463,7 +463,7 @@ def _repack_q4_k(
 # nibble layout (LSB-first):    bit0 bit1 bit2 bit3
 # packed 2-bit byte (LSB-first): c0   c1   c2   c3
 #   where c_k = 2 * bit_k, giving byte = (bit3<<7)|(bit2<<5)|(bit1<<3)|(bit0<<1).
-def _build_q1_0_expand_table() -> "np.ndarray":
+def _build_q1_0_expand_table() -> np.ndarray:
     table = np.zeros(16, dtype=np.uint8)
     for nibble in range(16):
         byte = 0
@@ -489,9 +489,9 @@ def _repack_q1_0(
     Dequant per llama.cpp: ``bit ? +scale : -scale``.
 
     MatMulNBits has no native 1-bit format, so we inflate each Q1_0 bit
-    ``b ∈ {0, 1}`` to a 2-bit code ``B ∈ {0, 2}``. With zero-point=1 and
+    ``b in {0, 1}`` to a 2-bit code ``B in {0, 2}``. With zero-point=1 and
     scale=d, the op then dequantizes to ``(B - 1) * d = {-d, +d}`` — an
-    exact equivalent of Q1_0 at 2× the on-disk weight bytes but bit-exact
+    exact equivalent of Q1_0 at 2x the on-disk weight bytes but bit-exact
     in values.
 
     Each 8-bit Q1_0 byte encodes 8 elements, producing 2 MatMulNBits 2-bit
@@ -503,7 +503,7 @@ def _repack_q1_0(
     scales = raw_scales.view(np.float16).reshape(n_out, n_blocks_per_row)
 
     # Expand each Q1_0 byte (8 bits) into 2 MatMulNBits 2-bit bytes
-    # via the precomputed 4-bit nibble → 8-bit lookup table.
+    # via the precomputed 4-bit nibble -> 8-bit lookup table.
     low_nibbles = raw_bits & 0x0F  # bits 0..3 of each Q1_0 byte
     high_nibbles = (raw_bits >> 4) & 0x0F  # bits 4..7
 
@@ -518,7 +518,7 @@ def _repack_q1_0(
     interleaved[:, 1::2] = ort_high
     weight = interleaved.reshape(n_out, n_blocks_per_row, blob_size)
 
-    # Zero points: all blocks share zp=1 (so dequant maps {0,2} → {-1,+1}).
+    # Zero points: all blocks share zp=1 (so dequant maps {0,2} -> {-1,+1}).
     # Packed as 4 ZPs per byte (bits=2): byte = (1<<6) | (1<<4) | (1<<2) | 1 = 0x55.
     # Tail of the last byte (when n_blocks_per_row % 4 != 0) is unused by ORT;
     # we still fill it with 0x55 for cleanliness.

--- a/src/mobius/integrations/gguf/_repacker_test.py
+++ b/src/mobius/integrations/gguf/_repacker_test.py
@@ -110,14 +110,14 @@ class TestRepackQ40:
         """Two blocks per row — zero points packed into one byte."""
         nibbles = [8] * 32
         block = _make_q4_0_block(scale=1.0, nibbles=nibbles)
-        # 1 row, 2 blocks → shape (1, 64)
+        # 1 row, 2 blocks -> shape (1, 64)
         raw = np.concatenate([block, block])
 
         result = repack_gguf_tensor(raw, _Q4_0, shape=(1, 64))
 
         assert result.weight.shape == (1, 2, 16)
         assert result.scales.shape == (1, 2)
-        # 2 blocks → 1 ZP byte, both nibbles = 8 → 0x88
+        # 2 blocks -> 1 ZP byte, both nibbles = 8 -> 0x88
         assert result.zero_points.shape == (1, 1)
         assert result.zero_points[0, 0] == 0x88
 
@@ -134,7 +134,7 @@ class TestRepackQ40:
         assert result.zero_points.shape == (3, 1)
 
     def test_nibble_ordering_reordered(self):
-        """Verify GGUF→ORT nibble reordering.
+        """Verify GGUF->ORT nibble reordering.
 
         GGUF: byte i has element[i] (low) and element[i+16] (high).
         ORT:  byte j has element[2j] (low) and element[2j+1] (high).
@@ -250,7 +250,7 @@ class TestRepackQ41:
 
     def test_zp_clamped_to_15(self):
         """Zero point is clamped to [0, 15] for 4-bit."""
-        # min = -100, scale = 1 → zp = 100 → clamp to 15
+        # min = -100, scale = 1 -> zp = 100 -> clamp to 15
         nibbles = [0] * 32
         block = _make_q4_1_block(scale=1.0, minimum=-100.0, nibbles=nibbles)
         raw = block.reshape(-1)
@@ -289,7 +289,7 @@ class TestRepackQ41:
         s = result.scales[0, 0].astype(np.float32)
         ort_deq = (elements - zp) * s
 
-        # Q4_1 → MatMulNBits is lossy (zero_point quantization)
+        # Q4_1 -> MatMulNBits is lossy (zero_point quantization)
         # Allow larger tolerance
         np.testing.assert_allclose(ort_deq, gguf_deq.ravel(), atol=0.5)
 
@@ -312,7 +312,7 @@ class TestRepackQ80:
         assert result.zero_points[0, 0] == 128
 
     def test_int8_to_uint8_conversion(self):
-        """Verify signed int8 → unsigned uint8 + 128 offset."""
+        """Verify signed int8 -> unsigned uint8 + 128 offset."""
         values = [-128, -1, 0, 1, 127] + [0] * 27
         block = _make_q8_0_block(scale=1.0, values=values)
         raw = block.reshape(-1)
@@ -365,7 +365,7 @@ class TestEdgeCases:
             repack_gguf_tensor(np.zeros(10, dtype=np.uint8), _Q4_0, (1, 32))
 
     def test_multi_block_multi_row(self):
-        """N=4, K=128 → 4 blocks per row."""
+        """N=4, K=128 -> 4 blocks per row."""
         n, k = 4, 128
         n_blocks = k // 32
         block_bytes = 18
@@ -380,7 +380,7 @@ class TestEdgeCases:
 
         assert result.weight.shape == (4, 4, 16)
         assert result.scales.shape == (4, 4)
-        # 4 blocks → 2 ZP bytes per row
+        # 4 blocks -> 2 ZP bytes per row
         assert result.zero_points.shape == (4, 2)
         assert result.zero_points[0, 0] == 0x88
         assert result.zero_points[0, 1] == 0x88
@@ -483,7 +483,7 @@ class TestUnpackQ4KScales:
 
 class TestRepackQ4K:
     def test_single_super_block_shapes(self):
-        """Single Q4_K super-block → 8 MatMulNBits sub-blocks."""
+        """Single Q4_K super-block -> 8 MatMulNBits sub-blocks."""
         sc = [10] * 8
         mn = [5] * 8
         nibs = [7] * 256
@@ -495,7 +495,7 @@ class TestRepackQ4K:
         assert isinstance(result, RepackedTensor)
         assert result.bits == 4
         assert result.block_size == 32
-        # 1 super-block → 8 sub-blocks
+        # 1 super-block -> 8 sub-blocks
         assert result.weight.shape == (1, 8, 16)
         assert result.scales.shape == (1, 8)
         assert result.zero_points.shape == (1, 4)  # 8 zps / 2
@@ -503,7 +503,7 @@ class TestRepackQ4K:
     def test_effective_scales(self):
         """Verify effective scale = d * sub_scale."""
         sc = [10, 20, 30, 40, 1, 2, 3, 4]
-        mn = [0] * 8  # zero mins → zp=0, no offset
+        mn = [0] * 8  # zero mins -> zp=0, no offset
         nibs = [0] * 256
         d_val = 0.5
         block = _make_q4_k_block(d=d_val, dmin=0.0, sub_scales=sc, sub_mins=mn, nibbles=nibs)
@@ -608,7 +608,7 @@ class TestRepackQ4K:
         np.testing.assert_allclose(ort_deq, gguf_deq, atol=atol)
 
     def test_multiple_rows_and_super_blocks(self):
-        """N=2 rows, K=512 → 2 super-blocks per row."""
+        """N=2 rows, K=512 -> 2 super-blocks per row."""
         sc = [10] * 8
         mn = [5] * 8
         nibs = [7] * 256
@@ -651,14 +651,14 @@ class TestRepackQ4K:
 
 
 class TestRepackQ10:
-    """Tests for Q1_0 (1-bit binary) → MatMulNBits 2-bit repacking."""
+    """Tests for Q1_0 (1-bit binary) -> MatMulNBits 2-bit repacking."""
 
     def test_in_can_repack(self):
         """Q1_0 (type 41) is recognized as repackable."""
         assert can_repack(_Q1_0) is True
 
     def test_single_block_shape(self):
-        """One Q1_0 block (128 elt) → one 32-byte MatMulNBits block, bits=2."""
+        """One Q1_0 block (128 elt) -> one 32-byte MatMulNBits block, bits=2."""
         bits = [1] * 128
         block = _make_q1_0_block(scale=0.5, bits=bits)
         raw = block.reshape(-1)
@@ -682,7 +682,7 @@ class TestRepackQ10:
         np.testing.assert_array_equal(result.zero_points, 0x55)
 
     def test_all_positive_bits_pack_to_code_2(self):
-        """All bits = 1 → every 2-bit code = 2; byte = 0xAA (10_10_10_10)."""
+        """All bits = 1 -> every 2-bit code = 2; byte = 0xAA (10_10_10_10)."""
         bits = [1] * 128
         block = _make_q1_0_block(scale=1.0, bits=bits)
         raw = block.reshape(-1)
@@ -691,7 +691,7 @@ class TestRepackQ10:
         np.testing.assert_array_equal(result.weight, 0xAA)
 
     def test_all_negative_bits_pack_to_code_0(self):
-        """All bits = 0 → every 2-bit code = 0; all bytes zero."""
+        """All bits = 0 -> every 2-bit code = 0; all bytes zero."""
         bits = [0] * 128
         block = _make_q1_0_block(scale=1.0, bits=bits)
         raw = block.reshape(-1)
@@ -703,7 +703,7 @@ class TestRepackQ10:
 
         Q1_0 dequant per llama.cpp: ``bit ? +d : -d``.
         MatMulNBits dequant: ``(B - zp) * scale``.
-        With zp=1, scale=d, B = 2*bit: result = (2*bit - 1) * d = ±d. ✓
+        With zp=1, scale=d, B = 2*bit: result = (2*bit - 1) * d = +/-d. ✓
         """
         rng = np.random.default_rng(0)
         bits = rng.integers(0, 2, size=128).tolist()
@@ -731,7 +731,7 @@ class TestRepackQ10:
         np.testing.assert_allclose(deq_ort, expected_deq, rtol=1e-3)
 
     def test_multi_block_multi_row(self):
-        """Multiple rows × multiple blocks pack into the expected shape."""
+        """Multiple rows x multiple blocks pack into the expected shape."""
         n, k = 4, 256  # 4 rows, 2 blocks per row
         rng = np.random.default_rng(1)
         blocks = [
@@ -743,14 +743,14 @@ class TestRepackQ10:
         ]
         raw = np.concatenate(blocks)
         result = repack_gguf_tensor(raw, _Q1_0, shape=(n, k))
-        # 4 rows × 2 blocks × 32 bytes
+        # 4 rows x 2 blocks x 32 bytes
         assert result.weight.shape == (n, 2, 32)
         assert result.scales.shape == (n, 2)
         # zero_points: ceil(2*2/8) = 1 byte per row
         assert result.zero_points.shape == (n, 1)
 
     def test_bit_order_lsb_first(self):
-        """Bit j of Q1_0 byte j//8 → code in slot j%4 of ORT byte (j//4)%(blob/4).
+        """Bit j of Q1_0 byte j//8 -> code in slot j%4 of ORT byte (j//4)%(blob/4).
 
         Sets only element 0 = +1 (bit 0 of Q1_0 byte 0) and verifies that
         ORT byte 0 has its low 2 bits = 2 and all other bits = 0.

--- a/src/mobius/integrations/gguf/_repacker_test.py
+++ b/src/mobius/integrations/gguf/_repacker_test.py
@@ -17,7 +17,24 @@ _Q4_0 = 2
 _Q4_1 = 3
 _Q8_0 = 8
 _Q4_K = 12
+_Q1_0 = 41
 _BLOCK_SIZE = 32
+
+
+def _make_q1_0_block(scale: float, bits: list[int]) -> np.ndarray:
+    """Build a single Q1_0 block (18 bytes) from scale + 128 binary signs.
+
+    GGUF packing per llama.cpp ``quantize_row_q1_0_ref``:
+        bit ``j % 8`` of ``qs[j // 8]`` holds element j (LSB-first).
+    Dequant: ``bit ? +scale : -scale``.
+    """
+    assert len(bits) == 128
+    scale_bytes = np.array([scale], dtype=np.float16).view(np.uint8)
+    packed = np.zeros(16, dtype=np.uint8)
+    for j in range(128):
+        if bits[j]:
+            packed[j // 8] |= 1 << (j % 8)
+    return np.concatenate([scale_bytes, packed])
 
 
 def _make_q4_0_block(scale: float, nibbles: list[int]) -> np.ndarray:
@@ -628,3 +645,134 @@ class TestRepackQ4K:
     def test_q4_k_in_can_repack(self):
         """Q4_K (type 12) is recognized as repackable."""
         assert can_repack(12) is True
+
+
+# ---- Q1_0 tests ----
+
+
+class TestRepackQ10:
+    """Tests for Q1_0 (1-bit binary) → MatMulNBits 2-bit repacking."""
+
+    def test_in_can_repack(self):
+        """Q1_0 (type 41) is recognized as repackable."""
+        assert can_repack(_Q1_0) is True
+
+    def test_single_block_shape(self):
+        """One Q1_0 block (128 elt) → one 32-byte MatMulNBits block, bits=2."""
+        bits = [1] * 128
+        block = _make_q1_0_block(scale=0.5, bits=bits)
+        raw = block.reshape(-1)
+        result = repack_gguf_tensor(raw, _Q1_0, shape=(1, 128))
+        assert isinstance(result, RepackedTensor)
+        assert result.bits == 2
+        assert result.block_size == 128
+        # 1 row, 1 block, 128*2/8 = 32 bytes blob
+        assert result.weight.shape == (1, 1, 32)
+        assert result.scales.shape == (1, 1)
+        # zero_points: ceil(1 * 2 / 8) = 1 byte
+        assert result.zero_points.shape == (1, 1)
+
+    def test_zero_points_are_0x55(self):
+        """All zero-points = 1 (packed as 0x55 = 01_01_01_01)."""
+        bits = [0] * 128
+        block = _make_q1_0_block(scale=1.0, bits=bits)
+        raw = block.reshape(-1)
+        result = repack_gguf_tensor(raw, _Q1_0, shape=(1, 128))
+        assert result.zero_points is not None
+        np.testing.assert_array_equal(result.zero_points, 0x55)
+
+    def test_all_positive_bits_pack_to_code_2(self):
+        """All bits = 1 → every 2-bit code = 2; byte = 0xAA (10_10_10_10)."""
+        bits = [1] * 128
+        block = _make_q1_0_block(scale=1.0, bits=bits)
+        raw = block.reshape(-1)
+        result = repack_gguf_tensor(raw, _Q1_0, shape=(1, 128))
+        # Each byte = (2<<6) | (2<<4) | (2<<2) | 2 = 0xAA
+        np.testing.assert_array_equal(result.weight, 0xAA)
+
+    def test_all_negative_bits_pack_to_code_0(self):
+        """All bits = 0 → every 2-bit code = 0; all bytes zero."""
+        bits = [0] * 128
+        block = _make_q1_0_block(scale=1.0, bits=bits)
+        raw = block.reshape(-1)
+        result = repack_gguf_tensor(raw, _Q1_0, shape=(1, 128))
+        np.testing.assert_array_equal(result.weight, 0x00)
+
+    def test_round_trip_dequantize(self):
+        """Repacked W (with zp=1, scale=d) reproduces Q1_0 dequant exactly.
+
+        Q1_0 dequant per llama.cpp: ``bit ? +d : -d``.
+        MatMulNBits dequant: ``(B - zp) * scale``.
+        With zp=1, scale=d, B = 2*bit: result = (2*bit - 1) * d = ±d. ✓
+        """
+        rng = np.random.default_rng(0)
+        bits = rng.integers(0, 2, size=128).tolist()
+        scale = 0.25
+        block = _make_q1_0_block(scale=scale, bits=bits)
+        raw = block.reshape(-1)
+        result = repack_gguf_tensor(raw, _Q1_0, shape=(1, 128))
+
+        # Unpack each ORT 2-bit code from the 32-byte blob
+        blob = result.weight[0, 0]  # (32,) uint8
+        codes = np.empty(128, dtype=np.uint8)
+        for byte_i in range(32):
+            for slot in range(4):
+                codes[byte_i * 4 + slot] = (blob[byte_i] >> (2 * slot)) & 0x3
+
+        # Each code should be 2 * original_bit
+        expected_codes = 2 * np.array(bits, dtype=np.uint8)
+        np.testing.assert_array_equal(codes, expected_codes)
+
+        # Dequantize via MatMulNBits formula and compare to llama.cpp Q1_0
+        scale_v = result.scales[0, 0].astype(np.float32)
+        zp = 1  # encoded as 0x55 across the byte
+        deq_ort = (codes.astype(np.float32) - zp) * scale_v
+        expected_deq = np.where(np.array(bits) == 1, scale, -scale).astype(np.float32)
+        np.testing.assert_allclose(deq_ort, expected_deq, rtol=1e-3)
+
+    def test_multi_block_multi_row(self):
+        """Multiple rows × multiple blocks pack into the expected shape."""
+        n, k = 4, 256  # 4 rows, 2 blocks per row
+        rng = np.random.default_rng(1)
+        blocks = [
+            _make_q1_0_block(
+                scale=float(rng.uniform(0.1, 1.0)),
+                bits=rng.integers(0, 2, size=128).tolist(),
+            )
+            for _ in range(n * 2)
+        ]
+        raw = np.concatenate(blocks)
+        result = repack_gguf_tensor(raw, _Q1_0, shape=(n, k))
+        # 4 rows × 2 blocks × 32 bytes
+        assert result.weight.shape == (n, 2, 32)
+        assert result.scales.shape == (n, 2)
+        # zero_points: ceil(2*2/8) = 1 byte per row
+        assert result.zero_points.shape == (n, 1)
+
+    def test_bit_order_lsb_first(self):
+        """Bit j of Q1_0 byte j//8 → code in slot j%4 of ORT byte (j//4)%(blob/4).
+
+        Sets only element 0 = +1 (bit 0 of Q1_0 byte 0) and verifies that
+        ORT byte 0 has its low 2 bits = 2 and all other bits = 0.
+        """
+        bits = [0] * 128
+        bits[0] = 1
+        block = _make_q1_0_block(scale=1.0, bits=bits)
+        raw = block.reshape(-1)
+        result = repack_gguf_tensor(raw, _Q1_0, shape=(1, 128))
+        blob = result.weight[0, 0]
+        # Code 0 (low 2 bits of byte 0) should be 2; everything else = 0
+        assert blob[0] == 0b00000010
+        np.testing.assert_array_equal(blob[1:], 0)
+
+        # Set element 7 (bit 7 of Q1_0 byte 0): this is slot 3 of ORT byte 1.
+        bits = [0] * 128
+        bits[7] = 1
+        block = _make_q1_0_block(scale=1.0, bits=bits)
+        raw = block.reshape(-1)
+        result = repack_gguf_tensor(raw, _Q1_0, shape=(1, 128))
+        blob = result.weight[0, 0]
+        # ORT byte 1 covers codes 4..7; code 3 of that byte sits in bits 6..7
+        assert blob[0] == 0
+        assert blob[1] == 0b10000000  # code 3 = 2 (binary 10) in slot 3
+        np.testing.assert_array_equal(blob[2:], 0)

--- a/src/mobius/integrations/gguf/_tencent_q1_0.py
+++ b/src/mobius/integrations/gguf/_tencent_q1_0.py
@@ -283,7 +283,6 @@ def _pack_inflated_4bit(
     <https://github.com/microsoft/onnxruntime/issues/28552>`_).
     """
     bits = 4
-    blob_size = TENCENT_Q1_0_ORT_BLOCK_SIZE * bits // 8  # 64
     n_ort_blocks_per_row = n_native * _SUBBLOCKS_PER_NATIVE
 
     # Unpack 2-bit codes → 4 codes per byte, LSB-first slot k holds code k.

--- a/src/mobius/integrations/gguf/_tencent_q1_0.py
+++ b/src/mobius/integrations/gguf/_tencent_q1_0.py
@@ -24,31 +24,34 @@ under-reads tensor data. We bypass the size calculation entirely by
 reading from the **explicit per-tensor file offset** stored in the
 GGUF header.
 
-The output of :func:`parse_tencent_q1_0_tensor` is a
-:class:`~mobius.integrations.gguf._repacker.RepackedTensor` that
-preserves the native 2-bit codes and pairs them with a float
-zero-point of ``1.5`` and an *effective* per-block scale of
-``2·stored_scale``. The ORT ``MatMulNBits`` op then dequantizes via
-``effective_scale · (B − 1.5) = stored_scale · {−3, −1, +1, +3}[c]``,
-exactly Tencent's SEQ codebook.
+Two MatMulNBits representations are available, selected by the
+``flags.tencent_q1_0_use_native_2bit`` flag:
 
-ORT version requirement: this representation needs the
-**float zero-point** path for ``bits=2`` that was added in
-`microsoft/onnxruntime#28354
-<https://github.com/microsoft/onnxruntime/pull/28354>`_ (merged
-2026-05-13, expected in onnxruntime 1.27 and later). Older
-versions throw
-``Only 4b quantization is supported for unpacked compute using
-non-MLAS de-quantization for now`` from
-``ComputeBUnpacked`` at first inference.
+* **Inflated bits=4** (default; ``flag=False``): each 2-bit code
+  ``c ∈ {0..3}`` is doubled to a 4-bit slot ``2c ∈ {0,2,4,6}`` and
+  paired with integer ``zero_point = 3``. Dequant: ``scale·(B − 3) =
+  scale · {−3, −1, +1, +3}[c]``. Doubles on-disk weight bytes (4 bpw
+  packed) but uses ORT's well-optimised bits=4 packed-uint8 kernel,
+  giving ~20× higher CPU throughput than the native form.
+
+* **Native bits=2** (``flag=True``): the 2-bit codes are copied
+  through unchanged and paired with float ``zero_point = 1.5`` and
+  ``effective_scale = 2·stored_scale``. Dequant:
+  ``effective_scale·(B − 1.5) = stored_scale · {−3,−1,+1,+3}[c]``.
+  Requires ORT ≥ 1.27 (`microsoft/onnxruntime#28354
+  <https://github.com/microsoft/onnxruntime/pull/28354>`_), and the
+  CPU path is currently a naive scalar fallback (`#28552
+  <https://github.com/microsoft/onnxruntime/issues/28552>`_).
+  Smaller and semantically faithful, but unusable for interactive
+  decode until an MLAS fast path lands.
 
 Block-size note: the native Tencent block size is 512 elements, but
 the ORT CPU dequant kernel silently returns zeros for ``block_size``
 larger than 256 (see `microsoft/onnxruntime#28551
-<https://github.com/microsoft/onnxruntime/issues/28551>`_). Each
-Tencent 512-element scale is therefore replicated across 4
-``MatMulNBits`` sub-blocks of 128 elements; the dequantized values
-are bit-identical.
+<https://github.com/microsoft/onnxruntime/issues/28551>`_). Both
+representations therefore expose ``block_size = 128`` to ORT by
+replicating each native scale across 4 sub-blocks; dequantized
+values are bit-identical to the native 512-element layout.
 """
 
 from __future__ import annotations
@@ -56,16 +59,17 @@ from __future__ import annotations
 __all__ = [
     "TENCENT_Q1_0_NATIVE_BLOCK_SIZE",
     "TENCENT_Q1_0_ORT_BLOCK_SIZE",
-    "TENCENT_Q1_0_ORT_BITS",
-    "TENCENT_Q1_0_ZERO_POINT",
+    "TENCENT_Q1_0_NATIVE_ZERO_POINT",
     "is_tencent_q1_0_layout",
     "parse_tencent_q1_0_tensor",
 ]
 
+import math
 import os
 
 import numpy as np
 
+from mobius._flags import flags
 from mobius.integrations.gguf._repacker import RepackedTensor
 
 # Native Tencent block size (one fp16 scale governs this many weights).
@@ -76,16 +80,10 @@ TENCENT_Q1_0_NATIVE_BLOCK_SIZE = 512
 # native scale across 4 ORT sub-blocks of 128 elements.
 TENCENT_Q1_0_ORT_BLOCK_SIZE = 128
 
-# Bit width emitted to ORT. We keep Tencent's native 2 bits/elt rather
-# than inflating to 4, halving the on-disk weight bytes. This relies on
-# the bits=2 float-zero-point path landed in ORT PR #28354.
-TENCENT_Q1_0_ORT_BITS = 2
-
 # Float zero point that produces the SEQ codebook centred between
-# integer codes 0..3:
-#   stored_scale · {-3, -1, +1, +3}[c]
-#     = (2 · stored_scale) · (c - 1.5)
-TENCENT_Q1_0_ZERO_POINT = 1.5
+# integer codes 0..3 in the native bits=2 representation:
+#   stored_scale · {-3, -1, +1, +3}[c] = (2 · stored_scale) · (c - 1.5)
+TENCENT_Q1_0_NATIVE_ZERO_POINT = 1.5
 
 # Per native block on-disk: 2 bytes (fp16 scale) + 512·2/8 = 128 bytes codes.
 _TENCENT_Q1_0_BLOCK_BYTES = 2 + TENCENT_Q1_0_NATIVE_BLOCK_SIZE // 4  # 130
@@ -140,6 +138,15 @@ def parse_tencent_q1_0_tensor(
 ) -> RepackedTensor:
     """Parse one Tencent-Q1_0 tensor into MatMulNBits-ready arrays.
 
+    Dispatches between two MatMulNBits representations based on
+    :attr:`flags.tencent_q1_0_use_native_2bit`:
+
+    * ``False`` (default): :func:`_pack_inflated_4bit` — codes inflated
+      to 4-bit slots, integer ``zp=3``. Fast on CPU EP but 2× the
+      on-disk weight bytes.
+    * ``True``: :func:`_pack_native_2bit` — codes passed through,
+      float ``zp=1.5``. Native 2 bpw but slow on CPU EP today.
+
     Args:
         file_path: Path to the source ``.gguf`` file.
         data_section_offset: Absolute byte offset where the GGUF data
@@ -148,27 +155,41 @@ def parse_tencent_q1_0_tensor(
             ``tensor_type == GGML_TYPE_Q1_0`` and a 2D shape.
 
     Returns:
-        A :class:`RepackedTensor` with ``bits=2`` and
-        ``block_size=128``. The 2-bit codes are passed through
-        unchanged (ORT's packing matches Tencent's LSB-first 4-codes-
-        per-byte layout); the per-block ``scales`` are
-        ``2·stored_scale`` so that ``effective_scale · (B − 1.5)``
-        matches the SEQ codebook ``stored_scale · {-3,-1,+1,+3}[B]``;
-        and ``zero_points`` is a float16 tensor of all 1.5.
-
-        Requires onnxruntime that includes the ``bits=2`` float
-        zero-point CPU path (PR #28354, expected in 1.27+).
+        A :class:`RepackedTensor` whose ``block_size`` is always 128.
+        The ``bits`` field is 2 or 4 depending on the flag.
     """
-    ne0 = int(tensor.shape[0])  # K (input features per output row)
-    ne1 = int(tensor.shape[1])  # N (output features)
+    native_scales, codes_2bit, ne1, n_native = _read_tencent_blocks(
+        file_path, data_section_offset, tensor
+    )
+    if flags.tencent_q1_0_use_native_2bit:
+        return _pack_native_2bit(native_scales, codes_2bit, ne1, n_native)
+    return _pack_inflated_4bit(native_scales, codes_2bit, ne1, n_native)
+
+
+def _read_tencent_blocks(
+    file_path: str | os.PathLike,
+    data_section_offset: int,
+    tensor,
+) -> tuple[np.ndarray, np.ndarray, int, int]:
+    """Read raw Tencent Q1_0 blocks from disk and unpack to (scales, codes).
+
+    Returns:
+        ``(native_scales, codes_2bit, ne1, n_native_blocks_per_row)`` where
+        ``native_scales`` is ``(N, n_native)`` float16 (the unmodified
+        on-disk per-block fp16 scale) and ``codes_2bit`` is
+        ``(N, n_native * 512 / 4)`` uint8 of the raw packed code bytes
+        (4 codes/byte, LSB-first within each byte).
+    """
+    ne0 = int(tensor.shape[0])  # K
+    ne1 = int(tensor.shape[1])  # N
     if ne0 % TENCENT_Q1_0_NATIVE_BLOCK_SIZE != 0:
         raise ValueError(
             f"Tensor {tensor.name!r} has K={ne0} not divisible by "
             f"Tencent Q1_0 native block size {TENCENT_Q1_0_NATIVE_BLOCK_SIZE}"
         )
 
-    n_native_blocks_per_row = ne0 // TENCENT_Q1_0_NATIVE_BLOCK_SIZE
-    bytes_per_row = n_native_blocks_per_row * _TENCENT_Q1_0_BLOCK_BYTES
+    n_native = ne0 // TENCENT_Q1_0_NATIVE_BLOCK_SIZE
+    bytes_per_row = n_native * _TENCENT_Q1_0_BLOCK_BYTES
     total_bytes = ne1 * bytes_per_row
 
     abs_offset = data_section_offset + _tensor_data_offset(tensor)
@@ -180,39 +201,54 @@ def parse_tencent_q1_0_tensor(
             f"Short read for {tensor.name!r}: got {len(blob)} bytes, expected {total_bytes}"
         )
 
-    arr = np.frombuffer(blob, dtype=np.uint8).reshape(
-        ne1, n_native_blocks_per_row, _TENCENT_Q1_0_BLOCK_BYTES
-    )
+    arr = np.frombuffer(blob, dtype=np.uint8).reshape(ne1, n_native, _TENCENT_Q1_0_BLOCK_BYTES)
 
-    # Per native-block fp16 scales. We expose 2·stored_scale to ORT so
-    # that effective_scale·(B−1.5) = stored_scale·{-3,-1,+1,+3}[B]
-    # matches Tencent's SEQ codebook exactly.
+    # First 2 bytes of each block: fp16 stored_scale.
     scales_raw = arr[:, :, :2].copy()
-    native_scales = scales_raw.view(np.float16).reshape(ne1, n_native_blocks_per_row)
-    native_scales = (native_scales.astype(np.float32) * 2.0).astype(np.float16)
+    native_scales = scales_raw.view(np.float16).reshape(ne1, n_native)
 
-    # 2-bit codes are stored as 4 codes per byte, LSB-first within each
-    # byte — ORT's MatMulNBits expects the same packing, so we copy the
-    # bytes through unchanged. Reshape only: each 512-element native
-    # block becomes _SUBBLOCKS_PER_NATIVE = 4 consecutive 128-element
-    # ORT sub-blocks of 32 bytes each (128·2/8 = 32).
-    codes_packed = arr[:, :, 2:]  # (N, n_native_blocks, 128)
-    blob_size = TENCENT_Q1_0_ORT_BLOCK_SIZE * TENCENT_Q1_0_ORT_BITS // 8  # 32
-    n_ort_blocks_per_row = n_native_blocks_per_row * _SUBBLOCKS_PER_NATIVE
-    weight = codes_packed.reshape(ne1, n_ort_blocks_per_row, blob_size).copy()
+    # Remaining bytes: 2-bit codes packed 4 per byte, LSB-first.
+    codes_2bit = arr[:, :, 2:].reshape(ne1, n_native, TENCENT_Q1_0_NATIVE_BLOCK_SIZE // 4)
+    return native_scales, codes_2bit, ne1, n_native
 
-    # Replicate each native scale across its 4 sub-blocks so the
-    # per-block scales array matches (N, n_ort_blocks).
-    scales = np.repeat(native_scales, _SUBBLOCKS_PER_NATIVE, axis=1)
 
-    # Float zero point: one fp32 value per ORT block, all = 1.5.
-    # ORT MatMulNBits<float> registers T3 = {uint8, float}, so float-zp
-    # must be float32 for fp32 models. (For fp16 models we'd want fp16;
-    # the GGUF builder currently uses fp32 weight application then casts,
-    # so float32 is the right intermediate dtype.)
+def _pack_native_2bit(
+    native_scales: np.ndarray,
+    codes_2bit: np.ndarray,
+    ne1: int,
+    n_native: int,
+) -> RepackedTensor:
+    """Pack Tencent codes as native ``MatMulNBits bits=2`` + float zp=1.5.
+
+    The on-disk 2-bit codes match ORT's bit-packing exactly, so the
+    bytes are copied through unchanged. We expose
+    ``effective_scale = 2 · stored_scale`` so that the
+    ``effective_scale · (B − 1.5)`` dequant formula produces
+    ``stored_scale · {−3, −1, +1, +3}[B]``.
+
+    Requires onnxruntime that includes the ``bits=2`` float zero-point
+    CPU path (PR #28354, expected in 1.27+). See
+    `microsoft/onnxruntime#28552
+    <https://github.com/microsoft/onnxruntime/issues/28552>`_ for the
+    CPU performance limitation that motivates the default-off
+    ``flags.tencent_q1_0_use_native_2bit``.
+    """
+    bits = 2
+    blob_size = TENCENT_Q1_0_ORT_BLOCK_SIZE * bits // 8  # 32
+    n_ort_blocks_per_row = n_native * _SUBBLOCKS_PER_NATIVE
+
+    # Bytes pass through; reshape splits each 512-elt native block into
+    # 4 consecutive 128-elt sub-blocks of 32 bytes each.
+    weight = codes_2bit.reshape(ne1, n_ort_blocks_per_row, blob_size).copy()
+
+    # effective_scale = 2 · stored_scale, replicated across the 4 sub-blocks.
+    effective_scales = (native_scales.astype(np.float32) * 2.0).astype(np.float16)
+    scales = np.repeat(effective_scales, _SUBBLOCKS_PER_NATIVE, axis=1)
+
+    # ORT MatMulNBits<float> registers T3 = {uint8, float}; use fp32.
     zero_points = np.full(
         (ne1, n_ort_blocks_per_row),
-        TENCENT_Q1_0_ZERO_POINT,
+        TENCENT_Q1_0_NATIVE_ZERO_POINT,
         dtype=np.float32,
     )
 
@@ -221,5 +257,64 @@ def parse_tencent_q1_0_tensor(
         scales=scales,
         zero_points=zero_points,
         block_size=TENCENT_Q1_0_ORT_BLOCK_SIZE,
-        bits=TENCENT_Q1_0_ORT_BITS,
+        bits=bits,
+    )
+
+
+def _pack_inflated_4bit(
+    native_scales: np.ndarray,
+    codes_2bit: np.ndarray,
+    ne1: int,
+    n_native: int,
+) -> RepackedTensor:
+    """Pack Tencent codes as ``MatMulNBits bits=4`` + integer zp=3.
+
+    Inflates each 2-bit code ``c ∈ {0..3}`` to a 4-bit slot ``2c ∈
+    {0,2,4,6}``. With integer ``zp=3``, the dequant formula
+    ``scale·(B − 3)`` produces ``scale · {−3, −1, +1, +3}[c]`` — the
+    same SEQ codebook as the native form. ``scales`` carry the
+    unmodified ``stored_scale`` (no factor-of-2 fold-in: the codebook
+    offset of ``3`` between slots already encodes the SEQ ``2×`` step).
+
+    Doubles on-disk weight bytes vs the native form but exercises
+    ORT's well-optimised bits=4 packed-uint8 path. This is the default
+    until ORT's bits=2 + float-zp kernel is optimised (see
+    `microsoft/onnxruntime#28552
+    <https://github.com/microsoft/onnxruntime/issues/28552>`_).
+    """
+    bits = 4
+    blob_size = TENCENT_Q1_0_ORT_BLOCK_SIZE * bits // 8  # 64
+    n_ort_blocks_per_row = n_native * _SUBBLOCKS_PER_NATIVE
+
+    # Unpack 2-bit codes → 4 codes per byte, LSB-first slot k holds code k.
+    codes = np.empty(
+        (ne1, n_native, TENCENT_Q1_0_NATIVE_BLOCK_SIZE),
+        dtype=np.uint8,
+    )
+    for slot in range(4):
+        codes[:, :, slot::4] = (codes_2bit >> (2 * slot)) & np.uint8(0x3)
+
+    # Inflate c → 2c so dequant scale·(2c − 3) = scale·{−3,−1,+1,+3}[c].
+    codes_inflated = (codes * 2).astype(np.uint8)
+
+    # Split each native 512-elt block into 4 sub-blocks of 128 elements,
+    # then pack two nibbles per byte: byte[j] = (code[2j+1] << 4) | code[2j].
+    sub = codes_inflated.reshape(ne1, n_ort_blocks_per_row, TENCENT_Q1_0_ORT_BLOCK_SIZE)
+    pairs = sub.reshape(ne1, n_ort_blocks_per_row, TENCENT_Q1_0_ORT_BLOCK_SIZE // 2, 2)
+    weight = (pairs[..., 0] | (pairs[..., 1] << 4)).astype(np.uint8)
+
+    scales = np.repeat(native_scales, _SUBBLOCKS_PER_NATIVE, axis=1)
+
+    # Integer zp=3 packed 2 per byte: (3 << 4) | 3 = 0x33.
+    zp_cols = math.ceil(n_ort_blocks_per_row * bits / 8)
+    zero_points = np.full((ne1, zp_cols), 0x33, dtype=np.uint8)
+    if n_ort_blocks_per_row % 2 == 1:  # pragma: no cover — n_ort_blocks always even (4·n_native)
+        zero_points[:, -1] = 0x03
+
+    return RepackedTensor(
+        weight=weight,
+        scales=scales,
+        zero_points=zero_points,
+        block_size=TENCENT_Q1_0_ORT_BLOCK_SIZE,
+        bits=bits,
     )

--- a/src/mobius/integrations/gguf/_tencent_q1_0.py
+++ b/src/mobius/integrations/gguf/_tencent_q1_0.py
@@ -1,0 +1,213 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Reader for Tencent's custom Q1_0 layout used by Hy-MT1.5-1.8B-2bit.
+
+The HuggingFace repo ``AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF`` reuses
+``GGML_TYPE_Q1_0`` (id 41) as a tag but stores tensors with an
+**entirely different per-tensor layout** than llama.cpp mainline:
+
+* Mainline Q1_0 block (18 bytes, 128 elements):
+    ``[fp16 d][16B packed 1-bit signs]`` — dequant: ``bit ? +d : -d``.
+
+* Tencent Q1_0 block (130 bytes, 512 elements):
+    ``[fp16 scale][128B packed 2-bit codes, LSB-first slots]``
+    Codes ``c ∈ {0,1,2,3}`` dequantize via the SEQ codebook
+    ``{-1.5, -0.5, 0.5, 1.5}`` scaled by ``2·scale`` (equivalently
+    ``{-3, -1, +1, +3}·scale``). Each output row of ``K`` elements
+    splits into ``K/512`` blocks, each with its own scale.
+
+Because the on-disk row stride differs (~4× larger than mainline),
+mainline llama.cpp refuses to load these files — every tensor after
+the first Q1_0 entry lands at the wrong offset. gguf-py likewise
+under-reads tensor data. We bypass the size calculation entirely by
+reading from the **explicit per-tensor file offset** stored in the
+GGUF header.
+
+The output of :func:`parse_tencent_q1_0_tensor` is a
+:class:`~mobius.integrations.gguf._repacker.RepackedTensor` whose 2-bit
+codes have been inflated to 4-bit slots (codes ∈ ``{0, 2, 4, 6}``) and
+paired with integer zero-point ``3``. ORT's ``MatMulNBits`` then
+computes ``scale · (B − 3)`` which equals ``{-3·s, -1·s, +1·s, +3·s}``,
+i.e. exactly Tencent's dequantization.
+
+Two implementation details forced by current ORT CPU kernel limits:
+
+* We use 4-bit MatMulNBits (not 2-bit) because the CPU kernel does not
+  yet support float-valued zero-points at ``bits=2``, which is what
+  the half-integer SEQ offset ``1.5`` would otherwise require.
+* The output ``block_size`` is ``128``, not Tencent's native ``512``,
+  because the CPU kernel silently produces zeros for
+  ``bits=4, block_size=512``. Each Tencent 512-element scale is
+  replicated across 4 consecutive ORT blocks of 128 elements; the
+  dequantized values are identical.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "TENCENT_Q1_0_NATIVE_BLOCK_SIZE",
+    "TENCENT_Q1_0_ORT_BLOCK_SIZE",
+    "is_tencent_q1_0_layout",
+    "parse_tencent_q1_0_tensor",
+]
+
+import math
+import os
+
+import numpy as np
+
+from mobius.integrations.gguf._repacker import RepackedTensor
+
+# Native Tencent block size (one fp16 scale governs this many weights).
+TENCENT_Q1_0_NATIVE_BLOCK_SIZE = 512
+
+# Block size we expose to ORT's MatMulNBits. The native 512 is rejected
+# silently by the CPU kernel (returns zeros), so we replicate each
+# native scale across 4 ORT sub-blocks of 128 elements.
+TENCENT_Q1_0_ORT_BLOCK_SIZE = 128
+
+# Per native block on-disk: 2 bytes (fp16 scale) + 512·2/8 = 128 bytes codes.
+_TENCENT_Q1_0_BLOCK_BYTES = 2 + TENCENT_Q1_0_NATIVE_BLOCK_SIZE // 4  # 130
+
+_SUBBLOCKS_PER_NATIVE = TENCENT_Q1_0_NATIVE_BLOCK_SIZE // TENCENT_Q1_0_ORT_BLOCK_SIZE  # 4
+
+
+def is_tencent_q1_0_layout(gguf_model) -> bool:
+    """Detect whether *gguf_model* uses Tencent's custom Q1_0 layout.
+
+    Heuristic: any Q1_0 (type 41) tensor whose total on-disk size exceeds
+    the mainline ``ggml_row_size`` value is using the Tencent layout. We
+    compute the actual byte span from consecutive tensor offsets and
+    compare against the mainline expectation.
+
+    Returns ``True`` iff the file is recognisably Tencent-formatted.
+    """
+    from gguf import GGMLQuantizationType
+
+    reader = gguf_model._reader
+    tensors = sorted(
+        reader.tensors,
+        key=lambda t: _tensor_data_offset(t),
+    )
+    for i, t in enumerate(tensors):
+        if t.tensor_type != GGMLQuantizationType.Q1_0:
+            continue
+        if i + 1 >= len(tensors):
+            continue
+        actual_span = _tensor_data_offset(tensors[i + 1]) - _tensor_data_offset(t)
+        ne0 = int(t.shape[0])
+        ne1 = int(t.shape[1]) if len(t.shape) > 1 else 1
+        mainline_size = ne0 * ne1 * 18 // 128
+        if actual_span >= mainline_size + 130:  # one Tencent block bigger
+            return True
+    return False
+
+
+def _tensor_data_offset(tensor) -> int:
+    """Return the file-relative data offset for a GGUF reader tensor."""
+    # Each tensor's metadata ends with the data offset (relative to the
+    # data section start). It is the last part in the field record.
+    return int(tensor.field.parts[tensor.field.data[-1]][0])
+
+
+def parse_tencent_q1_0_tensor(
+    file_path: str | os.PathLike,
+    data_section_offset: int,
+    tensor,
+) -> RepackedTensor:
+    """Parse one Tencent-Q1_0 tensor into MatMulNBits-ready arrays.
+
+    Args:
+        file_path: Path to the source ``.gguf`` file.
+        data_section_offset: Absolute byte offset where the GGUF data
+            section begins (``GGUFReader.data_offset``).
+        tensor: ``gguf.ReaderTensor`` for the target weight. Must have
+            ``tensor_type == GGML_TYPE_Q1_0`` and a 2D shape.
+
+    Returns:
+        A :class:`RepackedTensor` with ``bits=4`` and
+        ``block_size=512``. Codes are inflated from 2-bit ``c`` to 4-bit
+        ``2·c``; zero-points are packed integer ``3``; scales are the
+        per-block fp16 values read from disk (unchanged).
+    """
+    ne0 = int(tensor.shape[0])  # K (input features per output row)
+    ne1 = int(tensor.shape[1])  # N (output features)
+    if ne0 % TENCENT_Q1_0_NATIVE_BLOCK_SIZE != 0:
+        raise ValueError(
+            f"Tensor {tensor.name!r} has K={ne0} not divisible by "
+            f"Tencent Q1_0 native block size {TENCENT_Q1_0_NATIVE_BLOCK_SIZE}"
+        )
+
+    n_native_blocks_per_row = ne0 // TENCENT_Q1_0_NATIVE_BLOCK_SIZE
+    bytes_per_row = n_native_blocks_per_row * _TENCENT_Q1_0_BLOCK_BYTES
+    total_bytes = ne1 * bytes_per_row
+
+    abs_offset = data_section_offset + _tensor_data_offset(tensor)
+    with open(file_path, "rb") as f:
+        f.seek(abs_offset)
+        blob = f.read(total_bytes)
+    if len(blob) != total_bytes:
+        raise IOError(
+            f"Short read for {tensor.name!r}: got {len(blob)} bytes, expected {total_bytes}"
+        )
+
+    arr = np.frombuffer(blob, dtype=np.uint8).reshape(
+        ne1, n_native_blocks_per_row, _TENCENT_Q1_0_BLOCK_BYTES
+    )
+
+    # Per native-block fp16 scales: shape (N, n_native_blocks_per_row).
+    scales_raw = arr[:, :, :2].copy()
+    native_scales = scales_raw.view(np.float16).reshape(ne1, n_native_blocks_per_row)
+
+    # Unpack 2-bit codes (4 codes per byte, LSB-first within each byte).
+    codes_packed = arr[:, :, 2:]  # (N, n_native_blocks, native_block_size/4 = 128)
+    codes_2bit = np.empty(
+        (ne1, n_native_blocks_per_row, TENCENT_Q1_0_NATIVE_BLOCK_SIZE),
+        dtype=np.uint8,
+    )
+    for slot in range(4):
+        codes_2bit[:, :, slot::4] = (codes_packed >> (2 * slot)) & np.uint8(0x3)
+
+    # Inflate 2-bit codes to 4-bit slots so the result fits ORT's
+    # MatMulNBits bits=4 kernel:
+    #     2-bit code c ∈ {0,1,2,3} → 4-bit slot 2c ∈ {0,2,4,6}
+    # Combined with zp=3, dequant gives scale·(2c - 3) ∈ {-3,-1,+1,+3}·scale
+    # — exactly Tencent's SEQ-codebook dequantization.
+    codes_4bit = (codes_2bit * 2).astype(np.uint8)  # ∈ {0,2,4,6}
+
+    # Split each native 512-element block into _SUBBLOCKS_PER_NATIVE
+    # sub-blocks of TENCENT_Q1_0_ORT_BLOCK_SIZE elements, then pack two
+    # nibbles per byte for MatMulNBits:
+    #     byte[j] = (code[2j+1] << 4) | code[2j]
+    codes_sub = codes_4bit.reshape(
+        ne1,
+        n_native_blocks_per_row * _SUBBLOCKS_PER_NATIVE,
+        TENCENT_Q1_0_ORT_BLOCK_SIZE,
+    )
+    pairs = codes_sub.reshape(ne1, codes_sub.shape[1], TENCENT_Q1_0_ORT_BLOCK_SIZE // 2, 2)
+    weight = (pairs[..., 0] | (pairs[..., 1] << 4)).astype(np.uint8)
+    # Shape: (N, n_ort_blocks, ort_block_size * bits / 8 = 64)
+
+    n_ort_blocks_per_row = n_native_blocks_per_row * _SUBBLOCKS_PER_NATIVE
+
+    # Replicate each native scale across its 4 sub-blocks so the
+    # MatMulNBits per-block scales array matches the (N, n_ort_blocks)
+    # shape with identical values within each native group.
+    scales = np.repeat(native_scales, _SUBBLOCKS_PER_NATIVE, axis=1)
+
+    # Zero-points: integer 3 packed at 4 bits each, two per byte.
+    # byte = (3 << 4) | 3 = 0x33. Per output row: ceil(n_ort_blocks*4/8) bytes.
+    zp_cols = math.ceil(n_ort_blocks_per_row * 4 / 8)
+    zero_points = np.full((ne1, zp_cols), 0x33, dtype=np.uint8)
+    # Odd block count: high nibble of the last byte is padding; clear it.
+    if n_ort_blocks_per_row % 2 == 1:
+        zero_points[:, -1] = 0x03
+
+    return RepackedTensor(
+        weight=weight,
+        scales=scales,
+        zero_points=zero_points,
+        block_size=TENCENT_Q1_0_ORT_BLOCK_SIZE,
+        bits=4,
+    )

--- a/src/mobius/integrations/gguf/_tencent_q1_0.py
+++ b/src/mobius/integrations/gguf/_tencent_q1_0.py
@@ -88,7 +88,7 @@ def is_tencent_q1_0_layout(gguf_model) -> bool:
     reader = gguf_model._reader
     tensors = sorted(
         reader.tensors,
-        key=lambda t: _tensor_data_offset(t),
+        key=_tensor_data_offset,
     )
     for i, t in enumerate(tensors):
         if t.tensor_type != GGMLQuantizationType.Q1_0:

--- a/src/mobius/integrations/gguf/_tencent_q1_0.py
+++ b/src/mobius/integrations/gguf/_tencent_q1_0.py
@@ -12,12 +12,12 @@ The HuggingFace repo ``AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF`` reuses
 
 * Tencent Q1_0 block (130 bytes, 512 elements):
     ``[fp16 scale][128B packed 2-bit codes, LSB-first slots]``
-    Codes ``c ∈ {0,1,2,3}`` dequantize via the SEQ codebook
-    ``{-1.5, -0.5, 0.5, 1.5}`` scaled by ``2·scale`` (equivalently
-    ``{-3, -1, +1, +3}·scale``). Each output row of ``K`` elements
+    Codes ``c in {0,1,2,3}`` dequantize via the SEQ codebook
+    ``{-1.5, -0.5, 0.5, 1.5}`` scaled by ``2*scale`` (equivalently
+    ``{-3, -1, +1, +3}*scale``). Each output row of ``K`` elements
     splits into ``K/512`` blocks, each with its own scale.
 
-Because the on-disk row stride differs (~4× larger than mainline),
+Because the on-disk row stride differs (~4x larger than mainline),
 mainline llama.cpp refuses to load these files — every tensor after
 the first Q1_0 entry lands at the wrong offset. gguf-py likewise
 under-reads tensor data. We bypass the size calculation entirely by
@@ -28,17 +28,17 @@ Two MatMulNBits representations are available, selected by the
 ``flags.tencent_q1_0_use_native_2bit`` flag:
 
 * **Inflated bits=4** (default; ``flag=False``): each 2-bit code
-  ``c ∈ {0..3}`` is doubled to a 4-bit slot ``2c ∈ {0,2,4,6}`` and
-  paired with integer ``zero_point = 3``. Dequant: ``scale·(B − 3) =
-  scale · {−3, −1, +1, +3}[c]``. Doubles on-disk weight bytes (4 bpw
+  ``c in {0..3}`` is doubled to a 4-bit slot ``2c in {0,2,4,6}`` and
+  paired with integer ``zero_point = 3``. Dequant: ``scale*(B - 3) =
+  scale * {-3, -1, +1, +3}[c]``. Doubles on-disk weight bytes (4 bpw
   packed) but uses ORT's well-optimised bits=4 packed-uint8 kernel,
-  giving ~20× higher CPU throughput than the native form.
+  giving ~20x higher CPU throughput than the native form.
 
 * **Native bits=2** (``flag=True``): the 2-bit codes are copied
   through unchanged and paired with float ``zero_point = 1.5`` and
-  ``effective_scale = 2·stored_scale``. Dequant:
-  ``effective_scale·(B − 1.5) = stored_scale · {−3,−1,+1,+3}[c]``.
-  Requires ORT ≥ 1.27 (`microsoft/onnxruntime#28354
+  ``effective_scale = 2*stored_scale``. Dequant:
+  ``effective_scale*(B - 1.5) = stored_scale * {-3,-1,+1,+3}[c]``.
+  Requires ORT >= 1.27 (`microsoft/onnxruntime#28354
   <https://github.com/microsoft/onnxruntime/pull/28354>`_), and the
   CPU path is currently a naive scalar fallback (`#28552
   <https://github.com/microsoft/onnxruntime/issues/28552>`_).
@@ -82,15 +82,13 @@ TENCENT_Q1_0_ORT_BLOCK_SIZE = 128
 
 # Float zero point that produces the SEQ codebook centred between
 # integer codes 0..3 in the native bits=2 representation:
-#   stored_scale · {-3, -1, +1, +3}[c] = (2 · stored_scale) · (c - 1.5)
+#   stored_scale * {-3, -1, +1, +3}[c] = (2 * stored_scale) * (c - 1.5)
 TENCENT_Q1_0_NATIVE_ZERO_POINT = 1.5
 
-# Per native block on-disk: 2 bytes (fp16 scale) + 512·2/8 = 128 bytes codes.
+# Per native block on-disk: 2 bytes (fp16 scale) + 512*2/8 = 128 bytes codes.
 _TENCENT_Q1_0_BLOCK_BYTES = 2 + TENCENT_Q1_0_NATIVE_BLOCK_SIZE // 4  # 130
 
-_SUBBLOCKS_PER_NATIVE = (
-    TENCENT_Q1_0_NATIVE_BLOCK_SIZE // TENCENT_Q1_0_ORT_BLOCK_SIZE
-)  # 4
+_SUBBLOCKS_PER_NATIVE = TENCENT_Q1_0_NATIVE_BLOCK_SIZE // TENCENT_Q1_0_ORT_BLOCK_SIZE  # 4
 
 
 def is_tencent_q1_0_layout(gguf_model) -> bool:
@@ -142,7 +140,7 @@ def parse_tencent_q1_0_tensor(
     :attr:`flags.tencent_q1_0_use_native_2bit`:
 
     * ``False`` (default): :func:`_pack_inflated_4bit` — codes inflated
-      to 4-bit slots, integer ``zp=3``. Fast on CPU EP but 2× the
+      to 4-bit slots, integer ``zp=3``. Fast on CPU EP but 2x the
       on-disk weight bytes.
     * ``True``: :func:`_pack_native_2bit` — codes passed through,
       float ``zp=1.5``. Native 2 bpw but slow on CPU EP today.
@@ -197,7 +195,7 @@ def _read_tencent_blocks(
         f.seek(abs_offset)
         blob = f.read(total_bytes)
     if len(blob) != total_bytes:
-        raise IOError(
+        raise OSError(
             f"Short read for {tensor.name!r}: got {len(blob)} bytes, expected {total_bytes}"
         )
 
@@ -222,9 +220,9 @@ def _pack_native_2bit(
 
     The on-disk 2-bit codes match ORT's bit-packing exactly, so the
     bytes are copied through unchanged. We expose
-    ``effective_scale = 2 · stored_scale`` so that the
-    ``effective_scale · (B − 1.5)`` dequant formula produces
-    ``stored_scale · {−3, −1, +1, +3}[B]``.
+    ``effective_scale = 2 * stored_scale`` so that the
+    ``effective_scale * (B - 1.5)`` dequant formula produces
+    ``stored_scale * {-3, -1, +1, +3}[B]``.
 
     Requires onnxruntime that includes the ``bits=2`` float zero-point
     CPU path (PR #28354, expected in 1.27+). See
@@ -241,7 +239,7 @@ def _pack_native_2bit(
     # 4 consecutive 128-elt sub-blocks of 32 bytes each.
     weight = codes_2bit.reshape(ne1, n_ort_blocks_per_row, blob_size).copy()
 
-    # effective_scale = 2 · stored_scale, replicated across the 4 sub-blocks.
+    # effective_scale = 2 * stored_scale, replicated across the 4 sub-blocks.
     effective_scales = (native_scales.astype(np.float32) * 2.0).astype(np.float16)
     scales = np.repeat(effective_scales, _SUBBLOCKS_PER_NATIVE, axis=1)
 
@@ -269,12 +267,12 @@ def _pack_inflated_4bit(
 ) -> RepackedTensor:
     """Pack Tencent codes as ``MatMulNBits bits=4`` + integer zp=3.
 
-    Inflates each 2-bit code ``c ∈ {0..3}`` to a 4-bit slot ``2c ∈
+    Inflates each 2-bit code ``c in {0..3}`` to a 4-bit slot ``2c in
     {0,2,4,6}``. With integer ``zp=3``, the dequant formula
-    ``scale·(B − 3)`` produces ``scale · {−3, −1, +1, +3}[c]`` — the
+    ``scale*(B - 3)`` produces ``scale * {-3, -1, +1, +3}[c]`` — the
     same SEQ codebook as the native form. ``scales`` carry the
     unmodified ``stored_scale`` (no factor-of-2 fold-in: the codebook
-    offset of ``3`` between slots already encodes the SEQ ``2×`` step).
+    offset of ``3`` between slots already encodes the SEQ ``2x`` step).
 
     Doubles on-disk weight bytes vs the native form but exercises
     ORT's well-optimised bits=4 packed-uint8 path. This is the default
@@ -285,7 +283,7 @@ def _pack_inflated_4bit(
     bits = 4
     n_ort_blocks_per_row = n_native * _SUBBLOCKS_PER_NATIVE
 
-    # Unpack 2-bit codes → 4 codes per byte, LSB-first slot k holds code k.
+    # Unpack 2-bit codes -> 4 codes per byte, LSB-first slot k holds code k.
     codes = np.empty(
         (ne1, n_native, TENCENT_Q1_0_NATIVE_BLOCK_SIZE),
         dtype=np.uint8,
@@ -293,7 +291,7 @@ def _pack_inflated_4bit(
     for slot in range(4):
         codes[:, :, slot::4] = (codes_2bit >> (2 * slot)) & np.uint8(0x3)
 
-    # Inflate c → 2c so dequant scale·(2c − 3) = scale·{−3,−1,+1,+3}[c].
+    # Inflate c -> 2c so dequant scale*(2c - 3) = scale*{-3,-1,+1,+3}[c].
     codes_inflated = (codes * 2).astype(np.uint8)
 
     # Split each native 512-elt block into 4 sub-blocks of 128 elements,
@@ -307,7 +305,9 @@ def _pack_inflated_4bit(
     # Integer zp=3 packed 2 per byte: (3 << 4) | 3 = 0x33.
     zp_cols = math.ceil(n_ort_blocks_per_row * bits / 8)
     zero_points = np.full((ne1, zp_cols), 0x33, dtype=np.uint8)
-    if n_ort_blocks_per_row % 2 == 1:  # pragma: no cover — n_ort_blocks always even (4·n_native)
+    if (
+        n_ort_blocks_per_row % 2 == 1
+    ):  # pragma: no cover — n_ort_blocks always even (4*n_native)
         zero_points[:, -1] = 0x03
 
     return RepackedTensor(

--- a/src/mobius/integrations/gguf/_tencent_q1_0.py
+++ b/src/mobius/integrations/gguf/_tencent_q1_0.py
@@ -31,16 +31,24 @@ paired with integer zero-point ``3``. ORT's ``MatMulNBits`` then
 computes ``scale · (B − 3)`` which equals ``{-3·s, -1·s, +1·s, +3·s}``,
 i.e. exactly Tencent's dequantization.
 
-Two implementation details forced by current ORT CPU kernel limits:
+Two implementation details forced by current ORT CPU kernel limits
+(both expected to be fixed upstream — see TODOs below):
 
-* We use 4-bit MatMulNBits (not 2-bit) because the CPU kernel does not
-  yet support float-valued zero-points at ``bits=2``, which is what
-  the half-integer SEQ offset ``1.5`` would otherwise require.
+* We use 4-bit MatMulNBits (not 2-bit) because the ORT CPU kernel
+  rejects ``bits=2`` on its **unpacked (float) zero-point** path:
+  ``Only 4b quantization is supported for unpacked compute using
+  non-MLAS de-quantization for now``
+  (``contrib_ops/cpu/quantization/matmul_nbits.cc``). The integer-zp
+  path at ``bits=2`` works, but integer zp can only encode integer
+  offsets {0..3}, whereas SEQ's half-integer offset ``1.5`` requires
+  the float-zp path. TODO: drop the inflation once that path is
+  generalised to all ``bits`` values.
 * The output ``block_size`` is ``128``, not Tencent's native ``512``,
   because the CPU kernel silently produces zeros for
   ``bits=4, block_size=512``. Each Tencent 512-element scale is
   replicated across 4 consecutive ORT blocks of 128 elements; the
-  dequantized values are identical.
+  dequantized values are identical. TODO: drop the replication once
+  the kernel handles ``block_size > 256``.
 """
 
 from __future__ import annotations

--- a/src/mobius/integrations/gguf/_tencent_q1_0.py
+++ b/src/mobius/integrations/gguf/_tencent_q1_0.py
@@ -25,30 +25,30 @@ reading from the **explicit per-tensor file offset** stored in the
 GGUF header.
 
 The output of :func:`parse_tencent_q1_0_tensor` is a
-:class:`~mobius.integrations.gguf._repacker.RepackedTensor` whose 2-bit
-codes have been inflated to 4-bit slots (codes ∈ ``{0, 2, 4, 6}``) and
-paired with integer zero-point ``3``. ORT's ``MatMulNBits`` then
-computes ``scale · (B − 3)`` which equals ``{-3·s, -1·s, +1·s, +3·s}``,
-i.e. exactly Tencent's dequantization.
+:class:`~mobius.integrations.gguf._repacker.RepackedTensor` that
+preserves the native 2-bit codes and pairs them with a float
+zero-point of ``1.5`` and an *effective* per-block scale of
+``2·stored_scale``. The ORT ``MatMulNBits`` op then dequantizes via
+``effective_scale · (B − 1.5) = stored_scale · {−3, −1, +1, +3}[c]``,
+exactly Tencent's SEQ codebook.
 
-Two implementation details forced by current ORT CPU kernel limits
-(both expected to be fixed upstream — see TODOs below):
+ORT version requirement: this representation needs the
+**float zero-point** path for ``bits=2`` that was added in
+`microsoft/onnxruntime#28354
+<https://github.com/microsoft/onnxruntime/pull/28354>`_ (merged
+2026-05-13, expected in onnxruntime 1.27 and later). Older
+versions throw
+``Only 4b quantization is supported for unpacked compute using
+non-MLAS de-quantization for now`` from
+``ComputeBUnpacked`` at first inference.
 
-* We use 4-bit MatMulNBits (not 2-bit) because the ORT CPU kernel
-  rejects ``bits=2`` on its **unpacked (float) zero-point** path:
-  ``Only 4b quantization is supported for unpacked compute using
-  non-MLAS de-quantization for now``
-  (``contrib_ops/cpu/quantization/matmul_nbits.cc``). The integer-zp
-  path at ``bits=2`` works, but integer zp can only encode integer
-  offsets {0..3}, whereas SEQ's half-integer offset ``1.5`` requires
-  the float-zp path. TODO: drop the inflation once that path is
-  generalised to all ``bits`` values.
-* The output ``block_size`` is ``128``, not Tencent's native ``512``,
-  because the CPU kernel silently produces zeros for
-  ``bits=4, block_size=512``. Each Tencent 512-element scale is
-  replicated across 4 consecutive ORT blocks of 128 elements; the
-  dequantized values are identical. TODO: drop the replication once
-  the kernel handles ``block_size > 256``.
+Block-size note: the native Tencent block size is 512 elements, but
+the ORT CPU dequant kernel silently returns zeros for ``block_size``
+larger than 256 (see `microsoft/onnxruntime#28551
+<https://github.com/microsoft/onnxruntime/issues/28551>`_). Each
+Tencent 512-element scale is therefore replicated across 4
+``MatMulNBits`` sub-blocks of 128 elements; the dequantized values
+are bit-identical.
 """
 
 from __future__ import annotations
@@ -56,11 +56,12 @@ from __future__ import annotations
 __all__ = [
     "TENCENT_Q1_0_NATIVE_BLOCK_SIZE",
     "TENCENT_Q1_0_ORT_BLOCK_SIZE",
+    "TENCENT_Q1_0_ORT_BITS",
+    "TENCENT_Q1_0_ZERO_POINT",
     "is_tencent_q1_0_layout",
     "parse_tencent_q1_0_tensor",
 ]
 
-import math
 import os
 
 import numpy as np
@@ -75,10 +76,23 @@ TENCENT_Q1_0_NATIVE_BLOCK_SIZE = 512
 # native scale across 4 ORT sub-blocks of 128 elements.
 TENCENT_Q1_0_ORT_BLOCK_SIZE = 128
 
+# Bit width emitted to ORT. We keep Tencent's native 2 bits/elt rather
+# than inflating to 4, halving the on-disk weight bytes. This relies on
+# the bits=2 float-zero-point path landed in ORT PR #28354.
+TENCENT_Q1_0_ORT_BITS = 2
+
+# Float zero point that produces the SEQ codebook centred between
+# integer codes 0..3:
+#   stored_scale · {-3, -1, +1, +3}[c]
+#     = (2 · stored_scale) · (c - 1.5)
+TENCENT_Q1_0_ZERO_POINT = 1.5
+
 # Per native block on-disk: 2 bytes (fp16 scale) + 512·2/8 = 128 bytes codes.
 _TENCENT_Q1_0_BLOCK_BYTES = 2 + TENCENT_Q1_0_NATIVE_BLOCK_SIZE // 4  # 130
 
-_SUBBLOCKS_PER_NATIVE = TENCENT_Q1_0_NATIVE_BLOCK_SIZE // TENCENT_Q1_0_ORT_BLOCK_SIZE  # 4
+_SUBBLOCKS_PER_NATIVE = (
+    TENCENT_Q1_0_NATIVE_BLOCK_SIZE // TENCENT_Q1_0_ORT_BLOCK_SIZE
+)  # 4
 
 
 def is_tencent_q1_0_layout(gguf_model) -> bool:
@@ -134,10 +148,16 @@ def parse_tencent_q1_0_tensor(
             ``tensor_type == GGML_TYPE_Q1_0`` and a 2D shape.
 
     Returns:
-        A :class:`RepackedTensor` with ``bits=4`` and
-        ``block_size=512``. Codes are inflated from 2-bit ``c`` to 4-bit
-        ``2·c``; zero-points are packed integer ``3``; scales are the
-        per-block fp16 values read from disk (unchanged).
+        A :class:`RepackedTensor` with ``bits=2`` and
+        ``block_size=128``. The 2-bit codes are passed through
+        unchanged (ORT's packing matches Tencent's LSB-first 4-codes-
+        per-byte layout); the per-block ``scales`` are
+        ``2·stored_scale`` so that ``effective_scale · (B − 1.5)``
+        matches the SEQ codebook ``stored_scale · {-3,-1,+1,+3}[B]``;
+        and ``zero_points`` is a float16 tensor of all 1.5.
+
+        Requires onnxruntime that includes the ``bits=2`` float
+        zero-point CPU path (PR #28354, expected in 1.27+).
     """
     ne0 = int(tensor.shape[0])  # K (input features per output row)
     ne1 = int(tensor.shape[1])  # N (output features)
@@ -164,58 +184,42 @@ def parse_tencent_q1_0_tensor(
         ne1, n_native_blocks_per_row, _TENCENT_Q1_0_BLOCK_BYTES
     )
 
-    # Per native-block fp16 scales: shape (N, n_native_blocks_per_row).
+    # Per native-block fp16 scales. We expose 2·stored_scale to ORT so
+    # that effective_scale·(B−1.5) = stored_scale·{-3,-1,+1,+3}[B]
+    # matches Tencent's SEQ codebook exactly.
     scales_raw = arr[:, :, :2].copy()
     native_scales = scales_raw.view(np.float16).reshape(ne1, n_native_blocks_per_row)
+    native_scales = (native_scales.astype(np.float32) * 2.0).astype(np.float16)
 
-    # Unpack 2-bit codes (4 codes per byte, LSB-first within each byte).
-    codes_packed = arr[:, :, 2:]  # (N, n_native_blocks, native_block_size/4 = 128)
-    codes_2bit = np.empty(
-        (ne1, n_native_blocks_per_row, TENCENT_Q1_0_NATIVE_BLOCK_SIZE),
-        dtype=np.uint8,
-    )
-    for slot in range(4):
-        codes_2bit[:, :, slot::4] = (codes_packed >> (2 * slot)) & np.uint8(0x3)
-
-    # Inflate 2-bit codes to 4-bit slots so the result fits ORT's
-    # MatMulNBits bits=4 kernel:
-    #     2-bit code c ∈ {0,1,2,3} → 4-bit slot 2c ∈ {0,2,4,6}
-    # Combined with zp=3, dequant gives scale·(2c - 3) ∈ {-3,-1,+1,+3}·scale
-    # — exactly Tencent's SEQ-codebook dequantization.
-    codes_4bit = (codes_2bit * 2).astype(np.uint8)  # ∈ {0,2,4,6}
-
-    # Split each native 512-element block into _SUBBLOCKS_PER_NATIVE
-    # sub-blocks of TENCENT_Q1_0_ORT_BLOCK_SIZE elements, then pack two
-    # nibbles per byte for MatMulNBits:
-    #     byte[j] = (code[2j+1] << 4) | code[2j]
-    codes_sub = codes_4bit.reshape(
-        ne1,
-        n_native_blocks_per_row * _SUBBLOCKS_PER_NATIVE,
-        TENCENT_Q1_0_ORT_BLOCK_SIZE,
-    )
-    pairs = codes_sub.reshape(ne1, codes_sub.shape[1], TENCENT_Q1_0_ORT_BLOCK_SIZE // 2, 2)
-    weight = (pairs[..., 0] | (pairs[..., 1] << 4)).astype(np.uint8)
-    # Shape: (N, n_ort_blocks, ort_block_size * bits / 8 = 64)
-
+    # 2-bit codes are stored as 4 codes per byte, LSB-first within each
+    # byte — ORT's MatMulNBits expects the same packing, so we copy the
+    # bytes through unchanged. Reshape only: each 512-element native
+    # block becomes _SUBBLOCKS_PER_NATIVE = 4 consecutive 128-element
+    # ORT sub-blocks of 32 bytes each (128·2/8 = 32).
+    codes_packed = arr[:, :, 2:]  # (N, n_native_blocks, 128)
+    blob_size = TENCENT_Q1_0_ORT_BLOCK_SIZE * TENCENT_Q1_0_ORT_BITS // 8  # 32
     n_ort_blocks_per_row = n_native_blocks_per_row * _SUBBLOCKS_PER_NATIVE
+    weight = codes_packed.reshape(ne1, n_ort_blocks_per_row, blob_size).copy()
 
     # Replicate each native scale across its 4 sub-blocks so the
-    # MatMulNBits per-block scales array matches the (N, n_ort_blocks)
-    # shape with identical values within each native group.
+    # per-block scales array matches (N, n_ort_blocks).
     scales = np.repeat(native_scales, _SUBBLOCKS_PER_NATIVE, axis=1)
 
-    # Zero-points: integer 3 packed at 4 bits each, two per byte.
-    # byte = (3 << 4) | 3 = 0x33. Per output row: ceil(n_ort_blocks*4/8) bytes.
-    zp_cols = math.ceil(n_ort_blocks_per_row * 4 / 8)
-    zero_points = np.full((ne1, zp_cols), 0x33, dtype=np.uint8)
-    # Odd block count: high nibble of the last byte is padding; clear it.
-    if n_ort_blocks_per_row % 2 == 1:
-        zero_points[:, -1] = 0x03
+    # Float zero point: one fp32 value per ORT block, all = 1.5.
+    # ORT MatMulNBits<float> registers T3 = {uint8, float}, so float-zp
+    # must be float32 for fp32 models. (For fp16 models we'd want fp16;
+    # the GGUF builder currently uses fp32 weight application then casts,
+    # so float32 is the right intermediate dtype.)
+    zero_points = np.full(
+        (ne1, n_ort_blocks_per_row),
+        TENCENT_Q1_0_ZERO_POINT,
+        dtype=np.float32,
+    )
 
     return RepackedTensor(
         weight=weight,
         scales=scales,
         zero_points=zero_points,
         block_size=TENCENT_Q1_0_ORT_BLOCK_SIZE,
-        bits=4,
+        bits=TENCENT_Q1_0_ORT_BITS,
     )

--- a/src/mobius/integrations/gguf/_tencent_q1_0_test.py
+++ b/src/mobius/integrations/gguf/_tencent_q1_0_test.py
@@ -1,0 +1,157 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for the Tencent custom Q1_0 parser.
+
+We synthesize Tencent-layout blocks in-memory and verify that the
+repacked weights, scales, and zero-points dequantize via the
+MatMulNBits ``bits=4, zp=3`` formula to the SEQ codebook
+``{-3, -1, +1, +3} * scale``.
+"""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from mobius.integrations.gguf._tencent_q1_0 import (
+    TENCENT_Q1_0_NATIVE_BLOCK_SIZE,
+    TENCENT_Q1_0_ORT_BLOCK_SIZE,
+    parse_tencent_q1_0_tensor,
+)
+
+
+def _pack_2bit_codes_lsb(codes: np.ndarray) -> bytes:
+    """Pack 2-bit codes ``c ∈ {0..3}`` into bytes (4 codes per byte, LSB-first)."""
+    assert codes.ndim == 1
+    assert codes.size % 4 == 0
+    out = bytearray(codes.size // 4)
+    for i, c in enumerate(codes):
+        out[i // 4] |= (int(c) & 0x3) << (2 * (i % 4))
+    return bytes(out)
+
+
+def _make_tencent_q1_0_block(scale: float, codes: list[int]) -> bytes:
+    """Build a single 130-byte Tencent Q1_0 block."""
+    assert len(codes) == TENCENT_Q1_0_NATIVE_BLOCK_SIZE
+    scale_bytes = struct.pack("<e", scale)  # fp16
+    code_bytes = _pack_2bit_codes_lsb(np.array(codes, dtype=np.uint8))
+    return scale_bytes + code_bytes
+
+
+class _FakeTensor:
+    """Minimal stand-in for ``gguf.ReaderTensor`` used in tests."""
+
+    def __init__(self, name: str, shape: tuple[int, int], offset: int):
+        self.name = name
+        # gguf stores shape as np.uint64 elements
+        self.shape = np.array(shape, dtype=np.uint64)
+        self.field = _FakeField(offset)
+
+
+class _FakeField:
+    def __init__(self, offset: int):
+        # _tensor_data_offset reads parts[data[-1]][0]; we wire that path.
+        self.parts = [np.array([offset], dtype=np.uint64)]
+        self.data = [0]
+
+
+def _round_trip(file_path: Path, ne0: int, ne1: int, codes: np.ndarray, scales: np.ndarray):
+    """Write a synthetic Tencent-Q1_0 tensor to disk and parse it back."""
+    n_native = ne0 // TENCENT_Q1_0_NATIVE_BLOCK_SIZE
+    with open(file_path, "wb") as f:
+        for n in range(ne1):
+            for b in range(n_native):
+                start = b * TENCENT_Q1_0_NATIVE_BLOCK_SIZE
+                end = start + TENCENT_Q1_0_NATIVE_BLOCK_SIZE
+                f.write(
+                    _make_tencent_q1_0_block(float(scales[n, b]), codes[n, start:end].tolist())
+                )
+    tensor = _FakeTensor("w", (ne0, ne1), offset=0)
+    return parse_tencent_q1_0_tensor(file_path, data_section_offset=0, tensor=tensor)
+
+
+class TestTencentQ10:
+    def test_block_size_constants(self):
+        assert TENCENT_Q1_0_NATIVE_BLOCK_SIZE == 512
+        assert TENCENT_Q1_0_ORT_BLOCK_SIZE == 128
+        assert TENCENT_Q1_0_NATIVE_BLOCK_SIZE % TENCENT_Q1_0_ORT_BLOCK_SIZE == 0
+
+    def test_single_block_shape(self, tmp_path: Path):
+        ne0, ne1 = 512, 1  # one native block, one output row
+        codes = np.zeros((ne1, ne0), dtype=np.uint8)
+        scales = np.full((ne1, 1), 0.5, dtype=np.float16)
+        result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, scales)
+        # bits=4, block_size=128 → blob_size = 128*4/8 = 64 bytes per sub-block
+        # 512 native = 4 sub-blocks
+        assert result.bits == 4
+        assert result.block_size == 128
+        assert result.weight.shape == (1, 4, 64)
+        # Scales replicated 4× across sub-blocks
+        assert result.scales.shape == (1, 4)
+        np.testing.assert_array_equal(result.scales, 0.5)
+        # zero_points packed 0x33 per byte. 4 sub-blocks → 2 bytes
+        assert result.zero_points.shape == (1, 2)
+        np.testing.assert_array_equal(result.zero_points, 0x33)
+
+    def test_all_code_0_packs_as_zeros(self, tmp_path: Path):
+        """Code 0 → 4-bit slot 0; dequant scale·(0-3) = -3·scale."""
+        ne0, ne1 = 512, 1
+        codes = np.zeros((ne1, ne0), dtype=np.uint8)
+        scales = np.ones((ne1, 1), dtype=np.float16)
+        result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, scales)
+        np.testing.assert_array_equal(result.weight, 0x00)
+
+    def test_all_code_3_packs_as_0x66(self, tmp_path: Path):
+        """Code 3 → 4-bit slot 6; byte = (6<<4) | 6 = 0x66."""
+        ne0, ne1 = 512, 1
+        codes = np.full((ne1, ne0), 3, dtype=np.uint8)
+        scales = np.ones((ne1, 1), dtype=np.float16)
+        result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, scales)
+        np.testing.assert_array_equal(result.weight, 0x66)
+
+    def test_dequant_round_trip_matches_seq_codebook(self, tmp_path: Path):
+        """End-to-end: dequant via MatMulNBits formula gives ±{1,3}·scale."""
+        ne0, ne1 = 512, 2
+        rng = np.random.default_rng(123)
+        codes = rng.integers(0, 4, size=(ne1, ne0)).astype(np.uint8)
+        scales = np.array(
+            [[0.25], [0.0625]], dtype=np.float16
+        )  # one scale per row (only 1 native block)
+        result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, scales)
+
+        # Manually dequantize MatMulNBits-style: nibble - 3, then * scale
+        N, n_blocks, blob = result.weight.shape  # (2, 4, 64)
+        nibbles = np.empty((N, n_blocks, blob * 2), dtype=np.uint8)
+        nibbles[:, :, 0::2] = result.weight & 0xF
+        nibbles[:, :, 1::2] = (result.weight >> 4) & 0xF
+        sc = result.scales.astype(np.float32)
+        deq = (nibbles.astype(np.float32) - 3) * sc[:, :, None]
+        deq = deq.reshape(N, n_blocks * blob * 2)
+
+        # Reference dequant: scale * {-3,-1,+1,+3}[code]
+        codebook = np.array([-3, -1, 1, 3], dtype=np.float32)
+        ref = scales.astype(np.float32) * codebook[codes]
+
+        np.testing.assert_allclose(deq, ref, rtol=0, atol=1e-3)
+
+    def test_multi_native_block_replicates_scales(self, tmp_path: Path):
+        """Each native scale should appear 4× consecutively in result.scales."""
+        ne0, ne1 = 1024, 3  # 2 native blocks per row
+        codes = np.zeros((ne1, ne0), dtype=np.uint8)
+        scales = np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]], dtype=np.float16)
+        result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, scales)
+        # 2 native blocks × 4 sub-blocks = 8 ORT blocks
+        assert result.scales.shape == (3, 8)
+        # Row 0: [0.1, 0.1, 0.1, 0.1, 0.2, 0.2, 0.2, 0.2]
+        expected = np.repeat(scales, 4, axis=1)
+        np.testing.assert_array_equal(result.scales, expected)
+
+    def test_rejects_unaligned_k(self, tmp_path: Path):
+        """K not divisible by 512 raises."""
+        tensor = _FakeTensor("w", (256, 1), offset=0)
+        with pytest.raises(ValueError, match="not divisible"):
+            parse_tencent_q1_0_tensor(tmp_path / "t.bin", 0, tensor)

--- a/src/mobius/integrations/gguf/_tencent_q1_0_test.py
+++ b/src/mobius/integrations/gguf/_tencent_q1_0_test.py
@@ -85,70 +85,80 @@ class TestTencentQ10:
         codes = np.zeros((ne1, ne0), dtype=np.uint8)
         scales = np.full((ne1, 1), 0.5, dtype=np.float16)
         result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, scales)
-        # bits=4, block_size=128 → blob_size = 128*4/8 = 64 bytes per sub-block
+        # bits=2, block_size=128 → blob_size = 128*2/8 = 32 bytes per sub-block
         # 512 native = 4 sub-blocks
-        assert result.bits == 4
+        assert result.bits == 2
         assert result.block_size == 128
-        assert result.weight.shape == (1, 4, 64)
-        # Scales replicated 4× across sub-blocks
+        assert result.weight.shape == (1, 4, 32)
+        # Effective scale exposed to ORT = 2 * stored_scale
         assert result.scales.shape == (1, 4)
-        np.testing.assert_array_equal(result.scales, 0.5)
-        # zero_points packed 0x33 per byte. 4 sub-blocks → 2 bytes
-        assert result.zero_points.shape == (1, 2)
-        np.testing.assert_array_equal(result.zero_points, 0x33)
+        np.testing.assert_allclose(result.scales.astype(np.float32), 1.0, rtol=0, atol=1e-3)
+        # Float zero_points: one per sub-block, all = 1.5
+        assert result.zero_points.shape == (1, 4)
+        assert result.zero_points.dtype == np.float32
+        np.testing.assert_array_equal(result.zero_points, 1.5)
 
     def test_all_code_0_packs_as_zeros(self, tmp_path: Path):
-        """Code 0 → 4-bit slot 0; dequant scale·(0-3) = -3·scale."""
+        """Code 0 in every slot → byte 0x00."""
         ne0, ne1 = 512, 1
         codes = np.zeros((ne1, ne0), dtype=np.uint8)
         scales = np.ones((ne1, 1), dtype=np.float16)
         result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, scales)
         np.testing.assert_array_equal(result.weight, 0x00)
 
-    def test_all_code_3_packs_as_0x66(self, tmp_path: Path):
-        """Code 3 → 4-bit slot 6; byte = (6<<4) | 6 = 0x66."""
+    def test_all_code_3_packs_as_0xff(self, tmp_path: Path):
+        """Code 3 in every slot → byte (3<<6)|(3<<4)|(3<<2)|3 = 0xFF."""
         ne0, ne1 = 512, 1
         codes = np.full((ne1, ne0), 3, dtype=np.uint8)
         scales = np.ones((ne1, 1), dtype=np.float16)
         result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, scales)
-        np.testing.assert_array_equal(result.weight, 0x66)
+        np.testing.assert_array_equal(result.weight, 0xFF)
 
     def test_dequant_round_trip_matches_seq_codebook(self, tmp_path: Path):
-        """End-to-end: dequant via MatMulNBits formula gives ±{1,3}·scale."""
+        """End-to-end: MatMulNBits dequant via the emitted tensors gives
+        ``stored_scale · {-3,-1,+1,+3}[code]``."""
         ne0, ne1 = 512, 2
         rng = np.random.default_rng(123)
         codes = rng.integers(0, 4, size=(ne1, ne0)).astype(np.uint8)
-        scales = np.array(
+        stored_scales = np.array(
             [[0.25], [0.0625]], dtype=np.float16
-        )  # one scale per row (only 1 native block)
-        result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, scales)
+        )  # one stored_scale per row (only 1 native block)
+        result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, stored_scales)
 
-        # Manually dequantize MatMulNBits-style: nibble - 3, then * scale
-        N, n_blocks, blob = result.weight.shape  # (2, 4, 64)
-        nibbles = np.empty((N, n_blocks, blob * 2), dtype=np.uint8)
-        nibbles[:, :, 0::2] = result.weight & 0xF
-        nibbles[:, :, 1::2] = (result.weight >> 4) & 0xF
+        # Unpack 2-bit codes from result.weight (LSB-first, 4 per byte)
+        N, n_blocks, blob = result.weight.shape  # (2, 4, 32)
+        codes_unpacked = np.empty((N, n_blocks, blob * 4), dtype=np.uint8)
+        for slot in range(4):
+            codes_unpacked[:, :, slot::4] = (result.weight >> (2 * slot)) & np.uint8(0x3)
+
+        # MatMulNBits dequant: (B - zp) * scale, zp = 1.5, scale = 2*stored
         sc = result.scales.astype(np.float32)
-        deq = (nibbles.astype(np.float32) - 3) * sc[:, :, None]
-        deq = deq.reshape(N, n_blocks * blob * 2)
+        zp = result.zero_points.astype(np.float32)
+        deq = (codes_unpacked.astype(np.float32) - zp[:, :, None]) * sc[:, :, None]
+        deq = deq.reshape(N, n_blocks * blob * 4)
 
-        # Reference dequant: scale * {-3,-1,+1,+3}[code]
+        # Reference: stored_scale * {-3,-1,+1,+3}[code]
         codebook = np.array([-3, -1, 1, 3], dtype=np.float32)
-        ref = scales.astype(np.float32) * codebook[codes]
+        ref = stored_scales.astype(np.float32) * codebook[codes]
 
         np.testing.assert_allclose(deq, ref, rtol=0, atol=1e-3)
 
     def test_multi_native_block_replicates_scales(self, tmp_path: Path):
-        """Each native scale should appear 4× consecutively in result.scales."""
+        """Each native scale should appear 4× consecutively in result.scales
+        (with the 2× SEQ factor folded in)."""
         ne0, ne1 = 1024, 3  # 2 native blocks per row
         codes = np.zeros((ne1, ne0), dtype=np.uint8)
-        scales = np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]], dtype=np.float16)
-        result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, scales)
+        stored = np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]], dtype=np.float16)
+        result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, stored)
         # 2 native blocks × 4 sub-blocks = 8 ORT blocks
         assert result.scales.shape == (3, 8)
-        # Row 0: [0.1, 0.1, 0.1, 0.1, 0.2, 0.2, 0.2, 0.2]
-        expected = np.repeat(scales, 4, axis=1)
-        np.testing.assert_array_equal(result.scales, expected)
+        # Row 0: [0.2, 0.2, 0.2, 0.2, 0.4, 0.4, 0.4, 0.4] (2 × stored)
+        expected = np.repeat(
+            (stored.astype(np.float32) * 2.0).astype(np.float16), 4, axis=1
+        )
+        np.testing.assert_allclose(
+            result.scales.astype(np.float32), expected.astype(np.float32), rtol=0, atol=1e-3
+        )
 
     def test_rejects_unaligned_k(self, tmp_path: Path):
         """K not divisible by 512 raises."""

--- a/src/mobius/integrations/gguf/_tencent_q1_0_test.py
+++ b/src/mobius/integrations/gguf/_tencent_q1_0_test.py
@@ -74,94 +74,138 @@ def _round_trip(file_path: Path, ne0: int, ne1: int, codes: np.ndarray, scales: 
     return parse_tencent_q1_0_tensor(file_path, data_section_offset=0, tensor=tensor)
 
 
-class TestTencentQ10:
+class TestTencentQ10DefaultInflated4Bit:
+    """Default flag: bits=4 packed-uint8 zp=3 (fast on CPU EP, 2× weight bytes)."""
+
     def test_block_size_constants(self):
         assert TENCENT_Q1_0_NATIVE_BLOCK_SIZE == 512
         assert TENCENT_Q1_0_ORT_BLOCK_SIZE == 128
         assert TENCENT_Q1_0_NATIVE_BLOCK_SIZE % TENCENT_Q1_0_ORT_BLOCK_SIZE == 0
 
     def test_single_block_shape(self, tmp_path: Path):
-        ne0, ne1 = 512, 1  # one native block, one output row
+        ne0, ne1 = 512, 1
         codes = np.zeros((ne1, ne0), dtype=np.uint8)
         scales = np.full((ne1, 1), 0.5, dtype=np.float16)
         result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, scales)
-        # bits=2, block_size=128 → blob_size = 128*2/8 = 32 bytes per sub-block
-        # 512 native = 4 sub-blocks
-        assert result.bits == 2
+        # bits=4, block_size=128 → blob_size = 128*4/8 = 64 bytes per sub-block
+        assert result.bits == 4
         assert result.block_size == 128
-        assert result.weight.shape == (1, 4, 32)
-        # Effective scale exposed to ORT = 2 * stored_scale
+        assert result.weight.shape == (1, 4, 64)
+        # Scales unchanged (factor-of-2 encoded in codebook offset, not scale)
         assert result.scales.shape == (1, 4)
-        np.testing.assert_allclose(result.scales.astype(np.float32), 1.0, rtol=0, atol=1e-3)
-        # Float zero_points: one per sub-block, all = 1.5
-        assert result.zero_points.shape == (1, 4)
-        assert result.zero_points.dtype == np.float32
-        np.testing.assert_array_equal(result.zero_points, 1.5)
+        np.testing.assert_array_equal(result.scales, 0.5)
+        # Packed uint8 zp=3: byte = 0x33. n_blocks=4 → ceil(4*4/8)=2 bytes.
+        assert result.zero_points.shape == (1, 2)
+        assert result.zero_points.dtype == np.uint8
+        np.testing.assert_array_equal(result.zero_points, 0x33)
 
     def test_all_code_0_packs_as_zeros(self, tmp_path: Path):
-        """Code 0 in every slot → byte 0x00."""
+        """c=0 → slot 0 → nibble pair (0,0) → byte 0x00."""
         ne0, ne1 = 512, 1
         codes = np.zeros((ne1, ne0), dtype=np.uint8)
         scales = np.ones((ne1, 1), dtype=np.float16)
         result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, scales)
         np.testing.assert_array_equal(result.weight, 0x00)
 
-    def test_all_code_3_packs_as_0xff(self, tmp_path: Path):
-        """Code 3 in every slot → byte (3<<6)|(3<<4)|(3<<2)|3 = 0xFF."""
+    def test_all_code_3_packs_as_0x66(self, tmp_path: Path):
+        """c=3 → slot 6 → nibble pair (6,6) → byte (6<<4)|6 = 0x66."""
         ne0, ne1 = 512, 1
         codes = np.full((ne1, ne0), 3, dtype=np.uint8)
         scales = np.ones((ne1, 1), dtype=np.float16)
         result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, scales)
-        np.testing.assert_array_equal(result.weight, 0xFF)
+        np.testing.assert_array_equal(result.weight, 0x66)
 
     def test_dequant_round_trip_matches_seq_codebook(self, tmp_path: Path):
-        """End-to-end: MatMulNBits dequant via the emitted tensors gives
+        """End-to-end: MatMulNBits dequant from emitted tensors gives
         ``stored_scale · {-3,-1,+1,+3}[code]``."""
         ne0, ne1 = 512, 2
         rng = np.random.default_rng(123)
         codes = rng.integers(0, 4, size=(ne1, ne0)).astype(np.uint8)
-        stored_scales = np.array(
-            [[0.25], [0.0625]], dtype=np.float16
-        )  # one stored_scale per row (only 1 native block)
+        stored_scales = np.array([[0.25], [0.0625]], dtype=np.float16)
         result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, stored_scales)
 
-        # Unpack 2-bit codes from result.weight (LSB-first, 4 per byte)
-        N, n_blocks, blob = result.weight.shape  # (2, 4, 32)
-        codes_unpacked = np.empty((N, n_blocks, blob * 4), dtype=np.uint8)
-        for slot in range(4):
-            codes_unpacked[:, :, slot::4] = (result.weight >> (2 * slot)) & np.uint8(0x3)
+        # Unpack 4-bit codes (2 per byte: byte = (high<<4)|low)
+        N, n_blocks, blob = result.weight.shape  # (2, 4, 64)
+        nibbles = np.empty((N, n_blocks, blob * 2), dtype=np.uint8)
+        nibbles[:, :, 0::2] = result.weight & 0xF
+        nibbles[:, :, 1::2] = (result.weight >> 4) & 0xF
 
-        # MatMulNBits dequant: (B - zp) * scale, zp = 1.5, scale = 2*stored
+        # MatMulNBits dequant: (B - zp) * scale, zp=3, scale = stored_scale
         sc = result.scales.astype(np.float32)
-        zp = result.zero_points.astype(np.float32)
-        deq = (codes_unpacked.astype(np.float32) - zp[:, :, None]) * sc[:, :, None]
-        deq = deq.reshape(N, n_blocks * blob * 4)
+        deq = (nibbles.astype(np.float32) - 3.0) * sc[:, :, None]
+        deq = deq.reshape(N, n_blocks * blob * 2)
 
-        # Reference: stored_scale * {-3,-1,+1,+3}[code]
         codebook = np.array([-3, -1, 1, 3], dtype=np.float32)
         ref = stored_scales.astype(np.float32) * codebook[codes]
-
         np.testing.assert_allclose(deq, ref, rtol=0, atol=1e-3)
 
+
+class TestTencentQ10NativeBits2:
+    """Opt-in flag: bits=2 + float zp=1.5 (native SEQ layout)."""
+
+    def test_single_block_shape(self, tmp_path: Path):
+        from mobius._flags import override_flags
+
+        ne0, ne1 = 512, 1
+        codes = np.zeros((ne1, ne0), dtype=np.uint8)
+        scales = np.full((ne1, 1), 0.5, dtype=np.float16)
+        with override_flags(tencent_q1_0_use_native_2bit=True):
+            result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, scales)
+        # bits=2, block_size=128 → blob_size = 128*2/8 = 32 bytes per sub-block
+        assert result.bits == 2
+        assert result.block_size == 128
+        assert result.weight.shape == (1, 4, 32)
+        # Effective scale = 2 * stored_scale = 1.0
+        np.testing.assert_allclose(result.scales.astype(np.float32), 1.0, rtol=0, atol=1e-3)
+        # Float zp = 1.5
+        assert result.zero_points.dtype == np.float32
+        assert result.zero_points.shape == (1, 4)
+        np.testing.assert_array_equal(result.zero_points, 1.5)
+
+    def test_dequant_round_trip_matches_seq_codebook(self, tmp_path: Path):
+        """Native path: (B - 1.5) * (2·stored_scale) gives the SEQ codebook."""
+        from mobius._flags import override_flags
+
+        ne0, ne1 = 512, 2
+        rng = np.random.default_rng(456)
+        codes = rng.integers(0, 4, size=(ne1, ne0)).astype(np.uint8)
+        stored_scales = np.array([[0.25], [0.0625]], dtype=np.float16)
+        with override_flags(tencent_q1_0_use_native_2bit=True):
+            result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, stored_scales)
+
+        N, n_blocks, blob = result.weight.shape  # (2, 4, 32)
+        codes_out = np.empty((N, n_blocks, blob * 4), dtype=np.uint8)
+        for slot in range(4):
+            codes_out[:, :, slot::4] = (result.weight >> (2 * slot)) & np.uint8(0x3)
+
+        sc = result.scales.astype(np.float32)
+        zp = result.zero_points.astype(np.float32)
+        deq = (codes_out.astype(np.float32) - zp[:, :, None]) * sc[:, :, None]
+        deq = deq.reshape(N, n_blocks * blob * 4)
+
+        codebook = np.array([-3, -1, 1, 3], dtype=np.float32)
+        ref = stored_scales.astype(np.float32) * codebook[codes]
+        np.testing.assert_allclose(deq, ref, rtol=0, atol=1e-3)
+
+
+class TestTencentQ10Shared:
+    """Tests that don't depend on the flag setting."""
+
     def test_multi_native_block_replicates_scales(self, tmp_path: Path):
-        """Each native scale should appear 4× consecutively in result.scales
-        (with the 2× SEQ factor folded in)."""
+        """Each native scale appears 4× consecutively (both packings)."""
         ne0, ne1 = 1024, 3  # 2 native blocks per row
         codes = np.zeros((ne1, ne0), dtype=np.uint8)
         stored = np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]], dtype=np.float16)
         result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, stored)
-        # 2 native blocks × 4 sub-blocks = 8 ORT blocks
+        # 2 native × 4 sub-blocks = 8 ORT blocks per row.
         assert result.scales.shape == (3, 8)
-        # Row 0: [0.2, 0.2, 0.2, 0.2, 0.4, 0.4, 0.4, 0.4] (2 × stored)
-        expected = np.repeat(
-            (stored.astype(np.float32) * 2.0).astype(np.float16), 4, axis=1
-        )
-        np.testing.assert_allclose(
-            result.scales.astype(np.float32), expected.astype(np.float32), rtol=0, atol=1e-3
-        )
+        # Default (bits=4) keeps stored_scale; native (bits=2) doubles it.
+        # In default mode we expect plain replication:
+        expected = np.repeat(stored, 4, axis=1)
+        np.testing.assert_array_equal(result.scales, expected)
 
     def test_rejects_unaligned_k(self, tmp_path: Path):
-        """K not divisible by 512 raises."""
+        """K not divisible by 512 raises in both modes."""
         tensor = _FakeTensor("w", (256, 1), offset=0)
         with pytest.raises(ValueError, match="not divisible"):
             parse_tencent_q1_0_tensor(tmp_path / "t.bin", 0, tensor)

--- a/src/mobius/integrations/gguf/_tencent_q1_0_test.py
+++ b/src/mobius/integrations/gguf/_tencent_q1_0_test.py
@@ -25,7 +25,7 @@ from mobius.integrations.gguf._tencent_q1_0 import (
 
 
 def _pack_2bit_codes_lsb(codes: np.ndarray) -> bytes:
-    """Pack 2-bit codes ``c ∈ {0..3}`` into bytes (4 codes per byte, LSB-first)."""
+    """Pack 2-bit codes ``c in {0..3}`` into bytes (4 codes per byte, LSB-first)."""
     assert codes.ndim == 1
     assert codes.size % 4 == 0
     out = bytearray(codes.size // 4)
@@ -75,7 +75,7 @@ def _round_trip(file_path: Path, ne0: int, ne1: int, codes: np.ndarray, scales: 
 
 
 class TestTencentQ10DefaultInflated4Bit:
-    """Default flag: bits=4 packed-uint8 zp=3 (fast on CPU EP, 2× weight bytes)."""
+    """Default flag: bits=4 packed-uint8 zp=3 (fast on CPU EP, 2x weight bytes)."""
 
     def test_block_size_constants(self):
         assert TENCENT_Q1_0_NATIVE_BLOCK_SIZE == 512
@@ -87,20 +87,20 @@ class TestTencentQ10DefaultInflated4Bit:
         codes = np.zeros((ne1, ne0), dtype=np.uint8)
         scales = np.full((ne1, 1), 0.5, dtype=np.float16)
         result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, scales)
-        # bits=4, block_size=128 → blob_size = 128*4/8 = 64 bytes per sub-block
+        # bits=4, block_size=128 -> blob_size = 128*4/8 = 64 bytes per sub-block
         assert result.bits == 4
         assert result.block_size == 128
         assert result.weight.shape == (1, 4, 64)
         # Scales unchanged (factor-of-2 encoded in codebook offset, not scale)
         assert result.scales.shape == (1, 4)
         np.testing.assert_array_equal(result.scales, 0.5)
-        # Packed uint8 zp=3: byte = 0x33. n_blocks=4 → ceil(4*4/8)=2 bytes.
+        # Packed uint8 zp=3: byte = 0x33. n_blocks=4 -> ceil(4*4/8)=2 bytes.
         assert result.zero_points.shape == (1, 2)
         assert result.zero_points.dtype == np.uint8
         np.testing.assert_array_equal(result.zero_points, 0x33)
 
     def test_all_code_0_packs_as_zeros(self, tmp_path: Path):
-        """c=0 → slot 0 → nibble pair (0,0) → byte 0x00."""
+        """c=0 -> slot 0 -> nibble pair (0,0) -> byte 0x00."""
         ne0, ne1 = 512, 1
         codes = np.zeros((ne1, ne0), dtype=np.uint8)
         scales = np.ones((ne1, 1), dtype=np.float16)
@@ -108,7 +108,7 @@ class TestTencentQ10DefaultInflated4Bit:
         np.testing.assert_array_equal(result.weight, 0x00)
 
     def test_all_code_3_packs_as_0x66(self, tmp_path: Path):
-        """c=3 → slot 6 → nibble pair (6,6) → byte (6<<4)|6 = 0x66."""
+        """c=3 -> slot 6 -> nibble pair (6,6) -> byte (6<<4)|6 = 0x66."""
         ne0, ne1 = 512, 1
         codes = np.full((ne1, ne0), 3, dtype=np.uint8)
         scales = np.ones((ne1, 1), dtype=np.float16)
@@ -116,8 +116,12 @@ class TestTencentQ10DefaultInflated4Bit:
         np.testing.assert_array_equal(result.weight, 0x66)
 
     def test_dequant_round_trip_matches_seq_codebook(self, tmp_path: Path):
-        """End-to-end: MatMulNBits dequant from emitted tensors gives
-        ``stored_scale · {-3,-1,+1,+3}[code]``."""
+        """End-to-end MatMulNBits dequant matches the SEQ codebook.
+
+        The emitted ``(weight, scales, zero_points)`` triple, when
+        dequantized via ``(B - zp) * scale``, should give
+        ``stored_scale * {-3, -1, +1, +3}[code]``.
+        """
         ne0, ne1 = 512, 2
         rng = np.random.default_rng(123)
         codes = rng.integers(0, 4, size=(ne1, ne0)).astype(np.uint8)
@@ -125,15 +129,15 @@ class TestTencentQ10DefaultInflated4Bit:
         result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, stored_scales)
 
         # Unpack 4-bit codes (2 per byte: byte = (high<<4)|low)
-        N, n_blocks, blob = result.weight.shape  # (2, 4, 64)
-        nibbles = np.empty((N, n_blocks, blob * 2), dtype=np.uint8)
+        n, n_blocks, blob = result.weight.shape  # (2, 4, 64)
+        nibbles = np.empty((n, n_blocks, blob * 2), dtype=np.uint8)
         nibbles[:, :, 0::2] = result.weight & 0xF
         nibbles[:, :, 1::2] = (result.weight >> 4) & 0xF
 
         # MatMulNBits dequant: (B - zp) * scale, zp=3, scale = stored_scale
         sc = result.scales.astype(np.float32)
         deq = (nibbles.astype(np.float32) - 3.0) * sc[:, :, None]
-        deq = deq.reshape(N, n_blocks * blob * 2)
+        deq = deq.reshape(n, n_blocks * blob * 2)
 
         codebook = np.array([-3, -1, 1, 3], dtype=np.float32)
         ref = stored_scales.astype(np.float32) * codebook[codes]
@@ -151,7 +155,7 @@ class TestTencentQ10NativeBits2:
         scales = np.full((ne1, 1), 0.5, dtype=np.float16)
         with override_flags(tencent_q1_0_use_native_2bit=True):
             result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, scales)
-        # bits=2, block_size=128 → blob_size = 128*2/8 = 32 bytes per sub-block
+        # bits=2, block_size=128 -> blob_size = 128*2/8 = 32 bytes per sub-block
         assert result.bits == 2
         assert result.block_size == 128
         assert result.weight.shape == (1, 4, 32)
@@ -163,7 +167,7 @@ class TestTencentQ10NativeBits2:
         np.testing.assert_array_equal(result.zero_points, 1.5)
 
     def test_dequant_round_trip_matches_seq_codebook(self, tmp_path: Path):
-        """Native path: (B - 1.5) * (2·stored_scale) gives the SEQ codebook."""
+        """Native path: (B - 1.5) * (2 * stored_scale) gives the SEQ codebook."""
         from mobius._flags import override_flags
 
         ne0, ne1 = 512, 2
@@ -173,15 +177,15 @@ class TestTencentQ10NativeBits2:
         with override_flags(tencent_q1_0_use_native_2bit=True):
             result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, stored_scales)
 
-        N, n_blocks, blob = result.weight.shape  # (2, 4, 32)
-        codes_out = np.empty((N, n_blocks, blob * 4), dtype=np.uint8)
+        n, n_blocks, blob = result.weight.shape  # (2, 4, 32)
+        codes_out = np.empty((n, n_blocks, blob * 4), dtype=np.uint8)
         for slot in range(4):
             codes_out[:, :, slot::4] = (result.weight >> (2 * slot)) & np.uint8(0x3)
 
         sc = result.scales.astype(np.float32)
         zp = result.zero_points.astype(np.float32)
         deq = (codes_out.astype(np.float32) - zp[:, :, None]) * sc[:, :, None]
-        deq = deq.reshape(N, n_blocks * blob * 4)
+        deq = deq.reshape(n, n_blocks * blob * 4)
 
         codebook = np.array([-3, -1, 1, 3], dtype=np.float32)
         ref = stored_scales.astype(np.float32) * codebook[codes]
@@ -192,12 +196,12 @@ class TestTencentQ10Shared:
     """Tests that don't depend on the flag setting."""
 
     def test_multi_native_block_replicates_scales(self, tmp_path: Path):
-        """Each native scale appears 4× consecutively (both packings)."""
+        """Each native scale appears 4x consecutively (both packings)."""
         ne0, ne1 = 1024, 3  # 2 native blocks per row
         codes = np.zeros((ne1, ne0), dtype=np.uint8)
         stored = np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]], dtype=np.float16)
         result = _round_trip(tmp_path / "t.bin", ne0, ne1, codes, stored)
-        # 2 native × 4 sub-blocks = 8 ORT blocks per row.
+        # 2 native x 4 sub-blocks = 8 ORT blocks per row.
         assert result.scales.shape == (3, 8)
         # Default (bits=4) keeps stored_scale; native (bits=2) doubles it.
         # In default mode we expect plain replication:

--- a/src/mobius/integrations/gguf/_tensor_mapping.py
+++ b/src/mobius/integrations/gguf/_tensor_mapping.py
@@ -212,6 +212,16 @@ _LLAMA_FAMILY = frozenset(
 
 _GEMMA_FAMILY = frozenset({"gemma", "gemma2", "gemma3"})
 
+# HunYuan-v1 dense uses the Llama base but adds per-head Q/K layer-norms
+# (HF: ``query_layernorm`` / ``key_layernorm``), which mobius renames to
+# ``q_norm`` / ``k_norm`` inside the Attention component.
+_HUNYUAN_EXTRAS: dict[str, str] = {
+    "blk.{bid}.attn_q_norm": "model.layers.{bid}.self_attn.q_norm",
+    "blk.{bid}.attn_k_norm": "model.layers.{bid}.self_attn.k_norm",
+}
+
+_HUNYUAN_FAMILY = frozenset({"hunyuan-dense", "hunyuan_v1_dense"})
+
 _MOE_FAMILY = frozenset(
     {
         "qwen2moe",
@@ -267,6 +277,9 @@ def _build_mapping(
         result = dict(_GPT2_MAPPING)
     elif arch == "mamba":
         result = dict(_MAMBA_MAPPING)
+    elif arch in _HUNYUAN_FAMILY:
+        result = dict(_LLAMA_MAPPING)
+        result.update(_HUNYUAN_EXTRAS)
     elif arch in _MOE_FAMILY:
         result = dict(_LLAMA_MAPPING)
         result.update(_MOE_EXTRAS)
@@ -277,6 +290,7 @@ def _build_mapping(
             _LLAMA_FAMILY
             | _GEMMA_FAMILY
             | _MOE_FAMILY
+            | _HUNYUAN_FAMILY
             | {"gemma4", "phi3", "falcon", "gpt2", "mamba"}
         )
         raise ValueError(

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -77,6 +77,9 @@ _ORT_GENAI_MODEL_TYPE: dict[str, str] = {
     "gemma4_text": "gemma4_text",
     "mistral": "mistral",
     "mistral3": "mistral3",
+    # HunYuan-V1 dense / Hy-MT1.5 — generic decoder LLM type accepted by
+    # ORT GenAI (see onnxruntime-genai/src/models/model_type.h LLM list).
+    "hunyuan_v1_dense": "decoder",
     # Qwen VL models all use the same GenAI pipeline as qwen2_5_vl
     "qwen2_vl": "qwen2_5_vl",
     "qwen3_vl": "qwen2_5_vl",

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -641,6 +641,22 @@ def _write_genai_config(
     # Derive decoder filename from the actual package key
     decoder_filename = f"{decoder_key}/model.onnx" if decoder_key != "model" else "model.onnx"
 
+    # ORT GenAI's ``past_present_share_buffer`` mode requires the decoder
+    # graph to write the KV cache in place. Only ``com.microsoft.
+    # GroupQueryAttention`` does that; the standard ONNX ``Attention`` op
+    # concatenates ``past_key`` with the new ``K`` and returns a dynamic-
+    # shape ``present_key``, which is incompatible with the pre-allocated
+    # shared buffer. Introspect the graph: if there is at least one GQA
+    # node, the model supports shared-buffer mode; otherwise force it off
+    # regardless of the EP capability flag.
+    decoder_model = pkg.get(decoder_key)
+    supports_in_place_kv_cache: bool | None = None
+    if decoder_model is not None:
+        supports_in_place_kv_cache = any(
+            node.op_type == "GroupQueryAttention" and node.domain == "com.microsoft"
+            for node in decoder_model.graph
+        )
+
     generator = GenaiConfigGenerator.from_config(
         config,
         ort_model_type,
@@ -651,6 +667,7 @@ def _write_genai_config(
         pad_token_id=pad_token_id,
         decoder_inputs=decoder_inputs,
         decoder_filename=decoder_filename,
+        supports_in_place_kv_cache=supports_in_place_kv_cache,
     )
 
     if is_vlm:

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -67,6 +67,11 @@ class TestResolveOrtGenaiModelType:
         assert _resolve_ort_genai_model_type("gemma2") == "gemma"
         assert _resolve_ort_genai_model_type("llama") == "llama"
 
+    def test_hunyuan_v1_dense_maps_to_decoder(self):
+        # ORT GenAI accepts "decoder" as a generic LLM type for any
+        # decoder-only causal LM not in its built-in registry.
+        assert _resolve_ort_genai_model_type("hunyuan_v1_dense") == "decoder"
+
     def test_unknown_model_type_passthrough(self):
         assert _resolve_ort_genai_model_type("my_custom") == "my_custom"
 

--- a/src/mobius/integrations/ort_genai/genai_config.py
+++ b/src/mobius/integrations/ort_genai/genai_config.py
@@ -47,7 +47,12 @@ def _default_decoder_outputs() -> dict[str, str]:
 _SHARE_BUFFER_MAX_LENGTH_CAP = 4096
 
 
-def _default_search_params(*, ep: str, context_length: int) -> dict[str, Any]:
+def _default_search_params(
+    *,
+    ep: str,
+    context_length: int,
+    supports_in_place_kv_cache: bool | None = None,
+) -> dict[str, Any]:
     """Return sensible default search parameters.
 
     Args:
@@ -56,11 +61,23 @@ def _default_search_params(*, ep: str, context_length: int) -> dict[str, Any]:
             :data:`~mobius._execution_providers.ep_registry`.
         context_length: Model context window; used as the default
             ``max_length`` for generation so the limit matches the model.
+        supports_in_place_kv_cache: When ``True`` / ``False``, forces
+            ``past_present_share_buffer`` regardless of the EP flag.
+            ORT GenAI's shared-buffer mode requires the decoder graph to
+            update the KV cache *in place* — only the
+            ``com.microsoft.GroupQueryAttention`` op does that.  The
+            standard ONNX ``Attention`` op concatenates past/new K,V into
+            a dynamically-sized tensor, which is incompatible with the
+            pre-allocated buffer mode. When ``None`` (legacy callers),
+            falls back to the EP capability flag.
     """
     from mobius._execution_providers import ep_registry
 
     caps = ep_registry.get(ep)
-    share_buffer = caps.supports_past_present_share_buffer if caps is not None else False
+    if supports_in_place_kv_cache is None:
+        share_buffer = caps.supports_past_present_share_buffer if caps is not None else False
+    else:
+        share_buffer = supports_in_place_kv_cache
     cap_length = caps.cap_kv_buffer_max_length if caps is not None else False
     if share_buffer and cap_length:
         # Memory-constrained EPs (e.g. WebGPU on consumer GPUs) pre-allocate
@@ -151,6 +168,7 @@ class GenaiConfigGenerator:
         pad_token_id: int | None = None,
         decoder_inputs: dict[str, str] | None = None,
         decoder_filename: str | None = None,
+        supports_in_place_kv_cache: bool | None = None,
     ):
         self.model_type = model_type
         self.vocab_size = vocab_size
@@ -165,10 +183,16 @@ class GenaiConfigGenerator:
         self.eos_token_id = eos_token_id
         self.pad_token_id = pad_token_id
 
-        # Explicit decoder inputs (from graph introspection); None → use defaults
+        # Explicit decoder inputs (from graph introspection); None -> use defaults
         self._decoder_inputs = decoder_inputs
-        # Explicit decoder filename; None → use "model.onnx"
+        # Explicit decoder filename; None -> use "model.onnx"
         self._decoder_filename = decoder_filename
+        # Whether the exported decoder ONNX graph supports in-place KV-cache
+        # updates (i.e. uses ``com.microsoft.GroupQueryAttention`` rather than
+        # the standard ``Attention`` op that concatenates). ``None`` falls back
+        # to the EP capability flag, preserving existing behaviour for callers
+        # that don't introspect the graph.
+        self._supports_in_place_kv_cache = supports_in_place_kv_cache
 
         # Optional VLM fields (set via with_vision())
         self._vision: dict[str, Any] | None = None
@@ -194,6 +218,7 @@ class GenaiConfigGenerator:
         pad_token_id: int | None = None,
         decoder_inputs: dict[str, str] | None = None,
         decoder_filename: str | None = None,
+        supports_in_place_kv_cache: bool | None = None,
     ) -> GenaiConfigGenerator:
         """Create a generator from a BaseModelConfig-like dataclass.
 
@@ -227,6 +252,7 @@ class GenaiConfigGenerator:
             pad_token_id=pad,
             decoder_inputs=decoder_inputs,
             decoder_filename=decoder_filename,
+            supports_in_place_kv_cache=supports_in_place_kv_cache,
         )
 
     def with_vision(
@@ -410,7 +436,11 @@ class GenaiConfigGenerator:
             model["speech"] = self._audio
         model.update(self._vlm_token_ids)
 
-        search = _default_search_params(ep=self.ep, context_length=self.context_length)
+        search = _default_search_params(
+            ep=self.ep,
+            context_length=self.context_length,
+            supports_in_place_kv_cache=self._supports_in_place_kv_cache,
+        )
         search.update(self._search_overrides)
 
         return {

--- a/src/mobius/models/base.py
+++ b/src/mobius/models/base.py
@@ -51,10 +51,16 @@ class TextModel(nn.Module):
         linear_class = None
         qc = getattr(config, "quantization", None)
         if qc is not None and qc.quant_method != "none":
+            zp_dtype = (
+                config.dtype
+                if getattr(qc, "float_zero_point", False)
+                else ir.DataType.UINT8
+            )
             linear_class = make_quantized_linear_factory(
                 bits=qc.bits,
                 block_size=qc.group_size,
                 has_zero_point=not qc.sym,
+                zero_point_dtype=zp_dtype,
             )
 
         self.embed_tokens = Embedding(
@@ -265,10 +271,16 @@ class LayerNormTextModel(TextModel):
         qc = getattr(config, "quantization", None)
         linear_class = None
         if qc is not None and qc.quant_method != "none":
+            zp_dtype = (
+                config.dtype
+                if getattr(qc, "float_zero_point", False)
+                else ir.DataType.UINT8
+            )
             linear_class = make_quantized_linear_factory(
                 bits=qc.bits,
                 block_size=qc.group_size,
                 has_zero_point=not qc.sym,
+                zero_point_dtype=zp_dtype,
             )
         self.layers = nn.ModuleList(
             [

--- a/src/mobius/models/base.py
+++ b/src/mobius/models/base.py
@@ -52,9 +52,7 @@ class TextModel(nn.Module):
         qc = getattr(config, "quantization", None)
         if qc is not None and qc.quant_method != "none":
             zp_dtype = (
-                config.dtype
-                if getattr(qc, "float_zero_point", False)
-                else ir.DataType.UINT8
+                config.dtype if getattr(qc, "float_zero_point", False) else ir.DataType.UINT8
             )
             linear_class = make_quantized_linear_factory(
                 bits=qc.bits,
@@ -272,9 +270,7 @@ class LayerNormTextModel(TextModel):
         linear_class = None
         if qc is not None and qc.quant_method != "none":
             zp_dtype = (
-                config.dtype
-                if getattr(qc, "float_zero_point", False)
-                else ir.DataType.UINT8
+                config.dtype if getattr(qc, "float_zero_point", False) else ir.DataType.UINT8
             )
             linear_class = make_quantized_linear_factory(
                 bits=qc.bits,


### PR DESCRIPTION
## Summary

Adds two paths through the GGUF loader for GGML type 41 so mobius can ingest both standard and Tencent's custom variants of Q1_0.

### 1. Mainline Q1_0 — 1-bit binary

Layout (18 bytes / 128 elements): `[fp16 d][16B packed 1-bit signs]`. Dequant: `bit ? +d : -d`. Used by [prism-ml/Bonsai](https://huggingface.co/collections/prism-ml/bonsai) checkpoints.

Mapped to `MatMulNBits` `bits=2`, `zero_point=1`, codes ∈ {0, 2}, scale=d.

### 2. Tencent custom Q1_0 — 2-bit SEQ

Used by [`AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF`](https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF). Per-row layout: `[fp16 stored_scale][2-bit codes packed LSB-first]`, native block size 512, codebook `{−3, −1, +1, +3} · stored_scale`.

Mainline llama.cpp **refuses to load** these files because every tensor after the first Q1_0 entry lands at the wrong offset. We bypass the size calculation by reading each tensor from its explicit GGUF offset.

Two `MatMulNBits` representations, selected by a flag:

| | default | `MOBIUS_TENCENT_Q1_0_USE_NATIVE_2BIT=1` |
|---|---|---|
| ORT bits | 4 (inflated `2c ∈ {0,2,4,6}`, integer zp=3) | 2 (codes pass-through, float zp=1.5) |
| on-disk weight bpw | 4 (2× the source) | 2 (matches source) |
| CPU decode throughput | **~32 tok/s** | **~0.24 tok/s** |
| ORT version | any | **≥ 1.27** ([#28354](https://github.com/microsoft/onnxruntime/pull/28354)) |

Both representations produce **bit-identical dequantized weights** matching HF safetensors to bf16 rounding (`max_abs ≈ 2.5e-3` vs HF reference matmul). The 130× decode speed difference is purely the ORT CPU kernel: the bits=4 path is the mature MLAS fused path, the bits=2 + float-zp path is the kernel's own self-described "naive implementation, need to be optimized" scalar fallback. Tracked in [microsoft/onnxruntime#28552](https://github.com/microsoft/onnxruntime/issues/28552); once that lands the default can flip.

**Block-size workaround:** ORT silently returns zeros for `block_size > 256` ([#28551](https://github.com/microsoft/onnxruntime/issues/28551)). Both representations therefore expose `block_size = 128` by replicating each native 512-element scale across 4 sub-blocks.

## Other infrastructure changes

- New flag [`tencent_q1_0_use_native_2bit`](src/mobius/_flags.py) (default `False`).
- `QuantizedLinear` accepts `bits ∈ {2, 4, 8}` and a new `zero_point_dtype` argument. `UINT8` (default) keeps the bit-packed integer form; float dtypes produce one un-packed value per block.
- `QuantizationConfig` gains `float_zero_point`; `TextModel` passes `config.dtype` as the zp dtype when it is set.
- GGUF → `ArchitectureConfig` derivation now sets `rope_type` from `<arch>.rope.scaling.type` (defaulting to `"default"` when `rope.freq_base` is present). Without this fix, models with `rope.scaling.type = "none"` were built with no RoPE at all.
- For `hunyuan-dense` GGUFs whose `rope.freq_base` exceeds `1e6` (Tencent's pipeline bakes the dynamic-NTK exponent into a static value), the original HF config is restored: `rope_type="dynamic"`, `rope_theta=10000`, `alpha=1000`. Otherwise long prompts diverge.
- New GGUF arch mapping `hunyuan-dense → hunyuan_v1_dense` with `attn_q_norm`/`attn_k_norm` tensor name mappings.
- `_detect_quant_params` returns `block_size` explicitly so the `QuantizationConfig` matches the actual per-type group size.

## Verification

End-to-end on `tencent/Hy-MT1.5-1.8B-2bit`:
- **Per-tensor dequantization** matches HF safetensors to bf16-rounding precision (max abs `2.3e-5`).
- **Single-layer ORT matmul** vs HF dequantized matmul: max abs `2.5e-3`, mean `2.8e-4`.
- **Short-prompt greedy generation** with the chat template produces `Hello, world!<EOS>` token-for-token identical to HF.
- **Throughput** with default flag: 0.13 s prefill, 32.8 tok/s decode on CPU EP.

Tests:
- Split into `TestTencentQ10DefaultInflated4Bit`, `TestTencentQ10NativeBits2`, and `TestTencentQ10Shared` covering both flag values + shape/error invariants.
- Full test suite (`tests/build_graph_test.py src/`): **2752 passed, 0 failures**.

## Out of scope / follow-ups

- 1.25-bit Sherry (`AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF`, [llama.cpp PR #22836](https://github.com/ggml-org/llama.cpp/pull/22836) `STQ1_0`): needs a ternary-with-structured-sparsity codebook that doesn't map cleanly to `MatMulNBits`. Tracked in [microsoft/onnxruntime#28549](https://github.com/microsoft/onnxruntime/issues/28549).
- ORT MLAS fast path for `bits=2` + float zp: [microsoft/onnxruntime#28552](https://github.com/microsoft/onnxruntime/issues/28552). When that lands, flip the flag default and remove the bits=4 inflation path.
- ORT silent zero output for `block_size > 256`: [microsoft/onnxruntime#28551](https://github.com/microsoft/onnxruntime/issues/28551).