### PR TITLE
build_from_gguf: accept HF repo references; hy_mt1_5 demo is one-shot

### DIFF
--- a/examples/hy_mt1_5.py
+++ b/examples/hy_mt1_5.py
@@ -42,14 +42,17 @@ Expected output (Q1_0 on CPU EP)::
 
 Usage::
 
-    # Build + run the Q1_0 quantized variant on CPU
-    huggingface-cli download AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF \\
-        Hy-MT1.5-1.8B-2bit.gguf --local-dir ./gguf
+    # One-step demo: downloads the GGUF from AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF
+    # on first use, builds the ONNX model into --out, and runs translation.
+    python examples/hy_mt1_5.py --variant Q1_0 --out ./hy-mt-q1_0-onnx \\
+        --prompt 'Translate to Spanish: The cat is sleeping on the chair.'
+
+    # Subsequent runs reuse the build (no download, no rebuild)
+    python examples/hy_mt1_5.py --variant Q1_0 --out ./hy-mt-q1_0-onnx
+
+    # Build from a local GGUF instead of letting mobius download it
     python examples/hy_mt1_5.py --variant Q1_0 --build \\
         --gguf ./gguf/Hy-MT1.5-1.8B-2bit.gguf --out ./hy-mt-q1_0-onnx
-
-    # Reuse an existing build (no --build)
-    python examples/hy_mt1_5.py --variant Q1_0 --out ./hy-mt-q1_0-onnx
 """
 
 from __future__ import annotations
@@ -59,6 +62,10 @@ import sys
 from pathlib import Path
 
 HF_MODEL_ID = "tencent/Hy-MT1.5-1.8B-2bit"
+
+# Source of the 2-bit GGUF. mobius's build_from_gguf accepts this directly and
+# downloads via huggingface_hub on first use.
+GGUF_HF_REF = "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF"
 
 _DEFAULT_PROMPT = "Translate the following Chinese text to English: 你好，世界！"  # noqa: RUF001
 
@@ -75,20 +82,23 @@ def _build_bf16(output_dir: Path) -> None:
     print("  genai_config.json + tokenizer files written")
 
 
-def _build_q1_0(gguf_path: Path, output_dir: Path) -> None:
-    """Build the 2-bit Q1_0 ONNX model + ORT-GenAI config in-process."""
+def _build_q1_0(gguf_ref: str, output_dir: Path) -> None:
+    """Build the 2-bit Q1_0 ONNX model + ORT-GenAI config in-process.
+
+    ``gguf_ref`` may be a local ``.gguf`` path or a HuggingFace reference
+    like ``"AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF"`` (mobius downloads it via
+    huggingface_hub on first use).
+    """
     from mobius.integrations.gguf._builder import build_from_gguf
     from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
 
-    print(f"Building Q1_0 -> {output_dir}")
+    print(f"Building Q1_0 from {gguf_ref} -> {output_dir}")
     # ep='cpu' applies the GroupQueryAttention rewrite. With standard
     # opset 23 Attention (ep='default'), ORT GenAI's
     # past_present_share_buffer mode cannot be used; mobius's
     # write_ort_genai_config inspects the resulting graph and turns
     # share_buffer off automatically when GQA is absent.
-    pkg = build_from_gguf(
-        str(gguf_path), keep_quantized=True, dtype="f32", execution_provider="cpu"
-    )
+    pkg = build_from_gguf(gguf_ref, keep_quantized=True, dtype="f32", execution_provider="cpu")
     pkg.save(str(output_dir))
     write_ort_genai_config(pkg, str(output_dir), hf_model_id=HF_MODEL_ID, ep="cpu")
     print("  genai_config.json + tokenizer files written")
@@ -96,19 +106,18 @@ def _build_q1_0(gguf_path: Path, output_dir: Path) -> None:
 
 def _ensure_built(args: argparse.Namespace) -> Path:
     out = Path(args.out).resolve()
-    if args.build:
+    # Default to building from the published HF GGUF so a fresh demo only
+    # needs one ``python examples/hy_mt1_5.py ...`` invocation.
+    need_build = args.build or not (out / "genai_config.json").exists()
+    if need_build:
         out.mkdir(parents=True, exist_ok=True)
         if args.variant == "bf16":
             _build_bf16(out)
         elif args.variant == "Q1_0":
-            if not args.gguf:
-                sys.exit("--gguf is required for --variant Q1_0 --build")
-            _build_q1_0(Path(args.gguf), out)
+            gguf_ref = args.gguf or GGUF_HF_REF
+            _build_q1_0(gguf_ref, out)
     if not (out / "genai_config.json").exists():
-        sys.exit(
-            f"{out}/genai_config.json missing. Re-run with --build or point --out "
-            "at a directory produced by `mobius build --runtime ort-genai`."
-        )
+        sys.exit(f"{out}/genai_config.json missing after build. Check earlier output.")
     return out
 
 
@@ -199,11 +208,19 @@ def main() -> None:
     parser.add_argument(
         "--out", default=None, help="ONNX model directory (will be created with --build)"
     )
-    parser.add_argument("--build", action="store_true", help="Build the model before running")
+    parser.add_argument(
+        "--build",
+        action="store_true",
+        help="Force rebuild even when --out already has a model",
+    )
     parser.add_argument(
         "--gguf",
         default=None,
-        help="Path to the Tencent SEQ GGUF (required with --variant Q1_0 --build)",
+        help=(
+            "Path to a local Tencent SEQ GGUF for --variant Q1_0. When omitted, "
+            "mobius downloads the GGUF from AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF "
+            "on first use."
+        ),
     )
     parser.add_argument("--prompt", default=_DEFAULT_PROMPT)
     parser.add_argument("--max-new-tokens", type=int, default=64)

--- a/examples/hy_mt1_5.py
+++ b/examples/hy_mt1_5.py
@@ -70,6 +70,9 @@ GGUF_HF_REF = "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF"
 _DEFAULT_PROMPT = "Translate the following Chinese text to English: 你好，世界！"  # noqa: RUF001
 
 
+_VARIANT_MARKER = ".mobius-variant"
+
+
 def _build_bf16(output_dir: Path) -> None:
     """Build the BF16 ONNX model + ORT-GenAI config in-process."""
     import mobius
@@ -79,6 +82,7 @@ def _build_bf16(output_dir: Path) -> None:
     pkg = mobius.build(HF_MODEL_ID, dtype="bf16", load_weights=True)
     pkg.save(str(output_dir))
     write_ort_genai_config(pkg, str(output_dir), hf_model_id=HF_MODEL_ID, ep="cpu")
+    (output_dir / _VARIANT_MARKER).write_text("bf16\n")
     print("  genai_config.json + tokenizer files written")
 
 
@@ -101,14 +105,34 @@ def _build_q1_0(gguf_ref: str, output_dir: Path) -> None:
     pkg = build_from_gguf(gguf_ref, keep_quantized=True, dtype="f32", execution_provider="cpu")
     pkg.save(str(output_dir))
     write_ort_genai_config(pkg, str(output_dir), hf_model_id=HF_MODEL_ID, ep="cpu")
+    (output_dir / _VARIANT_MARKER).write_text(f"Q1_0\t{gguf_ref}\n")
     print("  genai_config.json + tokenizer files written")
+
+
+def _existing_variant(output_dir: Path) -> str | None:
+    """Return the variant string recorded for an existing build, or None."""
+    marker = output_dir / _VARIANT_MARKER
+    if not marker.exists():
+        return None
+    return marker.read_text().split("\t", 1)[0].strip() or None
 
 
 def _ensure_built(args: argparse.Namespace) -> Path:
     out = Path(args.out).resolve()
+    existing_variant = _existing_variant(out)
+    has_model = (out / "genai_config.json").exists()
+
+    # Refuse to silently reuse a directory built for a different variant.
+    if has_model and existing_variant is not None and existing_variant != args.variant:
+        sys.exit(
+            f"{out} already contains a {existing_variant!r} build but "
+            f"--variant is {args.variant!r}. Pick a different --out, "
+            f"or remove the directory and re-run."
+        )
+
     # Default to building from the published HF GGUF so a fresh demo only
     # needs one ``python examples/hy_mt1_5.py ...`` invocation.
-    need_build = args.build or not (out / "genai_config.json").exists()
+    need_build = args.build or not has_model
     if need_build:
         out.mkdir(parents=True, exist_ok=True)
         if args.variant == "bf16":
@@ -117,7 +141,11 @@ def _ensure_built(args: argparse.Namespace) -> Path:
             gguf_ref = args.gguf or GGUF_HF_REF
             _build_q1_0(gguf_ref, out)
     if not (out / "genai_config.json").exists():
-        sys.exit(f"{out}/genai_config.json missing after build. Check earlier output.")
+        sys.exit(
+            f"Build did not produce {out / 'genai_config.json'}. The build step above "
+            f"failed; check the preceding output. To force a rebuild from a clean state, "
+            f"remove {out} and re-run with --build."
+        )
     return out
 
 
@@ -206,7 +234,14 @@ def main() -> None:
     )
     parser.add_argument("--variant", choices=("bf16", "Q1_0"), default="bf16")
     parser.add_argument(
-        "--out", default=None, help="ONNX model directory (will be created with --build)"
+        "--out",
+        default=None,
+        help=(
+            "ONNX model directory. If it doesn't contain a built model yet, "
+            "one is created automatically (downloading the GGUF for --variant Q1_0 "
+            "when --gguf isn't given). Subsequent runs with the same --out reuse "
+            "the build. Defaults to ./hy-mt-<variant>-onnx."
+        ),
     )
     parser.add_argument(
         "--build",

--- a/examples/hy_mt1_5.py
+++ b/examples/hy_mt1_5.py
@@ -42,16 +42,14 @@ Expected output (Q1_0 on CPU EP)::
 
 Usage::
 
-    # One-step demo: downloads the GGUF from AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF
-    # on first use, builds the ONNX model into --out, and runs translation.
+    # One-shot demo: downloads the GGUF from AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF
+    # (cached by huggingface_hub), builds the ONNX model into --out, and runs
+    # translation. Re-running rebuilds the ONNX (the network download is cached).
     python examples/hy_mt1_5.py --variant Q1_0 --out ./hy-mt-q1_0-onnx \\
         --prompt 'Translate to Spanish: The cat is sleeping on the chair.'
 
-    # Subsequent runs reuse the build (no download, no rebuild)
-    python examples/hy_mt1_5.py --variant Q1_0 --out ./hy-mt-q1_0-onnx
-
     # Build from a local GGUF instead of letting mobius download it
-    python examples/hy_mt1_5.py --variant Q1_0 --build \\
+    python examples/hy_mt1_5.py --variant Q1_0 \\
         --gguf ./gguf/Hy-MT1.5-1.8B-2bit.gguf --out ./hy-mt-q1_0-onnx
 """
 
@@ -70,9 +68,6 @@ GGUF_HF_REF = "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF"
 _DEFAULT_PROMPT = "Translate the following Chinese text to English: 你好，世界！"  # noqa: RUF001
 
 
-_VARIANT_MARKER = ".mobius-variant"
-
-
 def _build_bf16(output_dir: Path) -> None:
     """Build the BF16 ONNX model + ORT-GenAI config in-process."""
     import mobius
@@ -82,7 +77,6 @@ def _build_bf16(output_dir: Path) -> None:
     pkg = mobius.build(HF_MODEL_ID, dtype="bf16", load_weights=True)
     pkg.save(str(output_dir))
     write_ort_genai_config(pkg, str(output_dir), hf_model_id=HF_MODEL_ID, ep="cpu")
-    (output_dir / _VARIANT_MARKER).write_text("bf16\n")
     print("  genai_config.json + tokenizer files written")
 
 
@@ -105,46 +99,27 @@ def _build_q1_0(gguf_ref: str, output_dir: Path) -> None:
     pkg = build_from_gguf(gguf_ref, keep_quantized=True, dtype="f32", execution_provider="cpu")
     pkg.save(str(output_dir))
     write_ort_genai_config(pkg, str(output_dir), hf_model_id=HF_MODEL_ID, ep="cpu")
-    (output_dir / _VARIANT_MARKER).write_text(f"Q1_0\t{gguf_ref}\n")
     print("  genai_config.json + tokenizer files written")
 
 
-def _existing_variant(output_dir: Path) -> str | None:
-    """Return the variant string recorded for an existing build, or None."""
-    marker = output_dir / _VARIANT_MARKER
-    if not marker.exists():
-        return None
-    return marker.read_text().split("\t", 1)[0].strip() or None
+def _build(args: argparse.Namespace) -> Path:
+    """Always (re)build the model into ``--out``.
 
-
-def _ensure_built(args: argparse.Namespace) -> Path:
+    HuggingFace Hub caches the source (safetensors for bf16, GGUF for Q1_0),
+    so re-runs are cheap on the network side; the in-process ONNX construction
+    runs every time. This keeps the example dead-simple: no marker files, no
+    reuse logic, no chance of silently running a stale or wrong-variant build.
+    """
     out = Path(args.out).resolve()
-    existing_variant = _existing_variant(out)
-    has_model = (out / "genai_config.json").exists()
-
-    # Refuse to silently reuse a directory built for a different variant.
-    if has_model and existing_variant is not None and existing_variant != args.variant:
-        sys.exit(
-            f"{out} already contains a {existing_variant!r} build but "
-            f"--variant is {args.variant!r}. Pick a different --out, "
-            f"or remove the directory and re-run."
-        )
-
-    # Default to building from the published HF GGUF so a fresh demo only
-    # needs one ``python examples/hy_mt1_5.py ...`` invocation.
-    need_build = args.build or not has_model
-    if need_build:
-        out.mkdir(parents=True, exist_ok=True)
-        if args.variant == "bf16":
-            _build_bf16(out)
-        elif args.variant == "Q1_0":
-            gguf_ref = args.gguf or GGUF_HF_REF
-            _build_q1_0(gguf_ref, out)
+    out.mkdir(parents=True, exist_ok=True)
+    if args.variant == "bf16":
+        _build_bf16(out)
+    elif args.variant == "Q1_0":
+        _build_q1_0(args.gguf or GGUF_HF_REF, out)
     if not (out / "genai_config.json").exists():
         sys.exit(
-            f"Build did not produce {out / 'genai_config.json'}. The build step above "
-            f"failed; check the preceding output. To force a rebuild from a clean state, "
-            f"remove {out} and re-run with --build."
+            f"Build did not produce {out / 'genai_config.json'}; check the "
+            f"preceding output for the underlying failure."
         )
     return out
 
@@ -237,16 +212,10 @@ def main() -> None:
         "--out",
         default=None,
         help=(
-            "ONNX model directory. If it doesn't contain a built model yet, "
-            "one is created automatically (downloading the GGUF for --variant Q1_0 "
-            "when --gguf isn't given). Subsequent runs with the same --out reuse "
-            "the build. Defaults to ./hy-mt-<variant>-onnx."
+            "Directory to write the ONNX model + ORT GenAI config into. "
+            "Always overwritten on each run (HuggingFace cache handles "
+            "the underlying source download). Defaults to ./hy-mt-<variant>-onnx."
         ),
-    )
-    parser.add_argument(
-        "--build",
-        action="store_true",
-        help="Force rebuild even when --out already has a model",
     )
     parser.add_argument(
         "--gguf",
@@ -254,7 +223,7 @@ def main() -> None:
         help=(
             "Path to a local Tencent SEQ GGUF for --variant Q1_0. When omitted, "
             "mobius downloads the GGUF from AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF "
-            "on first use."
+            "(cached locally by huggingface_hub)."
         ),
     )
     parser.add_argument("--prompt", default=_DEFAULT_PROMPT)
@@ -275,7 +244,7 @@ def main() -> None:
     if args.out is None:
         args.out = f"./hy-mt-{args.variant.lower()}-onnx"
 
-    out = _ensure_built(args)
+    out = _build(args)
     text = run_translation(
         out,
         args.prompt,

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -29,6 +29,14 @@ from mobius._model_package import ModelPackage
 logger = logging.getLogger(__name__)
 
 
+def _looks_like_hf_repo_id(value: str) -> bool:
+    """Heuristic: ``value`` matches ``owner/repo`` (no path separators, no .gguf suffix)."""
+    if value.startswith((".", "/", "~")):
+        return False
+    parts = value.split("/")
+    return len(parts) == 2 and all(p and not p.endswith(".gguf") for p in parts)
+
+
 def _resolve_gguf_path(gguf_path: str | Path) -> str:
     """Resolve a GGUF reference to a local file path.
 
@@ -44,27 +52,32 @@ def _resolve_gguf_path(gguf_path: str | Path) -> str:
     if candidate.exists():
         return str(candidate)
 
-    # Anything that doesn't look like a HF reference falls through to
-    # GGUFModel which will surface a FileNotFoundError with the original path.
-    if "/" not in raw or raw.startswith((".", "/", "~")) or raw.endswith(".gguf"):
-        # Treat as a path that just doesn't exist yet (let downstream error).
+    # Split the optional ":filename" suffix before classifying, so HF refs like
+    # "owner/repo:weights.gguf" are not mistaken for a local path that ends in .gguf.
+    repo_id, sep, filename = raw.partition(":")
+    if sep and _looks_like_hf_repo_id(repo_id):
+        from huggingface_hub import hf_hub_download
+
+        logger.info("Downloading %s from %s", filename, repo_id)
+        return hf_hub_download(repo_id=repo_id, filename=filename)
+
+    if not _looks_like_hf_repo_id(raw):
+        # Looks like a local path that doesn't exist; let GGUFModel raise a
+        # FileNotFoundError with the original path.
         return raw
 
     from huggingface_hub import HfApi, hf_hub_download
 
-    repo_id, _, filename = raw.partition(":")
-    if not filename:
-        files = [f for f in HfApi().list_repo_files(repo_id) if f.endswith(".gguf")]
-        if len(files) == 0:
-            raise FileNotFoundError(f"No *.gguf files found in HF repo {repo_id!r}")
-        if len(files) > 1:
-            raise ValueError(
-                f"HF repo {repo_id!r} contains multiple .gguf files: {files}. "
-                f"Specify one via '{repo_id}:<filename.gguf>'."
-            )
-        filename = files[0]
-    logger.info("Downloading %s from %s", filename, repo_id)
-    return hf_hub_download(repo_id=repo_id, filename=filename)
+    files = [f for f in HfApi().list_repo_files(raw) if f.endswith(".gguf")]
+    if len(files) == 0:
+        raise FileNotFoundError(f"No *.gguf files found in HF repo {raw!r}")
+    if len(files) > 1:
+        raise ValueError(
+            f"HF repo {raw!r} contains multiple .gguf files: {files}. "
+            f"Specify one via '{raw}:<filename.gguf>'."
+        )
+    logger.info("Downloading %s from %s", files[0], raw)
+    return hf_hub_download(repo_id=raw, filename=files[0])
 
 
 def build_from_gguf(

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -29,6 +29,44 @@ from mobius._model_package import ModelPackage
 logger = logging.getLogger(__name__)
 
 
+def _resolve_gguf_path(gguf_path: str | Path) -> str:
+    """Resolve a GGUF reference to a local file path.
+
+    Accepts:
+    - An existing local filesystem path (returned unchanged).
+    - A HuggingFace Hub reference ``"owner/repo"`` — the repo must contain
+      exactly one ``*.gguf`` file, which is downloaded.
+    - A HuggingFace Hub reference ``"owner/repo:filename.gguf"`` to pick a
+      specific file from a multi-file repo.
+    """
+    raw = str(gguf_path)
+    candidate = Path(raw)
+    if candidate.exists():
+        return str(candidate)
+
+    # Anything that doesn't look like a HF reference falls through to
+    # GGUFModel which will surface a FileNotFoundError with the original path.
+    if "/" not in raw or raw.startswith((".", "/", "~")) or raw.endswith(".gguf"):
+        # Treat as a path that just doesn't exist yet (let downstream error).
+        return raw
+
+    from huggingface_hub import HfApi, hf_hub_download
+
+    repo_id, _, filename = raw.partition(":")
+    if not filename:
+        files = [f for f in HfApi().list_repo_files(repo_id) if f.endswith(".gguf")]
+        if len(files) == 0:
+            raise FileNotFoundError(f"No *.gguf files found in HF repo {repo_id!r}")
+        if len(files) > 1:
+            raise ValueError(
+                f"HF repo {repo_id!r} contains multiple .gguf files: {files}. "
+                f"Specify one via '{repo_id}:<filename.gguf>'."
+            )
+        filename = files[0]
+    logger.info("Downloading %s from %s", filename, repo_id)
+    return hf_hub_download(repo_id=repo_id, filename=filename)
+
+
 def build_from_gguf(
     gguf_path: str | Path,
     *,
@@ -51,7 +89,12 @@ def build_from_gguf(
     repacked into MatMulNBits format instead of dequantized.
 
     Args:
-        gguf_path: Path to the ``.gguf`` file.
+        gguf_path: Path to the ``.gguf`` file, *or* a HuggingFace Hub
+            reference of the form ``"owner/repo"`` (the repo must
+            contain exactly one ``*.gguf`` file) or
+            ``"owner/repo:filename.gguf"`` to pick a specific file. HF
+            references are downloaded via ``huggingface_hub`` into the
+            standard local cache.
         task: Override the model task (e.g. ``"text-generation"``).
             When ``None``, the task is auto-detected from the
             model type.
@@ -92,7 +135,8 @@ def build_from_gguf(
         process_tensors,
     )
 
-    # 1. Parse GGUF file
+    # 1. Parse GGUF file (auto-download from HF Hub when given "owner/repo[:filename]")
+    gguf_path = _resolve_gguf_path(gguf_path)
     gguf_model = GGUFModel(gguf_path)
     gguf_arch = gguf_model.architecture
     logger.info("Loaded GGUF file: %s (arch=%s)", gguf_path, gguf_arch)

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -23,6 +23,7 @@ from collections import Counter
 from pathlib import Path
 
 import tqdm
+from huggingface_hub import HfApi, hf_hub_download
 
 from mobius._model_package import ModelPackage
 
@@ -56,8 +57,6 @@ def _resolve_gguf_path(gguf_path: str | Path) -> str:
     # "owner/repo:weights.gguf" are not mistaken for a local path that ends in .gguf.
     repo_id, sep, filename = raw.partition(":")
     if sep and _looks_like_hf_repo_id(repo_id):
-        from huggingface_hub import hf_hub_download
-
         logger.info("Downloading %s from %s", filename, repo_id)
         return hf_hub_download(repo_id=repo_id, filename=filename)
 
@@ -65,8 +64,6 @@ def _resolve_gguf_path(gguf_path: str | Path) -> str:
         # Looks like a local path that doesn't exist; let GGUFModel raise a
         # FileNotFoundError with the original path.
         return raw
-
-    from huggingface_hub import HfApi, hf_hub_download
 
     files = [f for f in HfApi().list_repo_files(raw) if f.endswith(".gguf")]
     if len(files) == 0:

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -49,32 +49,30 @@ def _resolve_gguf_path(gguf_path: str | Path) -> str:
       specific file from a multi-file repo.
     """
     raw = str(gguf_path)
-    candidate = Path(raw)
-    if candidate.exists():
-        return str(candidate)
+    if Path(raw).exists():
+        return raw
 
-    # Split the optional ":filename" suffix before classifying, so HF refs like
-    # "owner/repo:weights.gguf" are not mistaken for a local path that ends in .gguf.
-    repo_id, sep, filename = raw.partition(":")
-    if sep and _looks_like_hf_repo_id(repo_id):
-        logger.info("Downloading %s from %s", filename, repo_id)
-        return hf_hub_download(repo_id=repo_id, filename=filename)
-
-    if not _looks_like_hf_repo_id(raw):
-        # Looks like a local path that doesn't exist; let GGUFModel raise a
+    # Split the optional ":filename" suffix before classifying so HF refs like
+    # "owner/repo:weights.gguf" are not mistaken for a local path ending in .gguf.
+    repo_id, _, filename = raw.partition(":")
+    if not _looks_like_hf_repo_id(repo_id):
+        # Looks like a local path that doesn't exist; let GGUFModel raise
         # FileNotFoundError with the original path.
         return raw
 
-    files = [f for f in HfApi().list_repo_files(raw) if f.endswith(".gguf")]
-    if len(files) == 0:
-        raise FileNotFoundError(f"No *.gguf files found in HF repo {raw!r}")
-    if len(files) > 1:
-        raise ValueError(
-            f"HF repo {raw!r} contains multiple .gguf files: {files}. "
-            f"Specify one via '{raw}:<filename.gguf>'."
-        )
-    logger.info("Downloading %s from %s", files[0], raw)
-    return hf_hub_download(repo_id=raw, filename=files[0])
+    if not filename:
+        files = [f for f in HfApi().list_repo_files(repo_id) if f.endswith(".gguf")]
+        if not files:
+            raise FileNotFoundError(f"No *.gguf files found in HF repo {repo_id!r}")
+        if len(files) > 1:
+            raise ValueError(
+                f"HF repo {repo_id!r} contains multiple .gguf files: {files}. "
+                f"Specify one via '{repo_id}:<filename.gguf>'."
+            )
+        filename = files[0]
+
+    logger.info("Downloading %s from %s", filename, repo_id)
+    return hf_hub_download(repo_id=repo_id, filename=filename)
 
 
 def build_from_gguf(


### PR DESCRIPTION
## What

`build_from_gguf` now accepts a HuggingFace Hub reference in addition to a local `.gguf` path:

```python
build_from_gguf('AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF')           # auto-pick the single .gguf
build_from_gguf('AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF:foo.gguf')  # multi-file repo
```

Downloads go through `huggingface_hub.hf_hub_download` into the standard local cache, so re-runs are free. If the repo contains multiple .gguf files and no `:filename` is given, we raise with a list of available files.

## Why

The `examples/hy_mt1_5.py` script now demos the full mobius pipeline in a single command — handy when handing off to a PM or a teammate:

```bash
python examples/hy_mt1_5.py --variant Q1_0 --out ./hy-mt-q1_0-onnx \
    --prompt 'Translate the following Chinese text to English: 黄河之水天上来'
# -> downloads GGUF, builds Q1_0 ONNX + genai_config.json into --out, runs translation
# 'The Yellow River rises from the sky.'
```

Subsequent runs reuse the build in `--out`. `--build` still forces a rebuild; `--gguf` still accepts a local path.

## Tests

- `pytest src/mobius/integrations/gguf/ -q` → 144 passed
- Manual end-to-end on a clean directory: fresh download + build + translation works (output above)