### PR TITLE
Populate AudioConfig from sensevoice encoder_conf in _extract_audio_config

### DIFF
--- a/src/mobius/_configs.py
+++ b/src/mobius/_configs.py
@@ -774,6 +774,25 @@ def _extract_audio_config(config, parent_config, model_type: str) -> dict:
                 )
             }
 
+    # SenseVoice / FunASR-style: encoder config lives under "encoder_conf"
+    # and the mel-spec frontend under "frontend_conf". Top-level holds
+    # input_size + vocab_size. model_type is "sensevoice".
+    if model_type == "sensevoice":
+        encoder_conf = getattr(config, "encoder_conf", None) or {}
+        frontend_conf = getattr(config, "frontend_conf", None) or {}
+        if isinstance(encoder_conf, dict) and encoder_conf:
+            audio_fields.update(
+                attention_dim=encoder_conf.get("output_size"),
+                attention_heads=encoder_conf.get("attention_heads"),
+                num_blocks=encoder_conf.get("num_blocks"),
+                tp_num_blocks=encoder_conf.get("tp_blocks"),
+                linear_units=encoder_conf.get("linear_units"),
+                kernel_size=encoder_conf.get("kernel_size"),
+                input_size=getattr(config, "input_size", None),
+            )
+            if isinstance(frontend_conf, dict):
+                audio_fields["num_mel_bins"] = frontend_conf.get("n_mels")
+
     # Build AudioConfig sub-config if any audio fields are set
     has_audio = any(v is not None for v in audio_fields.values())
 


### PR DESCRIPTION
## What

`tests/arch_validation_test.py` failed for `sensevoice_small` with `AssertionError` in `SenseVoiceSmallModel.__init__` (`assert audio is not None`).

## Why

HuggingFace SenseVoice (`model_type=sensevoice`) keeps every encoder field nested under `encoder_conf`, plus `input_size`/`vocab_size` at the top level and `n_mels` under `frontend_conf`:

```json
{
  "model_type": "sensevoice",
  "vocab_size": 25055,
  "input_size": 560,
  "encoder_conf": {
    "output_size": 512,
    "attention_heads": 4,
    "num_blocks": 50,
    "tp_blocks": 20,
    "linear_units": 2048,
    "kernel_size": 11
  },
  "frontend_conf": {"n_mels": 80}
}
```

`_extract_audio_config` had no branch for `sensevoice`, so `config.audio` came back `None`. The L1 build_graph test still passed because its tiny synthetic config sets `config.audio` directly; only the L2 arch-validation path (real HF config) was broken.

## Fix

Map `encoder_conf.*` + top-level `input_size` + `frontend_conf.n_mels` into the corresponding `AudioConfig` fields. All target fields (`attention_dim`, `attention_heads`, `num_blocks`, `tp_num_blocks`, `linear_units`, `kernel_size`, `input_size`, `num_mel_bins`) already exist on `AudioConfig` — no new fields needed.

## Tests

```
pytest tests/arch_validation_test.py -k sensevoice_small -v
  test_config_downloads_and_parses    PASSED
  test_full_graph_builds              PASSED
  test_graph_shapes_consistent        PASSED
```

Full unit suite (`src/` + `tests/build_graph_test.py`): 2753 passed, 41 skipped, 0 failures.