### PR TITLE
configs refactor 1/3: split _configs.py into a package

### DIFF
--- a/src/mobius/_configs/__init__.py
+++ b/src/mobius/_configs/__init__.py
@@ -1,0 +1,128 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Model configuration dataclasses and HuggingFace → mobius conversion.
+
+This package re-exports the public surface that used to live in
+``mobius._configs`` (a single 2.6k-line module). The split keeps that
+import path working while letting each concern grow in its own file:
+
+* :mod:`._sub_configs` — pure-data dataclasses for sub-configs
+  (RoPE, vision, audio, codec, TTS) shared across model families.
+* :mod:`._quantization` — :class:`QuantizationConfig` and its HF parser.
+* :mod:`._base` — :class:`BaseModelConfig`, :class:`ArchitectureConfig`,
+  the per-model config subclasses, and the legacy ``_extract_*``
+  helpers that build sub-configs from HuggingFace fields.
+
+Follow-up PRs in this series convert the model-type switches inside the
+``_extract_*`` helpers into a registry-based dispatch, and move per-model
+config subclasses into their own files under ``per_model/``.
+"""
+
+from __future__ import annotations
+
+from mobius._configs._base import (
+    DEFAULT_INT,
+    ArchitectureConfig,
+    BambaConfig,
+    BaseModelConfig,
+    CausalLMConfig,
+    DepthAnythingConfig,
+    EncoderConfig,
+    Gemma2Config,
+    Gemma3nConfig,
+    Gemma4Config,
+    GraniteMoeHybridConfig,
+    JambaConfig,
+    JetMoeConfig,
+    LongcatFlashConfig,
+    Mamba2Config,
+    MambaConfig,
+    MllamaConfig,
+    NanoChatConfig,
+    NemotronHConfig,
+    Sam2Config,
+    SegformerConfig,
+    VisionLanguageConfig,
+    WhisperConfig,
+    YolosConfig,
+    Zamba2Config,
+    _as_int,
+    _extract_audio_config,
+    _extract_mrope_fields,
+    _extract_rope_config,
+    _extract_vision_config,
+    _first,
+    _first_not_none,
+    _nested_rope_theta,
+    _nested_rope_type,
+    _normalize_rope_scaling,
+    _resolve_dtype,
+    _resolve_hidden_act,
+    _shallow_fields,
+    _shared_expert_size,
+)
+from mobius._configs._quantization import QuantizationConfig
+from mobius._configs._sub_configs import (
+    AudioConfig,
+    CodecDecoderConfig,
+    CodecEncoderConfig,
+    CodePredictorConfig,
+    Gemma4AudioConfig,
+    RoPEConfig,
+    SpeakerEncoderConfig,
+    TTSConfig,
+    VisionConfig,
+)
+
+__all__ = [
+    "DEFAULT_INT",
+    "ArchitectureConfig",
+    "AudioConfig",
+    "BambaConfig",
+    "BaseModelConfig",
+    "CausalLMConfig",
+    "CodePredictorConfig",
+    "CodecDecoderConfig",
+    "CodecEncoderConfig",
+    "DepthAnythingConfig",
+    "EncoderConfig",
+    "Gemma2Config",
+    "Gemma3nConfig",
+    "Gemma4AudioConfig",
+    "Gemma4Config",
+    "GraniteMoeHybridConfig",
+    "JambaConfig",
+    "JetMoeConfig",
+    "LongcatFlashConfig",
+    "Mamba2Config",
+    "MambaConfig",
+    "MllamaConfig",
+    "NanoChatConfig",
+    "NemotronHConfig",
+    "QuantizationConfig",
+    "RoPEConfig",
+    "Sam2Config",
+    "SegformerConfig",
+    "SpeakerEncoderConfig",
+    "TTSConfig",
+    "VisionConfig",
+    "VisionLanguageConfig",
+    "WhisperConfig",
+    "YolosConfig",
+    "Zamba2Config",
+    "_as_int",
+    "_extract_audio_config",
+    "_extract_mrope_fields",
+    "_extract_rope_config",
+    "_extract_vision_config",
+    "_first",
+    "_first_not_none",
+    "_nested_rope_theta",
+    "_nested_rope_type",
+    "_normalize_rope_scaling",
+    "_resolve_dtype",
+    "_resolve_hidden_act",
+    "_shallow_fields",
+    "_shared_expert_size",
+]

--- a/src/mobius/_configs/_base.py
+++ b/src/mobius/_configs/_base.py
@@ -10,6 +10,19 @@ import onnx_ir as ir
 import torch
 from onnx_ir import tensor_adapters
 
+from mobius._configs._quantization import QuantizationConfig
+from mobius._configs._sub_configs import (
+    AudioConfig,
+    CodecDecoderConfig,
+    CodecEncoderConfig,
+    CodePredictorConfig,
+    Gemma4AudioConfig,
+    RoPEConfig,
+    SpeakerEncoderConfig,
+    TTSConfig,
+    VisionConfig,
+)
+
 DEFAULT_INT = -42
 
 
@@ -91,235 +104,6 @@ def _normalize_rope_scaling(rope_scaling: dict) -> dict:
     if "full_attention" in rope_scaling and isinstance(rope_scaling["full_attention"], dict):
         return rope_scaling["full_attention"]
     return rope_scaling
-
-
-@dataclasses.dataclass
-class RoPEConfig:
-    """Configuration for rotary position embeddings (RoPE).
-
-    Groups the 7 RoPE-related fields that were previously spread across
-    :class:`ArchitectureConfig` as flat attributes.
-    """
-
-    rope_type: str = "default"
-    rope_theta: float = 10_000.0
-    rope_scaling: dict | None = None
-    partial_rotary_factor: float = 1.0
-    rope_local_base_freq: float | None = None
-    original_max_position_embeddings: int | None = None
-    rope_interleave: bool = False
-
-
-@dataclasses.dataclass
-class VisionConfig:
-    """Configuration for the vision encoder in multimodal models.
-
-    This groups all vision-related fields that were previously scattered
-    as ``vision_*`` prefixed fields on :class:`ArchitectureConfig`.
-    """
-
-    hidden_size: int | None = None
-    intermediate_size: int | None = None
-    num_hidden_layers: int | None = None
-    num_attention_heads: int | None = None
-    image_size: int | None = None
-    patch_size: int | None = None
-    norm_eps: float = 1e-6
-    mm_tokens_per_image: int | None = None
-    image_token_id: int | None = None
-    # Pixtral / Mistral-3 vision fields
-    model_type: str | None = None
-    head_dim: int | None = None
-    rope_theta: float | None = None
-    # Qwen VL-specific
-    out_hidden_size: int | None = None
-    in_channels: int = 3
-    spatial_merge_size: int = 2
-    temporal_patch_size: int = 2
-    num_position_embeddings: int | None = None
-    deepstack_visual_indexes: list[int] | None = None
-    fullatt_block_indexes: list[int] | None = None
-    window_size: int | None = None
-    # MRoPE section (for multimodal position encoding)
-    mrope_section: list[int] | None = None
-    # Phi4MM image embedding
-    image_crop_size: int | None = None
-    # LoRA config
-    lora: dict | None = None
-    # Gemma4 SigLIP vision encoder uses clipped linear activations
-    use_clipped_linears: bool = False
-    # Gemma4 SigLIP patch position embedding table size (HF: position_embedding_size)
-    position_embedding_size: int | None = None
-    # Gemma4 VisionPooler spatial average pooling kernel size (3 → 3x3 pooling, N→N/9 tokens)
-    pooling_kernel_size: int | None = None
-    # MLP activation for vision encoder layers (e.g. "gelu_pytorch_tanh" for Gemma4 SigLIP)
-    hidden_act: str | None = None
-
-
-@dataclasses.dataclass
-class CodecDecoderConfig:
-    """Configuration for the codec decoder (codes → waveform)."""
-
-    codebook_dim: int = 512
-    codebook_size: int = 2048
-    latent_dim: int = 1024
-    hidden_size: int = 512
-    intermediate_size: int = 1024
-    num_hidden_layers: int = 8
-    num_attention_heads: int = 16
-    num_key_value_heads: int = 16
-    head_dim: int = 64
-    rms_norm_eps: float = 1e-5
-    rope_theta: float = 10000.0
-    max_position_embeddings: int = 8000
-    decoder_dim: int = 1536
-    num_quantizers: int = 16
-    upsample_rates: list[int] = dataclasses.field(default_factory=lambda: [8, 5, 4, 3])
-    upsampling_ratios: list[int] = dataclasses.field(default_factory=lambda: [2, 2])
-
-
-@dataclasses.dataclass
-class CodecEncoderConfig:
-    """Configuration for the codec encoder (waveform → codes)."""
-
-    codebook_dim: int = 256
-    codebook_size: int = 2048
-    hidden_size: int = 512
-    intermediate_size: int = 2048
-    num_hidden_layers: int = 8
-    num_attention_heads: int = 8
-    num_key_value_heads: int = 8
-    head_dim: int = 64
-    rope_theta: float = 10000.0
-    max_position_embeddings: int = 8000
-    num_quantizers: int = 32
-    num_semantic_quantizers: int = 1
-
-
-@dataclasses.dataclass
-class SpeakerEncoderConfig:
-    """Configuration for the ECAPA-TDNN speaker encoder in TTS models."""
-
-    mel_dim: int = 128
-    enc_dim: int = 1024
-    enc_channels: list[int] = dataclasses.field(
-        default_factory=lambda: [512, 512, 512, 512, 1536]
-    )
-    enc_kernel_sizes: list[int] = dataclasses.field(default_factory=lambda: [5, 3, 3, 3, 1])
-    enc_dilations: list[int] = dataclasses.field(default_factory=lambda: [1, 2, 3, 4, 1])
-    enc_attention_channels: int = 128
-    enc_res2net_scale: int = 8
-    enc_se_channels: int = 128
-
-
-@dataclasses.dataclass
-class CodePredictorConfig:
-    """Configuration for the TTS code predictor sub-model."""
-
-    hidden_size: int = 1024
-    intermediate_size: int = 3072
-    num_hidden_layers: int = 5
-    num_attention_heads: int = 16
-    num_key_value_heads: int = 8
-    head_dim: int = 128
-    vocab_size: int = 2048
-    num_code_groups: int = 16
-    rms_norm_eps: float = 1e-6
-    rope_theta: float = 1_000_000.0
-    hidden_act: str = "silu"
-    layer_types: list[str] | None = None
-
-
-@dataclasses.dataclass
-class TTSConfig:
-    """Configuration for Qwen3-TTS models.
-
-    Groups TTS-specific fields: talker parameters, code predictor config,
-    and speaker encoder config.
-    """
-
-    # Talker parameters
-    text_hidden_size: int = 2048
-    text_vocab_size: int = 151936
-    num_code_groups: int = 16
-    # Special token IDs
-    codec_bos_id: int = 2149
-    codec_eos_token_id: int = 2150
-    codec_pad_id: int = 2148
-    codec_think_id: int = 2154
-    codec_nothink_id: int = 2155
-    # Sub-configs
-    code_predictor: CodePredictorConfig | None = None
-    speaker_encoder: SpeakerEncoderConfig | None = None
-
-
-@dataclasses.dataclass
-class AudioConfig:
-    """Configuration for the audio encoder in multimodal models."""
-
-    attention_dim: int | None = None
-    attention_heads: int | None = None
-    num_blocks: int | None = None
-    linear_units: int | None = None
-    kernel_size: int | None = None
-    input_size: int | None = None
-    conv_channels: int | None = None
-    t5_bias_max_distance: int | None = None
-    projection_hidden_size: int | None = None
-    token_id: int | None = None
-    # Qwen3-ASR encoder config
-    d_model: int | None = None
-    encoder_layers: int | None = None
-    encoder_attention_heads: int | None = None
-    encoder_ffn_dim: int | None = None
-    num_mel_bins: int | None = None
-    max_source_positions: int | None = None
-    downsample_hidden_size: int | None = None
-    output_dim: int | None = None
-    activation_function: str = "gelu"
-    audio_token_id: int | None = None
-    audio_start_token_id: int | None = None
-    audio_end_token_id: int | None = None
-    classify_num: int | None = None
-    # Qwen3-ASR chunked conv parameters. ``n_window`` is half the
-    # number of mel frames per conv chunk (so chunk_size = 2 *
-    # n_window). ``n_window_infer`` is the attention window in mel
-    # frames; encoder self-attention is block-diagonal with windows
-    # of n_window_infer / (2 * n_window) post-conv chunks (~=
-    # n_window_infer * tokens_per_chunk / chunk_size_mel post-conv
-    # tokens). HF reference: QwenLM/Qwen3-ASR
-    # qwen_asr/core/transformers_backend/modeling_qwen3_asr.py
-    n_window: int | None = None
-    n_window_infer: int | None = None
-    # Fun-ASR / SenseVoice encoder config
-    tp_num_blocks: int | None = None
-    adaptor_proj_dim: int | None = None
-    adaptor_num_blocks: int | None = None
-    adaptor_ffn_dim: int | None = None
-    adaptor_num_heads: int | None = None
-    # LoRA config
-    lora: dict | None = None
-
-
-@dataclasses.dataclass
-class Gemma4AudioConfig(AudioConfig):
-    """Configuration for the Gemma4 Conformer audio encoder.
-
-    Extends :class:`AudioConfig` with Gemma4-specific fields:
-
-    - ``num_layers``: number of Conformer encoder blocks (12 for Gemma4)
-    - ``hidden_size``: encoder hidden dimension (1024 for Gemma4)
-    - ``subsampling_conv_channels``: channel sizes for 2D convolutional
-      subsampling layers (e.g. ``[128, 32]`` for Gemma4)
-    - ``use_causal_chunked_attn``: whether attention is causal + chunked
-      (streaming-compatible) rather than full bidirectional
-    """
-
-    num_layers: int = 12
-    hidden_size: int = 1024
-    subsampling_conv_channels: list[int] | None = None
-    use_causal_chunked_attn: bool = False
-    output_proj_dims: int | None = None
 
 
 def _first_not_none(*values, default=None):
@@ -801,55 +585,6 @@ def _extract_audio_config(config, parent_config, model_type: str) -> dict:
         result["audio"] = AudioConfig(**audio_fields)
 
     return result
-
-
-@dataclasses.dataclass
-class QuantizationConfig:
-    """Weight quantization parameters parsed from HuggingFace configs.
-
-    Captures the settings from ``quantization_config`` in HuggingFace model
-    configs (GPTQ, AWQ, etc.) so models can decide whether to use
-    :class:`~mobius.components.QuantizedLinear` instead of
-    :class:`~mobius.components.Linear`.
-    """
-
-    bits: int = 4
-    group_size: int = 128
-    quant_method: str = "none"
-    sym: bool = True
-    # When True, zero_points is a per-block float tensor rather than a
-    # bit-packed uint8. Required for codebooks with non-integer offsets
-    # (e.g. Tencent SEQ uses 1.5).
-    float_zero_point: bool = False
-
-    @classmethod
-    def from_transformers(cls, hf_config) -> QuantizationConfig | None:
-        """Parse ``quantization_config`` from a HuggingFace config.
-
-        Returns ``None`` when no quantization is configured.
-        """
-        qc = getattr(hf_config, "quantization_config", None)
-        if qc is None:
-            return None
-        # qc can be a dict or a HF QuantizationConfig object
-        if hasattr(qc, "to_dict"):
-            qc = qc.to_dict()
-        if not isinstance(qc, dict):
-            return None
-        method = qc.get("quant_method", "none")
-        if method == "none":
-            return None
-        # FP8 per-tensor quantization (float8_e4m3fn + scalar scale)
-        # is handled by dtype casting in _assign_weight(), not by
-        # QuantizedLinear block quantization.
-        if method == "fp8":
-            return None
-        return cls(
-            bits=qc.get("bits", 4),
-            group_size=qc.get("group_size", 128),
-            quant_method=method,
-            sym=qc.get("sym", True),
-        )
 
 
 @dataclasses.dataclass

--- a/src/mobius/_configs/_quantization.py
+++ b/src/mobius/_configs/_quantization.py
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Weight-quantization configuration parsed from HuggingFace configs."""
+
+from __future__ import annotations
+
+import dataclasses
+
+
+@dataclasses.dataclass
+class QuantizationConfig:
+    """Weight quantization parameters parsed from HuggingFace configs.
+
+    Captures the settings from ``quantization_config`` in HuggingFace model
+    configs (GPTQ, AWQ, etc.) so models can decide whether to use
+    :class:`~mobius.components.QuantizedLinear` instead of
+    :class:`~mobius.components.Linear`.
+    """
+
+    bits: int = 4
+    group_size: int = 128
+    quant_method: str = "none"
+    sym: bool = True
+    # When True, zero_points is a per-block float tensor rather than a
+    # bit-packed uint8. Required for codebooks with non-integer offsets
+    # (e.g. Tencent SEQ uses 1.5).
+    float_zero_point: bool = False
+
+    @classmethod
+    def from_transformers(cls, hf_config) -> QuantizationConfig | None:
+        """Parse ``quantization_config`` from a HuggingFace config.
+
+        Returns ``None`` when no quantization is configured.
+        """
+        qc = getattr(hf_config, "quantization_config", None)
+        if qc is None:
+            return None
+        # qc can be a dict or a HF QuantizationConfig object
+        if hasattr(qc, "to_dict"):
+            qc = qc.to_dict()
+        if not isinstance(qc, dict):
+            return None
+        method = qc.get("quant_method", "none")
+        if method == "none":
+            return None
+        # FP8 per-tensor quantization (float8_e4m3fn + scalar scale)
+        # is handled by dtype casting in _assign_weight(), not by
+        # QuantizedLinear block quantization.
+        if method == "fp8":
+            return None
+        return cls(
+            bits=qc.get("bits", 4),
+            group_size=qc.get("group_size", 128),
+            quant_method=method,
+            sym=qc.get("sym", True),
+        )

--- a/src/mobius/_configs/_sub_configs.py
+++ b/src/mobius/_configs/_sub_configs.py
@@ -1,0 +1,242 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Sub-configuration dataclasses used by :class:`ArchitectureConfig`.
+
+These are pure-data dataclasses with no extraction logic. The mapping
+from HuggingFace fields lives in :mod:`mobius._configs._base` (or, for
+model-specific quirks, in per-model extractor functions).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+
+@dataclasses.dataclass
+class RoPEConfig:
+    """Configuration for rotary position embeddings (RoPE).
+
+    Groups the 7 RoPE-related fields that were previously spread across
+    :class:`ArchitectureConfig` as flat attributes.
+    """
+
+    rope_type: str = "default"
+    rope_theta: float = 10_000.0
+    rope_scaling: dict | None = None
+    partial_rotary_factor: float = 1.0
+    rope_local_base_freq: float | None = None
+    original_max_position_embeddings: int | None = None
+    rope_interleave: bool = False
+
+
+@dataclasses.dataclass
+class VisionConfig:
+    """Configuration for the vision encoder in multimodal models.
+
+    This groups all vision-related fields that were previously scattered
+    as ``vision_*`` prefixed fields on :class:`ArchitectureConfig`.
+    """
+
+    hidden_size: int | None = None
+    intermediate_size: int | None = None
+    num_hidden_layers: int | None = None
+    num_attention_heads: int | None = None
+    image_size: int | None = None
+    patch_size: int | None = None
+    norm_eps: float = 1e-6
+    mm_tokens_per_image: int | None = None
+    image_token_id: int | None = None
+    # Pixtral / Mistral-3 vision fields
+    model_type: str | None = None
+    head_dim: int | None = None
+    rope_theta: float | None = None
+    # Qwen VL-specific
+    out_hidden_size: int | None = None
+    in_channels: int = 3
+    spatial_merge_size: int = 2
+    temporal_patch_size: int = 2
+    num_position_embeddings: int | None = None
+    deepstack_visual_indexes: list[int] | None = None
+    fullatt_block_indexes: list[int] | None = None
+    window_size: int | None = None
+    # MRoPE section (for multimodal position encoding)
+    mrope_section: list[int] | None = None
+    # Phi4MM image embedding
+    image_crop_size: int | None = None
+    # LoRA config
+    lora: dict | None = None
+    # Gemma4 SigLIP vision encoder uses clipped linear activations
+    use_clipped_linears: bool = False
+    # Gemma4 SigLIP patch position embedding table size (HF: position_embedding_size)
+    position_embedding_size: int | None = None
+    # Gemma4 VisionPooler spatial average pooling kernel size (3 → 3x3 pooling, N→N/9 tokens)
+    pooling_kernel_size: int | None = None
+    # MLP activation for vision encoder layers (e.g. "gelu_pytorch_tanh" for Gemma4 SigLIP)
+    hidden_act: str | None = None
+
+
+@dataclasses.dataclass
+class CodecDecoderConfig:
+    """Configuration for the codec decoder (codes → waveform)."""
+
+    codebook_dim: int = 512
+    codebook_size: int = 2048
+    latent_dim: int = 1024
+    hidden_size: int = 512
+    intermediate_size: int = 1024
+    num_hidden_layers: int = 8
+    num_attention_heads: int = 16
+    num_key_value_heads: int = 16
+    head_dim: int = 64
+    rms_norm_eps: float = 1e-5
+    rope_theta: float = 10000.0
+    max_position_embeddings: int = 8000
+    decoder_dim: int = 1536
+    num_quantizers: int = 16
+    upsample_rates: list[int] = dataclasses.field(default_factory=lambda: [8, 5, 4, 3])
+    upsampling_ratios: list[int] = dataclasses.field(default_factory=lambda: [2, 2])
+
+
+@dataclasses.dataclass
+class CodecEncoderConfig:
+    """Configuration for the codec encoder (waveform → codes)."""
+
+    codebook_dim: int = 256
+    codebook_size: int = 2048
+    hidden_size: int = 512
+    intermediate_size: int = 2048
+    num_hidden_layers: int = 8
+    num_attention_heads: int = 8
+    num_key_value_heads: int = 8
+    head_dim: int = 64
+    rope_theta: float = 10000.0
+    max_position_embeddings: int = 8000
+    num_quantizers: int = 32
+    num_semantic_quantizers: int = 1
+
+
+@dataclasses.dataclass
+class SpeakerEncoderConfig:
+    """Configuration for the ECAPA-TDNN speaker encoder in TTS models."""
+
+    mel_dim: int = 128
+    enc_dim: int = 1024
+    enc_channels: list[int] = dataclasses.field(
+        default_factory=lambda: [512, 512, 512, 512, 1536]
+    )
+    enc_kernel_sizes: list[int] = dataclasses.field(default_factory=lambda: [5, 3, 3, 3, 1])
+    enc_dilations: list[int] = dataclasses.field(default_factory=lambda: [1, 2, 3, 4, 1])
+    enc_attention_channels: int = 128
+    enc_res2net_scale: int = 8
+    enc_se_channels: int = 128
+
+
+@dataclasses.dataclass
+class CodePredictorConfig:
+    """Configuration for the TTS code predictor sub-model."""
+
+    hidden_size: int = 1024
+    intermediate_size: int = 3072
+    num_hidden_layers: int = 5
+    num_attention_heads: int = 16
+    num_key_value_heads: int = 8
+    head_dim: int = 128
+    vocab_size: int = 2048
+    num_code_groups: int = 16
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 1_000_000.0
+    hidden_act: str = "silu"
+    layer_types: list[str] | None = None
+
+
+@dataclasses.dataclass
+class TTSConfig:
+    """Configuration for Qwen3-TTS models.
+
+    Groups TTS-specific fields: talker parameters, code predictor config,
+    and speaker encoder config.
+    """
+
+    # Talker parameters
+    text_hidden_size: int = 2048
+    text_vocab_size: int = 151936
+    num_code_groups: int = 16
+    # Special token IDs
+    codec_bos_id: int = 2149
+    codec_eos_token_id: int = 2150
+    codec_pad_id: int = 2148
+    codec_think_id: int = 2154
+    codec_nothink_id: int = 2155
+    # Sub-configs
+    code_predictor: CodePredictorConfig | None = None
+    speaker_encoder: SpeakerEncoderConfig | None = None
+
+
+@dataclasses.dataclass
+class AudioConfig:
+    """Configuration for the audio encoder in multimodal models."""
+
+    attention_dim: int | None = None
+    attention_heads: int | None = None
+    num_blocks: int | None = None
+    linear_units: int | None = None
+    kernel_size: int | None = None
+    input_size: int | None = None
+    conv_channels: int | None = None
+    t5_bias_max_distance: int | None = None
+    projection_hidden_size: int | None = None
+    token_id: int | None = None
+    # Qwen3-ASR encoder config
+    d_model: int | None = None
+    encoder_layers: int | None = None
+    encoder_attention_heads: int | None = None
+    encoder_ffn_dim: int | None = None
+    num_mel_bins: int | None = None
+    max_source_positions: int | None = None
+    downsample_hidden_size: int | None = None
+    output_dim: int | None = None
+    activation_function: str = "gelu"
+    audio_token_id: int | None = None
+    audio_start_token_id: int | None = None
+    audio_end_token_id: int | None = None
+    classify_num: int | None = None
+    # Qwen3-ASR chunked conv parameters. ``n_window`` is half the
+    # number of mel frames per conv chunk (so chunk_size = 2 *
+    # n_window). ``n_window_infer`` is the attention window in mel
+    # frames; encoder self-attention is block-diagonal with windows
+    # of n_window_infer / (2 * n_window) post-conv chunks (~=
+    # n_window_infer * tokens_per_chunk / chunk_size_mel post-conv
+    # tokens). HF reference: QwenLM/Qwen3-ASR
+    # qwen_asr/core/transformers_backend/modeling_qwen3_asr.py
+    n_window: int | None = None
+    n_window_infer: int | None = None
+    # Fun-ASR / SenseVoice encoder config
+    tp_num_blocks: int | None = None
+    adaptor_proj_dim: int | None = None
+    adaptor_num_blocks: int | None = None
+    adaptor_ffn_dim: int | None = None
+    adaptor_num_heads: int | None = None
+    # LoRA config
+    lora: dict | None = None
+
+
+@dataclasses.dataclass
+class Gemma4AudioConfig(AudioConfig):
+    """Configuration for the Gemma4 Conformer audio encoder.
+
+    Extends :class:`AudioConfig` with Gemma4-specific fields:
+
+    - ``num_layers``: number of Conformer encoder blocks (12 for Gemma4)
+    - ``hidden_size``: encoder hidden dimension (1024 for Gemma4)
+    - ``subsampling_conv_channels``: channel sizes for 2D convolutional
+      subsampling layers (e.g. ``[128, 32]`` for Gemma4)
+    - ``use_causal_chunked_attn``: whether attention is causal + chunked
+      (streaming-compatible) rather than full bidirectional
+    """
+
+    num_layers: int = 12
+    hidden_size: int = 1024
+    subsampling_conv_channels: list[int] | None = None
+    use_causal_chunked_attn: bool = False
+    output_proj_dims: int | None = None


### PR DESCRIPTION
## Part 1 of 3

`src/mobius/_configs.py` had grown to **2591 lines** (9 sub-configs + 19 per-model configs + 3 mega-switch extractors + a 530-line `ArchitectureConfig.from_transformers`). This PR is the first of three mechanical refactors that carve it into a scalable package layout. **No behavior change** — every public name is still importable from `mobius._configs`.

```
src/mobius/_configs/
├── __init__.py        # re-exports everything that was in _configs.py
├── _sub_configs.py    # pure-data dataclasses (RoPE/Vision/Audio/Codec/TTS)
├── _quantization.py   # QuantizationConfig + from_transformers
└── _base.py           # BaseModelConfig, ArchitectureConfig, per-model
                       # subclasses, and the _extract_* helpers
```

## Follow-ups in this series

* **Part 2/3** — convert the `_extract_audio_config` / `_extract_vision_config` model_type switches into a decorator-registered dispatch so new models add a file under `per_model/` instead of a branch in the central function.
* **Part 3/3** — move per-model config subclasses (`Gemma2Config`, `MllamaConfig`, `NemotronHConfig`, …) into `per_model/` and carve up `ArchitectureConfig.from_transformers`.

## Tests

* 2769 passed (full `src/` + `tests/build_graph_test.py` + `tests/cli_test.py`)
* Ruff clean