### PR TITLE
tasks: declare vision/audio encoder inputs at config.dtype

### DIFF
--- a/src/mobius/tasks/_audio_ctc.py
+++ b/src/mobius/tasks/_audio_ctc.py
@@ -24,7 +24,6 @@ from mobius._configs import ArchitectureConfig
 from mobius._model_package import ModelPackage
 from mobius.tasks._base import (
     ModelTask,
-    _cast_encoder_input,
     _make_graph,
     _make_model,
 )
@@ -48,10 +47,9 @@ class AudioCTCTask(ModelTask):
 
         input_features = builder.input(
             "input_features",
-            dtype=ir.DataType.FLOAT,
+            dtype=config.dtype,
             shape=["batch", "time", input_dim],
         )
-        input_features = _cast_encoder_input(op, input_features, config)
         language_id = builder.input(
             "language_id",
             dtype=ir.DataType.INT64,

--- a/src/mobius/tasks/_base.py
+++ b/src/mobius/tasks/_base.py
@@ -130,18 +130,6 @@ def _make_model(graph: ir.Graph) -> ir.Model:
     return model
 
 
-def _cast_encoder_input(op, tensor, config: BaseModelConfig):
-    """Cast an f32 encoder input to the model's compute dtype if needed.
-
-    Vision/audio processors output float32. Encoder graph inputs are
-    declared as FLOAT, and this helper adds a Cast when the model uses
-    f16/bf16 so that the first encoder op receives matching types.
-    """
-    if config.dtype and config.dtype != ir.DataType.FLOAT:
-        return op.Cast(tensor, to=config.dtype)
-    return tensor
-
-
 class ModelTask(ABC):
     """Abstract base defining how to wire a module into an ONNX graph.
 

--- a/src/mobius/tasks/_fun_asr_speech_language.py
+++ b/src/mobius/tasks/_fun_asr_speech_language.py
@@ -26,7 +26,6 @@ from mobius._model_package import ModelPackage
 from mobius.tasks._base import (
     ComponentSpec,
     ModelTask,
-    _cast_encoder_input,
     _make_graph,
     _make_model,
     build_decoder_from_embeds,
@@ -96,10 +95,9 @@ class FunASRSpeechLanguageTask(ModelTask):
 
         input_features = builder.input(
             "input_features",
-            dtype=ir.DataType.FLOAT,
+            dtype=config.dtype,
             shape=[batch, seq_len, input_dim],
         )
-        input_features = _cast_encoder_input(op, input_features, config)
 
         audio_features = audio_encoder(op, input_features)
 

--- a/src/mobius/tasks/_gemma4.py
+++ b/src/mobius/tasks/_gemma4.py
@@ -28,7 +28,6 @@ from mobius._configs import Gemma4Config
 from mobius._model_package import ModelPackage
 from mobius.tasks._base import (
     ModelTask,
-    _cast_encoder_input,
     _make_graph,
     _make_model,
 )
@@ -305,10 +304,9 @@ class Gemma4Task(ModelTask):
 
         pixel_values = builder.input(
             "pixel_values",
-            dtype=ir.DataType.FLOAT,
+            dtype=config.dtype,
             shape=[batch, num_patches, pixel_dim],
         )
-        pixel_values = _cast_encoder_input(op, pixel_values, config)
         pixel_position_ids = builder.input(
             "pixel_position_ids",
             dtype=ir.DataType.INT64,
@@ -358,10 +356,9 @@ class Gemma4Task(ModelTask):
 
         input_features = builder.input(
             "input_features",
-            dtype=ir.DataType.FLOAT,
+            dtype=config.dtype,
             shape=[batch, time, input_size],
         )
-        input_features = _cast_encoder_input(op, input_features, config)
         input_features_mask = builder.input(
             "input_features_mask",
             dtype=ir.DataType.BOOL,

--- a/src/mobius/tasks/_hunyuan_vl_mot.py
+++ b/src/mobius/tasks/_hunyuan_vl_mot.py
@@ -20,7 +20,6 @@ from mobius._model_package import ModelPackage
 from mobius.tasks._base import (
     ComponentSpec,
     ModelTask,
-    _cast_encoder_input,
     _make_graph,
     _make_model,
     build_embedding_from_features,
@@ -139,10 +138,9 @@ class HunYuanVLMoTTask(ModelTask):
         op = builder.op
         pixel_values = builder.input(
             "pixel_values",
-            dtype=ir.DataType.FLOAT,
+            dtype=config.dtype,
             shape=[batch, 3, image_size, image_size],
         )
-        pixel_values = _cast_encoder_input(op, pixel_values, config)
         image_features = vision(op, pixel_values=pixel_values)
 
         builder.add_output(image_features, "image_features")

--- a/src/mobius/tasks/_multimodal.py
+++ b/src/mobius/tasks/_multimodal.py
@@ -12,7 +12,6 @@ from mobius._configs import ArchitectureConfig
 from mobius._model_package import ModelPackage
 from mobius.tasks._base import (
     ModelTask,
-    _cast_encoder_input,
     _make_graph,
     _make_model,
 )
@@ -75,18 +74,16 @@ class MultiModalTask(ModelTask):
         image_size = config.vision.image_size or 224 if config.vision else 224
         pixel_values = builder.input(
             "pixel_values",
-            dtype=ir.DataType.FLOAT,
+            dtype=config.dtype,
             shape=[batch, 3, image_size, image_size],
         )
-        pixel_values = _cast_encoder_input(op, pixel_values, config)
 
         audio_input_size = (config.audio.input_size if config.audio else None) or 80
         audio_features = builder.input(
             "audio_features",
-            dtype=ir.DataType.FLOAT,
+            dtype=config.dtype,
             shape=[batch, "audio_seq_len", audio_input_size],
         )
-        audio_features = _cast_encoder_input(op, audio_features, config)
 
         past_key_values = _make_kv_cache_inputs(
             builder,

--- a/src/mobius/tasks/_phi4mm_multimodal.py
+++ b/src/mobius/tasks/_phi4mm_multimodal.py
@@ -29,7 +29,6 @@ from mobius._model_package import ModelPackage
 from mobius.tasks._base import (
     ComponentSpec,
     ModelTask,
-    _cast_encoder_input,
     _make_graph,
     _make_model,
     build_decoder_from_embeds,
@@ -90,10 +89,9 @@ class Phi4MMMultiModalTask(ModelTask):
 
         pixel_values = builder.input(
             "pixel_values",
-            dtype=ir.DataType.FLOAT,
+            dtype=config.dtype,
             shape=[batch, 3, image_size, image_size],
         )
-        pixel_values = _cast_encoder_input(op, pixel_values, config)
         image_sizes = builder.input(
             "image_sizes",
             dtype=ir.DataType.INT64,
@@ -125,10 +123,9 @@ class Phi4MMMultiModalTask(ModelTask):
 
         audio_embeds = builder.input(
             "audio_embeds",
-            dtype=ir.DataType.FLOAT,
+            dtype=config.dtype,
             shape=[batch, audio_seq_len, input_size],
         )
-        audio_embeds = _cast_encoder_input(op, audio_embeds, config)
         audio_sizes = builder.input(
             "audio_sizes",
             dtype=ir.DataType.INT64,

--- a/src/mobius/tasks/_speech_language.py
+++ b/src/mobius/tasks/_speech_language.py
@@ -23,7 +23,6 @@ from mobius._model_package import ModelPackage
 from mobius.tasks._base import (
     ComponentSpec,
     ModelTask,
-    _cast_encoder_input,
     _make_graph,
     _make_model,
     build_decoder_from_embeds,
@@ -88,10 +87,9 @@ class SpeechLanguageTask(ModelTask):
 
         input_features = builder.input(
             "input_features",
-            dtype=ir.DataType.FLOAT,
+            dtype=config.dtype,
             shape=[batch, n_mels, mel_seq],
         )
-        input_features = _cast_encoder_input(op, input_features, config)
         # Mask is required: without it the encoder consumes padded mel
         # frames as if they were real audio, which causes the
         # downstream LLM to emit degenerate loops on any input padded

--- a/src/mobius/tasks/_vision_language.py
+++ b/src/mobius/tasks/_vision_language.py
@@ -12,7 +12,6 @@ from mobius._configs import ArchitectureConfig
 from mobius._model_package import ModelPackage
 from mobius.tasks._base import (
     ModelTask,
-    _cast_encoder_input,
     _make_graph,
     _make_model,
 )
@@ -74,10 +73,9 @@ class Qwen3VLVisionLanguageTask(ModelTask):
         pixel_dim = in_channels * temporal_patch_size * patch_size * patch_size
         pixel_values = builder.input(
             "pixel_values",
-            dtype=ir.DataType.FLOAT,
+            dtype=config.dtype,
             shape=[total_patches, pixel_dim],
         )
-        pixel_values = _cast_encoder_input(op, pixel_values, config)
         # Image grid dimensions for position embedding interpolation
         num_images = ir.SymbolicDim("num_images")
         grid_thw = builder.input(

--- a/src/mobius/tasks/_vision_language_3model.py
+++ b/src/mobius/tasks/_vision_language_3model.py
@@ -21,7 +21,6 @@ from mobius._model_package import ModelPackage
 from mobius.tasks._base import (
     ComponentSpec,
     ModelTask,
-    _cast_encoder_input,
     _make_graph,
     _make_model,
     build_decoder_from_embeds,
@@ -87,10 +86,9 @@ class VisionLanguageTask(ModelTask):
         op = builder.op
         pixel_values = builder.input(
             "pixel_values",
-            dtype=ir.DataType.FLOAT,
+            dtype=config.dtype,
             shape=[batch, 3, image_size, image_size],
         )
-        pixel_values = _cast_encoder_input(op, pixel_values, config)
         image_features = vision(op, pixel_values=pixel_values)
 
         builder.add_output(image_features, "image_features")
@@ -140,10 +138,9 @@ class QwenVLTask(VisionLanguageTask):
         op = builder.op
         pixel_values = builder.input(
             "pixel_values",
-            dtype=ir.DataType.FLOAT,
+            dtype=config.dtype,
             shape=[total_patches, pixel_dim],
         )
-        pixel_values = _cast_encoder_input(op, pixel_values, config)
         image_grid_thw = builder.input(
             "image_grid_thw",
             dtype=ir.DataType.INT64,
@@ -217,10 +214,9 @@ class PixtralVLTask(VisionLanguageTask):
         op = builder.op
         pixel_values = builder.input(
             "pixel_values",
-            dtype=ir.DataType.FLOAT,
+            dtype=config.dtype,
             shape=[batch, 3, height, width],
         )
-        pixel_values = _cast_encoder_input(op, pixel_values, config)
 
         image_features = vision(
             op,

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -1862,13 +1862,13 @@ class TestBuildGraphDtype:
         "dtype_str",
         ["f16", "bf16"],
     )
-    def test_multimodal_encoder_inputs_are_float32(self, dtype_str):
-        """Vision/audio encoder graph inputs stay f32 with Cast at entry.
+    def test_multimodal_encoder_inputs_match_model_dtype(self, dtype_str):
+        """Vision/audio encoder graph inputs use the model's compute dtype.
 
-        When building multimodal models with f16/bf16, encoder graph inputs
-        (pixel_values, input_features) must remain FLOAT because ORT GenAI's
-        image/audio processors output f32. A Cast node at graph entry converts
-        to the target dtype for the encoder's internal computation.
+        ORT GenAI's image/audio processor output doesn't have to be f32 —
+        the runtime can deliver inputs at the model's compute dtype
+        directly. Declaring the graph input as ``config.dtype`` removes
+        an extra Cast node at graph entry.
         """
         # Use a VL model with 3-model split (vision_encoder is separate)
         config = _base_config(
@@ -1889,27 +1889,28 @@ class TestBuildGraphDtype:
         task = get_task("vision-language")
         pkg = task.build(module, config)
 
-        # Vision encoder pixel_values input must be FLOAT
+        # Vision encoder pixel_values input must match config.dtype
         vision_model = pkg["vision_encoder"]
         pixel_values_input = vision_model.graph.inputs[0]
         assert pixel_values_input.name == "pixel_values"
-        assert pixel_values_input.dtype == ir.DataType.FLOAT, (
+        assert pixel_values_input.dtype == config.dtype, (
             f"Vision encoder input dtype is {pixel_values_input.dtype}, "
-            f"expected FLOAT (Cast should handle conversion to {dtype_str})"
+            f"expected {config.dtype} (no Cast at graph entry)"
         )
 
-        # First non-input node should be Cast to target dtype
+        # No Cast as the first node — inputs already arrive at the right dtype
         first_node = next(iter(vision_model.graph))
-        assert first_node.op_type == "Cast", (
-            f"Expected Cast as first node, got {first_node.op_type}"
+        assert first_node.op_type != "Cast" or first_node.inputs[0].name != "pixel_values", (
+            f"Unexpected Cast on pixel_values: graph input dtype {pixel_values_input.dtype} "
+            f"should already match the encoder's compute dtype."
         )
 
     @pytest.mark.parametrize(
         "dtype_str",
         ["f16", "bf16"],
     )
-    def test_gemma4_encoder_inputs_are_float32(self, dtype_str):
-        """Gemma4 vision and audio encoder inputs stay f32 in bf16/f16 builds."""
+    def test_gemma4_encoder_inputs_match_model_dtype(self, dtype_str):
+        """Gemma4 vision/audio encoder inputs match the model's compute dtype."""
         from mobius._configs import Gemma4AudioConfig, Gemma4Config
 
         config = Gemma4Config(
@@ -1957,17 +1958,17 @@ class TestBuildGraphDtype:
         task = get_task("gemma4")
         pkg = task.build(module, config)
 
-        # Vision encoder pixel_values must be FLOAT
+        # Vision encoder pixel_values must match config.dtype
         vision_model = pkg["vision_encoder"]
         pv_input = vision_model.graph.inputs[0]
         assert pv_input.name == "pixel_values"
-        assert pv_input.dtype == ir.DataType.FLOAT
+        assert pv_input.dtype == config.dtype
 
-        # Audio encoder input_features must be FLOAT
+        # Audio encoder input_features must match config.dtype
         audio_model = pkg["audio_encoder"]
         af_input = audio_model.graph.inputs[0]
         assert af_input.name == "input_features"
-        assert af_input.dtype == ir.DataType.FLOAT
+        assert af_input.dtype == config.dtype
 
 
 class TestBuildGraphMultiModal:


### PR DESCRIPTION
## Summary

Revert PR #275 (and the matching original change for `_gemma4.py` / `_vision_language_3model.py`) that declared vision/audio encoder graph inputs as `FLOAT` with a `Cast` at graph entry. Per discussion with the ORT GenAI team, the runtime does not require encoder inputs to be float32 — it can deliver vision / audio inputs at the same dtype the model was built with (`f16` / `bf16`).

Declaring the graph input at `config.dtype` directly:
- matches the model's internal compute dtype
- removes the extra `Cast` node at graph entry (one fewer op per inference)
- simplifies test harnesses that previously had to cast feature-extractor output to `np.float32`

## Before

```python
pixel_values = builder.input("pixel_values", dtype=ir.DataType.FLOAT, shape=[...])
pixel_values = _cast_encoder_input(op, pixel_values, config)   # adds Cast when config.dtype != FLOAT
```

## After

```python
pixel_values = builder.input("pixel_values", dtype=config.dtype, shape=[...])
```

## Files changed

- `tasks/_vision_language.py`, `_vision_language_3model.py`, `_multimodal.py`, `_audio_ctc.py`, `_speech_language.py`, `_hunyuan_vl_mot.py`, `_phi4mm_multimodal.py`, `_fun_asr_speech_language.py`, `_gemma4.py`: replace f32+Cast pattern with `dtype=config.dtype`
- `tasks/_base.py`: drop the now-unused `_cast_encoder_input` helper
- `tests/build_graph_test.py`: rewrite `test_multimodal_encoder_inputs_*` / `test_gemma4_encoder_inputs_*` to assert encoder inputs match `config.dtype` and that there is no `Cast` at graph entry

## Out of scope

Single-model encoder-only tasks (`_image_classification.py`, `_audio_feature_extraction.py`) still declare `FLOAT` because they have no separate compute dtype — the whole model is f32 and inputs go straight to the encoder.

## Tests

L1 + unit suite: 2763 passed, 43 skipped (no regressions). `ruff check` + `ruff format --check` both pass.
