### PR TITLE
Enhance embedding introspection for GenAI config

### DIFF
--- a/examples/gemma4_genai.py
+++ b/examples/gemma4_genai.py
@@ -77,8 +77,10 @@ def build_and_export(
     output_dir: str,
     *,
     dtype: str = "f32",
+    device: str = "cpu",
 ) -> None:
     """Build ONNX model with mobius CLI and write ORT GenAI config."""
+    ep = "cuda" if device == "cuda" else "cpu"
     cmd = [
         sys.executable,
         "-m",
@@ -88,6 +90,8 @@ def build_and_export(
         model_id,
         "--dtype",
         dtype,
+        "--ep",
+        ep,
         "--optimize",
         "--runtime",
         "ort-genai",
@@ -351,7 +355,7 @@ def main() -> None:
 
     # ----- Export-only path -----
     if args.save_to:
-        build_and_export(args.model, args.save_to, dtype=args.dtype)
+        build_and_export(args.model, args.save_to, dtype=args.dtype, device=args.device)
         return
 
     # ----- Resolve model directory -----
@@ -362,7 +366,7 @@ def main() -> None:
         default_dir = os.path.join("output", f"gemma4_{suffix}")
         model_dir = default_dir
         if not os.path.isfile(os.path.join(model_dir, "genai_config.json")):
-            build_and_export(args.model, model_dir, dtype=args.dtype)
+            build_and_export(args.model, model_dir, dtype=args.dtype, device=args.device)
 
     # ----- Inference -----
     print("=" * 60)

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -148,6 +148,21 @@ def _introspect_inputs(pkg: ModelPackage, key: str) -> dict[str, str] | None:
     return {n: n for n in _graph_input_names(model)}
 
 
+def _introspect_outputs(pkg: ModelPackage, key: str) -> dict[str, str] | None:
+    """Return ``{name: name}`` identity mapping for a sub-model's outputs.
+
+    Returns ``None`` when *key* is absent from *pkg*.
+    """
+    model = pkg.get(key)
+    if model is None:
+        return None
+    return {
+        out.name: out.name
+        for out in model.graph.outputs
+        if out.name is not None
+    }
+
+
 def _copy_tokenizer_files(
     model_id: str,
     output_dir: str,
@@ -712,6 +727,10 @@ def _write_genai_config(
                 vision_kwargs["input_names"] = vision_input_mapping
             if embedding_input_mapping is not None:
                 vision_kwargs["embedding_input_names"] = embedding_input_mapping
+
+            embedding_output_mapping = _introspect_outputs(pkg, "embedding")
+            if embedding_output_mapping is not None:
+                vision_kwargs["embedding_output_names"] = embedding_output_mapping
 
             generator.with_vision(image_token_id=image_token_id, **vision_kwargs)
 

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -156,11 +156,7 @@ def _introspect_outputs(pkg: ModelPackage, key: str) -> dict[str, str] | None:
     model = pkg.get(key)
     if model is None:
         return None
-    return {
-        out.name: out.name
-        for out in model.graph.outputs
-        if out.name is not None
-    }
+    return {out.name: out.name for out in model.graph.outputs if out.name is not None}
 
 
 def _copy_tokenizer_files(

--- a/src/mobius/integrations/ort_genai/genai_config.py
+++ b/src/mobius/integrations/ort_genai/genai_config.py
@@ -289,6 +289,8 @@ class GenaiConfigGenerator:
                 mapping.  When provided (e.g. from ONNX graph
                 introspection), used directly.  Defaults to
                 input_ids + image_features.
+            embedding_output_names: Override embedding model output name
+                mapping. Defaults to inputs_embeds.
             vision_start_token_id: Token ID for ``<|vision_start|>``.
             video_token_id: Token ID for video placeholders.
 

--- a/src/mobius/integrations/ort_genai/genai_config.py
+++ b/src/mobius/integrations/ort_genai/genai_config.py
@@ -266,6 +266,7 @@ class GenaiConfigGenerator:
         input_names: dict[str, str] | None = None,
         output_names: dict[str, str] | None = None,
         embedding_input_names: dict[str, str] | None = None,
+        embedding_output_names: dict[str, str] | None = None,
         vision_start_token_id: int | None = None,
         video_token_id: int | None = None,
     ) -> GenaiConfigGenerator:
@@ -321,7 +322,7 @@ class GenaiConfigGenerator:
         self._embedding = {
             "filename": embedding_filename,
             "inputs": embedding_input_names,
-            "outputs": {
+            "outputs": embedding_output_names if embedding_output_names is not None else {
                 "inputs_embeds": "inputs_embeds",
             },
             "session_options": _make_session_options(self.ep),

--- a/src/mobius/integrations/ort_genai/genai_config.py
+++ b/src/mobius/integrations/ort_genai/genai_config.py
@@ -322,7 +322,9 @@ class GenaiConfigGenerator:
         self._embedding = {
             "filename": embedding_filename,
             "inputs": embedding_input_names,
-            "outputs": embedding_output_names if embedding_output_names is not None else {
+            "outputs": embedding_output_names
+            if embedding_output_names is not None
+            else {
                 "inputs_embeds": "inputs_embeds",
             },
             "session_options": _make_session_options(self.ep),


### PR DESCRIPTION
## Summary

Two fixes for Gemma4 multimodal export and genai_config generation.


### Introspect embedding model outputs in genai_config.json

The Gemma4 embedding model produces `per_layer_inputs` alongside `inputs_embeds`, but `genai_config.json` only listed `inputs_embeds` in the embedding outputs section. This caused onnxruntime-genai to not bind the `per_layer_inputs` output, so ORT allocated a separate buffer and the decoder received uninitialized data.

Added `_introspect_outputs()` to auto-discover embedding model outputs from the ONNX graph, and `embedding_output_names` parameter to `GenaiConfigGenerator.with_vision()`.

**Files:** `integrations/ort_genai/auto_export.py`, `integrations/ort_genai/genai_config.py`

### Pass `--ep` to mobius CLI in export script

`build_and_export()` in `gemma4_genai.py` did not pass the execution provider to `mobius build`. This caused all exports to use the default EP (which has empty `gqa_dtypes`), so KV-shared layers fell back to standard Attention instead of GQA — leading to `past_present_share_buffer` failures at runtime.

Now `--device cuda` correctly maps to `--ep cuda`, producing all-GQA models.

**Files:** `examples/gemma4_genai.py`

### Testing

- CPU fp32 export: GQA=35, Attention=0 ✅
- CUDA fp16 export: GQA=35, Attention=0 ✅
- Text-only generation (CPU): clean output ✅
- Multimodal image+text generation: no NaN, pixel_position_ids extracted correctly ✅
- per_layer_inputs forwarded from embedding to decoder ✅
- Backward compatible: existing non-Gemma4 models unaffected ✅