### PR TITLE
Architecture diff: recurse into subgraphs (make control-flow/phase-split changes visible)

### DIFF
--- a/src/mobius/_graph_diff.py
+++ b/src/mobius/_graph_diff.py
@@ -54,11 +54,23 @@ def _dtype_str(value: ir.Value) -> str:
     return "UNKNOWN"
 
 
+# Sentinel keys marking a recursively-canonicalised subgraph payload inside an
+# attribute's comparable value.  diff_graphs uses these to render subgraph
+# deltas readably instead of dumping a raw nested canonical dict.
+_SUBGRAPH_KEY = "__subgraph__"
+_SUBGRAPHS_KEY = "__subgraphs__"
+
+
 def _attr_to_comparable(attr: ir.Attr) -> Any:
     """Convert an attribute to a JSON-serialisable comparable value.
 
-    Graph and tensor attributes are reduced to their type string so
-    that canonicalisation stays lightweight.
+    Most attributes reduce to their scalar / list value.  GRAPH-typed
+    attributes (``If``'s ``then_branch`` / ``else_branch``, ``Loop`` /
+    ``Scan`` bodies) are *recursively canonicalised* so subgraph structure
+    participates in the diff — without this, per-layer phase-split ``If``
+    subgraphs are invisible to the architecture diff.  Remaining opaque
+    types (TENSOR, SPARSE_TENSOR, TYPE_PROTO, …) are recorded as their type
+    string to keep canonicalisation lightweight.
     """
     simple_types = {
         ir.AttributeType.FLOAT,
@@ -74,7 +86,14 @@ def _attr_to_comparable(attr: ir.Attr) -> Any:
         if isinstance(v, tuple):
             return list(v)
         return v
-    # For TENSOR, GRAPH etc. just record the type
+    # Recurse into subgraphs so their node structure is compared, not collapsed.
+    # Subgraphs reuse canonicalize_graph, so inner node/value names are ignored
+    # the same way top-level ones are (see canonicalize_graph's name-independence).
+    if attr.type == ir.AttributeType.GRAPH:
+        return {_SUBGRAPH_KEY: canonicalize_graph(attr.value)}
+    if attr.type == ir.AttributeType.GRAPHS:
+        return {_SUBGRAPHS_KEY: [canonicalize_graph(g) for g in attr.value]}
+    # For TENSOR, SPARSE_TENSOR, TYPE_PROTO, … just record the type.
     return f"<{attr.type.name}>"
 
 
@@ -203,13 +222,92 @@ def _describe_port_diff(base_port: dict, head_port: dict) -> str:
     return "; ".join(parts) or "changed"
 
 
+def _is_subgraph_payload(value: Any) -> bool:
+    """True if *value* is a recursively-canonicalised subgraph payload."""
+    return isinstance(value, dict) and (_SUBGRAPH_KEY in value or _SUBGRAPHS_KEY in value)
+
+
+def _subgraph_list(value: Any) -> list[dict]:
+    """Extract the list of subgraph canonical forms from an attr payload."""
+    if isinstance(value, dict):
+        if _SUBGRAPH_KEY in value:
+            return [value[_SUBGRAPH_KEY]]
+        if _SUBGRAPHS_KEY in value:
+            return list(value[_SUBGRAPHS_KEY])
+    return []
+
+
+# Nested sub-change types that make a subgraph delta *structurally* significant
+# (a node/branch was added/removed, rewired, or the subgraph interface moved),
+# as opposed to a mere inner-attribute tweak.  Any of these promotes the
+# containing attribute to a subgraph_structure_change → MODERATE.  Note this is
+# uniformly MODERATE: unlike a *top-level* interface_change (MAJOR, an external
+# model-contract break), a subgraph's interface is internal control-flow plumbing,
+# so it stays MODERATE here — a deliberate asymmetry.
+# ``subgraph_structure_change`` is included so structural significance
+# *propagates* upward through nested subgraphs (e.g. an If inside an If).
+_STRUCTURAL_SUB_TYPES = frozenset(
+    {
+        "added_node",
+        "removed_node",
+        "changed_connectivity",
+        "interface_change",
+        "subgraph_structure_change",
+    }
+)
+
+
+def _describe_subgraph_attr_change(key: str, base_val: Any, head_val: Any) -> tuple[str, bool]:
+    """Describe a GRAPH-typed attribute change, recursing into the subgraph(s).
+
+    Returns ``(detail, structural)`` where *detail* is a readable summary
+    that surfaces the nested diff (e.g. ``"then_branch: node[0] Concat:
+    axis: 0 → 1"`` or ``"then_branch: + Mul; - Add"``) and *structural* is
+    True when the nested delta adds/removes a node or branch, rewires
+    connectivity, or changes the subgraph interface — i.e. a change that
+    should outrank a pure inner-attribute tweak.
+    """
+    base_subs = _subgraph_list(base_val)
+    head_subs = _subgraph_list(head_val)
+    count = max(len(base_subs), len(head_subs))
+    structural = False
+    parts: list[str] = []
+    for idx in range(count):
+        bs = base_subs[idx] if idx < len(base_subs) else None
+        hs = head_subs[idx] if idx < len(head_subs) else None
+        # The attribute *key* already names a single subgraph (then_branch,
+        # body, …); only disambiguate by index when there are several (GRAPHS).
+        label = "" if count == 1 else f"subgraph[{idx}]"
+        if bs is None or hs is None:
+            # A whole branch/body was added or removed.
+            structural = True
+            verb = "added" if bs is None else "removed"
+            parts.append(f"{label} {verb}".strip())
+            continue
+        sub_changes = diff_graphs(bs, hs)
+        if not sub_changes:
+            continue
+        if {c["type"] for c in sub_changes} & _STRUCTURAL_SUB_TYPES:
+            structural = True
+        inner = "; ".join(c["details"] for c in sub_changes)
+        parts.append(f"{label}: {inner}" if label else inner)
+    detail = f"{key}: " + ("; ".join(parts) if parts else "subgraph changed")
+    return detail, structural
+
+
 def diff_graphs(base: dict, head: dict) -> list[dict[str, Any]]:
     """Compare two canonical graph representations.
 
     Returns a list of change dicts.  Each dict has a ``"type"`` key with
     one of: ``"added_node"``, ``"removed_node"``, ``"changed_attrs"``,
+    ``"subgraph_structure_change"``, ``"changed_connectivity"``,
     ``"interface_change"``, ``"initializer_change"``.  A ``"details"``
     key carries human-readable information about the change.
+
+    ``subgraph_structure_change`` is emitted for a GRAPH-typed attribute
+    (``If`` branches, ``Loop`` / ``Scan`` bodies) whose nested graph gains
+    or loses a node/branch, is rewired, or changes interface; a subgraph
+    delta that only tweaks an inner attribute stays ``changed_attrs``.
     """
     changes: list[dict[str, Any]] = []
 
@@ -304,19 +402,32 @@ def diff_graphs(base: dict, head: dict) -> list[dict[str, Any]]:
         if bn["attributes"] != hn["attributes"]:
             ba = bn["attributes"]
             ha = hn["attributes"]
-            attr_details: list[str] = []
+            plain_details: list[str] = []
             all_keys = sorted(set(ba) | set(ha))
             for k in all_keys:
                 bv = ba.get(k)
                 hv = ha.get(k)
-                if bv != hv:
-                    attr_details.append(f"{k}: {bv!r} → {hv!r}")
-            changes.append(
-                {
-                    "type": "changed_attrs",
-                    "details": (f"node[{i}] {bn['op_type']}: " + ", ".join(attr_details)),
-                }
-            )
+                if bv == hv:
+                    continue
+                if _is_subgraph_payload(bv) or _is_subgraph_payload(hv):
+                    detail, structural = _describe_subgraph_attr_change(k, bv, hv)
+                    changes.append(
+                        {
+                            "type": (
+                                "subgraph_structure_change" if structural else "changed_attrs"
+                            ),
+                            "details": f"node[{i}] {bn['op_type']}: {detail}",
+                        }
+                    )
+                else:
+                    plain_details.append(f"{k}: {bv!r} → {hv!r}")
+            if plain_details:
+                changes.append(
+                    {
+                        "type": "changed_attrs",
+                        "details": (f"node[{i}] {bn['op_type']}: " + ", ".join(plain_details)),
+                    }
+                )
         if bn["input_ids"] != hn["input_ids"]:
             changes.append(
                 {
@@ -343,7 +454,12 @@ def _change_status(change_list: list[dict[str, Any]]) -> str:
     types = {c["type"] for c in change_list}
     if types & {"interface_change"}:
         return _STATUS_MAJOR
-    if types & {"added_node", "removed_node", "changed_connectivity"}:
+    if types & {
+        "added_node",
+        "removed_node",
+        "changed_connectivity",
+        "subgraph_structure_change",
+    }:
         return _STATUS_MODERATE
     if types & {"changed_attrs", "initializer_change"}:
         return _STATUS_MINOR
@@ -459,6 +575,7 @@ def render_markdown(
             removed = [c for c in change_list if c["type"] == "removed_node"]
             attrs = [c for c in change_list if c["type"] == "changed_attrs"]
             connectivity = [c for c in change_list if c["type"] == "changed_connectivity"]
+            subgraph = [c for c in change_list if c["type"] == "subgraph_structure_change"]
             iface = [c for c in change_list if c["type"] == "interface_change"]
             inits = [c for c in change_list if c["type"] == "initializer_change"]
 
@@ -471,6 +588,12 @@ def render_markdown(
             if removed:
                 lines.append("**Removed nodes:**")
                 for c in removed:
+                    lines.append(f"- `{c['details']}`")
+                lines.append("")
+
+            if subgraph:
+                lines.append("**Subgraph structure changes:**")
+                for c in subgraph:
                     lines.append(f"- `{c['details']}`")
                 lines.append("")
 

--- a/src/mobius/_graph_diff_test.py
+++ b/src/mobius/_graph_diff_test.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import onnx_ir as ir
 
 from mobius._graph_diff import (
+    _SUBGRAPH_KEY,
+    _SUBGRAPHS_KEY,
     canonicalize_graph,
     diff_graphs,
     render_markdown,
@@ -611,3 +613,376 @@ class TestRoundTrip:
         head = _add_relu_graph()
         changes = diff_graphs(canonicalize_graph(base), canonicalize_graph(head))
         assert len(changes) > 0
+
+
+# ------------------------------------------------------------------
+# Subgraph recursion — helpers (graphs containing an If with subgraphs)
+# ------------------------------------------------------------------
+
+
+def _if_graph(
+    *,
+    then_op: str = "Add",
+    else_op: str = "Sub",
+    then_axis: int | None = None,
+    then_domain: str = "",
+    then_node_name: str = "then_op",
+    else_node_name: str = "else_op",
+) -> ir.Graph:
+    """Return a graph: y = If(cond) {then: then_op(x,x)} {else: else_op(x,x)}.
+
+    ``then_axis`` (when given) attaches an ``axis`` attribute to the
+    then-branch node so inner-attribute deltas can be exercised.
+    ``then_domain`` sets the then-branch node's op domain (diff_graphs does
+    not compare domain, so this exercises the 'subgraph changed' fallback).
+    ``*_node_name`` allow renaming inner nodes to prove names are ignored.
+    """
+    x = ir.val("x", type=ir.TensorType(ir.DataType.FLOAT), shape=ir.Shape([1, 4]))
+    cond = ir.val("cond", type=ir.TensorType(ir.DataType.BOOL), shape=ir.Shape([]))
+
+    then_attrs = [ir.AttrInt64("axis", then_axis)] if then_axis is not None else []
+    then_node = ir.Node(then_domain, then_op, [x, x], then_attrs, name=then_node_name)
+    then_out = then_node.outputs[0]
+    then_out.name = "then_out"
+    then_g = ir.Graph([], [then_out], nodes=[then_node], name="then_branch")
+
+    else_node = ir.Node("", else_op, [x, x], name=else_node_name)
+    else_out = else_node.outputs[0]
+    else_out.name = "else_out"
+    else_g = ir.Graph([], [else_out], nodes=[else_node], name="else_branch")
+
+    if_node = ir.Node(
+        "",
+        "If",
+        [cond],
+        [ir.AttrGraph("then_branch", then_g), ir.AttrGraph("else_branch", else_g)],
+        name="if_node",
+    )
+    if_out = if_node.outputs[0]
+    if_out.name = "y"
+    return ir.Graph([x, cond], [if_out], nodes=[if_node])
+
+
+# ------------------------------------------------------------------
+# Subgraph recursion — tests (architect D12: descend into subgraphs)
+# ------------------------------------------------------------------
+
+
+def _nested_if_graph(
+    *, inner_then_op: str = "Add", inner_then_axis: int | None = None
+) -> ir.Graph:
+    """Return a graph whose If then-branch itself contains an If (depth 2).
+
+    ``inner_then_axis`` attaches an ``axis`` attribute to the innermost
+    then-branch node, to exercise a *pure inner-attribute* delta nested
+    two levels deep (which must stay MINOR, not promote to structural).
+    """
+    x = ir.val("x", type=ir.TensorType(ir.DataType.FLOAT), shape=ir.Shape([1, 4]))
+    cond = ir.val("cond", type=ir.TensorType(ir.DataType.BOOL), shape=ir.Shape([]))
+
+    # Innermost two branches.
+    inner_then_attrs = (
+        [ir.AttrInt64("axis", inner_then_axis)] if inner_then_axis is not None else []
+    )
+    inner_then = ir.Node("", inner_then_op, [x, x], inner_then_attrs, name="inner_then")
+    it_out = inner_then.outputs[0]
+    it_out.name = "it_out"
+    inner_then_g = ir.Graph([], [it_out], nodes=[inner_then], name="inner_then_branch")
+
+    inner_else = ir.Node("", "Sub", [x, x], name="inner_else")
+    ie_out = inner_else.outputs[0]
+    ie_out.name = "ie_out"
+    inner_else_g = ir.Graph([], [ie_out], nodes=[inner_else], name="inner_else_branch")
+
+    inner_if = ir.Node(
+        "",
+        "If",
+        [cond],
+        [
+            ir.AttrGraph("then_branch", inner_then_g),
+            ir.AttrGraph("else_branch", inner_else_g),
+        ],
+        name="inner_if",
+    )
+    inner_if_out = inner_if.outputs[0]
+    inner_if_out.name = "inner_if_out"
+    # Outer then-branch wraps the inner If; outer else-branch is a plain op.
+    outer_then_g = ir.Graph([], [inner_if_out], nodes=[inner_if], name="outer_then")
+
+    outer_else = ir.Node("", "Mul", [x, x], name="outer_else")
+    oe_out = outer_else.outputs[0]
+    oe_out.name = "oe_out"
+    outer_else_g = ir.Graph([], [oe_out], nodes=[outer_else], name="outer_else")
+
+    outer_if = ir.Node(
+        "",
+        "If",
+        [cond],
+        [
+            ir.AttrGraph("then_branch", outer_then_g),
+            ir.AttrGraph("else_branch", outer_else_g),
+        ],
+        name="outer_if",
+    )
+    out = outer_if.outputs[0]
+    out.name = "y"
+    return ir.Graph([x, cond], [out], nodes=[outer_if])
+
+
+def _graphs_attr_graph(*, body_ops: list[str]) -> ir.Graph:
+    """Return a graph with a node carrying a GRAPHS-plural attribute.
+
+    GRAPHS is rare for standard ops (``If`` / ``Loop`` / ``Scan`` bodies are
+    GRAPH singular), so this uses a synthetic op purely to exercise the
+    plural recursion branch in ``_attr_to_comparable``.
+    """
+    x = ir.val("x", type=ir.TensorType(ir.DataType.FLOAT), shape=ir.Shape([1, 4]))
+
+    bodies = []
+    for idx, op in enumerate(body_ops):
+        n = ir.Node("", op, [x, x], name=f"body_{idx}")
+        o = n.outputs[0]
+        o.name = f"body_out_{idx}"
+        bodies.append(ir.Graph([], [o], nodes=[n], name=f"body_g_{idx}"))
+
+    multi = ir.Node("", "CustomMulti", [x], [ir.AttrGraphs("bodies", bodies)], name="cm")
+    out = multi.outputs[0]
+    out.name = "y"
+    return ir.Graph([x], [out], nodes=[multi])
+
+
+def _if_graph_branch_output_dtype(*, then_dtype: ir.DataType) -> ir.Graph:
+    """If-graph whose then-branch *output dtype* varies (subgraph interface)."""
+    x = ir.val("x", type=ir.TensorType(ir.DataType.FLOAT), shape=ir.Shape([1, 4]))
+    cond = ir.val("cond", type=ir.TensorType(ir.DataType.BOOL), shape=ir.Shape([]))
+
+    cast = ir.Node("", "Cast", [x], [ir.AttrInt64("to", int(then_dtype))], name="cast")
+    then_out = cast.outputs[0]
+    then_out.name = "then_out"
+    then_out.type = ir.TensorType(then_dtype)
+    then_out.shape = ir.Shape([1, 4])
+    then_g = ir.Graph([], [then_out], nodes=[cast], name="then_branch")
+
+    else_node = ir.Node("", "Identity", [x], name="else_node")
+    else_out = else_node.outputs[0]
+    else_out.name = "else_out"
+    else_out.type = ir.TensorType(ir.DataType.FLOAT)
+    else_out.shape = ir.Shape([1, 4])
+    else_g = ir.Graph([], [else_out], nodes=[else_node], name="else_branch")
+
+    if_node = ir.Node(
+        "",
+        "If",
+        [cond],
+        [ir.AttrGraph("then_branch", then_g), ir.AttrGraph("else_branch", else_g)],
+        name="if_node",
+    )
+    if_out = if_node.outputs[0]
+    if_out.name = "y"
+    return ir.Graph([x, cond], [if_out], nodes=[if_node])
+
+
+class TestSubgraphRecursion:
+    """canonicalize_graph / diff_graphs descend into GRAPH-typed attrs."""
+
+    def test_canonicalize_descends_into_subgraphs(self) -> None:
+        """GRAPH attrs are recursively canonicalised, not collapsed to a type."""
+        canon = canonicalize_graph(_if_graph(then_op="Add", else_op="Sub"))
+        if_attrs = canon["nodes"][0]["attributes"]
+        # Not collapsed to the old "<GRAPH>" placeholder.
+        assert if_attrs["then_branch"] != "<GRAPH>"
+        assert if_attrs["else_branch"] != "<GRAPH>"
+        # Nested canonical form carries the subgraph's op sequence.
+        then_sub = if_attrs["then_branch"][_SUBGRAPH_KEY]
+        else_sub = if_attrs["else_branch"][_SUBGRAPH_KEY]
+        assert then_sub["op_sequence"] == ["Add"]
+        assert else_sub["op_sequence"] == ["Sub"]
+
+    def test_identical_subgraphs_no_diff(self) -> None:
+        """Two structurally identical If-graphs produce no diff."""
+        base = canonicalize_graph(_if_graph(then_op="Add", else_op="Sub"))
+        head = canonicalize_graph(_if_graph(then_op="Add", else_op="Sub"))
+        assert diff_graphs(base, head) == []
+
+    def test_subgraph_node_names_ignored(self) -> None:
+        """Renaming inner subgraph nodes does not produce a spurious diff."""
+        base = canonicalize_graph(_if_graph(then_node_name="a", else_node_name="b"))
+        head = canonicalize_graph(_if_graph(then_node_name="x", else_node_name="y"))
+        assert diff_graphs(base, head) == []
+
+    def test_then_branch_op_delta_is_structural(self) -> None:
+        """A differing then-branch op is a MODERATE subgraph_structure_change."""
+        base = canonicalize_graph(_if_graph(then_op="Add", else_op="Sub"))
+        head = canonicalize_graph(_if_graph(then_op="Mul", else_op="Sub"))
+        changes = diff_graphs(base, head)
+        structural = [c for c in changes if c["type"] == "subgraph_structure_change"]
+        assert structural, "op delta inside a branch must be structural"
+        assert any("then_branch" in c["details"] for c in structural)
+        # The op-level subgraph delta is surfaced (added/removed inner node).
+        assert any("Add" in c["details"] and "Mul" in c["details"] for c in structural)
+
+    def test_else_branch_op_delta_is_structural(self) -> None:
+        """A differing else-branch op is detected independently of then-branch."""
+        base = canonicalize_graph(_if_graph(then_op="Add", else_op="Sub"))
+        head = canonicalize_graph(_if_graph(then_op="Add", else_op="Div"))
+        changes = diff_graphs(base, head)
+        structural = [c for c in changes if c["type"] == "subgraph_structure_change"]
+        assert any("else_branch" in c["details"] for c in structural)
+
+    def test_structural_subgraph_change_is_moderate(self) -> None:
+        """render_markdown rates a subgraph structure change as MODERATE (🟡)."""
+        base = canonicalize_graph(_if_graph(then_op="Add", else_op="Sub"))
+        head = canonicalize_graph(_if_graph(then_op="Mul", else_op="Sub"))
+        changes = diff_graphs(base, head)
+        diffs = {
+            "model": {
+                "sub": {
+                    "changes": changes,
+                    "_base_ops": base["op_sequence"],
+                    "_head_ops": head["op_sequence"],
+                    "_base_node_count": len(base["nodes"]),
+                    "_head_node_count": len(head["nodes"]),
+                }
+            }
+        }
+        md = render_markdown(diffs)
+        assert "🟡" in md
+        assert "Subgraph structure changes" in md
+
+    def test_inner_attribute_delta_is_minor_and_surfaced(self) -> None:
+        """A pure inner-attribute tweak (Concat axis) stays changed_attrs/MINOR.
+
+        The actual nested detail (``axis: 0 → 1``) must be surfaced, not an
+        opaque ``"N sub-change(s)"`` summary.
+        """
+        base = canonicalize_graph(_if_graph(then_op="Concat", else_op="Sub", then_axis=0))
+        head = canonicalize_graph(_if_graph(then_op="Concat", else_op="Sub", then_axis=1))
+        changes = diff_graphs(base, head)
+        # Not promoted to structural — it's an inner-attr-only change.
+        assert not any(c["type"] == "subgraph_structure_change" for c in changes)
+        attr_changes = [c for c in changes if c["type"] == "changed_attrs"]
+        assert attr_changes
+        detail = " ".join(c["details"] for c in attr_changes)
+        assert "then_branch" in detail
+        # The real inner delta is surfaced.
+        assert "axis" in detail and "0" in detail and "1" in detail
+
+    def test_nested_subgraph_delta_detected(self) -> None:
+        """A delta in an If-inside-an-If (depth 2) propagates to the top diff."""
+        base = canonicalize_graph(_nested_if_graph(inner_then_op="Add"))
+        head = canonicalize_graph(_nested_if_graph(inner_then_op="Mul"))
+        changes = diff_graphs(base, head)
+        structural = [c for c in changes if c["type"] == "subgraph_structure_change"]
+        assert structural, "innermost branch op delta must surface at the top"
+        assert any("then_branch" in c["details"] for c in structural)
+
+    def test_nested_pure_attr_delta_stays_minor(self) -> None:
+        """A pure inner-attr tweak nested two levels deep stays changed_attrs/MINOR.
+
+        (Code-review NIT: lock the severity boundary — nesting must not
+        spuriously promote a non-structural change to structural.)
+        """
+        base = canonicalize_graph(_nested_if_graph(inner_then_op="Concat", inner_then_axis=0))
+        head = canonicalize_graph(_nested_if_graph(inner_then_op="Concat", inner_then_axis=1))
+        changes = diff_graphs(base, head)
+        assert not any(c["type"] == "subgraph_structure_change" for c in changes)
+        attr_changes = [c for c in changes if c["type"] == "changed_attrs"]
+        assert attr_changes
+        # The innermost axis delta is still surfaced through both nesting levels.
+        detail = " ".join(c["details"] for c in attr_changes)
+        assert "then_branch" in detail and "axis" in detail
+
+    def test_subgraph_changed_fallback_path(self) -> None:
+        """A subgraph delta invisible to diff_graphs hits the readable fallback.
+
+        (Code-review NIT: lock the ``"subgraph changed"`` fallback.)  The
+        then-branch node's *domain* differs; canonicalize records domain so
+        the attribute payloads differ, but diff_graphs does not compare
+        domain, so the nested diff is empty → the summary falls back to
+        ``"subgraph changed"`` and is classified MINOR (changed_attrs).
+        """
+        base = canonicalize_graph(_if_graph(then_op="Add", then_domain=""))
+        head = canonicalize_graph(_if_graph(then_op="Add", then_domain="custom.domain"))
+        changes = diff_graphs(base, head)
+        assert not any(c["type"] == "subgraph_structure_change" for c in changes)
+        attr_changes = [c for c in changes if c["type"] == "changed_attrs"]
+        assert any("subgraph changed" in c["details"] for c in attr_changes)
+
+    def test_graphs_plural_attr_recursed_and_diffed(self) -> None:
+        """GRAPHS-plural attrs are canonicalised and per-body deltas detected."""
+        base = canonicalize_graph(_graphs_attr_graph(body_ops=["Add", "Add"]))
+        head = canonicalize_graph(_graphs_attr_graph(body_ops=["Add", "Mul"]))
+        # Plural payload is recursed, not collapsed.
+        bodies_attr = base["nodes"][0]["attributes"]["bodies"]
+        assert bodies_attr != "<GRAPHS>"
+        changes = diff_graphs(base, head)
+        structural = [c for c in changes if c["type"] == "subgraph_structure_change"]
+        assert structural
+        # Plural payload genuinely drove the AttributeType.GRAPHS branch.
+        assert _SUBGRAPHS_KEY in bodies_attr
+        assert len(bodies_attr[_SUBGRAPHS_KEY]) == 2
+        # The differing body is identified by index.
+        assert any("subgraph[1]" in c["details"] for c in structural)
+
+    def test_graphs_plural_branch_count_change_is_structural(self) -> None:
+        """Adding/removing a body in a GRAPHS-plural attr is structural."""
+        base = canonicalize_graph(_graphs_attr_graph(body_ops=["Add"]))
+        head = canonicalize_graph(_graphs_attr_graph(body_ops=["Add", "Mul"]))
+        changes = diff_graphs(base, head)
+        structural = [c for c in changes if c["type"] == "subgraph_structure_change"]
+        assert structural
+        assert any("added" in c["details"] or "removed" in c["details"] for c in structural)
+
+    def test_subgraph_interface_change_is_structural(self) -> None:
+        """A subgraph *interface* (output dtype) change is structural."""
+        base = canonicalize_graph(_if_graph_branch_output_dtype(then_dtype=ir.DataType.FLOAT))
+        head = canonicalize_graph(
+            _if_graph_branch_output_dtype(then_dtype=ir.DataType.FLOAT16)
+        )
+        changes = diff_graphs(base, head)
+        structural = [c for c in changes if c["type"] == "subgraph_structure_change"]
+        assert structural, "subgraph interface change must be structural"
+        assert any("then_branch" in c["details"] for c in structural)
+
+    def test_subgraph_delta_does_not_perturb_top_level_ops(self) -> None:
+        """The top-level op sequence is unchanged when only a subgraph differs."""
+        base = canonicalize_graph(_if_graph(then_op="Add", else_op="Sub"))
+        head = canonicalize_graph(_if_graph(then_op="Mul", else_op="Sub"))
+        # Both still have exactly one top-level If node.
+        assert base["op_sequence"] == ["If"] == head["op_sequence"]
+        changes = diff_graphs(base, head)
+        # No spurious added/removed at the top level.
+        assert not any(c["type"] in {"added_node", "removed_node"} for c in changes)
+
+    def test_top_level_op_swap_not_double_counted(self) -> None:
+        """An op_type swap at the same position is structural-only, never MINOR.
+
+        (Reviewer 6def2895 (a): pick one classification — structural wins.)
+        """
+
+        def _single(op: str) -> ir.Graph:
+            x = ir.val("x", type=ir.TensorType(ir.DataType.FLOAT), shape=ir.Shape([1, 4]))
+            n = ir.Node("", op, [x, x], name="n")
+            o = n.outputs[0]
+            o.name = "y"
+            return ir.Graph([x], [o], nodes=[n])
+
+        changes = diff_graphs(
+            canonicalize_graph(_single("Add")), canonicalize_graph(_single("Mul"))
+        )
+        types = {c["type"] for c in changes}
+        assert types == {"added_node", "removed_node"}
+        assert "changed_attrs" not in types
+
+    def test_subgraph_op_swap_is_structural_only(self) -> None:
+        """MEA↔Flash-style op swap *inside* a branch is structural, not MINOR.
+
+        A same-position op_type swap within a subgraph must classify as
+        subgraph_structure_change only — not additionally as changed_attrs.
+        """
+        base = canonicalize_graph(_if_graph(then_op="Add", else_op="Sub"))
+        head = canonicalize_graph(_if_graph(then_op="Mul", else_op="Sub"))
+        changes = diff_graphs(base, head)
+        # Exactly one change for the swapped branch, classified structural.
+        assert [c["type"] for c in changes] == ["subgraph_structure_change"]
+        assert not any(c["type"] == "changed_attrs" for c in changes)


### PR DESCRIPTION
## Motivation

Per the architecture review, the Architecture-Diff tooling should descend
into ONNX subgraphs so control-flow changes are visible in CI. This is the
separate, standalone PR for that work.

The Architecture Diff currently collapses every `GRAPH`-typed attribute
(an `If`'s `then_branch` / `else_branch`, a `Loop` / `Scan` body) to a bare
type string and never recurses into it. Any change that lives *inside* a
subgraph is therefore invisible to the diff, even though the top-level op
sequence is unchanged.

## Why it matters now

PR #328 (static-cache attention) introduces a per-layer phase split:
`If(Greater(seq_len, 1))` selects a prefill (masked) path vs a decode path.
Because the `If` node itself is present on both the base and head graphs,
the top-level op sequence is identical — the only signal that anything
changed lives inside the branch subgraphs that the diff was discarding. So
a structural change of this kind would pass the Architecture Diff CI
silently.

## The fix

- Recurse `GRAPH` and `GRAPHS` attributes into nested canonical forms so
  subgraph node structure participates in the comparison. This reuses the
  existing canonicalization (inner node/value names are ignored the same
  way top-level names already are), so it is deterministic and
  name-independent.
- Add a dedicated `subgraph_structure_change` record at **MODERATE**
  severity for structurally significant subgraph deltas — a node or branch
  added, removed, or rewired, or a subgraph interface change. A pure
  inner-attribute tweak (e.g. a `Concat` `axis`) stays `changed_attrs`
  (**MINOR**). Structural significance propagates upward through nested
  subgraphs (an `If` inside an `If`).
- Surface the nested detail in the rendered report
  (e.g. `then_branch: node[0] Concat: axis: 0 -> 1`).

The change is additive and backward-compatible: non-`GRAPH` attributes are
handled exactly as before, and the existing consumer (which reads only the
op sequence, node counts, and the change list) is unaffected.

## Tests

Adds regression coverage for subgraph recursion, the
structural-vs-minor severity boundary (including nested cases),
`GRAPHS`-plural bodies, op-swap-not-double-counted, and the readable
fallback path. Full suite passes; lint and format are clean.

## Review

Triple-reviewed (correctness/adversarial, readability, and code review)
prior to opening.

## Known limitation / possible follow-up

`diff_graphs` does not compare node `domain` or `num_outputs`. As a result,
a subgraph delta that differs *only* by operator domain (e.g. a
standard-domain op swapped for a same-named contrib-domain op) is detected
but rated as a non-structural `changed_attrs` (MINOR) via the readable
`subgraph changed` fallback, rather than as a structural change. This is
pre-existing behavior at the top level too and is out of scope here; it can
be addressed in a follow-up if desired.
