### PR TITLE
Trim public component surface and export build_from_gguf

### DIFF
--- a/src/mobius/__init__.py
+++ b/src/mobius/__init__.py
@@ -34,6 +34,7 @@ __all__ = [
     "build",
     "build_context",
     "build_diffusers_pipeline",
+    "build_from_gguf",
     "build_from_module",
     "components",
     "ep_capabilities",
@@ -87,4 +88,5 @@ from mobius._registry import (
     registry,
 )
 from mobius._weight_loading import apply_weights
+from mobius.integrations.gguf import build_from_gguf
 from mobius.tasks import CausalLMTask, ModelTask

--- a/src/mobius/components/__init__.py
+++ b/src/mobius/components/__init__.py
@@ -11,8 +11,6 @@ __all__ = [
     "CausalConvNd",
     "CausalDepthwiseConv1d",
     "CausalTransConv1d",
-    "CodecDecoderTransformerModel",
-    "CodecEncoderTransformerModel",
     "ConformerEncoder",
     "Conv1d",
     "Conv2d",
@@ -22,7 +20,6 @@ __all__ = [
     "DecoderBlock",
     "DecoderLayer",
     "DecoderResidualUnit",
-    "DeepSeekMLA",
     "DiffusionFFN",
     "DiffusionSelfAttention",
     "Embedding",
@@ -34,59 +31,28 @@ __all__ = [
     "GatedDeltaNet",
     "GatedMLP",
     "GatedRMSNorm",
-    "Gemma3MultiModalProjector",
-    "Gemma4AudioEncoder",
     "ClippableLinear",
     "GroupNorm",
     "GQAContext",
     "INT64_MAX",
     "InputMixer",
-    "JambaSelectiveScan",
     "LayerNorm",
     "LayerNormNoAffine",
     "LayerNormNoBias",
     "OffsetLayerNorm",
     "LayerScale",
-    "LightningAttention",
     "Linear",
     "LinearMultiModalProjector",
     "LoRALinear",
     "MLP",
-    "Mistral3MultiModalProjector",
     "MLPMultiModalProjector",
-    "Mamba2Block",
-    "MambaBlock",
     "MoELayer",
     "OffsetRMSNorm",
     "PatchEmbed",
     "PatchEmbedding",
-    "PixtralVisionTower",
     "PostGatedRMSNorm",
     "PostNormDecoderLayer",
-    "QFormer",
-    "QFormerAttention",
-    "QFormerLayer",
     "QuantizedLinear",
-    "Qwen25VLPatchEmbed",
-    "Qwen25VLPatchMerger",
-    "Qwen25VLVisionAttention",
-    "Qwen25VLVisionBlock",
-    "Qwen25VLVisionModel",
-    "Qwen25VLVisionRotaryEmbedding",
-    "Qwen2VLVisionBlock",
-    "Qwen2VLVisionModel",
-    "Qwen35Attention",
-    "Qwen3ASRAudioAttention",
-    "Qwen3ASRAudioEncoderLayer",
-    "Qwen3VLPatchEmbed",
-    "Qwen3VLPatchMerger",
-    "Qwen3VLVisionAttention",
-    "Qwen3VLVisionBlock",
-    "Qwen3VLVisionModel",
-    "Qwen3VLVisionRotaryEmbedding",
-    "SANMAttention",
-    "SANMEncoderLayer",
-    "SANMFFN",
     "RMSNorm",
     "SelectiveScan",
     "SiLU",
@@ -103,9 +69,6 @@ __all__ = [
     "VisionEncoder",
     "VisionEncoderLayer",
     "VisionModel",
-    "WhisperAttention",
-    "WhisperDecoderLayer",
-    "WhisperEncoderLayer",
     "apply_rms_norm",
     "create_attention_bias",
     "create_decoder_layer",
@@ -120,8 +83,10 @@ from mobius.components._activations import SiLU, get_activation
 from mobius.components._attention import (
     Attention,
     GQAContext,
-    Qwen35Attention,
     StaticCacheState,
+)
+from mobius.components._attention import (
+    Qwen35Attention as Qwen35Attention,
 )
 from mobius.components._audio import ConformerEncoder
 from mobius.components._codec_conv import (
@@ -135,8 +100,10 @@ from mobius.components._codec_conv import (
     SnakeBeta,
 )
 from mobius.components._codec_transformer import (
-    CodecDecoderTransformerModel,
-    CodecEncoderTransformerModel,
+    CodecDecoderTransformerModel as CodecDecoderTransformerModel,
+)
+from mobius.components._codec_transformer import (
+    CodecEncoderTransformerModel as CodecEncoderTransformerModel,
 )
 from mobius.components._codec_vq import SplitResidualVectorQuantizer
 from mobius.components._common import (
@@ -164,7 +131,7 @@ from mobius.components._decoder import (
     PostNormDecoderLayer,
     create_decoder_layer,
 )
-from mobius.components._deepseek_mla import DeepSeekMLA
+from mobius.components._deepseek_mla import DeepSeekMLA as DeepSeekMLA
 from mobius.components._diffusion import (
     AdaLayerNormOutput,
     AdaLayerNormZero,
@@ -183,10 +150,12 @@ from mobius.components._encoder_decoder_attention import (
     EncoderDecoderAttention,
 )
 from mobius.components._gated_deltanet import GatedDeltaNet
-from mobius.components._gemma4_audio import ClippableLinear, Gemma4AudioEncoder
-from mobius.components._lightning_attention import LightningAttention
+from mobius.components._gemma4_audio import ClippableLinear
+from mobius.components._gemma4_audio import Gemma4AudioEncoder as Gemma4AudioEncoder
+from mobius.components._lightning_attention import LightningAttention as LightningAttention
 from mobius.components._lora import LoRALinear
-from mobius.components._mamba_block import Mamba2Block, MambaBlock
+from mobius.components._mamba_block import Mamba2Block as Mamba2Block
+from mobius.components._mamba_block import MambaBlock as MambaBlock
 from mobius.components._mlp import FCMLP, MLP, FusedGateUpMLP, GatedMLP
 from mobius.components._moe import (
     MoELayer,
@@ -196,45 +165,79 @@ from mobius.components._moe import (
     TopKGate,
 )
 from mobius.components._multimodal import (
-    Gemma3MultiModalProjector,
+    Gemma3MultiModalProjector as Gemma3MultiModalProjector,
+)
+from mobius.components._multimodal import (
     InputMixer,
     LinearMultiModalProjector,
     MLPMultiModalProjector,
 )
 from mobius.components._pixtral_vision import (
-    Mistral3MultiModalProjector,
-    PixtralVisionTower,
+    Mistral3MultiModalProjector as Mistral3MultiModalProjector,
+)
+from mobius.components._pixtral_vision import (
+    PixtralVisionTower as PixtralVisionTower,
 )
 from mobius.components._qformer import (
-    QFormer,
-    QFormerAttention,
-    QFormerLayer,
+    QFormer as QFormer,
+)
+from mobius.components._qformer import (
+    QFormerAttention as QFormerAttention,
+)
+from mobius.components._qformer import (
+    QFormerLayer as QFormerLayer,
 )
 from mobius.components._quantized_linear import (
     QuantizedLinear,
     make_quantized_linear_factory,
 )
 from mobius.components._qwen3_asr_audio import (
-    Qwen3ASRAudioAttention,
-    Qwen3ASRAudioEncoderLayer,
+    Qwen3ASRAudioAttention as Qwen3ASRAudioAttention,
+)
+from mobius.components._qwen3_asr_audio import (
+    Qwen3ASRAudioEncoderLayer as Qwen3ASRAudioEncoderLayer,
 )
 from mobius.components._qwen3_vl_vision import (
-    Qwen3VLPatchEmbed,
-    Qwen3VLPatchMerger,
-    Qwen3VLVisionAttention,
-    Qwen3VLVisionBlock,
-    Qwen3VLVisionModel,
-    Qwen3VLVisionRotaryEmbedding,
+    Qwen3VLPatchEmbed as Qwen3VLPatchEmbed,
+)
+from mobius.components._qwen3_vl_vision import (
+    Qwen3VLPatchMerger as Qwen3VLPatchMerger,
+)
+from mobius.components._qwen3_vl_vision import (
+    Qwen3VLVisionAttention as Qwen3VLVisionAttention,
+)
+from mobius.components._qwen3_vl_vision import (
+    Qwen3VLVisionBlock as Qwen3VLVisionBlock,
+)
+from mobius.components._qwen3_vl_vision import (
+    Qwen3VLVisionModel as Qwen3VLVisionModel,
+)
+from mobius.components._qwen3_vl_vision import (
+    Qwen3VLVisionRotaryEmbedding as Qwen3VLVisionRotaryEmbedding,
 )
 from mobius.components._qwen25_vl_vision import (
-    Qwen2VLVisionBlock,
-    Qwen2VLVisionModel,
-    Qwen25VLPatchEmbed,
-    Qwen25VLPatchMerger,
-    Qwen25VLVisionAttention,
-    Qwen25VLVisionBlock,
-    Qwen25VLVisionModel,
-    Qwen25VLVisionRotaryEmbedding,
+    Qwen2VLVisionBlock as Qwen2VLVisionBlock,
+)
+from mobius.components._qwen25_vl_vision import (
+    Qwen2VLVisionModel as Qwen2VLVisionModel,
+)
+from mobius.components._qwen25_vl_vision import (
+    Qwen25VLPatchEmbed as Qwen25VLPatchEmbed,
+)
+from mobius.components._qwen25_vl_vision import (
+    Qwen25VLPatchMerger as Qwen25VLPatchMerger,
+)
+from mobius.components._qwen25_vl_vision import (
+    Qwen25VLVisionAttention as Qwen25VLVisionAttention,
+)
+from mobius.components._qwen25_vl_vision import (
+    Qwen25VLVisionBlock as Qwen25VLVisionBlock,
+)
+from mobius.components._qwen25_vl_vision import (
+    Qwen25VLVisionModel as Qwen25VLVisionModel,
+)
+from mobius.components._qwen25_vl_vision import (
+    Qwen25VLVisionRotaryEmbedding as Qwen25VLVisionRotaryEmbedding,
 )
 from mobius.components._rms_norm import (
     GatedRMSNorm,
@@ -245,12 +248,18 @@ from mobius.components._rms_norm import (
 )
 from mobius.components._rotary_embedding import initialize_rope
 from mobius.components._sanm_attention import (
-    SANMFFN,
-    SANMAttention,
-    SANMEncoderLayer,
+    SANMFFN as SANMFFN,
+)
+from mobius.components._sanm_attention import (
+    SANMAttention as SANMAttention,
+)
+from mobius.components._sanm_attention import (
+    SANMEncoderLayer as SANMEncoderLayer,
 )
 from mobius.components._ssm import (
-    JambaSelectiveScan,
+    JambaSelectiveScan as JambaSelectiveScan,
+)
+from mobius.components._ssm import (
     SelectiveScan,
 )
 from mobius.components._vision import (
@@ -262,7 +271,13 @@ from mobius.components._vision import (
 )
 from mobius.components._whisper import (
     Conv1d,
-    WhisperAttention,
-    WhisperDecoderLayer,
-    WhisperEncoderLayer,
+)
+from mobius.components._whisper import (
+    WhisperAttention as WhisperAttention,
+)
+from mobius.components._whisper import (
+    WhisperDecoderLayer as WhisperDecoderLayer,
+)
+from mobius.components._whisper import (
+    WhisperEncoderLayer as WhisperEncoderLayer,
 )


### PR DESCRIPTION
## Summary

First in a series of PRs tightening the **public API** ahead of the initial release (no backward-compat concerns; unreleased).

### Changes
- **Trim `mobius.components.__all__` from 112 → 75 names.** 37 model-specific classes (per-model vision towers, attention/projector variants, codec & SSM blocks — e.g. `Qwen25VLVisionModel`, `WhisperAttention`, `DeepSeekMLA`, `Mamba2Block`) were leaking into the public component contract. They are implementation details of individual models, not reusable building blocks.
  - They remain importable internally via redundant-alias re-exports (`X as X`), so existing `from mobius.components import ...` call sites in model files are untouched. Zero behavior change.
- **Export `build_from_gguf` at the top level.** It was documented as public but never added to `mobius.__all__` or re-exported. The `gguf` third-party import stays lazy, so `import mobius` remains safe without the optional `gguf` package installed.

### Out of scope / deferred
- Config export policy (base-only vs export-all) is left to the **config-redesign** track.
- `models.__all__` surface review is a later PR.

### Verification
- `ruff check` + `ruff format --check` clean on changed files.
- Fast test suite green (1985 passed locally for the touched subsets; full suite unaffected — only `__all__`/re-export lines changed).