### PR TITLE
Add rename_weight_keys helper and adopt it in pure-rename models

### DIFF
--- a/src/mobius/_weight_utils.py
+++ b/src/mobius/_weight_utils.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import math
+from collections.abc import Sequence
 
 import torch
 
@@ -269,6 +270,50 @@ def rename_mlp_projections(
     return name.replace(f".mlp.{old_up}.", f".mlp.{new_up}.").replace(
         f".mlp.{old_down}.", f".mlp.{new_down}."
     )
+
+
+def rename_weight_keys(
+    state_dict: dict[str, torch.Tensor],
+    replacements: Sequence[tuple[str, str]],
+) -> dict[str, torch.Tensor]:
+    """Apply ordered substring replacements to every key in a state dict.
+
+    Centralises the ``for name, tensor in state_dict.items(): name =
+    name.replace(...)`` rename loop that is duplicated across many model
+    ``preprocess_weights`` implementations.  Each ``(old, new)`` pair is
+    applied with :py:meth:`str.replace` to the *progressively updated* key,
+    so the replacements are **ordered** and may cascade (the output of an
+    earlier replacement can match the input of a later one) — this matches
+    the semantics of the hand-written loops it replaces.  Use substrings
+    specific enough (e.g. dot-delimited like ``".attention_layernorm."``)
+    to avoid renaming unintended portions of a key.
+
+    Tensor values are shared with *state_dict* (not cloned), matching the
+    behaviour of the loops this replaces.
+
+    Args:
+        state_dict: Weight dictionary to transform (not modified).
+        replacements: Ordered sequence of ``(old, new)`` substring pairs.
+
+    Returns:
+        A new dictionary with renamed keys.
+
+    Raises:
+        ValueError: If two distinct source keys map to the same renamed key
+            (a collision that would otherwise silently drop a tensor).
+    """
+    result: dict[str, torch.Tensor] = {}
+    for name, tensor in state_dict.items():
+        new_name = name
+        for old, new in replacements:
+            new_name = new_name.replace(old, new)
+        if new_name in result:
+            raise ValueError(
+                f"Weight key collision after rename: {name!r} -> {new_name!r} "
+                f"(already produced by another key)"
+            )
+        result[new_name] = tensor
+    return result
 
 
 def split_codegen_qkv(

--- a/src/mobius/_weight_utils.py
+++ b/src/mobius/_weight_utils.py
@@ -303,6 +303,7 @@ def rename_weight_keys(
             (a collision that would otherwise silently drop a tensor).
     """
     result: dict[str, torch.Tensor] = {}
+    producers: dict[str, str] = {}
     for name, tensor in state_dict.items():
         new_name = name
         for old, new in replacements:
@@ -310,9 +311,10 @@ def rename_weight_keys(
         if new_name in result:
             raise ValueError(
                 f"Weight key collision after rename: {name!r} -> {new_name!r} "
-                f"(already produced by another key)"
+                f"(already produced by {producers[new_name]!r})"
             )
         result[new_name] = tensor
+        producers[new_name] = name
     return result
 
 

--- a/src/mobius/_weight_utils_test.py
+++ b/src/mobius/_weight_utils_test.py
@@ -213,13 +213,22 @@ class TestRenameWeightKeys:
         assert result["new.k"].data_ptr() == t.data_ptr()
 
     def test_collision_raises(self):
-        """Two source keys mapping to the same renamed key raises."""
+        """Two source keys mapping to the same renamed key raises.
+
+        The error message must name both the colliding key and the original
+        producer key to aid debugging in large checkpoints.
+        """
         state_dict = {
             "a.weight": torch.tensor(1.0),
             "b.weight": torch.tensor(2.0),
         }
-        with pytest.raises(ValueError, match="collision"):
+        with pytest.raises(ValueError, match="collision") as exc_info:
             rename_weight_keys(state_dict, [("a.", "x."), ("b.", "x.")])
+        message = str(exc_info.value)
+        # The producer ("a.weight", processed first) and the colliding key
+        # ("b.weight") must both appear.
+        assert "a.weight" in message
+        assert "b.weight" in message
 
     def test_empty_state_dict(self):
         """Empty input returns empty output."""

--- a/src/mobius/_weight_utils_test.py
+++ b/src/mobius/_weight_utils_test.py
@@ -12,6 +12,7 @@ from mobius._weight_utils import (
     merge_lora_weights,
     preprocess_awq_weights,
     preprocess_gptq_weights,
+    rename_weight_keys,
     split_codegen_qkv,
     split_fused_qkv,
     split_gate_up_proj,
@@ -167,6 +168,62 @@ class TestStripPrefix:
         t = torch.randn(3, 4)
         result = strip_prefix({"prefix.key": t}, "prefix")
         assert result["key"].data_ptr() == t.data_ptr()
+
+
+class TestRenameWeightKeys:
+    """Tests for rename_weight_keys."""
+
+    def test_applies_replacements(self):
+        """Each (old, new) pair is applied to every key."""
+        state_dict = {
+            "model.layers.0.attention_layernorm.weight": torch.tensor(1.0),
+            "model.layers.0.feedforward_layernorm.weight": torch.tensor(2.0),
+            "model.embed.weight": torch.tensor(3.0),
+        }
+        result = rename_weight_keys(
+            state_dict,
+            [
+                (".attention_layernorm.", ".input_layernorm."),
+                (".feedforward_layernorm.", ".post_attention_layernorm."),
+            ],
+        )
+        assert set(result.keys()) == {
+            "model.layers.0.input_layernorm.weight",
+            "model.layers.0.post_attention_layernorm.weight",
+            "model.embed.weight",
+        }
+
+    def test_replacements_are_ordered_and_cascade(self):
+        """Replacements apply to the progressively updated key, in order."""
+        state_dict = {"a.weight": torch.tensor(1.0)}
+        result = rename_weight_keys(state_dict, [("a.", "b."), ("b.", "c.")])
+        assert list(result.keys()) == ["c.weight"]
+
+    def test_no_replacements_is_identity(self):
+        """An empty replacement list returns a key-equivalent copy."""
+        state_dict = {"x.weight": torch.tensor(1.0)}
+        result = rename_weight_keys(state_dict, [])
+        assert list(result.keys()) == ["x.weight"]
+        assert result is not state_dict
+
+    def test_shares_tensor_values(self):
+        """Tensor values are shared, not cloned."""
+        t = torch.randn(2, 3)
+        result = rename_weight_keys({"old.k": t}, [("old.", "new.")])
+        assert result["new.k"].data_ptr() == t.data_ptr()
+
+    def test_collision_raises(self):
+        """Two source keys mapping to the same renamed key raises."""
+        state_dict = {
+            "a.weight": torch.tensor(1.0),
+            "b.weight": torch.tensor(2.0),
+        }
+        with pytest.raises(ValueError, match="collision"):
+            rename_weight_keys(state_dict, [("a.", "x."), ("b.", "x.")])
+
+    def test_empty_state_dict(self):
+        """Empty input returns empty output."""
+        assert rename_weight_keys({}, [("a", "b")]) == {}
 
 
 class TestSplitFusedQkvValidation:

--- a/src/mobius/models/chatglm.py
+++ b/src/mobius/models/chatglm.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import torch
 
+from mobius._weight_utils import rename_weight_keys
 from mobius.models.base import CausalLMModel
 
 
@@ -19,16 +20,14 @@ class ChatGLMCausalLMModel(CausalLMModel):
         self, state_dict: dict[str, torch.Tensor]
     ) -> dict[str, torch.Tensor]:
         state_dict = super().preprocess_weights(state_dict)
-        for key in list(state_dict.keys()):
-            # Map ChatGLM MLP attribute names
-            if "dense_4h_to_h" in key:
-                new_key = key.replace("dense_4h_to_h", "down_proj")
-                state_dict[new_key] = state_dict.pop(key)
-            elif "dense_h_to_4h" in key:
-                new_key = key.replace("dense_h_to_4h", "up_proj")
-                state_dict[new_key] = state_dict.pop(key)
-            # Map ChatGLM attention attribute names
-            if "self_attention" in key:
-                new_key = key.replace("self_attention", "self_attn")
-                state_dict[new_key] = state_dict.pop(key)
-        return state_dict
+        # ChatGLM uses HF-specific attribute names:
+        #   dense_h_to_4h / dense_4h_to_h → up_proj / down_proj (FCMLP naming)
+        #   self_attention → self_attn
+        return rename_weight_keys(
+            state_dict,
+            [
+                ("dense_4h_to_h", "down_proj"),
+                ("dense_h_to_4h", "up_proj"),
+                ("self_attention", "self_attn"),
+            ],
+        )

--- a/src/mobius/models/cogvideox.py
+++ b/src/mobius/models/cogvideox.py
@@ -28,6 +28,7 @@ import torch
 from onnxscript import OpBuilder, nn
 
 from mobius._diffusers_configs import CogVideoXConfig
+from mobius._weight_utils import rename_weight_keys
 from mobius.components import LayerNorm as _LayerNorm
 from mobius.components import Linear as _Linear
 from mobius.components._activations import SiLU as _SiLU
@@ -648,9 +649,10 @@ class CogVideoXTransformer3DModel(nn.Module):
         - ``ff.net.0.proj.*`` → ``ff.gelu_proj.*``
         - ``ff.net.2.*`` → ``ff.linear_out.*``
         """
-        new_state_dict: dict[str, torch.Tensor] = {}
-        for name, tensor in state_dict.items():
-            name = name.replace(".ff.net.0.proj.", ".ff.gelu_proj.")
-            name = name.replace(".ff.net.2.", ".ff.linear_out.")
-            new_state_dict[name] = tensor
-        return new_state_dict
+        return rename_weight_keys(
+            state_dict,
+            [
+                (".ff.net.0.proj.", ".ff.gelu_proj."),
+                (".ff.net.2.", ".ff.linear_out."),
+            ],
+        )

--- a/src/mobius/models/hunyuan_dit.py
+++ b/src/mobius/models/hunyuan_dit.py
@@ -32,6 +32,7 @@ import numpy as np
 import torch
 from onnxscript import OpBuilder, nn
 
+from mobius._weight_utils import rename_weight_keys
 from mobius.components import LayerNorm as _LayerNorm
 from mobius.components import Linear as _Linear
 from mobius.components import SiLU as _SiLU
@@ -577,13 +578,14 @@ class HunyuanDiT2DModel(nn.Module):
         - blocks.{i}.ff.net.2 → blocks.{i}.ff.linear_out
         - time_extra_emb.timestep_embedder → time_embed (simplified)
         """
-        new_state_dict: dict[str, torch.Tensor] = {}
-        for key, value in state_dict.items():
-            new_key = key
-            # GEGLU FFN renames
-            new_key = new_key.replace(".ff.net.0.proj.", ".ff.geglu.proj.")
-            new_key = new_key.replace(".ff.net.2.", ".ff.linear_out.")
-            # Timestep embedding (simplified from HF's combined embedding)
-            new_key = new_key.replace("time_extra_emb.timestep_embedder.", "time_embed.")
-            new_state_dict[new_key] = value
+        new_state_dict: dict[str, torch.Tensor] = rename_weight_keys(
+            state_dict,
+            [
+                # GEGLU FFN renames
+                (".ff.net.0.proj.", ".ff.geglu.proj."),
+                (".ff.net.2.", ".ff.linear_out."),
+                # Timestep embedding (simplified from HF's combined embedding)
+                ("time_extra_emb.timestep_embedder.", "time_embed."),
+            ],
+        )
         return new_state_dict

--- a/src/mobius/models/hunyuan_v1.py
+++ b/src/mobius/models/hunyuan_v1.py
@@ -19,6 +19,7 @@ import dataclasses
 import torch
 
 from mobius._configs import ArchitectureConfig
+from mobius._weight_utils import rename_weight_keys
 from mobius.models.base import CausalLMModel
 
 
@@ -42,9 +43,10 @@ class HunYuanV1DenseCausalLMModel(CausalLMModel):
         state_dict = super().preprocess_weights(state_dict)
         # HF uses .query_layernorm. / .key_layernorm.;
         # ONNX Attention uses .q_norm. / .k_norm.
-        return {
-            k.replace(".query_layernorm.", ".q_norm.").replace(
-                ".key_layernorm.", ".k_norm."
-            ): v
-            for k, v in state_dict.items()
-        }
+        return rename_weight_keys(
+            state_dict,
+            [
+                (".query_layernorm.", ".q_norm."),
+                (".key_layernorm.", ".k_norm."),
+            ],
+        )

--- a/src/mobius/models/phi.py
+++ b/src/mobius/models/phi.py
@@ -16,7 +16,7 @@ import torch
 from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
-from mobius._weight_utils import split_fused_qkv
+from mobius._weight_utils import rename_weight_keys, split_fused_qkv
 from mobius.components import (
     FCMLP,
     ConformerEncoder,
@@ -192,12 +192,14 @@ class PhiCausalLMModel(CausalLMModel):
         2. MLP up:   ``mlp.fc1.*`` → ``mlp.up_proj.*``
         3. MLP down: ``mlp.fc2.*`` → ``mlp.down_proj.*``
         """
-        new_state_dict: dict[str, torch.Tensor] = {}
-        for key, value in state_dict.items():
-            key = key.replace(".self_attn.dense.", ".self_attn.o_proj.")
-            key = key.replace(".mlp.fc1.", ".mlp.up_proj.")
-            key = key.replace(".mlp.fc2.", ".mlp.down_proj.")
-            new_state_dict[key] = value
+        new_state_dict: dict[str, torch.Tensor] = rename_weight_keys(
+            state_dict,
+            [
+                (".self_attn.dense.", ".self_attn.o_proj."),
+                (".mlp.fc1.", ".mlp.up_proj."),
+                (".mlp.fc2.", ".mlp.down_proj."),
+            ],
+        )
         return super().preprocess_weights(new_state_dict)
 
 


### PR DESCRIPTION
## Summary

DRY refactor: centralise the duplicated weight-key rename loop.

Many model `preprocess_weights` implementations hand-write the same idiom:

```python
new = {}
for name, tensor in state_dict.items():
    name = name.replace(old1, new1)
    name = name.replace(old2, new2)
    new[name] = tensor
```

### Changes
- **Add `rename_weight_keys(state_dict, replacements)`** to `_weight_utils.py`. Applies an ordered sequence of `(old, new)` substring replacements to every key (replacements cascade, matching the hand-written loops it replaces), shares tensor values (no clone), and **raises `ValueError` on a key collision** (two source keys mapping to the same renamed key) so a silently-dropped weight becomes a hard error instead of a subtle bug.
- **Adopt it in 5 pure-substring-rename models:** `phi`, `hunyuan_dit`, `cogvideox`, `hunyuan_v1`, `chatglm`. Behaviour-preserving.
- Add 6 unit tests covering replacement application, ordered/cascading semantics, identity, value-sharing, collision-raises, and empty input.

### Out of scope (deliberately left as-is)
Models with interleaved tensor transforms (reshape/split/filter + rename) keep their custom loops — forcing them through the helper would obscure control flow. The vision-tower `fc1/fc2` rename triple-duplication (gemma3/llava/mllama) is a separate, filtering-based pattern best handled in the multimodal-task DRY PR.

### Verification
- Fast suite: **2795 passed** (baseline 2789 + 6 new tests), 43 skipped.
- `ruff check` + `ruff format --check` clean on all changed files.