### PR TITLE
Add QNN (Qualcomm Hexagon HTP) execution-provider profile

### DIFF
--- a/src/mobius/_execution_providers.py
+++ b/src/mobius/_execution_providers.py
@@ -267,6 +267,28 @@ def _register_builtins() -> None:
             enable_graph_capture=True,
             supports_past_present_share_buffer=True,
         ),
+        # Qualcomm Hexagon NPU via the QNN EP (onnxruntime-qnn QAIRT plugin),
+        # HTP backend. The HTP runs a static-shaped, QDQ-quantized QNN context
+        # binary with no kernels for ORT contrib fused ops, so everything is
+        # decomposed to standard ONNX. The gemma4 multimodal decoder forgoes GQA
+        # (bidirectional-vision overlay), so standard Attention is emitted and
+        # static-shaped downstream. provider_options are the HTP launch defaults;
+        # soc_model and the EP-context binary path are set per-device at build time.
+        EpCapabilities(
+            name="qnn",
+            gqa_dtypes=frozenset(),  # no GroupQueryAttention (no QNN GQA builder)
+            qkv_pack_dtypes=frozenset(),  # no PackQKV
+            supports_fused_rope=False,  # SeparateRoPE + UnpackQKV
+            supports_skip_layer_norm=False,  # inline Skip[Simplified]LayerNorm
+            supports_packed_multi_head_attention=False,  # inline PackedMHA
+            provider_options={
+                "backend_path": "QnnHtp.dll",
+                "htp_performance_mode": "burst",
+                "htp_graph_finalization_optimization_mode": "3",
+                "enable_htp_shared_memory_allocator": "1",
+            },
+            supports_past_present_share_buffer=False,  # standard-Attention KV concat
+        ),
         # onnx-standard: ONNX-only runtime — emits zero custom-domain ops.
         # All com.microsoft ops (SkipLayerNorm, PackedMHA) are expanded via
         # InlinePass to their standard-ONNX function bodies. No GQA or QKV

--- a/src/mobius/integrations/ort_genai/ep_config.py
+++ b/src/mobius/integrations/ort_genai/ep_config.py
@@ -26,6 +26,7 @@ _ORT_PROVIDER_NAMES: dict[str, str] = {
     "dml": "dml",
     "webgpu": "webgpu",
     "trt-rtx": "NvTensorRtRtx",
+    "qnn": "QNN",
 }
 
 


### PR DESCRIPTION
## What
Registers a `qnn` execution-provider profile so the ORT-GenAI builder can target the Qualcomm Hexagon NPU (HTP backend, via the onnxruntime-qnn QAIRT plugin):
- `_execution_providers.py`: new `EpCapabilities(name="qnn", ...)`.
- `integrations/ort_genai/ep_config.py`: map `qnn` → `QNN` for ORT-GenAI provider dispatch.

## Why
Bringing up gemma-4-12B (`gemma4_unified`) on Qualcomm Copilot+ devices (Snapdragon X Elite / X2 Elite). The HTP runs a statically-shaped, QDQ-quantized graph compiled to a QNN context binary and has no kernels for ORT contrib fused ops, so the build must emit standard ONNX primitives the QNN op builders can lower.

## How
The profile **reuses the existing rewrite infrastructure** rather than adding new passes:
- `supports_fused_rope=False` → `SeparateRoPE` / `UnpackQKV`
- `supports_skip_layer_norm=False` → skip-norm inlined to standard ops
- `supports_packed_multi_head_attention=False` → PackedMHA expanded
- `gqa_dtypes=frozenset()` → no GroupQueryAttention (the gemma-4 multimodal decoder forgoes GQA anyway — bidirectional-vision overlay); standard Attention is emitted and static-shaped downstream
- `supports_past_present_share_buffer=False` (standard-Attention KV concat can't alias a shared buffer)
- `provider_options` = onnxruntime-qnn HTP launch defaults; `soc_model` + EP-context binary path are device-specific, set at build/validation time.

## Validation
Building gemma-4-12B with `execution_provider="qnn"` emits pure ai.onnx (zero `com.microsoft` contrib ops).