### PR TITLE
Teach the direct GQA path to emit sliding-window local_window_size

### DIFF
--- a/.agents/skills/adding-a-new-model/SKILL.md
+++ b/.agents/skills/adding-a-new-model/SKILL.md
@@ -112,6 +112,12 @@ class MyCausalLMModel(CausalLMModel):
         self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
 ```
 
+> If your text model **subclasses `TextModel`** (rather than `nn.Module`) and
+> overrides `__init__` with `nn.Module.__init__(self)` to swap in a custom
+> decoder layer, you must also set `self.config = config` in that subclass —
+> `TextModel.forward` reads `self.config`. See troubleshooting §7.
+
+
 #### Class metadata attributes
 
 Every registered model class should set two class-level attributes:
@@ -395,6 +401,25 @@ differs between loads, suspect `_init_weights` corruption. Set
 `torch.manual_seed(42)` before `from_pretrained` — if that makes outputs
 deterministic, `_init_weights` is the culprit. Then compare specific
 parameters between the loaded model and the safetensors checkpoint.
+
+### 7. `AttributeError: '<X>TextModel' object has no attribute 'config'`
+
+**Symptom:** Building (or running build-graph / GQA rewrite-rule tests for)
+a model raises `AttributeError: '…TextModel' object has no attribute
+'config'` from inside `TextModel.forward` (e.g. `_gqa_local_window_size`).
+
+**Root cause:** The base `TextModel.__init__` sets `self.config = config`,
+and `TextModel.forward` relies on it (sliding-window detection, etc.). A
+`TextModel` **subclass** that overrides `__init__` with
+`nn.Module.__init__(self)` — instead of `super().__init__(config)` — to swap
+in a custom decoder layer must re-establish the contract by setting
+`self.config = config` itself. Forgetting it crashes only that model.
+
+**Fix:** Add `self.config = config` right after `nn.Module.__init__(self)`
+in the subclass `__init__`. Real examples: `Glm4TextModel` (`models/glm.py`),
+`_LoRATextModel` (`models/phi.py`). Do **not** paper over it with
+`getattr(self, "config", None)` in the base — that silently disables
+config-driven features for the offending subclass.
 
 > For additional troubleshooting (gated attention split ordering, DeltaNet
 > scaling, identity node folding, fp32 upcast patterns, multi-token prefill,

--- a/.agents/skills/attention-optimization/SKILL.md
+++ b/.agents/skills/attention-optimization/SKILL.md
@@ -35,7 +35,7 @@ Use this skill when:
 | Pattern | Recommended mask type |
 |---------|----------------------|
 | Simple causal-only | No mask — use `is_causal=1` (enables Flash) |
-| Sliding window (simple model) | Bool mask (precise, less memory) |
+| Sliding window (simple, GQA path) | GQA `local_window_size` (fast path); bool mask only if you must use ONNX Attention |
 | KV-shared layers | Float additive bias |
 | Mixed head_dim (e.g. Gemma4) | Float additive bias |
 | Padding + causal | `nonpad_kv_seqlens` or bool mask |
@@ -280,6 +280,13 @@ use custom per-layer `GQAContext`s instead.
 > cache. Also, the post-hoc GQA rewrite (`RotaryAttentionToGQA`) cannot
 > recover a window from an already-baked float mask, so sliding windows
 > must be set on the **direct** GQA path (GQAContext), not via the rewrite.
+>
+> Decode trade-off: a non-default `local_window_size != -1` disqualifies the
+> dedicated `seq==1` **XQA** decode kernel (which requires `local_window==-1`,
+> see the CUDA cascade table above), so windowed GQA decode falls back to
+> Flash-decode/MEA. This is still on the fast GQA path and is the correct
+> trade for models that genuinely need the window; do not set it on
+> full-attention models.
 
 ## Key takeaways for model builders
 

--- a/.agents/skills/attention-optimization/SKILL.md
+++ b/.agents/skills/attention-optimization/SKILL.md
@@ -23,8 +23,8 @@ Use this skill when:
 | Scenario | Recommended | Why |
 |----------|------------|-----|
 | Causal only | `attn_mask=None` + `is_causal=1` | Enables Flash (fastest for prefill) |
-| Padding (batch>1) | `nonpad_kv_seqlens` (best) or bool mask | `nonpad_kv_seqlens` enables Flash + shared buffer with no mask |
-| Sliding window (simple) | Bool mask | Equally precise as float, uses less memory |
+| Padding (batch>1) | `nonpad_kv_seqlens` (prefill) or bool mask | `nonpad_kv_seqlens` enables Flash with no mask, but is rejected with past KV (decode) |
+| Sliding window (simple) | GQA `local_window_size` or bool mask | `local_window_size` keeps the fast GQA path; bool mask if you need ONNX Attention |
 | Complex (sliding+KV-shared+dual head_dim) | Float additive bias | Avoids mask construction bugs in multi-constraint patterns |
 | Custom pattern | Float additive bias | Arbitrary values |
 
@@ -116,7 +116,7 @@ single-token decode (memory-bandwidth bound regardless of kernel):
 | Symmetric heads | `head_size == v_head_size` |
 | GPU | SM≥8.0 (Ampere or newer) |
 
-### `nonpad_kv_seqlens` — the best padding solution
+### `nonpad_kv_seqlens` — a **prefill-only** padding solution
 
 ONNX Attention opset 24 adds `nonpad_kv_seqlens` input, which tells
 the kernel the actual (non-padded) KV sequence length per batch item.
@@ -124,18 +124,31 @@ This enables Flash Attention with variable-length sequences **without
 providing an explicit mask** — the kernel applies causal masking
 internally using the sequence length info.
 
+> ⚠️ **Prefill only.** ORT *rejects* `nonpad_kv_seqlens` when `past_key` /
+> `past_value` are also supplied: *"nonpad_kv_seqlens should not be used
+> together with past_key and past_value inputs."* So it only helps the
+> first (prefill) pass, not autoregressive decode steps that feed a KV
+> cache. For batched decode with padding, fall back to a bool/float mask
+> or the GQA contrib op (which takes `seqlens_k` alongside past KV).
+
+> ⚠️ **No in-place KV buffer.** The opset-24 ONNX `Attention` schema has
+> **no `past_present_share_buffer` attribute**. `present = concat(past,
+> new)` is materialised every step (an O(N) copy), and `past`/`present`
+> are distinct tensors. Only the contrib **GroupQueryAttention** op
+> writes new tokens into a shared, pre-allocated KV buffer in place. This
+> is the main residual reason GQA out-paces ONNX `Attention` during
+> decode even after IO-binding the cache (see "GQA vs ONNX Attention").
+
 ```python
-# Enables Flash + past_present_share_buffer for efficient KV cache
+# Prefill only: NO past_key/past_value, NO past_present_share_buffer
+# (that attribute does not exist on the opset-24 Attention schema).
 attn_out = op.Attention(
     query, key, value,
-    attn_mask=None,           # nullptr → Flash eligible
-    past_key=past_k,
-    past_value=past_v,
-    nonpad_kv_seqlens=seqlens_k,  # opset 24
+    attn_mask=None,                # nullptr → Flash eligible
+    nonpad_kv_seqlens=seqlens_k,   # opset 24, prefill pass only
     q_num_heads=num_heads,
     kv_num_heads=kv_heads,
     is_causal=1,
-    past_present_share_buffer=1,
 )
 ```
 
@@ -214,24 +227,51 @@ borrow K/V from a layer with different `head_size`, creating
 | Attention bias | ❌ Rejected | ✅ Supported |
 | Flash Attention | ✅ (no mask) | ✅ (no mask) |
 | XQA kernel | ✅ | ❌ |
-| KV cache management | Built-in (`past_present_share_buffer`) | Manual (separate past/present) |
-| Variable-length | Via `seqlens_k` | Via `nonpad_kv_seqlens` (opset 24) |
+| In-place KV buffer | ✅ `past_present_share_buffer` (writes 1 token in place) | ❌ none — `present=concat(past,new)`, O(N) copy/step |
+| Sliding window | ✅ `local_window_size` attribute | Via float/bool bias only |
+| Variable-length | Via `seqlens_k` (works with past KV) | Via `nonpad_kv_seqlens` (prefill only) |
 
 **Guideline:** Use Contrib GQA when you don't need attention bias
-(simple causal models). Use ONNX Attention when you need float bias
-(sliding window, KV-shared, padding).
+(simple causal models, sliding-window via `local_window_size`). Use ONNX
+Attention when you need a float bias (KV-shared, dual head_dim, or
+mixed/alternating per-layer windows that one global window can't express).
+
+### GQA sliding window via `local_window_size`
+
+GroupQueryAttention takes a `local_window_size` attribute that masks each
+query to the most recent `W` keys (positions `[i-W+1, i]`) — exactly
+matching HuggingFace `sliding_window=W`. This keeps a uniform-window model
+on the fast GQA path instead of forcing it onto ONNX `Attention` with a
+baked float window mask. In mobius this is wired in `TextModel.forward`
+from `config.sliding_window` (see `GQAContext.local_window_size`), guarded
+to uniformly-sliding models — mixed `layer_types` (Gemma2/3/4, gpt-oss)
+use custom per-layer `GQAContext`s instead.
+
+> Note: `local_window_size` only *masks* attention; it does not shrink the
+> physical KV buffer, so bounding memory still needs a circular/static
+> cache. Also, the post-hoc GQA rewrite (`RotaryAttentionToGQA`) cannot
+> recover a window from an already-baked float mask, so sliding windows
+> must be set on the **direct** GQA path (GQAContext), not via the rewrite.
 
 ## Key takeaways for model builders
 
 1. **Flash requires `attn_mask == nullptr`** — any explicit mask
    disables Flash. Use `is_causal=1` instead.
 2. **`nonpad_kv_seqlens`** enables Flash with variable-length sequences
-   without an explicit mask.
+   without an explicit mask — but **prefill only** (rejected when
+   `past_key`/`past_value` are present).
 3. **GQA contrib op rejects `attention_bias`** — use standard ONNX
    `Attention` if you need bias with GQA.
 4. **SM≥8.0** (Ampere+) required for Flash on all paths.
 5. **Float bias is safer** than bool mask for complex attention patterns.
 6. **MEA requires alignment** — `total_kv % 4 == 0` for bias tensors.
+7. **Only GQA has an in-place KV buffer** (`past_present_share_buffer`).
+   ONNX `Attention` (opset 24) has no such attribute and re-concats the
+   cache each step — the main reason GQA wins during decode even after
+   IO-binding the cache.
+8. **Sliding window on the fast path:** set GQA `local_window_size` (=
+   `config.sliding_window`) for uniform-window models instead of baking a
+   float window mask into ONNX `Attention`.
 
 ## Cross-references
 

--- a/.agents/skills/attention-optimization/SKILL.md
+++ b/.agents/skills/attention-optimization/SKILL.md
@@ -23,7 +23,7 @@ Use this skill when:
 | Scenario | Recommended | Why |
 |----------|------------|-----|
 | Causal only | `attn_mask=None` + `is_causal=1` | Enables Flash (fastest for prefill) |
-| Padding (batch>1) | `nonpad_kv_seqlens` (prefill) or bool mask | `nonpad_kv_seqlens` enables Flash with no mask, but is rejected with past KV (decode) |
+| Padding (batch>1) | `nonpad_kv_seqlens` (+ static cache) or bool mask | `nonpad_kv_seqlens` enables Flash with no mask; pair with `TensorScatter` static cache for decode (can't combine with `past_key`/`past_value` inputs) |
 | Sliding window (simple) | GQA `local_window_size` or bool mask | `local_window_size` keeps the fast GQA path; bool mask if you need ONNX Attention |
 | Complex (sliding+KV-shared+dual head_dim) | Float additive bias | Avoids mask construction bugs in multi-constraint patterns |
 | Custom pattern | Float additive bias | Arbitrary values |
@@ -116,7 +116,7 @@ single-token decode (memory-bandwidth bound regardless of kernel):
 | Symmetric heads | `head_size == v_head_size` |
 | GPU | SM≥8.0 (Ampere or newer) |
 
-### `nonpad_kv_seqlens` — a **prefill-only** padding solution
+### `nonpad_kv_seqlens` — variable-length without an explicit mask
 
 ONNX Attention opset 24 adds `nonpad_kv_seqlens` input, which tells
 the kernel the actual (non-padded) KV sequence length per batch item.
@@ -124,28 +124,56 @@ This enables Flash Attention with variable-length sequences **without
 providing an explicit mask** — the kernel applies causal masking
 internally using the sequence length info.
 
-> ⚠️ **Prefill only.** ORT *rejects* `nonpad_kv_seqlens` when `past_key` /
-> `past_value` are also supplied: *"nonpad_kv_seqlens should not be used
-> together with past_key and past_value inputs."* So it only helps the
-> first (prefill) pass, not autoregressive decode steps that feed a KV
-> cache. For batched decode with padding, fall back to a bool/float mask
-> or the GQA contrib op (which takes `seqlens_k` alongside past KV).
+> ⚠️ **Cannot be combined with the `past_key` / `past_value` inputs.** ORT
+> *rejects* `nonpad_kv_seqlens` when `past_key`/`past_value` are supplied:
+> *"nonpad_kv_seqlens should not be used together with past_key and
+> past_value inputs."* It is therefore **not** usable with the *growing*
+> (dynamic) cache mode beyond the prefill pass. It **is** used at every
+> decode step in the **static-cache** mode below, where the full cache is
+> passed in the `key`/`value` slots and `past_key`/`past_value` are unused.
 
-> ⚠️ **No in-place KV buffer.** The opset-24 ONNX `Attention` schema has
-> **no `past_present_share_buffer` attribute**. `present = concat(past,
-> new)` is materialised every step (an O(N) copy), and `past`/`present`
-> are distinct tensors. Only the contrib **GroupQueryAttention** op
-> writes new tokens into a shared, pre-allocated KV buffer in place. This
-> is the main residual reason GQA out-paces ONNX `Attention` during
-> decode even after IO-binding the cache (see "GQA vs ONNX Attention").
+#### In-place KV for ONNX Attention via `TensorScatter` (static cache)
+
+The opset-24 ONNX `Attention` schema has **no `past_present_share_buffer`
+attribute**, so the naive dynamic mode does `present = concat(past, new)`
+every step (an O(N) copy of distinct `past`/`present` tensors). But ONNX
+`Attention` **can** still update a KV cache *in place* — by pairing it with
+the opset-24 **`TensorScatter`** op:
+
+1. Pre-allocate a fixed-size KV buffer (`StaticCacheState` in mobius).
+2. `TensorScatter` writes the new token(s) into the buffer at
+   `write_indices` (in place when the buffer is IO-bound to the same
+   device memory) — no growing concat.
+3. Pass the **full** scattered cache in the `key`/`value` slots (not
+   `past_key`/`past_value`), with `nonpad_kv_seqlens` giving the valid
+   length and `is_causal=1` for masking.
+
+So in-place KV is **not** GQA-exclusive. The contrib **GroupQueryAttention**
+op has a built-in shared buffer (`past_present_share_buffer`); ONNX
+`Attention` reaches the same effect explicitly with `TensorScatter` +
+static cache. GQA's residual decode edge comes mostly from its dedicated
+`seq==1` decode kernels (XQA / Flash-decode), not from buffer management
+alone.
 
 ```python
-# Prefill only: NO past_key/past_value, NO past_present_share_buffer
-# (that attribute does not exist on the opset-24 Attention schema).
+# Dynamic (growing) mode — nonpad_kv_seqlens is PREFILL ONLY here,
+# because it cannot be combined with past_key/past_value:
 attn_out = op.Attention(
     query, key, value,
     attn_mask=None,                # nullptr → Flash eligible
     nonpad_kv_seqlens=seqlens_k,   # opset 24, prefill pass only
+    q_num_heads=num_heads,
+    kv_num_heads=kv_heads,
+    is_causal=1,
+)
+
+# Static-cache mode — in-place KV at EVERY step (prefill + decode):
+updated_k = op.TensorScatter(key_cache, key, write_indices, axis=1)
+updated_v = op.TensorScatter(value_cache, value, write_indices, axis=1)
+attn_out = op.Attention(
+    query, updated_k, updated_v,   # full cache in key/value slots
+    None, None, None,              # no attn_mask, no past_key/past_value
+    nonpad_kv_seqlens,             # valid length per batch — used every step
     q_num_heads=num_heads,
     kv_num_heads=kv_heads,
     is_causal=1,
@@ -227,9 +255,9 @@ borrow K/V from a layer with different `head_size`, creating
 | Attention bias | ❌ Rejected | ✅ Supported |
 | Flash Attention | ✅ (no mask) | ✅ (no mask) |
 | XQA kernel | ✅ | ❌ |
-| In-place KV buffer | ✅ `past_present_share_buffer` (writes 1 token in place) | ❌ none — `present=concat(past,new)`, O(N) copy/step |
+| In-place KV buffer | ✅ built-in `past_present_share_buffer` | ✅ via `TensorScatter` + static cache (no growing concat) |
 | Sliding window | ✅ `local_window_size` attribute | Via float/bool bias only |
-| Variable-length | Via `seqlens_k` (works with past KV) | Via `nonpad_kv_seqlens` (prefill only) |
+| Variable-length | Via `seqlens_k` (works with past KV) | Via `nonpad_kv_seqlens` (with static cache, not the `past_key`/`past_value` inputs) |
 
 **Guideline:** Use Contrib GQA when you don't need attention bias
 (simple causal models, sliding-window via `local_window_size`). Use ONNX
@@ -258,17 +286,20 @@ use custom per-layer `GQAContext`s instead.
 1. **Flash requires `attn_mask == nullptr`** — any explicit mask
    disables Flash. Use `is_causal=1` instead.
 2. **`nonpad_kv_seqlens`** enables Flash with variable-length sequences
-   without an explicit mask — but **prefill only** (rejected when
-   `past_key`/`past_value` are present).
+   without an explicit mask. It cannot be combined with the
+   `past_key`/`past_value` inputs (so it is prefill-only in the *growing*
+   cache mode), but it is used at **every** step in the static-cache mode
+   (full cache in the `key`/`value` slots).
 3. **GQA contrib op rejects `attention_bias`** — use standard ONNX
    `Attention` if you need bias with GQA.
 4. **SM≥8.0** (Ampere+) required for Flash on all paths.
 5. **Float bias is safer** than bool mask for complex attention patterns.
 6. **MEA requires alignment** — `total_kv % 4 == 0` for bias tensors.
-7. **Only GQA has an in-place KV buffer** (`past_present_share_buffer`).
-   ONNX `Attention` (opset 24) has no such attribute and re-concats the
-   cache each step — the main reason GQA wins during decode even after
-   IO-binding the cache.
+7. **In-place KV is not GQA-exclusive.** GQA has a built-in shared buffer
+   (`past_present_share_buffer`); ONNX `Attention` (opset 24) has no such
+   attribute but reaches the same effect with **`TensorScatter` + a static
+   cache** (vs. the naive growing `concat(past, new)`). GQA's residual
+   decode edge is mostly its dedicated `seq==1` kernels (XQA/Flash-decode).
 8. **Sliding window on the fast path:** set GQA `local_window_size` (=
    `config.sliding_window`) for uniform-window models instead of baking a
    float window mask into ONNX `Attention`.

--- a/src/mobius/_configs/_base.py
+++ b/src/mobius/_configs/_base.py
@@ -71,6 +71,25 @@ def _resolve_hidden_act(config, model_type: str) -> str | None:
     )
 
 
+def _resolve_sliding_window(config) -> int | None:
+    """Resolve the effective sliding-window size, honoring HF's enable gate.
+
+    Qwen2/Qwen3 keep a non-null ``sliding_window`` in the config even when the
+    window is disabled, signalling activation through the separate
+    ``use_sliding_window`` flag (HF's ``__post_init__`` nulls ``sliding_window``
+    when it is ``False``). A raw ``config.json`` fallback that bypasses
+    ``__post_init__`` would otherwise leak a window onto a model that does not
+    use one, so the gate must be re-applied here. ``use_sliding_window`` defaults
+    to ``True`` so models without the flag (e.g. Mistral) are unaffected.
+    """
+    window = getattr(config, "sliding_window", None) or getattr(config, "window_size", None)
+    if window is None:
+        return None
+    if getattr(config, "use_sliding_window", True) is False:
+        return None
+    return window
+
+
 def _nested_rope_theta(rope_scaling: dict, key: str) -> float | None:
     """Extract rope_theta from a nested rope_scaling dict (e.g. Gemma3)."""
     sub = rope_scaling.get(key)
@@ -575,9 +594,7 @@ class ArchitectureConfig(BaseModelConfig):
             ),
             no_rope_layers=getattr(config, "no_rope_layers", None),
             full_attention_interval=(getattr(config, "full_attention_interval", None)),
-            sliding_window=(
-                getattr(config, "sliding_window", None) or getattr(config, "window_size", None)
-            ),
+            sliding_window=_resolve_sliding_window(config),
             # Linear attention (DeltaNet) parameters
             linear_conv_kernel_dim=(getattr(config, "linear_conv_kernel_dim", 4)),
             linear_key_head_dim=(getattr(config, "linear_key_head_dim", None)),

--- a/src/mobius/models/base.py
+++ b/src/mobius/models/base.py
@@ -13,6 +13,8 @@ Qwen2ForCausalLM structure.
 
 from __future__ import annotations
 
+import logging
+
 import onnx_ir as ir
 import torch
 from onnxscript import OpBuilder, nn
@@ -37,6 +39,8 @@ from mobius.components import (
 )
 from mobius.components._attention import GQAContext
 from mobius.components._rotary_embedding import BaseRope, _MRopeBase
+
+logger = logging.getLogger(__name__)
 
 
 class TextModel(nn.Module):
@@ -146,6 +150,23 @@ class TextModel(nn.Module):
             # in Attention.forward() (which checks `if position_embeddings is not None`).
             position_embeddings = None
         else:
+            # This path (CPU fp32, DML, non-fused RoPE, mRoPE, static cache)
+            # builds at most a bool padding mask; it has no way to express a
+            # sliding window. Warn if the model expects one so the divergence
+            # from HuggingFace for sequences longer than the window is not
+            # silent. (For seq <= window the result is identical regardless.)
+            if self._gqa_local_window_size() > 0:
+                logger.warning(
+                    "Model declares a uniform sliding window "
+                    "(sliding_window=%s) but is being built through a non-GQA "
+                    "attention path (build dtype=%s); the exported graph uses "
+                    "full causal attention and will diverge from HuggingFace "
+                    "for sequences longer than the window. Build with a "
+                    "GQA-capable execution provider/dtype (e.g. CUDA or DML "
+                    "with float16/bfloat16) to apply the window.",
+                    getattr(self.config, "sliding_window", None),
+                    dtype,
+                )
             # NoPE models (e.g. NemotronH, GraniteMoeHybrid) have
             # ``rotary_emb = None`` because ``initialize_rope`` returned
             # ``None`` for ``config.rope_type is None``. Skip building
@@ -195,15 +216,25 @@ class TextModel(nn.Module):
         *uniform* sliding window across all layers. Models with alternating
         full/sliding layers (Gemma2/3/4, gpt-oss) use custom model classes with
         per-layer masks and do not take this path.
+
+        ``-1`` is ORT's documented sentinel for "no local window" (full causal
+        attention); it is returned whenever the window is absent, non-positive,
+        or cannot be represented by a single global window.
         """
         sliding_window = getattr(self.config, "sliding_window", None)
-        if sliding_window is None or sliding_window <= 0:
+        if not sliding_window or sliding_window <= 0:
             return -1
-        # Mixed schedules (some "full_attention", some "sliding_attention")
-        # cannot be expressed by one global window — leave it disabled.
+        # A single global window can only stand in for the per-layer schedule
+        # when every layer slides. Treat an empty, partial, or mixed
+        # ``layer_types`` (some "full_attention", some "sliding_attention") as
+        # non-uniform and leave the window disabled.
         layer_types = getattr(self.config, "layer_types", None)
-        if layer_types is not None and any(t != "sliding_attention" for t in layer_types):
-            return -1
+        if layer_types is not None:
+            num_layers = getattr(self.config, "num_hidden_layers", None)
+            if len(layer_types) != num_layers or any(
+                t != "sliding_attention" for t in layer_types
+            ):
+                return -1
         return int(sliding_window)
 
 

--- a/src/mobius/models/base.py
+++ b/src/mobius/models/base.py
@@ -44,6 +44,7 @@ class TextModel(nn.Module):
 
     def __init__(self, config: ArchitectureConfig, mlp_class: type | None = None):
         super().__init__()
+        self.config = config
         self._dtype = config.dtype
 
         # If the config has quantization, swap Linear for QuantizedLinear
@@ -138,6 +139,7 @@ class TextModel(nn.Module):
                 total_seq_len=total_seq_len,
                 cos_cache=self.rotary_emb.cos_cache,  # [max_seq, rotary_dim]
                 sin_cache=self.rotary_emb.sin_cache,  # [max_seq, rotary_dim]
+                local_window_size=self._gqa_local_window_size(),
             )
             # position_embeddings not needed: GroupQueryAttention handles RoPE
             # internally via do_rotary=1. Passing None skips apply_rotary_pos_emb
@@ -182,6 +184,27 @@ class TextModel(nn.Module):
 
         hidden_states = self.norm(op, hidden_states)
         return hidden_states, present_key_values
+
+    def _gqa_local_window_size(self) -> int:
+        """Sliding-window size to pass to GroupQueryAttention, or -1 if unused.
+
+        GQA's ``local_window_size=W`` masks each query to the most recent ``W``
+        keys (positions ``[i-W+1, i]``), which matches HuggingFace's
+        ``sliding_window=W`` semantics exactly. The global GQAContext built here
+        is shared by every layer, so this only applies when the model uses a
+        *uniform* sliding window across all layers. Models with alternating
+        full/sliding layers (Gemma2/3/4, gpt-oss) use custom model classes with
+        per-layer masks and do not take this path.
+        """
+        sliding_window = getattr(self.config, "sliding_window", None)
+        if sliding_window is None or sliding_window <= 0:
+            return -1
+        # Mixed schedules (some "full_attention", some "sliding_attention")
+        # cannot be expressed by one global window — leave it disabled.
+        layer_types = getattr(self.config, "layer_types", None)
+        if layer_types is not None and any(t != "sliding_attention" for t in layer_types):
+            return -1
+        return int(sliding_window)
 
 
 class CausalLMModel(nn.Module):

--- a/src/mobius/models/glm.py
+++ b/src/mobius/models/glm.py
@@ -149,6 +149,7 @@ class Glm4TextModel(TextModel):
         nn.Module.__init__(self)
         from mobius.components import Embedding, initialize_rope
 
+        self.config = config
         self._dtype = config.dtype
         self.embed_tokens = Embedding(
             config.vocab_size, config.hidden_size, config.pad_token_id

--- a/src/mobius/models/phi.py
+++ b/src/mobius/models/phi.py
@@ -285,6 +285,7 @@ class _LoRATextModel(TextModel):
         self, config: ArchitectureConfig, lora_adapters: list[tuple[str, int, float]]
     ):
         nn.Module.__init__(self)
+        self.config = config
         lora_factory = _make_lora_linear_factory(lora_adapters)
         self.embed_tokens = Embedding(
             config.vocab_size, config.hidden_size, config.pad_token_id

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -5105,3 +5105,73 @@ class TestBuildSpeechGraph:
         task = get_task(_default_task_for_model(model_type))
         pkg = task.build(module, config)
         _assert_outputs_have_shapes_and_dtypes(pkg, model_type)
+
+
+class TestGQASlidingWindow:
+    """Wire ``config.sliding_window`` into GQA's ``local_window_size``.
+
+    On the direct GQA path (``TextModel.forward``), GQA
+    ``local_window_size=W`` masks each query to the most recent ``W`` keys
+    (positions ``[i-W+1, i]``), matching HuggingFace ``sliding_window=W``.
+    Because the global GQAContext is shared by every layer, the window is only
+    emitted for models with a *uniform* sliding window across all layers.
+    """
+
+    @staticmethod
+    def _build_gqa_decoder(**overrides):
+        from mobius.models.base import CausalLMModel
+
+        config = ArchitectureConfig(
+            hidden_size=64,
+            intermediate_size=128,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=16,
+            num_hidden_layers=2,
+            vocab_size=256,
+            max_position_embeddings=128,
+            hidden_act="silu",
+            rms_norm_eps=1e-6,
+            rope_type="default",
+            rope_theta=10000.0,
+            pad_token_id=0,
+            dtype=ir.DataType.FLOAT16,
+            **overrides,
+        )
+        module = CausalLMModel(config)
+        # execution_provider="cuda" + fp16 activates the direct GQA path.
+        pkg = build_from_module(module, config, execution_provider="cuda")
+        model = pkg["model"]
+        gqa_nodes = [n for n in model.graph if n.op_type == "GroupQueryAttention"]
+        assert gqa_nodes, "expected GroupQueryAttention nodes on the cuda/fp16 path"
+        return gqa_nodes
+
+    def test_uniform_sliding_window_sets_local_window_size(self):
+        """A uniform sliding window is forwarded to every GQA node verbatim."""
+        gqa_nodes = self._build_gqa_decoder(sliding_window=3000)
+        for node in gqa_nodes:
+            assert node.attributes["local_window_size"].value == 3000
+
+    def test_no_sliding_window_omits_local_window_size(self):
+        """Full-attention models must not carry a local_window_size attribute."""
+        gqa_nodes = self._build_gqa_decoder(sliding_window=None)
+        for node in gqa_nodes:
+            assert "local_window_size" not in node.attributes
+
+    def test_mixed_layer_types_omits_local_window_size(self):
+        """A per-layer schedule cannot be expressed by one global window."""
+        gqa_nodes = self._build_gqa_decoder(
+            sliding_window=8,
+            layer_types=["sliding_attention", "full_attention"],
+        )
+        for node in gqa_nodes:
+            assert "local_window_size" not in node.attributes
+
+    def test_all_sliding_layer_types_sets_local_window_size(self):
+        """An explicit all-sliding schedule is uniform, so window is emitted."""
+        gqa_nodes = self._build_gqa_decoder(
+            sliding_window=8,
+            layer_types=["sliding_attention", "sliding_attention"],
+        )
+        for node in gqa_nodes:
+            assert node.attributes["local_window_size"].value == 8

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -3765,6 +3765,36 @@ class TestBuildMoshiLM:
         assert "text_logits" in outputs
         assert "present.0.key" in outputs
 
+    def test_temporal_gqa_emits_sliding_window(self):
+        """Temporal GQA nodes carry Moshi's sliding window as local_window_size.
+
+        On the GQA (fp16/cuda) path, the temporal transformer's uniform sliding
+        window (Moshi ``context``) must reach every GroupQueryAttention node as
+        ``local_window_size``.  PersonaPlex deploys this fp16 path, so without it
+        long streams would silently run full causal attention.
+        """
+        import dataclasses
+
+        import onnx_ir as ir
+
+        from mobius.models.moshi import MoshiTemporalModel, moshi_temporal_config
+        from mobius.tasks import MoshiTemporalTask
+
+        full_window = moshi_temporal_config().sliding_window
+        assert full_window and full_window > 0, "Moshi temporal must be sliding"
+
+        config = dataclasses.replace(self._temporal_tiny_config(), dtype=ir.DataType.FLOAT16)
+        pkg = build_from_module(
+            MoshiTemporalModel(config),
+            config,
+            task=MoshiTemporalTask(),
+            execution_provider="cuda",
+        )
+        gqa_nodes = [n for n in pkg["model"].graph if n.op_type == "GroupQueryAttention"]
+        assert len(gqa_nodes) == config.num_hidden_layers
+        for node in gqa_nodes:
+            assert node.attributes["local_window_size"].value == full_window
+
     def test_depformer_io(self):
         """Depformer model I/O: hidden + prev_token + substep_index -> logits."""
         from mobius.models.moshi import MoshiDepformerModel, moshi_depformer_config
@@ -5118,16 +5148,16 @@ class TestGQASlidingWindow:
     """
 
     @staticmethod
-    def _build_gqa_decoder(**overrides):
+    def _build_gqa_model(**overrides):
         from mobius.models.base import CausalLMModel
 
+        overrides.setdefault("num_hidden_layers", 2)
         config = ArchitectureConfig(
             hidden_size=64,
             intermediate_size=128,
             num_attention_heads=4,
             num_key_value_heads=2,
             head_dim=16,
-            num_hidden_layers=2,
             vocab_size=256,
             max_position_embeddings=128,
             hidden_act="silu",
@@ -5140,11 +5170,27 @@ class TestGQASlidingWindow:
         )
         module = CausalLMModel(config)
         # execution_provider="cuda" + fp16 activates the direct GQA path.
-        pkg = build_from_module(module, config, execution_provider="cuda")
-        model = pkg["model"]
+        return build_from_module(module, config, execution_provider="cuda")["model"]
+
+    @classmethod
+    def _build_gqa_decoder(cls, **overrides):
+        model = cls._build_gqa_model(**overrides)
         gqa_nodes = [n for n in model.graph if n.op_type == "GroupQueryAttention"]
         assert gqa_nodes, "expected GroupQueryAttention nodes on the cuda/fp16 path"
         return gqa_nodes
+
+    @staticmethod
+    def _fill_fp16_weights(model, seed):
+        """Deterministically fill uninitialised params, honouring fp16 dtype."""
+        rng = np.random.default_rng(seed)
+        npdt = {ir.DataType.FLOAT16: np.float16, ir.DataType.FLOAT: np.float32}
+        for init in model.graph.initializers.values():
+            if init.const_value is None:
+                shape = [int(d) for d in init.shape]
+                arr = (rng.standard_normal(shape) * 0.1).astype(
+                    npdt.get(init.dtype, np.float32)
+                )
+                init.const_value = ir.Tensor(arr)
 
     def test_uniform_sliding_window_sets_local_window_size(self):
         """A uniform sliding window is forwarded to every GQA node verbatim."""
@@ -5175,3 +5221,52 @@ class TestGQASlidingWindow:
         )
         for node in gqa_nodes:
             assert node.attributes["local_window_size"].value == 8
+
+    def test_window_confines_receptive_field(self):
+        """The sliding window must actually bound each query's receptive field.
+
+        Property test (no golden, weight-agnostic): with window ``W`` over
+        ``L`` layers, the last position can only be influenced by inputs within
+        ``L*(W-1)`` steps. Perturbing an out-of-window token must leave the
+        windowed model's last-position logits unchanged, while the same
+        perturbation *does* change the full-attention twin's logits — proving
+        the window is genuinely applied (and exercising seq > window, unlike
+        the short-sequence Moshi parity golden). Runs the fp16 GQA op on CPU.
+        """
+        from mobius._testing.ort_inference import OnnxModelSession
+
+        window, seq, layers = 4, 24, 2
+        # Pos 0 is well outside the last position's receptive field
+        # (layers*(window-1) = 6 << seq-1 = 23).
+        windowed = self._build_gqa_model(sliding_window=window, num_hidden_layers=layers)
+        full = self._build_gqa_model(sliding_window=None, num_hidden_layers=layers)
+        # Same seed + identical structure (only the GQA attr differs) => same weights.
+        self._fill_fp16_weights(windowed, seed=1234)
+        self._fill_fp16_weights(full, seed=1234)
+
+        def feeds(first_token):
+            ids = np.arange(1, seq + 1, dtype=np.int64).reshape(1, seq)
+            ids[0, 0] = first_token
+            f = {"input_ids": ids, "attention_mask": np.ones((1, seq), np.int64)}
+            for i in range(layers):
+                f[f"past_key_values.{i}.key"] = np.zeros((1, 2, 0, 16), np.float16)
+                f[f"past_key_values.{i}.value"] = np.zeros((1, 2, 0, 16), np.float16)
+            return f
+
+        def last_logits(model, first_token):
+            sess = OnnxModelSession(model)
+            out = sess.run(feeds(first_token))
+            return out["logits"][0, -1].astype(np.float32)
+
+        # Windowed: perturbing the out-of-window first token leaves the last
+        # position's logits unchanged.
+        w_a = last_logits(windowed, first_token=5)
+        w_b = last_logits(windowed, first_token=200)
+        np.testing.assert_allclose(w_a, w_b, atol=1e-3)
+
+        # Full attention: the same perturbation DOES reach the last position.
+        f_a = last_logits(full, first_token=5)
+        f_b = last_logits(full, first_token=200)
+        assert np.abs(f_a - f_b).max() > 1e-2, (
+            "full-attention twin should be sensitive to the first token"
+        )

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -5270,3 +5270,116 @@ class TestGQASlidingWindow:
         assert np.abs(f_a - f_b).max() > 1e-2, (
             "full-attention twin should be sensitive to the first token"
         )
+
+    def test_empty_layer_types_omits_local_window_size(self):
+        """An empty ``layer_types`` is not a valid uniform schedule.
+
+        ``all(... for t in [])`` is vacuously True, so an unhardened guard
+        would wrongly treat ``[]`` as uniform-sliding. The length check against
+        ``num_hidden_layers`` rejects it, leaving the window disabled.
+        """
+        gqa_nodes = self._build_gqa_decoder(
+            sliding_window=8,
+            layer_types=[],
+            num_hidden_layers=2,
+        )
+        for node in gqa_nodes:
+            assert "local_window_size" not in node.attributes
+
+    def test_non_gqa_path_warns_on_uniform_window(self, caplog):
+        """Non-GQA (static-cache) export of a uniform-sliding model warns.
+
+        That path cannot represent the window, so the warning flags the
+        divergence from HuggingFace for sequences longer than the window.
+        """
+        import logging
+
+        from mobius.models.base import CausalLMModel
+
+        config = ArchitectureConfig(
+            hidden_size=64,
+            intermediate_size=128,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=16,
+            vocab_size=256,
+            max_position_embeddings=128,
+            hidden_act="silu",
+            rms_norm_eps=1e-6,
+            rope_type="default",
+            rope_theta=10000.0,
+            pad_token_id=0,
+            num_hidden_layers=2,
+            sliding_window=8,
+            dtype=ir.DataType.FLOAT,
+        )
+        module = CausalLMModel(config)
+        # Static cache feeds attention_mask=None, taking the non-GQA else
+        # branch that cannot express the window.
+        from mobius.tasks import CausalLMTask
+
+        task = CausalLMTask(static_cache=True, max_seq_len=128)
+        with caplog.at_level(logging.WARNING, logger="mobius.models.base"):
+            build_from_module(module, config, task=task, execution_provider="cpu")
+        assert "sliding window" in caplog.text
+
+    def test_partial_layer_types_omits_local_window_size(self):
+        """A ``layer_types`` shorter than the layer count is not uniform."""
+        gqa_nodes = self._build_gqa_decoder(
+            sliding_window=8,
+            layer_types=["sliding_attention"],
+            num_hidden_layers=2,
+        )
+        for node in gqa_nodes:
+            assert "local_window_size" not in node.attributes
+
+
+class TestResolveSlidingWindow:
+    """``from_transformers`` must honor HF's ``use_sliding_window`` gate.
+
+    Qwen2/Qwen3 keep a non-null ``sliding_window`` in the config even when the
+    window is disabled and signal activation via ``use_sliding_window``. A raw
+    ``config.json`` fallback bypasses HF's ``__post_init__`` (which would null
+    the field), so the gate is re-applied in ``_resolve_sliding_window``.
+    """
+
+    @staticmethod
+    def _cfg(**attrs):
+        from types import SimpleNamespace
+
+        defaults = dict(
+            model_type="qwen2",
+            hidden_size=64,
+            intermediate_size=128,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            num_hidden_layers=2,
+            vocab_size=256,
+            max_position_embeddings=128,
+            hidden_act="silu",
+            rms_norm_eps=1e-6,
+            rope_theta=10000.0,
+        )
+        defaults.update(attrs)
+        return SimpleNamespace(**defaults)
+
+    def test_disabled_window_is_nulled(self):
+        """``use_sliding_window=False`` drops a non-null ``sliding_window``."""
+        cfg = ArchitectureConfig.from_transformers(
+            self._cfg(sliding_window=4096, use_sliding_window=False), "qwen2"
+        )
+        assert cfg.sliding_window is None
+
+    def test_enabled_window_is_kept(self):
+        """``use_sliding_window=True`` keeps the window."""
+        cfg = ArchitectureConfig.from_transformers(
+            self._cfg(sliding_window=4096, use_sliding_window=True), "qwen2"
+        )
+        assert cfg.sliding_window == 4096
+
+    def test_window_without_flag_is_kept(self):
+        """Models without ``use_sliding_window`` (e.g. Mistral) are unaffected."""
+        cfg = ArchitectureConfig.from_transformers(
+            self._cfg(model_type="mistral", sliding_window=4096), "mistral"
+        )
+        assert cfg.sliding_window == 4096


### PR DESCRIPTION
## Summary

Uniform sliding-window decoders (e.g. **Moshi/PersonaPlex temporal**, `sliding_window=3000`) take the **direct GQA path** in `TextModel.forward`, but that path built a global `GQAContext` that **never set `local_window_size`**. The window was silently dropped and every layer ran *full* causal attention — incorrect for these models, and it forfeits GQA's sliding-window kernel path.

This wires `config.sliding_window` → `GQAContext.local_window_size`, guarded to **uniformly-sliding** models.

## What changed

- **`models/base.py`** — `TextModel` now stores `self.config` and computes `_gqa_local_window_size()`:
  - Returns `config.sliding_window` when set and the schedule is uniform.
  - Returns `-1` (disabled) for full-attention models and for **mixed** `layer_types` (some full, some sliding) — those use custom per-layer `GQAContext`s (Gemma2/3/4, gpt-oss) and can't be expressed by one global window.
- **`attention-optimization` skill** — corrected/expanded:
  - `nonpad_kv_seqlens` is **prefill-only** (ORT *rejects* it together with `past_key`/`past_value`).
  - Opset-24 ONNX `Attention` has **no `past_present_share_buffer`** / no in-place KV buffer (`present = concat(past, new)` each step) — only GQA writes in place. This is the main residual reason GQA out-paces ONNX `Attention` during decode (context for #369).
  - Documented GQA `local_window_size` for sliding windows + the rewrite-path limitation.
- **Tests** — assert the emitted `GroupQueryAttention` carries `local_window_size == sliding_window` for uniform/all-sliding configs, and omits it for full-attention and mixed-`layer_types` configs.

## Why the direct path (not the rewrite)

The post-hoc `RotaryAttentionToGQA` rewrite only sees an already-baked float mask and cannot recover the window size, so windowing must be set on the **direct** GQA path. Uniform-sliding base-`TextModel` models always take the direct path on GQA-capable EPs; the rewrite only fires for non-standard-RoPE/DML cases that emit a padding-only mask. Documented as a known limitation.

## Validation

- **Semantics (standalone, ORT CPU):** proved `local_window_size=W` ⇒ query attends keys `[i-W+1, i]`, **exactly** matching HF `sliding_window=W` (max diff `8.8e-8`).
- **End-to-end (ORT CUDA, fp16):** ORT loads + runs the GQA node with `local_window_size`. Windowed vs full twin: **identical** for `seq ≤ W`, **diverges** for `seq > W` (window actively masking).
- **Moshi temporal:** every GQA node now emits `local_window_size=3000`.
- **Regression:** `1284 passed, 42 skipped` across `build_graph_test.py` + attention/component suites. Non-sliding models are unchanged (helper returns `-1`).
- Lint clean (`lintrunner`).