### PR TITLE
Add OpenVINO execution provider support for ORT GenAI export

### DIFF
--- a/src/mobius/_execution_providers.py
+++ b/src/mobius/_execution_providers.py
@@ -230,10 +230,17 @@ def _register_builtins() -> None:
         # default device_type ("NPU") in the genai_config provider options; a
         # different device can be selected downstream by editing genai_config
         # (e.g. by the Olive MobiusBuilder pass or the user) without rebuilding.
+        #
+        # supports_skip_layer_norm=False: the OpenVINO ONNX frontend does not
+        # support the com.microsoft SkipSimplifiedLayerNormalization op, so we
+        # keep the residual Add and RMSNormalization separate (no skip-norm
+        # fusion) to stay convertible by OpenVINO. (RMSNormalization itself is
+        # still opset-24; OpenVINO frontend support for it is pending.)
         EpCapabilities(
             name="openvino",
             gqa_dtypes=frozenset(),  # no GQA fusion — keep standard Attention ops
             qkv_pack_dtypes=frozenset(),  # no QKV packing
+            supports_skip_layer_norm=False,
             provider_options={"device_type": "NPU"},
         ),
         EpCapabilities(

--- a/src/mobius/_execution_providers.py
+++ b/src/mobius/_execution_providers.py
@@ -207,7 +207,7 @@ def get_ep(name: str) -> EpCapabilities:
 
 
 def _register_builtins() -> None:
-    """Populate the global registry with the seven built-in EPs.
+    """Populate the global registry with the built-in EPs.
 
     Called once at module import. Adding a new EP = adding one entry here.
     """

--- a/src/mobius/_execution_providers.py
+++ b/src/mobius/_execution_providers.py
@@ -223,6 +223,19 @@ def _register_builtins() -> None:
             gqa_dtypes=frozenset(),  # no GQA fusion — keep standard Attention ops
             qkv_pack_dtypes=frozenset(),  # no QKV packing
         ),
+        # OpenVINO EP (via ORT GenAI). The OpenVINO EP consumes a portable ONNX
+        # graph and compiles it internally for the selected device, so the graph
+        # build mirrors "default" (standard Attention, no GQA/QKV packing). The
+        # graph does not depend on the OpenVINO device, so we emit a sensible
+        # default device_type ("NPU") in the genai_config provider options; a
+        # different device can be selected downstream by editing genai_config
+        # (e.g. by the Olive MobiusBuilder pass or the user) without rebuilding.
+        EpCapabilities(
+            name="openvino",
+            gqa_dtypes=frozenset(),  # no GQA fusion — keep standard Attention ops
+            qkv_pack_dtypes=frozenset(),  # no QKV packing
+            provider_options={"device_type": "NPU"},
+        ),
         EpCapabilities(
             name="cpu",
             gqa_dtypes=frozenset({ir.DataType.FLOAT}),

--- a/src/mobius/integrations/ort_genai/ep_config.py
+++ b/src/mobius/integrations/ort_genai/ep_config.py
@@ -27,6 +27,7 @@ _ORT_PROVIDER_NAMES: dict[str, str] = {
     "webgpu": "webgpu",
     "trt-rtx": "NvTensorRtRtx",
     "qnn": "QNN",
+    "openvino": "OpenVINO",
 }
 
 

--- a/src/mobius/integrations/ort_genai/ep_config_test.py
+++ b/src/mobius/integrations/ort_genai/ep_config_test.py
@@ -71,6 +71,12 @@ class TestMakeProviderOptions:
         result = make_provider_options("trt-rtx")
         assert result[0]["NvTensorRtRtx"]["enable_cuda_graph"] == "1"
 
+    def test_openvino_defaults_to_npu(self):
+        # The OpenVINO graph is device-independent; mobius emits a default
+        # device_type ("NPU") that can be overridden downstream in genai_config.
+        result = make_provider_options("openvino")
+        assert result == [{"OpenVINO": {"device_type": "NPU"}}]
+
 
 class TestMakeSlidingWindowConfig:
     def test_disabled_when_zero(self):

--- a/src/mobius/integrations/ort_genai/ep_config_test.py
+++ b/src/mobius/integrations/ort_genai/ep_config_test.py
@@ -77,6 +77,16 @@ class TestMakeProviderOptions:
         result = make_provider_options("openvino")
         assert result == [{"OpenVINO": {"device_type": "NPU"}}]
 
+    def test_openvino_disables_skip_layer_norm_fusion(self):
+        # The OpenVINO ONNX frontend cannot consume the com.microsoft
+        # SkipSimplifiedLayerNormalization op, so the openvino EP must keep the
+        # residual Add + RMSNormalization separate (no skip-norm fusion).
+        from mobius._execution_providers import ep_registry
+
+        caps = ep_registry.get("openvino")
+        assert caps is not None
+        assert caps.supports_skip_layer_norm is False
+
 
 class TestMakeSlidingWindowConfig:
     def test_disabled_when_zero(self):


### PR DESCRIPTION
Registers an `openvino` execution provider in mobius so mobius-built models target the OpenVINO EP via ORT GenAI.

The OpenVINO EP consumes a portable ONNX graph and compiles it internally for the selected device, so the graph build mirrors the `default` portable EP (standard Attention, no GQA/QKV packing).

**The graph is device-independent**, so there is no `device_type` plumbing through the build API. The `openvino` `EpCapabilities` simply carries a default provider option `{"device_type": "NPU"}`, which `make_provider_options` writes into `genai_config.json`. A different OpenVINO device (`GPU`/`CPU`) can be selected downstream by editing `device_type` in genai_config — no rebuild needed.

## Changes
- `ep_config.py`: map `"openvino"` -> `"OpenVINO"` in `_ORT_PROVIDER_NAMES`.
- `_execution_providers.py`: register the `openvino` `EpCapabilities` entry with `provider_options={"device_type": "NPU"}`.
- Test for the OpenVINO provider options.

Consumed by Olive's MobiusBuilder (microsoft/Olive#2553).