### PR TITLE
Fix GGUF→ONNX Q4 conversion for Qwen2/Qwen3 (missing biases + wrong permute)

### DIFF
--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -470,6 +470,7 @@ def _load_quantized_state_dict(
 
     num_heads = getattr(config, "num_attention_heads", None)
     num_kv_heads = getattr(config, "num_key_value_heads", None)
+    model_type = getattr(config, "model_type", None)
 
     # Detect Tencent's non-mainline Q1_0 layout once per file. Reading
     # such tensors requires a custom parser keyed on the explicit
@@ -528,8 +529,10 @@ def _load_quantized_state_dict(
             s = torch.from_numpy(repacked.scales)
 
             # Apply Q/K row permutation to quantized tensors
-            # (same transform as _process_llama, on all arrays)
-            if _needs_qk_permute(hf_name, num_heads, num_kv_heads):
+            # (same transform as _process_llama, on all arrays). Only
+            # llama-family archs use the interleaved-rope permute; Qwen
+            # and others must NOT be permuted.
+            if _needs_qk_permute(hf_name, num_heads, num_kv_heads, model_type):
                 n_head = (
                     num_heads
                     if ".q_proj." in hf_name or ".qkv_proj." in hf_name
@@ -542,7 +545,7 @@ def _load_quantized_state_dict(
             state_dict[f"{stem}.scales"] = s
             if repacked.zero_points is not None:
                 zp = torch.from_numpy(repacked.zero_points)
-                if _needs_qk_permute(hf_name, num_heads, num_kv_heads):
+                if _needs_qk_permute(hf_name, num_heads, num_kv_heads, model_type):
                     zp = _reverse_permute(zp, n_head)
                 state_dict[f"{stem}.zero_points"] = zp
             n_repacked += 1
@@ -573,15 +576,24 @@ def _needs_qk_permute(
     hf_name: str,
     num_heads: int | None,
     num_kv_heads: int | None,
+    model_type: str | None = None,
 ) -> bool:
     """Check if this tensor needs Q/K reverse-permutation.
 
-    Name-based gating (``.q_proj.``, ``.k_proj.``, ``.qkv_proj.``) is
-    sufficient without a model_type guard because non-llama architectures
-    use different projection names (``.query_key_value.``, ``.c_attn.``,
-    etc.) that won't match these patterns.
+    Two conditions must hold: the tensor must be a Q/K projection weight,
+    AND the model architecture must actually use llama.cpp's
+    interleaved-rope permute. Name-based gating alone is insufficient —
+    Qwen2/Qwen3 use ``.q_proj.``/``.k_proj.`` names too but store Q/K in
+    plain HF order (NEOX rope) and must NOT be permuted, or their
+    attention heads get scrambled and the model emits garbage.
     """
+    from mobius.integrations.gguf._tensor_processors import (
+        needs_llama_qk_permute,
+    )
+
     if num_heads is None or num_kv_heads is None:
+        return False
+    if not needs_llama_qk_permute(model_type):
         return False
     return (
         ".q_proj." in hf_name or ".k_proj." in hf_name or ".qkv_proj." in hf_name

--- a/src/mobius/integrations/gguf/_config_mapping.py
+++ b/src/mobius/integrations/gguf/_config_mapping.py
@@ -333,6 +333,12 @@ def gguf_to_config(
         rms_norm_eps=hf_fields.get("rms_norm_eps", 1e-5),
         hidden_act=hidden_act,
         tie_word_embeddings=_infer_tie_embeddings(model),
+        # Projection biases are not in GGUF metadata; infer from tensor
+        # presence. Qwen2/Qwen3 carry Q/K/V biases — omitting them breaks
+        # attention and yields garbage output.
+        attn_qkv_bias=_infer_attn_qkv_bias(model),
+        attn_o_bias=_infer_attn_o_bias(model),
+        mlp_bias=_infer_mlp_bias(model),
         partial_rotary_factor=partial_rotary_factor,
         rope_interleave=rope_interleave,
         # MoE fields (None when not present → non-MoE model)
@@ -567,3 +573,31 @@ def _infer_tie_embeddings(model: Any) -> bool:
     for both input and output).
     """
     return "output.weight" not in model.tensor_names
+
+
+def _infer_attn_qkv_bias(model: Any) -> bool:
+    """Infer whether Q/K/V projections have bias from tensor presence.
+
+    llama.cpp names attention projection biases ``blk.N.attn_{q,k,v}.bias``
+    (or a fused ``blk.N.attn_qkv.bias``). Models such as Qwen2/Qwen3 carry
+    these biases; if the config default (``False``) is used instead, the
+    graph builder omits the bias ``Add`` after each projection and the
+    model produces garbage output.
+    """
+    return any(
+        n.endswith(("attn_q.bias", "attn_k.bias", "attn_v.bias", "attn_qkv.bias"))
+        for n in model.tensor_names
+    )
+
+
+def _infer_attn_o_bias(model: Any) -> bool:
+    """Infer whether the attention output projection has a bias tensor."""
+    return any(n.endswith("attn_output.bias") for n in model.tensor_names)
+
+
+def _infer_mlp_bias(model: Any) -> bool:
+    """Infer whether MLP/FFN projections have bias tensors."""
+    return any(
+        n.endswith(("ffn_up.bias", "ffn_down.bias", "ffn_gate.bias"))
+        for n in model.tensor_names
+    )

--- a/src/mobius/integrations/gguf/_reader_test.py
+++ b/src/mobius/integrations/gguf/_reader_test.py
@@ -17,6 +17,9 @@ import pytest
 from mobius.integrations.gguf._config_mapping import (
     GGUF_ARCH_TO_MODEL_TYPE,
     _extract_config_fields,
+    _infer_attn_o_bias,
+    _infer_attn_qkv_bias,
+    _infer_mlp_bias,
     _infer_tie_embeddings,
     gguf_to_config,
 )
@@ -416,6 +419,48 @@ class TestConfigMapping:
         model = GGUFModel(llama_gguf)
         config = gguf_to_config(model)
         assert config.tie_word_embeddings is False
+
+    def test_infer_projection_biases_from_tensor_names(self):
+        """Q/K/V, output, and MLP biases are inferred from tensor names.
+
+        Regression for the invalid Q4 bug: Qwen2 carries Q/K/V biases in
+        GGUF (``blk.N.attn_{q,k,v}.bias``). If ``attn_qkv_bias`` is not
+        inferred, the graph builder omits the bias Add and the model emits
+        garbage. Attention-output and MLP biases are absent for Qwen2.
+        """
+
+        class _FakeModel:
+            def __init__(self, names):
+                self.tensor_names = names
+
+        qwen_like = _FakeModel(
+            [
+                "blk.0.attn_q.weight",
+                "blk.0.attn_q.bias",
+                "blk.0.attn_k.bias",
+                "blk.0.attn_v.bias",
+                "blk.0.ffn_down.weight",
+            ]
+        )
+        assert _infer_attn_qkv_bias(qwen_like) is True
+        assert _infer_attn_o_bias(qwen_like) is False
+        assert _infer_mlp_bias(qwen_like) is False
+
+        no_bias = _FakeModel(["blk.0.attn_q.weight", "blk.0.ffn_down.weight"])
+        assert _infer_attn_qkv_bias(no_bias) is False
+        assert _infer_attn_o_bias(no_bias) is False
+        assert _infer_mlp_bias(no_bias) is False
+
+        full_bias = _FakeModel(
+            [
+                "blk.0.attn_qkv.bias",
+                "blk.0.attn_output.bias",
+                "blk.0.ffn_up.bias",
+            ]
+        )
+        assert _infer_attn_qkv_bias(full_bias) is True
+        assert _infer_attn_o_bias(full_bias) is True
+        assert _infer_mlp_bias(full_bias) is True
 
     def test_custom_rope_theta(self, tmp_path: Path):
         path = tmp_path / "rope.gguf"

--- a/src/mobius/integrations/gguf/_tensor_processors.py
+++ b/src/mobius/integrations/gguf/_tensor_processors.py
@@ -30,7 +30,12 @@ Usage::
 
 from __future__ import annotations
 
-__all__ = ["process_tensors", "_reverse_permute"]
+__all__ = [
+    "process_tensors",
+    "_reverse_permute",
+    "needs_llama_qk_permute",
+    "LLAMA_QK_PERMUTE_MODEL_TYPES",
+]
 
 import logging
 from typing import Any
@@ -39,6 +44,22 @@ import numpy as np
 import torch
 
 logger = logging.getLogger(__name__)
+
+# Model types whose GGUF Q/K weights are stored with llama.cpp's
+# interleaved-rope permutation and therefore require reverse-permutation
+# on import. These are the architectures whose llama.cpp converter calls
+# ``permute()`` on ``attn_q``/``attn_k`` (GGML "normal" rope).
+#
+# Qwen2/Qwen3, Gemma, GPT-2, Mamba, etc. use non-interleaved (NEOX-style)
+# rope and store Q/K in plain HF row order — applying the permute to them
+# scrambles the attention heads and produces garbage output. They must
+# NOT be reverse-permuted.
+LLAMA_QK_PERMUTE_MODEL_TYPES = frozenset({"llama", "mistral"})
+
+
+def needs_llama_qk_permute(model_type: str | None) -> bool:
+    """Return True if this model type needs llama.cpp Q/K reverse-permute."""
+    return model_type in LLAMA_QK_PERMUTE_MODEL_TYPES
 
 
 def process_tensors(
@@ -111,10 +132,20 @@ def _reverse_permute(
 ) -> torch.Tensor:
     """Reverse the Q/K weight permutation applied by llama.cpp.
 
-    llama.cpp interleaves head dimensions as:
-        ``(n_head, dim, 2, ...) -> swapaxes(2,1) -> reshape``
+    llama.cpp's forward permute (``convert_hf_to_gguf.py``) is::
 
-    We reverse this to get standard HF layout.
+        weights.reshape(n_head, 2, dim, ...).swapaxes(1, 2).reshape(orig)
+
+    where ``dim = out_features // n_head // 2``. The exact inverse — and
+    the transform HF's ``modeling_gguf_pytorch_utils._reverse_permute_weights``
+    applies when loading GGUF — reshapes with ``dim`` and ``2`` swapped::
+
+        weights.reshape(n_head, dim, 2, ...).swapaxes(1, 2).reshape(orig)
+
+    Using the forward reshape order here (``(n_head, 2, dim)``) only
+    coincidentally inverts the permute when ``dim == 2`` (head_dim == 4);
+    for real head dims (e.g. 64) it scrambles the Q/K rows, corrupting
+    rope and producing garbage output.
 
     Args:
         weights: The Q or K projection weight tensor.
@@ -122,7 +153,7 @@ def _reverse_permute(
             for Q weights, ``num_key_value_heads`` for K weights.
     """
     dim = weights.shape[0] // n_head // 2
-    w = weights.reshape(n_head, 2, dim, *weights.shape[1:])
+    w = weights.reshape(n_head, dim, 2, *weights.shape[1:])
     return w.swapaxes(1, 2).reshape(weights.shape)
 
 
@@ -199,11 +230,14 @@ def _process_mamba(
 
 # Map model_type → processor function.
 # Architectures not listed here need no tensor transforms.
+#
+# NOTE: Qwen2/Qwen3 are intentionally NOT mapped to ``_process_llama``.
+# Unlike Llama/Mistral, llama.cpp does not permute Qwen Q/K weights
+# (Qwen uses NEOX-style rope), so reverse-permuting them corrupts the
+# attention heads. See ``LLAMA_QK_PERMUTE_MODEL_TYPES``.
 _PROCESSORS: dict[str, Any] = {
     "llama": _process_llama,
     "mistral": _process_llama,
-    "qwen2": _process_llama,
-    "qwen3": _process_llama,
     "gemma": _process_gemma,
     "gemma2": _process_gemma,
     "gemma3": _process_gemma,

--- a/src/mobius/integrations/gguf/_tensor_processors_test.py
+++ b/src/mobius/integrations/gguf/_tensor_processors_test.py
@@ -99,15 +99,114 @@ class TestProcessTensorsLlama:
             original,
         )
 
+    def test_reverse_matches_hf_reference_head_dim_64(self) -> None:
+        """Reverse permute must match HF's reference for real head dims.
+
+        Regression test for the Q4/Q-K garbage-output bug: the old code
+        reshaped as ``(n_head, 2, dim)`` which only inverts llama.cpp's
+        permute when ``dim == 2`` (head_dim == 4). For head_dim == 64 it
+        scrambled Q/K rows. This asserts the exact inverse of llama.cpp's
+        forward permute is recovered, and cross-checks HF's reference
+        ``_reverse_permute_weights`` formula.
+        """
+        config = self._make_config(num_heads=14, num_kv_heads=14)
+        # Qwen2.5-0.5B geometry: hidden=896, 14 heads, head_dim=64.
+        original_q = torch.randn(896, 896)
+        q_perm = self._forward_permute(original_q, 14)
+
+        state_dict = {"model.layers.0.self_attn.q_proj.weight": q_perm}
+        result = process_tensors(state_dict, config)
+        torch.testing.assert_close(
+            result["model.layers.0.self_attn.q_proj.weight"],
+            original_q,
+        )
+
+        # Cross-check against HF's exact reference formula.
+        dim = q_perm.shape[0] // 14 // 2
+        hf_ref = (
+            q_perm.reshape(14, dim, 2, *q_perm.shape[1:]).swapaxes(2, 1).reshape(q_perm.shape)
+        )
+        torch.testing.assert_close(
+            result["model.layers.0.self_attn.q_proj.weight"],
+            hf_ref,
+        )
+
     @staticmethod
     def _forward_permute(weights: torch.Tensor, n_head: int) -> torch.Tensor:
-        """Simulate llama.cpp's forward permutation.
+        """Simulate llama.cpp's forward permutation (HF -> GGUF).
 
-        Reference: convert_hf_to_gguf.py permute()
+        Reference: ``convert_hf_to_gguf.py`` ``LlamaModel.permute``::
+
+            weights.reshape(n_head, 2, dim, ...).swapaxes(1, 2).reshape(orig)
+
+        The reverse permute in production must exactly invert this for any
+        head dim, not only ``dim == 2``.
         """
         dim = weights.shape[0] // n_head // 2
-        w = weights.reshape(n_head, dim, 2, *weights.shape[1:])
+        w = weights.reshape(n_head, 2, dim, *weights.shape[1:])
         return w.swapaxes(1, 2).reshape(weights.shape)
+
+
+class TestQwenNotPermuted:
+    """Regression: Qwen2/Qwen3 Q/K must NOT be reverse-permuted.
+
+    Qwen uses NEOX-style rope and stores Q/K in plain HF order. Applying
+    the llama interleaved-rope permute scrambles attention heads and
+    produces garbage output (root cause of the invalid Q4 benchmark).
+    """
+
+    def test_needs_llama_qk_permute_helper(self) -> None:
+        from mobius.integrations.gguf._tensor_processors import (
+            needs_llama_qk_permute,
+        )
+
+        assert needs_llama_qk_permute("llama") is True
+        assert needs_llama_qk_permute("mistral") is True
+        assert needs_llama_qk_permute("qwen2") is False
+        assert needs_llama_qk_permute("qwen3") is False
+        assert needs_llama_qk_permute("gemma2") is False
+        assert needs_llama_qk_permute(None) is False
+
+    def test_qwen2_qk_weights_unchanged(self) -> None:
+        config = SimpleNamespace(
+            model_type="qwen2",
+            num_attention_heads=14,
+            num_key_value_heads=2,
+        )
+        q = torch.randn(896, 896)
+        k = torch.randn(128, 896)
+        state_dict = {
+            "model.layers.0.self_attn.q_proj.weight": q.clone(),
+            "model.layers.0.self_attn.k_proj.weight": k.clone(),
+        }
+        result = process_tensors(state_dict, config)
+        # Qwen has no registered processor → weights pass through untouched.
+        torch.testing.assert_close(result["model.layers.0.self_attn.q_proj.weight"], q)
+        torch.testing.assert_close(result["model.layers.0.self_attn.k_proj.weight"], k)
+
+
+class TestBuilderNeedsQkPermute:
+    """Regression: the quantized inline permute gate must honor model_type."""
+
+    def test_qwen2_quantized_not_permuted(self) -> None:
+        from mobius.integrations.gguf._builder import _needs_qk_permute
+
+        name = "model.layers.0.self_attn.q_proj.weight"
+        assert _needs_qk_permute(name, 14, 2, "qwen2") is False
+        assert _needs_qk_permute(name, 14, 2, "qwen3") is False
+
+    def test_llama_quantized_permuted(self) -> None:
+        from mobius.integrations.gguf._builder import _needs_qk_permute
+
+        name = "model.layers.0.self_attn.q_proj.weight"
+        assert _needs_qk_permute(name, 32, 32, "llama") is True
+        assert _needs_qk_permute(name, 32, 32, "mistral") is True
+
+    def test_non_qk_tensor_never_permuted(self) -> None:
+        from mobius.integrations.gguf._builder import _needs_qk_permute
+
+        name = "model.layers.0.self_attn.v_proj.weight"
+        assert _needs_qk_permute(name, 32, 32, "llama") is False
 
 
 class TestProcessTensorsGemma:


### PR DESCRIPTION
Converted Qwen2.5 Q4 GGUF models emitted garbage despite a correct MatMulNBits weight repack (layer-0 dequant matched GGUF exactly, max_abs_diff=0.0). Two independent bugs:

1. **Missing attention QKV biases** — `gguf_to_config` never inferred projection-bias flags, so `attn_qkv_bias` defaulted to False. Qwen2 carries large q/k/v biases (q≈79, k≈130); omitting the bias `Add` wrecks attention. Added tensor-presence inference (`_infer_attn_qkv_bias/_infer_attn_o_bias/_infer_mlp_bias`).
2. **Spurious/mis-shaped Q/K reverse-permute** — Qwen2/Qwen3 use NEOX rope and are NOT permuted by llama.cpp, but were mapped to the Llama interleaved-rope reverse-permute. `_reverse_permute` also used the forward reshape `(n_head,2,dim)` instead of the inverse `(n_head,dim,2)` (only correct at head_dim=4). Gated the permute on model_type (llama/mistral only) and fixed the reshape.

**Verified:** converted Qwen2.5-0.5B Q4 now produces coherent output ("The capital of France is Paris."); isolation confirmed both bugs are independently fatal. `pytest src/mobius/integrations/gguf/` → 151 passed.