### PR TITLE
Add Q4_K_M GGUF→ONNX conversion support

### DIFF
--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -8,10 +8,10 @@ pipeline.  Two modes:
 
 - **Dequantized** (default): All quantized tensors are dequantized to
   float.  Simple, but loses the compression benefit of quantization.
-- **Quantized** (``keep_quantized=True``): Linear-layer weights that
-  use supported GGUF types are repacked into MatMulNBits format.
-  Quantized token embeddings are repacked for GatherBlockQuantized.
-  Other tensors (norms and unsupported quant types) are dequantized.
+- **Quantized** (``keep_quantized=True``): Linear-layer weights are
+  normalized to a common MatMulNBits layout, including mixed presets
+  such as Q4_K_M. Compatible quantized token embeddings are repacked
+  for GatherBlockQuantized. Other tensors are dequantized.
 """
 
 from __future__ import annotations
@@ -108,9 +108,9 @@ def build_from_gguf(
             model type.
         dtype: Override model dtype (e.g. ``"f16"``). When ``None``,
             defaults to float32.
-        keep_quantized: When ``True``, preserve quantization for
-            supported GGUF types (Q4_0, Q4_1, Q8_0) by repacking
-            linear-layer weights into MatMulNBits format.
+        keep_quantized: When ``True``, preserve quantized linear-layer
+            weights in MatMulNBits format. Mixed Q4_K_M source types are
+            normalized to 4-bit, block-32 weights.
         execution_provider: Target execution provider for EP-aware
             optimisations (e.g. ``"cpu"`` to apply the
             GroupQueryAttention rewrite). Defaults to ``"default"``
@@ -328,16 +328,16 @@ def _normalize_gguf_weights(
 
 
 def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, int, bool]:
-    """Detect bits, block size, and symmetry from dominant GGUF quant type.
+    """Detect the common MatMulNBits target for GGUF projection weights.
 
-    Scans block-level (projection) tensors and returns the bit-width,
-    block size, and symmetry flag of the most common repackable type.
+    Q4_K-containing mixed presets target 4-bit, block-32 asymmetric
+    MatMulNBits. Other files use the most common directly repackable type.
 
     Returns:
         ``(bits, block_size, is_symmetric)`` tuple.
 
     Raises:
-        ValueError: If no repackable quantized tensors are found.
+        ValueError: If no mapped or repackable weight tensors are found.
     """
     from gguf import GGMLQuantizationType
 
@@ -366,19 +366,39 @@ def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, int, bool]:
     counts: Counter = Counter()
     for name, _raw, qtype, _shape in gguf_model.tensor_items_raw():
         hf_name = map_gguf_to_hf_names(name, gguf_arch)
-        if hf_name is None:
+        if hf_name is None or not hf_name.endswith(".weight"):
             continue
-        if can_repack(qtype.value if hasattr(qtype, "value") else qtype):
-            counts[qtype] += 1
+        counts[qtype] += 1
 
     if not counts:
         raise ValueError(
-            "No repackable quantized tensors found in GGUF file. "
+            "No mapped weight tensors found in GGUF file. "
             "Use keep_quantized=False for dequantized import."
         )
 
-    dominant = counts.most_common(1)[0][0]
-    params = repack_quant_params(dominant.value)
+    # Q4_K_M is deliberately a mixed preset. Depending on tensor dimensions
+    # and importance it may contain mostly Q5_0 plus Q4_K, Q6_K, and Q8_0.
+    # The presence of Q4_K identifies the desired 4-bit MatMulNBits target;
+    # choosing only among already-repackable types would incorrectly select
+    # Q8_0 for the official Qwen2.5-0.5B Q4_K_M file.
+    if GGMLQuantizationType.Q4_K in counts:
+        dominant = GGMLQuantizationType.Q4_K
+    else:
+        repackable_counts = Counter(
+            {
+                qtype: count
+                for qtype, count in counts.items()
+                if can_repack(qtype.value if hasattr(qtype, "value") else qtype)
+            }
+        )
+        if not repackable_counts:
+            raise ValueError(
+                "No repackable quantized tensors found in GGUF file. "
+                "Use keep_quantized=False for dequantized import."
+            )
+        dominant = repackable_counts.most_common(1)[0][0]
+    dominant_value = dominant.value if hasattr(dominant, "value") else dominant
+    params = repack_quant_params(dominant_value)
     assert params is not None
     bits, block_size = params
     is_sym = type_symmetry[dominant]
@@ -478,12 +498,13 @@ def _load_quantized_state_dict(
     module,
     config,
 ) -> dict:
-    """Load tensors, repacking supported quantized types.
+    """Load tensors, normalizing quantized projections to MatMulNBits.
 
-    Projection weights (Q/K/V/O and MLP) that use repackable GGUF
-    types are converted to MatMulNBits format. Quantized embeddings
-    are converted to GatherBlockQuantized format. All other tensors
-    (norms and unsupported quant types) are dequantized.
+    Projection weights (Q/K/V/O and MLP) are converted to the graph's
+    common MatMulNBits format. Mixed source types are dequantized and
+    requantized when they do not already match that target. Compatible
+    quantized embeddings are converted for GatherBlockQuantized. Norms
+    and other non-linear tensors remain dequantized.
 
     For llama-family models, quantized Q/K weights receive the
     row-level reverse-permutation that ``process_tensors`` would
@@ -496,6 +517,7 @@ def _load_quantized_state_dict(
     from mobius.components import QuantizedEmbedding, QuantizedLinear
     from mobius.integrations.gguf._repacker import (
         can_repack,
+        repack_dequantized_tensor,
         repack_gguf_tensor,
     )
     from mobius.integrations.gguf._tencent_q1_0 import (
@@ -538,6 +560,10 @@ def _load_quantized_state_dict(
 
     state_dict: dict[str, torch.Tensor] = {}
     n_repacked = 0
+    n_requantized = 0
+    target_bits = config.quantization.bits
+    target_block_size = config.quantization.group_size
+    target_symmetric = config.quantization.sym
 
     for gguf_name, raw, qtype, np_shape in tqdm.tqdm(
         gguf_model.tensor_items_raw(),
@@ -552,15 +578,14 @@ def _load_quantized_state_dict(
         # Determine the int value of the quant type for can_repack
         qtype_val = qtype.value if hasattr(qtype, "value") else qtype
 
-        # Repack if the tensor is repackable AND its target ONNX
-        # parameter is from a QuantizedLinear module.
+        # Repack every target QuantizedLinear weight. Mixed GGUF presets
+        # otherwise leave unsupported source types as full float matrices,
+        # which cannot fit the graph's packed MatMulNBits initializer shape.
         stem = hf_name[: -len(".weight")] if hf_name.endswith(".weight") else None
         is_tencent_q1_0_tensor = tencent_q1_0 and qtype == GGMLQuantizationType.Q1_0
-        is_quantized_embedding = stem in quantized_embedding_stems
-        should_repack = (
-            stem is not None
-            and (stem in quantized_stems or is_quantized_embedding)
-            and (can_repack(qtype_val) or is_tencent_q1_0_tensor)
+        is_quantized_embedding = stem is not None and stem in quantized_embedding_stems
+        should_repack = stem is not None and (
+            stem in quantized_stems or is_quantized_embedding
         )
 
         if should_repack:
@@ -570,13 +595,31 @@ def _load_quantized_state_dict(
                     data_section_offset,
                     tensors_by_name[gguf_name],
                 )
-            else:
+            elif can_repack(qtype_val):
                 shape_2d = (int(np_shape[0]), int(np_shape[1]))
                 repacked = repack_gguf_tensor(
                     raw.ravel().view(np.uint8),
                     qtype_val,
                     shape_2d,
                 )
+                if repacked.bits != target_bits or repacked.block_size != target_block_size:
+                    values = gguf_model.dequantize_raw_tensor(raw, qtype, np_shape)
+                    repacked = repack_dequantized_tensor(
+                        values,
+                        bits=target_bits,
+                        block_size=target_block_size,
+                        symmetric=target_symmetric,
+                    )
+                    n_requantized += 1
+            else:
+                values = gguf_model.dequantize_raw_tensor(raw, qtype, np_shape)
+                repacked = repack_dequantized_tensor(
+                    values,
+                    bits=target_bits,
+                    block_size=target_block_size,
+                    symmetric=target_symmetric,
+                )
+                n_requantized += 1
             w = torch.from_numpy(repacked.weight)
             s = torch.from_numpy(repacked.scales)
 
@@ -619,10 +662,11 @@ def _load_quantized_state_dict(
             state_dict[hf_name] = torch.from_numpy(arr)
 
     logger.info(
-        "Loaded %d tensors (%d repacked for quantized ops, %d dequantized)",
+        "Loaded %d state_dict entries (%d GGUF tensors repacked for quantized ops, "
+        "%d requantized from mixed source types)",
         len(state_dict),
         n_repacked,
-        len(state_dict) - n_repacked,
+        n_requantized,
     )
     return state_dict
 

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -261,6 +261,31 @@ class TestBuildQuantizedGguf:
 
         assert not _can_quantize_embedding(model, "llama", bits=4, block_size=128)
 
+    def test_detect_q4_k_m_mixed_profile(self):
+        """Q4_K presence selects a 4-bit target despite more Q5_0 tensors."""
+        from gguf import GGMLQuantizationType
+
+        from mobius.integrations.gguf._builder import _detect_quant_params
+
+        class _MixedModel:
+            def tensor_items_raw(self):
+                for i in range(5):
+                    yield (
+                        f"blk.{i}.attn_q.weight",
+                        np.empty(0, dtype=np.uint8),
+                        GGMLQuantizationType.Q5_0,
+                        (64, 64),
+                    )
+                yield (
+                    "blk.0.ffn_down.weight",
+                    np.empty(0, dtype=np.uint8),
+                    GGMLQuantizationType.Q4_K,
+                    (64, 128),
+                )
+
+        bits, block_size, is_sym = _detect_quant_params(_MixedModel(), "llama")
+        assert (bits, block_size, is_sym) == (4, 32, False)
+
 
 class TestRawTensorIterator:
     """Tests for GGUFModel.tensor_items_raw()."""
@@ -298,3 +323,14 @@ class TestRawTensorIterator:
         assert len(f32_items) > 0
         for _name, _raw, qtype, _shape in f32_items:
             assert qtype == GGMLQuantizationType.F32
+
+    def test_dequantize_raw_tensor_matches_get_tensor(self, q4_0_gguf: Path):
+        from mobius.integrations.gguf._reader import GGUFModel
+
+        model = GGUFModel(q4_0_gguf)
+        name, raw, qtype, shape = next(
+            item for item in model.tensor_items_raw() if len(item[3]) == 2
+        )
+        expected = model.get_tensor(name)
+        actual = model.dequantize_raw_tensor(raw, qtype, shape)
+        np.testing.assert_array_equal(actual, expected)

--- a/src/mobius/integrations/gguf/_reader.py
+++ b/src/mobius/integrations/gguf/_reader.py
@@ -226,21 +226,32 @@ class GGUFModel:
         Returns:
             Numpy array in row-major shape order.
         """
-        from gguf import GGMLQuantizationType, dequantize
-
-        data = tensor.data
-        qtype = tensor.tensor_type
         # GGUF stores shape in GGML (column-major) order; reverse
         # to get numpy (row-major) shape.
         np_shape = tuple(reversed(tensor.shape))
+        return self.dequantize_raw_tensor(tensor.data, tensor.tensor_type, np_shape)
 
-        if qtype in (GGMLQuantizationType.F32, GGMLQuantizationType.F16):
-            return data.reshape(np_shape)
+    def dequantize_raw_tensor(
+        self,
+        raw_data: np.ndarray,
+        quant_type: Any,
+        np_shape: tuple[int, ...],
+    ) -> np.ndarray:
+        """Dequantize raw GGUF tensor data into its logical numpy shape.
+
+        K-quant blocks are contiguous over the flattened tensor and may cross
+        logical row boundaries. Delegating the complete raw array to gguf's
+        reference dequantizer before reshaping preserves that layout.
+        """
+        from gguf import GGMLQuantizationType, dequantize
+
+        if quant_type in (GGMLQuantizationType.F32, GGMLQuantizationType.F16):
+            return raw_data.reshape(np_shape)
         # All other types (quantized, BF16) go through dequantize().
         # BF16 is intentionally NOT in the fast path above because
         # numpy has no native bfloat16 dtype — the gguf library's
         # dequantize() converts BF16 bytes to float32.
-        return dequantize(data, qtype).reshape(np_shape)
+        return dequantize(raw_data, quant_type).reshape(np_shape)
 
     def tensor_items(self) -> Iterator[tuple[str, np.ndarray]]:
         """Iterate over ``(name, dequantized_array)`` pairs.
@@ -268,7 +279,9 @@ class GGUFModel:
             Tuples of ``(name, raw_data, quant_type, np_shape)`` where:
 
             - *name*: GGUF tensor name
-            - *raw_data*: Raw bytes as uint8 numpy array (flat)
+            - *raw_data*: Raw tensor storage. Quantized K-blocks are
+              contiguous over the flattened logical tensor and are not
+              independently padded at row boundaries.
             - *quant_type*: :class:`gguf.GGMLQuantizationType` value
             - *np_shape*: Logical shape in numpy (row-major) order
         """

--- a/src/mobius/integrations/gguf/_repacker.py
+++ b/src/mobius/integrations/gguf/_repacker.py
@@ -23,13 +23,10 @@ MatMulNBits expects:
 
 from __future__ import annotations
 
-import logging
 import math
 from dataclasses import dataclass
 
 import numpy as np
-
-logger = logging.getLogger(__name__)
 
 _BLOCK_SIZE = 32
 
@@ -114,8 +111,8 @@ def repack_gguf_tensor(
         raw_data: Raw bytes as a uint8 numpy array (flat).
         gguf_type: GGUF quantization type ID (e.g. 2 for Q4_0).
         shape: Logical weight shape ``(N, K)`` where N = out_features,
-            K = in_features.  GGUF tensors are typically stored as
-            ``(N, K)`` with blocks laid out row-by-row.
+            K = in_features. K-quant super-blocks are contiguous over the
+            flattened tensor and may cross logical row boundaries.
 
     Returns:
         A ``RepackedTensor`` with MatMulNBits-compatible arrays.
@@ -135,7 +132,15 @@ def repack_gguf_tensor(
     block_bytes = _BLOCK_BYTES[gguf_type]
     gguf_block_elems = _GGUF_BLOCK_ELEMENTS[gguf_type]
     n_blocks_per_row = math.ceil(k_in / gguf_block_elems)
-    total_blocks = n_out * n_blocks_per_row
+    if gguf_type == _GGUF_Q4_K:
+        # K-quant super-blocks are laid out over the flattened tensor, not
+        # independently padded at each logical row boundary. This matters for
+        # dimensions such as Qwen2's K=896: rows end halfway through a
+        # 256-element Q4_K super-block, while they still align perfectly to
+        # MatMulNBits' 32-element blocks.
+        total_blocks = math.ceil(n_out * k_in / gguf_block_elems)
+    else:
+        total_blocks = n_out * n_blocks_per_row
     expected_bytes = total_blocks * block_bytes
 
     if raw_data.size != expected_bytes:
@@ -153,7 +158,7 @@ def repack_gguf_tensor(
     elif gguf_type == _GGUF_Q4_1:
         return _repack_q4_1(blocks, n_out, n_blocks_per_row)
     elif gguf_type == _GGUF_Q4_K:
-        return _repack_q4_k(blocks, n_out, n_blocks_per_row)
+        return _repack_q4_k(blocks, n_out, k_in)
     elif gguf_type == _GGUF_Q1_0:
         return _repack_q1_0(blocks, n_out, n_blocks_per_row)
     else:
@@ -363,26 +368,26 @@ def _unpack_q4_k_scales(
 def _repack_q4_k(
     blocks: np.ndarray,
     n_out: int,
-    n_super_blocks_per_row: int,
+    k_in: int,
 ) -> RepackedTensor:
-    """Repack Q4_K super-blocks into MatMulNBits sub-blocks.
+    """Dequantize Q4_K super-blocks and requantize to MatMulNBits.
 
     Q4_K uses 256-element super-blocks with a two-level scale hierarchy:
-    ``value = d * sub_scale[i] * nibble - dmin * sub_min[i]``.  Each
-    super-block is decomposed into 8 sub-blocks of 32 elements, and the
-    two-level hierarchy is flattened to MatMulNBits' single-level format:
-    ``value = (nibble - zero_point) * effective_scale``.
+    ``value = d * sub_scale[i] * nibble - dmin * sub_min[i]``. Its
+    fractional effective zero-points cannot generally be represented by
+    MatMulNBits' packed uint4 zero-points. We therefore reference-dequantize
+    the super-blocks, restore the logical row layout, and affine-requantize
+    each 32-element MatMulNBits block.
 
-    **This flattening is lossy.**  The additive offset ``dmin * sub_min``
-    is approximated as a multiplicative zero-point by dividing and
-    rounding.  Rounding error is at most 0.5 * eff_scale.  Clamping
-    error can be much larger when the offset exceeds 15 * eff_scale
-    (i.e., when ``round(dmin * sub_min / eff_scale) > 15``).
+    Requantization is lossy, but every source value is represented within
+    half of the emitted block scale (apart from floating-point roundoff).
+    Unlike directly rounding Q4_K's effective zero-point, this never clamps
+    a large source offset to 15 while keeping an incompatible source scale.
 
     Args:
         blocks: uint8 array, shape ``(total_super_blocks, 144)``.
         n_out: Number of output rows (N dimension).
-        n_super_blocks_per_row: Super-blocks per row.
+        k_in: Number of input columns (K dimension).
 
     Returns:
         A ``RepackedTensor`` with ``block_size=32`` and ``bits=4``.
@@ -404,29 +409,9 @@ def _repack_q4_k(
     sub_scales_f = sub_scales.astype(np.float32)  # (total, 8)
     sub_mins_f = sub_mins.astype(np.float32)  # (total, 8)
 
-    # Effective per-sub-block scale: d * sub_scale[i]
+    # Effective per-sub-block scale and minimum.
     eff_scales = d[:, None] * sub_scales_f  # (total, 8)
-
-    # Effective zero-point: zp = round(dmin * sub_min / eff_scale)
-    # GGUF dequant: d * sub_scale * nibble - dmin * sub_min
-    # MatMulNBits: (nibble - zp) * eff_scale = eff_scale * nibble - eff_scale * zp
-    # So eff_scale * zp = dmin * sub_min -> zp = dmin * sub_min / eff_scale
-    numerator = dmin[:, None] * sub_mins_f  # (total, 8)
-    with np.errstate(divide="ignore", invalid="ignore"):
-        zp_float = np.where(
-            eff_scales != 0,
-            np.round(numerator / eff_scales),
-            0.0,
-        )
-    zp_uint4 = np.clip(zp_float, 0, 15).astype(np.uint8)  # (total, 8)
-
-    n_clamped = int(np.count_nonzero(zp_float > 15) + np.count_nonzero(zp_float < 0))
-    if n_clamped > 0.05 * zp_float.size:
-        logger.warning(
-            "%d/%d Q4_K zero-points clamped — precision loss may be significant",
-            n_clamped,
-            zp_float.size,
-        )
+    eff_mins = dmin[:, None] * sub_mins_f  # (total, 8)
 
     # Unpack 4-bit quants from Q4_K layout.
     # 128 bytes = 4 groups of 32 bytes. Each group encodes two sub-blocks:
@@ -437,33 +422,89 @@ def _repack_q4_k(
     qs = (qs >> shifts) & np.uint8(0x0F)  # (total, 4, 2, 32)
     qs = qs.reshape(total, 8, 32)  # (total, 8, 32) — 8 sub-blocks
 
-    # Repack each sub-block's 32 nibbles -> 16 MatMulNBits bytes.
-    # ORT format: byte[j] = (element[2j+1] << 4) | element[2j]
-    pairs = qs.reshape(total, 8, 16, 2)
-    ort_packed = (pairs[..., 1] << 4) | pairs[..., 0]  # (total, 8, 16)
+    dequantized = (
+        eff_scales[:, :, None] * qs.astype(np.float32) - eff_mins[:, :, None]
+    ).reshape(-1)
+    logical_elements = n_out * k_in
+    if dequantized.size < logical_elements:
+        raise ValueError(
+            f"Q4_K data has {dequantized.size} elements, "
+            f"but shape ({n_out}, {k_in}) requires {logical_elements}"
+        )
 
-    # Reshape to output dimensions: 8 sub-blocks per super-block
-    n_sub_blocks_per_row = n_super_blocks_per_row * 8
-    weight = ort_packed.reshape(n_out, n_sub_blocks_per_row, 16)
-    scales_out = eff_scales.astype(np.float16).reshape(n_out, n_sub_blocks_per_row)
+    values = dequantized[:logical_elements].reshape(n_out, k_in)
+    return repack_dequantized_tensor(values, bits=4, block_size=_BLOCK_SIZE)
 
-    # Pack two 4-bit zero-points per byte
-    zp_2d = zp_uint4.reshape(n_out, n_sub_blocks_per_row)
-    zp_cols = math.ceil(n_sub_blocks_per_row / 2)
-    # n_sub_blocks_per_row is always a multiple of 8, so always even
-    zp_padded = zp_2d
-    if n_sub_blocks_per_row % 2 == 1:  # pragma: no cover — safety
-        zp_padded = np.zeros((n_out, n_sub_blocks_per_row + 1), dtype=np.uint8)
-        zp_padded[:, :n_sub_blocks_per_row] = zp_2d
-    zp_pairs = zp_padded.reshape(n_out, zp_cols, 2)
-    zero_points = zp_pairs[:, :, 0] | (zp_pairs[:, :, 1] << 4)
+
+def repack_dequantized_tensor(
+    values: np.ndarray,
+    *,
+    bits: int = 4,
+    block_size: int = _BLOCK_SIZE,
+    symmetric: bool = False,
+) -> RepackedTensor:
+    """Affine-quantize a float matrix into MatMulNBits layout.
+
+    This is used for mixed GGUF presets such as Q4_K_M, where projection
+    tensors may use Q4_K, Q5_0, Q6_K, and Q8_0 within one model while the
+    ONNX graph must use one MatMulNBits configuration throughout.
+    """
+    if values.ndim != 2:
+        raise ValueError(f"Expected 2D values (N, K), got shape {values.shape}")
+    if bits != 4 or block_size != _BLOCK_SIZE:
+        raise ValueError(
+            "Float requantization currently supports only "
+            f"bits=4, block_size={_BLOCK_SIZE}; got bits={bits}, "
+            f"block_size={block_size}"
+        )
+
+    n_out, k_in = values.shape
+    n_blocks = math.ceil(k_in / block_size)
+    padded_k = n_blocks * block_size
+    padded = np.zeros((n_out, padded_k), dtype=np.float32)
+    padded[:, :k_in] = values.astype(np.float32, copy=False)
+    blocks = padded.reshape(n_out, n_blocks, block_size)
+
+    if symmetric:
+        # MatMulNBits' implicit uint4 zero-point is 8. Choose a scale that
+        # covers the asymmetric signed code range [-8, 7].
+        block_min = blocks.min(axis=-1)
+        block_max = blocks.max(axis=-1)
+        scales = np.maximum(-block_min / 8.0, block_max / 7.0)
+        zero_points = np.full_like(scales, 8, dtype=np.uint8)
+    else:
+        # Include zero in the representable range so the rounded zero-point
+        # always fits in uint4 without changing the selected scale.
+        block_min = np.minimum(blocks.min(axis=-1), 0.0)
+        block_max = np.maximum(blocks.max(axis=-1), 0.0)
+        scales = (block_max - block_min) / 15.0
+        safe_scales = np.where(scales != 0, scales, 1.0)
+        zero_points = np.clip(np.rint(-block_min / safe_scales), 0, 15).astype(np.uint8)
+
+    safe_scales = np.where(scales != 0, scales, 1.0)
+    quants = np.rint(blocks / safe_scales[:, :, None])
+    quants += zero_points[:, :, None]
+    quants = np.clip(quants, 0, 15).astype(np.uint8)
+    quants = np.where(scales[:, :, None] != 0, quants, 0).astype(np.uint8)
+
+    pairs = quants.reshape(n_out, n_blocks, block_size // 2, 2)
+    weight = (pairs[..., 1] << 4) | pairs[..., 0]
+
+    if symmetric:
+        packed_zero_points = None
+    else:
+        zp_cols = math.ceil(n_blocks / 2)
+        zp_padded = np.zeros((n_out, zp_cols * 2), dtype=np.uint8)
+        zp_padded[:, :n_blocks] = zero_points
+        zp_pairs = zp_padded.reshape(n_out, zp_cols, 2)
+        packed_zero_points = zp_pairs[:, :, 0] | (zp_pairs[:, :, 1] << 4)
 
     return RepackedTensor(
         weight=weight,
-        scales=scales_out,
-        zero_points=zero_points,
-        block_size=_BLOCK_SIZE,
-        bits=4,
+        scales=scales.astype(np.float32),
+        zero_points=packed_zero_points,
+        block_size=block_size,
+        bits=bits,
     )
 
 

--- a/src/mobius/integrations/gguf/_repacker_test.py
+++ b/src/mobius/integrations/gguf/_repacker_test.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from gguf import quants
 
 from mobius.integrations.gguf._repacker import (
     RepackedTensor,
     _unpack_q4_k_scales,
     can_repack,
+    repack_dequantized_tensor,
     repack_gguf_tensor,
 )
 
@@ -439,6 +441,25 @@ def _make_q4_k_block(
     return np.concatenate([d_bytes, dmin_bytes, scales_bytes, qs_bytes])
 
 
+def _dequantize_repacked_q4(result: RepackedTensor, k_in: int) -> np.ndarray:
+    """Dequantize a 4-bit RepackedTensor with MatMulNBits semantics."""
+    n_out, n_blocks, _ = result.weight.shape
+    packed = result.weight
+    quants = np.empty((n_out, n_blocks, 32), dtype=np.float32)
+    quants[:, :, 0::2] = packed & 0x0F
+    quants[:, :, 1::2] = (packed >> 4) & 0x0F
+
+    if result.zero_points is None:
+        zero_points = np.full((n_out, n_blocks), 8.0, dtype=np.float32)
+    else:
+        zero_points = np.empty((n_out, n_blocks), dtype=np.float32)
+        zero_points[:, 0::2] = result.zero_points & 0x0F
+        zero_points[:, 1::2] = (result.zero_points >> 4)[:, : n_blocks // 2]
+
+    values = (quants - zero_points[:, :, None]) * result.scales[:, :, None]
+    return values.reshape(n_out, -1)[:, :k_in]
+
+
 class TestUnpackQ4KScales:
     def test_simple_values(self):
         """Pack known 6-bit values and verify round-trip."""
@@ -500,59 +521,36 @@ class TestRepackQ4K:
         assert result.scales.shape == (1, 8)
         assert result.zero_points.shape == (1, 4)  # 8 zps / 2
 
-    def test_effective_scales(self):
-        """Verify effective scale = d * sub_scale."""
+    def test_requantized_values_stay_within_half_scale(self):
+        """Affine requantization bounds each value by half a block scale."""
         sc = [10, 20, 30, 40, 1, 2, 3, 4]
         mn = [0] * 8  # zero mins -> zp=0, no offset
-        nibs = [0] * 256
+        nibs = list(range(16)) * 16
         d_val = 0.5
         block = _make_q4_k_block(d=d_val, dmin=0.0, sub_scales=sc, sub_mins=mn, nibbles=nibs)
-        raw = block.reshape(-1)
+        gguf_deq = quants.dequantize(
+            block.reshape(1, -1), quants.GGMLQuantizationType.Q4_K
+        ).reshape(1, 256)
+        result = repack_gguf_tensor(block, _Q4_K, shape=(1, 256))
+        ort_deq = _dequantize_repacked_q4(result, 256)
 
-        result = repack_gguf_tensor(raw, _Q4_K, shape=(1, 256))
+        error = np.abs(ort_deq - gguf_deq).reshape(1, 8, 32)
+        assert np.all(error.max(axis=-1) <= result.scales * 0.51 + 1e-6)
 
-        for i, s in enumerate(sc):
-            expected = np.float16(d_val * s)
-            np.testing.assert_almost_equal(result.scales[0, i], expected, decimal=2)
-
-    def test_zero_point_computation(self):
-        """Verify zp = round(dmin * sub_min / eff_scale), clamped."""
-        d_val = 1.0
-        dmin_val = 1.0
-        # Use sub_scale=1 so eff_scale=1.0, making zp = sub_min (direct)
-        sc = [1] * 8
-        # sub_min values in valid 6-bit range [0, 63]
-        # zp = round(dmin * mn[i] / (d * sc[i])) = mn[i], clamped to [0,15]
-        mn = [3, 5, 10, 0, 1, 63, 1, 2]
-        expected_zp = [3, 5, 10, 0, 1, 15, 1, 2]  # 63 clamped to 15
-        nibs = [0] * 256
+    def test_constant_negative_blocks_use_valid_zero_points(self):
+        """A large Q4_K offset is requantized instead of clamping its source zp."""
         block = _make_q4_k_block(
-            d=d_val, dmin=dmin_val, sub_scales=sc, sub_mins=mn, nibbles=nibs
+            d=1.0,
+            dmin=1.0,
+            sub_scales=[0] * 8,
+            sub_mins=[50] * 8,
+            nibbles=[8] * 256,
         )
-        raw = block.reshape(-1)
+        result = repack_gguf_tensor(block, _Q4_K, shape=(1, 256))
+        ort_deq = _dequantize_repacked_q4(result, 256)
 
-        result = repack_gguf_tensor(raw, _Q4_K, shape=(1, 256))
-
-        # Unpack 4-bit zero points from packed bytes
-        zp_packed = result.zero_points[0]  # (4,) bytes
-        zps = []
-        for byte_val in zp_packed:
-            zps.append(int(byte_val) & 0x0F)
-            zps.append((int(byte_val) >> 4) & 0x0F)
-        assert zps == expected_zp
-
-    def test_zero_effective_scale_gives_zero_zp(self):
-        """When d=0 or sub_scale=0, zp should be 0 (no division by 0)."""
-        sc = [0] * 8
-        mn = [50] * 8
-        nibs = [8] * 256
-        block = _make_q4_k_block(d=1.0, dmin=1.0, sub_scales=sc, sub_mins=mn, nibbles=nibs)
-        raw = block.reshape(-1)
-
-        result = repack_gguf_tensor(raw, _Q4_K, shape=(1, 256))
-
-        # All zps should be 0
-        assert np.all(result.zero_points == 0)
+        assert np.all(result.zero_points == 0xFF)
+        np.testing.assert_allclose(ort_deq, -50.0, atol=float(result.scales.max()) * 0.51)
 
     def test_round_trip_dequantize(self):
         """Compare repacked MatMulNBits dequant against gguf native."""
@@ -583,29 +581,37 @@ class TestRepackQ4K:
         raw = block.reshape(-1)
         result = repack_gguf_tensor(raw, _Q4_K, shape=(1, 256))
 
-        # Manually dequantize from MatMulNBits format
-        ort_deq = np.empty(256, dtype=np.float32)
-        zp_packed = result.zero_points[0]
-        for sb in range(8):
-            packed = result.weight[0, sb]  # (16,) uint8
-            low = (packed & 0x0F).astype(np.float32)
-            high = ((packed >> 4) & 0x0F).astype(np.float32)
-            elements = np.empty(32, dtype=np.float32)
-            elements[0::2] = low
-            elements[1::2] = high
-            s = result.scales[0, sb].astype(np.float32)
-            byte_idx = sb // 2
-            if sb % 2 == 0:
-                zp = float(zp_packed[byte_idx] & 0x0F)
-            else:
-                zp = float((zp_packed[byte_idx] >> 4) & 0x0F)
-            ort_deq[sb * 32 : (sb + 1) * 32] = (elements - zp) * s
+        ort_deq = _dequantize_repacked_q4(result, 256).ravel()
+        max_abs_diff = float(np.max(np.abs(ort_deq - gguf_deq)))
+        tolerance = float(result.scales.max()) * 0.51 + 1e-6
+        assert max_abs_diff <= tolerance
 
-        # Lossy: allow tolerance proportional to effective scale
-        # Typical max error ≈ 0.5 * max(eff_scale)
-        max_eff_scale = float(d_val) * max(sc)
-        atol = max_eff_scale * 0.6
-        np.testing.assert_allclose(ort_deq, gguf_deq, atol=atol)
+    def test_super_blocks_may_cross_logical_rows(self):
+        """Flattened Q4_K blocks are reshaped only after reference dequant."""
+        rng = np.random.RandomState(7)
+        source_blocks = []
+        for i in range(3):
+            source_blocks.append(
+                _make_q4_k_block(
+                    d=0.01 * (i + 1),
+                    dmin=0.004 * (i + 1),
+                    sub_scales=[10 + i] * 8,
+                    sub_mins=[3 + i] * 8,
+                    nibbles=rng.randint(0, 16, size=256).tolist(),
+                )
+            )
+        raw = np.concatenate(source_blocks)
+        shape = (8, 96)  # 768 values: rows split across three 256-value blocks
+
+        gguf_deq = quants.dequantize(
+            raw.reshape(3, -1), quants.GGMLQuantizationType.Q4_K
+        ).reshape(shape)
+        result = repack_gguf_tensor(raw, _Q4_K, shape=shape)
+        ort_deq = _dequantize_repacked_q4(result, shape[1])
+
+        assert result.weight.shape == (8, 3, 16)
+        max_abs_diff = float(np.max(np.abs(ort_deq - gguf_deq)))
+        assert max_abs_diff <= float(result.scales.max()) * 0.51 + 1e-6
 
     def test_multiple_rows_and_super_blocks(self):
         """N=2 rows, K=512 -> 2 super-blocks per row."""
@@ -645,6 +651,19 @@ class TestRepackQ4K:
     def test_q4_k_in_can_repack(self):
         """Q4_K (type 12) is recognized as repackable."""
         assert can_repack(12) is True
+
+
+class TestRepackDequantizedTensor:
+    def test_asymmetric_q4_round_trip_bound(self):
+        rng = np.random.default_rng(0)
+        values = rng.normal(size=(3, 70)).astype(np.float32)
+        result = repack_dequantized_tensor(values)
+        dequantized = _dequantize_repacked_q4(result, values.shape[1])
+
+        max_abs_diff = float(np.max(np.abs(dequantized - values)))
+        assert max_abs_diff <= float(result.scales.max()) * 0.51 + 1e-6
+        assert result.weight.shape == (3, 3, 16)
+        assert result.zero_points.shape == (3, 2)
 
 
 # ---- Q1_0 tests ----


### PR DESCRIPTION
build-gguf previously only handled Q4_0; Q4_K_M (llama.cpp's default deployment quant) failed. Adds Q4_K_M support:

- Reference-dequantizes Q4_K super-blocks (256-elem, 8 sub-blocks, 6-bit scales/mins per llama.cpp `dequantize_row_q4_K`), then affine-requantizes into packed uint4 MatMulNBits blocks (block_size=32). Mixed Q5_0/Q6_K/Q8_0 projections use the same target.
- Correctness test: worst Q4_K max_abs_diff 0.037 < tolerance 0.061.
- Verified end-to-end: converted `Qwen2.5-0.5B-Instruct-GGUF:q4_k_m` → 168 MatMulNBits → onnx-genai output 'The capital of France is Paris.'

lintrunner clean; gguf pytest 154 passed.