### PR TITLE
Quantized token embedding via GatherBlockQuantized (272MB→76MB)

### DIFF
--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -351,7 +351,10 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
         raise SystemExit(1)
 
     if args.keep_quantized:
-        print("Quantized mode: preserving GGUF quantization as MatMulNBits...")
+        print(
+            "Quantized mode: preserving GGUF quantization as "
+            "MatMulNBits/GatherBlockQuantized..."
+        )
 
     gguf_path = args.gguf_path
     output_dir = args.output or os.path.splitext(gguf_path)[0] + "_onnx"
@@ -594,7 +597,10 @@ def main(argv: list[str] | None = None) -> None:
     gguf_parser.add_argument(
         "--keep-quantized",
         action="store_true",
-        help="Preserve quantization via MatMulNBits (Q4_0/Q4_1/Q8_0).",
+        help=(
+            "Preserve supported projection and embedding quantization via "
+            "MatMulNBits/GatherBlockQuantized."
+        ),
     )
     gguf_parser.add_argument(
         "--dtype",

--- a/src/mobius/_configs/_quantization.py
+++ b/src/mobius/_configs/_quantization.py
@@ -27,11 +27,11 @@ class QuantizationConfig:
     # (e.g. Tencent SEQ uses 1.5).
     float_zero_point: bool = False
     # When True, the input embedding table is block-wise quantized and is
-    # looked up with GatherBlockQuantized instead of a plain Gather. Set by
-    # Olive RTN exports that pass ``embeds: true``.
+    # looked up with GatherBlockQuantized instead of a plain Gather. Used by
+    # Olive RTN exports and quantized GGUF imports.
     quantize_embeddings: bool = False
     # When True, the LM head projection is block-wise quantized (MatMulNBits).
-    # Set by Olive RTN exports that pass ``lm_head: true``.
+    # Used by Olive RTN exports and tied quantized GGUF imports.
     quantize_lm_head: bool = False
     # When True, the input embedding and LM head share one weight table. Olive
     # RTN records this in its own config (``tie_word_embeddings``) and may clear

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -9,9 +9,9 @@ pipeline.  Two modes:
 - **Dequantized** (default): All quantized tensors are dequantized to
   float.  Simple, but loses the compression benefit of quantization.
 - **Quantized** (``keep_quantized=True``): Linear-layer weights that
-  use supported GGUF types (Q4_0, Q4_1, Q8_0) are repacked into
-  MatMulNBits format.  Other tensors (norms, embeddings) are
-  dequantized as usual.
+  use supported GGUF types are repacked into MatMulNBits format.
+  Quantized token embeddings are repacked for GatherBlockQuantized.
+  Other tensors (norms and unsupported quant types) are dequantized.
 """
 
 from __future__ import annotations
@@ -169,6 +169,12 @@ def build_from_gguf(
         bits, block_size, is_sym = _detect_quant_params(gguf_model, gguf_arch)
         # Float zero-point only when actually using Tencent's native 2-bit form.
         float_zp = is_tencent_q1_0_layout(gguf_model) and flags.tencent_q1_0_use_native_2bit
+        quantize_embeddings = _can_quantize_embedding(
+            gguf_model,
+            gguf_arch,
+            bits=bits,
+            block_size=block_size,
+        )
         config = dataclasses.replace(
             config,
             quantization=QuantizationConfig(
@@ -177,14 +183,18 @@ def build_from_gguf(
                 quant_method="gguf",
                 sym=is_sym,
                 float_zero_point=float_zp,
+                quantize_embeddings=quantize_embeddings,
+                quantize_lm_head=quantize_embeddings and config.tie_word_embeddings,
+                tie_word_embeddings=quantize_embeddings and config.tie_word_embeddings,
             ),
         )
         logger.info(
-            "Quantized mode: bits=%d, block_size=%d, symmetric=%s, float_zp=%s",
+            "Quantized mode: bits=%d, block_size=%d, symmetric=%s, float_zp=%s, embedding=%s",
             bits,
             block_size,
             is_sym,
             float_zp,
+            quantize_embeddings,
         )
 
     # 4. Look up module class and resolve task
@@ -331,13 +341,13 @@ def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, int, bool]:
     """
     from gguf import GGMLQuantizationType
 
-    from mobius.integrations.gguf._repacker import can_repack
+    from mobius.integrations.gguf._repacker import can_repack, repack_quant_params
     from mobius.integrations.gguf._tencent_q1_0 import is_tencent_q1_0_layout
     from mobius.integrations.gguf._tensor_mapping import (
         map_gguf_to_hf_names,
     )
 
-    # Per-type parameters: (bits, block_size, is_symmetric).
+    # Symmetry of each supported GGUF quantization type.
     #
     # Mainline Q1_0 (1-bit binary) is repacked into 2-bit MatMulNBits
     # with zp=1 — see _repack_q1_0. Tencent's custom Q1_0 (2-bit SEQ,
@@ -345,12 +355,12 @@ def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, int, bool]:
     # parse_tencent_q1_0_tensor — because the ORT CPU unpacked-float-zp
     # path is currently only implemented for bits=4, and the half-integer
     # SEQ offset 1.5 cannot be expressed with integer zp at bits=2.
-    type_params: dict = {
-        GGMLQuantizationType.Q4_0: (4, 32, True),
-        GGMLQuantizationType.Q4_1: (4, 32, False),
-        GGMLQuantizationType.Q4_K: (4, 32, False),
-        GGMLQuantizationType.Q8_0: (8, 32, True),
-        GGMLQuantizationType.Q1_0: (2, 128, False),
+    type_symmetry: dict = {
+        GGMLQuantizationType.Q4_0: True,
+        GGMLQuantizationType.Q4_1: False,
+        GGMLQuantizationType.Q4_K: False,
+        GGMLQuantizationType.Q8_0: True,
+        GGMLQuantizationType.Q1_0: False,
     }
 
     counts: Counter = Counter()
@@ -368,7 +378,10 @@ def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, int, bool]:
         )
 
     dominant = counts.most_common(1)[0][0]
-    bits, block_size, is_sym = type_params[dominant]
+    params = repack_quant_params(dominant.value)
+    assert params is not None
+    bits, block_size = params
+    is_sym = type_symmetry[dominant]
 
     # Tencent Q1_0 files reuse the Q1_0 type id but ship a different
     # on-disk layout (2-bit SEQ, 512-element blocks, fp16 scale per block).
@@ -393,6 +406,40 @@ def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, int, bool]:
         block_size,
     )
     return bits, block_size, is_sym
+
+
+def _can_quantize_embedding(
+    gguf_model,
+    gguf_arch: str,
+    *,
+    bits: int,
+    block_size: int,
+) -> bool:
+    """Return whether the token embedding can use GatherBlockQuantized.
+
+    The graph has one quantization configuration shared by its quantized
+    modules. Preserve the GGUF embedding only when its repacked representation
+    uses the same bit width and block size as the projection weights.
+    """
+    from mobius.integrations.gguf._repacker import repack_quant_params
+    from mobius.integrations.gguf._tencent_q1_0 import is_tencent_q1_0_layout
+    from mobius.integrations.gguf._tensor_mapping import map_gguf_to_hf_names
+
+    # Tencent files reuse the Q1_0 type id for a custom layout that gguf-py
+    # cannot size correctly. Embeddings from those files must stay dequantized.
+    if is_tencent_q1_0_layout(gguf_model):
+        return False
+
+    for tensor in gguf_model._reader.tensors:
+        if map_gguf_to_hf_names(tensor.name, gguf_arch) != "model.embed_tokens.weight":
+            continue
+        shape = tuple(reversed(tensor.shape))
+        if len(shape) != 2:
+            return False
+        qtype = tensor.tensor_type
+        qtype_val = qtype.value if hasattr(qtype, "value") else qtype
+        return repack_quant_params(qtype_val) == (bits, block_size)
+    return False
 
 
 def _load_dequantized_state_dict(
@@ -434,8 +481,9 @@ def _load_quantized_state_dict(
     """Load tensors, repacking supported quantized types.
 
     Projection weights (Q/K/V/O and MLP) that use repackable GGUF
-    types are converted to MatMulNBits format.  All other tensors
-    (norms, embeddings, unsupported quant types) are dequantized.
+    types are converted to MatMulNBits format. Quantized embeddings
+    are converted to GatherBlockQuantized format. All other tensors
+    (norms and unsupported quant types) are dequantized.
 
     For llama-family models, quantized Q/K weights receive the
     row-level reverse-permutation that ``process_tensors`` would
@@ -445,7 +493,7 @@ def _load_quantized_state_dict(
     import torch
     from gguf import GGMLQuantizationType, dequantize
 
-    from mobius.components import QuantizedLinear
+    from mobius.components import QuantizedEmbedding, QuantizedLinear
     from mobius.integrations.gguf._repacker import (
         can_repack,
         repack_gguf_tensor,
@@ -464,9 +512,12 @@ def _load_quantized_state_dict(
     # Collect module paths that use QuantizedLinear so we know
     # which .weight parameters should receive repacked data.
     quantized_stems = set()
+    quantized_embedding_stems = set()
     for mod_name, mod in module.named_modules():
         if isinstance(mod, QuantizedLinear):
             quantized_stems.add(mod_name)
+        elif isinstance(mod, QuantizedEmbedding):
+            quantized_embedding_stems.add(mod_name)
 
     num_heads = getattr(config, "num_attention_heads", None)
     num_kv_heads = getattr(config, "num_key_value_heads", None)
@@ -505,9 +556,10 @@ def _load_quantized_state_dict(
         # parameter is from a QuantizedLinear module.
         stem = hf_name[: -len(".weight")] if hf_name.endswith(".weight") else None
         is_tencent_q1_0_tensor = tencent_q1_0 and qtype == GGMLQuantizationType.Q1_0
+        is_quantized_embedding = stem in quantized_embedding_stems
         should_repack = (
             stem is not None
-            and stem in quantized_stems
+            and (stem in quantized_stems or is_quantized_embedding)
             and (can_repack(qtype_val) or is_tencent_q1_0_tensor)
         )
 
@@ -541,7 +593,10 @@ def _load_quantized_state_dict(
                 w = _reverse_permute(w, n_head)
                 s = _reverse_permute(s, n_head)
 
-            state_dict[hf_name] = w
+            if is_quantized_embedding:
+                state_dict[f"{stem}.qweight"] = w.reshape(w.shape[0], -1)
+            else:
+                state_dict[hf_name] = w
             state_dict[f"{stem}.scales"] = s
             if repacked.zero_points is not None:
                 zp = torch.from_numpy(repacked.zero_points)
@@ -564,7 +619,7 @@ def _load_quantized_state_dict(
             state_dict[hf_name] = torch.from_numpy(arr)
 
     logger.info(
-        "Loaded %d tensors (%d repacked as MatMulNBits, %d dequantized)",
+        "Loaded %d tensors (%d repacked for quantized ops, %d dequantized)",
         len(state_dict),
         n_repacked,
         len(state_dict) - n_repacked,

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -20,11 +20,14 @@ def _write_quantized_gguf(
     num_kv_heads: int = 2,
     intermediate_size: int = 128,
     vocab_size: int = 256,
+    quantize_embedding: bool = False,
+    tie_embeddings: bool = False,
 ) -> None:
     """Write a GGUF file with Q4_0 quantized projection weights.
 
-    Norms and embeddings are float32; all linear-layer weights in
-    decoder blocks are Q4_0 (4-bit symmetric, block_size=32).
+    Norms are float32; all linear-layer weights in decoder blocks are
+    Q4_0 (4-bit symmetric, block_size=32). The embedding can optionally
+    be Q4_0 and tied to the LM head.
     """
     from gguf import GGMLQuantizationType, GGUFWriter
 
@@ -63,8 +66,10 @@ def _write_quantized_gguf(
                 )
         writer.add_tensor(name, raw, raw_dtype=GGMLQuantizationType.Q4_0)
 
-    # Embeddings (float32)
-    _add_f32("token_embd.weight", (vocab_size, hidden_size))
+    if quantize_embedding:
+        _add_q4_0("token_embd.weight", vocab_size, hidden_size)
+    else:
+        _add_f32("token_embd.weight", (vocab_size, hidden_size))
 
     for i in range(num_layers):
         # Projection weights (Q4_0)
@@ -95,9 +100,10 @@ def _write_quantized_gguf(
         _add_f32(f"blk.{i}.attn_norm.weight", (hidden_size,))
         _add_f32(f"blk.{i}.ffn_norm.weight", (hidden_size,))
 
-    # Output norm + lm_head (float32)
+    # Output norm + optional untied lm_head (float32)
     _add_f32("output_norm.weight", (hidden_size,))
-    _add_f32("output.weight", (vocab_size, hidden_size))
+    if not tie_embeddings:
+        _add_f32("output.weight", (vocab_size, hidden_size))
 
     writer.write_header_to_file()
     writer.write_kv_data_to_file()
@@ -110,6 +116,22 @@ def q4_0_gguf(tmp_path: Path) -> Path:
     """Create a Q4_0 quantized GGUF test file."""
     path = tmp_path / "test_q4_0.gguf"
     _write_quantized_gguf(path)
+    return path
+
+
+@pytest.fixture
+def q4_0_embedding_gguf(tmp_path: Path) -> Path:
+    """Create a GGUF with a Q4_0 token embedding."""
+    path = tmp_path / "test_q4_0_embedding.gguf"
+    _write_quantized_gguf(path, quantize_embedding=True)
+    return path
+
+
+@pytest.fixture
+def q4_0_tied_embedding_gguf(tmp_path: Path) -> Path:
+    """Create a GGUF with one Q4_0 table shared by embedding and LM head."""
+    path = tmp_path / "test_q4_0_tied_embedding.gguf"
+    _write_quantized_gguf(path, quantize_embedding=True, tie_embeddings=True)
     return path
 
 
@@ -135,6 +157,39 @@ class TestBuildQuantizedGguf:
         assert "MatMulNBits" in op_types, (
             f"Expected MatMulNBits in ops, got: {sorted(op_types)}"
         )
+
+    def test_quantized_embedding_uses_gatherblockquantized(self, q4_0_embedding_gguf: Path):
+        """A quantized GGUF embedding remains packed in the ONNX graph."""
+        import onnx_ir as ir
+
+        from mobius.integrations.gguf import build_from_gguf
+
+        model = build_from_gguf(q4_0_embedding_gguf, keep_quantized=True)["model"]
+        gather_nodes = [node for node in model.graph if node.op_type == "GatherBlockQuantized"]
+        assert len(gather_nodes) == 1
+        assert gather_nodes[0].domain == "com.microsoft"
+
+        qweight = model.graph.initializers["model.embed_tokens.qweight"]
+        assert qweight.dtype == ir.DataType.UINT8
+        assert list(qweight.shape) == [256, 32]
+        assert list(model.graph.initializers["model.embed_tokens.scales"].shape) == [
+            256,
+            2,
+        ]
+        assert "model.embed_tokens.weight" not in model.graph.initializers
+
+    def test_tied_quantized_embedding_drives_matmulnbits_head(
+        self, q4_0_tied_embedding_gguf: Path
+    ):
+        """Tied embedding/head share one packed table across both contrib ops."""
+        from mobius.integrations.gguf import build_from_gguf
+
+        model = build_from_gguf(q4_0_tied_embedding_gguf, keep_quantized=True)["model"]
+        op_types = [node.op_type for node in model.graph]
+        assert op_types.count("GatherBlockQuantized") == 1
+        assert "MatMulNBits" in op_types
+        assert "model.embed_tokens.qweight" in model.graph.initializers
+        assert not any(name.startswith("lm_head.") for name in model.graph.initializers)
 
     def test_norms_are_float(self, q4_0_gguf: Path):
         """Norm weights remain float, not quantized."""
@@ -174,6 +229,37 @@ class TestBuildQuantizedGguf:
         assert bits == 4
         assert block_size == 32
         assert is_sym is True
+
+    def test_embedding_quantization_check_is_metadata_only(self, monkeypatch):
+        """Embedding compatibility does not read or repack tensor data."""
+        from types import SimpleNamespace
+
+        from gguf import GGMLQuantizationType
+
+        from mobius.integrations.gguf import _tencent_q1_0
+        from mobius.integrations.gguf._builder import _can_quantize_embedding
+
+        monkeypatch.setattr(_tencent_q1_0, "is_tencent_q1_0_layout", lambda _model: False)
+        tensor = SimpleNamespace(
+            name="token_embd.weight",
+            tensor_type=GGMLQuantizationType.Q4_0,
+            shape=(64, 256),
+        )
+        model = SimpleNamespace(_reader=SimpleNamespace(tensors=[tensor]))
+
+        assert _can_quantize_embedding(model, "llama", bits=4, block_size=32)
+
+    def test_tencent_q1_0_embedding_is_not_quantized(self, monkeypatch):
+        """Tencent Q1_0 detection short-circuits before inspecting tensors."""
+        from types import SimpleNamespace
+
+        from mobius.integrations.gguf import _tencent_q1_0
+        from mobius.integrations.gguf._builder import _can_quantize_embedding
+
+        monkeypatch.setattr(_tencent_q1_0, "is_tencent_q1_0_layout", lambda _model: True)
+        model = SimpleNamespace()
+
+        assert not _can_quantize_embedding(model, "llama", bits=4, block_size=128)
 
 
 class TestRawTensorIterator:

--- a/src/mobius/integrations/gguf/_repacker.py
+++ b/src/mobius/integrations/gguf/_repacker.py
@@ -62,6 +62,15 @@ _GGUF_BLOCK_ELEMENTS = {
 
 _SUPPORTED_TYPES = frozenset(_BLOCK_BYTES.keys())
 
+# MatMulNBits representation produced for each supported GGUF type.
+_REPACK_PARAMS = {
+    _GGUF_Q4_0: (4, 32),
+    _GGUF_Q4_1: (4, 32),
+    _GGUF_Q8_0: (8, 32),
+    _GGUF_Q4_K: (4, 32),
+    _GGUF_Q1_0: (2, 128),
+}
+
 
 @dataclass
 class RepackedTensor:
@@ -86,7 +95,12 @@ class RepackedTensor:
 
 def can_repack(gguf_type: int) -> bool:
     """Return True if the GGUF type can be repacked to MatMulNBits."""
-    return gguf_type in _SUPPORTED_TYPES
+    return repack_quant_params(gguf_type) is not None
+
+
+def repack_quant_params(gguf_type: int) -> tuple[int, int] | None:
+    """Return the ``(bits, block_size)`` produced for a GGUF type."""
+    return _REPACK_PARAMS.get(gguf_type)
 
 
 def repack_gguf_tensor(

--- a/src/mobius/models/base.py
+++ b/src/mobius/models/base.py
@@ -83,8 +83,8 @@ class TextModel(nn.Module):
             config.vocab_size, config.hidden_size, config.pad_token_id
         )
         if qc is not None and getattr(qc, "quantize_embeddings", False):
-            # Olive RTN (embeds: true) quantizes the embedding table; look it
-            # up with GatherBlockQuantized instead of a plain Gather.
+            # Keep the block-quantized embedding table packed and dequantize
+            # only the selected token rows.
             self.embed_tokens = QuantizedEmbedding(
                 config.vocab_size,
                 config.hidden_size,
@@ -456,7 +456,12 @@ class CausalLMModel(nn.Module):
                 quantize_lm_head=getattr(qc, "quantize_lm_head", False),
                 tie_word_embeddings=tie,
             )
-        if self.config.tie_word_embeddings:
+        tied_quantized_table = (
+            qc is not None
+            and getattr(qc, "quantize_embeddings", False)
+            and getattr(qc, "quantize_lm_head", False)
+        )
+        if self.config.tie_word_embeddings and not tied_quantized_table:
             # Ensure both embed_tokens.weight and lm_head.weight are present so
             # apply_weights can assign each to its initializer.  For graph-level
             # tied models (standard CausalLMModel) both ir.Values are the same


### PR DESCRIPTION
The token-embedding table was emitted as fp16 `[151936,896]` ≈ 272 MB (a plain Gather) even in Q4 models — larger than WebGPU's 256 MiB buffer limit and a big bandwidth cost. This keeps it quantized:

- Emits `com.microsoft.GatherBlockQuantized` with Q4 packed data `[151936,448]` + fp16 scales.
- Size: **272.27 MB → 68.07 MB data + 8.51 MB scales**.
- Tied LM head continues to share the table via MatMulNBits.
- Verified: CPU EP coherent ('Paris'); WebGPU EP places GatherBlockQuantized on `WebGpuExecutionProvider` (on-device) with coherent output.

Note: a runtime-side WebGPU stability issue (stale KV validation) is tracked separately in onnx-genai. lintrunner clean; gguf pytest 153 passed.