### PR TITLE
Add DeepSeek-V4-Flash export support

### DIFF
--- a/DSV4_FLASH_EXPORT.md
+++ b/DSV4_FLASH_EXPORT.md
@@ -1,0 +1,58 @@
+# DeepSeek-V4-Flash export design
+
+## Source configuration
+
+The authoritative checkpoint is
+[`deepseek-ai/DeepSeek-V4-Flash`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash);
+the target GGUF is
+[`unsloth/DeepSeek-V4-Flash-GGUF`](https://huggingface.co/unsloth/DeepSeek-V4-Flash-GGUF).
+
+- HF: `model_type=deepseek_v4`, `DeepseekV4ForCausalLM`.
+- GGUF: `general.architecture=deepseek4`.
+- 43 layers, hidden size 4096, 64 attention heads, one shared KV head,
+  head size 512, rotary size 64, Q LoRA rank 1024.
+- Output projection: 8 groups, rank 1024.
+- MoE: 256 routed experts, top 6, intermediate size 2048, one shared
+  expert, scale 1.5, normalized `sqrt(softplus(logit))` routing. The first
+  three layers select experts from a token-id hash table.
+- Hyper-Connections: multiplicity 4, 20 Sinkhorn iterations, epsilon `1e-6`.
+- Context: 1,048,576. Raw/local KV uses base theta 10,000; compressed
+  history uses YaRN factor 16 from 65,536 with theta 160,000.
+- Sparse attention: 128-token local window plus learned KV compression
+  (`compress_ratios` alternating 4/128), a learned indexer for ratio-4
+  layers, compressed theta 160,000, and attention sinks.
+- One MTP layer is present but is not part of ordinary target-model logits.
+
+## V3 reuse and V4 differences
+
+V3's shared-expert MoE structure and low-rank Q path remain useful concepts,
+but V4 is not the V3 MLA layout: it has a single normalized 512-wide KV
+projection, inverse RoPE on attention outputs, grouped low-rank output
+projection, sqrt-softplus/hash routing, clamped SwiGLU, and
+Hyper-Connections. A separate model module avoids forcing those semantics
+into `DeepSeekMLA`.
+
+This increment exports the V4 projections, full Hyper-Connections, V4 MoE
+routing/shared experts, and KV-cache-compatible **dense causal attention**.
+The dense graph is a structurally valid fallback for short-context bring-up,
+but it is not numerically equivalent to CSA/HCA's learned compressed-history
+selection. Compression, indexer tensors, attention sinks, and MTP are
+explicitly skipped during weight preprocessing, so this support remains
+preview-quality until the sparse runtime path lands.
+
+## Quantization and follow-ups
+
+Mobius can quantize the implemented `Linear` layers to its existing 4-bit or
+8-bit `MatMulNBits` path. Unsloth Dynamic files also contain mixed low-bit
+expert tensors (including 2/1-bit variants, and packed FP4/MXFP4 in some
+presets) that are not directly representable by the currently deployed
+MatMulNBits kernels.
+
+Follow-ups:
+
+1. Add runtime custom ops for compressed sparse attention/cache management
+   and expose them through mobius execution-provider capability config.
+2. Add a packed sub-4-bit/MXFP4 expert custom op, or track the needed
+   MatMulNBits functionality in ONNX Runtime and teach the GGUF repacker to
+   preserve those tensors.
+3. Export the optional MTP head as a separate speculative-decoding component.

--- a/DSV4_FLASH_EXPORT.md
+++ b/DSV4_FLASH_EXPORT.md
@@ -34,11 +34,16 @@ into `DeepSeekMLA`.
 
 This increment exports the V4 projections, full Hyper-Connections, V4 MoE
 routing/shared experts, and KV-cache-compatible **dense causal attention**.
-The dense graph is a structurally valid fallback for short-context bring-up,
-but it is not numerically equivalent to CSA/HCA's learned compressed-history
-selection. Compression, indexer tensors, attention sinks, and MTP are
-explicitly skipped during weight preprocessing, so this support remains
-preview-quality until the sparse runtime path lands.
+The fallback includes the official per-head attention sinks. It follows the
+checkpoint's `compress_ratios` schedule and retains every learned compressor
+and ratio-4 indexer tensor in the ONNX graph, but does not yet execute
+compressed-history selection. The dense path is therefore correct as causal
+attention, while not numerically equivalent to CSA/HCA at long context.
+
+The official single MTP block is exported as `mtp/model.onnx`. It consumes the
+target's raw Hyper-Connection state plus the next-token embedding, runs the
+complete MTP block, and emits `mtp_hidden` for the target's shared LM head.
+`mtp_config.json` records this external orchestration contract.
 
 ## Quantization and follow-ups
 
@@ -51,8 +56,9 @@ MatMulNBits kernels.
 Follow-ups:
 
 1. Add runtime custom ops for compressed sparse attention/cache management
-   and expose them through mobius execution-provider capability config.
+   and replace the dense fallback while reusing the exported tensors.
 2. Add a packed sub-4-bit/MXFP4 expert custom op, or track the needed
    MatMulNBits functionality in ONNX Runtime and teach the GGUF repacker to
    preserve those tensors.
-3. Export the optional MTP head as a separate speculative-decoding component.
+3. Add iterative MTP cache/state orchestration to ORT GenAI; the exported
+   sidecar currently declares `runtime_orchestration: external`.

--- a/src/mobius/_configs/_base.py
+++ b/src/mobius/_configs/_base.py
@@ -134,6 +134,35 @@ def _first_not_none(*values, default=None):
     return default
 
 
+def _leading_layer_type_count(layer_types, target: str) -> int:
+    count = 0
+    for layer_type in layer_types or ():
+        if layer_type != target:
+            break
+        count += 1
+    return count
+
+
+def _deepseek_v4_compress_ratios(config) -> list[int] | None:
+    ratios = getattr(config, "compress_ratios", None)
+    if ratios is not None:
+        return list(ratios)
+    layer_types = getattr(config, "layer_types", None)
+    rates = getattr(config, "compress_rates", None)
+    if not layer_types or not rates:
+        return None
+    return [
+        (
+            rates.get("compressed_sparse_attention", 4)
+            if layer_type == "compressed_sparse_attention"
+            else rates.get("heavily_compressed_attention", 128)
+            if layer_type == "heavily_compressed_attention"
+            else 0
+        )
+        for layer_type in layer_types
+    ]
+
+
 # Models that use RoPE but hardcode rope_theta entirely in model __init__,
 # not in config JSON.  These are NOT detectable via config introspection
 # without trust_remote_code.  When a new model fails L2 with missing RoPE:
@@ -422,6 +451,20 @@ class ArchitectureConfig(BaseModelConfig):
     qk_rope_head_dim: int | None = None
     v_head_dim: int | None = None
     rope_interleave: bool = False
+
+    # DeepSeek-V4 compressed sparse attention / Hyper-Connections.
+    o_groups: int = 1
+    o_lora_rank: int | None = None
+    index_n_heads: int | None = None
+    index_head_dim: int | None = None
+    index_topk: int | None = None
+    compress_ratios: list[int] | None = None
+    compress_rope_theta: float | None = None
+    hc_mult: int = 1
+    hc_sinkhorn_iters: int = 1
+    hc_eps: float = 1e-6
+    num_hash_layers: int = 0
+    swiglu_limit: float = 0.0
 
     # Vision shared fields (accessed as top-level config.X by tasks)
     mm_tokens_per_image: int | None = None
@@ -806,6 +849,25 @@ class ArchitectureConfig(BaseModelConfig):
             qk_nope_head_dim=getattr(config, "qk_nope_head_dim", None),
             qk_rope_head_dim=getattr(config, "qk_rope_head_dim", None),
             v_head_dim=getattr(config, "v_head_dim", None),
+            # DeepSeek-V4 compressed sparse attention / Hyper-Connections
+            o_groups=getattr(config, "o_groups", 1),
+            o_lora_rank=getattr(config, "o_lora_rank", None),
+            index_n_heads=getattr(config, "index_n_heads", None),
+            index_head_dim=getattr(config, "index_head_dim", None),
+            index_topk=getattr(config, "index_topk", None),
+            compress_ratios=_deepseek_v4_compress_ratios(config),
+            compress_rope_theta=getattr(config, "compress_rope_theta", None),
+            hc_mult=getattr(config, "hc_mult", 1),
+            hc_sinkhorn_iters=getattr(config, "hc_sinkhorn_iters", 1),
+            hc_eps=getattr(config, "hc_eps", 1e-6),
+            num_hash_layers=(
+                getattr(config, "num_hash_layers", None)
+                or getattr(config, "n_hash_layers", 0)
+                or _leading_layer_type_count(
+                    getattr(config, "mlp_layer_types", None), "hash_moe"
+                )
+            ),
+            swiglu_limit=getattr(config, "swiglu_limit", 0.0),
             # Encoder-specific
             type_vocab_size=getattr(config, "type_vocab_size", 0),
             # Encoder-decoder

--- a/src/mobius/_configs/_base.py
+++ b/src/mobius/_configs/_base.py
@@ -465,6 +465,7 @@ class ArchitectureConfig(BaseModelConfig):
     hc_eps: float = 1e-6
     num_hash_layers: int = 0
     swiglu_limit: float = 0.0
+    num_nextn_predict_layers: int = 0
 
     # Vision shared fields (accessed as top-level config.X by tasks)
     mm_tokens_per_image: int | None = None
@@ -868,6 +869,7 @@ class ArchitectureConfig(BaseModelConfig):
                 )
             ),
             swiglu_limit=getattr(config, "swiglu_limit", 0.0),
+            num_nextn_predict_layers=getattr(config, "num_nextn_predict_layers", 0),
             # Encoder-specific
             type_vocab_size=getattr(config, "type_vocab_size", 0),
             # Encoder-decoder

--- a/src/mobius/_registry.py
+++ b/src/mobius/_registry.py
@@ -543,7 +543,7 @@ _REGISTRATIONS: dict[str, ModelRegistration] = {
     "deepseek_v2": ModelRegistration(DeepSeekV3CausalLMModel),
     "deepseek_v2_moe": ModelRegistration(DeepSeekV3CausalLMModel),
     "deepseek_v3": ModelRegistration(DeepSeekV3CausalLMModel),
-    "deepseek_v4": ModelRegistration(DeepSeekV4CausalLMModel),
+    "deepseek_v4": ModelRegistration(DeepSeekV4CausalLMModel, task="deepseek-v4"),
     "deepseek_vl_v2": ModelRegistration(DeepSeekOCR2CausalLMModel),
     # --- SSM (Mamba / Mamba2) ---
     "falcon_mamba": ModelRegistration(MambaCausalLMModel),
@@ -1226,7 +1226,7 @@ _VARIANT_LABELS: dict[str, str] = {
     "deepseek_v2": "mla",
     "deepseek_v2_moe": "mla+moe",
     "deepseek_v3": "mla+moe",
-    "deepseek_v4": "dense-hca-fallback+moe+hc",
+    "deepseek_v4": "dense-csa-fallback+mtp+moe+hc",
     "phi3small": "blocksparse",
     "falcon_h1": "hybrid-ssm",
     "mamba": "ssm",

--- a/src/mobius/_registry.py
+++ b/src/mobius/_registry.py
@@ -37,6 +37,7 @@ from mobius.models import (
     ChatGLMCausalLMModel,
     DeepSeekOCR2CausalLMModel,
     DeepSeekV3CausalLMModel,
+    DeepSeekV4CausalLMModel,
     DFlashDraftModel,
     DiffLlamaCausalLMModel,
     DogeCausalLMModel,
@@ -542,6 +543,7 @@ _REGISTRATIONS: dict[str, ModelRegistration] = {
     "deepseek_v2": ModelRegistration(DeepSeekV3CausalLMModel),
     "deepseek_v2_moe": ModelRegistration(DeepSeekV3CausalLMModel),
     "deepseek_v3": ModelRegistration(DeepSeekV3CausalLMModel),
+    "deepseek_v4": ModelRegistration(DeepSeekV4CausalLMModel),
     "deepseek_vl_v2": ModelRegistration(DeepSeekOCR2CausalLMModel),
     # --- SSM (Mamba / Mamba2) ---
     "falcon_mamba": ModelRegistration(MambaCausalLMModel),
@@ -908,6 +910,7 @@ _TEST_MODEL_IDS: dict[str, str] = {
     "deepseek_v2": "deepseek-ai/DeepSeek-V2-Lite",
     "deepseek_v2_moe": "deepseek-ai/DeepSeek-V2-Lite",
     "deepseek_v3": "deepseek-ai/DeepSeek-V3",
+    "deepseek_v4": "deepseek-ai/DeepSeek-V4-Flash",
 
     # --- SSM (Mamba) ---
     "mamba": "state-spaces/mamba-130m-hf",
@@ -1151,6 +1154,7 @@ _FAMILY_OVERRIDES: dict[str, str] = {
     "deepseek_v2": "deepseek",
     "deepseek_v2_moe": "deepseek",
     "deepseek_v3": "deepseek",
+    "deepseek_v4": "deepseek",
     "deepseek_vl_v2": "deepseek",
     "olmo": "olmo",
     "olmo2": "olmo",
@@ -1222,6 +1226,7 @@ _VARIANT_LABELS: dict[str, str] = {
     "deepseek_v2": "mla",
     "deepseek_v2_moe": "mla+moe",
     "deepseek_v3": "mla+moe",
+    "deepseek_v4": "dense-hca-fallback+moe+hc",
     "phi3small": "blocksparse",
     "falcon_h1": "hybrid-ssm",
     "mamba": "ssm",

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -666,7 +666,7 @@ def _load_quantized_state_dict(
     quantized_stems = set()
     quantized_embedding_stems = set()
     for mod_name, mod in module.named_modules():
-        if isinstance(mod, QuantizedLinear):
+        if isinstance(mod, QuantizedLinear) or getattr(mod, "_gguf_quantized_linear", False):
             quantized_stems.add(mod_name)
         elif isinstance(mod, QuantizedEmbedding):
             quantized_embedding_stems.add(mod_name)

--- a/src/mobius/integrations/gguf/_config_mapping.py
+++ b/src/mobius/integrations/gguf/_config_mapping.py
@@ -58,6 +58,7 @@ GGUF_ARCH_TO_MODEL_TYPE: dict[str, str] = {
     "nemotron": "nemotron",
     "t5": "t5",
     "hunyuan-dense": "hunyuan_v1_dense",
+    "deepseek4": "deepseek_v4",
     "deci": "llama",  # DeciLM uses Llama architecture
 }
 
@@ -87,6 +88,33 @@ _DEFAULT_KEY_MAP: dict[str, str] = {
     "ssm.group_count": "linear_num_key_heads",
     "ssm.time_step_rank": "linear_num_value_heads",
     "ssm.conv_kernel": "linear_conv_kernel_dim",
+}
+
+_ARCH_KEY_MAPS: dict[str, dict[str, str]] = {
+    "deepseek4": {
+        "attention.key_length": "head_dim",
+        "rope.dimension_count": "qk_rope_head_dim",
+        "attention.q_lora_rank": "q_lora_rank",
+        "attention.sliding_window": "sliding_window",
+        "expert_count": "num_local_experts",
+        "expert_used_count": "num_experts_per_tok",
+        "expert_feed_forward_length": "moe_intermediate_size",
+        "expert_shared_count": "n_shared_experts",
+        "expert_weights_scale": "routed_scaling_factor",
+        "expert_weights_norm": "norm_topk_prob",
+        "swiglu_clamp_exp": "swiglu_limit",
+        "attention.indexer.head_count": "index_n_heads",
+        "attention.indexer.key_length": "index_head_dim",
+        "attention.indexer.top_k": "index_topk",
+        "attention.output_group_count": "o_groups",
+        "attention.output_lora_rank": "o_lora_rank",
+        "attention.compress_ratios": "compress_ratios",
+        "attention.compress_rope_freq_base": "compress_rope_theta",
+        "hyper_connection.count": "hc_mult",
+        "hyper_connection.sinkhorn_iterations": "hc_sinkhorn_iters",
+        "hyper_connection.epsilon": "hc_eps",
+        "hash_layer_count": "num_hash_layers",
+    }
 }
 
 
@@ -142,12 +170,18 @@ def _extract_config_fields(
             gguf_arch,
             len(hf_fields),
         )
-    else:
-        # Fallback to standard key names
-        for gguf_suffix, hf_key in _DEFAULT_KEY_MAP.items():
-            full_key = f"{gguf_arch}.{gguf_suffix}"
-            if full_key in metadata:
-                hf_fields[hf_key] = metadata[full_key]
+    # Always apply standard and mobius architecture-specific mappings. This
+    # fills fields omitted by Transformers mappings and supports new GGUF
+    # architectures before they are added upstream.
+    fallback_mapping = {
+        **_DEFAULT_KEY_MAP,
+        **_ARCH_KEY_MAPS.get(gguf_arch, {}),
+    }
+    for gguf_suffix, hf_key in fallback_mapping.items():
+        full_key = f"{gguf_arch}.{gguf_suffix}"
+        if full_key in metadata:
+            hf_fields[hf_key] = metadata[full_key]
+    if hf_mapping is None:
         logger.debug(
             "Used default GGUF key mapping for '%s': %d fields",
             gguf_arch,
@@ -258,7 +292,9 @@ def gguf_to_config(
 
     # Derive rope_interleave from rope.dimension_sections metadata.
     rope_sections = metadata.get(f"{gguf_arch}.rope.dimension_sections")
-    rope_interleave = rope_sections is not None and any(s > 0 for s in rope_sections)
+    rope_interleave = gguf_arch == "deepseek4" or (
+        rope_sections is not None and any(s > 0 for s in rope_sections)
+    )
 
     # Derive rope_type from rope.scaling.type. GGUF stores the scaling
     # variant under ``<arch>.rope.scaling.type`` (or omits the key for the
@@ -285,6 +321,17 @@ def gguf_to_config(
                 rope_scaling_type,
             )
             rope_type = "default"
+
+    if rope_type == "yarn":
+        rope_scaling = {
+            "type": "yarn",
+            "factor": metadata.get(f"{gguf_arch}.rope.scaling.factor", 1.0),
+            "original_max_position_embeddings": metadata.get(
+                f"{gguf_arch}.rope.scaling.original_context_length"
+            ),
+            "beta_fast": metadata.get(f"{gguf_arch}.rope.scaling.yarn_beta_fast", 32.0),
+            "beta_slow": metadata.get(f"{gguf_arch}.rope.scaling.yarn_beta_slow", 1.0),
+        }
 
     # HunYuan-V1-Dense: HF runs dynamic-NTK RoPE with rope_theta=10000 and
     # alpha=1000. The Tencent quantization pipeline bakes those into a
@@ -318,6 +365,10 @@ def gguf_to_config(
 
     # Build config — required fields validated above, optional fields
     # use safe defaults
+    swiglu_limit = hf_fields.get("swiglu_limit", 0.0)
+    if isinstance(swiglu_limit, (list, np.ndarray)):
+        swiglu_limit = swiglu_limit[0] if len(swiglu_limit) else 0.0
+
     config = ArchitectureConfig(
         hidden_size=hidden_size,
         intermediate_size=hf_fields.get("intermediate_size", 4 * hidden_size),
@@ -346,6 +397,34 @@ def gguf_to_config(
         num_experts_per_tok=hf_fields.get("num_experts_per_tok"),
         moe_intermediate_size=hf_fields.get("moe_intermediate_size"),
         shared_expert_intermediate_size=hf_fields.get("shared_expert_intermediate_size"),
+        n_shared_experts=hf_fields.get("n_shared_experts"),
+        norm_topk_prob=hf_fields.get("norm_topk_prob", True),
+        routed_scaling_factor=hf_fields.get("routed_scaling_factor", 1.0),
+        scoring_func=(
+            "sqrtsoftplus"
+            if gguf_arch == "deepseek4"
+            else hf_fields.get("scoring_func", "softmax")
+        ),
+        q_lora_rank=hf_fields.get("q_lora_rank"),
+        qk_rope_head_dim=hf_fields.get("qk_rope_head_dim"),
+        o_groups=hf_fields.get("o_groups", 1),
+        o_lora_rank=hf_fields.get("o_lora_rank"),
+        index_n_heads=hf_fields.get("index_n_heads"),
+        index_head_dim=hf_fields.get("index_head_dim"),
+        index_topk=hf_fields.get("index_topk"),
+        compress_ratios=hf_fields.get("compress_ratios"),
+        compress_rope_theta=hf_fields.get("compress_rope_theta"),
+        hc_mult=hf_fields.get("hc_mult", 1),
+        hc_sinkhorn_iters=hf_fields.get("hc_sinkhorn_iters", 1),
+        hc_eps=hf_fields.get("hc_eps", 1e-6),
+        num_hash_layers=hf_fields.get("num_hash_layers", 0),
+        swiglu_limit=swiglu_limit,
+        sliding_window=hf_fields.get("sliding_window"),
+        original_max_position_embeddings=(
+            rope_scaling.get("original_max_position_embeddings")
+            if rope_scaling is not None
+            else None
+        ),
         # Hybrid architecture fields
         layer_types=layer_types,
         full_attention_interval=full_attention_interval,

--- a/src/mobius/integrations/gguf/_reader_test.py
+++ b/src/mobius/integrations/gguf/_reader_test.py
@@ -409,6 +409,69 @@ class TestConfigMapping:
         assert GGUF_ARCH_TO_MODEL_TYPE["mistral"] == "llama"
         assert GGUF_ARCH_TO_MODEL_TYPE["qwen2"] == "qwen2"
         assert GGUF_ARCH_TO_MODEL_TYPE["phi3"] == "phi3"
+        assert GGUF_ARCH_TO_MODEL_TYPE["deepseek4"] == "deepseek_v4"
+
+    def test_deepseek4_config_extraction(self):
+        metadata = {
+            "general.architecture": "deepseek4",
+            "deepseek4.embedding_length": 4096,
+            "deepseek4.block_count": 43,
+            "deepseek4.attention.head_count": 64,
+            "deepseek4.attention.head_count_kv": 1,
+            "deepseek4.attention.key_length": 512,
+            "deepseek4.context_length": 1048576,
+            "deepseek4.rope.dimension_count": 64,
+            "deepseek4.rope.freq_base": 10000.0,
+            "deepseek4.rope.scaling.type": "yarn",
+            "deepseek4.rope.scaling.factor": 16.0,
+            "deepseek4.rope.scaling.original_context_length": 65536,
+            "deepseek4.rope.scaling.yarn_beta_fast": 32.0,
+            "deepseek4.rope.scaling.yarn_beta_slow": 1.0,
+            "deepseek4.attention.layer_norm_rms_epsilon": 1e-6,
+            "deepseek4.expert_count": 256,
+            "deepseek4.expert_used_count": 6,
+            "deepseek4.expert_feed_forward_length": 2048,
+            "deepseek4.expert_shared_count": 1,
+            "deepseek4.expert_weights_scale": 1.5,
+            "deepseek4.expert_weights_norm": True,
+            "deepseek4.swiglu_clamp_exp": [10.0] * 43,
+            "deepseek4.attention.q_lora_rank": 1024,
+            "deepseek4.attention.sliding_window": 128,
+            "deepseek4.attention.output_group_count": 8,
+            "deepseek4.attention.output_lora_rank": 1024,
+            "deepseek4.attention.indexer.head_count": 64,
+            "deepseek4.attention.indexer.key_length": 128,
+            "deepseek4.attention.indexer.top_k": 512,
+            "deepseek4.attention.compress_ratios": [0, 0, 4, 128],
+            "deepseek4.attention.compress_rope_freq_base": 160000.0,
+            "deepseek4.hyper_connection.count": 4,
+            "deepseek4.hyper_connection.sinkhorn_iterations": 20,
+            "deepseek4.hyper_connection.epsilon": 1e-6,
+            "deepseek4.hash_layer_count": 3,
+        }
+
+        class _FakeModel:
+            architecture = "deepseek4"
+
+            def __init__(self, values):
+                self.metadata = values
+                self.tensor_names = ["token_embd.weight", "output.weight"]
+
+            def get_metadata(self, key, default=None):
+                return self.metadata.get(key, default)
+
+        config = gguf_to_config(_FakeModel(metadata))
+        assert config.model_type == "deepseek_v4"
+        assert config.head_dim == 512
+        assert config.qk_rope_head_dim == 64
+        assert config.num_local_experts == 256
+        assert config.scoring_func == "sqrtsoftplus"
+        assert config.hc_mult == 4
+        assert config.num_hash_layers == 3
+        assert config.swiglu_limit == pytest.approx(10.0)
+        assert config.rope_interleave is True
+        assert config.rope_type == "yarn"
+        assert config.original_max_position_embeddings == 65536
 
     def test_tie_embeddings_detected(self, tied_gguf: Path):
         model = GGUFModel(tied_gguf)

--- a/src/mobius/integrations/gguf/_tensor_mapping.py
+++ b/src/mobius/integrations/gguf/_tensor_mapping.py
@@ -208,6 +208,39 @@ _QWEN35MOE_EXTRAS: dict[str, str] = {
     "blk.{bid}.post_attention_norm": ("model.layers.{bid}.post_attention_layernorm"),
 }
 
+_DEEPSEEK4_MAPPING: dict[str, str] = {
+    "token_embd": "model.embed_tokens",
+    "output": "lm_head",
+    "output_norm": "model.norm",
+    "output_hc_fn": "model.hc_head_fn",
+    "output_hc_base": "model.hc_head_base@",
+    "output_hc_scale": "model.hc_head_scale@",
+    "blk.{bid}.attn_q_a": "model.layers.{bid}.self_attn.q_a_proj",
+    "blk.{bid}.attn_q_a_norm": "model.layers.{bid}.self_attn.q_a_layernorm",
+    "blk.{bid}.attn_q_b": "model.layers.{bid}.self_attn.q_b_proj",
+    "blk.{bid}.attn_kv": "model.layers.{bid}.self_attn.kv_proj",
+    "blk.{bid}.attn_kv_a_norm": "model.layers.{bid}.self_attn.kv_layernorm",
+    "blk.{bid}.attn_output_a": "model.layers.{bid}.self_attn.o_a_proj",
+    "blk.{bid}.attn_output_b": "model.layers.{bid}.self_attn.o_b_proj",
+    "blk.{bid}.attn_norm": "model.layers.{bid}.input_layernorm",
+    "blk.{bid}.ffn_norm": "model.layers.{bid}.post_attention_layernorm",
+    "blk.{bid}.ffn_gate_inp": "model.layers.{bid}.mlp.gate",
+    "blk.{bid}.exp_probs_b": "model.layers.{bid}.mlp.gate",
+    "blk.{bid}.ffn_gate_tid2eid": "model.layers.{bid}.mlp.gate.tid2eid@",
+    "blk.{bid}.ffn_gate_exps": "model.layers.{bid}.mlp.experts.gate_proj",
+    "blk.{bid}.ffn_up_exps": "model.layers.{bid}.mlp.experts.up_proj",
+    "blk.{bid}.ffn_down_exps": "model.layers.{bid}.mlp.experts.down_proj",
+    "blk.{bid}.ffn_gate_shexp": "model.layers.{bid}.mlp.shared_experts.gate_proj",
+    "blk.{bid}.ffn_up_shexp": "model.layers.{bid}.mlp.shared_experts.up_proj",
+    "blk.{bid}.ffn_down_shexp": "model.layers.{bid}.mlp.shared_experts.down_proj",
+    "blk.{bid}.hc_attn_fn": "model.layers.{bid}.hc_attn_fn",
+    "blk.{bid}.hc_attn_base": "model.layers.{bid}.hc_attn_base@",
+    "blk.{bid}.hc_attn_scale": "model.layers.{bid}.hc_attn_scale@",
+    "blk.{bid}.hc_ffn_fn": "model.layers.{bid}.hc_ffn_fn",
+    "blk.{bid}.hc_ffn_base": "model.layers.{bid}.hc_ffn_base@",
+    "blk.{bid}.hc_ffn_scale": "model.layers.{bid}.hc_ffn_scale@",
+}
+
 # Architectures sharing the llama HF naming convention.
 _LLAMA_FAMILY = frozenset(
     {
@@ -305,13 +338,15 @@ def _build_mapping(
         result.update(_MOE_EXTRAS)
         if arch == "qwen35moe":
             result.update(_QWEN35MOE_EXTRAS)
+    elif arch == "deepseek4":
+        result = dict(_DEEPSEEK4_MAPPING)
     else:
         supported = sorted(
             _LLAMA_FAMILY
             | _GEMMA_FAMILY
             | _MOE_FAMILY
             | _HUNYUAN_FAMILY
-            | {"gemma4", "phi3", "falcon", "gpt2", "mamba"}
+            | {"deepseek4", "gemma4", "phi3", "falcon", "gpt2", "mamba"}
         )
         raise ValueError(
             f"Unsupported GGUF architecture: {architecture!r}. "
@@ -367,10 +402,15 @@ def map_gguf_to_hf_names(
         lookup = _BLK_PATTERN.sub(_BLK_TEMPLATE, stem)
         hf_pattern = mapping.get(lookup)
         if hf_pattern is not None:
-            return hf_pattern.replace("{bid}", bid) + suffix
+            hf_pattern = hf_pattern.replace("{bid}", bid)
+            if hf_pattern.endswith("@"):
+                return hf_pattern[:-1]
+            return hf_pattern + suffix
     else:
         hf_stem = mapping.get(stem)
         if hf_stem is not None:
+            if hf_stem.endswith("@"):
+                return hf_stem[:-1]
             return hf_stem + suffix
 
     return None

--- a/src/mobius/integrations/gguf/_tensor_mapping.py
+++ b/src/mobius/integrations/gguf/_tensor_mapping.py
@@ -222,6 +222,23 @@ _DEEPSEEK4_MAPPING: dict[str, str] = {
     "blk.{bid}.attn_kv_a_norm": "model.layers.{bid}.self_attn.kv_layernorm",
     "blk.{bid}.attn_output_a": "model.layers.{bid}.self_attn.o_a_proj",
     "blk.{bid}.attn_output_b": "model.layers.{bid}.self_attn.o_b_proj",
+    "blk.{bid}.attn_sinks": "model.layers.{bid}.self_attn.attn_sink@",
+    "blk.{bid}.attn_compressor_kv": "model.layers.{bid}.self_attn.compressor.wkv",
+    "blk.{bid}.attn_compressor_gate": "model.layers.{bid}.self_attn.compressor.wgate",
+    "blk.{bid}.attn_compressor_ape": "model.layers.{bid}.self_attn.compressor.ape@",
+    "blk.{bid}.attn_compressor_norm": "model.layers.{bid}.self_attn.compressor.norm",
+    "blk.{bid}.indexer.attn_q_b": "model.layers.{bid}.self_attn.indexer.wq_b",
+    "blk.{bid}.indexer.proj": "model.layers.{bid}.self_attn.indexer.weights_proj",
+    "blk.{bid}.indexer_compressor_kv": ("model.layers.{bid}.self_attn.indexer.compressor.wkv"),
+    "blk.{bid}.indexer_compressor_gate": (
+        "model.layers.{bid}.self_attn.indexer.compressor.wgate"
+    ),
+    "blk.{bid}.indexer_compressor_ape": (
+        "model.layers.{bid}.self_attn.indexer.compressor.ape@"
+    ),
+    "blk.{bid}.indexer_compressor_norm": (
+        "model.layers.{bid}.self_attn.indexer.compressor.norm"
+    ),
     "blk.{bid}.attn_norm": "model.layers.{bid}.input_layernorm",
     "blk.{bid}.ffn_norm": "model.layers.{bid}.post_attention_layernorm",
     "blk.{bid}.ffn_gate_inp": "model.layers.{bid}.mlp.gate",

--- a/src/mobius/integrations/gguf/_tensor_mapping_test.py
+++ b/src/mobius/integrations/gguf/_tensor_mapping_test.py
@@ -297,6 +297,15 @@ class TestMapGGUFToHFNames:
             "blk.2.ffn_gate_tid2eid.weight": "model.layers.2.mlp.gate.tid2eid",
             "blk.2.exp_probs_b.bias": "model.layers.2.mlp.gate.bias",
             "blk.2.hc_attn_fn.weight": "model.layers.2.hc_attn_fn.weight",
+            "blk.2.attn_sinks.weight": "model.layers.2.self_attn.attn_sink",
+            "blk.2.attn_compressor_ape.weight": ("model.layers.2.self_attn.compressor.ape"),
+            "blk.2.attn_compressor_kv.weight": (
+                "model.layers.2.self_attn.compressor.wkv.weight"
+            ),
+            "blk.2.indexer.attn_q_b.weight": ("model.layers.2.self_attn.indexer.wq_b.weight"),
+            "blk.2.indexer_compressor_norm.weight": (
+                "model.layers.2.self_attn.indexer.compressor.norm.weight"
+            ),
             "output_hc_fn.weight": "model.hc_head_fn.weight",
             "output_hc_base.weight": "model.hc_head_base",
         }

--- a/src/mobius/integrations/gguf/_tensor_mapping_test.py
+++ b/src/mobius/integrations/gguf/_tensor_mapping_test.py
@@ -289,6 +289,20 @@ class TestMapGGUFToHFNames:
             "model.layers.0.mlp.experts.gate_proj.weight"
         )
 
+    def test_deepseek4_mapping(self) -> None:
+        expected = {
+            "blk.2.attn_q_a.weight": "model.layers.2.self_attn.q_a_proj.weight",
+            "blk.2.attn_kv.weight": "model.layers.2.self_attn.kv_proj.weight",
+            "blk.2.attn_output_a.weight": "model.layers.2.self_attn.o_a_proj.weight",
+            "blk.2.ffn_gate_tid2eid.weight": "model.layers.2.mlp.gate.tid2eid",
+            "blk.2.exp_probs_b.bias": "model.layers.2.mlp.gate.bias",
+            "blk.2.hc_attn_fn.weight": "model.layers.2.hc_attn_fn.weight",
+            "output_hc_fn.weight": "model.hc_head_fn.weight",
+            "output_hc_base.weight": "model.hc_head_base",
+        }
+        for source, target in expected.items():
+            assert map_gguf_to_hf_names(source, "deepseek4") == target
+
     # ---- Unsupported architecture ----
 
     def test_unsupported_raises(self) -> None:

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -719,7 +719,9 @@ def _write_genai_config(
         decoder_inputs["past_value_names"] = "past_key_values.%d.value"
 
     # Derive decoder filename from the actual package key
-    decoder_filename = f"{decoder_key}/model.onnx" if decoder_key != "model" else "model.onnx"
+    decoder_filename = (
+        f"{decoder_key}/model.onnx" if len(pkg) > 1 or decoder_key != "model" else "model.onnx"
+    )
 
     # ORT GenAI's ``past_present_share_buffer`` mode requires the decoder
     # graph to write the KV cache in place. Only ``com.microsoft.
@@ -985,6 +987,34 @@ def write_ort_genai_config(
     )
 
     result: dict[str, str] = {"genai_config": genai_path}
+
+    if "mtp" in pkg:
+        mtp_model = pkg["mtp"]
+        mtp_path = os.path.join(directory, "mtp_config.json")
+        with open(mtp_path, "w") as f:
+            json.dump(
+                {
+                    "model": {"filename": "mtp/model.onnx"},
+                    "inputs": [
+                        value.name
+                        for value in mtp_model.graph.inputs
+                        if value.name is not None
+                    ],
+                    "outputs": [
+                        value.name
+                        for value in mtp_model.graph.outputs
+                        if value.name is not None
+                    ],
+                    "num_nextn_predict_layers": getattr(config, "num_nextn_predict_layers", 0),
+                    "shared_embedding": "model.embed_tokens",
+                    "shared_lm_head": "lm_head",
+                    "runtime_orchestration": "external",
+                },
+                f,
+                indent=2,
+            )
+            f.write("\n")
+        result["mtp_config"] = mtp_path
 
     # Copy tokenizer files — HF Hub takes precedence; local dir is the fallback
     # for --config mode where no HF model ID is available.

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -86,6 +86,7 @@ _ORT_GENAI_MODEL_TYPE: dict[str, str] = {
     # HunYuan-V1 dense / Hy-MT1.5 — generic decoder LLM type accepted by
     # ORT GenAI (see onnxruntime-genai/src/models/model_type.h LLM list).
     "hunyuan_v1_dense": "decoder",
+    "deepseek_v4": "decoder",
     # Qwen VL models all use the same GenAI pipeline as qwen2_5_vl
     "qwen2_vl": "qwen2_5_vl",
     "qwen3_vl": "qwen2_5_vl",

--- a/src/mobius/models/__init__.py
+++ b/src/mobius/models/__init__.py
@@ -25,6 +25,7 @@ __all__ = [
     "ControlNetModel",
     "DeepSeekOCR2CausalLMModel",
     "DeepSeekV3CausalLMModel",
+    "DeepSeekV4CausalLMModel",
     "DFlashDraftModel",
     "Eagle3DraftModel",
     "DiTTransformer2DModel",
@@ -164,6 +165,7 @@ from mobius.models.controlnet import ControlNetModel
 from mobius.models.ctrl import CTRLCausalLMModel
 from mobius.models.deepseek import DeepSeekV3CausalLMModel
 from mobius.models.deepseek_ocr2 import DeepSeekOCR2CausalLMModel
+from mobius.models.deepseek_v4 import DeepSeekV4CausalLMModel
 from mobius.models.dflash import DFlashDraftModel
 from mobius.models.diffllama import DiffLlamaCausalLMModel
 from mobius.models.distilbert import DistilBertModel

--- a/src/mobius/models/deepseek_v4.py
+++ b/src/mobius/models/deepseek_v4.py
@@ -1,17 +1,21 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""DeepSeek-V4 dense-backbone export.
+"""DeepSeek-V4 export with a sink-aware dense CSA fallback and MTP sidecar.
 
 The released V4 architecture replaces V3 MLA with compressed sparse attention
 and adds Hyper-Connections. This module implements the V4 projections,
 Hyper-Connections, hash/sqrt-softplus MoE routing, and a dense causal-attention
-fallback. Learned KV compression, sparse indexing, attention sinks, and MTP are
-intentionally deferred until the runtime exposes suitable cache/sparse ops.
+fallback with the learned attention sinks. The official per-layer compression
+schedule is represented by exported compressor/indexer tensors, and the
+checkpoint's MTP block is exported as a standalone sidecar. Executing learned
+KV compression and sparse selection still requires runtime cache/sparse ops;
+until those land, the target and MTP graphs attend densely for correctness.
 """
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 
 import onnx_ir as ir
@@ -45,6 +49,78 @@ def _projection_class(config: ArchitectureConfig):
         has_zero_point=not quantization.sym,
         zero_point_dtype=zero_point_dtype,
     )
+
+
+def _shape_anchor(op: OpBuilder, parameters: list[ir.Value]) -> ir.Value:
+    """Reference one element of each deferred-runtime tensor and produce zero."""
+    total = None
+    for parameter in parameters:
+        first = op.Gather(op.Reshape(parameter, [-1]), [0])
+        present = op.Cast(
+            op.Equal(first, first),
+            to=ir.DataType.INT64,
+        )
+        total = present if total is None else op.Add(total, present)
+    assert total is not None
+    return op.ReduceSum(op.Mul(total, 0), [0], keepdims=False)
+
+
+class DeepSeekV4DeferredProjection(nn.Module):
+    """Projection parameters exported for a runtime path not yet executed."""
+
+    def __init__(
+        self,
+        config: ArchitectureConfig,
+        in_features: int,
+        out_features: int,
+    ):
+        super().__init__()
+        quantization = config.quantization
+        self._gguf_quantized_linear = (
+            quantization is not None and quantization.quant_method != "none"
+        )
+        if quantization is None or quantization.quant_method == "none":
+            self.weight = nn.Parameter([out_features, in_features])
+            self.scales = None
+            self.zero_points = None
+            return
+
+        n_blocks = (in_features + quantization.group_size - 1) // quantization.group_size
+        blob_size = quantization.group_size * quantization.bits // 8
+        self.weight = nn.Parameter(
+            [out_features, n_blocks, blob_size],
+            dtype=ir.DataType.UINT8,
+        )
+        self.scales = nn.Parameter([out_features, n_blocks])
+        if quantization.sym:
+            self.zero_points = None
+        elif quantization.float_zero_point:
+            self.zero_points = nn.Parameter([out_features, n_blocks], dtype=config.dtype)
+        else:
+            packed_zero_points = (n_blocks * quantization.bits + 7) // 8
+            self.zero_points = nn.Parameter(
+                [out_features, packed_zero_points],
+                dtype=ir.DataType.UINT8,
+            )
+
+    def forward(self, op: OpBuilder) -> ir.Value:
+        return _shape_anchor(
+            op,
+            [
+                value
+                for value in (self.weight, self.scales, self.zero_points)
+                if value is not None
+            ],
+        )
+
+
+class DeepSeekV4DeferredNorm(nn.Module):
+    def __init__(self, hidden_size: int):
+        super().__init__()
+        self.weight = nn.Parameter([hidden_size])
+
+    def forward(self, op: OpBuilder) -> ir.Value:
+        return _shape_anchor(op, [self.weight])
 
 
 class DeepSeekV4Gate(nn.Module):
@@ -158,10 +234,62 @@ class DeepSeekV4MoE(nn.Module):
         return op.Add(result, self.shared_experts(op, hidden_states))
 
 
-class DeepSeekV4Attention(nn.Module):
-    """V4 MQA projections using dense causal attention as a safe fallback."""
+class DeepSeekV4CompressorTensors(nn.Module):
+    """Official learned compressor tensors retained for sparse-runtime handoff."""
+
+    def __init__(self, config: ArchitectureConfig, compress_ratio: int, head_dim: int):
+        super().__init__()
+        overlap_factor = 2 if compress_ratio == 4 else 1
+        self.ape = nn.Parameter([compress_ratio, overlap_factor * head_dim])
+        self.wkv = DeepSeekV4DeferredProjection(
+            config, config.hidden_size, overlap_factor * head_dim
+        )
+        self.wgate = DeepSeekV4DeferredProjection(
+            config, config.hidden_size, overlap_factor * head_dim
+        )
+        self.norm = DeepSeekV4DeferredNorm(head_dim)
+
+    def forward(self, op: OpBuilder) -> ir.Value:
+        anchor = _shape_anchor(
+            op,
+            [
+                self.ape,
+            ],
+        )
+        anchor = op.Add(anchor, self.wkv(op))
+        anchor = op.Add(anchor, self.wgate(op))
+        return op.Add(anchor, self.norm(op))
+
+
+class DeepSeekV4IndexerTensors(nn.Module):
+    """Official ratio-4 sparse indexer tensors retained in the dense graph."""
 
     def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+        assert config.q_lora_rank is not None
+        assert config.index_n_heads is not None
+        assert config.index_head_dim is not None
+        self.wq_b = DeepSeekV4DeferredProjection(
+            config,
+            config.q_lora_rank,
+            config.index_n_heads * config.index_head_dim,
+        )
+        self.weights_proj = DeepSeekV4DeferredProjection(
+            config, config.hidden_size, config.index_n_heads
+        )
+        self.compressor = DeepSeekV4CompressorTensors(
+            config, compress_ratio=4, head_dim=config.index_head_dim
+        )
+
+    def forward(self, op: OpBuilder) -> ir.Value:
+        own = op.Add(self.wq_b(op), self.weights_proj(op))
+        return op.Add(own, self.compressor(op))
+
+
+class DeepSeekV4Attention(nn.Module):
+    """V4 MQA projections using sink-aware dense causal attention."""
+
+    def __init__(self, config: ArchitectureConfig, layer_id: int):
         super().__init__()
         assert config.q_lora_rank is not None
         assert config.qk_rope_head_dim is not None
@@ -198,6 +326,20 @@ class DeepSeekV4Attention(nn.Module):
         self.eps = config.rms_norm_eps
         self.scale = self.head_dim**-0.5
         self.rope_interleave = config.rope_interleave
+        ratios = config.compress_ratios or []
+        self.compress_ratio = ratios[layer_id] if layer_id < len(ratios) else 0
+        if self.compress_ratio not in (0, 4, 128):
+            raise ValueError(
+                "DeepSeek-V4 supports compression ratios 0, 4, and 128; "
+                f"layer {layer_id} requested {self.compress_ratio}"
+            )
+        self.attn_sink = nn.Parameter([self.num_heads], dtype=ir.DataType.FLOAT)
+        self.compressor = (
+            DeepSeekV4CompressorTensors(config, self.compress_ratio, self.head_dim)
+            if self.compress_ratio
+            else None
+        )
+        self.indexer = DeepSeekV4IndexerTensors(config) if self.compress_ratio == 4 else None
 
     def _rotate(
         self,
@@ -224,6 +366,35 @@ class DeepSeekV4Attention(nn.Module):
         rope = op.Reshape(rope, [0, 0, num_heads, self.rope_dim])
         return op.Reshape(op.Concat(nope, rope, axis=-1), [0, 0, -1])
 
+    def _expand_kv(
+        self,
+        op: OpBuilder,
+        value: ir.Value,
+        batch: ir.Value,
+        sequence_length: ir.Value,
+    ) -> ir.Value:
+        value = op.Unsqueeze(value, [2])
+        value = op.Expand(
+            value,
+            op.Concat(
+                batch,
+                [1, self.num_heads],
+                sequence_length,
+                [self.head_dim],
+                axis=0,
+            ),
+        )
+        return op.Reshape(
+            value,
+            op.Concat(
+                batch,
+                [self.num_heads],
+                sequence_length,
+                [self.head_dim],
+                axis=0,
+            ),
+        )
+
     def forward(
         self,
         op: OpBuilder,
@@ -245,19 +416,47 @@ class DeepSeekV4Attention(nn.Module):
 
         kv = self.kv_layernorm(op, self.kv_proj(op, hidden_states))
         kv = self._rotate(op, kv, position_embeddings, 1)
-        output, present_key, present_value = op.Attention(
-            query,
-            kv,
-            kv,
-            attention_bias,
-            past_key_value[0] if past_key_value is not None else None,
-            past_key_value[1] if past_key_value is not None else None,
-            q_num_heads=self.num_heads,
-            kv_num_heads=1,
-            scale=self.scale,
-            _outputs=3,
+        batch = op.Shape(query, start=0, end=1)
+        query_length = op.Shape(query, start=1, end=2)
+        query = op.Transpose(
+            op.Reshape(query, [0, 0, self.num_heads, self.head_dim]),
+            perm=[0, 2, 1, 3],
+        )
+        key = op.Transpose(op.Reshape(kv, [0, 0, 1, self.head_dim]), perm=[0, 2, 1, 3])
+        value = key
+        if past_key_value is not None:
+            key = op.Concat(past_key_value[0], key, axis=2)
+            value = op.Concat(past_key_value[1], value, axis=2)
+        present_key, present_value = key, value
+
+        kv_length = op.Shape(key, start=2, end=3)
+        key = self._expand_kv(op, key, batch, kv_length)
+        value = self._expand_kv(op, value, batch, kv_length)
+        scores = op.Mul(
+            op.MatMul(query, op.Transpose(key, perm=[0, 1, 3, 2])),
+            self.scale,
+        )
+        scores = op.Add(scores, attention_bias)
+        sinks = op.Expand(
+            op.Reshape(
+                op.CastLike(self.attn_sink, scores),
+                [1, self.num_heads, 1, 1],
+            ),
+            op.Concat(batch, [self.num_heads], query_length, [1], axis=0),
+        )
+        probabilities = op.Softmax(op.Concat(scores, sinks, axis=-1), axis=-1)
+        probabilities = op.Slice(probabilities, [0], [-1], [3])
+        output = op.Reshape(
+            op.Transpose(op.MatMul(probabilities, value), perm=[0, 2, 1, 3]),
+            [0, 0, -1],
         )
         output = self._rotate(op, output, position_embeddings, self.num_heads, inverse=True)
+
+        if self.compressor is not None:
+            anchor = self.compressor(op)
+            if self.indexer is not None:
+                anchor = op.Add(anchor, self.indexer(op))
+            output = op.Add(output, op.CastLike(anchor, output))
 
         group_width = self.num_heads * self.head_dim // self.o_groups
         groups = op.Split(
@@ -284,7 +483,7 @@ class DeepSeekV4Attention(nn.Module):
 class DeepSeekV4DecoderLayer(nn.Module):
     def __init__(self, config: ArchitectureConfig, layer_id: int):
         super().__init__()
-        self.self_attn = DeepSeekV4Attention(config)
+        self.self_attn = DeepSeekV4Attention(config, layer_id)
         self.mlp = DeepSeekV4MoE(config, layer_id)
         self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
@@ -420,10 +619,21 @@ class DeepSeekV4TextModel(nn.Module):
         self.hc_head_scale = nn.Parameter([1])
         rope_config = config
         if config.qk_rope_head_dim is not None:
-            import dataclasses
-
             rope_config = dataclasses.replace(config, head_dim=config.qk_rope_head_dim)
-        self.rotary_emb = initialize_rope(rope_config)
+        self.rotary_emb = initialize_rope(
+            dataclasses.replace(
+                rope_config,
+                rope_type="default",
+                rope_scaling=None,
+                original_max_position_embeddings=None,
+            )
+        )
+        self.compressed_rotary_emb = initialize_rope(
+            dataclasses.replace(
+                rope_config,
+                rope_theta=config.compress_rope_theta or config.rope_theta,
+            )
+        )
         self._dtype = config.dtype
 
     def _hc_head(self, op, states):
@@ -458,6 +668,7 @@ class DeepSeekV4TextModel(nn.Module):
             [1, 1, self.hc_mult, 1],
         )
         position_embeddings = self.rotary_emb(op, position_ids)
+        compressed_position_embeddings = self.compressed_rotary_emb(op, position_ids)
         attention_bias = create_attention_bias(
             op,
             input_ids=hidden_states if input_ids is None else input_ids,
@@ -467,30 +678,104 @@ class DeepSeekV4TextModel(nn.Module):
         presents = []
         past_kvs = past_key_values or [None] * len(self.layers)
         for layer, past_kv in zip(self.layers, past_kvs):
+            layer_position_embeddings = (
+                compressed_position_embeddings
+                if layer.self_attn.compress_ratio
+                else position_embeddings
+            )
             hidden_states, present = layer(
                 op,
                 hidden_states,
                 input_ids,
                 attention_bias,
-                position_embeddings,
+                layer_position_embeddings,
                 past_kv,
             )
             presents.append(present)
-        return self.norm(op, self._hc_head(op, hidden_states)), presents
+        return self.norm(op, self._hc_head(op, hidden_states)), presents, hidden_states
+
+
+class DeepSeekV4Mtp(DeepSeekV4DecoderLayer):
+    """Official single MTP block, sharing target embeddings and LM head externally."""
+
+    def __init__(self, config: ArchitectureConfig, layer_id: int):
+        super().__init__(config, layer_id)
+        projection = _projection_class(config)
+        self.e_proj = projection(config.hidden_size, config.hidden_size, bias=False)
+        self.h_proj = projection(config.hidden_size, config.hidden_size, bias=False)
+        self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hc_head_fn = Linear(
+            config.hc_mult * config.hidden_size, config.hc_mult, bias=False
+        )
+        self.hc_head_base = nn.Parameter([config.hc_mult])
+        self.hc_head_scale = nn.Parameter([1])
+        self.hc_mult = config.hc_mult
+        self.hc_eps = config.hc_eps
+        rope_config = dataclasses.replace(
+            config,
+            head_dim=config.qk_rope_head_dim,
+            rope_type="default",
+            rope_scaling=None,
+            original_max_position_embeddings=None,
+        )
+        self.rotary_emb = initialize_rope(rope_config)
+        self._dtype = config.dtype
+
+    def _hc_head(self, op: OpBuilder, states: ir.Value) -> ir.Value:
+        flat = op.Reshape(states, [0, 0, -1])
+        rms = op.Sqrt(op.Add(op.ReduceMean(op.Mul(flat, flat), [-1], keepdims=True), 1e-6))
+        mixes = op.Div(self.hc_head_fn(op, flat), rms)
+        weights = op.Add(
+            op.Sigmoid(op.Add(op.Mul(mixes, self.hc_head_scale), self.hc_head_base)),
+            self.hc_eps,
+        )
+        return op.ReduceSum(op.Mul(op.Unsqueeze(weights, [-1]), states), [2], keepdims=False)
+
+    def forward(
+        self,
+        op: OpBuilder,
+        inputs_embeds: ir.Value,
+        hidden_states: ir.Value,
+        attention_mask: ir.Value,
+        position_ids: ir.Value,
+        past_key_value: tuple | None = None,
+    ):
+        hidden_states = op.Add(
+            op.Unsqueeze(self.e_proj(op, self.enorm(op, inputs_embeds)), [2]),
+            self.h_proj(op, self.hnorm(op, hidden_states)),
+        )
+        position_embeddings = self.rotary_emb(op, position_ids)
+        attention_bias = create_attention_bias(
+            op,
+            input_ids=inputs_embeds,
+            attention_mask=attention_mask,
+            dtype=self._dtype,
+        )
+        hidden_states, present = super().forward(
+            op,
+            hidden_states,
+            None,
+            attention_bias,
+            position_embeddings,
+            past_key_value,
+        )
+        return self.norm(op, self._hc_head(op, hidden_states)), present
 
 
 class DeepSeekV4CausalLMModel(CausalLMModel):
-    """DeepSeek-V4 Causal LM with dense HCA fallback and V4 MoE/HC blocks."""
+    """DeepSeek-V4 Causal LM with dense CSA fallback and an MTP sidecar."""
 
-    default_task: str = "text-generation"
+    default_task: str = "deepseek-v4"
     category: str = "Mixture of Experts"
 
     def __init__(self, config: ArchitectureConfig):
         nn.Module.__init__(self)
         if any(config.compress_ratios or ()):
             logger.warning(
-                "DeepSeek-V4 compressed sparse attention is not implemented; "
-                "exporting the dense causal-attention preview backbone."
+                "DeepSeek-V4 sparse cache execution requires runtime support; "
+                "exporting sink-aware dense attention with CSA/HCA tensors retained."
             )
         self.config = config
         self.model = DeepSeekV4TextModel(config)
@@ -500,6 +785,31 @@ class DeepSeekV4CausalLMModel(CausalLMModel):
             )
         else:
             self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+        if config.num_nextn_predict_layers not in (0, 1):
+            raise ValueError("DeepSeek-V4 MTP export supports exactly one MTP layer")
+        self.mtp = nn.ModuleList(
+            [
+                DeepSeekV4Mtp(config, config.num_hidden_layers + index)
+                for index in range(config.num_nextn_predict_layers)
+            ]
+        )
+
+    def forward(
+        self,
+        op: OpBuilder,
+        input_ids: ir.Value,
+        attention_mask: ir.Value,
+        position_ids: ir.Value,
+        past_key_values: list | None = None,
+    ):
+        hidden_states, presents, _ = self.model(
+            op,
+            input_ids,
+            attention_mask,
+            position_ids,
+            past_key_values,
+        )
+        return self.lm_head(op, hidden_states), presents
 
     def preprocess_weights(
         self, state_dict: dict[str, torch.Tensor]
@@ -508,14 +818,7 @@ class DeepSeekV4CausalLMModel(CausalLMModel):
         renamed: dict[str, torch.Tensor] = {}
         skipped = 0
         for key, value in state_dict.items():
-            if key.startswith("mtp.") or any(
-                marker in key
-                for marker in (
-                    ".compressor.",
-                    ".indexer.",
-                    ".attn.attn_sink",
-                )
-            ):
+            if key.startswith("mtp.") and len(self.mtp) == 0:
                 skipped += 1
                 continue
             new_key = key
@@ -533,6 +836,16 @@ class DeepSeekV4CausalLMModel(CausalLMModel):
                 )
             elif new_key.startswith("layers."):
                 new_key = f"model.{new_key}"
+            elif new_key.startswith("mtp."):
+                try:
+                    mtp_index = int(new_key.split(".", 2)[1])
+                except (IndexError, ValueError):
+                    skipped += 1
+                    continue
+                if mtp_index >= len(self.mtp):
+                    skipped += 1
+                    continue
+            if new_key.startswith(("model.layers.", "mtp.")):
                 new_key = new_key.replace(".attn.wq_a.", ".self_attn.q_a_proj.")
                 new_key = new_key.replace(".attn.q_norm.", ".self_attn.q_a_layernorm.")
                 new_key = new_key.replace(".attn.wq_b.", ".self_attn.q_b_proj.")
@@ -540,6 +853,7 @@ class DeepSeekV4CausalLMModel(CausalLMModel):
                 new_key = new_key.replace(".attn.kv_norm.", ".self_attn.kv_layernorm.")
                 new_key = new_key.replace(".attn.wo_a.", ".self_attn.o_a_proj.")
                 new_key = new_key.replace(".attn.wo_b.", ".self_attn.o_b_proj.")
+                new_key = new_key.replace(".attn.", ".self_attn.")
                 new_key = new_key.replace(".attn_norm.", ".input_layernorm.")
                 new_key = new_key.replace(".ffn_norm.", ".post_attention_layernorm.")
                 new_key = new_key.replace(".ffn.gate.", ".mlp.gate.")
@@ -553,8 +867,8 @@ class DeepSeekV4CausalLMModel(CausalLMModel):
             renamed[new_key] = value
         if skipped:
             logger.warning(
-                "Skipped %d DeepSeek-V4 CSA/HCA/MTP tensors unsupported by "
-                "the dense preview backbone.",
+                "Skipped %d DeepSeek-V4 MTP tensors outside the configured "
+                "num_nextn_predict_layers.",
                 skipped,
             )
         return super().preprocess_weights(renamed)

--- a/src/mobius/models/deepseek_v4.py
+++ b/src/mobius/models/deepseek_v4.py
@@ -136,12 +136,13 @@ class DeepSeekV4Gate(nn.Module):
         self.score_func = config.scoring_func
         self.hash_routing = layer_id < config.num_hash_layers
         self.weight = nn.Parameter([self.num_experts, config.hidden_size])
+        # Hash-routed layers do not consume this bias, but DeepSeek V4 GGUF
+        # checkpoints provide it for every layer.
+        self.bias = nn.Parameter([self.num_experts])
         if self.hash_routing:
             self.tid2eid = nn.Parameter(
                 [config.vocab_size, self.top_k], dtype=ir.DataType.INT32
             )
-        else:
-            self.bias = nn.Parameter([self.num_experts])
 
     def forward(
         self,
@@ -161,7 +162,10 @@ class DeepSeekV4Gate(nn.Module):
             scores = op.Sqrt(op.Softplus(logits))
 
         if self.hash_routing:
-            selected_experts = op.Gather(self.tid2eid, input_ids, axis=0)
+            selected_experts = op.Cast(
+                op.Gather(self.tid2eid, input_ids, axis=0),
+                to=ir.DataType.INT64.value,
+            )
         else:
             choice_scores = op.Add(scores, self.bias)
             _, selected_experts = op.TopK(

--- a/src/mobius/models/deepseek_v4.py
+++ b/src/mobius/models/deepseek_v4.py
@@ -1,0 +1,560 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""DeepSeek-V4 dense-backbone export.
+
+The released V4 architecture replaces V3 MLA with compressed sparse attention
+and adds Hyper-Connections. This module implements the V4 projections,
+Hyper-Connections, hash/sqrt-softplus MoE routing, and a dense causal-attention
+fallback. Learned KV compression, sparse indexing, attention sinks, and MTP are
+intentionally deferred until the runtime exposes suitable cache/sparse ops.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import onnx_ir as ir
+import torch
+from onnxscript import OpBuilder, nn
+
+from mobius._configs import ArchitectureConfig
+from mobius.components import (
+    Embedding,
+    Linear,
+    QuantizedEmbedding,
+    RMSNorm,
+    create_attention_bias,
+    initialize_rope,
+    make_quantized_linear_factory,
+)
+from mobius.components._rotary_embedding import apply_rotary_pos_emb
+from mobius.models.base import CausalLMModel
+
+logger = logging.getLogger(__name__)
+
+
+def _projection_class(config: ArchitectureConfig):
+    quantization = config.quantization
+    if quantization is None or quantization.quant_method == "none":
+        return Linear
+    zero_point_dtype = config.dtype if quantization.float_zero_point else ir.DataType.UINT8
+    return make_quantized_linear_factory(
+        bits=quantization.bits,
+        block_size=quantization.group_size,
+        has_zero_point=not quantization.sym,
+        zero_point_dtype=zero_point_dtype,
+    )
+
+
+class DeepSeekV4Gate(nn.Module):
+    """V4 sqrt-softplus router with hash routing for the first layers."""
+
+    def __init__(self, config: ArchitectureConfig, layer_id: int):
+        super().__init__()
+        assert config.num_local_experts is not None
+        assert config.num_experts_per_tok is not None
+        self.num_experts = config.num_local_experts
+        self.top_k = config.num_experts_per_tok
+        self.route_scale = config.routed_scaling_factor
+        self.score_func = config.scoring_func
+        self.hash_routing = layer_id < config.num_hash_layers
+        self.weight = nn.Parameter([self.num_experts, config.hidden_size])
+        if self.hash_routing:
+            self.tid2eid = nn.Parameter(
+                [config.vocab_size, self.top_k], dtype=ir.DataType.INT32
+            )
+        else:
+            self.bias = nn.Parameter([self.num_experts])
+
+    def forward(
+        self,
+        op: OpBuilder,
+        hidden_states: ir.Value,
+        input_ids: ir.Value,
+    ):
+        logits = op.MatMul(
+            op.Cast(hidden_states, to=ir.DataType.FLOAT.value),
+            op.Transpose(self.weight, perm=[1, 0]),
+        )
+        if self.score_func == "softmax":
+            scores = op.Softmax(logits, axis=-1)
+        elif self.score_func == "sigmoid":
+            scores = op.Sigmoid(logits)
+        else:
+            scores = op.Sqrt(op.Softplus(logits))
+
+        if self.hash_routing:
+            selected_experts = op.Gather(self.tid2eid, input_ids, axis=0)
+        else:
+            choice_scores = op.Add(scores, self.bias)
+            _, selected_experts = op.TopK(
+                choice_scores,
+                op.Constant(value_ints=[self.top_k]),
+                axis=-1,
+                _outputs=2,
+            )
+
+        routing_weights = op.GatherElements(scores, selected_experts, axis=-1)
+        if self.score_func != "softmax":
+            weight_sum = op.ReduceSum(routing_weights, [-1], keepdims=True)
+            routing_weights = op.Div(routing_weights, op.Add(weight_sum, 1e-20))
+        if self.route_scale != 1.0:  # noqa: RUF069
+            routing_weights = op.Mul(routing_weights, self.route_scale)
+        return routing_weights, selected_experts
+
+
+class _DeepSeekV4Expert(nn.Module):
+    def __init__(self, config: ArchitectureConfig, intermediate_size: int):
+        super().__init__()
+        projection = _projection_class(config)
+        self.gate_proj = projection(config.hidden_size, intermediate_size, bias=False)
+        self.up_proj = projection(config.hidden_size, intermediate_size, bias=False)
+        self.down_proj = projection(intermediate_size, config.hidden_size, bias=False)
+        self.limit = config.swiglu_limit
+
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
+        gate = self.gate_proj(op, hidden_states)
+        up = self.up_proj(op, hidden_states)
+        if self.limit > 0:
+            gate = op.Clip(gate, None, self.limit)
+            up = op.Clip(up, -self.limit, self.limit)
+        return self.down_proj(op, op.Mul(op.Mul(gate, op.Sigmoid(gate)), up))
+
+
+class DeepSeekV4MoE(nn.Module):
+    def __init__(self, config: ArchitectureConfig, layer_id: int):
+        super().__init__()
+        assert config.num_local_experts is not None
+        assert config.moe_intermediate_size is not None
+        self.gate = DeepSeekV4Gate(config, layer_id)
+        self.experts = nn.ModuleList(
+            [
+                _DeepSeekV4Expert(config, config.moe_intermediate_size)
+                for _ in range(config.num_local_experts)
+            ]
+        )
+        shared_size = config.moe_intermediate_size * (config.n_shared_experts or 1)
+        self.shared_experts = _DeepSeekV4Expert(config, shared_size)
+
+    def forward(
+        self,
+        op: OpBuilder,
+        hidden_states: ir.Value,
+        input_ids: ir.Value,
+    ):
+        routing_weights, selected_experts = self.gate(op, hidden_states, input_ids)
+        result = None
+        for expert_idx, expert in enumerate(self.experts):
+            expert_output = expert(op, hidden_states)
+            match = op.Equal(selected_experts, op.Constant(value_int=expert_idx))
+            weight = op.ReduceSum(
+                op.Mul(routing_weights, op.CastLike(match, routing_weights)),
+                [-1],
+                keepdims=True,
+            )
+            contribution = op.Mul(expert_output, weight)
+            result = contribution if result is None else op.Add(result, contribution)
+        return op.Add(result, self.shared_experts(op, hidden_states))
+
+
+class DeepSeekV4Attention(nn.Module):
+    """V4 MQA projections using dense causal attention as a safe fallback."""
+
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+        assert config.q_lora_rank is not None
+        assert config.qk_rope_head_dim is not None
+        assert config.o_lora_rank is not None
+        self.num_heads = config.num_attention_heads
+        self.head_dim = config.head_dim
+        self.rope_dim = config.qk_rope_head_dim
+        self.nope_dim = self.head_dim - self.rope_dim
+        self.o_groups = config.o_groups
+        self.o_lora_rank = config.o_lora_rank
+        assert self.num_heads % self.o_groups == 0
+        projection = _projection_class(config)
+
+        self.q_a_proj = projection(config.hidden_size, config.q_lora_rank, bias=False)
+        self.q_a_layernorm = RMSNorm(config.q_lora_rank, eps=config.rms_norm_eps)
+        self.q_b_proj = projection(
+            config.q_lora_rank,
+            self.num_heads * self.head_dim,
+            bias=False,
+        )
+        self.kv_proj = projection(config.hidden_size, self.head_dim, bias=False)
+        self.kv_layernorm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        group_width = self.num_heads * self.head_dim // self.o_groups
+        self.o_a_proj = projection(
+            group_width,
+            self.o_groups * self.o_lora_rank,
+            bias=False,
+        )
+        self.o_b_proj = projection(
+            self.o_groups * self.o_lora_rank,
+            config.hidden_size,
+            bias=False,
+        )
+        self.eps = config.rms_norm_eps
+        self.scale = self.head_dim**-0.5
+        self.rope_interleave = config.rope_interleave
+
+    def _rotate(
+        self,
+        op: OpBuilder,
+        value: ir.Value,
+        position_embeddings: tuple,
+        num_heads: int,
+        *,
+        inverse: bool = False,
+    ):
+        value = op.Reshape(value, [0, 0, num_heads, self.head_dim])
+        nope, rope = op.Split(value, [self.nope_dim, self.rope_dim], axis=-1, _outputs=2)
+        rope = op.Reshape(rope, [0, 0, -1])
+        if inverse:
+            position_embeddings = (position_embeddings[0], op.Neg(position_embeddings[1]))
+        rope = apply_rotary_pos_emb(
+            op,
+            rope,
+            position_embeddings,
+            num_heads=num_heads,
+            rotary_embedding_dim=0,
+            interleaved=self.rope_interleave,
+        )
+        rope = op.Reshape(rope, [0, 0, num_heads, self.rope_dim])
+        return op.Reshape(op.Concat(nope, rope, axis=-1), [0, 0, -1])
+
+    def forward(
+        self,
+        op: OpBuilder,
+        hidden_states: ir.Value,
+        attention_bias: ir.Value,
+        position_embeddings: tuple,
+        past_key_value: tuple | None = None,
+    ):
+        query = self.q_b_proj(op, self.q_a_layernorm(op, self.q_a_proj(op, hidden_states)))
+        query_4d = op.Reshape(query, [0, 0, self.num_heads, self.head_dim])
+        query_rms = op.Sqrt(
+            op.Add(
+                op.ReduceMean(op.Mul(query_4d, query_4d), [-1], keepdims=True),
+                self.eps,
+            )
+        )
+        query = op.Reshape(op.Div(query_4d, query_rms), [0, 0, -1])
+        query = self._rotate(op, query, position_embeddings, self.num_heads)
+
+        kv = self.kv_layernorm(op, self.kv_proj(op, hidden_states))
+        kv = self._rotate(op, kv, position_embeddings, 1)
+        output, present_key, present_value = op.Attention(
+            query,
+            kv,
+            kv,
+            attention_bias,
+            past_key_value[0] if past_key_value is not None else None,
+            past_key_value[1] if past_key_value is not None else None,
+            q_num_heads=self.num_heads,
+            kv_num_heads=1,
+            scale=self.scale,
+            _outputs=3,
+        )
+        output = self._rotate(op, output, position_embeddings, self.num_heads, inverse=True)
+
+        group_width = self.num_heads * self.head_dim // self.o_groups
+        groups = op.Split(
+            output,
+            [group_width] * self.o_groups,
+            axis=-1,
+            _outputs=self.o_groups,
+        )
+        projected_groups = []
+        for group_idx, group in enumerate(groups):
+            projected = self.o_a_proj(op, group)
+            projected_groups.append(
+                op.Slice(
+                    projected,
+                    [group_idx * self.o_lora_rank],
+                    [(group_idx + 1) * self.o_lora_rank],
+                    [-1],
+                )
+            )
+        output = self.o_b_proj(op, op.Concat(*projected_groups, axis=-1))
+        return output, (present_key, present_value)
+
+
+class DeepSeekV4DecoderLayer(nn.Module):
+    def __init__(self, config: ArchitectureConfig, layer_id: int):
+        super().__init__()
+        self.self_attn = DeepSeekV4Attention(config)
+        self.mlp = DeepSeekV4MoE(config, layer_id)
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hc_mult = config.hc_mult
+        self.hc_iters = config.hc_sinkhorn_iters
+        self.hc_eps = config.hc_eps
+        hc_dim = config.hc_mult * config.hidden_size
+        mix_dim = (2 + config.hc_mult) * config.hc_mult
+        self.hc_attn_fn = Linear(hc_dim, mix_dim, bias=False)
+        self.hc_attn_base = nn.Parameter([mix_dim])
+        self.hc_attn_scale = nn.Parameter([3])
+        self.hc_ffn_fn = Linear(hc_dim, mix_dim, bias=False)
+        self.hc_ffn_base = nn.Parameter([mix_dim])
+        self.hc_ffn_scale = nn.Parameter([3])
+
+    def _hc_pre(self, op, states, fn, scale, base):
+        flat = op.Reshape(states, [0, 0, -1])
+        rms = op.Sqrt(op.Add(op.ReduceMean(op.Mul(flat, flat), [-1], keepdims=True), 1e-6))
+        mixes = op.Div(fn(op, flat), rms)
+        pre_raw, post_raw, comb_raw = op.Split(
+            mixes,
+            [self.hc_mult, self.hc_mult, self.hc_mult * self.hc_mult],
+            axis=-1,
+            _outputs=3,
+        )
+        base_pre, base_post, base_comb = op.Split(
+            base,
+            [self.hc_mult, self.hc_mult, self.hc_mult * self.hc_mult],
+            axis=-1,
+            _outputs=3,
+        )
+        scale_pre, scale_post, scale_comb = op.Split(scale, [1, 1, 1], axis=-1, _outputs=3)
+        pre = op.Add(
+            op.Sigmoid(op.Add(op.Mul(pre_raw, scale_pre), base_pre)),
+            self.hc_eps,
+        )
+        post = op.Mul(op.Sigmoid(op.Add(op.Mul(post_raw, scale_post), base_post)), 2.0)
+        comb = op.Reshape(
+            op.Add(op.Mul(comb_raw, scale_comb), base_comb),
+            [0, 0, self.hc_mult, self.hc_mult],
+        )
+        comb = op.Add(op.Softmax(comb, axis=-1), self.hc_eps)
+        comb = op.Div(
+            comb,
+            op.Add(op.ReduceSum(comb, [-2], keepdims=True), self.hc_eps),
+        )
+        for _ in range(max(self.hc_iters - 1, 0)):
+            comb = op.Div(
+                comb,
+                op.Add(op.ReduceSum(comb, [-1], keepdims=True), self.hc_eps),
+            )
+            comb = op.Div(
+                comb,
+                op.Add(op.ReduceSum(comb, [-2], keepdims=True), self.hc_eps),
+            )
+        reduced = op.ReduceSum(op.Mul(op.Unsqueeze(pre, [-1]), states), [2], keepdims=False)
+        return reduced, post, comb
+
+    @staticmethod
+    def _hc_post(op, value, residual, post, comb):
+        injected = op.Mul(op.Unsqueeze(post, [-1]), op.Unsqueeze(value, [-2]))
+        mixed = op.ReduceSum(
+            op.Mul(op.Unsqueeze(comb, [-1]), op.Unsqueeze(residual, [-2])),
+            [2],
+            keepdims=False,
+        )
+        return op.Add(injected, mixed)
+
+    def forward(
+        self,
+        op: OpBuilder,
+        hidden_states: ir.Value,
+        input_ids: ir.Value,
+        attention_bias: ir.Value,
+        position_embeddings: tuple,
+        past_key_value: tuple | None = None,
+    ):
+        residual = hidden_states
+        value, post, comb = self._hc_pre(
+            op,
+            hidden_states,
+            self.hc_attn_fn,
+            self.hc_attn_scale,
+            self.hc_attn_base,
+        )
+        value, present = self.self_attn(
+            op,
+            self.input_layernorm(op, value),
+            attention_bias,
+            position_embeddings,
+            past_key_value,
+        )
+        hidden_states = self._hc_post(op, value, residual, post, comb)
+
+        residual = hidden_states
+        value, post, comb = self._hc_pre(
+            op,
+            hidden_states,
+            self.hc_ffn_fn,
+            self.hc_ffn_scale,
+            self.hc_ffn_base,
+        )
+        value = self.mlp(op, self.post_attention_layernorm(op, value), input_ids)
+        hidden_states = self._hc_post(op, value, residual, post, comb)
+        return hidden_states, present
+
+
+class DeepSeekV4TextModel(nn.Module):
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+        self.embed_tokens = Embedding(config.vocab_size, config.hidden_size)
+        if config.quantization is not None and config.quantization.quantize_embeddings:
+            self.embed_tokens = QuantizedEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                bits=config.quantization.bits,
+                block_size=config.quantization.group_size,
+                has_zero_point=not config.quantization.sym,
+                padding_idx=config.pad_token_id,
+            )
+        self.layers = nn.ModuleList(
+            [
+                DeepSeekV4DecoderLayer(config, layer_id)
+                for layer_id in range(config.num_hidden_layers)
+            ]
+        )
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hc_mult = config.hc_mult
+        self.hc_eps = config.hc_eps
+        hc_dim = config.hc_mult * config.hidden_size
+        self.hc_head_fn = Linear(hc_dim, config.hc_mult, bias=False)
+        self.hc_head_base = nn.Parameter([config.hc_mult])
+        self.hc_head_scale = nn.Parameter([1])
+        rope_config = config
+        if config.qk_rope_head_dim is not None:
+            import dataclasses
+
+            rope_config = dataclasses.replace(config, head_dim=config.qk_rope_head_dim)
+        self.rotary_emb = initialize_rope(rope_config)
+        self._dtype = config.dtype
+
+    def _hc_head(self, op, states):
+        flat = op.Reshape(states, [0, 0, -1])
+        rms = op.Sqrt(op.Add(op.ReduceMean(op.Mul(flat, flat), [-1], keepdims=True), 1e-6))
+        mixes = op.Div(self.hc_head_fn(op, flat), rms)
+        weights = op.Add(
+            op.Sigmoid(
+                op.Add(
+                    op.Mul(mixes, self.hc_head_scale),
+                    self.hc_head_base,
+                )
+            ),
+            self.hc_eps,
+        )
+        return op.ReduceSum(op.Mul(op.Unsqueeze(weights, [-1]), states), [2], keepdims=False)
+
+    def forward(
+        self,
+        op: OpBuilder,
+        input_ids: ir.Value,
+        attention_mask: ir.Value,
+        position_ids: ir.Value,
+        past_key_values: list | None = None,
+        inputs_embeds: ir.Value | None = None,
+    ):
+        hidden_states = (
+            inputs_embeds if inputs_embeds is not None else self.embed_tokens(op, input_ids)
+        )
+        hidden_states = op.Expand(
+            op.Unsqueeze(hidden_states, [-2]),
+            [1, 1, self.hc_mult, 1],
+        )
+        position_embeddings = self.rotary_emb(op, position_ids)
+        attention_bias = create_attention_bias(
+            op,
+            input_ids=hidden_states if input_ids is None else input_ids,
+            attention_mask=attention_mask,
+            dtype=self._dtype,
+        )
+        presents = []
+        past_kvs = past_key_values or [None] * len(self.layers)
+        for layer, past_kv in zip(self.layers, past_kvs):
+            hidden_states, present = layer(
+                op,
+                hidden_states,
+                input_ids,
+                attention_bias,
+                position_embeddings,
+                past_kv,
+            )
+            presents.append(present)
+        return self.norm(op, self._hc_head(op, hidden_states)), presents
+
+
+class DeepSeekV4CausalLMModel(CausalLMModel):
+    """DeepSeek-V4 Causal LM with dense HCA fallback and V4 MoE/HC blocks."""
+
+    default_task: str = "text-generation"
+    category: str = "Mixture of Experts"
+
+    def __init__(self, config: ArchitectureConfig):
+        nn.Module.__init__(self)
+        if any(config.compress_ratios or ()):
+            logger.warning(
+                "DeepSeek-V4 compressed sparse attention is not implemented; "
+                "exporting the dense causal-attention preview backbone."
+            )
+        self.config = config
+        self.model = DeepSeekV4TextModel(config)
+        if config.quantization is not None and config.quantization.quantize_lm_head:
+            self.lm_head = _projection_class(config)(
+                config.hidden_size, config.vocab_size, bias=False
+            )
+        else:
+            self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def preprocess_weights(
+        self, state_dict: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        """Map the official DeepSeek checkpoint names to mobius modules."""
+        renamed: dict[str, torch.Tensor] = {}
+        skipped = 0
+        for key, value in state_dict.items():
+            if key.startswith("mtp.") or any(
+                marker in key
+                for marker in (
+                    ".compressor.",
+                    ".indexer.",
+                    ".attn.attn_sink",
+                )
+            ):
+                skipped += 1
+                continue
+            new_key = key
+            if new_key == "embed.weight":
+                new_key = "model.embed_tokens.weight"
+            elif new_key == "head.weight":
+                new_key = "lm_head.weight"
+            elif new_key == "norm.weight":
+                new_key = "model.norm.weight"
+            elif new_key.startswith("hc_head_"):
+                new_key = (
+                    f"model.{new_key}.weight"
+                    if new_key == "hc_head_fn"
+                    else f"model.{new_key}"
+                )
+            elif new_key.startswith("layers."):
+                new_key = f"model.{new_key}"
+                new_key = new_key.replace(".attn.wq_a.", ".self_attn.q_a_proj.")
+                new_key = new_key.replace(".attn.q_norm.", ".self_attn.q_a_layernorm.")
+                new_key = new_key.replace(".attn.wq_b.", ".self_attn.q_b_proj.")
+                new_key = new_key.replace(".attn.wkv.", ".self_attn.kv_proj.")
+                new_key = new_key.replace(".attn.kv_norm.", ".self_attn.kv_layernorm.")
+                new_key = new_key.replace(".attn.wo_a.", ".self_attn.o_a_proj.")
+                new_key = new_key.replace(".attn.wo_b.", ".self_attn.o_b_proj.")
+                new_key = new_key.replace(".attn_norm.", ".input_layernorm.")
+                new_key = new_key.replace(".ffn_norm.", ".post_attention_layernorm.")
+                new_key = new_key.replace(".ffn.gate.", ".mlp.gate.")
+                new_key = new_key.replace(".ffn.experts.", ".mlp.experts.")
+                new_key = new_key.replace(".ffn.shared_experts.", ".mlp.shared_experts.")
+                new_key = new_key.replace(".w1.", ".gate_proj.")
+                new_key = new_key.replace(".w2.", ".down_proj.")
+                new_key = new_key.replace(".w3.", ".up_proj.")
+                if ".hc_" in new_key and new_key.endswith("_fn"):
+                    new_key = f"{new_key}.weight"
+            renamed[new_key] = value
+        if skipped:
+            logger.warning(
+                "Skipped %d DeepSeek-V4 CSA/HCA/MTP tensors unsupported by "
+                "the dense preview backbone.",
+                skipped,
+            )
+        return super().preprocess_weights(renamed)

--- a/src/mobius/models/deepseek_v4_flash_test.py
+++ b/src/mobius/models/deepseek_v4_flash_test.py
@@ -1,0 +1,166 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from mobius._builder import build_from_module
+from mobius._configs import ArchitectureConfig, QuantizationConfig
+from mobius._testing import count_op_type, make_config
+from mobius.models.deepseek_v4 import DeepSeekV4CausalLMModel
+
+
+def _tiny_config(**overrides):
+    values = dict(
+        model_type="deepseek_v4",
+        hidden_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=16,
+        q_lora_rank=8,
+        qk_rope_head_dim=4,
+        o_groups=2,
+        o_lora_rank=8,
+        num_local_experts=2,
+        num_experts_per_tok=1,
+        moe_intermediate_size=16,
+        n_shared_experts=1,
+        scoring_func="sqrtsoftplus",
+        routed_scaling_factor=1.5,
+        num_hash_layers=1,
+        hc_mult=2,
+        hc_sinkhorn_iters=2,
+        swiglu_limit=10.0,
+        rope_interleave=True,
+    )
+    values.update(overrides)
+    return make_config(**values)
+
+
+def test_real_config_fields_extract():
+    hf_config = SimpleNamespace(
+        model_type="deepseek_v4",
+        vocab_size=129280,
+        hidden_size=4096,
+        intermediate_size=None,
+        num_hidden_layers=43,
+        num_attention_heads=64,
+        num_key_value_heads=1,
+        head_dim=512,
+        max_position_embeddings=1048576,
+        hidden_act="silu",
+        rms_norm_eps=1e-6,
+        rope_theta=10000,
+        rope_scaling={
+            "type": "yarn",
+            "factor": 16,
+            "original_max_position_embeddings": 65536,
+            "beta_fast": 32,
+            "beta_slow": 1,
+        },
+        q_lora_rank=1024,
+        qk_rope_head_dim=64,
+        o_groups=8,
+        o_lora_rank=1024,
+        n_routed_experts=256,
+        num_experts_per_tok=6,
+        moe_intermediate_size=2048,
+        n_shared_experts=1,
+        norm_topk_prob=True,
+        routed_scaling_factor=1.5,
+        scoring_func="sqrtsoftplus",
+        num_hash_layers=None,
+        mlp_layer_types=["hash_moe", "hash_moe", "hash_moe", "moe"],
+        hc_mult=4,
+        hc_sinkhorn_iters=20,
+        hc_eps=1e-6,
+        index_n_heads=64,
+        index_head_dim=128,
+        index_topk=512,
+        compress_ratios=None,
+        layer_types=[
+            "sliding_attention",
+            "sliding_attention",
+            "compressed_sparse_attention",
+            "heavily_compressed_attention",
+        ],
+        compress_rates={
+            "compressed_sparse_attention": 4,
+            "heavily_compressed_attention": 128,
+        },
+        compress_rope_theta=160000,
+        sliding_window=128,
+        swiglu_limit=10.0,
+        tie_word_embeddings=False,
+        attention_bias=False,
+        pad_token_id=0,
+    )
+    config = ArchitectureConfig.from_transformers(hf_config)
+    assert config.model_type == "deepseek_v4"
+    assert config.head_dim == 512
+    assert config.qk_rope_head_dim == 64
+    assert config.num_local_experts == 256
+    assert config.num_hash_layers == 3
+    assert config.hc_mult == 4
+    assert config.compress_ratios == [0, 0, 4, 128]
+    assert config.rope_type == "yarn"
+
+
+def test_tiny_graph_builds_v4_backbone():
+    config = _tiny_config()
+    graph = build_from_module(DeepSeekV4CausalLMModel(config), config)["model"].graph
+    assert graph.num_nodes() > 0
+    assert count_op_type(graph, "Attention") == config.num_hidden_layers
+    assert count_op_type(graph, "Softplus") >= config.num_hidden_layers
+    assert count_op_type(graph, "TopK") >= 1
+    assert count_op_type(graph, "Gather") >= 1
+    assert count_op_type(graph, "RMSNormalization") >= 1
+
+
+def test_parameter_shapes_match_v4_projections():
+    config = _tiny_config(num_hidden_layers=1)
+    model = DeepSeekV4CausalLMModel(config)
+    attn = model.model.layers[0].self_attn
+    assert list(attn.q_b_proj.weight.shape) == [32, 8]
+    assert list(attn.kv_proj.weight.shape) == [16, 32]
+    assert list(attn.o_a_proj.weight.shape) == [16, 16]
+    assert list(attn.o_b_proj.weight.shape) == [32, 16]
+
+
+def test_four_and_eight_bit_graphs_use_matmul_nbits():
+    for bits in (4, 8):
+        config = _tiny_config(
+            num_hidden_layers=1,
+            quantization=QuantizationConfig(
+                bits=bits,
+                group_size=16,
+                quant_method="gguf",
+                sym=False,
+            ),
+        )
+        graph = build_from_module(DeepSeekV4CausalLMModel(config), config)["model"].graph
+        assert count_op_type(graph, "MatMulNBits") > 0
+
+
+def test_official_weight_names_are_remapped():
+    config = _tiny_config(num_hidden_layers=1)
+    model = DeepSeekV4CausalLMModel(config)
+    weights = {
+        "embed.weight": torch.zeros(config.vocab_size, config.hidden_size),
+        "layers.0.attn.wq_a.weight": torch.zeros(config.q_lora_rank, config.hidden_size),
+        "layers.0.ffn.experts.0.w1.weight": torch.zeros(
+            config.moe_intermediate_size, config.hidden_size
+        ),
+        "layers.0.hc_attn_base": torch.zeros((2 + config.hc_mult) * config.hc_mult),
+        "mtp.0.e_proj.weight": torch.zeros(config.hidden_size, config.hidden_size),
+    }
+    result = model.preprocess_weights(weights)
+    assert "model.embed_tokens.weight" in result
+    assert "model.layers.0.self_attn.q_a_proj.weight" in result
+    assert "model.layers.0.mlp.experts.0.gate_proj.weight" in result
+    assert "model.layers.0.hc_attn_base" in result
+    assert not any(key.startswith("mtp.") for key in result)

--- a/src/mobius/models/deepseek_v4_flash_test.py
+++ b/src/mobius/models/deepseek_v4_flash_test.py
@@ -3,13 +3,18 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
+import numpy as np
+import onnx_ir as ir
 import torch
 
 from mobius._builder import build_from_module
+from mobius._config_resolver import _default_task_for_model
 from mobius._configs import ArchitectureConfig, QuantizationConfig
 from mobius._testing import count_op_type, make_config
+from mobius.integrations.ort_genai import export_package
 from mobius.models.deepseek_v4 import DeepSeekV4CausalLMModel
 
 
@@ -36,6 +41,9 @@ def _tiny_config(**overrides):
         hc_sinkhorn_iters=2,
         swiglu_limit=10.0,
         rope_interleave=True,
+        index_n_heads=2,
+        index_head_dim=8,
+        index_topk=4,
     )
     values.update(overrides)
     return make_config(**values)
@@ -96,6 +104,7 @@ def test_real_config_fields_extract():
         sliding_window=128,
         swiglu_limit=10.0,
         tie_word_embeddings=False,
+        num_nextn_predict_layers=1,
         attention_bias=False,
         pad_token_id=0,
     )
@@ -107,18 +116,99 @@ def test_real_config_fields_extract():
     assert config.num_hash_layers == 3
     assert config.hc_mult == 4
     assert config.compress_ratios == [0, 0, 4, 128]
+    assert config.num_nextn_predict_layers == 1
     assert config.rope_type == "yarn"
+    assert _default_task_for_model("deepseek_v4") == "deepseek-v4"
 
 
 def test_tiny_graph_builds_v4_backbone():
     config = _tiny_config()
     graph = build_from_module(DeepSeekV4CausalLMModel(config), config)["model"].graph
     assert graph.num_nodes() > 0
-    assert count_op_type(graph, "Attention") == config.num_hidden_layers
+    assert count_op_type(graph, "Attention") == 0
+    assert count_op_type(graph, "Softmax") >= config.num_hidden_layers
+    assert count_op_type(graph, "ScatterElements") == 0
     assert count_op_type(graph, "Softplus") >= config.num_hidden_layers
     assert count_op_type(graph, "TopK") >= 1
     assert count_op_type(graph, "Gather") >= 1
     assert count_op_type(graph, "RMSNormalization") >= 1
+    assert sum("attn_sink" in name for name in graph.initializers) == config.num_hidden_layers
+    assert "hidden_states" not in {value.name for value in graph.outputs}
+
+
+def test_csa_schedule_exports_compressor_and_indexer_tensors_with_dense_attention():
+    config = _tiny_config(
+        num_hidden_layers=4,
+        compress_ratios=[0, 0, 4, 128],
+    )
+    graph = build_from_module(DeepSeekV4CausalLMModel(config), config, task="deepseek-v4")[
+        "model"
+    ].graph
+    names = set(graph.initializers)
+
+    assert "model.layers.2.self_attn.compressor.wkv.weight" in names
+    assert "model.layers.2.self_attn.compressor.wgate.weight" in names
+    assert "model.layers.2.self_attn.compressor.ape" in names
+    assert "model.layers.2.self_attn.compressor.norm.weight" in names
+    assert "model.layers.2.self_attn.indexer.wq_b.weight" in names
+    assert "model.layers.2.self_attn.indexer.weights_proj.weight" in names
+    assert "model.layers.2.self_attn.indexer.compressor.wkv.weight" in names
+    assert "model.layers.3.self_attn.compressor.wkv.weight" in names
+    assert not any("model.layers.3.self_attn.indexer" in name for name in names)
+    assert count_op_type(graph, "Attention") == 0
+    assert count_op_type(graph, "ScatterElements") == 0
+    assert count_op_type(graph, "Softmax") >= config.num_hidden_layers
+
+
+def test_mtp_sidecar_exports_official_block_and_hyper_connection_state():
+    config = _tiny_config(
+        num_nextn_predict_layers=1,
+        compress_ratios=[0, 0, 0],
+    )
+    package = build_from_module(DeepSeekV4CausalLMModel(config), config, task="deepseek-v4")
+
+    assert set(package) == {"model", "mtp"}
+    assert "hidden_states" in {value.name for value in package["model"].graph.outputs}
+    mtp_graph = package["mtp"].graph
+    names = set(mtp_graph.initializers)
+    assert "mtp.0.e_proj.weight" in names
+    assert "mtp.0.h_proj.weight" in names
+    assert "mtp.0.hc_head_fn.weight" in names
+    assert "mtp.0.self_attn.attn_sink" in names
+    assert count_op_type(mtp_graph, "Softmax") >= 1
+    assert {value.name for value in mtp_graph.outputs} == {
+        "mtp_hidden",
+        "present.0.key",
+        "present.0.value",
+    }
+
+
+def test_ort_genai_sidecar_metadata(tmp_path):
+    config = _tiny_config(
+        num_nextn_predict_layers=1,
+        compress_ratios=[0, 0, 0],
+    )
+    package = build_from_module(DeepSeekV4CausalLMModel(config), config, task="deepseek-v4")
+
+    for model in package.values():
+        for initializer in model.graph.initializers.values():
+            if initializer.const_value is None:
+                initializer.const_value = ir.tensor(
+                    np.zeros(initializer.shape, dtype=initializer.dtype.numpy())
+                )
+    result = export_package(package, str(tmp_path), progress_bar=False)
+    assert (tmp_path / "model" / "model.onnx").is_file()
+    assert (tmp_path / "mtp" / "model.onnx").is_file()
+    with open(result["genai_config"]) as f:
+        genai_config = json.load(f)
+    assert genai_config["model"]["decoder"]["filename"] == "model/model.onnx"
+    with open(result["mtp_config"]) as f:
+        sidecar = json.load(f)
+
+    assert sidecar["model"]["filename"] == "mtp/model.onnx"
+    assert sidecar["num_nextn_predict_layers"] == 1
+    assert "hidden_states" in sidecar["inputs"]
+    assert "mtp_hidden" in sidecar["outputs"]
 
 
 def test_parameter_shapes_match_v4_projections():
@@ -135,6 +225,7 @@ def test_four_and_eight_bit_graphs_use_matmul_nbits():
     for bits in (4, 8):
         config = _tiny_config(
             num_hidden_layers=1,
+            compress_ratios=[4],
             quantization=QuantizationConfig(
                 bits=bits,
                 group_size=16,
@@ -144,10 +235,17 @@ def test_four_and_eight_bit_graphs_use_matmul_nbits():
         )
         graph = build_from_module(DeepSeekV4CausalLMModel(config), config)["model"].graph
         assert count_op_type(graph, "MatMulNBits") > 0
+        assert "model.layers.0.self_attn.compressor.wkv.scales" in graph.initializers
+        model = DeepSeekV4CausalLMModel(config)
+        assert model.model.layers[0].self_attn.compressor.wkv._gguf_quantized_linear
 
 
 def test_official_weight_names_are_remapped():
-    config = _tiny_config(num_hidden_layers=1)
+    config = _tiny_config(
+        num_hidden_layers=4,
+        num_nextn_predict_layers=1,
+        compress_ratios=[0, 0, 4, 128, 0],
+    )
     model = DeepSeekV4CausalLMModel(config)
     weights = {
         "embed.weight": torch.zeros(config.vocab_size, config.hidden_size),
@@ -156,11 +254,21 @@ def test_official_weight_names_are_remapped():
             config.moe_intermediate_size, config.hidden_size
         ),
         "layers.0.hc_attn_base": torch.zeros((2 + config.hc_mult) * config.hc_mult),
+        "layers.2.attn.attn_sink": torch.zeros(config.num_attention_heads),
+        "layers.2.attn.compressor.ape": torch.zeros(4, 2 * config.head_dim),
+        "layers.2.attn.indexer.weights_proj.weight": torch.zeros(
+            config.index_n_heads, config.hidden_size
+        ),
         "mtp.0.e_proj.weight": torch.zeros(config.hidden_size, config.hidden_size),
+        "mtp.0.hc_head_fn": torch.zeros(config.hc_mult, config.hc_mult * config.hidden_size),
     }
     result = model.preprocess_weights(weights)
     assert "model.embed_tokens.weight" in result
     assert "model.layers.0.self_attn.q_a_proj.weight" in result
     assert "model.layers.0.mlp.experts.0.gate_proj.weight" in result
     assert "model.layers.0.hc_attn_base" in result
-    assert not any(key.startswith("mtp.") for key in result)
+    assert "model.layers.2.self_attn.attn_sink" in result
+    assert "model.layers.2.self_attn.compressor.ape" in result
+    assert "model.layers.2.self_attn.indexer.weights_proj.weight" in result
+    assert "mtp.0.e_proj.weight" in result
+    assert "mtp.0.hc_head_fn.weight" in result

--- a/src/mobius/models/deepseek_v4_flash_test.py
+++ b/src/mobius/models/deepseek_v4_flash_test.py
@@ -219,6 +219,7 @@ def test_parameter_shapes_match_v4_projections():
     assert list(attn.kv_proj.weight.shape) == [16, 32]
     assert list(attn.o_a_proj.weight.shape) == [16, 16]
     assert list(attn.o_b_proj.weight.shape) == [32, 16]
+    assert list(model.model.layers[0].mlp.gate.bias.shape) == [config.num_local_experts]
 
 
 def test_four_and_eight_bit_graphs_use_matmul_nbits():

--- a/src/mobius/tasks/__init__.py
+++ b/src/mobius/tasks/__init__.py
@@ -28,6 +28,7 @@ __all__ = [
     "CodecTask",
     "ComponentSpec",
     "ControlNetTask",
+    "DeepSeekV4Task",
     "DFlashDraftTask",
     "Eagle3DraftTask",
     "Qwen35MtpTask",
@@ -86,6 +87,7 @@ from mobius.tasks._causal_lm import (
 from mobius.tasks._codec import CodecTask
 from mobius.tasks._controlnet import ControlNetTask
 from mobius.tasks._ctc_asr import CTCAsrTask
+from mobius.tasks._deepseek_v4 import DeepSeekV4Task
 from mobius.tasks._denoising import DenoisingTask
 from mobius.tasks._dflash import DFlashDraftTask
 from mobius.tasks._eagle3 import Eagle3DraftTask
@@ -143,6 +145,7 @@ TASK_REGISTRY: dict[str, type[ModelTask]] = {
     "moshi-depformer": MoshiDepformerTask,
     "moshi-temporal": MoshiTemporalTask,
     "text-generation": CausalLMTask,
+    "deepseek-v4": DeepSeekV4Task,
     "hybrid-text-generation": HybridCausalLMTask,
     "dflash-draft": DFlashDraftTask,
     "eagle3-draft": Eagle3DraftTask,

--- a/src/mobius/tasks/_deepseek_v4.py
+++ b/src/mobius/tasks/_deepseek_v4.py
@@ -1,0 +1,121 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Graph tasks for the DeepSeek-V4 target decoder and MTP sidecar."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import onnx_ir as ir
+
+from mobius._configs import ArchitectureConfig
+from mobius._model_package import ModelPackage
+from mobius.tasks._base import ModelTask, _make_graph, _make_model
+from mobius.tasks._cache_utils import _make_kv_cache_inputs, _register_kv_cache_outputs
+
+
+class DeepSeekV4Task(ModelTask):
+    """Build the target decoder plus the optional official single-layer MTP head."""
+
+    model_roles: ClassVar[dict[str, str]] = {"model": "decoder", "mtp": "decoder"}
+
+    @staticmethod
+    def _inputs(builder, config: ArchitectureConfig, num_layers: int):
+        batch = ir.SymbolicDim("batch")
+        sequence_length = ir.SymbolicDim("sequence_length")
+        past_sequence_length = ir.SymbolicDim("past_sequence_length")
+        attention_mask = builder.input(
+            "attention_mask",
+            ir.DataType.INT64,
+            [batch, "past_sequence_length + sequence_length"],
+        )
+        position_ids = builder.input(
+            "position_ids", ir.DataType.INT64, [batch, sequence_length]
+        )
+        past_key_values = _make_kv_cache_inputs(
+            builder,
+            num_layers,
+            1,
+            config.head_dim,
+            config.dtype,
+            batch,
+            past_sequence_length,
+        )
+        return (
+            batch,
+            sequence_length,
+            attention_mask,
+            position_ids,
+            past_key_values,
+        )
+
+    @staticmethod
+    def _outputs(
+        builder,
+        presents,
+        config: ArchitectureConfig,
+        batch,
+    ) -> None:
+        _register_kv_cache_outputs(
+            builder,
+            presents,
+            batch=batch,
+            num_kv_heads=1,
+            key_head_dim=config.head_dim,
+            value_head_dim=config.head_dim,
+            total_seq_len="past_sequence_length + sequence_length",
+            dtype=config.dtype,
+        )
+
+    def _build_target(self, module, config: ArchitectureConfig):
+        graph, builder = _make_graph("deepseek_v4")
+        batch, sequence_length, attention_mask, position_ids, past_key_values = self._inputs(
+            builder, config, config.num_hidden_layers
+        )
+        input_ids = builder.input("input_ids", ir.DataType.INT64, [batch, sequence_length])
+        hidden_states, presents, hc_states = module.model(
+            builder.op,
+            input_ids,
+            attention_mask,
+            position_ids,
+            past_key_values,
+        )
+        builder.add_output(module.lm_head(builder.op, hidden_states), "logits")
+        if len(module.mtp):
+            builder.add_output(hc_states, "hidden_states")
+        self._outputs(builder, presents, config, batch)
+        return _make_model(graph)
+
+    def _build_mtp(self, module, config: ArchitectureConfig):
+        graph, builder = _make_graph("deepseek_v4_mtp")
+        batch, sequence_length, attention_mask, position_ids, past_key_values = self._inputs(
+            builder, config, 1
+        )
+        inputs_embeds = builder.input(
+            "inputs_embeds",
+            config.dtype,
+            [batch, sequence_length, config.hidden_size],
+        )
+        hidden_states = builder.input(
+            "hidden_states",
+            config.dtype,
+            [batch, sequence_length, config.hc_mult, config.hidden_size],
+        )
+        mtp_hidden, present = module.mtp[0](
+            builder.op,
+            inputs_embeds,
+            hidden_states,
+            attention_mask,
+            position_ids,
+            past_key_values[0],
+        )
+        builder.add_output(mtp_hidden, "mtp_hidden")
+        self._outputs(builder, [present], config, batch)
+        return _make_model(graph)
+
+    def build(self, module, config: ArchitectureConfig) -> ModelPackage:
+        models = {"model": self._build_target(module, config)}
+        if len(module.mtp):
+            models["mtp"] = self._build_mtp(module, config)
+        return ModelPackage(models, config=config)

--- a/tests/_test_configs.py
+++ b/tests/_test_configs.py
@@ -588,6 +588,36 @@ CAUSAL_LM_CONFIGS: list[tuple[str, dict, bool]] = [
         True,
     ),
     (
+        "deepseek_v4",
+        {
+            "num_key_value_heads": 1,
+            "head_dim": 16,
+            "q_lora_rank": 32,
+            "qk_rope_head_dim": 8,
+            "o_groups": 2,
+            "o_lora_rank": 16,
+            "num_local_experts": 4,
+            "num_experts_per_tok": 2,
+            "moe_intermediate_size": 32,
+            "n_shared_experts": 1,
+            "routed_scaling_factor": 1.5,
+            "scoring_func": "sqrtsoftplus",
+            "num_hash_layers": 1,
+            "hc_mult": 2,
+            "hc_sinkhorn_iters": 2,
+            "swiglu_limit": 10.0,
+            "rope_interleave": True,
+            "rope_type": "yarn",
+            "rope_scaling": {
+                "factor": 4.0,
+                "beta_fast": 32,
+                "beta_slow": 1,
+                "original_max_position_embeddings": 128,
+            },
+        },
+        True,
+    ),
+    (
         "deepseek_v2",
         {
             # MLA: kv heads must equal attn heads (see MLA note near top of file).

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -330,6 +330,35 @@ class TestCLIBuildRuntime:
         native_writer.assert_called_once()
         generic_writer.assert_not_called()
 
+    def test_runtime_onnx_genai_calls_write_inference_metadata(self):
+        """--runtime onnx-genai writes inference_metadata (not genai_config)."""
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            mock.patch(
+                "mobius.integrations.onnx_genai.write_inference_metadata",
+                return_value="inference_metadata.yaml",
+            ) as mock_meta,
+            mock.patch(
+                "mobius.integrations.ort_genai.write_ort_genai_config",
+                return_value={},
+            ) as mock_ort,
+            mock.patch("mobius._model_package.ModelPackage.save"),
+        ):
+            main(
+                [
+                    "build",
+                    "--model",
+                    "Qwen/Qwen2.5-0.5B",
+                    tmpdir,
+                    "--no-weights",
+                    "--runtime",
+                    "onnx-genai",
+                ]
+            )
+        mock_meta.assert_called_once()
+        mock_ort.assert_not_called()
+        mock_ort.assert_not_called()
+
     def test_no_runtime_does_not_call_write_ort_genai_config(self):
         """Omitting --runtime does NOT call write_ort_genai_config()."""
         with (

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -330,35 +330,6 @@ class TestCLIBuildRuntime:
         native_writer.assert_called_once()
         generic_writer.assert_not_called()
 
-    def test_runtime_onnx_genai_calls_write_inference_metadata(self):
-        """--runtime onnx-genai writes inference_metadata (not genai_config)."""
-        with (
-            tempfile.TemporaryDirectory() as tmpdir,
-            mock.patch(
-                "mobius.integrations.onnx_genai.write_inference_metadata",
-                return_value="inference_metadata.yaml",
-            ) as mock_meta,
-            mock.patch(
-                "mobius.integrations.ort_genai.write_ort_genai_config",
-                return_value={},
-            ) as mock_ort,
-            mock.patch("mobius._model_package.ModelPackage.save"),
-        ):
-            main(
-                [
-                    "build",
-                    "--model",
-                    "Qwen/Qwen2.5-0.5B",
-                    tmpdir,
-                    "--no-weights",
-                    "--runtime",
-                    "onnx-genai",
-                ]
-            )
-        mock_meta.assert_called_once()
-        mock_ort.assert_not_called()
-        mock_ort.assert_not_called()
-
     def test_no_runtime_does_not_call_write_ort_genai_config(self):
         """Omitting --runtime does NOT call write_ort_genai_config()."""
         with (

--- a/tests/model_coverage_test.py
+++ b/tests/model_coverage_test.py
@@ -208,6 +208,7 @@ _COVERAGE_SKIP: dict[str, str] = {
     "arctic": "Very large MoE (480B) — no small public checkpoint",
     "dbrx": "Large MoE (132B) — no small public checkpoint",
     "deepseek_v3": "Very large MoE (671B) — no small public checkpoint",
+    "deepseek_v4": "Very large MoE (284B) — no small public checkpoint",
     "llama4_text": "Very large MoE (109B) — no small public checkpoint",
     "qwen3_5_moe": "Large MoE (22B) — no small public checkpoint",
     # --- Models without test_model_id ---


### PR DESCRIPTION
## Summary
- register `deepseek_v4` and map the real GGUF `deepseek4` architecture
- export V4 Q/KV/grouped-output projections, Hyper-Connections, hash/sqrt-softplus MoE routing, shared experts, and clamped SwiGLU
- add dense causal-attention preview fallback with KV cache plus 4/8-bit MatMulNBits graph support
- add GGUF metadata/tensor mappings and `onnx-genai` / `ort-genai` runtime aliases
- document the authoritative HF/GGUF config and V3-to-V4 architecture gap

## Validation
- `151 passed` focused DeepSeek/GGUF/config tests
- `37 passed` DeepSeek graph/checker tests
- `759 passed, 210 skipped` V4/GGUF/model-coverage tests
- `5 passed` runtime CLI tests
- Ruff lint and format checks pass

## Deferred follow-ups
- CSA/HCA learned KV compression, sparse indexer, attention sinks, and per-layer compressed RoPE (dense fallback is not numerically equivalent)
- optional MTP component export
- direct packed dynamic int2/int1 and MXFP4 expert import: add a runtime custom op plus mobius EP-capability configuration, and/or track the required MatMulNBits functionality in ONNX Runtime
- optimized split-GGUF packed-expert repacking for the Unsloth shards

Closes no issue.