### PR TITLE
Emit BlockQuantizedMatMul for MXFP4 / IQ4_NL GGUF weights

### DIFF
--- a/src/mobius/components/__init__.py
+++ b/src/mobius/components/__init__.py
@@ -7,6 +7,7 @@ __all__ = [
     "Attention",
     "BatchNorm2d",
     "BertEmbeddings",
+    "BlockQuantizedLinear",
     "CausalConv1d",
     "CausalConvNd",
     "CausalDepthwiseConv1d",
@@ -192,6 +193,7 @@ from mobius.components._qformer import (
     QFormerLayer as QFormerLayer,
 )
 from mobius.components._quantized_linear import (
+    BlockQuantizedLinear,
     QuantizedEmbedding,
     QuantizedLinear,
     TiedQuantizedLMHead,

--- a/src/mobius/components/_quantized_linear.py
+++ b/src/mobius/components/_quantized_linear.py
@@ -4,8 +4,8 @@
 """Quantized linear and embedding layers.
 
 ``QuantizedLinear`` uses ``MatMulNBits``; ``QuantizedEmbedding`` uses
-``GatherBlockQuantized``. ``BlockQuantizedLinear`` preserves native GGUF
-MXFP4 and IQ4_NL blocks for onnx-genai's CPU execution provider.
+``GatherBlockQuantized``. ``BlockQuantizedLinear`` preserves runtime-supported
+native GGUF IQ/MXFP4 blocks for onnx-genai's CPU execution provider.
 """
 
 from __future__ import annotations
@@ -30,8 +30,16 @@ _MICROSOFT_DOMAIN = "com.microsoft"
 _ONNX_GENAI_DOMAIN = "com.github.onnxruntime.genai"
 
 _NATIVE_BLOCK_FORMATS = {
-    "mxfp4": 17,
-    "iq4_nl": 18,
+    "mxfp4": (32, 17),
+    "iq4_nl": (32, 18),
+    "iq4_xs": (256, 136),
+    "iq3_s": (256, 110),
+    "iq3_xxs": (256, 98),
+    "iq2_xxs": (256, 66),
+    "iq2_xs": (256, 74),
+    "iq2_s": (256, 82),
+    "iq1_s": (256, 50),
+    "iq1_m": (256, 56),
 }
 
 
@@ -190,9 +198,9 @@ class BlockQuantizedLinear(nn.Module):
         self._k = in_features
         self._n = out_features
         self._format = format
-        block_bytes = _NATIVE_BLOCK_FORMATS[format]
+        block_elements, block_bytes = _NATIVE_BLOCK_FORMATS[format]
         self.weight = nn.Parameter(
-            [out_features, math.ceil(in_features / 32), block_bytes],
+            [out_features, math.ceil(in_features / block_elements), block_bytes],
             dtype=ir.DataType.UINT8,
         )
         self.bias = nn.Parameter([out_features]) if bias else None

--- a/src/mobius/components/_quantized_linear.py
+++ b/src/mobius/components/_quantized_linear.py
@@ -1,10 +1,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Quantized linear and embedding layers (com.microsoft domain).
+"""Quantized linear and embedding layers.
 
 ``QuantizedLinear`` uses ``MatMulNBits``; ``QuantizedEmbedding`` uses
-``GatherBlockQuantized``.
+``GatherBlockQuantized``. ``BlockQuantizedLinear`` preserves native GGUF
+MXFP4 and IQ4_NL blocks for onnx-genai's CPU execution provider.
 """
 
 from __future__ import annotations
@@ -26,6 +27,12 @@ from mobius._build_context import ep_capabilities
 #   zero_points:    [N, ceil(n_blocks*bits/8)] (uint8, optional, bit-packed)
 
 _MICROSOFT_DOMAIN = "com.microsoft"
+_ONNX_GENAI_DOMAIN = "com.github.onnxruntime.genai"
+
+_NATIVE_BLOCK_FORMATS = {
+    "mxfp4": 17,
+    "iq4_nl": 18,
+}
 
 
 def _accuracy_level_attrs(bits: int) -> dict[str, int]:
@@ -156,6 +163,68 @@ class QuantizedLinear(nn.Module):
         )
         if self.bias is not None:
             result = op.Add(result, self.bias)
+        return result
+
+
+class BlockQuantizedLinear(nn.Module):
+    """Linear layer backed by native GGUF block quantization.
+
+    The packed weight retains llama.cpp's serialized block layout, including
+    the per-block E8M0/fp16 scale. No dequantization or affine repacking occurs.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        *,
+        format: str,
+        bias: bool = False,
+    ):
+        super().__init__()
+        if format not in _NATIVE_BLOCK_FORMATS:
+            raise ValueError(
+                f"format must be one of {sorted(_NATIVE_BLOCK_FORMATS)}, got {format!r}"
+            )
+
+        self._k = in_features
+        self._n = out_features
+        self._format = format
+        block_bytes = _NATIVE_BLOCK_FORMATS[format]
+        self.weight = nn.Parameter(
+            [out_features, math.ceil(in_features / 32), block_bytes],
+            dtype=ir.DataType.UINT8,
+        )
+        self.bias = nn.Parameter([out_features]) if bias else None
+
+    def forward(self, op: OpBuilder, x: ir.Value) -> ir.Value:
+        output_dtype = x.dtype
+        activation = x if x.dtype == ir.DataType.FLOAT else op.Cast(x, to=ir.DataType.FLOAT)
+        inputs: list[ir.Value | None] = [activation, self.weight]
+        if self.bias is not None:
+            bias = (
+                self.bias
+                if self.bias.dtype == ir.DataType.FLOAT
+                else op.Cast(self.bias, to=ir.DataType.FLOAT)
+            )
+            inputs.append(bias)
+
+        result = op.BlockQuantizedMatMul(
+            *inputs,
+            K=self._k,
+            N=self._n,
+            format=self._format,
+            block_layout_version=1,
+            _domain=_ONNX_GENAI_DOMAIN,
+        )
+        result.dtype = ir.DataType.FLOAT
+        if x.shape is not None:
+            result.shape = ir.Shape([*x.shape[:-1], self._n])
+        if output_dtype not in (None, ir.DataType.FLOAT):
+            result = op.Cast(result, to=output_dtype)
+            result.dtype = output_dtype
+            if x.shape is not None:
+                result.shape = ir.Shape([*x.shape[:-1], self._n])
         return result
 
 

--- a/src/mobius/components/_quantized_linear.py
+++ b/src/mobius/components/_quantized_linear.py
@@ -206,6 +206,7 @@ class BlockQuantizedLinear(nn.Module):
         self.bias = nn.Parameter([out_features]) if bias else None
 
     def forward(self, op: OpBuilder, x: ir.Value) -> ir.Value:
+        op.builder.graph.opset_imports[_ONNX_GENAI_DOMAIN] = 1
         output_dtype = x.dtype
         activation = x if x.dtype == ir.DataType.FLOAT else op.Cast(x, to=ir.DataType.FLOAT)
         inputs: list[ir.Value | None] = [activation, self.weight]

--- a/src/mobius/components/_quantized_linear_test.py
+++ b/src/mobius/components/_quantized_linear_test.py
@@ -262,17 +262,34 @@ class TestQuantizedLinearForward:
 
 class TestBlockQuantizedLinear:
     @pytest.mark.parametrize(
-        ("format_name", "block_bytes"),
-        [("mxfp4", 17), ("iq4_nl", 18)],
+        ("format_name", "block_elements", "block_bytes"),
+        [
+            ("mxfp4", 32, 17),
+            ("iq4_nl", 32, 18),
+            ("iq4_xs", 256, 136),
+            ("iq3_s", 256, 110),
+            ("iq3_xxs", 256, 98),
+            ("iq2_xxs", 256, 66),
+            ("iq2_xs", 256, 74),
+            ("iq2_s", 256, 82),
+            ("iq1_s", 256, 50),
+            ("iq1_m", 256, 56),
+        ],
     )
-    def test_emits_native_block_contract(self, format_name: str, block_bytes: int):
+    def test_emits_native_block_contract(
+        self,
+        format_name: str,
+        block_elements: int,
+        block_bytes: int,
+    ):
         linear = BlockQuantizedLinear(
             IN_FEATURES,
             OUT_FEATURES,
             format=format_name,
             bias=True,
         )
-        assert linear.weight.shape == [OUT_FEATURES, 2, block_bytes]
+        expected_blocks = (IN_FEATURES + block_elements - 1) // block_elements
+        assert linear.weight.shape == [OUT_FEATURES, expected_blocks, block_bytes]
 
         b, op, graph = create_test_builder()
         x = create_test_input(b, "x", [1, 4, IN_FEATURES])
@@ -292,7 +309,7 @@ class TestBlockQuantizedLinear:
 
     def test_rejects_runtime_unsupported_iq_format(self):
         with pytest.raises(ValueError, match="format must be one of"):
-            BlockQuantizedLinear(IN_FEATURES, OUT_FEATURES, format="iq4_xs")
+            BlockQuantizedLinear(IN_FEATURES, OUT_FEATURES, format="q4_k")
 
 
 class TestMakeQuantizedLinearFactory:

--- a/src/mobius/components/_quantized_linear_test.py
+++ b/src/mobius/components/_quantized_linear_test.py
@@ -16,7 +16,7 @@ from mobius._testing import (
     create_test_builder,
     create_test_input,
 )
-from mobius.components._quantized_linear import QuantizedLinear
+from mobius.components._quantized_linear import BlockQuantizedLinear, QuantizedLinear
 
 # Test dimensions
 IN_FEATURES = 64
@@ -258,6 +258,41 @@ class TestQuantizedLinearForward:
         assert "scales" in names
         assert "zero_points" in names
         assert "bias" in names
+
+
+class TestBlockQuantizedLinear:
+    @pytest.mark.parametrize(
+        ("format_name", "block_bytes"),
+        [("mxfp4", 17), ("iq4_nl", 18)],
+    )
+    def test_emits_native_block_contract(self, format_name: str, block_bytes: int):
+        linear = BlockQuantizedLinear(
+            IN_FEATURES,
+            OUT_FEATURES,
+            format=format_name,
+            bias=True,
+        )
+        assert linear.weight.shape == [OUT_FEATURES, 2, block_bytes]
+
+        b, op, graph = create_test_builder()
+        x = create_test_input(b, "x", [1, 4, IN_FEATURES])
+        result = linear(op, x)
+        b._adapt_outputs([result], "")
+
+        node = next(node for node in graph if node.op_type == "BlockQuantizedMatMul")
+        assert node.domain == "com.github.onnxruntime.genai"
+        assert len(node.inputs) == 3
+        attrs = {attribute.name: attribute.value for attribute in node.attributes.values()}
+        assert attrs == {
+            "K": IN_FEATURES,
+            "N": OUT_FEATURES,
+            "format": format_name,
+            "block_layout_version": 1,
+        }
+
+    def test_rejects_runtime_unsupported_iq_format(self):
+        with pytest.raises(ValueError, match="format must be one of"):
+            BlockQuantizedLinear(IN_FEATURES, OUT_FEATURES, format="iq4_xs")
 
 
 class TestMakeQuantizedLinearFactory:

--- a/src/mobius/components/_quantized_linear_test.py
+++ b/src/mobius/components/_quantized_linear_test.py
@@ -298,6 +298,7 @@ class TestBlockQuantizedLinear:
 
         node = next(node for node in graph if node.op_type == "BlockQuantizedMatMul")
         assert node.domain == "com.github.onnxruntime.genai"
+        assert graph.opset_imports["com.github.onnxruntime.genai"] == 1
         assert len(node.inputs) == 3
         attrs = {attribute.name: attribute.value for attribute in node.attributes.values()}
         assert attrs == {

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -10,8 +10,8 @@ pipeline.  Two modes:
   float.  Simple, but loses the compression benefit of quantization.
 - **Quantized** (``keep_quantized=True``): Affine linear-layer weights are
   repacked into MatMulNBits format and token embeddings into
-  GatherBlockQuantized format. Native MXFP4 and IQ4_NL projection blocks are
-  preserved for BlockQuantizedMatMul. Mixed presets such as Q4_K_M are
+  GatherBlockQuantized format. Runtime-supported native IQ/MXFP4 projection
+  blocks are preserved for BlockQuantizedMatMul. Mixed presets such as Q4_K_M are
   normalized to one affine layout. Other tensors are dequantized.
 """
 
@@ -97,8 +97,8 @@ def build_from_gguf(
     8. Apply weights to the ONNX model
 
     When *keep_quantized* is ``True``, supported affine tensors are repacked
-    into MatMulNBits format, while MXFP4 and IQ4_NL projection blocks are
-    retained byte-for-byte for BlockQuantizedMatMul.
+    into MatMulNBits format, while runtime-supported native IQ/MXFP4 projection
+    blocks are retained byte-for-byte for BlockQuantizedMatMul.
 
     Args:
         gguf_path: Path to the ``.gguf`` file, *or* a HuggingFace Hub
@@ -302,26 +302,31 @@ def _is_quantized_weight(key: str, state_dict: dict) -> bool:
 
 
 def _is_native_block_weight(key: str, state_dict: dict) -> bool:
-    """Check for a packed MXFP4/IQ4_NL weight with embedded block scales."""
+    """Check for a packed runtime-native GGUF weight."""
+    from mobius.integrations.gguf._repacker import NATIVE_BLOCK_BYTE_SIZES
+
     if not key.endswith(".weight"):
         return False
     value = state_dict[key]
     return (
         value.dtype.is_floating_point is False
         and value.dim() == 3
-        and value.shape[-1] in (17, 18)
+        and value.shape[-1] in NATIVE_BLOCK_BYTE_SIZES
     )
+
+
+def _native_block_spec(qtype):
+    """Return the runtime-native layout for a GGUF quantization enum."""
+    from mobius.integrations.gguf._repacker import native_block_spec
+
+    qtype_val = qtype.value if hasattr(qtype, "value") else qtype
+    return native_block_spec(qtype_val)
 
 
 def _native_block_format(qtype) -> str | None:
     """Return the runtime format string for supported native GGUF blocks."""
-    return {
-        # ggml type IDs: IQ4_NL=20, MXFP4=39.
-        "MXFP4": "mxfp4",
-        "IQ4_NL": "iq4_nl",
-        # TODO: Keep IQ2_XXS=16, IQ1_S=19, IQ3_S=21, IQ4_XS=23 and the other
-        # IQ variants on the dequantize/requantize fallback until implemented.
-    }.get(getattr(qtype, "name", None))
+    spec = _native_block_spec(qtype)
+    return spec.format if spec is not None else None
 
 
 def _native_block_target_stems(
@@ -358,7 +363,7 @@ def _replace_child_module(root, path: str, replacement) -> None:
 
 
 def _replace_native_block_linears(module, gguf_model, gguf_arch: str) -> None:
-    """Swap MatMulNBits scaffolding for source-native MXFP4/IQ4_NL linears."""
+    """Swap MatMulNBits scaffolding for runtime-supported native linears."""
     from mobius.components import BlockQuantizedLinear, QuantizedLinear
     from mobius.integrations.gguf._tensor_mapping import map_gguf_to_hf_names
 
@@ -389,7 +394,7 @@ def _replace_native_block_linears(module, gguf_model, gguf_arch: str) -> None:
 
     if replacements:
         logger.info(
-            "Preserving %d GGUF projection weights as native MXFP4/IQ4_NL blocks",
+            "Preserving %d GGUF projection weights as runtime-native IQ/MXFP4 blocks",
             len(replacements),
         )
 
@@ -623,6 +628,14 @@ def _can_quantize_lm_head(gguf_model, gguf_arch: str) -> bool:
         "Q8_0",
         "MXFP4",
         "IQ4_NL",
+        "IQ4_XS",
+        "IQ3_S",
+        "IQ3_XXS",
+        "IQ2_XXS",
+        "IQ2_XS",
+        "IQ2_S",
+        "IQ1_S",
+        "IQ1_M",
     }
     for name, _raw, qtype, shape in gguf_model.tensor_items_raw():
         if map_gguf_to_hf_names(name, gguf_arch) != "lm_head.weight":
@@ -763,6 +776,7 @@ def _load_quantized_state_dict(
     from mobius.components import BlockQuantizedLinear, QuantizedEmbedding, QuantizedLinear
     from mobius.integrations.gguf._repacker import (
         can_repack,
+        preserve_native_blocks,
         repack_dequantized_tensor,
         repack_gguf_tensor,
     )
@@ -842,20 +856,21 @@ def _load_quantized_state_dict(
             np_shape,
             set(native_block_stems),
         )
-        native_format = _native_block_format(qtype)
-        if native_targets and native_format is not None:
-            block_bytes = 17 if native_format == "mxfp4" else 18
+        native_spec = _native_block_spec(qtype)
+        if native_targets and native_spec is not None:
             n_out = int(np_shape[-2])
             k_in = int(np_shape[-1])
-            n_blocks = (k_in + 31) // 32
-            expected_bytes = len(native_targets) * n_out * n_blocks * block_bytes
-            packed = raw.ravel().view(np.uint8)
-            if packed.size != expected_bytes:
-                raise ValueError(
-                    f"Native {native_format} data size mismatch for {hf_name}: "
-                    f"got {packed.size} bytes, expected {expected_bytes}"
-                )
-            packed = packed.reshape(len(native_targets), n_out, n_blocks, block_bytes)
+            packed = preserve_native_blocks(
+                raw,
+                qtype_val,
+                (len(native_targets) * n_out, k_in),
+            )
+            packed = packed.reshape(
+                len(native_targets),
+                n_out,
+                packed.shape[-2],
+                native_spec.bytes,
+            )
             for index, native_stem in enumerate(native_targets):
                 w = torch.from_numpy(np.array(packed[index], copy=True))
                 target_name = f"{native_stem}.weight"

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -8,11 +8,11 @@ pipeline.  Two modes:
 
 - **Dequantized** (default): All quantized tensors are dequantized to
   float.  Simple, but loses the compression benefit of quantization.
-- **Quantized** (``keep_quantized=True``): Linear-layer weights, including
-  a quantized output head, are repacked into MatMulNBits format and token
-  embeddings into GatherBlockQuantized format. Mixed presets such as
-  Q4_K_M are normalized to one quantization layout. Other tensors are
-  dequantized.
+- **Quantized** (``keep_quantized=True``): Affine linear-layer weights are
+  repacked into MatMulNBits format and token embeddings into
+  GatherBlockQuantized format. Native MXFP4 and IQ4_NL projection blocks are
+  preserved for BlockQuantizedMatMul. Mixed presets such as Q4_K_M are
+  normalized to one affine layout. Other tensors are dequantized.
 """
 
 from __future__ import annotations
@@ -91,12 +91,14 @@ def build_from_gguf(
     2. Look up the model class and task from the registry
     3. Build the ONNX graph (standard ``build_from_module`` pipeline)
     4. Map GGUF tensor names → HuggingFace names
-    5. Apply architecture-specific tensor processors
-    6. Run ``preprocess_weights()`` (HF → ONNX name mapping)
-    7. Apply weights to the ONNX model
+    5. Replace native-block projection modules when present
+    6. Apply architecture-specific tensor processors
+    7. Run ``preprocess_weights()`` (HF → ONNX name mapping)
+    8. Apply weights to the ONNX model
 
-    When *keep_quantized* is ``True``, supported quantized tensors are
-    repacked into MatMulNBits format instead of dequantized.
+    When *keep_quantized* is ``True``, supported affine tensors are repacked
+    into MatMulNBits format, while MXFP4 and IQ4_NL projection blocks are
+    retained byte-for-byte for BlockQuantizedMatMul.
 
     Args:
         gguf_path: Path to the ``.gguf`` file, *or* a HuggingFace Hub
@@ -233,6 +235,8 @@ def build_from_gguf(
 
     # 5. Build ONNX graph
     module = module_class(config)
+    if keep_quantized:
+        _replace_native_block_linears(module, gguf_model, gguf_arch)
     pkg = build_from_module(module, config, task, execution_provider=execution_provider)
     logger.info(
         "Built ONNX graph for %s (%d components)",
@@ -260,7 +264,9 @@ def build_from_gguf(
             k
             for k in state_dict
             if not (
-                k.endswith((".scales", ".zero_points")) or _is_quantized_weight(k, state_dict)
+                k.endswith((".scales", ".zero_points"))
+                or _is_quantized_weight(k, state_dict)
+                or _is_native_block_weight(k, state_dict)
             )
         }
         float_dict = {k: state_dict[k] for k in float_keys}
@@ -293,6 +299,99 @@ def _is_quantized_weight(key: str, state_dict: dict) -> bool:
         return False
     stem = key[: -len(".weight")]
     return f"{stem}.scales" in state_dict
+
+
+def _is_native_block_weight(key: str, state_dict: dict) -> bool:
+    """Check for a packed MXFP4/IQ4_NL weight with embedded block scales."""
+    if not key.endswith(".weight"):
+        return False
+    value = state_dict[key]
+    return (
+        value.dtype.is_floating_point is False
+        and value.dim() == 3
+        and value.shape[-1] in (17, 18)
+    )
+
+
+def _native_block_format(qtype) -> str | None:
+    """Return the runtime format string for supported native GGUF blocks."""
+    return {
+        # ggml type IDs: IQ4_NL=20, MXFP4=39.
+        "MXFP4": "mxfp4",
+        "IQ4_NL": "iq4_nl",
+        # TODO: Keep IQ2_XXS=16, IQ1_S=19, IQ3_S=21, IQ4_XS=23 and the other
+        # IQ variants on the dequantize/requantize fallback until implemented.
+    }.get(getattr(qtype, "name", None))
+
+
+def _native_block_target_stems(
+    hf_name: str,
+    np_shape: tuple[int, ...],
+    available_stems: set[str],
+) -> list[str]:
+    """Map a GGUF weight to one or more native-block module stems."""
+    if not hf_name.endswith(".weight"):
+        return []
+    stem = hf_name[: -len(".weight")]
+    if stem in available_stems:
+        return [stem]
+
+    if len(np_shape) == 3 and ".experts." in stem:
+        prefix, projection = stem.rsplit(".experts.", 1)
+        for container in (f"{prefix}.experts", f"{prefix}.moe.experts"):
+            candidates = [f"{container}.{i}.{projection}" for i in range(np_shape[0])]
+            if all(candidate in available_stems for candidate in candidates):
+                return candidates
+    return []
+
+
+def _replace_child_module(root, path: str, replacement) -> None:
+    """Replace a named ONNXScript child module while retaining its graph name."""
+    parts = path.split(".")
+    parent = root
+    for part in parts[:-1]:
+        parent = parent._modules[part]
+    child_name = parts[-1]
+    old = parent._modules[child_name]
+    replacement._set_name(old.name)
+    setattr(parent, child_name, replacement)
+
+
+def _replace_native_block_linears(module, gguf_model, gguf_arch: str) -> None:
+    """Swap MatMulNBits scaffolding for source-native MXFP4/IQ4_NL linears."""
+    from mobius.components import BlockQuantizedLinear, QuantizedLinear
+    from mobius.integrations.gguf._tensor_mapping import map_gguf_to_hf_names
+
+    module_map = dict(module.named_modules())
+    quantized_stems = {
+        name for name, child in module_map.items() if isinstance(child, QuantizedLinear)
+    }
+    replacements: dict[str, str] = {}
+    for gguf_name, _raw, qtype, np_shape in gguf_model.tensor_items_raw():
+        format_name = _native_block_format(qtype)
+        if format_name is None:
+            continue
+        hf_name = map_gguf_to_hf_names(gguf_name, gguf_arch)
+        if hf_name is None:
+            continue
+        for stem in _native_block_target_stems(hf_name, np_shape, quantized_stems):
+            replacements[stem] = format_name
+
+    for stem, format_name in replacements.items():
+        old = module_map[stem]
+        replacement = BlockQuantizedLinear(
+            old._k,
+            old._n,
+            format=format_name,
+            bias=old.bias is not None,
+        )
+        _replace_child_module(module, stem, replacement)
+
+    if replacements:
+        logger.info(
+            "Preserving %d GGUF projection weights as native MXFP4/IQ4_NL blocks",
+            len(replacements),
+        )
 
 
 def _normalize_gguf_weights(
@@ -421,6 +520,21 @@ def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, int, bool]:
             }
         )
         if not repackable_counts:
+            native_counts = Counter(
+                {
+                    qtype: count
+                    for qtype, count in counts.items()
+                    if _native_block_format(qtype)
+                }
+            )
+            if native_counts:
+                dominant = native_counts.most_common(1)[0][0]
+                logger.info(
+                    "Native GGUF quant type %s selected; using temporary "
+                    "4-bit/block-32 module scaffolding",
+                    dominant,
+                )
+                return 4, 32, True
             raise ValueError(
                 "No repackable quantized tensors found in GGUF file. "
                 "Use keep_quantized=False for dequantized import."
@@ -507,6 +621,8 @@ def _can_quantize_lm_head(gguf_model, gguf_arch: str) -> bool:
         "Q5_K",
         "Q6_K",
         "Q8_0",
+        "MXFP4",
+        "IQ4_NL",
     }
     for name, _raw, qtype, shape in gguf_model.tensor_items_raw():
         if map_gguf_to_hf_names(name, gguf_arch) != "lm_head.weight":
@@ -628,7 +744,7 @@ def _load_quantized_state_dict(
     module,
     config,
 ) -> dict:
-    """Load tensors, normalizing quantized projections to MatMulNBits.
+    """Load tensors, preserving native blocks or normalizing to MatMulNBits.
 
     Projection weights (Q/K/V/O, MLP, and a quantized output head) are
     converted to the graph's common MatMulNBits format, and token embeddings
@@ -644,7 +760,7 @@ def _load_quantized_state_dict(
     import torch
     from gguf import GGMLQuantizationType, dequantize
 
-    from mobius.components import QuantizedEmbedding, QuantizedLinear
+    from mobius.components import BlockQuantizedLinear, QuantizedEmbedding, QuantizedLinear
     from mobius.integrations.gguf._repacker import (
         can_repack,
         repack_dequantized_tensor,
@@ -664,10 +780,13 @@ def _load_quantized_state_dict(
     # Collect module paths that use QuantizedLinear so we know
     # which .weight parameters should receive repacked data.
     quantized_stems = set()
+    native_block_stems: dict[str, str] = {}
     quantized_embedding_stems = set()
     for mod_name, mod in module.named_modules():
         if isinstance(mod, QuantizedLinear):
             quantized_stems.add(mod_name)
+        elif isinstance(mod, BlockQuantizedLinear):
+            native_block_stems[mod_name] = mod._format
         elif isinstance(mod, QuantizedEmbedding):
             quantized_embedding_stems.add(mod_name)
 
@@ -718,7 +837,43 @@ def _load_quantized_state_dict(
             stem in quantized_stems or is_quantized_embedding
         )
 
-        if should_repack:
+        native_targets = _native_block_target_stems(
+            hf_name,
+            np_shape,
+            set(native_block_stems),
+        )
+        native_format = _native_block_format(qtype)
+        if native_targets and native_format is not None:
+            block_bytes = 17 if native_format == "mxfp4" else 18
+            n_out = int(np_shape[-2])
+            k_in = int(np_shape[-1])
+            n_blocks = (k_in + 31) // 32
+            expected_bytes = len(native_targets) * n_out * n_blocks * block_bytes
+            packed = raw.ravel().view(np.uint8)
+            if packed.size != expected_bytes:
+                raise ValueError(
+                    f"Native {native_format} data size mismatch for {hf_name}: "
+                    f"got {packed.size} bytes, expected {expected_bytes}"
+                )
+            packed = packed.reshape(len(native_targets), n_out, n_blocks, block_bytes)
+            for index, native_stem in enumerate(native_targets):
+                w = torch.from_numpy(np.array(packed[index], copy=True))
+                target_name = f"{native_stem}.weight"
+                if _needs_qk_permute(
+                    target_name,
+                    num_heads,
+                    num_kv_heads,
+                    model_type,
+                ):
+                    n_head = (
+                        num_heads
+                        if ".q_proj." in target_name or ".qkv_proj." in target_name
+                        else num_kv_heads
+                    )
+                    w = _reverse_permute(w, n_head)
+                state_dict[target_name] = w
+            n_repacked += len(native_targets)
+        elif should_repack:
             if is_tencent_q1_0_tensor:
                 repacked = parse_tencent_q1_0_tensor(
                     gguf_path,

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -355,10 +355,17 @@ def _replace_child_module(root, path: str, replacement) -> None:
     parts = path.split(".")
     parent = root
     for part in parts[:-1]:
-        parent = parent._modules[part]
+        try:
+            parent = getattr(parent, part)
+        except AttributeError as error:
+            raise AttributeError(f"Module path {path!r} has no child {part!r}") from error
     child_name = parts[-1]
-    old = parent._modules[child_name]
-    replacement._set_name(old.name)
+    try:
+        old = getattr(parent, child_name)
+    except AttributeError as error:
+        raise AttributeError(f"Module path {path!r} has no child {child_name!r}") from error
+    if hasattr(replacement, "_set_name") and hasattr(old, "name"):
+        replacement._set_name(old.name)
     setattr(parent, child_name, replacement)
 
 

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -509,6 +509,22 @@ def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, int, bool]:
             "Use keep_quantized=False for dequantized import."
         )
 
+    native_counts = Counter(
+        {qtype: count for qtype, count in counts.items() if _native_block_format(qtype)}
+    )
+    if native_counts:
+        asymmetric_types = {"Q2_K", "Q4_1", "Q4_K", "Q5_1", "Q5_K"}
+        is_sym = not any(
+            getattr(qtype, "name", None) in asymmetric_types
+            for qtype in counts
+            if qtype not in native_counts
+        )
+        logger.info(
+            "Native GGUF quant types present; using 4-bit/block-32 module "
+            "scaffolding for non-native quantized tensors",
+        )
+        return 4, 32, is_sym
+
     # Q4_K_M is deliberately a mixed preset. Depending on tensor dimensions
     # and importance it may contain mostly Q5_0 plus Q4_K, Q6_K, and Q8_0.
     # The presence of Q4_K identifies the desired 4-bit MatMulNBits target;
@@ -525,21 +541,6 @@ def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, int, bool]:
             }
         )
         if not repackable_counts:
-            native_counts = Counter(
-                {
-                    qtype: count
-                    for qtype, count in counts.items()
-                    if _native_block_format(qtype)
-                }
-            )
-            if native_counts:
-                dominant = native_counts.most_common(1)[0][0]
-                logger.info(
-                    "Native GGUF quant type %s selected; using temporary "
-                    "4-bit/block-32 module scaffolding",
-                    dominant,
-                )
-                return 4, 32, True
             raise ValueError(
                 "No repackable quantized tensors found in GGUF file. "
                 "Use keep_quantized=False for dequantized import."

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -21,7 +21,9 @@ def _write_quantized_gguf(
     intermediate_size: int = 128,
     vocab_size: int = 256,
     quantize_embedding: bool = False,
+    embedding_quantization: str | None = None,
     projection_quantization: str = "q4_0",
+    value_projection_quantization: str | None = None,
     output_quantization: str | None = None,
     tie_embeddings: bool = False,
 ) -> None:
@@ -87,6 +89,28 @@ def _write_quantized_gguf(
                 )
         writer.add_tensor(name, raw, raw_dtype=GGMLQuantizationType.Q8_0)
 
+    def _add_q5_1(name: str, n_out: int, k_in: int) -> None:
+        """Write a Q5_1-quantized weight tensor."""
+        block_size = 32
+        block_bytes = 24  # 2B scale + 2B min + 4B high bits + 16B low nibbles
+        n_blocks = k_in // block_size
+        bytes_per_row = n_blocks * block_bytes
+        raw = np.zeros((n_out, bytes_per_row), dtype=np.uint8)
+        for row in range(n_out):
+            for b in range(n_blocks):
+                off = b * block_bytes
+                scale = np.random.uniform(0.01, 1.0)
+                minimum = np.random.uniform(-0.5, 0.5)
+                raw[row, off : off + 2] = np.array([scale], dtype=np.float16).view(np.uint8)
+                raw[row, off + 2 : off + 4] = np.array([minimum], dtype=np.float16).view(
+                    np.uint8
+                )
+                raw[row, off + 4 : off + 8] = np.random.randint(0, 256, size=4, dtype=np.uint8)
+                raw[row, off + 8 : off + 24] = np.random.randint(
+                    0, 256, size=16, dtype=np.uint8
+                )
+        writer.add_tensor(name, raw, raw_dtype=GGMLQuantizationType.Q5_1)
+
     def _add_native(name: str, n_out: int, k_in: int, format_name: str) -> None:
         """Write deterministic native blocks with embedded scales."""
         qtype, block_elements, block_bytes = {
@@ -109,6 +133,8 @@ def _write_quantized_gguf(
 
     if quantize_embedding:
         _add_q4_0("token_embd.weight", vocab_size, hidden_size)
+    elif embedding_quantization == "q8_0":
+        _add_q8_0("token_embd.weight", vocab_size, hidden_size)
     else:
         _add_f32("token_embd.weight", (vocab_size, hidden_size))
 
@@ -118,8 +144,13 @@ def _write_quantized_gguf(
             "q8_0": _add_q8_0,
         }[projection_quantization]
     else:
+
         def add_projection(name: str, n_out: int, k_in: int) -> None:
             _add_native(name, n_out, k_in, projection_quantization)
+
+    add_value_projection = (
+        _add_q5_1 if value_projection_quantization == "q5_1" else add_projection
+    )
 
     for i in range(num_layers):
         add_projection(
@@ -132,7 +163,7 @@ def _write_quantized_gguf(
             num_kv_heads * head_dim,
             hidden_size,
         )
-        add_projection(
+        add_value_projection(
             f"blk.{i}.attn_v.weight",
             num_kv_heads * head_dim,
             hidden_size,
@@ -241,6 +272,22 @@ def native_block_gguf(tmp_path: Path, request) -> tuple[Path, str, int, int]:
     return path, format_name, block_elements, block_bytes
 
 
+@pytest.fixture
+def mixed_native_q5_q8_gguf(tmp_path: Path) -> Path:
+    """Create native IQ projections with a Q5_1 value projection and Q8 embedding."""
+    path = tmp_path / "test_mixed_native_q5_q8.gguf"
+    _write_quantized_gguf(
+        path,
+        hidden_size=256,
+        num_kv_heads=4,
+        intermediate_size=256,
+        embedding_quantization="q8_0",
+        projection_quantization="iq4_xs",
+        value_projection_quantization="q5_1",
+    )
+    return path
+
+
 class TestBuildQuantizedGguf:
     """Tests for build_from_gguf(keep_quantized=True)."""
 
@@ -289,11 +336,39 @@ class TestBuildQuantizedGguf:
         assert weight.dtype == ir.DataType.UINT8
         n_blocks = (256 + block_elements - 1) // block_elements
         assert list(weight.shape) == [256, n_blocks, block_bytes]
-        expected = np.arange(
-            256 * n_blocks * block_bytes, dtype=np.uint8
-        ).reshape(256, n_blocks, block_bytes)
+        expected = np.arange(256 * n_blocks * block_bytes, dtype=np.uint8).reshape(
+            256, n_blocks, block_bytes
+        )
         np.testing.assert_array_equal(weight.const_value.numpy(), expected)
         assert "model.layers.0.self_attn.o_proj.scales" not in model.graph.initializers
+
+        assert model.graph.opset_imports["com.github.onnxruntime.genai"] == 1
+        proto = ir.serde.serialize_model(model)
+        imports = {opset.domain: opset.version for opset in proto.opset_import}
+        assert imports["com.github.onnxruntime.genai"] == 1
+
+    def test_mixed_native_quantization_uses_q4_scaffold(self, mixed_native_q5_q8_gguf: Path):
+        """Native IQ tensors force Q5_1 fallback weights onto a Q4 scaffold."""
+        from mobius.integrations.gguf import build_from_gguf
+
+        model = build_from_gguf(mixed_native_q5_q8_gguf, keep_quantized=True)["model"]
+        native_nodes = [node for node in model.graph if node.op_type == "BlockQuantizedMatMul"]
+        assert len(native_nodes) == 6
+
+        value_nodes = [
+            node
+            for node in model.graph
+            if node.op_type == "MatMulNBits"
+            and node.inputs[1].name == "model.layers.0.self_attn.v_proj.weight"
+        ]
+        assert len(value_nodes) == 1
+        assert value_nodes[0].attributes["bits"].value == 4
+        assert value_nodes[0].attributes["block_size"].value == 32
+        assert "model.layers.0.self_attn.v_proj.zero_points" in model.graph.initializers
+
+        native_weight = model.graph.initializers["model.layers.0.self_attn.o_proj.weight"]
+        expected = np.arange(256 * 136, dtype=np.uint8).reshape(256, 1, 136)
+        np.testing.assert_array_equal(native_weight.const_value.numpy(), expected)
 
     def test_quantized_embedding_uses_gatherblockquantized(self, q4_0_embedding_gguf: Path):
         """A quantized GGUF embedding remains packed in the ONNX graph."""

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -25,10 +25,10 @@ def _write_quantized_gguf(
     output_quantization: str | None = None,
     tie_embeddings: bool = False,
 ) -> None:
-    """Write a GGUF file with Q4_0 quantized projection weights.
+    """Write a GGUF file with quantized projection weights.
 
     Norms are float32; all linear-layer weights in decoder blocks are
-    Q4_0 (4-bit symmetric, block_size=32). The embedding can optionally
+    encoded with *projection_quantization*. The embedding can optionally
     be Q4_0 and tied to the LM head.
     """
     from gguf import GGMLQuantizationType, GGUFWriter
@@ -87,6 +87,18 @@ def _write_quantized_gguf(
                 )
         writer.add_tensor(name, raw, raw_dtype=GGMLQuantizationType.Q8_0)
 
+    def _add_native(name: str, n_out: int, k_in: int, format_name: str) -> None:
+        """Write deterministic native blocks with embedded scales."""
+        qtype, block_bytes = {
+            "mxfp4": (GGMLQuantizationType.MXFP4, 17),
+            "iq4_nl": (GGMLQuantizationType.IQ4_NL, 18),
+        }[format_name]
+        n_blocks = (k_in + 31) // 32
+        raw = np.arange(n_out * n_blocks * block_bytes, dtype=np.uint8).reshape(
+            n_out, n_blocks * block_bytes
+        )
+        writer.add_tensor(name, raw, raw_dtype=qtype)
+
     if quantize_embedding:
         _add_q4_0("token_embd.weight", vocab_size, hidden_size)
     else:
@@ -95,6 +107,8 @@ def _write_quantized_gguf(
     add_projection = {
         "q4_0": _add_q4_0,
         "q8_0": _add_q8_0,
+        "mxfp4": lambda name, n_out, k_in: _add_native(name, n_out, k_in, "mxfp4"),
+        "iq4_nl": lambda name, n_out, k_in: _add_native(name, n_out, k_in, "iq4_nl"),
     }[projection_quantization]
 
     for i in range(num_layers):
@@ -189,6 +203,16 @@ def q8_0_projection_q4_head_gguf(tmp_path: Path) -> Path:
     return path
 
 
+@pytest.fixture(params=["mxfp4", "iq4_nl"])
+def native_block_gguf(tmp_path: Path, request) -> tuple[Path, str, int]:
+    """Create a GGUF whose projection weights use a runtime-native block format."""
+    format_name = request.param
+    path = tmp_path / f"test_{format_name}.gguf"
+    _write_quantized_gguf(path, projection_quantization=format_name)
+    block_bytes = 17 if format_name == "mxfp4" else 18
+    return path, format_name, block_bytes
+
+
 class TestBuildQuantizedGguf:
     """Tests for build_from_gguf(keep_quantized=True)."""
 
@@ -211,6 +235,34 @@ class TestBuildQuantizedGguf:
         assert "MatMulNBits" in op_types, (
             f"Expected MatMulNBits in ops, got: {sorted(op_types)}"
         )
+
+    def test_native_blocks_emit_block_quantized_matmul_and_preserve_bytes(
+        self,
+        native_block_gguf: tuple[Path, str, int],
+    ):
+        """MXFP4/IQ4_NL projections retain their exact GGUF block bytes."""
+        import onnx_ir as ir
+
+        from mobius.integrations.gguf import build_from_gguf
+
+        path, format_name, block_bytes = native_block_gguf
+        model = build_from_gguf(path, keep_quantized=True)["model"]
+        nodes = [node for node in model.graph if node.op_type == "BlockQuantizedMatMul"]
+        assert len(nodes) == 7
+        assert all(node.domain == "com.github.onnxruntime.genai" for node in nodes)
+        for node in nodes:
+            attrs = {attribute.name: attribute.value for attribute in node.attributes.values()}
+            assert attrs["format"] == format_name
+            assert attrs["block_layout_version"] == 1
+            assert "K" in attrs
+            assert "N" in attrs
+
+        weight = model.graph.initializers["model.layers.0.self_attn.o_proj.weight"]
+        assert weight.dtype == ir.DataType.UINT8
+        assert list(weight.shape) == [64, 2, block_bytes]
+        expected = np.arange(64 * 2 * block_bytes, dtype=np.uint8).reshape(64, 2, block_bytes)
+        np.testing.assert_array_equal(weight.const_value.numpy(), expected)
+        assert "model.layers.0.self_attn.o_proj.scales" not in model.graph.initializers
 
     def test_quantized_embedding_uses_gatherblockquantized(self, q4_0_embedding_gguf: Path):
         """A quantized GGUF embedding remains packed in the ONNX graph."""
@@ -378,6 +430,27 @@ class TestBuildQuantizedGguf:
 
         bits, block_size, is_sym = _detect_quant_params(_MixedModel(), "llama")
         assert (bits, block_size, is_sym) == (4, 32, False)
+
+    @pytest.mark.parametrize("qtype_name", ["IQ1_S", "IQ2_XXS", "IQ3_S", "IQ4_XS"])
+    def test_unsupported_iq_formats_do_not_select_native_op(self, qtype_name: str):
+        """IQ formats rejected by the runtime remain on the existing fallback."""
+        from gguf import GGMLQuantizationType
+
+        from mobius.integrations.gguf._builder import _native_block_format
+
+        assert _native_block_format(getattr(GGMLQuantizationType, qtype_name)) is None
+
+    @pytest.mark.parametrize("moe_container", ["experts", "moe.experts"])
+    def test_native_moe_tensor_maps_to_each_expert(self, moe_container: str):
+        """Stacked GGUF MoE blocks route to standard and DeepSeek expert paths."""
+        from mobius.integrations.gguf._builder import _native_block_target_stems
+
+        available = {f"model.layers.0.mlp.{moe_container}.{i}.gate_proj" for i in range(3)}
+        assert _native_block_target_stems(
+            "model.layers.0.mlp.experts.gate_proj.weight",
+            (3, 64, 64),
+            available,
+        ) == sorted(available, key=lambda name: int(name.split(".")[-2]))
 
 
 class TestRawTensorIterator:

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -89,11 +89,19 @@ def _write_quantized_gguf(
 
     def _add_native(name: str, n_out: int, k_in: int, format_name: str) -> None:
         """Write deterministic native blocks with embedded scales."""
-        qtype, block_bytes = {
-            "mxfp4": (GGMLQuantizationType.MXFP4, 17),
-            "iq4_nl": (GGMLQuantizationType.IQ4_NL, 18),
+        qtype, block_elements, block_bytes = {
+            "mxfp4": (GGMLQuantizationType.MXFP4, 32, 17),
+            "iq4_nl": (GGMLQuantizationType.IQ4_NL, 32, 18),
+            "iq4_xs": (GGMLQuantizationType.IQ4_XS, 256, 136),
+            "iq3_s": (GGMLQuantizationType.IQ3_S, 256, 110),
+            "iq3_xxs": (GGMLQuantizationType.IQ3_XXS, 256, 98),
+            "iq2_xxs": (GGMLQuantizationType.IQ2_XXS, 256, 66),
+            "iq2_xs": (GGMLQuantizationType.IQ2_XS, 256, 74),
+            "iq2_s": (GGMLQuantizationType.IQ2_S, 256, 82),
+            "iq1_s": (GGMLQuantizationType.IQ1_S, 256, 50),
+            "iq1_m": (GGMLQuantizationType.IQ1_M, 256, 56),
         }[format_name]
-        n_blocks = (k_in + 31) // 32
+        n_blocks = (k_in + block_elements - 1) // block_elements
         raw = np.arange(n_out * n_blocks * block_bytes, dtype=np.uint8).reshape(
             n_out, n_blocks * block_bytes
         )
@@ -104,12 +112,14 @@ def _write_quantized_gguf(
     else:
         _add_f32("token_embd.weight", (vocab_size, hidden_size))
 
-    add_projection = {
-        "q4_0": _add_q4_0,
-        "q8_0": _add_q8_0,
-        "mxfp4": lambda name, n_out, k_in: _add_native(name, n_out, k_in, "mxfp4"),
-        "iq4_nl": lambda name, n_out, k_in: _add_native(name, n_out, k_in, "iq4_nl"),
-    }[projection_quantization]
+    if projection_quantization in {"q4_0", "q8_0"}:
+        add_projection = {
+            "q4_0": _add_q4_0,
+            "q8_0": _add_q8_0,
+        }[projection_quantization]
+    else:
+        def add_projection(name: str, n_out: int, k_in: int) -> None:
+            _add_native(name, n_out, k_in, projection_quantization)
 
     for i in range(num_layers):
         add_projection(
@@ -203,14 +213,32 @@ def q8_0_projection_q4_head_gguf(tmp_path: Path) -> Path:
     return path
 
 
-@pytest.fixture(params=["mxfp4", "iq4_nl"])
-def native_block_gguf(tmp_path: Path, request) -> tuple[Path, str, int]:
+@pytest.fixture(
+    params=[
+        ("mxfp4", 32, 17),
+        ("iq4_nl", 32, 18),
+        ("iq4_xs", 256, 136),
+        ("iq3_s", 256, 110),
+        ("iq3_xxs", 256, 98),
+        ("iq2_xxs", 256, 66),
+        ("iq2_xs", 256, 74),
+        ("iq2_s", 256, 82),
+        ("iq1_s", 256, 50),
+        ("iq1_m", 256, 56),
+    ]
+)
+def native_block_gguf(tmp_path: Path, request) -> tuple[Path, str, int, int]:
     """Create a GGUF whose projection weights use a runtime-native block format."""
-    format_name = request.param
+    format_name, block_elements, block_bytes = request.param
     path = tmp_path / f"test_{format_name}.gguf"
-    _write_quantized_gguf(path, projection_quantization=format_name)
-    block_bytes = 17 if format_name == "mxfp4" else 18
-    return path, format_name, block_bytes
+    _write_quantized_gguf(
+        path,
+        hidden_size=256,
+        num_kv_heads=4,
+        intermediate_size=256,
+        projection_quantization=format_name,
+    )
+    return path, format_name, block_elements, block_bytes
 
 
 class TestBuildQuantizedGguf:
@@ -238,14 +266,14 @@ class TestBuildQuantizedGguf:
 
     def test_native_blocks_emit_block_quantized_matmul_and_preserve_bytes(
         self,
-        native_block_gguf: tuple[Path, str, int],
+        native_block_gguf: tuple[Path, str, int, int],
     ):
-        """MXFP4/IQ4_NL projections retain their exact GGUF block bytes."""
+        """Runtime-native IQ/MXFP4 projections retain their exact GGUF bytes."""
         import onnx_ir as ir
 
         from mobius.integrations.gguf import build_from_gguf
 
-        path, format_name, block_bytes = native_block_gguf
+        path, format_name, block_elements, block_bytes = native_block_gguf
         model = build_from_gguf(path, keep_quantized=True)["model"]
         nodes = [node for node in model.graph if node.op_type == "BlockQuantizedMatMul"]
         assert len(nodes) == 7
@@ -254,13 +282,16 @@ class TestBuildQuantizedGguf:
             attrs = {attribute.name: attribute.value for attribute in node.attributes.values()}
             assert attrs["format"] == format_name
             assert attrs["block_layout_version"] == 1
-            assert "K" in attrs
-            assert "N" in attrs
+            assert attrs["K"] == 256
+            assert attrs["N"] == 256
 
         weight = model.graph.initializers["model.layers.0.self_attn.o_proj.weight"]
         assert weight.dtype == ir.DataType.UINT8
-        assert list(weight.shape) == [64, 2, block_bytes]
-        expected = np.arange(64 * 2 * block_bytes, dtype=np.uint8).reshape(64, 2, block_bytes)
+        n_blocks = (256 + block_elements - 1) // block_elements
+        assert list(weight.shape) == [256, n_blocks, block_bytes]
+        expected = np.arange(
+            256 * n_blocks * block_bytes, dtype=np.uint8
+        ).reshape(256, n_blocks, block_bytes)
         np.testing.assert_array_equal(weight.const_value.numpy(), expected)
         assert "model.layers.0.self_attn.o_proj.scales" not in model.graph.initializers
 
@@ -431,14 +462,13 @@ class TestBuildQuantizedGguf:
         bits, block_size, is_sym = _detect_quant_params(_MixedModel(), "llama")
         assert (bits, block_size, is_sym) == (4, 32, False)
 
-    @pytest.mark.parametrize("qtype_name", ["IQ1_S", "IQ2_XXS", "IQ3_S", "IQ4_XS"])
-    def test_unsupported_iq_formats_do_not_select_native_op(self, qtype_name: str):
-        """IQ formats rejected by the runtime remain on the existing fallback."""
+    def test_runtime_unsupported_format_does_not_select_native_op(self):
+        """A GGUF type outside the runtime contract remains on the fallback."""
         from gguf import GGMLQuantizationType
 
         from mobius.integrations.gguf._builder import _native_block_format
 
-        assert _native_block_format(getattr(GGMLQuantizationType, qtype_name)) is None
+        assert _native_block_format(GGMLQuantizationType.Q5_0) is None
 
     @pytest.mark.parametrize("moe_container", ["experts", "moe.experts"])
     def test_native_moe_tensor_maps_to_each_expert(self, moe_container: str):

--- a/src/mobius/integrations/gguf/_repacker.py
+++ b/src/mobius/integrations/gguf/_repacker.py
@@ -1,11 +1,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Repack GGUF quantized blocks into ORT MatMulNBits format.
+"""Preserve or repack GGUF quantized blocks for ORT custom operators.
 
 Converts raw GGUF block data for Q4_0, Q4_1, Q8_0, Q4_K, and Q1_0
 quantization types into the (weight, scales, zero_points) tensors
 expected by the ``com.microsoft.MatMulNBits`` operator.
+
+The runtime-native IQ/MXFP4 formats are retained byte-for-byte for
+``com.github.onnxruntime.genai.BlockQuantizedMatMul``.
 
 GGUF block layouts:
     Q4_0 (18 bytes, 32 elt):  [fp16 scale][16B packed nibbles]
@@ -35,6 +38,16 @@ _GGUF_Q4_0 = 2
 _GGUF_Q4_1 = 3
 _GGUF_Q8_0 = 8
 _GGUF_Q4_K = 12
+_GGUF_IQ2_XXS = 16
+_GGUF_IQ2_XS = 17
+_GGUF_IQ3_XXS = 18
+_GGUF_IQ1_S = 19
+_GGUF_IQ4_NL = 20
+_GGUF_IQ3_S = 21
+_GGUF_IQ2_S = 22
+_GGUF_IQ4_XS = 23
+_GGUF_IQ1_M = 29
+_GGUF_MXFP4 = 39
 _GGUF_Q1_0 = 41
 
 # Block byte sizes per GGUF type
@@ -69,6 +82,30 @@ _REPACK_PARAMS = {
 }
 
 
+@dataclass(frozen=True)
+class NativeBlockSpec:
+    """Serialized GGUF block layout accepted directly by the runtime."""
+
+    format: str
+    elements: int
+    bytes: int
+
+
+_NATIVE_BLOCK_SPECS = {
+    _GGUF_MXFP4: NativeBlockSpec("mxfp4", 32, 17),
+    _GGUF_IQ4_NL: NativeBlockSpec("iq4_nl", 32, 18),
+    _GGUF_IQ4_XS: NativeBlockSpec("iq4_xs", 256, 136),
+    _GGUF_IQ3_S: NativeBlockSpec("iq3_s", 256, 110),
+    _GGUF_IQ3_XXS: NativeBlockSpec("iq3_xxs", 256, 98),
+    _GGUF_IQ2_XXS: NativeBlockSpec("iq2_xxs", 256, 66),
+    _GGUF_IQ2_XS: NativeBlockSpec("iq2_xs", 256, 74),
+    _GGUF_IQ2_S: NativeBlockSpec("iq2_s", 256, 82),
+    _GGUF_IQ1_S: NativeBlockSpec("iq1_s", 256, 50),
+    _GGUF_IQ1_M: NativeBlockSpec("iq1_m", 256, 56),
+}
+NATIVE_BLOCK_BYTE_SIZES = frozenset(spec.bytes for spec in _NATIVE_BLOCK_SPECS.values())
+
+
 @dataclass
 class RepackedTensor:
     """MatMulNBits-compatible representation of a quantized weight.
@@ -88,6 +125,36 @@ class RepackedTensor:
     zero_points: np.ndarray | None
     block_size: int
     bits: int
+
+
+def native_block_spec(gguf_type: int) -> NativeBlockSpec | None:
+    """Return the runtime-native block layout for a GGUF type, if supported."""
+    return _NATIVE_BLOCK_SPECS.get(gguf_type)
+
+
+def preserve_native_blocks(
+    raw_data: np.ndarray,
+    gguf_type: int,
+    shape: tuple[int, ...],
+) -> np.ndarray:
+    """Validate and reshape raw GGUF blocks without changing any bytes."""
+    spec = native_block_spec(gguf_type)
+    if spec is None:
+        raise ValueError(f"GGUF type {gguf_type} is not runtime-native")
+    if len(shape) != 2:
+        raise ValueError(f"Expected 2D shape (N, K), got {shape}")
+
+    n_out, k_in = shape
+    n_blocks = math.ceil(k_in / spec.elements)
+    expected_bytes = n_out * n_blocks * spec.bytes
+    packed = raw_data.ravel().view(np.uint8)
+    if packed.size != expected_bytes:
+        raise ValueError(
+            f"Native {spec.format} data size mismatch: got {packed.size} bytes, "
+            f"expected {expected_bytes} for shape {shape} "
+            f"with {n_out * n_blocks} blocks x {spec.bytes} bytes"
+        )
+    return packed.reshape(n_out, n_blocks, spec.bytes)
 
 
 def can_repack(gguf_type: int) -> bool:

--- a/src/mobius/integrations/gguf/_repacker_test.py
+++ b/src/mobius/integrations/gguf/_repacker_test.py
@@ -11,6 +11,8 @@ from mobius.integrations.gguf._repacker import (
     RepackedTensor,
     _unpack_q4_k_scales,
     can_repack,
+    native_block_spec,
+    preserve_native_blocks,
     repack_dequantized_tensor,
     repack_gguf_tensor,
 )
@@ -21,6 +23,51 @@ _Q8_0 = 8
 _Q4_K = 12
 _Q1_0 = 41
 _BLOCK_SIZE = 32
+
+
+@pytest.mark.parametrize(
+    ("qtype_name", "qtype_value", "format_name", "block_elements", "block_bytes"),
+    [
+        ("MXFP4", 39, "mxfp4", 32, 17),
+        ("IQ4_NL", 20, "iq4_nl", 32, 18),
+        ("IQ4_XS", 23, "iq4_xs", 256, 136),
+        ("IQ3_S", 21, "iq3_s", 256, 110),
+        ("IQ3_XXS", 18, "iq3_xxs", 256, 98),
+        ("IQ2_XXS", 16, "iq2_xxs", 256, 66),
+        ("IQ2_XS", 17, "iq2_xs", 256, 74),
+        ("IQ2_S", 22, "iq2_s", 256, 82),
+        ("IQ1_S", 19, "iq1_s", 256, 50),
+        ("IQ1_M", 29, "iq1_m", 256, 56),
+    ],
+)
+def test_native_block_specs_match_gguf_and_preserve_bytes(
+    qtype_name: str,
+    qtype_value: int,
+    format_name: str,
+    block_elements: int,
+    block_bytes: int,
+):
+    from gguf import GGMLQuantizationType
+
+    qtype = getattr(GGMLQuantizationType, qtype_name)
+    assert qtype.value == qtype_value
+    spec = native_block_spec(qtype.value)
+    assert spec is not None
+    assert (spec.format, spec.elements, spec.bytes) == (
+        format_name,
+        block_elements,
+        block_bytes,
+    )
+
+    raw = np.arange(2 * block_bytes, dtype=np.uint8)
+    packed = preserve_native_blocks(raw, qtype.value, (2, block_elements))
+    assert packed.shape == (2, 1, block_bytes)
+    np.testing.assert_array_equal(packed.reshape(-1), raw)
+
+
+def test_native_block_size_mismatch_is_rejected():
+    with pytest.raises(ValueError, match="Native iq1_m data size mismatch"):
+        preserve_native_blocks(np.zeros(55, dtype=np.uint8), 29, (1, 256))
 
 
 def _make_q1_0_block(scale: float, bits: list[int]) -> np.ndarray:


### PR DESCRIPTION
## Summary

Wires mobius to emit native `BlockQuantizedMatMul` nodes (domain `com.github.onnxruntime.genai`) when a source GGUF weight is in **MXFP4** (ggml 39) or **IQ4_NL** (ggml 20) format, instead of dequantizing to f32. This connects the exporter to onnx-genai's runtime `BlockQuantizedMatMul` op, enabling real unsloth dynamic-quant GLM-5.2 / DeepSeek-V4-Flash GGUFs to run sub-4-bit end-to-end.

## Contract (verified against the runtime parser)
- Domain: `com.github.onnxruntime.genai`
- Attributes: `K`, `N`, `format` (lowercase `mxfp4` / `iq4_nl`), `block_layout_version=1`
- Raw serialized blocks preserved **byte-exact** (17 bytes MXFP4, 18 bytes IQ4_NL); no repack/dequant.

## Scope
- MXFP4 + IQ4_NL → `BlockQuantizedMatMul`.
- IQ1_S / IQ2_XXS / IQ3_S / IQ4_XS remain on the existing fallback path (the runtime does not yet support them; emitting the op would produce unloadable models). Marked as follow-ups.

## Tests
- 241 passing; Ruff clean.

Depends on onnx-genai runtime `BlockQuantizedMatMul` (MXFP4 + IQ4_NL, CPU).