### PR TITLE
feat: any-to-any onnx-genai pipeline support (VLM/ASR/codec/GGUF + Qwen3-TTS)

### DIFF
--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -367,15 +367,10 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
     mmproj_path = getattr(args, "mmproj", None)
 
     if args.keep_quantized:
-        if mmproj_path is not None:
-            print(
-                "Note: --keep-quantized is ignored when building a multimodal (--mmproj) package."
-            )
-        else:
-            print(
-                "Quantized mode: preserving GGUF quantization as "
-                "MatMulNBits/GatherBlockQuantized..."
-            )
+        print(
+            "Quantized mode: preserving GGUF quantization as "
+            "MatMulNBits/GatherBlockQuantized..."
+        )
 
     gguf_path = args.gguf_path
     output_dir = args.output or os.path.splitext(gguf_path)[0] + "_onnx"
@@ -390,6 +385,7 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
             mmproj_path,
             dtype=args.dtype,
             execution_provider=args.execution_provider,
+            keep_quantized=args.keep_quantized,
         )
     else:
         pkg = build_from_gguf(

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -377,12 +377,10 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
     os.makedirs(output_dir, exist_ok=True)
 
     if mmproj_path is not None:
-        from mobius.integrations.gguf import build_gemma4_vlm_from_gguf
-
         print(f"Multimodal mode: fusing vision/audio encoder from mmproj {mmproj_path}...")
-        pkg = build_gemma4_vlm_from_gguf(
+        pkg = build_from_gguf(
             gguf_path,
-            mmproj_path,
+            mmproj=mmproj_path,
             dtype=args.dtype,
             execution_provider=args.execution_provider,
             keep_quantized=args.keep_quantized,
@@ -710,13 +708,14 @@ def main(argv: list[str] | None = None) -> None:
     )
     gguf_parser.add_argument(
         "--runtime",
-        choices=["onnx-genai"],
+        choices=["ort-genai", "onnx-genai"],
         default=None,
         help=(
             "Generate runtime-specific config files after building. "
             "'onnx-genai' writes inference_metadata.yaml plus a tokenizer.json "
-            "reconstructed from the GGUF's embedded tokenizer metadata, so the "
-            "quantized model runs directly in the onnx-genai runtime."
+            "reconstructed from the GGUF's embedded tokenizer metadata; "
+            "'ort-genai' writes genai_config.json + copies tokenizer files. "
+            "Either way the quantized model runs directly in the target runtime."
         ),
     )
     gguf_parser.set_defaults(func=_cmd_build_gguf)

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -393,6 +393,22 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
             path = os.path.join(output_dir, "model.onnx")
         print(f"Saved {name} to {path}")
 
+    if getattr(args, "runtime", None) == "onnx-genai":
+        from mobius.integrations.gguf import write_gguf_tokenizer_json
+        from mobius.integrations.onnx_genai import write_onnx_genai_config
+
+        # A GGUF checkpoint has no Hugging Face source directory, so the
+        # tokenizer is reconstructed from the file's embedded ggml metadata
+        # rather than copied from a `source`.
+        tokenizer_path = write_gguf_tokenizer_json(gguf_path, output_dir)
+        if tokenizer_path is not None:
+            print(f"  tokenizer: {tokenizer_path}")
+        artifacts = write_onnx_genai_config(
+            pkg, output_dir, config=getattr(pkg, "config", None), source=None
+        )
+        for name, path in artifacts.items():
+            print(f"  {name}: {path}")
+
 
 def _cmd_convert_comfyui(args: argparse.Namespace) -> None:
     """Execute the 'convert-comfyui' subcommand."""
@@ -665,6 +681,17 @@ def main(argv: list[str] | None = None) -> None:
             "Target execution provider for EP-aware graph optimisations "
             "(e.g. 'cpu' to apply the GroupQueryAttention rewrite). "
             "Defaults to 'default' (portable ONNX, no vendor fusions)."
+        ),
+    )
+    gguf_parser.add_argument(
+        "--runtime",
+        choices=["onnx-genai"],
+        default=None,
+        help=(
+            "Generate runtime-specific config files after building. "
+            "'onnx-genai' writes inference_metadata.yaml plus a tokenizer.json "
+            "reconstructed from the GGUF's embedded tokenizer metadata, so the "
+            "quantized model runs directly in the onnx-genai runtime."
         ),
     )
     gguf_parser.set_defaults(func=_cmd_build_gguf)

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -364,22 +364,40 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
         )
         raise SystemExit(1)
 
+    mmproj_path = getattr(args, "mmproj", None)
+
     if args.keep_quantized:
-        print(
-            "Quantized mode: preserving GGUF quantization as "
-            "MatMulNBits/GatherBlockQuantized..."
-        )
+        if mmproj_path is not None:
+            print(
+                "Note: --keep-quantized is ignored when building a multimodal (--mmproj) package."
+            )
+        else:
+            print(
+                "Quantized mode: preserving GGUF quantization as "
+                "MatMulNBits/GatherBlockQuantized..."
+            )
 
     gguf_path = args.gguf_path
     output_dir = args.output or os.path.splitext(gguf_path)[0] + "_onnx"
     os.makedirs(output_dir, exist_ok=True)
 
-    pkg = build_from_gguf(
-        gguf_path,
-        dtype=args.dtype,
-        keep_quantized=args.keep_quantized,
-        execution_provider=args.execution_provider,
-    )
+    if mmproj_path is not None:
+        from mobius.integrations.gguf import build_gemma4_vlm_from_gguf
+
+        print(f"Multimodal mode: fusing vision/audio encoder from mmproj {mmproj_path}...")
+        pkg = build_gemma4_vlm_from_gguf(
+            gguf_path,
+            mmproj_path,
+            dtype=args.dtype,
+            execution_provider=args.execution_provider,
+        )
+    else:
+        pkg = build_from_gguf(
+            gguf_path,
+            dtype=args.dtype,
+            keep_quantized=args.keep_quantized,
+            execution_provider=args.execution_provider,
+        )
 
     pkg.save(
         output_dir,
@@ -650,6 +668,17 @@ def main(argv: list[str] | None = None) -> None:
         default=None,
         metavar="DIR",
         help="Output directory (default: <gguf_stem>_onnx/).",
+    )
+    gguf_parser.add_argument(
+        "--mmproj",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Path to a companion 'clip' mmproj GGUF (vision/audio encoder). "
+            "When set, builds a full multimodal package (decoder + "
+            "vision_encoder + embedding) instead of a text-only model. "
+            "Currently supports Gemma4 vision; audio is experimental."
+        ),
     )
     gguf_parser.add_argument(
         "--keep-quantized",

--- a/src/mobius/_config_resolver.py
+++ b/src/mobius/_config_resolver.py
@@ -161,8 +161,20 @@ def _dict_to_pretrained_config(d: dict):
             setattr(config, k, v)
 
     # Recursively convert known nested config keys
+    rope_keys = ("rope_scaling", "rope_parameters")
     for key in nested_config_keys:
         val = getattr(config, key, None)
         if isinstance(val, dict):
-            setattr(config, key, _dict_to_pretrained_config(val))
+            # Capture the raw rope fields before conversion: constructing a
+            # nested PretrainedConfig runs HF rope standardization, which
+            # silently drops non-standard rope_scaling formats (e.g. the
+            # Qwen3-TTS talker's ``{"interleaved": True, "mrope_section": ...,
+            # "type": "default"}``). Restore them onto the converted config so
+            # _extract_mrope_fields / _extract_rope_config can still read them.
+            raw_rope = {k: val[k] for k in rope_keys if k in val}
+            nested = _dict_to_pretrained_config(val)
+            for k, v in raw_rope.items():
+                if getattr(nested, k, None) is None:
+                    setattr(nested, k, v)
+            setattr(config, key, nested)
     return config

--- a/src/mobius/_config_resolver.py
+++ b/src/mobius/_config_resolver.py
@@ -174,7 +174,11 @@ def _dict_to_pretrained_config(d: dict):
             raw_rope = {k: val[k] for k in rope_keys if k in val}
             nested = _dict_to_pretrained_config(val)
             for k, v in raw_rope.items():
-                if getattr(nested, k, None) is None:
+                # The raw config.json value is authoritative for our extractors.
+                # Restore it whenever HF standardization dropped (None) OR
+                # rewrote it to a different value, so non-standard formats
+                # (e.g. Qwen3-TTS's ``interleaved``/``mrope_section``) survive.
+                if getattr(nested, k, None) != v:
                     setattr(nested, k, v)
             setattr(config, key, nested)
     return config

--- a/src/mobius/_configs/_base.py
+++ b/src/mobius/_configs/_base.py
@@ -269,8 +269,14 @@ def _extract_mrope_fields(config) -> dict:
     rope_scaling = getattr(config, "rope_scaling", None) or {}
     rope_parameters = getattr(config, "rope_parameters", None) or {}
     result: dict = {}
-    mrope_interleaved = rope_scaling.get("mrope_interleaved", False) or rope_parameters.get(
-        "mrope_interleaved", False
+    # Some models (e.g. Qwen3-TTS talker) spell the interleaved flag as the
+    # bare ``interleaved`` key inside ``rope_scaling`` rather than the
+    # ``mrope_interleaved`` name that Qwen3-VL uses. Accept both spellings.
+    mrope_interleaved = (
+        rope_scaling.get("mrope_interleaved", False)
+        or rope_scaling.get("interleaved", False)
+        or rope_parameters.get("mrope_interleaved", False)
+        or rope_parameters.get("interleaved", False)
     )
     if mrope_interleaved:
         result["mrope_interleaved"] = True

--- a/src/mobius/_configs_test.py
+++ b/src/mobius/_configs_test.py
@@ -442,6 +442,20 @@ class TestExtractRopeConfig:
         assert result["mrope_interleaved"] is True
         assert result["mrope_section"] == [8, 16, 8]
 
+    def test_mrope_interleaved_alias_from_rope_scaling(self):
+        """Qwen3-TTS talker spells the flag as bare ``interleaved``."""
+
+        class Cfg:
+            rope_scaling: ClassVar[dict] = {
+                "interleaved": True,
+                "mrope_section": [24, 20, 20],
+                "rope_type": "default",
+            }
+
+        result = _extract_mrope_fields(Cfg())
+        assert result["mrope_interleaved"] is True
+        assert result["mrope_section"] == [24, 20, 20]
+
     def test_original_max_position_embeddings(self):
         class Cfg:
             original_max_position_embeddings = 8192

--- a/src/mobius/integrations/gguf/__init__.py
+++ b/src/mobius/integrations/gguf/__init__.py
@@ -10,7 +10,14 @@ Usage::
 
     from mobius.integrations.gguf import build_from_gguf
 
+    # Text-only model
     pkg = build_from_gguf("path/to/model.gguf")
+
+    # Multimodal (text + companion mmproj vision/audio encoder)
+    pkg = build_from_gguf("path/to/model.gguf", mmproj="path/to/mmproj.gguf")
+
+:func:`build_from_gguf` is the single entry point; passing ``mmproj`` delegates
+to :func:`build_gemma4_vlm_from_gguf` for the multimodal assembly.
 """
 
 from __future__ import annotations

--- a/src/mobius/integrations/gguf/__init__.py
+++ b/src/mobius/integrations/gguf/__init__.py
@@ -16,5 +16,6 @@ Usage::
 from __future__ import annotations
 
 from mobius.integrations.gguf._builder import build_from_gguf
+from mobius.integrations.gguf._tokenizer import write_gguf_tokenizer_json
 
-__all__ = ["build_from_gguf"]
+__all__ = ["build_from_gguf", "write_gguf_tokenizer_json"]

--- a/src/mobius/integrations/gguf/__init__.py
+++ b/src/mobius/integrations/gguf/__init__.py
@@ -16,6 +16,11 @@ Usage::
 from __future__ import annotations
 
 from mobius.integrations.gguf._builder import build_from_gguf
+from mobius.integrations.gguf._mmproj import build_gemma4_vlm_from_gguf
 from mobius.integrations.gguf._tokenizer import write_gguf_tokenizer_json
 
-__all__ = ["build_from_gguf", "write_gguf_tokenizer_json"]
+__all__ = [
+    "build_from_gguf",
+    "build_gemma4_vlm_from_gguf",
+    "write_gguf_tokenizer_json",
+]

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -509,6 +509,68 @@ def _require_supported_requantization(
         )
 
 
+def repack_gguf_weight_to_target(
+    gguf_model,
+    raw,
+    qtype,
+    np_shape,
+    *,
+    target_bits: int,
+    target_block_size: int,
+    target_symmetric: bool,
+    tensor_name: str,
+):
+    """Repack one 2-D GGUF weight to the graph's common MatMulNBits target.
+
+    Reuses the shared repacker machinery: a tensor whose native repacked layout
+    already matches ``(target_bits, target_block_size)`` is repacked directly;
+    otherwise it is dequantized and requantized to the target layout. This is
+    the single-tensor building block reused by both the text-only
+    (:func:`_load_quantized_state_dict`) and the multimodal quantized loaders.
+
+    Args:
+        gguf_model: The source :class:`GGUFModel`.
+        raw: Raw tensor bytes (as returned by ``tensor_items_raw``).
+        qtype: The GGUF quantization type of the tensor.
+        np_shape: The tensor's logical ``(N, K)`` shape.
+        target_bits: Target MatMulNBits bit width.
+        target_block_size: Target MatMulNBits block size.
+        target_symmetric: Whether the requantization path should omit
+            zero-points (symmetric). Only used when requantizing.
+        tensor_name: Name used for error messages.
+
+    Returns:
+        A ``RepackedTensor`` with the target ``(bits, block_size)`` layout.
+    """
+    import numpy as np
+
+    from mobius.integrations.gguf._repacker import (
+        can_repack,
+        repack_dequantized_tensor,
+        repack_gguf_tensor,
+    )
+
+    qtype_val = qtype.value if hasattr(qtype, "value") else qtype
+    if can_repack(qtype_val):
+        shape_2d = (int(np_shape[0]), int(np_shape[1]))
+        repacked = repack_gguf_tensor(raw.ravel().view(np.uint8), qtype_val, shape_2d)
+        if repacked.bits == target_bits and repacked.block_size == target_block_size:
+            return repacked
+
+    _require_supported_requantization(
+        bits=target_bits,
+        block_size=target_block_size,
+        tensor_name=tensor_name,
+    )
+    values = gguf_model.dequantize_raw_tensor(raw, qtype, np_shape)
+    return repack_dequantized_tensor(
+        values,
+        bits=target_bits,
+        block_size=target_block_size,
+        symmetric=target_symmetric,
+    )
+
+
 def _load_dequantized_state_dict(
     gguf_model,
     gguf_arch: str,

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -83,6 +83,7 @@ def build_from_gguf(
     dtype: str | None = None,
     keep_quantized: bool = False,
     execution_provider: str = "default",
+    mmproj: str | Path | None = None,
 ) -> ModelPackage:
     """Build an ONNX :class:`ModelPackage` from a GGUF file.
 
@@ -116,6 +117,12 @@ def build_from_gguf(
             optimisations (e.g. ``"cpu"`` to apply the
             GroupQueryAttention rewrite). Defaults to ``"default"``
             (portable, no vendor fusions).
+        mmproj: Optional path (or HF ref) to a companion ``clip``
+            multimodal-projector GGUF. When set, this becomes the single
+            entry point for a multimodal build: the text GGUF and the
+            mmproj vision/audio encoder are fused into one multimodal
+            :class:`ModelPackage` (delegates to
+            :func:`build_gemma4_vlm_from_gguf`).
 
     Returns:
         A :class:`ModelPackage` containing the built model(s).
@@ -126,6 +133,20 @@ def build_from_gguf(
         KeyError: If the GGUF architecture is not in the registry.
     """
     import dataclasses
+
+    # A companion mmproj GGUF turns this into a multimodal build: the text +
+    # vision/audio encoders are assembled by the dedicated VLM builder. Keep
+    # build_from_gguf as the single public entry point (text-only or multimodal).
+    if mmproj is not None:
+        from mobius.integrations.gguf._mmproj import build_gemma4_vlm_from_gguf
+
+        return build_gemma4_vlm_from_gguf(
+            gguf_path,
+            mmproj,
+            dtype=dtype,
+            execution_provider=execution_provider,
+            keep_quantized=keep_quantized,
+        )
 
     from mobius._builder import (
         build_from_module,

--- a/src/mobius/integrations/gguf/_config_mapping.py
+++ b/src/mobius/integrations/gguf/_config_mapping.py
@@ -548,10 +548,66 @@ def _gemma4_postprocess(
     )
 
 
+# Gemma3 interleaves sliding-window (local) and full (global) attention. The
+# local RoPE base frequency is a fixed architectural constant that GGUF does not
+# store (only the global ``gemma3.rope.freq_base`` is present), so it must be
+# defaulted. Source: HF Gemma3TextConfig.rope_local_base_freq default value.
+_GEMMA3_DEFAULT_ROPE_LOCAL_BASE_FREQ = 10_000.0
+
+# Gemma3 interleaves sliding-window (local) and full (global) attention on a
+# fixed period: every ``sliding_window_pattern``-th layer is full attention.
+# GGUF stores neither the per-layer types nor the period, so default to the HF
+# Gemma3 value. Source: HF Gemma3TextConfig.sliding_window_pattern default.
+_GEMMA3_DEFAULT_SLIDING_WINDOW_PATTERN = 6
+
+
+def _gemma3_postprocess(
+    config: ArchitectureConfig,
+    metadata: dict[str, Any],
+) -> ArchitectureConfig:
+    """Populate Gemma3 fields that GGUF omits.
+
+    GGUF carries only the global RoPE base (``gemma3.rope.freq_base``) and the
+    sliding-window size, but not the local RoPE base or the per-layer
+    local/global attention pattern that ``Gemma3TextModel`` requires. Without
+    them the model builds its local rotary embedding from
+    ``rope_local_base_freq = None`` (crash) and iterates ``layer_types = None``
+    (crash). Default both to the known Gemma3 constants when GGUF does not
+    provide them.
+
+    Args:
+        config: The base config extracted from GGUF metadata.
+        metadata: The raw GGUF key-value metadata.
+
+    Returns:
+        The config with ``rope_local_base_freq`` and ``layer_types`` populated.
+    """
+    if getattr(config, "rope_local_base_freq", None) is None:
+        local_freq_base = metadata.get("gemma3.rope.local_freq_base") or metadata.get(
+            "gemma3.rope.freq_base_local"
+        )
+        config.rope_local_base_freq = (
+            float(local_freq_base)
+            if local_freq_base is not None
+            else _GEMMA3_DEFAULT_ROPE_LOCAL_BASE_FREQ
+        )
+    if getattr(config, "layer_types", None) is None:
+        pattern = (
+            metadata.get("gemma3.attention.sliding_window_pattern")
+            or _GEMMA3_DEFAULT_SLIDING_WINDOW_PATTERN
+        )
+        config.layer_types = [
+            "full_attention" if (index + 1) % pattern == 0 else "sliding_attention"
+            for index in range(config.num_hidden_layers)
+        ]
+    return config
+
+
 # Architecture-specific config postprocessors.
 # Each takes a base ArchitectureConfig + raw metadata and returns
 # an architecture-specific config subclass.
 _CONFIG_POSTPROCESSORS: dict[str, Any] = {
+    "gemma3_text": _gemma3_postprocess,
     "gemma4_text": _gemma4_postprocess,
 }
 

--- a/src/mobius/integrations/gguf/_config_mapping.py
+++ b/src/mobius/integrations/gguf/_config_mapping.py
@@ -495,6 +495,41 @@ def _gemma4_postprocess(
     # --- Per-layer input gating ---
     hidden_size_per_layer_input = metadata.get(f"{arch}.embedding_length_per_layer_input")
 
+    # --- Double-wide MLP (per-layer feed-forward length) ---
+    # Gemma4 E2B/E4B store feed_forward_length as a per-layer array: the base
+    # intermediate size for standalone layers and 2x that for the KV-shared
+    # layers (use_double_wide_mlp).  Gemma4DecoderLayer expects a scalar base
+    # size and re-derives the doubling from use_double_wide_mlp + is_kv_shared,
+    # so collapse the array back to (base, use_double_wide_mlp) here.
+    use_double_wide_mlp = False
+    intermediate_size = config.intermediate_size
+    if isinstance(intermediate_size, (list, np.ndarray)):
+        values = [int(v) for v in intermediate_size]
+        distinct = sorted(set(values))
+        if len(distinct) == 1:
+            intermediate_size = distinct[0]
+        elif len(distinct) == 2 and distinct[1] == 2 * distinct[0]:
+            base, wide = distinct
+            shared = int(num_kv_shared_layers) if num_kv_shared_layers is not None else 0
+            first_shared = config.num_hidden_layers - shared
+            expected = [
+                wide if (shared > 0 and i >= first_shared) else base
+                for i in range(config.num_hidden_layers)
+            ]
+            if values != expected:
+                raise ValueError(
+                    "Gemma4 per-layer feed_forward_length does not match the "
+                    "double-wide-MLP pattern (wide layers must be the last "
+                    f"{shared} KV-shared layers): {values}"
+                )
+            intermediate_size = base
+            use_double_wide_mlp = True
+        else:
+            raise ValueError(
+                f"Unexpected Gemma4 per-layer feed_forward_length array: {values}"
+            )
+        config = dataclasses.replace(config, intermediate_size=intermediate_size)
+
     # --- Per-layer KV heads (num_global_key_value_heads) ---
     # GGUF stores per-layer KV head counts as an array.  When full-attention
     # layers use fewer KV heads than sliding layers, extract the minority
@@ -541,6 +576,7 @@ def _gemma4_postprocess(
         hidden_size_per_layer_input=int(hidden_size_per_layer_input)
         if hidden_size_per_layer_input is not None
         else 0,
+        use_double_wide_mlp=use_double_wide_mlp,
         # Fields without GGUF metadata — use Gemma4Config defaults
         vocab_size_per_layer_input=config.vocab_size
         if (hidden_size_per_layer_input or 0) > 0

--- a/src/mobius/integrations/gguf/_config_mapping_test.py
+++ b/src/mobius/integrations/gguf/_config_mapping_test.py
@@ -1,0 +1,64 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for architecture-specific GGUF config postprocessing."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestGemma3Postprocess:
+    """Gemma3 config postprocessing fills fields GGUF omits."""
+
+    def test_defaults_local_rope_and_layer_types(self) -> None:
+        from mobius._configs import ArchitectureConfig
+        from mobius.integrations.gguf._config_mapping import _gemma3_postprocess
+
+        config = ArchitectureConfig(
+            hidden_size=1152,
+            num_hidden_layers=26,
+            num_attention_heads=4,
+            num_key_value_heads=1,
+            vocab_size=262144,
+            intermediate_size=6912,
+        )
+        # GGUF carries only the global rope base and the sliding-window size.
+        result = _gemma3_postprocess(config, {"gemma3.rope.freq_base": 1_000_000.0})
+
+        assert result.rope_local_base_freq == pytest.approx(10_000.0)
+        assert result.layer_types is not None
+        assert len(result.layer_types) == 26
+        # Every 6th layer (1-indexed) is full attention; the rest sliding.
+        assert result.layer_types[5] == "full_attention"
+        assert result.layer_types[0] == "sliding_attention"
+        assert result.layer_types[11] == "full_attention"
+
+    def test_respects_explicit_gguf_values(self) -> None:
+        from mobius._configs import ArchitectureConfig
+        from mobius.integrations.gguf._config_mapping import _gemma3_postprocess
+
+        config = ArchitectureConfig(
+            hidden_size=1152,
+            num_hidden_layers=4,
+            num_attention_heads=4,
+            num_key_value_heads=1,
+            vocab_size=256,
+            intermediate_size=512,
+        )
+        result = _gemma3_postprocess(
+            config,
+            {
+                "gemma3.rope.local_freq_base": 20_000.0,
+                "gemma3.attention.sliding_window_pattern": 2,
+            },
+        )
+
+        assert result.rope_local_base_freq == pytest.approx(20_000.0)
+        # Pattern of 2 → every other layer (1-indexed even) is full attention.
+        assert result.layer_types == [
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+            "full_attention",
+        ]

--- a/src/mobius/integrations/gguf/_config_mapping_test.py
+++ b/src/mobius/integrations/gguf/_config_mapping_test.py
@@ -62,3 +62,61 @@ class TestGemma3Postprocess:
             "sliding_attention",
             "full_attention",
         ]
+
+
+class TestGemma4DoubleWideMlp:
+    """Gemma4 per-layer feed_forward_length arrays collapse to a scalar base."""
+
+    def _base_config(self, intermediate_size, num_layers=4):
+        from mobius._configs import ArchitectureConfig
+
+        return ArchitectureConfig(
+            hidden_size=1536,
+            num_hidden_layers=num_layers,
+            num_attention_heads=8,
+            num_key_value_heads=1,
+            vocab_size=262144,
+            intermediate_size=intermediate_size,
+        )
+
+    def test_uniform_array_collapses_to_scalar(self) -> None:
+        from mobius.integrations.gguf._config_mapping import _gemma4_postprocess
+
+        result = _gemma4_postprocess(self._base_config([8192, 8192, 8192, 8192]), {})
+
+        assert result.intermediate_size == 8192
+        assert result.use_double_wide_mlp is False
+
+    def test_double_wide_tail_layers_set_flag(self) -> None:
+        from mobius.integrations.gguf._config_mapping import _gemma4_postprocess
+
+        # Last 2 KV-shared layers are double-wide (2x the base).
+        result = _gemma4_postprocess(
+            self._base_config([6144, 6144, 12288, 12288]),
+            {"gemma4.attention.shared_kv_layers": 2},
+        )
+
+        assert result.intermediate_size == 6144
+        assert result.use_double_wide_mlp is True
+        assert result.num_kv_shared_layers == 2
+
+    def test_scalar_intermediate_size_unchanged(self) -> None:
+        from mobius.integrations.gguf._config_mapping import _gemma4_postprocess
+
+        result = _gemma4_postprocess(self._base_config(8192), {})
+
+        assert result.intermediate_size == 8192
+        assert result.use_double_wide_mlp is False
+
+    def test_mismatched_double_wide_pattern_raises(self) -> None:
+        import pytest
+
+        from mobius.integrations.gguf._config_mapping import _gemma4_postprocess
+
+        # Double-wide layers must be the trailing KV-shared layers; a leading
+        # wide layer does not match the expected pattern.
+        with pytest.raises(ValueError, match="double-wide-MLP pattern"):
+            _gemma4_postprocess(
+                self._base_config([12288, 6144, 6144, 6144]),
+                {"gemma4.attention.shared_kv_layers": 2},
+            )

--- a/src/mobius/integrations/gguf/_mmproj.py
+++ b/src/mobius/integrations/gguf/_mmproj.py
@@ -134,6 +134,35 @@ def _resolve_local_path(path: str | Path) -> str:
     return _resolve_gguf_path(path)
 
 
+# Text-GGUF tensors whose names are not covered by the block ``gemma4`` text
+# mapping; they route to their HF language-model names directly.
+_PER_LAYER_TOP_HF_NAMES = {
+    "per_layer_token_embd.weight": "language_model.embed_tokens_per_layer.weight",
+    "per_layer_model_proj.weight": "language_model.per_layer_model_projection.weight",
+    "per_layer_proj_norm.weight": "language_model.per_layer_projection_norm.weight",
+}
+
+
+def _text_gguf_name_to_hf_multimodal(gguf_name: str) -> str | None:
+    """Map one text-GGUF tensor name to its HF multimodal (``language_model.*``) name.
+
+    Returns ``None`` for tensors that have no multimodal counterpart.
+    """
+    from mobius.integrations.gguf._tensor_mapping import map_gguf_to_hf_names
+
+    if gguf_name in _PER_LAYER_TOP_HF_NAMES:
+        return _PER_LAYER_TOP_HF_NAMES[gguf_name]
+    text_hf = map_gguf_to_hf_names(gguf_name, "gemma4")
+    if text_hf is None:
+        return None
+    # gemma4 text mapping yields ``model.*`` / ``lm_head.*``; nest under the
+    # multimodal ``language_model.`` namespace (HF Gemma4 stores the decoder
+    # layers directly under language_model, so strip the ``model.`` prefix).
+    if text_hf.startswith("model."):
+        return "language_model." + text_hf[len("model.") :]
+    return "language_model." + text_hf
+
+
 def _text_gguf_to_hf_multimodal(text_gguf: Any) -> dict:
     """Load text-backbone GGUF tensors as HF multimodal (``language_model.*``).
 
@@ -143,34 +172,122 @@ def _text_gguf_to_hf_multimodal(text_gguf: Any) -> dict:
     """
     import torch
 
-    from mobius.integrations.gguf._tensor_mapping import map_gguf_to_hf_names
-
-    # The three top-level per-layer-input tensors are not covered by the block
-    # text mapping; route them to their HF language-model names directly.
-    per_layer_top = {
-        "per_layer_token_embd.weight": "language_model.embed_tokens_per_layer.weight",
-        "per_layer_model_proj.weight": "language_model.per_layer_model_projection.weight",
-        "per_layer_proj_norm.weight": "language_model.per_layer_projection_norm.weight",
-    }
-
     state_dict: dict[str, torch.Tensor] = {}
     for gguf_name, array in text_gguf.tensor_items():
-        if gguf_name in per_layer_top:
-            hf_name = per_layer_top[gguf_name]
-        else:
-            text_hf = map_gguf_to_hf_names(gguf_name, "gemma4")
-            if text_hf is None:
-                continue
-            # gemma4 text mapping yields ``model.*`` / ``lm_head.*``; nest under
-            # the multimodal ``language_model.`` namespace (HF Gemma4 stores the
-            # decoder layers directly under language_model, so strip ``model.``).
-            if text_hf.startswith("model."):
-                hf_name = "language_model." + text_hf[len("model.") :]
-            else:
-                hf_name = "language_model." + text_hf
+        hf_name = _text_gguf_name_to_hf_multimodal(gguf_name)
+        if hf_name is None:
+            continue
 
         values = np.array(array).astype(np.float32)
         # layer_scalar is an nn.Parameter (no ``.weight`` module suffix, shape [1]).
+        if hf_name.endswith(".layer_scalar.weight"):
+            hf_name = hf_name[: -len(".weight")]
+            values = values.reshape(-1)[:1]
+        state_dict[hf_name] = torch.from_numpy(values)
+    return state_dict
+
+
+# HF projection-weight name suffixes (under ``language_model.layers.N.``) that
+# become MatMulNBits QuantizedLinear layers in the quantized text decoder.
+_QUANTIZED_LINEAR_SUFFIXES = (
+    ".self_attn.q_proj.weight",
+    ".self_attn.k_proj.weight",
+    ".self_attn.v_proj.weight",
+    ".self_attn.o_proj.weight",
+    ".mlp.gate_proj.weight",
+    ".mlp.up_proj.weight",
+    ".mlp.down_proj.weight",
+)
+
+# HF token-embedding weight names that become GatherBlockQuantized tables.
+_QUANTIZED_EMBEDDING_NAMES = (
+    "language_model.embed_tokens.weight",
+    "language_model.embed_tokens_per_layer.weight",
+)
+
+
+def _text_gguf_to_hf_multimodal_quantized(
+    text_gguf: Any,
+    config: Any,
+    *,
+    bits: int,
+    block_size: int,
+    symmetric: bool,
+) -> dict:
+    """Load text-backbone GGUF tensors, quantizing the decoder + token embeddings.
+
+    Mirrors :func:`_text_gguf_to_hf_multimodal` but keeps the text decoder
+    projections in MatMulNBits form (``.weight`` uint8 + ``.scales`` [+
+    ``.zero_points``]) and the token-embedding tables in GatherBlockQuantized
+    form (``.qweight`` + ``.scales`` [+ ``.zero_points``]).  Norms and the
+    float per-layer projections stay dequantized.  Vision/audio weights are
+    loaded separately and always stay float.
+
+    Names are the HF multimodal ``language_model.*`` names that
+    :meth:`Gemma4Model.preprocess_weights` expects.
+    """
+    import torch
+
+    from mobius.integrations.gguf._builder import repack_gguf_weight_to_target
+
+    quantize_lm_head = bool(getattr(config.quantization, "quantize_lm_head", False))
+    tie_word_embeddings = bool(config.tie_word_embeddings)
+
+    def _emit_linear(state_dict: dict, stem: str, repacked) -> None:
+        state_dict[f"{stem}.weight"] = torch.from_numpy(repacked.weight)
+        state_dict[f"{stem}.scales"] = torch.from_numpy(repacked.scales)
+        if repacked.zero_points is not None:
+            state_dict[f"{stem}.zero_points"] = torch.from_numpy(repacked.zero_points)
+
+    def _emit_embedding(state_dict: dict, stem: str, repacked) -> None:
+        weight = repacked.weight
+        state_dict[f"{stem}.qweight"] = torch.from_numpy(weight.reshape(weight.shape[0], -1))
+        state_dict[f"{stem}.scales"] = torch.from_numpy(repacked.scales)
+        if repacked.zero_points is not None:
+            state_dict[f"{stem}.zero_points"] = torch.from_numpy(repacked.zero_points)
+
+    state_dict: dict[str, torch.Tensor] = {}
+    for gguf_name, raw, qtype, np_shape in text_gguf.tensor_items_raw():
+        hf_name = _text_gguf_name_to_hf_multimodal(gguf_name)
+        if hf_name is None:
+            continue
+
+        is_quant_linear = hf_name.endswith(_QUANTIZED_LINEAR_SUFFIXES) or (
+            quantize_lm_head and hf_name == "language_model.lm_head.weight"
+        )
+        is_quant_embedding = hf_name in _QUANTIZED_EMBEDDING_NAMES
+
+        if (is_quant_linear or is_quant_embedding) and len(np_shape) == 2:
+            repacked = repack_gguf_weight_to_target(
+                text_gguf,
+                raw,
+                qtype,
+                np_shape,
+                target_bits=bits,
+                target_block_size=block_size,
+                target_symmetric=symmetric,
+                tensor_name=hf_name,
+            )
+            stem = hf_name[: -len(".weight")]
+            if is_quant_embedding:
+                _emit_embedding(state_dict, stem, repacked)
+                # A tied quantized LM head shares the token-embedding table but,
+                # because the decoder is a separate ONNX graph, needs its own
+                # MatMulNBits copy (same repacked bytes, linear layout).
+                if (
+                    hf_name == "language_model.embed_tokens.weight"
+                    and quantize_lm_head
+                    and tie_word_embeddings
+                ):
+                    _emit_linear(state_dict, "language_model.lm_head", repacked)
+            else:
+                _emit_linear(state_dict, stem, repacked)
+            continue
+
+        # Everything else (norms, float per-layer projections) stays float.
+        values = np.array(text_gguf.dequantize_raw_tensor(raw, qtype, np_shape)).astype(
+            np.float32
+        )
         if hf_name.endswith(".layer_scalar.weight"):
             hf_name = hf_name[: -len(".weight")]
             values = values.reshape(-1)[:1]
@@ -209,6 +326,7 @@ def build_gemma4_vlm_from_gguf(
     execution_provider: str = "default",
     image_token_id: int | None = None,
     include_audio: bool = False,
+    keep_quantized: bool = False,
 ) -> ModelPackage:
     """Build a full Gemma4 multimodal ONNX package from text + mmproj GGUFs.
 
@@ -222,10 +340,25 @@ def build_gemma4_vlm_from_gguf(
             value carried by the text config is used (if any).
         include_audio: When ``True``, also build the (experimental) audio
             encoder. Off by default — see the module docstring.
+        keep_quantized: When ``True``, preserve the text backbone's GGUF
+            quantization: the decoder projections become MatMulNBits and the
+            token-embedding tables become GatherBlockQuantized (int4), roughly
+            an 8x size reduction over the dequantized package. The
+            vision (and audio) encoder always stay float because their weights
+            come from the mmproj as F16 — see the "Mixed precision" note below.
 
     Returns:
         A :class:`ModelPackage` with ``decoder`` + ``vision_encoder`` +
         ``embedding`` components (plus ``audio_encoder`` if ``include_audio``).
+
+    Mixed precision:
+        ``keep_quantized`` yields a mixed-precision package. Only the Gemma4
+        *text* components read ``config.quantization`` (see
+        :func:`mobius.models.gemma4._text_linear_class`); the vision/audio
+        encoder modules always build float ``Linear`` layers, so a single
+        module-global :class:`QuantizationConfig` quantizes the decoder +
+        embedding while leaving the mmproj-sourced vision encoder float — no
+        per-module quantization opt-out is required.
     """
     import dataclasses
 
@@ -267,13 +400,68 @@ def build_gemma4_vlm_from_gguf(
         if resolved is not None:
             config = dataclasses.replace(config, dtype=resolved)
 
+    # 1b. Quantized mode: set the module-global quantization config from the
+    # text GGUF BEFORE building so the text graph emits MatMulNBits /
+    # GatherBlockQuantized. The vision/audio encoders ignore it and stay float.
+    quant_params: tuple[int, int, bool] | None = None
+    if keep_quantized:
+        from mobius._configs import QuantizationConfig
+        from mobius.integrations.gguf._builder import (
+            _can_quantize_embedding,
+            _can_quantize_lm_head,
+            _detect_quant_params,
+        )
+
+        bits, block_size, is_symmetric = _detect_quant_params(text_gguf, "gemma4")
+        quant_params = (bits, block_size, is_symmetric)
+        quantize_embeddings = _can_quantize_embedding(
+            text_gguf, "gemma4", bits=bits, block_size=block_size
+        )
+        quantize_lm_head = (
+            quantize_embeddings
+            if config.tie_word_embeddings
+            else _can_quantize_lm_head(text_gguf, "gemma4")
+        )
+        config = dataclasses.replace(
+            config,
+            quantization=QuantizationConfig(
+                bits=bits,
+                group_size=block_size,
+                quant_method="gguf",
+                sym=is_symmetric,
+                quantize_embeddings=quantize_embeddings,
+                quantize_lm_head=quantize_lm_head,
+                tie_word_embeddings=quantize_lm_head and config.tie_word_embeddings,
+            ),
+        )
+        logger.info(
+            "Quantized multimodal mode: bits=%d, block_size=%d, symmetric=%s, "
+            "embedding=%s, lm_head=%s (vision/audio stay float)",
+            bits,
+            block_size,
+            is_symmetric,
+            quantize_embeddings,
+            quantize_lm_head,
+        )
+
     # 2. Build the multimodal graph (decoder + vision + embedding [+ audio]).
     module = Gemma4Model(config)
     pkg = Gemma4Task().build(module, config)
     logger.info("Built Gemma4 VLM graph (%d components: %s)", len(pkg), list(pkg))
 
-    # 3. Assemble the combined HF-multimodal state dict from both GGUFs.
-    state_dict = _text_gguf_to_hf_multimodal(text_gguf)
+    # 3. Assemble the combined HF-multimodal state dict from both GGUFs. The
+    #    text backbone is quantized when requested; vision/audio always float.
+    if keep_quantized:
+        bits, block_size, is_symmetric = quant_params
+        state_dict = _text_gguf_to_hf_multimodal_quantized(
+            text_gguf,
+            config,
+            bits=bits,
+            block_size=block_size,
+            symmetric=is_symmetric,
+        )
+    else:
+        state_dict = _text_gguf_to_hf_multimodal(text_gguf)
     state_dict.update(_mmproj_vision_to_hf(mmproj_gguf))
     if include_audio:
         state_dict.update(_mmproj_audio_to_hf(mmproj_gguf))

--- a/src/mobius/integrations/gguf/_mmproj.py
+++ b/src/mobius/integrations/gguf/_mmproj.py
@@ -1,0 +1,307 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Build a full Gemma4 multimodal ONNX package from GGUF (text + mmproj).
+
+Gemma4's text backbone ships in one ``*.gguf`` file while its vision (and
+audio) encoders live in a companion ``mmproj-*.gguf`` whose
+``general.architecture`` is ``clip``.  :func:`build_gemma4_vlm_from_gguf`
+assembles both into a single onnx-genai-ready :class:`ModelPackage`:
+
+- **decoder** — the Gemma4 text decoder (from the text GGUF), taking
+  ``inputs_embeds``.
+- **vision_encoder** — the Gemma4 SigLIP vision encoder + projector (from the
+  mmproj), taking ``pixel_values`` + ``pixel_position_ids``.
+- **embedding** — scaled token lookup that fuses text + image features (built
+  from the text config, reusing :class:`Gemma4EmbeddingModel`).
+
+The mmproj ``clip.vision.*`` metadata is read into a :class:`VisionConfig`
+(:func:`read_mmproj_vision_config`) and merged onto the text
+:class:`Gemma4Config`; the mmproj ``v.*``/``mm.*`` tensors are mapped to their
+HF names (:mod:`_mmproj_mapping`) so they flow through the same tested
+``Gemma4Model.preprocess_weights`` path as a real HF checkpoint.
+
+Audio: :func:`read_mmproj_audio_config` extracts the Conformer
+:class:`Gemma4AudioConfig` and the audio tensor mapping exists
+(:func:`map_mmproj_audio_to_hf`), but the audio encoder is **not** yet wired
+into the assembled package — its Conformer forward-pass weight layout still
+needs validation against llama.cpp's ``clip.cpp`` gemma4a reference.  Pass
+``include_audio=True`` to opt in to the (experimental) audio path.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "build_gemma4_vlm_from_gguf",
+    "read_mmproj_audio_config",
+    "read_mmproj_vision_config",
+]
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from mobius._model_package import ModelPackage
+
+logger = logging.getLogger(__name__)
+
+# Gemma4 vision RoPE base frequency. The ``clip`` mmproj metadata does not store
+# it, so use the HF Gemma4VisionAttention default. Source: HF Gemma4 vision.
+_GEMMA4_VISION_ROPE_THETA = 100.0
+# Gemma4 vision pooler spatial average pooling kernel (k x k). Not present in
+# mmproj metadata; the SigLIP encoder pools N patches to N/k^2 soft tokens.
+_DEFAULT_POOLING_KERNEL_SIZE = 4
+
+
+def read_mmproj_vision_config(gguf_model: Any):
+    """Extract a Gemma4 :class:`VisionConfig` from ``clip.vision.*`` metadata.
+
+    Args:
+        gguf_model: A :class:`GGUFModel` for a ``clip`` mmproj file.
+
+    Returns:
+        A populated :class:`VisionConfig`, or ``None`` if the file has no
+        vision encoder (``clip.has_vision_encoder`` is false/absent).
+    """
+    from mobius._configs._sub_configs import VisionConfig
+
+    md = gguf_model.metadata
+    if not md.get("clip.has_vision_encoder"):
+        return None
+
+    # Position embedding table size is authoritative from the tensor itself
+    # ([2, pos_emb_size, hidden]); metadata carries no equivalent key.
+    pos_emb_size = int(gguf_model.get_tensor("v.position_embd.weight").shape[1])
+
+    return VisionConfig(
+        hidden_size=int(md["clip.vision.embedding_length"]),
+        intermediate_size=int(md["clip.vision.feed_forward_length"]),
+        num_hidden_layers=int(md["clip.vision.block_count"]),
+        num_attention_heads=int(md["clip.vision.attention.head_count"]),
+        image_size=int(md["clip.vision.image_size"]),
+        patch_size=int(md["clip.vision.patch_size"]),
+        norm_eps=float(md.get("clip.vision.attention.layer_norm_epsilon", 1e-6)),
+        # The mmproj carries activation-range stats, not clipped-linear weights,
+        # so the encoder uses plain (non-clipped) Linear layers.
+        use_clipped_linears=False,
+        position_embedding_size=pos_emb_size,
+        pooling_kernel_size=_DEFAULT_POOLING_KERNEL_SIZE,
+        hidden_act="gelu_pytorch_tanh",
+        rope_theta=_GEMMA4_VISION_ROPE_THETA,
+    )
+
+
+def read_mmproj_audio_config(gguf_model: Any):
+    """Extract a Gemma4 :class:`Gemma4AudioConfig` from ``clip.audio.*``.
+
+    Args:
+        gguf_model: A :class:`GGUFModel` for a ``clip`` mmproj file.
+
+    Returns:
+        A populated :class:`Gemma4AudioConfig`, or ``None`` if the file has no
+        audio encoder (``clip.has_audio_encoder`` is false/absent).
+    """
+    from mobius._configs._sub_configs import Gemma4AudioConfig
+
+    md = gguf_model.metadata
+    if not md.get("clip.has_audio_encoder"):
+        return None
+
+    # Subsampling conv channel sizes are read from the conv tensors:
+    # a.conv1d.0.weight [c0, 1, 3, 3], a.conv1d.1.weight [c1, c0, 3, 3].
+    conv0 = int(gguf_model.get_tensor("a.conv1d.0.weight").shape[0])
+    conv1 = int(gguf_model.get_tensor("a.conv1d.1.weight").shape[0])
+    # Projector output dim = mm.a.input_projection input width.
+    output_proj_dims = int(gguf_model.get_tensor("mm.a.input_projection.weight").shape[1])
+
+    return Gemma4AudioConfig(
+        input_size=int(md["clip.audio.num_mel_bins"]),
+        hidden_size=int(md["clip.audio.embedding_length"]),
+        num_layers=int(md["clip.audio.block_count"]),
+        attention_heads=int(md["clip.audio.attention.head_count"]),
+        linear_units=int(md["clip.audio.feed_forward_length"]),
+        subsampling_conv_channels=[conv0, conv1],
+        output_proj_dims=output_proj_dims,
+        rms_norm_eps=float(md.get("clip.audio.attention.layer_norm_epsilon", 1e-6)),
+    )
+
+
+def _resolve_local_path(path: str | Path) -> str:
+    from mobius.integrations.gguf._builder import _resolve_gguf_path
+
+    return _resolve_gguf_path(path)
+
+
+def _text_gguf_to_hf_multimodal(text_gguf: Any) -> dict:
+    """Load text-backbone GGUF tensors as HF multimodal (``language_model.*``).
+
+    Reuses the text ``gemma4`` GGUF→HF name mapping, then rewrites names into
+    the multimodal ``language_model.*`` namespace that
+    ``Gemma4Model.preprocess_weights`` expects.
+    """
+    import torch
+
+    from mobius.integrations.gguf._tensor_mapping import map_gguf_to_hf_names
+
+    # The three top-level per-layer-input tensors are not covered by the block
+    # text mapping; route them to their HF language-model names directly.
+    per_layer_top = {
+        "per_layer_token_embd.weight": "language_model.embed_tokens_per_layer.weight",
+        "per_layer_model_proj.weight": "language_model.per_layer_model_projection.weight",
+        "per_layer_proj_norm.weight": "language_model.per_layer_projection_norm.weight",
+    }
+
+    state_dict: dict[str, torch.Tensor] = {}
+    for gguf_name, array in text_gguf.tensor_items():
+        if gguf_name in per_layer_top:
+            hf_name = per_layer_top[gguf_name]
+        else:
+            text_hf = map_gguf_to_hf_names(gguf_name, "gemma4")
+            if text_hf is None:
+                continue
+            # gemma4 text mapping yields ``model.*`` / ``lm_head.*``; nest under
+            # the multimodal ``language_model.`` namespace (HF Gemma4 stores the
+            # decoder layers directly under language_model, so strip ``model.``).
+            if text_hf.startswith("model."):
+                hf_name = "language_model." + text_hf[len("model.") :]
+            else:
+                hf_name = "language_model." + text_hf
+
+        values = np.array(array).astype(np.float32)
+        # layer_scalar is an nn.Parameter (no ``.weight`` module suffix, shape [1]).
+        if hf_name.endswith(".layer_scalar.weight"):
+            hf_name = hf_name[: -len(".weight")]
+            values = values.reshape(-1)[:1]
+        state_dict[hf_name] = torch.from_numpy(values)
+    return state_dict
+
+
+def _mmproj_vision_to_hf(mmproj_gguf: Any) -> dict:
+    """Load mmproj vision tensors as HF names (``vision_tower.*``/``embed_vision.*``)."""
+    import torch
+
+    from mobius.integrations.gguf._mmproj_mapping import map_mmproj_vision_to_hf
+
+    state_dict: dict[str, torch.Tensor] = {}
+    for name in mmproj_gguf.tensor_names:
+        if not (name.startswith("v.") or name == "mm.input_projection.weight"):
+            continue
+        hf_name = map_mmproj_vision_to_hf(name)
+        if hf_name is None:
+            continue
+        values = np.array(mmproj_gguf.get_tensor(name)).astype(np.float32)
+        if name == "v.patch_embd.weight":
+            # Conv patch embed [out, in_ch, kh, kw] → Linear [out, in_ch*kh*kw].
+            # The flattening order (in_ch, kh, kw) row-major matches the
+            # pre-patchified pixel_values layout consumed by the encoder.
+            values = values.reshape(values.shape[0], -1)
+        state_dict[hf_name] = torch.from_numpy(values)
+    return state_dict
+
+
+def build_gemma4_vlm_from_gguf(
+    text_gguf_path: str | Path,
+    mmproj_gguf_path: str | Path,
+    *,
+    dtype: str | None = None,
+    execution_provider: str = "default",
+    image_token_id: int | None = None,
+    include_audio: bool = False,
+) -> ModelPackage:
+    """Build a full Gemma4 multimodal ONNX package from text + mmproj GGUFs.
+
+    Args:
+        text_gguf_path: Path (or HF ref) to the Gemma4 text-backbone GGUF.
+        mmproj_gguf_path: Path (or HF ref) to the companion ``clip`` mmproj GGUF.
+        dtype: Optional dtype override (e.g. ``"f16"``); defaults to float32.
+        execution_provider: Target EP for EP-aware optimisations.
+        image_token_id: Vocabulary id of the image soft-token placeholder used
+            to scatter image features into text embeddings. When ``None``, the
+            value carried by the text config is used (if any).
+        include_audio: When ``True``, also build the (experimental) audio
+            encoder. Off by default — see the module docstring.
+
+    Returns:
+        A :class:`ModelPackage` with ``decoder`` + ``vision_encoder`` +
+        ``embedding`` components (plus ``audio_encoder`` if ``include_audio``).
+    """
+    import dataclasses
+
+    from mobius._builder import resolve_dtype
+    from mobius.integrations.gguf._config_mapping import gguf_to_config
+    from mobius.integrations.gguf._reader import GGUFModel
+    from mobius.models.gemma4 import Gemma4Model
+    from mobius.tasks._gemma4 import Gemma4Task
+
+    text_gguf = GGUFModel(_resolve_local_path(text_gguf_path))
+    mmproj_gguf = GGUFModel(_resolve_local_path(mmproj_gguf_path))
+    if mmproj_gguf.architecture != "clip":
+        raise ValueError(
+            f"Expected a 'clip' mmproj GGUF, got architecture "
+            f"{mmproj_gguf.architecture!r} for {mmproj_gguf_path!r}."
+        )
+    logger.info("Building Gemma4 VLM from text=%s mmproj=%s", text_gguf_path, mmproj_gguf_path)
+
+    # 1. Text config + merged vision/audio sub-configs.
+    config = gguf_to_config(text_gguf)
+    vision_config = read_mmproj_vision_config(mmproj_gguf)
+    if vision_config is None:
+        raise ValueError(
+            "mmproj GGUF has no vision encoder (clip.has_vision_encoder is unset)."
+        )
+    config = dataclasses.replace(config, vision=vision_config)
+
+    if include_audio:
+        config = dataclasses.replace(config, audio=read_mmproj_audio_config(mmproj_gguf))
+    else:
+        # Vision-only VLM: drop any audio sub-config so the package is the
+        # 3-component (decoder + vision + embedding) multimodal shape.
+        config = dataclasses.replace(config, audio=None)
+
+    if image_token_id is not None:
+        config = dataclasses.replace(config, image_token_id=image_token_id)
+    if dtype is not None:
+        resolved = resolve_dtype(dtype)
+        if resolved is not None:
+            config = dataclasses.replace(config, dtype=resolved)
+
+    # 2. Build the multimodal graph (decoder + vision + embedding [+ audio]).
+    module = Gemma4Model(config)
+    pkg = Gemma4Task().build(module, config)
+    logger.info("Built Gemma4 VLM graph (%d components: %s)", len(pkg), list(pkg))
+
+    # 3. Assemble the combined HF-multimodal state dict from both GGUFs.
+    state_dict = _text_gguf_to_hf_multimodal(text_gguf)
+    state_dict.update(_mmproj_vision_to_hf(mmproj_gguf))
+    if include_audio:
+        state_dict.update(_mmproj_audio_to_hf(mmproj_gguf))
+
+    # 4. Run the tested HF→ONNX preprocessing and apply. Names are already
+    #    component-qualified after preprocessing, so no prefix_map is needed.
+    state_dict = module.preprocess_weights(state_dict)
+    pkg.apply_weights(state_dict)
+    logger.info("Applied %d mapped weights to the Gemma4 VLM package", len(state_dict))
+
+    return pkg
+
+
+def _mmproj_audio_to_hf(mmproj_gguf: Any) -> dict:
+    """Load mmproj audio tensors as HF names (experimental; see module docstring)."""
+    import torch
+
+    from mobius.integrations.gguf._mmproj_mapping import map_mmproj_audio_to_hf
+
+    state_dict: dict[str, torch.Tensor] = {}
+    for name in mmproj_gguf.tensor_names:
+        if not (name.startswith("a.") or name == "mm.a.input_projection.weight"):
+            continue
+        hf_name = map_mmproj_audio_to_hf(name)
+        if hf_name is None:
+            continue
+        values = np.array(mmproj_gguf.get_tensor(name)).astype(np.float32)
+        if hf_name.endswith(".per_dim_scale"):
+            values = values.reshape(-1)
+        state_dict[hf_name] = torch.from_numpy(values)
+    return state_dict

--- a/src/mobius/integrations/gguf/_mmproj.py
+++ b/src/mobius/integrations/gguf/_mmproj.py
@@ -445,8 +445,16 @@ def build_gemma4_vlm_from_gguf(
         )
 
     # 2. Build the multimodal graph (decoder + vision + embedding [+ audio]).
+    #    Route through build_from_module so each component gets the EP-aware
+    #    optimize_model passes (GQA fusion, etc.) — the same pipeline the
+    #    text-only build_from_gguf path uses; calling Gemma4Task().build()
+    #    directly would skip those optimizations.
+    from mobius._builder import build_from_module
+
     module = Gemma4Model(config)
-    pkg = Gemma4Task().build(module, config)
+    pkg = build_from_module(
+        module, config, task=Gemma4Task(), execution_provider=execution_provider
+    )
     logger.info("Built Gemma4 VLM graph (%d components: %s)", len(pkg), list(pkg))
 
     # 3. Assemble the combined HF-multimodal state dict from both GGUFs. The

--- a/src/mobius/integrations/gguf/_mmproj_mapping.py
+++ b/src/mobius/integrations/gguf/_mmproj_mapping.py
@@ -1,0 +1,179 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""GGUF ``clip`` mmproj → HuggingFace tensor name mapping (Gemma4 vision/audio).
+
+Gemma4's vision and audio encoders ship in a *companion* ``mmproj-*.gguf`` file
+whose ``general.architecture`` is ``clip`` (not ``gemma4``).  Its tensors use a
+different naming scheme than the text backbone:
+
+- Vision tower tensors are prefixed ``v.`` (e.g. ``v.blk.0.attn_q.weight``,
+  ``v.patch_embd.weight``, ``v.position_embd.weight``).
+- Audio tower tensors are prefixed ``a.`` (e.g. ``a.blk.0.attn_q.weight``,
+  ``a.conv1d.0.weight``, ``a.pre_encode.out.weight``).
+- Cross-modal projectors are ``mm.input_projection.weight`` (vision→text) and
+  ``mm.a.input_projection.weight`` (audio→text).
+
+This module maps those names onto the **HuggingFace** names that
+:meth:`mobius.models.gemma4.Gemma4Model.preprocess_weights` consumes
+(``vision_tower.*`` / ``embed_vision.*`` / ``audio_tower.*`` / ``embed_audio.*``),
+so the mmproj weights flow through the *same* tested preprocessing path as a
+real HF Gemma4 checkpoint before being applied to the ONNX graph.
+
+Companion activation-range tensors (``.input_max`` / ``.input_min`` /
+``.output_max`` / ``.output_min``) that llama.cpp stores next to each weight are
+**not** model weights and are skipped — see :func:`is_mmproj_stat_tensor`.
+
+The name derivation was verified against ``unsloth/gemma-4-E2B-it-GGUF``'s
+``mmproj-F16.gguf`` (``clip.vision.projector_type = gemma4v``,
+``clip.audio.projector_type = gemma4a``) by round-tripping through
+``preprocess_weights`` and checking every ONNX initializer receives a weight.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "is_mmproj_stat_tensor",
+    "map_mmproj_audio_to_hf",
+    "map_mmproj_vision_to_hf",
+]
+
+import re
+
+# ---------------------------------------------------------------------------
+# Vision tower (v.* / mm.input_projection)
+# ---------------------------------------------------------------------------
+# Per-block stem → HF Gemma4VisionEncoderLayer stem. The mmproj SigLIP-style
+# block has a 4-norm structure (ln1 = pre-attention, ln2 = pre-feedforward,
+# attn_post_norm = post-attention, ffn_post_norm = post-feedforward), SwiGLU
+# gate/up/down FFN, and per-head Q/K RMSNorms.
+_VISION_BLOCK_STEMS: dict[str, str] = {
+    "ln1.weight": "input_layernorm.weight",
+    "ln2.weight": "pre_feedforward_layernorm.weight",
+    "attn_post_norm.weight": "post_attention_layernorm.weight",
+    "ffn_post_norm.weight": "post_feedforward_layernorm.weight",
+    "attn_q.weight": "self_attn.q_proj.weight",
+    "attn_k.weight": "self_attn.k_proj.weight",
+    "attn_v.weight": "self_attn.v_proj.weight",
+    "attn_out.weight": "self_attn.o_proj.weight",
+    "attn_q_norm.weight": "self_attn.q_norm.weight",
+    "attn_k_norm.weight": "self_attn.k_norm.weight",
+    "ffn_gate.weight": "mlp.gate_proj.weight",
+    "ffn_up.weight": "mlp.up_proj.weight",
+    "ffn_down.weight": "mlp.down_proj.weight",
+}
+
+# ---------------------------------------------------------------------------
+# Audio tower (a.* / mm.a.input_projection)
+# ---------------------------------------------------------------------------
+# Per-block stem → HF Gemma4 Conformer block stem. Mapped against the ONNX
+# module parameter names of ``_Gemma4AudioEncoderModel`` (feed_forward1/2,
+# self_attn, lconv1d, norm_*). NOTE: the Conformer forward-pass wiring for the
+# mmproj audio tower is still being validated (see build_gemma4_vlm_from_gguf),
+# so this mapping is provided for completeness and unit-tested for name shape
+# but not yet applied to a built audio graph.
+_AUDIO_BLOCK_STEMS: dict[str, str] = {
+    "ffn_norm.weight": "feed_forward1.pre_layer_norm.weight",
+    "ffn_up.weight": "feed_forward1.ffw_layer_1.weight",
+    "ffn_down.weight": "feed_forward1.ffw_layer_2.weight",
+    "ffn_post_norm.weight": "feed_forward1.post_layer_norm.weight",
+    "ffn_norm_1.weight": "feed_forward2.pre_layer_norm.weight",
+    "ffn_up_1.weight": "feed_forward2.ffw_layer_1.weight",
+    "ffn_down_1.weight": "feed_forward2.ffw_layer_2.weight",
+    "ffn_post_norm_1.weight": "feed_forward2.post_layer_norm.weight",
+    "attn_pre_norm.weight": "norm_pre_attn.weight",
+    "attn_post_norm.weight": "norm_post_attn.weight",
+    "ln2.weight": "norm_out.weight",
+    "attn_q.weight": "self_attn.q_proj.weight",
+    "attn_k.weight": "self_attn.k_proj.weight",
+    "attn_v.weight": "self_attn.v_proj.weight",
+    "attn_out.weight": "self_attn.post.weight",
+    "attn_k_rel.weight": "self_attn.relative_k_proj.weight",
+    "per_dim_scale.weight": "self_attn.per_dim_scale",
+    "norm_conv.weight": "lconv1d.pre_layer_norm.weight",
+    "conv_pw1.weight": "lconv1d.linear_start.weight",
+    "conv_dw.weight": "lconv1d.depthwise_conv1d.weight",
+    "conv_norm.weight": "lconv1d.conv_norm.weight",
+    "conv_pw2.weight": "lconv1d.linear_end.weight",
+}
+
+_VISION_BLK = re.compile(r"^v\.blk\.(\d+)\.(.+)$")
+_AUDIO_BLK = re.compile(r"^a\.blk\.(\d+)\.(.+)$")
+
+_STAT_SUFFIXES = (".input_max", ".input_min", ".output_max", ".output_min")
+
+
+def is_mmproj_stat_tensor(name: str) -> bool:
+    """Return ``True`` for llama.cpp activation-range stats (not weights).
+
+    Each quantizable linear in the mmproj carries companion
+    ``.input_max``/``.input_min``/``.output_max``/``.output_min`` scalar
+    tensors describing the observed activation range. These are calibration
+    statistics, not learnable parameters, and must be skipped.
+    """
+    return name.endswith(_STAT_SUFFIXES)
+
+
+def map_mmproj_vision_to_hf(name: str) -> str | None:
+    """Map a ``clip`` mmproj vision tensor name to its HF Gemma4 name.
+
+    Returns the HuggingFace name consumed by
+    :meth:`Gemma4Model.preprocess_weights` (``vision_tower.*`` /
+    ``embed_vision.*``), or ``None`` if the tensor is skipped (activation-range
+    stats or the audio tower).
+
+    The mapping mirrors :mod:`_tensor_mapping` for the text backbone.
+    """
+    if is_mmproj_stat_tensor(name):
+        return None
+
+    blk = _VISION_BLK.match(name)
+    if blk is not None:
+        idx, stem = blk.group(1), blk.group(2)
+        hf_stem = _VISION_BLOCK_STEMS.get(stem)
+        if hf_stem is None:
+            return None
+        return f"vision_tower.encoder.layers.{idx}.{hf_stem}"
+
+    if name == "v.patch_embd.weight":
+        # Conv patch embedding [out, in_ch, kh, kw] → HF input_proj Linear
+        # [out, in_ch*kh*kw]. The 4D→2D flattening is applied by the builder.
+        return "vision_tower.patch_embedder.input_proj.weight"
+    if name == "v.position_embd.weight":
+        # [2, pos_emb_size, hidden] x/y coordinate position table.
+        return "vision_tower.patch_embedder.position_embedding_table"
+    if name == "mm.input_projection.weight":
+        return "embed_vision.embedding_projection.weight"
+    return None
+
+
+def map_mmproj_audio_to_hf(name: str) -> str | None:
+    """Map a ``clip`` mmproj audio tensor name to its HF Gemma4 name.
+
+    Returns the HuggingFace name (``audio_tower.*`` / ``embed_audio.*``), or
+    ``None`` if skipped. See the module docstring: the audio Conformer
+    forward-pass wiring is not yet applied to a built graph, so this is
+    provided and name-tested but treated as experimental by the builder.
+    """
+    if is_mmproj_stat_tensor(name):
+        return None
+
+    blk = _AUDIO_BLK.match(name)
+    if blk is not None:
+        idx, stem = blk.group(1), blk.group(2)
+        hf_stem = _AUDIO_BLOCK_STEMS.get(stem)
+        if hf_stem is None:
+            return None
+        return f"audio_tower.layers.{idx}.{hf_stem}"
+
+    audio_top: dict[str, str] = {
+        "a.conv1d.0.weight": "audio_tower.subsample_conv_projection.conv0.weight",
+        "a.conv1d.0.norm.weight": "audio_tower.subsample_conv_projection.norm0.weight",
+        "a.conv1d.1.weight": "audio_tower.subsample_conv_projection.conv1.weight",
+        "a.conv1d.1.norm.weight": "audio_tower.subsample_conv_projection.norm1.weight",
+        "a.input_projection.weight": (
+            "audio_tower.subsample_conv_projection.input_proj_linear.weight"
+        ),
+        "mm.a.input_projection.weight": "embed_audio.embedding_projection.weight",
+    }
+    return audio_top.get(name)

--- a/src/mobius/integrations/gguf/_mmproj_mapping_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_mapping_test.py
@@ -1,0 +1,161 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Unit tests for the GGUF ``clip`` mmproj → HF tensor-name mapping."""
+
+from __future__ import annotations
+
+import pytest
+
+from mobius.integrations.gguf._mmproj_mapping import (
+    is_mmproj_stat_tensor,
+    map_mmproj_audio_to_hf,
+    map_mmproj_vision_to_hf,
+)
+
+
+class TestStatTensorDetection:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "v.blk.0.attn_q.weight.input_max",
+            "v.blk.0.attn_q.weight.input_min",
+            "v.blk.0.attn_q.weight.output_max",
+            "v.blk.0.attn_q.weight.output_min",
+            "a.blk.3.ffn_up.weight.output_min",
+        ],
+    )
+    def test_stat_tensors_detected(self, name: str):
+        assert is_mmproj_stat_tensor(name) is True
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "v.blk.0.attn_q.weight",
+            "v.patch_embd.weight",
+            "mm.input_projection.weight",
+            "a.conv1d.0.weight",
+        ],
+    )
+    def test_real_weights_not_flagged(self, name: str):
+        assert is_mmproj_stat_tensor(name) is False
+
+
+class TestVisionMapping:
+    @pytest.mark.parametrize(
+        ("gguf_name", "expected"),
+        [
+            (
+                "v.blk.0.attn_q.weight",
+                "vision_tower.encoder.layers.0.self_attn.q_proj.weight",
+            ),
+            (
+                "v.blk.7.attn_k.weight",
+                "vision_tower.encoder.layers.7.self_attn.k_proj.weight",
+            ),
+            (
+                "v.blk.2.attn_v.weight",
+                "vision_tower.encoder.layers.2.self_attn.v_proj.weight",
+            ),
+            (
+                "v.blk.2.attn_out.weight",
+                "vision_tower.encoder.layers.2.self_attn.o_proj.weight",
+            ),
+            (
+                "v.blk.1.attn_q_norm.weight",
+                "vision_tower.encoder.layers.1.self_attn.q_norm.weight",
+            ),
+            (
+                "v.blk.1.attn_k_norm.weight",
+                "vision_tower.encoder.layers.1.self_attn.k_norm.weight",
+            ),
+            (
+                "v.blk.0.ln1.weight",
+                "vision_tower.encoder.layers.0.input_layernorm.weight",
+            ),
+            (
+                "v.blk.0.ln2.weight",
+                "vision_tower.encoder.layers.0.pre_feedforward_layernorm.weight",
+            ),
+            (
+                "v.blk.0.attn_post_norm.weight",
+                "vision_tower.encoder.layers.0.post_attention_layernorm.weight",
+            ),
+            (
+                "v.blk.0.ffn_post_norm.weight",
+                "vision_tower.encoder.layers.0.post_feedforward_layernorm.weight",
+            ),
+            (
+                "v.blk.4.ffn_gate.weight",
+                "vision_tower.encoder.layers.4.mlp.gate_proj.weight",
+            ),
+            (
+                "v.blk.4.ffn_up.weight",
+                "vision_tower.encoder.layers.4.mlp.up_proj.weight",
+            ),
+            (
+                "v.blk.4.ffn_down.weight",
+                "vision_tower.encoder.layers.4.mlp.down_proj.weight",
+            ),
+            (
+                "v.patch_embd.weight",
+                "vision_tower.patch_embedder.input_proj.weight",
+            ),
+            (
+                "v.position_embd.weight",
+                "vision_tower.patch_embedder.position_embedding_table",
+            ),
+            (
+                "mm.input_projection.weight",
+                "embed_vision.embedding_projection.weight",
+            ),
+        ],
+    )
+    def test_vision_names(self, gguf_name: str, expected: str):
+        assert map_mmproj_vision_to_hf(gguf_name) == expected
+
+    def test_stat_tensors_skipped(self):
+        assert map_mmproj_vision_to_hf("v.blk.0.attn_q.weight.input_max") is None
+
+    def test_unknown_stem_skipped(self):
+        assert map_mmproj_vision_to_hf("v.blk.0.mystery.weight") is None
+
+    def test_audio_tensor_not_mapped_by_vision(self):
+        assert map_mmproj_vision_to_hf("a.blk.0.attn_q.weight") is None
+
+
+class TestAudioMapping:
+    @pytest.mark.parametrize(
+        ("gguf_name", "expected"),
+        [
+            (
+                "a.blk.0.attn_q.weight",
+                "audio_tower.layers.0.self_attn.q_proj.weight",
+            ),
+            (
+                "a.blk.0.per_dim_scale.weight",
+                "audio_tower.layers.0.self_attn.per_dim_scale",
+            ),
+            (
+                "a.blk.0.conv_dw.weight",
+                "audio_tower.layers.0.lconv1d.depthwise_conv1d.weight",
+            ),
+            (
+                "a.conv1d.0.weight",
+                "audio_tower.subsample_conv_projection.conv0.weight",
+            ),
+            (
+                "a.input_projection.weight",
+                "audio_tower.subsample_conv_projection.input_proj_linear.weight",
+            ),
+            (
+                "mm.a.input_projection.weight",
+                "embed_audio.embedding_projection.weight",
+            ),
+        ],
+    )
+    def test_audio_names(self, gguf_name: str, expected: str):
+        assert map_mmproj_audio_to_hf(gguf_name) == expected
+
+    def test_stat_tensors_skipped(self):
+        assert map_mmproj_audio_to_hf("a.blk.0.attn_q.weight.output_min") is None

--- a/src/mobius/integrations/gguf/_mmproj_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_test.py
@@ -1,0 +1,228 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for GGUF ``clip`` mmproj config extraction and vision-encoder build.
+
+Builds a small synthetic ``clip`` mmproj GGUF with :class:`GGUFWriter` (mirroring
+``_builder_test.py``), then exercises the mmproj config readers and the vision
+encoder build+run path end-to-end on CPU.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# Small synthetic vision encoder dimensions.
+_VISION_HIDDEN = 16
+_VISION_FFN = 32
+_VISION_LAYERS = 2
+_VISION_HEADS = 2
+_IMAGE_SIZE = 16
+_PATCH_SIZE = 4
+_POS_EMB_SIZE = 8
+_TEXT_HIDDEN = 32
+
+# Small synthetic audio encoder dimensions.
+_AUDIO_HIDDEN = 16
+_AUDIO_FFN = 32
+_AUDIO_LAYERS = 2
+_AUDIO_HEADS = 2
+_NUM_MEL_BINS = 8
+_AUDIO_CONV0 = 16
+_AUDIO_CONV1 = 16
+_AUDIO_PROJ_OUT = 24
+
+
+def _write_clip_mmproj_gguf(path: Path, *, with_audio: bool = True) -> None:
+    """Write a small synthetic Gemma4 ``clip`` mmproj GGUF for tests."""
+    from gguf import GGUFWriter
+
+    head_dim = _VISION_HIDDEN // _VISION_HEADS
+    writer = GGUFWriter(str(path), "clip")
+
+    # --- vision metadata ---
+    writer.add_bool("clip.has_vision_encoder", True)
+    writer.add_string("clip.vision.projector_type", "gemma4v")
+    writer.add_uint32("clip.vision.embedding_length", _VISION_HIDDEN)
+    writer.add_uint32("clip.vision.feed_forward_length", _VISION_FFN)
+    writer.add_uint32("clip.vision.block_count", _VISION_LAYERS)
+    writer.add_uint32("clip.vision.attention.head_count", _VISION_HEADS)
+    writer.add_uint32("clip.vision.image_size", _IMAGE_SIZE)
+    writer.add_uint32("clip.vision.patch_size", _PATCH_SIZE)
+    writer.add_float32("clip.vision.attention.layer_norm_epsilon", 1e-6)
+
+    def _f32(name: str, shape: tuple[int, ...]) -> None:
+        writer.add_tensor(name, np.random.randn(*shape).astype(np.float32))
+
+    # patch embed (conv layout) + position table + projector.
+    _f32("v.patch_embd.weight", (_VISION_HIDDEN, 3, _PATCH_SIZE, _PATCH_SIZE))
+    _f32("v.position_embd.weight", (2, _POS_EMB_SIZE, _VISION_HIDDEN))
+    _f32("mm.input_projection.weight", (_TEXT_HIDDEN, _VISION_HIDDEN))
+    # A companion activation-range stat tensor that must be skipped.
+    _f32("mm.input_projection.weight.input_max", (1,))
+
+    for layer in range(_VISION_LAYERS):
+        prefix = f"v.blk.{layer}."
+        for norm in ("ln1", "ln2", "attn_post_norm", "ffn_post_norm"):
+            _f32(prefix + norm + ".weight", (_VISION_HIDDEN,))
+        for proj in ("attn_q", "attn_k", "attn_v", "attn_out"):
+            _f32(prefix + proj + ".weight", (_VISION_HIDDEN, _VISION_HIDDEN))
+        for qk_norm in ("attn_q_norm", "attn_k_norm"):
+            _f32(prefix + qk_norm + ".weight", (head_dim,))
+        _f32(prefix + "ffn_gate.weight", (_VISION_FFN, _VISION_HIDDEN))
+        _f32(prefix + "ffn_up.weight", (_VISION_FFN, _VISION_HIDDEN))
+        _f32(prefix + "ffn_down.weight", (_VISION_HIDDEN, _VISION_FFN))
+        # Stat tensor next to a quantizable linear — must be skipped.
+        _f32(prefix + "attn_q.weight.output_min", (1,))
+
+    # --- audio metadata (best-effort, for config-extraction tests) ---
+    if with_audio:
+        writer.add_bool("clip.has_audio_encoder", True)
+        writer.add_string("clip.audio.projector_type", "gemma4a")
+        writer.add_uint32("clip.audio.embedding_length", _AUDIO_HIDDEN)
+        writer.add_uint32("clip.audio.feed_forward_length", _AUDIO_FFN)
+        writer.add_uint32("clip.audio.block_count", _AUDIO_LAYERS)
+        writer.add_uint32("clip.audio.attention.head_count", _AUDIO_HEADS)
+        writer.add_uint32("clip.audio.num_mel_bins", _NUM_MEL_BINS)
+        writer.add_float32("clip.audio.attention.layer_norm_epsilon", 1e-6)
+        _f32("a.conv1d.0.weight", (_AUDIO_CONV0, 1, 3, 3))
+        _f32("a.conv1d.1.weight", (_AUDIO_CONV1, _AUDIO_CONV0, 3, 3))
+        _f32("mm.a.input_projection.weight", (_AUDIO_HIDDEN, _AUDIO_PROJ_OUT))
+
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_tensors_to_file()
+    writer.close()
+
+
+@pytest.fixture
+def clip_mmproj_gguf(tmp_path: Path) -> Path:
+    path = tmp_path / "mmproj.gguf"
+    _write_clip_mmproj_gguf(path)
+    return path
+
+
+class TestReadVisionConfig:
+    def test_extracts_expected_fields(self, clip_mmproj_gguf: Path):
+        from mobius.integrations.gguf._mmproj import read_mmproj_vision_config
+        from mobius.integrations.gguf._reader import GGUFModel
+
+        config = read_mmproj_vision_config(GGUFModel(str(clip_mmproj_gguf)))
+
+        assert config is not None
+        assert config.hidden_size == _VISION_HIDDEN
+        assert config.intermediate_size == _VISION_FFN
+        assert config.num_hidden_layers == _VISION_LAYERS
+        assert config.num_attention_heads == _VISION_HEADS
+        assert config.image_size == _IMAGE_SIZE
+        assert config.patch_size == _PATCH_SIZE
+        assert config.position_embedding_size == _POS_EMB_SIZE
+        assert config.use_clipped_linears is False
+        assert config.norm_eps == pytest.approx(1e-6)
+
+    def test_returns_none_without_vision_encoder(self, tmp_path: Path):
+        from mobius.integrations.gguf._mmproj import read_mmproj_vision_config
+        from mobius.integrations.gguf._reader import GGUFModel
+
+        path = tmp_path / "audio_only.gguf"
+        _write_clip_mmproj_gguf(path, with_audio=True)
+        model = GGUFModel(str(path))
+        model.metadata["clip.has_vision_encoder"] = False
+        assert read_mmproj_vision_config(model) is None
+
+
+class TestReadAudioConfig:
+    def test_extracts_expected_fields(self, clip_mmproj_gguf: Path):
+        from mobius.integrations.gguf._mmproj import read_mmproj_audio_config
+        from mobius.integrations.gguf._reader import GGUFModel
+
+        config = read_mmproj_audio_config(GGUFModel(str(clip_mmproj_gguf)))
+
+        assert config is not None
+        assert config.hidden_size == _AUDIO_HIDDEN
+        assert config.num_layers == _AUDIO_LAYERS
+        assert config.attention_heads == _AUDIO_HEADS
+        assert config.input_size == _NUM_MEL_BINS
+        assert config.subsampling_conv_channels == [_AUDIO_CONV0, _AUDIO_CONV1]
+        assert config.output_proj_dims == _AUDIO_PROJ_OUT
+
+    def test_returns_none_without_audio_encoder(self, tmp_path: Path):
+        from mobius.integrations.gguf._mmproj import read_mmproj_audio_config
+        from mobius.integrations.gguf._reader import GGUFModel
+
+        path = tmp_path / "vision_only.gguf"
+        _write_clip_mmproj_gguf(path, with_audio=False)
+        assert read_mmproj_audio_config(GGUFModel(str(path))) is None
+
+
+class TestVisionEncoderBuildAndRun:
+    """Build the Gemma4 vision encoder from the synthetic mmproj and run it."""
+
+    def test_builds_applies_and_runs(self, clip_mmproj_gguf: Path, tmp_path: Path):
+        import onnxruntime as ort
+        import torch
+
+        from mobius._configs import Gemma4Config
+        from mobius._model_package import ModelPackage
+        from mobius.integrations.gguf._mmproj import read_mmproj_vision_config
+        from mobius.integrations.gguf._mmproj_mapping import map_mmproj_vision_to_hf
+        from mobius.integrations.gguf._reader import GGUFModel
+        from mobius.models.gemma4 import _Gemma4VisionEncoderModel
+        from mobius.tasks._gemma4 import Gemma4Task
+
+        gguf_model = GGUFModel(str(clip_mmproj_gguf))
+        vision_config = read_mmproj_vision_config(gguf_model)
+        config = Gemma4Config(
+            hidden_size=_TEXT_HIDDEN,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            vocab_size=64,
+            vision=vision_config,
+        )
+
+        module = _Gemma4VisionEncoderModel(config)
+        model = Gemma4Task()._build_vision(module, config)
+        package = ModelPackage({"vision_encoder": model}, config=config)
+
+        # Map mmproj vision tensors → HF names, then through the module's own
+        # preprocessing (vision_tower.* / embed_vision.* → module params).
+        state_dict: dict[str, torch.Tensor] = {}
+        for name in gguf_model.tensor_names:
+            if not (name.startswith("v.") or name == "mm.input_projection.weight"):
+                continue
+            hf_name = map_mmproj_vision_to_hf(name)
+            if hf_name is None:
+                continue
+            values = np.array(gguf_model.get_tensor(name)).astype(np.float32)
+            if name == "v.patch_embd.weight":
+                values = values.reshape(values.shape[0], -1)
+            state_dict[hf_name] = torch.from_numpy(values)
+
+        state_dict = module.preprocess_weights(state_dict)
+        package.apply_weights(state_dict)
+
+        out_dir = tmp_path / "vision_out"
+        package.save(str(out_dir), progress_bar=False)
+
+        session = ort.InferenceSession(
+            str(out_dir / "model.onnx"), providers=["CPUExecutionProvider"]
+        )
+        grid = _IMAGE_SIZE // _PATCH_SIZE
+        num_patches = grid * grid
+        pixel_values = np.random.rand(1, num_patches, 3 * _PATCH_SIZE * _PATCH_SIZE).astype(
+            np.float32
+        )
+        xs, ys = np.meshgrid(np.arange(grid), np.arange(grid), indexing="ij")
+        pixel_position_ids = np.stack([xs.ravel(), ys.ravel()], axis=-1)[None].astype(np.int64)
+
+        outputs = session.run(
+            None,
+            {"pixel_values": pixel_values, "pixel_position_ids": pixel_position_ids},
+        )
+        image_features = outputs[0]
+        assert image_features.ndim == 2
+        assert image_features.shape[1] == _TEXT_HIDDEN
+        assert np.isfinite(image_features).all()

--- a/src/mobius/integrations/gguf/_mmproj_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_test.py
@@ -320,7 +320,6 @@ class TestKeepQuantizedMixedPrecision:
         """
         import dataclasses
 
-        import onnx
         import onnx_ir as ir
         import onnxruntime as ort
 
@@ -381,7 +380,7 @@ class TestKeepQuantizedMixedPrecision:
             init.const_value = ir.tensor(values)
 
         decoder_path = tmp_path / "decoder.onnx"
-        onnx.save(ir.to_proto(model), str(decoder_path))
+        ir.save(model, str(decoder_path))
 
         # Session creation runs shape inference — the KV-shared fix is what keeps
         # this from failing with a MatMul "Incompatible dimensions" error.

--- a/src/mobius/integrations/gguf/_mmproj_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_test.py
@@ -226,3 +226,165 @@ class TestVisionEncoderBuildAndRun:
         assert image_features.ndim == 2
         assert image_features.shape[1] == _TEXT_HIDDEN
         assert np.isfinite(image_features).all()
+
+
+def _component_op_types(model) -> set[str]:
+    """Collect every ONNX op type used across a component's graph."""
+    return {node.op_type for node in model.graph}
+
+
+class TestKeepQuantizedMixedPrecision:
+    """A ``keep_quantized`` multimodal build must be mixed precision.
+
+    The Gemma4 *text* decoder + token embedding honour ``config.quantization``
+    (MatMulNBits / GatherBlockQuantized), while the mmproj-sourced vision
+    encoder stays float — see ``build_gemma4_vlm_from_gguf``'s "Mixed
+    precision" note. This asserts that property directly on the built graphs,
+    using the same ``Gemma4Model`` + ``Gemma4Task`` build path the multimodal
+    builder uses, without needing a full quantized text GGUF.
+    """
+
+    def test_decoder_and_embedding_quantized_vision_stays_float(self, clip_mmproj_gguf: Path):
+        import dataclasses
+
+        from mobius._configs import Gemma4Config, QuantizationConfig
+        from mobius.integrations.gguf._mmproj import read_mmproj_vision_config
+        from mobius.integrations.gguf._reader import GGUFModel
+        from mobius.models.gemma4 import Gemma4Model
+        from mobius.tasks._gemma4 import Gemma4Task
+
+        vision_config = read_mmproj_vision_config(GGUFModel(str(clip_mmproj_gguf)))
+        assert vision_config is not None
+
+        config = Gemma4Config(
+            hidden_size=32,
+            num_hidden_layers=4,
+            num_attention_heads=4,
+            num_key_value_heads=1,
+            head_dim=8,
+            global_head_dim=16,
+            num_global_key_value_heads=1,
+            vocab_size=64,
+            layer_types=[
+                "sliding_attention",
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+            ],
+            num_kv_shared_layers=1,
+            hidden_size_per_layer_input=8,
+            vocab_size_per_layer_input=64,
+            intermediate_size=64,
+            hidden_act="gelu_pytorch_tanh",
+            vision=vision_config,
+        )
+        # A single module-global quantization config: only the Gemma4 text
+        # components read it; the vision encoder ignores it and stays float.
+        config = dataclasses.replace(
+            config,
+            quantization=QuantizationConfig(
+                bits=4,
+                group_size=32,
+                quant_method="gguf",
+                sym=False,
+                quantize_embeddings=True,
+                quantize_lm_head=True,
+            ),
+        )
+
+        package = Gemma4Task().build(Gemma4Model(config), config)
+        assert set(package) == {"decoder", "vision_encoder", "embedding"}
+
+        decoder_ops = _component_op_types(package["decoder"])
+        embedding_ops = _component_op_types(package["embedding"])
+        vision_ops = _component_op_types(package["vision_encoder"])
+
+        # Text decoder projections are packed 4-bit matmuls.
+        assert "MatMulNBits" in decoder_ops
+        # Token-embedding table stays packed (int4 gather).
+        assert "GatherBlockQuantized" in embedding_ops
+        # The mmproj-sourced vision encoder is float — no quantized ops.
+        assert "MatMulNBits" not in vision_ops
+        assert "GatherBlockQuantized" not in vision_ops
+
+    def test_quantized_decoder_loads_in_onnxruntime(
+        self, clip_mmproj_gguf: Path, tmp_path: Path
+    ):
+        """The quantized decoder (incl. KV-shared layers) loads in ORT.
+
+        Session creation runs onnxruntime's shape inference, which is where the
+        pre-fix graph failed for KV-shared layers with a MatMul "Incompatible
+        dimensions" error. This guards the fix that gives KV-shared layers'
+        shared K/V a static hidden size so onnxruntime can shape-infer the
+        attention output width.
+        """
+        import dataclasses
+
+        import onnx
+        import onnx_ir as ir
+        import onnxruntime as ort
+
+        from mobius._configs import Gemma4Config, QuantizationConfig
+        from mobius.integrations.gguf._mmproj import read_mmproj_vision_config
+        from mobius.integrations.gguf._reader import GGUFModel
+        from mobius.models.gemma4 import _Gemma4DecoderModel
+        from mobius.tasks._gemma4 import Gemma4Task
+
+        vision_config = read_mmproj_vision_config(GGUFModel(str(clip_mmproj_gguf)))
+        config = Gemma4Config(
+            hidden_size=32,
+            num_hidden_layers=6,
+            num_attention_heads=4,
+            num_key_value_heads=1,
+            head_dim=8,
+            global_head_dim=16,
+            num_global_key_value_heads=1,
+            vocab_size=64,
+            layer_types=[
+                "sliding_attention",
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "full_attention",
+            ],
+            num_kv_shared_layers=2,
+            hidden_size_per_layer_input=8,
+            vocab_size_per_layer_input=64,
+            intermediate_size=64,
+            hidden_act="gelu_pytorch_tanh",
+            vision=vision_config,
+        )
+        config = dataclasses.replace(
+            config,
+            quantization=QuantizationConfig(
+                bits=4,
+                group_size=32,
+                quant_method="gguf",
+                sym=False,
+                quantize_embeddings=True,
+                quantize_lm_head=True,
+            ),
+        )
+
+        model = Gemma4Task()._build_decoder(_Gemma4DecoderModel(config), config)
+        # Fill random data so the graph can be serialized and loaded by ORT.
+        for init in model.graph.initializers.values():
+            if init.const_value is not None:
+                continue
+            shape = tuple(d if isinstance(d, int) else 1 for d in init.shape)
+            np_dtype = init.dtype.numpy() if init.dtype is not None else np.float32
+            if np.issubdtype(np_dtype, np.integer):
+                values = np.random.randint(0, 7, size=shape).astype(np_dtype)
+            else:
+                values = (np.random.rand(*shape).astype(np.float32) * 0.1).astype(np_dtype)
+            init.const_value = ir.tensor(values)
+
+        decoder_path = tmp_path / "decoder.onnx"
+        onnx.save(ir.to_proto(model), str(decoder_path))
+
+        # Session creation runs shape inference — the KV-shared fix is what keeps
+        # this from failing with a MatMul "Incompatible dimensions" error.
+        session = ort.InferenceSession(str(decoder_path), providers=["CPUExecutionProvider"])
+        input_names = {graph_input.name for graph_input in session.get_inputs()}
+        assert "inputs_embeds" in input_names

--- a/src/mobius/integrations/gguf/_reader.py
+++ b/src/mobius/integrations/gguf/_reader.py
@@ -91,17 +91,19 @@ def _parse_array(data: list[int], parts: list, element_type) -> list[Any]:
     from gguf import GGUFValueType
 
     if element_type == GGUFValueType.STRING:
-        # String arrays: each part after the header is a string
+        # String arrays: `data` holds the value-part indices (skipping the field
+        # key name and length-prefix parts), exactly like the numeric path below.
+        # Iterating parts directly would wrongly include the field key name as the
+        # first element, shifting every string by one.
         result = []
-        for part in parts[:-1]:
-            # Skip non-data parts (length prefixes, type markers)
-            if part.dtype == np.uint8 and len(part) > 0:
-                try:
-                    result.append(array("B", list(part)).tobytes().decode())
-                except UnicodeDecodeError:
-                    result.append(
-                        array("B", list(part)).tobytes().decode("utf-8", errors="replace")
-                    )
+        for idx in data:
+            part = parts[idx]
+            try:
+                result.append(array("B", list(part)).tobytes().decode())
+            except UnicodeDecodeError:
+                result.append(
+                    array("B", list(part)).tobytes().decode("utf-8", errors="replace")
+                )
         return result
 
     # Numeric arrays: data indices point into the parts list

--- a/src/mobius/integrations/gguf/_tensor_mapping.py
+++ b/src/mobius/integrations/gguf/_tensor_mapping.py
@@ -71,6 +71,19 @@ _GEMMA2_EXTRAS: dict[str, str] = {
     "blk.{bid}.post_ffn_norm": ("model.layers.{bid}.post_feedforward_layernorm"),
 }
 
+# Gemma3 uses the llama.cpp Gemma tensor names (same as Gemma4's norm subset),
+# NOT the ``pre_ffn_norm``/``post_ffn_norm`` names in _GEMMA2_EXTRAS: ``ffn_norm``
+# is the pre-feedforward norm (overriding the Llama post-attention mapping),
+# ``post_ffw_norm`` is the post-feedforward norm, ``post_attention_norm`` is the
+# post-attention norm, and each attention block carries per-head Q/K norms.
+_GEMMA3_EXTRAS: dict[str, str] = {
+    "blk.{bid}.ffn_norm": ("model.layers.{bid}.pre_feedforward_layernorm"),
+    "blk.{bid}.post_attention_norm": ("model.layers.{bid}.post_attention_layernorm"),
+    "blk.{bid}.post_ffw_norm": ("model.layers.{bid}.post_feedforward_layernorm"),
+    "blk.{bid}.attn_q_norm": "model.layers.{bid}.self_attn.q_norm",
+    "blk.{bid}.attn_k_norm": "model.layers.{bid}.self_attn.k_norm",
+}
+
 # Gemma 4 extras on top of the Llama base + Gemma2 extras.
 # Gemma 4 GGUF tensor names are taken from llama.cpp constants (gguf-py/gguf/constants.py).
 #
@@ -259,6 +272,13 @@ def _build_mapping(
 
     if arch in _LLAMA_FAMILY:
         result = dict(_LLAMA_MAPPING)
+    elif arch == "gemma3":
+        # Gemma3 uses the llama.cpp Gemma tensor names (ffn_norm as the
+        # pre-feedforward norm, plus post_attention/post_ffw norms and Q/K
+        # norms), distinct from the older _GEMMA2_EXTRAS names — keep it out of
+        # the shared _GEMMA_FAMILY path.
+        result = dict(_LLAMA_MAPPING)
+        result.update(_GEMMA3_EXTRAS)
     elif arch in _GEMMA_FAMILY:
         result = dict(_LLAMA_MAPPING)
         result.update(_GEMMA2_EXTRAS)

--- a/src/mobius/integrations/gguf/_tensor_mapping_test.py
+++ b/src/mobius/integrations/gguf/_tensor_mapping_test.py
@@ -115,6 +115,40 @@ class TestMapGGUFToHFNames:
         result = map_gguf_to_hf_names("blk.0.attn_q.weight", "gemma2")
         assert result == "model.layers.0.self_attn.q_proj.weight"
 
+    # ---- Gemma 3 ----
+
+    def test_gemma3_uses_llama_cpp_norm_names(self) -> None:
+        # Gemma3 GGUF uses the llama.cpp Gemma tensor names (like Gemma4), NOT
+        # the pre_ffn_norm/post_ffn_norm names used for Gemma2.
+        assert (
+            map_gguf_to_hf_names("blk.0.ffn_norm.weight", "gemma3")
+            == "model.layers.0.pre_feedforward_layernorm.weight"
+        )
+        assert (
+            map_gguf_to_hf_names("blk.0.post_ffw_norm.weight", "gemma3")
+            == "model.layers.0.post_feedforward_layernorm.weight"
+        )
+        assert (
+            map_gguf_to_hf_names("blk.0.post_attention_norm.weight", "gemma3")
+            == "model.layers.0.post_attention_layernorm.weight"
+        )
+
+    def test_gemma3_maps_qk_norms(self) -> None:
+        assert (
+            map_gguf_to_hf_names("blk.0.attn_q_norm.weight", "gemma3")
+            == "model.layers.0.self_attn.q_norm.weight"
+        )
+        assert (
+            map_gguf_to_hf_names("blk.0.attn_k_norm.weight", "gemma3")
+            == "model.layers.0.self_attn.k_norm.weight"
+        )
+
+    def test_gemma3_inherits_llama_base(self) -> None:
+        assert (
+            map_gguf_to_hf_names("blk.2.attn_q.weight", "gemma3")
+            == "model.layers.2.self_attn.q_proj.weight"
+        )
+
     # ---- Gemma 4 ----
 
     def test_gemma4_inherits_llama_base(self) -> None:

--- a/src/mobius/integrations/gguf/_tokenizer.py
+++ b/src/mobius/integrations/gguf/_tokenizer.py
@@ -1,0 +1,79 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Extract a Hugging Face ``tokenizer.json`` from a GGUF file.
+
+A GGUF checkpoint embeds its tokenizer as ``tokenizer.ggml.*`` metadata
+(tokens, scores/merges, token types, and special-token ids). The onnx-genai
+runtime loads ``<package>/tokenizer.json`` — the ``tokenizers``-library fast
+tokenizer serialization — so a model built from a GGUF file needs that file
+materialized alongside the ONNX weights.
+
+``transformers`` (5.x) can reconstruct a fast tokenizer directly from a GGUF
+file via ``AutoTokenizer.from_pretrained(directory, gguf_file=filename)``; this
+module wraps that and serializes the fast backend to ``tokenizer.json``,
+mirroring the diffusion CLIP tokenizer helper in
+``mobius.integrations.onnx_genai.auto_export``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def write_gguf_tokenizer_json(gguf_path: str | Path, output_dir: str | Path) -> str | None:
+    """Write ``tokenizer.json`` for a GGUF-built package.
+
+    Reconstructs the fast tokenizer from the GGUF ``tokenizer.ggml.*`` metadata
+    and serializes it to ``<output_dir>/tokenizer.json``. This is best-effort:
+    it logs a warning and returns ``None`` (never raising) when ``transformers``
+    is unavailable or the GGUF's tokenizer model cannot be converted, so the
+    build is not blocked — the onnx-genai runners can be given a
+    ``tokenizer.json`` separately.
+
+    Args:
+        gguf_path: Path to the ``.gguf`` file whose embedded tokenizer to emit.
+        output_dir: Package directory to write ``tokenizer.json`` into.
+
+    Returns:
+        The written ``tokenizer.json`` path, or ``None`` if it could not be
+        emitted.
+    """
+    gguf_path = Path(gguf_path)
+    try:
+        from transformers import AutoTokenizer
+    except ImportError:
+        _LOGGER.warning(
+            "transformers is not available; skipping tokenizer.json emission. "
+            "The onnx-genai runners will need a tokenizer.json supplied separately."
+        )
+        return None
+    try:
+        tokenizer = AutoTokenizer.from_pretrained(
+            str(gguf_path.parent),
+            gguf_file=gguf_path.name,
+            use_fast=True,
+        )
+    except Exception as error:  # best-effort; never block the build
+        _LOGGER.warning(
+            "Could not reconstruct a tokenizer from the GGUF file %r: %s; "
+            "skipping tokenizer.json emission.",
+            str(gguf_path),
+            error,
+        )
+        return None
+    backend = getattr(tokenizer, "backend_tokenizer", None)
+    if backend is None:
+        _LOGGER.warning(
+            "Reconstructed a slow tokenizer from %r with no fast backend; "
+            "skipping tokenizer.json emission.",
+            str(gguf_path),
+        )
+        return None
+    path = os.path.join(str(output_dir), "tokenizer.json")
+    backend.save(path)
+    return path

--- a/src/mobius/integrations/gguf/_tokenizer.py
+++ b/src/mobius/integrations/gguf/_tokenizer.py
@@ -117,9 +117,7 @@ def _reconstruct_tokenizer_from_ggml(gguf_path: Path, output_dir: str | Path) ->
         vocab = {token: index for index, token in enumerate(tokens)}
         # llama.cpp stores BPE merges as space-joined "left right" pairs.
         merges = [
-            (parts[0], parts[1])
-            for merge in merges_raw
-            if len(parts := merge.split(" ")) == 2
+            (parts[0], parts[1]) for merge in merges_raw if len(parts := merge.split(" ")) == 2
         ]
         unknown_token = tokens[unknown_id] if unknown_id < len(tokens) else None
 

--- a/src/mobius/integrations/gguf/_tokenizer.py
+++ b/src/mobius/integrations/gguf/_tokenizer.py
@@ -90,7 +90,7 @@ def _reconstruct_tokenizer_from_ggml(gguf_path: Path, output_dir: str | Path) ->
     round-trip fails.
     """
     try:
-        from tokenizers import Tokenizer, decoders, models, pre_tokenizers, processors
+        from tokenizers import Tokenizer, decoders, pre_tokenizers, processors
         from tokenizers.models import BPE
 
         from mobius.integrations.gguf._reader import GGUFModel
@@ -119,7 +119,7 @@ def _reconstruct_tokenizer_from_ggml(gguf_path: Path, output_dir: str | Path) ->
         merges = [
             (parts[0], parts[1])
             for merge in merges_raw
-            if len((parts := merge.split(" "))) == 2
+            if len(parts := merge.split(" ")) == 2
         ]
         unknown_token = tokens[unknown_id] if unknown_id < len(tokens) else None
 
@@ -183,10 +183,6 @@ def _reconstruct_tokenizer_from_ggml(gguf_path: Path, output_dir: str | Path) ->
 
         path = os.path.join(str(output_dir), "tokenizer.json")
         tokenizer.save(path)
-        _LOGGER.info(
-            "Reconstructed tokenizer.json from GGUF metadata (%d tokens).", len(tokens)
-        )
-        return path
     except Exception as error:  # best-effort; never block the build
         _LOGGER.warning(
             "Failed to reconstruct tokenizer from GGUF metadata %r: %s; "
@@ -195,3 +191,8 @@ def _reconstruct_tokenizer_from_ggml(gguf_path: Path, output_dir: str | Path) ->
             error,
         )
         return None
+    else:
+        _LOGGER.info(
+            "Reconstructed tokenizer.json from GGUF metadata (%d tokens).", len(tokens)
+        )
+        return path

--- a/src/mobius/integrations/gguf/_tokenizer.py
+++ b/src/mobius/integrations/gguf/_tokenizer.py
@@ -58,14 +58,14 @@ def write_gguf_tokenizer_json(gguf_path: str | Path, output_dir: str | Path) -> 
             gguf_file=gguf_path.name,
             use_fast=True,
         )
-    except Exception as error:  # best-effort; never block the build
-        _LOGGER.warning(
-            "Could not reconstruct a tokenizer from the GGUF file %r: %s; "
-            "skipping tokenizer.json emission.",
+    except Exception as error:  # best-effort; transformers may not know the arch
+        _LOGGER.info(
+            "transformers could not load a tokenizer from %r (%s); "
+            "reconstructing directly from the GGUF tokenizer metadata.",
             str(gguf_path),
             error,
         )
-        return None
+        return _reconstruct_tokenizer_from_ggml(gguf_path, output_dir)
     backend = getattr(tokenizer, "backend_tokenizer", None)
     if backend is None:
         _LOGGER.warning(
@@ -77,3 +77,121 @@ def write_gguf_tokenizer_json(gguf_path: str | Path, output_dir: str | Path) -> 
     path = os.path.join(str(output_dir), "tokenizer.json")
     backend.save(path)
     return path
+
+
+def _reconstruct_tokenizer_from_ggml(gguf_path: Path, output_dir: str | Path) -> str | None:
+    """Build ``tokenizer.json`` directly from GGUF ``tokenizer.ggml.*`` metadata.
+
+    Fallback for GGUF architectures whose tokenizer ``transformers`` does not yet
+    support (e.g. ``gemma4``). Reconstructs the fast BPE tokenizer from the
+    embedded tokens + merges + special-token ids and validates it with an
+    encode→decode round-trip. Best-effort: logs a warning and returns ``None``
+    (never raising) if the required metadata or libraries are missing, or the
+    round-trip fails.
+    """
+    try:
+        from tokenizers import Tokenizer, decoders, models, pre_tokenizers, processors
+        from tokenizers.models import BPE
+
+        from mobius.integrations.gguf._reader import GGUFModel
+    except ImportError as error:
+        _LOGGER.warning("Cannot reconstruct tokenizer (missing dependency: %s).", error)
+        return None
+
+    try:
+        metadata = GGUFModel(str(gguf_path)).metadata
+        tokens = metadata.get("tokenizer.ggml.tokens")
+        merges_raw = metadata.get("tokenizer.ggml.merges")
+        if not tokens or not merges_raw:
+            _LOGGER.warning(
+                "GGUF %r has no tokenizer.ggml.tokens/merges; skipping tokenizer.json.",
+                str(gguf_path),
+            )
+            return None
+        token_types = metadata.get("tokenizer.ggml.token_type") or []
+        unknown_id = int(metadata.get("tokenizer.ggml.unknown_token_id", 0))
+        bos_id = metadata.get("tokenizer.ggml.bos_token_id")
+        add_bos = bool(metadata.get("tokenizer.ggml.add_bos_token", False))
+        add_space_prefix = bool(metadata.get("tokenizer.ggml.add_space_prefix", False))
+
+        vocab = {token: index for index, token in enumerate(tokens)}
+        # llama.cpp stores BPE merges as space-joined "left right" pairs.
+        merges = [
+            (parts[0], parts[1])
+            for merge in merges_raw
+            if len((parts := merge.split(" "))) == 2
+        ]
+        unknown_token = tokens[unknown_id] if unknown_id < len(tokens) else None
+
+        tokenizer = Tokenizer(
+            BPE(
+                vocab=vocab,
+                merges=merges,
+                unk_token=unknown_token,
+                fuse_unk=True,
+                byte_fallback=True,
+            )
+        )
+        # SentencePiece semantics: '▁' marks word boundaries; unknown bytes fall
+        # back to <0xNN> byte tokens.
+        prepend_scheme = "always" if add_space_prefix else "never"
+        tokenizer.pre_tokenizer = pre_tokenizers.Metaspace(
+            replacement="▁", prepend_scheme=prepend_scheme
+        )
+        tokenizer.decoder = decoders.Sequence(
+            [
+                decoders.Replace("▁", " "),
+                decoders.ByteFallback(),
+                decoders.Fuse(),
+                decoders.Strip(content=" ", left=1, right=0),
+            ]
+        )
+        # Preserve control / user-defined tokens (llama.cpp types 3 and 4) as
+        # atomic special tokens so they are never split.
+        from tokenizers import AddedToken
+
+        special_tokens = [
+            AddedToken(str(tokens[index]), special=True, normalized=False)
+            for index, token_type in enumerate(token_types)
+            if token_type in (3, 4) and index < len(tokens)
+        ]
+        if special_tokens:
+            tokenizer.add_special_tokens(special_tokens)
+
+        if add_bos and bos_id is not None and int(bos_id) < len(tokens):
+            bos_token = tokens[int(bos_id)]
+            tokenizer.post_processor = processors.TemplateProcessing(
+                single=f"{bos_token} $A",
+                pair=f"{bos_token} $A {bos_token} $B",
+                special_tokens=[(bos_token, int(bos_id))],
+            )
+
+        # Sanity check: encode→decode round-trip. This is a soft signal (a small
+        # or byte-incomplete vocab may not represent arbitrary text); the token
+        # ids are correct by construction from the ggml ordering, so warn rather
+        # than discard a reconstructed tokenizer.
+        for sample in ("Hello, world!", "The capital of France is Paris."):
+            decoded = tokenizer.decode(tokenizer.encode(sample).ids)
+            if decoded.strip() != sample.strip():
+                _LOGGER.warning(
+                    "Reconstructed tokenizer round-trip differs (%r -> %r); "
+                    "emitting anyway (ids follow the GGUF vocab order).",
+                    sample,
+                    decoded,
+                )
+                break
+
+        path = os.path.join(str(output_dir), "tokenizer.json")
+        tokenizer.save(path)
+        _LOGGER.info(
+            "Reconstructed tokenizer.json from GGUF metadata (%d tokens).", len(tokens)
+        )
+        return path
+    except Exception as error:  # best-effort; never block the build
+        _LOGGER.warning(
+            "Failed to reconstruct tokenizer from GGUF metadata %r: %s; "
+            "skipping tokenizer.json emission.",
+            str(gguf_path),
+            error,
+        )
+        return None

--- a/src/mobius/integrations/gguf/_tokenizer_test.py
+++ b/src/mobius/integrations/gguf/_tokenizer_test.py
@@ -103,3 +103,57 @@ class TestGgufOnnxGenaiEmission:
         )
 
         assert (out_dir / "inference_metadata.yaml").exists()
+
+
+def _write_gguf_with_bpe_tokenizer(path):
+    """Write a minimal GGUF carrying a byte-fallback BPE tokenizer."""
+    from gguf import GGUFWriter
+
+    writer = GGUFWriter(str(path), "llama")
+    writer.add_context_length(8)
+    writer.add_embedding_length(8)
+    writer.add_block_count(1)
+    writer.add_head_count(1)
+    # tokens: specials + a few pieces that compose via merges (SentencePiece '▁').
+    tokens = ["<pad>", "<eos>", "<bos>", "<unk>", "▁", "h", "i", "▁h", "▁hi"]
+    types = [3, 3, 3, 2, 1, 1, 1, 1, 1]  # 3=control, 2=unknown, 1=normal
+    merges = ["▁ h", "▁h i"]  # ▁+h -> ▁h ; ▁h+i -> ▁hi
+    writer.add_tokenizer_model("llama")
+    writer.add_token_list(tokens)
+    writer.add_token_types(types)
+    writer.add_token_merges(merges)
+    writer.add_bos_token_id(2)
+    writer.add_eos_token_id(1)
+    writer.add_unk_token_id(3)
+    writer.add_add_bos_token(True)
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_tensors_to_file()
+    writer.close()
+
+
+class TestReconstructTokenizerFromGgml:
+    """Fallback reconstruction of tokenizer.json from GGUF ggml metadata."""
+
+    def test_reconstructs_bpe_tokenizer_with_correct_ids(self, tmp_path):
+        from tokenizers import Tokenizer
+
+        from mobius.integrations.gguf._tokenizer import _reconstruct_tokenizer_from_ggml
+
+        gguf_path = tmp_path / "tok.gguf"
+        _write_gguf_with_bpe_tokenizer(gguf_path)
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        result = _reconstruct_tokenizer_from_ggml(gguf_path, out_dir)
+
+        assert result == str(out_dir / "tokenizer.json")
+        tok = Tokenizer.from_file(result)
+        assert tok.get_vocab_size() == 9
+        # Token ids match the ggml ordering (no off-by-one from the reader).
+        assert tok.token_to_id("<bos>") == 2
+        assert tok.token_to_id("<eos>") == 1
+        # add_bos_token=True prepends <bos>; '▁hi' composes via the two merges.
+        enc = tok.encode("hi")
+        assert enc.ids[0] == 2  # <bos>
+        assert tok.decode(enc.ids) == "hi"

--- a/src/mobius/integrations/gguf/_tokenizer_test.py
+++ b/src/mobius/integrations/gguf/_tokenizer_test.py
@@ -1,0 +1,105 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for GGUF → onnx-genai runtime config emission (tokenizer + metadata)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+import pytest
+
+
+def _write_tokenizerless_gguf(path: Path) -> None:
+    """Write a minimal weights-only llama GGUF with no tokenizer metadata."""
+    from gguf import GGUFWriter
+
+    writer = GGUFWriter(str(path), "llama")
+    writer.add_context_length(64)
+    writer.add_embedding_length(16)
+    writer.add_feed_forward_length(32)
+    writer.add_block_count(1)
+    writer.add_head_count(2)
+    writer.add_head_count_kv(2)
+    writer.add_layer_norm_rms_eps(1e-5)
+    writer.add_vocab_size(32)
+    writer.add_tensor("token_embd.weight", np.random.randn(32, 16).astype(np.float32))
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_tensors_to_file()
+    writer.close()
+
+
+class TestWriteGgufTokenizerJson:
+    """Tests for ``write_gguf_tokenizer_json`` (best-effort tokenizer emission)."""
+
+    def test_skips_gracefully_without_tokenizer_metadata(self, tmp_path: Path):
+        """A GGUF with no ggml tokenizer metadata yields no tokenizer.json, no raise."""
+        from mobius.integrations.gguf import write_gguf_tokenizer_json
+
+        gguf_path = tmp_path / "tokenizerless.gguf"
+        _write_tokenizerless_gguf(gguf_path)
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        result = write_gguf_tokenizer_json(gguf_path, out_dir)
+
+        assert result is None
+        assert not (out_dir / "tokenizer.json").exists()
+
+    def test_serializes_reconstructed_fast_tokenizer(self, tmp_path: Path):
+        """When transformers reconstructs a fast tokenizer, its backend is saved."""
+        from mobius.integrations.gguf import _tokenizer
+
+        gguf_path = tmp_path / "model.gguf"
+        gguf_path.write_bytes(b"GGUF")
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        saved_to: dict[str, str] = {}
+
+        class _FakeBackend:
+            def save(self, path: str) -> None:
+                saved_to["path"] = path
+                Path(path).write_text("{}")
+
+        fake_tokenizer = mock.Mock()
+        fake_tokenizer.backend_tokenizer = _FakeBackend()
+
+        fake_transformers = mock.Mock()
+        fake_transformers.AutoTokenizer.from_pretrained.return_value = fake_tokenizer
+
+        with mock.patch.dict("sys.modules", {"transformers": fake_transformers}):
+            result = _tokenizer.write_gguf_tokenizer_json(gguf_path, out_dir)
+
+        expected = os.path.join(str(out_dir), "tokenizer.json")
+        assert result == expected
+        assert saved_to["path"] == expected
+        assert (out_dir / "tokenizer.json").exists()
+        # Loaded from the GGUF file via its embedded metadata, not an HF repo.
+        _, kwargs = fake_transformers.AutoTokenizer.from_pretrained.call_args
+        assert kwargs["gguf_file"] == "model.gguf"
+
+
+class TestGgufOnnxGenaiEmission:
+    """The onnx-genai metadata is emitted for a GGUF-built decoder package."""
+
+    def test_write_onnx_genai_config_emits_inference_metadata(self, tmp_path: Path):
+        pytest.importorskip("onnx")
+        from mobius.integrations.gguf import build_from_gguf
+        from mobius.integrations.onnx_genai import write_onnx_genai_config
+
+        gguf_path = tmp_path / "model.gguf"
+        _write_tokenizerless_gguf(gguf_path)
+        pkg = build_from_gguf(gguf_path)
+        out_dir = tmp_path / "onnx"
+        out_dir.mkdir()
+
+        write_onnx_genai_config(
+            pkg, str(out_dir), config=getattr(pkg, "config", None), source=None
+        )
+
+        assert (out_dir / "inference_metadata.yaml").exists()

--- a/src/mobius/integrations/onnx_genai/__init__.py
+++ b/src/mobius/integrations/onnx_genai/__init__.py
@@ -50,6 +50,7 @@ from mobius.integrations.onnx_genai.inference_metadata import (
     load_diffusers_scheduler_config,
     write_diffusion_pipeline_metadata,
     write_multimodal_pipeline_metadata,
+    write_speech_to_text_pipeline_metadata,
 )
 
 __all__ = [
@@ -71,5 +72,6 @@ __all__ = [
     "write_decoder_metadata",
     "write_diffusion_pipeline_metadata",
     "write_multimodal_pipeline_metadata",
+    "write_speech_to_text_pipeline_metadata",
     "write_onnx_genai_config",
 ]

--- a/src/mobius/integrations/onnx_genai/__init__.py
+++ b/src/mobius/integrations/onnx_genai/__init__.py
@@ -44,10 +44,12 @@ from mobius.integrations.onnx_genai.decoder_metadata import (
 )
 from mobius.integrations.onnx_genai.inference_metadata import (
     SchedulerConfig,
+    build_audio_codec_pipeline_metadata,
     build_diffusion_pipeline_metadata,
     build_language_diffusion_pipeline_metadata,
     build_multimodal_pipeline_metadata,
     load_diffusers_scheduler_config,
+    write_audio_codec_pipeline_metadata,
     write_diffusion_pipeline_metadata,
     write_multimodal_pipeline_metadata,
     write_speech_to_text_pipeline_metadata,
@@ -60,6 +62,7 @@ __all__ = [
     "build_decoder_metadata",
     "build_diffusion_pipeline_metadata",
     "build_language_diffusion_pipeline_metadata",
+    "build_audio_codec_pipeline_metadata",
     "build_multimodal_pipeline_metadata",
     "build_pipeline_metadata_for_workflow",
     "convert_comfyui_workflow",
@@ -71,6 +74,7 @@ __all__ = [
     "translate_comfyui_workflow_file",
     "write_decoder_metadata",
     "write_diffusion_pipeline_metadata",
+    "write_audio_codec_pipeline_metadata",
     "write_multimodal_pipeline_metadata",
     "write_speech_to_text_pipeline_metadata",
     "write_onnx_genai_config",

--- a/src/mobius/integrations/onnx_genai/__init__.py
+++ b/src/mobius/integrations/onnx_genai/__init__.py
@@ -13,12 +13,17 @@ model families Mobius builds:
   ``model.attention`` + ``kv_cache`` sections for an autoregressive LLM.
 * **Multimodal pipelines** — :func:`write_multimodal_pipeline_metadata` emits a
   composite encoder/fusion/autoregressive-decoder pipeline.
+* **Speech-to-text (ASR)** — :func:`write_speech_to_text_pipeline_metadata` emits
+  a Whisper-style cross-attention encode→decode pipeline.
+* **Audio codec / multi-decoder TTS** — :func:`write_audio_codec_pipeline_metadata`
+  and :func:`write_tts_pipeline_metadata` emit audio-to-audio and
+  ``pre_embedder``-driven ``nested_autoregressive`` (Qwen3-TTS) pipelines.
 * **Diffusion pipelines** — :func:`write_diffusion_pipeline_metadata` emits an
   iterative pipeline for a denoiser plus optional VAE / text encoder.
 
 :func:`write_onnx_genai_config` is the unified entry point: it inspects the
-built package and dispatches to the decoder or diffusion writer, so
-``mobius build --runtime onnx-genai`` works for LLMs and diffusion models alike.
+built package and dispatches to the matching writer, so
+``mobius build --runtime onnx-genai`` works across every model family above.
 
 The core model/task/component layers remain runtime-agnostic; all onnx-genai
 specific code lives here.
@@ -48,11 +53,14 @@ from mobius.integrations.onnx_genai.inference_metadata import (
     build_diffusion_pipeline_metadata,
     build_language_diffusion_pipeline_metadata,
     build_multimodal_pipeline_metadata,
+    build_speech_to_text_pipeline_metadata,
+    build_tts_pipeline_metadata,
     load_diffusers_scheduler_config,
     write_audio_codec_pipeline_metadata,
     write_diffusion_pipeline_metadata,
     write_multimodal_pipeline_metadata,
     write_speech_to_text_pipeline_metadata,
+    write_tts_pipeline_metadata,
 )
 
 __all__ = [
@@ -65,6 +73,8 @@ __all__ = [
     "build_audio_codec_pipeline_metadata",
     "build_multimodal_pipeline_metadata",
     "build_pipeline_metadata_for_workflow",
+    "build_speech_to_text_pipeline_metadata",
+    "build_tts_pipeline_metadata",
     "convert_comfyui_workflow",
     "decoder_metadata_from_config",
     "load_diffusers_scheduler_config",
@@ -77,5 +87,6 @@ __all__ = [
     "write_audio_codec_pipeline_metadata",
     "write_multimodal_pipeline_metadata",
     "write_speech_to_text_pipeline_metadata",
+    "write_tts_pipeline_metadata",
     "write_onnx_genai_config",
 ]

--- a/src/mobius/integrations/onnx_genai/__init__.py
+++ b/src/mobius/integrations/onnx_genai/__init__.py
@@ -11,9 +11,10 @@ model families Mobius builds:
 * **Decoder-only language models** — :func:`write_decoder_metadata` /
   :func:`decoder_metadata_from_config` (in ``decoder_metadata``) emit the
   ``model.attention`` + ``kv_cache`` sections for an autoregressive LLM.
-* **Diffusion pipelines** — :func:`write_diffusion_pipeline_metadata` and the
-  builders in ``inference_metadata`` emit the iterative ``pipeline`` section for
-  a multi-model package (denoiser + optional VAE / text encoder).
+* **Multimodal pipelines** — :func:`write_multimodal_pipeline_metadata` emits a
+  composite encoder/fusion/autoregressive-decoder pipeline.
+* **Diffusion pipelines** — :func:`write_diffusion_pipeline_metadata` emits an
+  iterative pipeline for a denoiser plus optional VAE / text encoder.
 
 :func:`write_onnx_genai_config` is the unified entry point: it inspects the
 built package and dispatches to the decoder or diffusion writer, so
@@ -45,8 +46,10 @@ from mobius.integrations.onnx_genai.inference_metadata import (
     SchedulerConfig,
     build_diffusion_pipeline_metadata,
     build_language_diffusion_pipeline_metadata,
+    build_multimodal_pipeline_metadata,
     load_diffusers_scheduler_config,
     write_diffusion_pipeline_metadata,
+    write_multimodal_pipeline_metadata,
 )
 
 __all__ = [
@@ -56,6 +59,7 @@ __all__ = [
     "build_decoder_metadata",
     "build_diffusion_pipeline_metadata",
     "build_language_diffusion_pipeline_metadata",
+    "build_multimodal_pipeline_metadata",
     "build_pipeline_metadata_for_workflow",
     "convert_comfyui_workflow",
     "decoder_metadata_from_config",
@@ -66,5 +70,6 @@ __all__ = [
     "translate_comfyui_workflow_file",
     "write_decoder_metadata",
     "write_diffusion_pipeline_metadata",
+    "write_multimodal_pipeline_metadata",
     "write_onnx_genai_config",
 ]

--- a/src/mobius/integrations/onnx_genai/auto_export.py
+++ b/src/mobius/integrations/onnx_genai/auto_export.py
@@ -165,6 +165,22 @@ def _audio_codec_codes_dtype(pkg: Any) -> str:
     return "int64"
 
 
+def _looks_like_multi_decoder_tts(pkg: Any) -> bool:
+    """Detect a nested multi-decoder TTS package (e.g. Qwen3-TTS).
+
+    The defining signal is a ``talker`` plus a ``code_predictor`` decoder — a
+    dual, nested autoregressive shape (the code_predictor expands each talker
+    frame's residual codebooks). This shape is designed but not yet executable by
+    the onnx-genai composite runtime (see DESIGN.md §20.3), so it is detected
+    only to raise a precise, actionable error rather than mis-emitting.
+    """
+    try:
+        names = set(pkg.keys())
+    except AttributeError:
+        return False
+    return {"talker", "code_predictor"} <= names
+
+
 def _multimodal_component_kwargs(pkg: Any) -> dict[str, str]:
     """Derive multimodal component filenames from a package's component keys."""
     try:
@@ -322,11 +338,21 @@ def write_onnx_genai_config(
         )
         return {"inference_metadata": path}
 
+    # A nested multi-decoder TTS stack (talker + code_predictor) is a designed
+    # but not-yet-executable shape — give a precise, actionable error rather than
+    # the generic multi-component message below.
+    if _looks_like_multi_decoder_tts(pkg):
+        raise NotImplementedError(
+            "Multi-decoder TTS packages (talker + code_predictor, e.g. Qwen3-TTS) "
+            "need the nested_autoregressive strategy, which is designed but not yet "
+            "implemented in the onnx-genai runtime or this emitter — see "
+            "onnx-genai docs/DESIGN.md §20.3 'Multi-decoder TTS'."
+        )
+
     # Fallback: a single-component decoder language model. A multi-component
-    # package that matched none of the composite shapes above (e.g. a
-    # multi-decoder TTS stack: talker + code_predictor + vocoder) would be
-    # silently mis-emitted as a bare decoder — fail loudly instead so an
-    # unsupported shape is obvious rather than producing wrong metadata.
+    # package that matched none of the composite shapes above would be silently
+    # mis-emitted as a bare decoder — fail loudly instead so an unsupported shape
+    # is obvious rather than producing wrong metadata.
     try:
         component_names = sorted(pkg.keys())
     except (AttributeError, TypeError):

--- a/src/mobius/integrations/onnx_genai/auto_export.py
+++ b/src/mobius/integrations/onnx_genai/auto_export.py
@@ -27,6 +27,7 @@ from mobius.integrations.onnx_genai.inference_metadata import (
     write_diffusion_pipeline_metadata,
     write_multimodal_pipeline_metadata,
     write_speech_to_text_pipeline_metadata,
+    write_tts_pipeline_metadata,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -233,6 +234,41 @@ def _looks_like_multi_decoder_tts(pkg: Any) -> bool:
     return {"talker", "code_predictor"} <= names
 
 
+def _has_tts_pre_embedder(pkg: Any) -> bool:
+    """True when a multi-decoder TTS package carries the pre-embedder component.
+
+    The ``talker_step_embedder`` materializes the talker's per-step
+    ``inputs_embeds`` (``frame_codes [+ text_embed] -> inputs_embeds``); its
+    presence is what makes the package emittable to the ``pre_embedder``-driven
+    ``nested_autoregressive`` contract.
+    """
+    try:
+        names = set(pkg.keys())
+    except AttributeError:
+        return False
+    return "talker_step_embedder" in names
+
+
+def _tts_component_kwargs(pkg: Any, config: Any) -> dict[str, Any]:
+    """Derive pre-embedder-driven TTS metadata kwargs from a package + config.
+
+    Mobius saves each component into ``<component>/model.onnx``. ``num_code_groups``
+    comes from the TTS config (the RVQ residual count per frame).
+    """
+    tts = getattr(config, "tts", None)
+    num_code_groups = getattr(tts, "num_code_groups", None) if tts is not None else None
+    if not num_code_groups:
+        raise ValueError(
+            "TTS metadata requires config.tts.num_code_groups (RVQ codes per frame)"
+        )
+    return {
+        "num_code_groups": num_code_groups,
+        "talker_filename": "talker/model.onnx",
+        "code_predictor_filename": "code_predictor/model.onnx",
+        "pre_embedder_filename": "talker_step_embedder/model.onnx",
+    }
+
+
 def _multimodal_component_kwargs(pkg: Any) -> dict[str, str]:
     """Derive multimodal component filenames from a package's component keys."""
     try:
@@ -399,16 +435,32 @@ def write_onnx_genai_config(
         return artifacts
 
     # A nested multi-decoder TTS stack (talker + code_predictor) uses the
-    # nested_autoregressive strategy, which the onnx-genai runtime now supports;
-    # this emitter does not yet map the Qwen3-TTS component graph, so fail with a
-    # precise, actionable error rather than the generic multi-component message.
+    # nested_autoregressive strategy. When the package also carries the
+    # `talker_step_embedder` pre-embedder (the real Qwen3-TTS shape), emit the
+    # pre-embedder-driven contract the onnx-genai runtime executes; otherwise the
+    # component graph is not yet mappable, so fail with a precise, actionable error.
     if _looks_like_multi_decoder_tts(pkg):
-        raise NotImplementedError(
-            "Multi-decoder TTS packages (talker + code_predictor, e.g. Qwen3-TTS) "
-            "use the nested_autoregressive strategy. The onnx-genai runtime supports "
-            "it, but this emitter does not yet map the multi-decoder TTS component "
-            "graph to it — see onnx-genai docs/DESIGN.md §20.3 'Multi-decoder TTS'."
+        if not _has_tts_pre_embedder(pkg):
+            raise NotImplementedError(
+                "Multi-decoder TTS packages (talker + code_predictor, e.g. Qwen3-TTS) "
+                "use the nested_autoregressive strategy. This package lacks the "
+                "`talker_step_embedder` pre-embedder that materializes the talker "
+                "inputs_embeds, so it cannot yet be mapped to the runtime contract — "
+                "see onnx-genai docs/DESIGN.md §20.3 'Multi-decoder TTS'."
+            )
+        decoder_metadata = decoder_metadata_from_config(
+            resolved_config, kv_native_dtype=kv_native_dtype
         )
+        path = write_tts_pipeline_metadata(
+            output_dir,
+            decoder_metadata=decoder_metadata,
+            **_tts_component_kwargs(pkg, resolved_config),
+        )
+        artifacts = {"inference_metadata": path}
+        tokenizer_path = _write_hf_tokenizer(output_dir, source)
+        if tokenizer_path is not None:
+            artifacts["tokenizer"] = tokenizer_path
+        return artifacts
 
     # Fallback: a single-component decoder language model. A multi-component
     # package that matched none of the composite shapes above would be silently

--- a/src/mobius/integrations/onnx_genai/auto_export.py
+++ b/src/mobius/integrations/onnx_genai/auto_export.py
@@ -23,6 +23,7 @@ from mobius.integrations.onnx_genai.decoder_metadata import (
 from mobius.integrations.onnx_genai.inference_metadata import (
     SchedulerConfig,
     load_diffusers_scheduler_config,
+    write_audio_codec_pipeline_metadata,
     write_diffusion_pipeline_metadata,
     write_multimodal_pipeline_metadata,
     write_speech_to_text_pipeline_metadata,
@@ -126,6 +127,44 @@ def _looks_like_speech_to_text(pkg: Any) -> bool:
     return "encoder_hidden_states" in decoder_inputs
 
 
+def _looks_like_audio_codec(pkg: Any) -> bool:
+    """Detect an audio-to-audio neural codec package.
+
+    The signal is structural: an ``encoder`` that outputs ``codes`` feeding a
+    ``decoder`` that consumes ``codes`` via a pure single-pass path (no
+    ``encoder_hidden_states`` cross-attention, no autoregressive text decode).
+    This separates a codec from Whisper-style ASR and from an image VAE (which
+    exchanges ``latent``/``sample`` rather than ``codes``).
+    """
+    try:
+        names = set(pkg.keys())
+    except AttributeError:
+        return False
+    if not {"encoder", "decoder"} <= names:
+        return False
+    try:
+        encoder_outputs = {value.name for value in pkg["encoder"].graph.outputs}
+        decoder_inputs = {value.name for value in pkg["decoder"].graph.inputs}
+    except AttributeError:
+        return False
+    return (
+        "codes" in encoder_outputs
+        and "codes" in decoder_inputs
+        and "encoder_hidden_states" not in decoder_inputs
+    )
+
+
+def _audio_codec_codes_dtype(pkg: Any) -> str:
+    """Return the metadata dtype of the codec ``codes`` tensor (default int64)."""
+    try:
+        for value in pkg["decoder"].graph.inputs:
+            if value.name == "codes" and value.dtype is not None:
+                return "fp32" if "FLOAT" in value.dtype.name else "int64"
+    except (AttributeError, KeyError):
+        pass
+    return "int64"
+
+
 def _multimodal_component_kwargs(pkg: Any) -> dict[str, str]:
     """Derive multimodal component filenames from a package's component keys."""
     try:
@@ -222,6 +261,14 @@ def write_onnx_genai_config(
             if tokenizer_path is not None:
                 artifacts["tokenizer"] = tokenizer_path
         return artifacts
+
+    if _looks_like_audio_codec(pkg):
+        # A neural codec produces tensors (waveform), not tokens, so it needs no
+        # decoder config — emit before the config requirement below.
+        path = write_audio_codec_pipeline_metadata(
+            output_dir, codes_dtype=_audio_codec_codes_dtype(pkg)
+        )
+        return {"inference_metadata": path}
 
     resolved_config = config if config is not None else getattr(pkg, "config", None)
     if resolved_config is None:

--- a/src/mobius/integrations/onnx_genai/auto_export.py
+++ b/src/mobius/integrations/onnx_genai/auto_export.py
@@ -398,15 +398,16 @@ def write_onnx_genai_config(
             artifacts["tokenizer"] = tokenizer_path
         return artifacts
 
-    # A nested multi-decoder TTS stack (talker + code_predictor) is a designed
-    # but not-yet-executable shape — give a precise, actionable error rather than
-    # the generic multi-component message below.
+    # A nested multi-decoder TTS stack (talker + code_predictor) uses the
+    # nested_autoregressive strategy, which the onnx-genai runtime now supports;
+    # this emitter does not yet map the Qwen3-TTS component graph, so fail with a
+    # precise, actionable error rather than the generic multi-component message.
     if _looks_like_multi_decoder_tts(pkg):
         raise NotImplementedError(
             "Multi-decoder TTS packages (talker + code_predictor, e.g. Qwen3-TTS) "
-            "need the nested_autoregressive strategy, which is designed but not yet "
-            "implemented in the onnx-genai runtime or this emitter — see "
-            "onnx-genai docs/DESIGN.md §20.3 'Multi-decoder TTS'."
+            "use the nested_autoregressive strategy. The onnx-genai runtime supports "
+            "it, but this emitter does not yet map the multi-decoder TTS component "
+            "graph to it — see onnx-genai docs/DESIGN.md §20.3 'Multi-decoder TTS'."
         )
 
     # Fallback: a single-component decoder language model. A multi-component

--- a/src/mobius/integrations/onnx_genai/auto_export.py
+++ b/src/mobius/integrations/onnx_genai/auto_export.py
@@ -281,9 +281,7 @@ def _tts_component_kwargs(pkg: Any, config: Any) -> dict[str, Any]:
     except (AttributeError, TypeError):
         names = set()
     kwargs["prefill_embedder_filename"] = (
-        "talker_prefill_embedder/model.onnx"
-        if "talker_prefill_embedder" in names
-        else None
+        "talker_prefill_embedder/model.onnx" if "talker_prefill_embedder" in names else None
     )
     return kwargs
 

--- a/src/mobius/integrations/onnx_genai/auto_export.py
+++ b/src/mobius/integrations/onnx_genai/auto_export.py
@@ -209,12 +209,16 @@ def _looks_like_audio_codec(pkg: Any) -> bool:
 
 def _audio_codec_codes_dtype(pkg: Any) -> str:
     """Return the metadata dtype of the codec ``codes`` tensor (default int64)."""
+    # ONNX elem-type names -> onnx-genai metadata dtype tags. Float codes keep
+    # their precision (fp16/bf16/fp32) so the runtime binds the right buffer type.
+    float_dtypes = {"FLOAT": "fp32", "FLOAT16": "fp16", "BFLOAT16": "bf16"}
     try:
         for value in pkg["decoder"].graph.inputs:
             if value.name == "codes" and value.dtype is not None:
-                return "fp32" if "FLOAT" in value.dtype.name else "int64"
+                return float_dtypes.get(value.dtype.name, "int64")
     except (AttributeError, KeyError):
-        pass
+        # Missing/partial codec structure: fall back to the documented default.
+        return "int64"
     return "int64"
 
 
@@ -223,9 +227,12 @@ def _looks_like_multi_decoder_tts(pkg: Any) -> bool:
 
     The defining signal is a ``talker`` plus a ``code_predictor`` decoder — a
     dual, nested autoregressive shape (the code_predictor expands each talker
-    frame's residual codebooks). This shape is designed but not yet executable by
-    the onnx-genai composite runtime (see DESIGN.md §20.3), so it is detected
-    only to raise a precise, actionable error rather than mis-emitting.
+    frame's residual codebooks). When the package also carries the
+    ``talker_step_embedder`` pre-embedder (see :func:`_has_tts_pre_embedder`),
+    the dispatcher emits a runnable ``pre_embedder``-driven
+    ``nested_autoregressive`` contract; without it the component graph is not yet
+    mappable, so detection triggers a precise, actionable error rather than
+    mis-emitting (see DESIGN.md §20.3).
     """
     try:
         names = set(pkg.keys())

--- a/src/mobius/integrations/onnx_genai/auto_export.py
+++ b/src/mobius/integrations/onnx_genai/auto_export.py
@@ -268,12 +268,24 @@ def _tts_component_kwargs(pkg: Any, config: Any) -> dict[str, Any]:
         raise ValueError(
             "TTS metadata requires config.tts.num_code_groups (RVQ codes per frame)"
         )
-    return {
+    kwargs: dict[str, Any] = {
         "num_code_groups": num_code_groups,
         "talker_filename": "talker/model.onnx",
         "code_predictor_filename": "code_predictor/model.onnx",
         "pre_embedder_filename": "talker_step_embedder/model.onnx",
     }
+    # Emit the prefill/trailing-text component only when the package carries it;
+    # otherwise the prefill-less shape (talker frame 0 + zero text_embed) is used.
+    try:
+        names = set(pkg.keys())
+    except (AttributeError, TypeError):
+        names = set()
+    kwargs["prefill_embedder_filename"] = (
+        "talker_prefill_embedder/model.onnx"
+        if "talker_prefill_embedder" in names
+        else None
+    )
+    return kwargs
 
 
 def _multimodal_component_kwargs(pkg: Any) -> dict[str, str]:

--- a/src/mobius/integrations/onnx_genai/auto_export.py
+++ b/src/mobius/integrations/onnx_genai/auto_export.py
@@ -87,6 +87,58 @@ def _write_clip_tokenizer(output_dir: str, source: str | None) -> str | None:
     return path
 
 
+def _write_hf_tokenizer(output_dir: str, source: str | None) -> str | None:
+    """Emit ``tokenizer.json`` for a text-producing package from its HF source.
+
+    Decoder-LM, multimodal (VLM / speech-language ASR), and Whisper-style ASR
+    packages all reference ``<package>/tokenizer.json`` in their emitted metadata
+    so the onnx-genai runtime can tokenize prompts from the package alone. This
+    reconstructs that file from the source model's fast tokenizer, mirroring the
+    diffusion CLIP tokenizer helper. Best-effort: it logs a warning and returns
+    ``None`` (never raising) when ``transformers`` is unavailable, no ``source``
+    is known, or the source has no fast tokenizer, so the build is not blocked.
+
+    Args:
+        output_dir: Package directory to write ``tokenizer.json`` into.
+        source: The Hugging Face model id or local directory carrying the
+            tokenizer.
+
+    Returns:
+        The written ``tokenizer.json`` path, or ``None`` if it could not be
+        emitted.
+    """
+    if not source:
+        return None
+    try:
+        from transformers import AutoTokenizer
+    except ImportError:
+        _LOGGER.warning(
+            "transformers is not available; skipping tokenizer.json emission. "
+            "The onnx-genai runners will need a tokenizer.json supplied separately."
+        )
+        return None
+    try:
+        tokenizer = AutoTokenizer.from_pretrained(source, use_fast=True)
+    except Exception as error:  # best-effort; never block the build
+        _LOGGER.warning(
+            "Could not load a tokenizer from %r: %s; skipping tokenizer.json emission.",
+            source,
+            error,
+        )
+        return None
+    backend = getattr(tokenizer, "backend_tokenizer", None)
+    if backend is None:
+        _LOGGER.warning(
+            "Loaded a slow tokenizer for %r with no fast backend; skipping "
+            "tokenizer.json emission.",
+            source,
+        )
+        return None
+    path = os.path.join(output_dir, "tokenizer.json")
+    backend.save(path)
+    return path
+
+
 def _looks_like_diffusion(pkg: Any) -> bool:
     try:
         names = set(pkg.keys())
@@ -325,7 +377,11 @@ def write_onnx_genai_config(
             decoder_metadata=decoder_metadata,
             **kwargs,
         )
-        return {"inference_metadata": path}
+        artifacts = {"inference_metadata": path}
+        tokenizer_path = _write_hf_tokenizer(output_dir, source)
+        if tokenizer_path is not None:
+            artifacts["tokenizer"] = tokenizer_path
+        return artifacts
 
     if _looks_like_speech_to_text(pkg):
         decoder_metadata = decoder_metadata_from_config(
@@ -336,7 +392,11 @@ def write_onnx_genai_config(
             decoder_metadata=decoder_metadata,
             **kwargs,
         )
-        return {"inference_metadata": path}
+        artifacts = {"inference_metadata": path}
+        tokenizer_path = _write_hf_tokenizer(output_dir, source)
+        if tokenizer_path is not None:
+            artifacts["tokenizer"] = tokenizer_path
+        return artifacts
 
     # A nested multi-decoder TTS stack (talker + code_predictor) is a designed
     # but not-yet-executable shape — give a precise, actionable error rather than
@@ -368,4 +428,8 @@ def write_onnx_genai_config(
     path = write_decoder_metadata(
         output_dir, config=resolved_config, kv_native_dtype=kv_native_dtype
     )
-    return {"inference_metadata": path}
+    artifacts = {"inference_metadata": path}
+    tokenizer_path = _write_hf_tokenizer(output_dir, source)
+    if tokenizer_path is not None:
+        artifacts["tokenizer"] = tokenizer_path
+    return artifacts

--- a/src/mobius/integrations/onnx_genai/auto_export.py
+++ b/src/mobius/integrations/onnx_genai/auto_export.py
@@ -25,6 +25,7 @@ from mobius.integrations.onnx_genai.inference_metadata import (
     load_diffusers_scheduler_config,
     write_diffusion_pipeline_metadata,
     write_multimodal_pipeline_metadata,
+    write_speech_to_text_pipeline_metadata,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -101,6 +102,28 @@ def _looks_like_multimodal(pkg: Any) -> bool:
     except AttributeError:
         return False
     return "decoder" in names and bool(names & {"vision_encoder", "audio_encoder"})
+
+
+def _looks_like_speech_to_text(pkg: Any) -> bool:
+    """Detect a cross-attention encoder-decoder ASR package (e.g. Whisper).
+
+    The signal is structural rather than name-based: an ``encoder`` and a
+    ``decoder`` component where the decoder consumes ``encoder_hidden_states``
+    (cross-attention). This separates Whisper-style ASR from a codec, whose
+    ``encoder``/``decoder`` are pure single-pass and share no such input.
+    """
+    try:
+        names = set(pkg.keys())
+    except AttributeError:
+        return False
+    if not {"encoder", "decoder"} <= names:
+        return False
+    decoder = pkg["decoder"]
+    try:
+        decoder_inputs = {value.name for value in decoder.graph.inputs}
+    except AttributeError:
+        return False
+    return "encoder_hidden_states" in decoder_inputs
 
 
 def _multimodal_component_kwargs(pkg: Any) -> dict[str, str]:
@@ -214,6 +237,17 @@ def write_onnx_genai_config(
             resolved_config, kv_native_dtype=kv_native_dtype
         )
         path = write_multimodal_pipeline_metadata(
+            output_dir,
+            decoder_metadata=decoder_metadata,
+            **kwargs,
+        )
+        return {"inference_metadata": path}
+
+    if _looks_like_speech_to_text(pkg):
+        decoder_metadata = decoder_metadata_from_config(
+            resolved_config, kv_native_dtype=kv_native_dtype
+        )
+        path = write_speech_to_text_pipeline_metadata(
             output_dir,
             decoder_metadata=decoder_metadata,
             **kwargs,

--- a/src/mobius/integrations/onnx_genai/auto_export.py
+++ b/src/mobius/integrations/onnx_genai/auto_export.py
@@ -228,6 +228,27 @@ def write_onnx_genai_config(
 ) -> dict[str, str]:
     """Write ``inference_metadata.yaml`` into ``output_dir`` and return its path.
 
+    This is the single entry point that inspects a built ``ModelPackage`` and
+    emits the onnx-genai runtime contract for it. Package shapes are matched in
+    order of decreasing specificity; the first match wins:
+
+    ===================== ============================================ =================================
+    Pipeline shape        Structural signal (detector)                 Emitted ``strategy``
+    ===================== ============================================ =================================
+    Diffusion             denoiser / VAE present                       ``iterative``
+    Audio codec           encoder→``codes``→decoder, no cross-attn     ``composite`` (two single_pass)
+    Multimodal VLM        decoder + vision/audio encoder + fusion      ``composite`` (encoders→fuse→AR)
+    Speech-to-text (ASR)  decoder consumes ``encoder_hidden_states``   ``composite`` (encode→AR)
+    Decoder LM            fallback (a config is required)              bare decoder (``kv_cache`` + attn)
+    ===================== ============================================ =================================
+
+    Detection is **structural** (graph input/output names + component roles),
+    not name-based, so a codec is never mistaken for ASR and vice versa. To add a
+    modality, add a ``_looks_like_X`` structural detector plus a
+    ``build_X_pipeline_metadata`` builder and insert a dispatch branch ordered by
+    specificity. Tensor-only pipelines (diffusion, codec) are matched before the
+    ``config`` requirement because they carry no autoregressive decoder.
+
     For decoder and multimodal packages, ``config`` (or ``pkg.config``) supplies
     the decoder attention dimensions. Diffusion component filenames are taken
     from ``kwargs`` or discovered from the package; ``num_inference_steps`` /
@@ -300,6 +321,23 @@ def write_onnx_genai_config(
             **kwargs,
         )
         return {"inference_metadata": path}
+
+    # Fallback: a single-component decoder language model. A multi-component
+    # package that matched none of the composite shapes above (e.g. a
+    # multi-decoder TTS stack: talker + code_predictor + vocoder) would be
+    # silently mis-emitted as a bare decoder — fail loudly instead so an
+    # unsupported shape is obvious rather than producing wrong metadata.
+    try:
+        component_names = sorted(pkg.keys())
+    except (AttributeError, TypeError):
+        component_names = []
+    if len(component_names) > 1:
+        raise ValueError(
+            "onnx-genai config emission does not recognize this multi-component "
+            f"package shape (components: {component_names}). Supported composite "
+            "shapes: diffusion, audio codec, multimodal VLM, speech-to-text. "
+            "Multi-decoder pipelines such as TTS require a dedicated emitter."
+        )
 
     path = write_decoder_metadata(
         output_dir, config=resolved_config, kv_native_dtype=kv_native_dtype

--- a/src/mobius/integrations/onnx_genai/auto_export.py
+++ b/src/mobius/integrations/onnx_genai/auto_export.py
@@ -155,7 +155,14 @@ def _looks_like_multimodal(pkg: Any) -> bool:
         names = set(pkg.keys())
     except AttributeError:
         return False
-    return "decoder" in names and bool(names & {"vision_encoder", "audio_encoder"})
+    # Require the `embedding` fusion component: the multimodal metadata wires
+    # encoder(s) -> embedding -> decoder, so without it we would emit metadata
+    # referencing a non-existent embedding model.
+    return (
+        "decoder" in names
+        and "embedding" in names
+        and bool(names & {"vision_encoder", "audio_encoder"})
+    )
 
 
 def _looks_like_speech_to_text(pkg: Any) -> bool:
@@ -283,7 +290,20 @@ def _tts_component_kwargs(pkg: Any, config: Any) -> dict[str, Any]:
     kwargs["prefill_embedder_filename"] = (
         "talker_prefill_embedder/model.onnx" if "talker_prefill_embedder" in names else None
     )
+    kwargs["activation_dtype"] = _activation_dtype_tag(config)
     return kwargs
+
+
+def _activation_dtype_tag(config: Any) -> str:
+    """Map a model config's activation dtype to the metadata dtype tag.
+
+    The composite dataflow edges (inputs_embeds, encoder_hidden_states, …) carry
+    the model's activation dtype, so metadata must reflect it (fp16/bf16 builds
+    would otherwise be mislabeled fp32).
+    """
+    dtype = getattr(config, "dtype", None)
+    name = getattr(dtype, "name", "") or ""
+    return {"FLOAT16": "fp16", "BFLOAT16": "bf16"}.get(name.upper(), "fp32")
 
 
 def _multimodal_component_kwargs(pkg: Any) -> dict[str, str]:
@@ -428,6 +448,7 @@ def write_onnx_genai_config(
         path = write_multimodal_pipeline_metadata(
             output_dir,
             decoder_metadata=decoder_metadata,
+            activation_dtype=_activation_dtype_tag(resolved_config),
             **kwargs,
         )
         artifacts = {"inference_metadata": path}
@@ -443,6 +464,7 @@ def write_onnx_genai_config(
         path = write_speech_to_text_pipeline_metadata(
             output_dir,
             decoder_metadata=decoder_metadata,
+            activation_dtype=_activation_dtype_tag(resolved_config),
             **kwargs,
         )
         artifacts = {"inference_metadata": path}

--- a/src/mobius/integrations/onnx_genai/auto_export.py
+++ b/src/mobius/integrations/onnx_genai/auto_export.py
@@ -4,9 +4,10 @@
 """Write onnx-genai ``inference_metadata.yaml`` for a built Mobius package.
 
 Dispatches on the package/config: a decoder-only LLM emits the
-``model.attention`` + ``kv_cache`` document; a diffusion package (denoiser +
-optional VAE / text encoder) emits the iterative ``pipeline`` document. This is
-the onnx-genai analogue of :func:`mobius.integrations.ort_genai.write_ort_genai_config`.
+``model.attention`` + ``kv_cache`` document; a multimodal package emits a
+composite encoder/fusion/decoder pipeline; and a diffusion package emits an
+iterative pipeline. This is the onnx-genai analogue of
+:func:`mobius.integrations.ort_genai.write_ort_genai_config`.
 """
 
 from __future__ import annotations
@@ -15,11 +16,15 @@ import logging
 import os
 from typing import Any
 
-from mobius.integrations.onnx_genai.decoder_metadata import write_decoder_metadata
+from mobius.integrations.onnx_genai.decoder_metadata import (
+    decoder_metadata_from_config,
+    write_decoder_metadata,
+)
 from mobius.integrations.onnx_genai.inference_metadata import (
     SchedulerConfig,
     load_diffusers_scheduler_config,
     write_diffusion_pipeline_metadata,
+    write_multimodal_pipeline_metadata,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -90,6 +95,32 @@ def _looks_like_diffusion(pkg: Any) -> bool:
     )
 
 
+def _looks_like_multimodal(pkg: Any) -> bool:
+    try:
+        names = set(pkg.keys())
+    except AttributeError:
+        return False
+    return "decoder" in names and bool(names & {"vision_encoder", "audio_encoder"})
+
+
+def _multimodal_component_kwargs(pkg: Any) -> dict[str, str]:
+    """Derive multimodal component filenames from a package's component keys."""
+    try:
+        names = set(pkg.keys())
+    except AttributeError:
+        return {}
+
+    derived = {
+        "decoder_filename": "decoder/model.onnx",
+        "embedding_filename": "embedding/model.onnx",
+    }
+    if "vision_encoder" in names:
+        derived["vision_encoder_filename"] = "vision_encoder/model.onnx"
+    if "audio_encoder" in names:
+        derived["audio_encoder_filename"] = "audio_encoder/model.onnx"
+    return derived
+
+
 def _diffusion_component_kwargs(pkg: Any) -> dict[str, Any]:
     """Derive diffusion-pipeline metadata filenames from a package's component keys.
 
@@ -135,13 +166,10 @@ def write_onnx_genai_config(
 ) -> dict[str, str]:
     """Write ``inference_metadata.yaml`` into ``output_dir`` and return its path.
 
-    For a decoder LLM, ``config`` (or ``pkg.config``) supplies the attention
-    dimensions. For a diffusion package, the denoiser/VAE/text-encoder filenames
-    are taken from ``kwargs`` (see :func:`build_diffusion_pipeline_metadata`) or
-    defaulted; ``num_inference_steps`` / ``scheduler`` / ``guidance_scale`` set
-    the loop. When ``scheduler`` is not given and ``source`` (the diffusers
-    checkpoint dir or HF id) is provided, the scheduler is auto-read from the
-    checkpoint's ``scheduler/scheduler_config.json`` (falling back to DDIM).
+    For decoder and multimodal packages, ``config`` (or ``pkg.config``) supplies
+    the decoder attention dimensions. Diffusion component filenames are taken
+    from ``kwargs`` or discovered from the package; ``num_inference_steps`` /
+    ``scheduler`` / ``guidance_scale`` set the loop.
     """
     os.makedirs(output_dir, exist_ok=True)
     if _looks_like_diffusion(pkg):
@@ -178,6 +206,20 @@ def write_onnx_genai_config(
             "onnx-genai decoder metadata requires a model config (pass config=... "
             "or a package carrying `.config`)"
         )
+    if _looks_like_multimodal(pkg):
+        derived = _multimodal_component_kwargs(pkg)
+        for name, value in derived.items():
+            kwargs.setdefault(name, value)
+        decoder_metadata = decoder_metadata_from_config(
+            resolved_config, kv_native_dtype=kv_native_dtype
+        )
+        path = write_multimodal_pipeline_metadata(
+            output_dir,
+            decoder_metadata=decoder_metadata,
+            **kwargs,
+        )
+        return {"inference_metadata": path}
+
     path = write_decoder_metadata(
         output_dir, config=resolved_config, kv_native_dtype=kv_native_dtype
     )

--- a/src/mobius/integrations/onnx_genai/auto_export_test.py
+++ b/src/mobius/integrations/onnx_genai/auto_export_test.py
@@ -169,6 +169,55 @@ def test_dispatch_vision_multimodal_pipeline(tmp_path):
     assert pipeline["strategy"]["kind"] == "composite"
 
 
+def test_dispatch_audio_only_multimodal_pipeline(tmp_path):
+    # The audio-only fusion shape used by speech-language ASR models such as
+    # qwen3_asr and fun_asr: audio_encoder -> embedding fusion -> AR decoder.
+    pkg = _MultimodalPkg(
+        {
+            "decoder": object(),
+            "audio_encoder": object(),
+            "embedding": object(),
+        }
+    )
+    artifacts = write_onnx_genai_config(pkg, str(tmp_path))
+
+    with open(artifacts["inference_metadata"]) as handle:
+        metadata = yaml.safe_load(handle)
+
+    pipeline = metadata["pipeline"]
+    assert pipeline["models"] == {
+        "audio_encoder": {
+            "filename": "audio_encoder/model.onnx",
+            "type": "audio_encoder",
+        },
+        "embedding": {"filename": "embedding/model.onnx", "type": "encoder"},
+        "decoder": {
+            "filename": "decoder/model.onnx",
+            "type": "decoder",
+            "tokenizer": "tokenizer.json",
+        },
+    }
+    assert pipeline["dataflow"] == [
+        {
+            "from": "audio_encoder.audio_features",
+            "to": "embedding.audio_features",
+            "dtype": "fp32",
+            "device_transfer": False,
+        },
+        {
+            "from": "embedding.inputs_embeds",
+            "to": "decoder.inputs_embeds",
+            "dtype": "fp32",
+            "device_transfer": False,
+        },
+    ]
+    assert [stage["name"] for stage in pipeline["strategy"]["stages"]] == [
+        "encode_audio",
+        "fuse_embeddings",
+        "decode",
+    ]
+
+
 def test_dispatch_vision_and_audio_multimodal_pipeline(tmp_path):
     pkg = _MultimodalPkg(
         {

--- a/src/mobius/integrations/onnx_genai/auto_export_test.py
+++ b/src/mobius/integrations/onnx_genai/auto_export_test.py
@@ -390,12 +390,16 @@ class _TTSPkg(dict):
 
 def test_dispatch_multi_decoder_tts_with_pre_embedder(tmp_path):
     # The real Qwen3-TTS shape: talker + code_predictor + talker_step_embedder
-    # emits the pre_embedder-driven nested_autoregressive contract.
+    # (+ talker_prefill_embedder) emits the pre_embedder/prefill-driven
+    # nested_autoregressive contract.
     pkg = _TTSPkg(
         {
             "talker": _FakeModel(["inputs_embeds"], ["logits", "last_hidden_state"]),
             "code_predictor": _FakeModel(["inputs_embeds"], ["logits"]),
             "talker_step_embedder": _FakeModel(["frame_codes"], ["inputs_embeds"]),
+            "talker_prefill_embedder": _FakeModel(
+                ["text_ids"], ["prefill_embeds", "trailing_text_embeds"]
+            ),
             "embedding": _FakeModel(["text_ids"]),
         }
     )
@@ -405,11 +409,18 @@ def test_dispatch_multi_decoder_tts_with_pre_embedder(tmp_path):
         metadata = yaml.safe_load(handle)
 
     pipeline = metadata["pipeline"]
-    assert set(pipeline["models"]) == {"talker", "talker_step_embedder", "code_predictor"}
+    assert set(pipeline["models"]) == {
+        "talker",
+        "talker_step_embedder",
+        "code_predictor",
+        "talker_prefill_embedder",
+    }
     stage = pipeline["strategy"]["stages"][0]["strategy"]
     assert stage["kind"] == "nested_autoregressive"
     assert stage["pre_embedder"] == "talker_step_embedder"
+    assert stage["prefill_embedder"] == "talker_prefill_embedder"
     assert stage["num_code_groups"] == 16
+    assert pipeline["phases"]["talker_prefill_embedder"]["run_on"] == "prompt_only"
     assert {
         "from": "talker_step_embedder.inputs_embeds",
         "to": "talker.inputs_embeds",

--- a/src/mobius/integrations/onnx_genai/auto_export_test.py
+++ b/src/mobius/integrations/onnx_genai/auto_export_test.py
@@ -27,6 +27,10 @@ class _DiffusionPkg(dict):
     pass
 
 
+class _MultimodalPkg(dict):
+    config = _Cfg()
+
+
 def test_dispatch_decoder(tmp_path):
     arts = write_onnx_genai_config(
         object(), str(tmp_path), config=_Cfg(), kv_native_dtype="bf16"
@@ -125,3 +129,83 @@ def test_dispatch_diffusion_auto_reads_scheduler_from_source(tmp_path):
     with open(arts["inference_metadata"]) as handle:
         meta = yaml.safe_load(handle)
     assert meta["pipeline"]["strategy"]["scheduler_config"]["kind"] == "euler"
+
+
+def test_dispatch_vision_multimodal_pipeline(tmp_path):
+    pkg = _MultimodalPkg(
+        {
+            "decoder": object(),
+            "vision_encoder": object(),
+            "embedding": object(),
+        }
+    )
+    artifacts = write_onnx_genai_config(pkg, str(tmp_path), kv_native_dtype="bf16")
+
+    with open(artifacts["inference_metadata"]) as handle:
+        metadata = yaml.safe_load(handle)
+
+    assert metadata["required_capabilities"] == [
+        "kv_cache",
+        "grouped_query_attention",
+    ]
+    assert metadata["kv_cache"] == {"native_dtype": "bf16"}
+    pipeline = metadata["pipeline"]
+    assert pipeline["models"] == {
+        "vision_encoder": {
+            "filename": "vision_encoder/model.onnx",
+            "type": "vision_encoder",
+        },
+        "embedding": {
+            "filename": "embedding/model.onnx",
+            "type": "encoder",
+        },
+        "decoder": {
+            "filename": "decoder/model.onnx",
+            "type": "decoder",
+            "tokenizer": "tokenizer.json",
+        },
+    }
+    assert pipeline["strategy"]["kind"] == "composite"
+
+
+def test_dispatch_vision_and_audio_multimodal_pipeline(tmp_path):
+    pkg = _MultimodalPkg(
+        {
+            "decoder": object(),
+            "vision_encoder": object(),
+            "audio_encoder": object(),
+            "embedding": object(),
+        }
+    )
+    artifacts = write_onnx_genai_config(pkg, str(tmp_path))
+
+    with open(artifacts["inference_metadata"]) as handle:
+        metadata = yaml.safe_load(handle)
+
+    pipeline = metadata["pipeline"]
+    assert pipeline["dataflow"] == [
+        {
+            "from": "vision_encoder.image_features",
+            "to": "embedding.image_features",
+            "dtype": "fp32",
+            "device_transfer": False,
+        },
+        {
+            "from": "audio_encoder.audio_features",
+            "to": "embedding.audio_features",
+            "dtype": "fp32",
+            "device_transfer": False,
+        },
+        {
+            "from": "embedding.inputs_embeds",
+            "to": "decoder.inputs_embeds",
+            "dtype": "fp32",
+            "device_transfer": False,
+        },
+    ]
+    assert [stage["name"] for stage in pipeline["strategy"]["stages"]] == [
+        "encode_vision",
+        "encode_audio",
+        "fuse_embeddings",
+        "decode",
+    ]

--- a/src/mobius/integrations/onnx_genai/auto_export_test.py
+++ b/src/mobius/integrations/onnx_genai/auto_export_test.py
@@ -385,3 +385,37 @@ def test_unrecognized_multi_component_package_fails_loudly(tmp_path):
     )
     with pytest.raises(ValueError, match="multi-component"):
         write_onnx_genai_config(pkg, str(tmp_path))
+
+
+def test_decoder_emits_tokenizer_from_source(tmp_path):
+    # A text-producing package emits tokenizer.json from its HF source so the
+    # onnx-genai package is self-contained.
+    from unittest import mock
+
+    saved = {}
+
+    class _FakeBackend:
+        def save(self, path):
+            saved["path"] = path
+            with open(path, "w") as handle:
+                handle.write("{}")
+
+    fake_tok = mock.Mock()
+    fake_tok.backend_tokenizer = _FakeBackend()
+    fake_tf = mock.Mock()
+    fake_tf.AutoTokenizer.from_pretrained.return_value = fake_tok
+
+    with mock.patch.dict("sys.modules", {"transformers": fake_tf}):
+        artifacts = write_onnx_genai_config(
+            object(), str(tmp_path), config=_Cfg(), source="some/model-id"
+        )
+
+    assert artifacts.get("tokenizer") == str(tmp_path / "tokenizer.json")
+    assert (tmp_path / "tokenizer.json").exists()
+    fake_tf.AutoTokenizer.from_pretrained.assert_called_once()
+
+
+def test_decoder_without_source_skips_tokenizer(tmp_path):
+    artifacts = write_onnx_genai_config(object(), str(tmp_path), config=_Cfg())
+    assert "tokenizer" not in artifacts
+    assert not (tmp_path / "tokenizer.json").exists()

--- a/src/mobius/integrations/onnx_genai/auto_export_test.py
+++ b/src/mobius/integrations/onnx_genai/auto_export_test.py
@@ -417,8 +417,8 @@ def test_dispatch_multi_decoder_tts_with_pre_embedder(tmp_path):
     }
     stage = pipeline["strategy"]["stages"][0]["strategy"]
     assert stage["kind"] == "nested_autoregressive"
-    assert stage["pre_embedder"] == "talker_step_embedder"
-    assert stage["prefill_embedder"] == "talker_prefill_embedder"
+    assert stage["pre_embedder"]["component"] == "talker_step_embedder"
+    assert stage["prefill_embedder"]["component"] == "talker_prefill_embedder"
     assert stage["num_code_groups"] == 16
     assert pipeline["phases"]["talker_prefill_embedder"]["run_on"] == "prompt_only"
     assert {

--- a/src/mobius/integrations/onnx_genai/auto_export_test.py
+++ b/src/mobius/integrations/onnx_genai/auto_export_test.py
@@ -311,14 +311,27 @@ def test_dispatch_audio_codec_pipeline(tmp_path):
     ]
 
 
-def test_unrecognized_multi_component_package_fails_loudly(tmp_path):
-    # A multi-decoder TTS-like stack matches no composite shape and must NOT be
-    # silently emitted as a bare decoder.
+def test_multi_decoder_tts_raises_precise_not_implemented(tmp_path):
+    # A nested multi-decoder TTS stack (talker + code_predictor) is a designed
+    # but unimplemented shape and must fail with a precise, actionable error.
     pkg = _EncoderDecoderPkg(
         {
             "talker": _FakeModel(["inputs_embeds"]),
             "code_predictor": _FakeModel(["inputs_embeds"]),
-            "vocoder": _FakeModel(["codes"]),
+            "embedding": _FakeModel(["text_ids"]),
+        }
+    )
+    with pytest.raises(NotImplementedError, match="nested_autoregressive"):
+        write_onnx_genai_config(pkg, str(tmp_path))
+
+
+def test_unrecognized_multi_component_package_fails_loudly(tmp_path):
+    # A multi-component package matching no known shape must not be silently
+    # emitted as a bare decoder.
+    pkg = _EncoderDecoderPkg(
+        {
+            "widget": _FakeModel(["x"]),
+            "gadget": _FakeModel(["y"]),
         }
     )
     with pytest.raises(ValueError, match="multi-component"):

--- a/src/mobius/integrations/onnx_genai/auto_export_test.py
+++ b/src/mobius/integrations/onnx_genai/auto_export_test.py
@@ -212,20 +212,22 @@ def test_dispatch_vision_and_audio_multimodal_pipeline(tmp_path):
 
 
 class _FakeValue:
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, dtype: object | None = None) -> None:
         self.name = name
+        self.dtype = dtype
 
 
 class _FakeGraph:
-    def __init__(self, input_names: list[str]) -> None:
+    def __init__(self, input_names: list[str], output_names: list[str] | None = None) -> None:
         self.inputs = [_FakeValue(name) for name in input_names]
+        self.outputs = [_FakeValue(name) for name in (output_names or [])]
 
 
 class _FakeModel:
-    """Minimal stand-in for an ir.Model exposing graph input names."""
+    """Minimal stand-in for an ir.Model exposing graph input/output names."""
 
-    def __init__(self, input_names: list[str]) -> None:
-        self.graph = _FakeGraph(input_names)
+    def __init__(self, input_names: list[str], output_names: list[str] | None = None) -> None:
+        self.graph = _FakeGraph(input_names, output_names)
 
 
 class _EncoderDecoderPkg(dict):
@@ -236,7 +238,7 @@ def test_dispatch_speech_to_text_pipeline(tmp_path):
     # Whisper-style ASR: the decoder consumes encoder_hidden_states (cross-attn).
     pkg = _EncoderDecoderPkg(
         {
-            "encoder": _FakeModel(["input_features"]),
+            "encoder": _FakeModel(["input_features"], ["encoder_hidden_states"]),
             "decoder": _FakeModel(["decoder_input_ids", "encoder_hidden_states"]),
         }
     )
@@ -272,13 +274,13 @@ def test_dispatch_speech_to_text_pipeline(tmp_path):
     ]
 
 
-def test_codec_not_treated_as_speech_to_text(tmp_path):
-    # A codec has encoder+decoder but no encoder_hidden_states cross-attention,
-    # so it must NOT be emitted as a Whisper-style ASR pipeline.
+def test_dispatch_audio_codec_pipeline(tmp_path):
+    # A neural codec: encoder outputs codes consumed by a single-pass decoder,
+    # with no cross-attention. It is a pure tensor pipeline (no decoder config).
     pkg = _EncoderDecoderPkg(
         {
-            "encoder": _FakeModel(["waveform"]),
-            "decoder": _FakeModel(["codes"]),
+            "encoder": _FakeModel(["waveform"], ["codes"]),
+            "decoder": _FakeModel(["codes"], ["waveform"]),
         }
     )
     artifacts = write_onnx_genai_config(pkg, str(tmp_path))
@@ -286,4 +288,23 @@ def test_codec_not_treated_as_speech_to_text(tmp_path):
     with open(artifacts["inference_metadata"]) as handle:
         metadata = yaml.safe_load(handle)
 
-    assert "pipeline" not in metadata
+    # No decoder capabilities (produces tensors, not tokens).
+    assert "model" not in metadata
+    pipeline = metadata["pipeline"]
+    assert pipeline["models"] == {
+        "encoder": {"filename": "encoder.onnx", "type": "audio_encoder"},
+        "decoder": {"filename": "decoder.onnx", "type": "vocoder"},
+    }
+    assert pipeline["dataflow"] == [
+        {
+            "from": "encoder.codes",
+            "to": "decoder.codes",
+            "dtype": "int64",
+            "device_transfer": False,
+        }
+    ]
+    stages = pipeline["strategy"]["stages"]
+    assert [stage["strategy"]["kind"] for stage in stages] == [
+        "single_pass",
+        "single_pass",
+    ]

--- a/src/mobius/integrations/onnx_genai/auto_export_test.py
+++ b/src/mobius/integrations/onnx_genai/auto_export_test.py
@@ -360,9 +360,9 @@ def test_dispatch_audio_codec_pipeline(tmp_path):
     ]
 
 
-def test_multi_decoder_tts_raises_precise_not_implemented(tmp_path):
-    # A nested multi-decoder TTS stack (talker + code_predictor) is a designed
-    # but unimplemented shape and must fail with a precise, actionable error.
+def test_multi_decoder_tts_without_pre_embedder_raises_precise_not_implemented(tmp_path):
+    # A nested multi-decoder TTS stack lacking the talker_step_embedder
+    # pre-embedder cannot yet be mapped and must fail with a precise error.
     pkg = _EncoderDecoderPkg(
         {
             "talker": _FakeModel(["inputs_embeds"]),
@@ -372,6 +372,50 @@ def test_multi_decoder_tts_raises_precise_not_implemented(tmp_path):
     )
     with pytest.raises(NotImplementedError, match="nested_autoregressive"):
         write_onnx_genai_config(pkg, str(tmp_path))
+
+
+@dataclasses.dataclass
+class _TTSSubCfg:
+    num_code_groups: int = 16
+
+
+@dataclasses.dataclass
+class _TTSCfg(_Cfg):
+    tts: _TTSSubCfg = dataclasses.field(default_factory=_TTSSubCfg)
+
+
+class _TTSPkg(dict):
+    config = _TTSCfg()
+
+
+def test_dispatch_multi_decoder_tts_with_pre_embedder(tmp_path):
+    # The real Qwen3-TTS shape: talker + code_predictor + talker_step_embedder
+    # emits the pre_embedder-driven nested_autoregressive contract.
+    pkg = _TTSPkg(
+        {
+            "talker": _FakeModel(["inputs_embeds"], ["logits", "last_hidden_state"]),
+            "code_predictor": _FakeModel(["inputs_embeds"], ["logits"]),
+            "talker_step_embedder": _FakeModel(["frame_codes"], ["inputs_embeds"]),
+            "embedding": _FakeModel(["text_ids"]),
+        }
+    )
+    artifacts = write_onnx_genai_config(pkg, str(tmp_path))
+
+    with open(artifacts["inference_metadata"]) as handle:
+        metadata = yaml.safe_load(handle)
+
+    pipeline = metadata["pipeline"]
+    assert set(pipeline["models"]) == {"talker", "talker_step_embedder", "code_predictor"}
+    stage = pipeline["strategy"]["stages"][0]["strategy"]
+    assert stage["kind"] == "nested_autoregressive"
+    assert stage["pre_embedder"] == "talker_step_embedder"
+    assert stage["num_code_groups"] == 16
+    assert {
+        "from": "talker_step_embedder.inputs_embeds",
+        "to": "talker.inputs_embeds",
+        "dtype": "fp32",
+        "device_transfer": False,
+    } in pipeline["dataflow"]
 
 
 def test_unrecognized_multi_component_package_fails_loudly(tmp_path):

--- a/src/mobius/integrations/onnx_genai/auto_export_test.py
+++ b/src/mobius/integrations/onnx_genai/auto_export_test.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import dataclasses
 
+import pytest
 import yaml
 
 from mobius.integrations.onnx_genai import write_onnx_genai_config
@@ -308,3 +309,17 @@ def test_dispatch_audio_codec_pipeline(tmp_path):
         "single_pass",
         "single_pass",
     ]
+
+
+def test_unrecognized_multi_component_package_fails_loudly(tmp_path):
+    # A multi-decoder TTS-like stack matches no composite shape and must NOT be
+    # silently emitted as a bare decoder.
+    pkg = _EncoderDecoderPkg(
+        {
+            "talker": _FakeModel(["inputs_embeds"]),
+            "code_predictor": _FakeModel(["inputs_embeds"]),
+            "vocoder": _FakeModel(["codes"]),
+        }
+    )
+    with pytest.raises(ValueError, match="multi-component"):
+        write_onnx_genai_config(pkg, str(tmp_path))

--- a/src/mobius/integrations/onnx_genai/auto_export_test.py
+++ b/src/mobius/integrations/onnx_genai/auto_export_test.py
@@ -251,9 +251,9 @@ def test_dispatch_speech_to_text_pipeline(tmp_path):
     assert metadata["kv_cache"] == {"native_dtype": "bf16"}
     pipeline = metadata["pipeline"]
     assert pipeline["models"] == {
-        "encoder": {"filename": "encoder.onnx", "type": "encoder"},
+        "encoder": {"filename": "encoder/model.onnx", "type": "encoder"},
         "decoder": {
-            "filename": "decoder.onnx",
+            "filename": "decoder/model.onnx",
             "type": "decoder",
             "tokenizer": "tokenizer.json",
         },
@@ -293,8 +293,8 @@ def test_dispatch_audio_codec_pipeline(tmp_path):
     assert "model" not in metadata
     pipeline = metadata["pipeline"]
     assert pipeline["models"] == {
-        "encoder": {"filename": "encoder.onnx", "type": "audio_encoder"},
-        "decoder": {"filename": "decoder.onnx", "type": "vocoder"},
+        "encoder": {"filename": "encoder/model.onnx", "type": "audio_encoder"},
+        "decoder": {"filename": "decoder/model.onnx", "type": "vocoder"},
     }
     assert pipeline["dataflow"] == [
         {

--- a/src/mobius/integrations/onnx_genai/auto_export_test.py
+++ b/src/mobius/integrations/onnx_genai/auto_export_test.py
@@ -209,3 +209,81 @@ def test_dispatch_vision_and_audio_multimodal_pipeline(tmp_path):
         "fuse_embeddings",
         "decode",
     ]
+
+
+class _FakeValue:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeGraph:
+    def __init__(self, input_names: list[str]) -> None:
+        self.inputs = [_FakeValue(name) for name in input_names]
+
+
+class _FakeModel:
+    """Minimal stand-in for an ir.Model exposing graph input names."""
+
+    def __init__(self, input_names: list[str]) -> None:
+        self.graph = _FakeGraph(input_names)
+
+
+class _EncoderDecoderPkg(dict):
+    config = _Cfg()
+
+
+def test_dispatch_speech_to_text_pipeline(tmp_path):
+    # Whisper-style ASR: the decoder consumes encoder_hidden_states (cross-attn).
+    pkg = _EncoderDecoderPkg(
+        {
+            "encoder": _FakeModel(["input_features"]),
+            "decoder": _FakeModel(["decoder_input_ids", "encoder_hidden_states"]),
+        }
+    )
+    artifacts = write_onnx_genai_config(pkg, str(tmp_path), kv_native_dtype="bf16")
+
+    with open(artifacts["inference_metadata"]) as handle:
+        metadata = yaml.safe_load(handle)
+
+    assert metadata["kv_cache"] == {"native_dtype": "bf16"}
+    pipeline = metadata["pipeline"]
+    assert pipeline["models"] == {
+        "encoder": {"filename": "encoder.onnx", "type": "encoder"},
+        "decoder": {
+            "filename": "decoder.onnx",
+            "type": "decoder",
+            "tokenizer": "tokenizer.json",
+        },
+    }
+    assert pipeline["dataflow"] == [
+        {
+            "from": "encoder.encoder_hidden_states",
+            "to": "decoder.encoder_hidden_states",
+            "dtype": "fp32",
+            "device_transfer": False,
+        }
+    ]
+    stages = pipeline["strategy"]["stages"]
+    assert pipeline["strategy"]["kind"] == "composite"
+    assert [stage["name"] for stage in stages] == ["encode_audio", "decode_transcript"]
+    assert [stage["strategy"]["kind"] for stage in stages] == [
+        "single_pass",
+        "autoregressive",
+    ]
+
+
+def test_codec_not_treated_as_speech_to_text(tmp_path):
+    # A codec has encoder+decoder but no encoder_hidden_states cross-attention,
+    # so it must NOT be emitted as a Whisper-style ASR pipeline.
+    pkg = _EncoderDecoderPkg(
+        {
+            "encoder": _FakeModel(["waveform"]),
+            "decoder": _FakeModel(["codes"]),
+        }
+    )
+    artifacts = write_onnx_genai_config(pkg, str(tmp_path))
+
+    with open(artifacts["inference_metadata"]) as handle:
+        metadata = yaml.safe_load(handle)
+
+    assert "pipeline" not in metadata

--- a/src/mobius/integrations/onnx_genai/inference_metadata.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata.py
@@ -482,6 +482,89 @@ def write_multimodal_pipeline_metadata(
     return path
 
 
+def build_speech_to_text_pipeline_metadata(
+    *,
+    encoder_filename: str = "encoder.onnx",
+    decoder_filename: str = "decoder.onnx",
+    tokenizer_filename: str = "tokenizer.json",
+    decoder_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build metadata for a cross-attention encoder-decoder ASR pipeline.
+
+    This is the Whisper-style speech-to-text shape (DESIGN.md §20): the audio
+    encoder runs once for the prompt and produces ``encoder_hidden_states``,
+    which the autoregressive decoder consumes via cross-attention (distinct from
+    the multimodal ``inputs_embeds`` fusion shape). The decoder then runs for
+    every generation step.
+
+    Args:
+        encoder_filename: Audio encoder ONNX filename relative to the package
+            root.
+        decoder_filename: Decoder ONNX filename relative to the package root.
+        tokenizer_filename: Tokenizer filename used by the decoder.
+        decoder_metadata: Optional output from
+            :func:`decoder_metadata_from_config`; its decoder capabilities are
+            retained at the document top level.
+
+    Returns:
+        A dict with a top-level ``pipeline`` key and any decoder capabilities.
+    """
+    metadata = dict(decoder_metadata or {})
+    metadata["pipeline"] = {
+        "models": {
+            "encoder": {"filename": encoder_filename, "type": "encoder"},
+            "decoder": {
+                "filename": decoder_filename,
+                "type": "decoder",
+                "tokenizer": tokenizer_filename,
+            },
+        },
+        "dataflow": [
+            {
+                "from": "encoder.encoder_hidden_states",
+                "to": "decoder.encoder_hidden_states",
+                "dtype": "fp32",
+                "device_transfer": False,
+            }
+        ],
+        "strategy": {
+            "kind": "composite",
+            "stages": [
+                {
+                    "name": "encode_audio",
+                    "strategy": {"kind": "single_pass", "model": "encoder"},
+                    "run_on": "prompt_only",
+                },
+                {
+                    "name": "decode_transcript",
+                    "strategy": {"kind": "autoregressive", "decoder": "decoder"},
+                    "run_on": "every_step",
+                },
+            ],
+        },
+        "phases": {
+            "encoder": {"run_on": "prompt_only"},
+            "decoder": {"run_on": "every_step"},
+        },
+    }
+    return metadata
+
+
+def write_speech_to_text_pipeline_metadata(
+    directory: str,
+    *,
+    filename: str = "inference_metadata.yaml",
+    **kwargs: Any,
+) -> str:
+    """Build and write composite speech-to-text metadata into ``directory``."""
+    metadata = build_speech_to_text_pipeline_metadata(**kwargs)
+    os.makedirs(directory, exist_ok=True)
+    path = os.path.join(directory, filename)
+    with open(path, "w", encoding="utf-8") as handle:
+        yaml.safe_dump(metadata, handle, sort_keys=False)
+    return path
+
+
 def write_diffusion_pipeline_metadata(
     directory: str,
     *,

--- a/src/mobius/integrations/onnx_genai/inference_metadata.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Emit onnx-genai ``inference_metadata`` for diffusion pipelines.
+"""Emit onnx-genai ``inference_metadata`` for multi-model pipelines.
 
 Mobius builds the neural components of a diffusion model (denoiser transformer,
 VAE, and — externally — a text encoder) as separate ONNX graphs, but does not
@@ -20,12 +20,10 @@ The emitted contract matches onnx-genai's pipeline schema:
 ``denoiser`` / ``num_steps`` / ``timestep_input`` / ``scheduler_config`` /
 ``cfg_conditioning_input`` and denoiser self-edge loop-carried dataflow).
 
-Note:
-    This module covers *diffusion* pipelines only. Autoregressive
-    decoder-only LLM metadata (``model.attention`` + ``kv_cache``) lives in the
-    sibling :mod:`mobius.integrations.onnx_genai.decoder_metadata` module;
-    :func:`mobius.integrations.onnx_genai.write_onnx_genai_config` dispatches to
-    whichever applies for a built package.
+Autoregressive decoder-only LLM metadata (``model.attention`` + ``kv_cache``)
+lives in the sibling :mod:`mobius.integrations.onnx_genai.decoder_metadata`
+module. Composite multimodal pipelines retain those decoder properties while
+declaring their encoder, fusion, and decoder execution stages here.
 """
 
 from __future__ import annotations
@@ -348,6 +346,140 @@ def build_diffusion_pipeline_metadata(
     if phases:
         pipeline["phases"] = phases
     return {"pipeline": pipeline}
+
+
+def build_multimodal_pipeline_metadata(
+    *,
+    decoder_filename: str = "decoder.onnx",
+    embedding_filename: str = "embedding.onnx",
+    vision_encoder_filename: str | None = None,
+    audio_encoder_filename: str | None = None,
+    tokenizer_filename: str = "tokenizer.json",
+    decoder_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build metadata for an encoder-to-fusion-to-decoder multimodal pipeline.
+
+    At least one modality encoder is required. Each encoder and the embedding
+    fusion model runs once for the prompt; the decoder then runs
+    autoregressively for every generation step.
+
+    Args:
+        decoder_filename: Decoder ONNX filename relative to the package root.
+        embedding_filename: Embedding fusion ONNX filename.
+        vision_encoder_filename: Optional vision encoder ONNX filename.
+        audio_encoder_filename: Optional audio encoder ONNX filename.
+        tokenizer_filename: Tokenizer filename used by the decoder.
+        decoder_metadata: Optional output from
+            :func:`decoder_metadata_from_config`. Its decoder capabilities are
+            retained at the document top level.
+
+    Returns:
+        A dict with a top-level ``pipeline`` key and any decoder capabilities.
+    """
+    if vision_encoder_filename is None and audio_encoder_filename is None:
+        raise ValueError("a multimodal pipeline requires a vision or audio encoder")
+
+    models: dict[str, Any] = {}
+    dataflow: list[dict[str, Any]] = []
+    stages: list[dict[str, Any]] = []
+    phases: dict[str, Any] = {}
+
+    def add_encoder(
+        name: str,
+        filename: str,
+        model_type: str,
+        output_name: str,
+        stage_name: str,
+    ) -> None:
+        models[name] = {"filename": filename, "type": model_type}
+        dataflow.append(
+            {
+                "from": f"{name}.{output_name}",
+                "to": f"embedding.{output_name}",
+                "dtype": "fp32",
+                "device_transfer": False,
+            }
+        )
+        stages.append(
+            {
+                "name": stage_name,
+                "strategy": {"kind": "single_pass", "model": name},
+                "run_on": "prompt_only",
+            }
+        )
+        phases[name] = {"run_on": "prompt_only"}
+
+    if vision_encoder_filename is not None:
+        add_encoder(
+            "vision_encoder",
+            vision_encoder_filename,
+            "vision_encoder",
+            "image_features",
+            "encode_vision",
+        )
+    if audio_encoder_filename is not None:
+        add_encoder(
+            "audio_encoder",
+            audio_encoder_filename,
+            "audio_encoder",
+            "audio_features",
+            "encode_audio",
+        )
+
+    models["embedding"] = {"filename": embedding_filename, "type": "encoder"}
+    models["decoder"] = {
+        "filename": decoder_filename,
+        "type": "decoder",
+        "tokenizer": tokenizer_filename,
+    }
+    dataflow.append(
+        {
+            "from": "embedding.inputs_embeds",
+            "to": "decoder.inputs_embeds",
+            "dtype": "fp32",
+            "device_transfer": False,
+        }
+    )
+    stages.extend(
+        [
+            {
+                "name": "fuse_embeddings",
+                "strategy": {"kind": "single_pass", "model": "embedding"},
+                "run_on": "prompt_only",
+            },
+            {
+                "name": "decode",
+                "strategy": {"kind": "autoregressive", "decoder": "decoder"},
+                "run_on": "every_step",
+            },
+        ]
+    )
+    phases["embedding"] = {"run_on": "prompt_only"}
+    phases["decoder"] = {"run_on": "every_step"}
+
+    metadata = dict(decoder_metadata or {})
+    metadata["pipeline"] = {
+        "models": models,
+        "dataflow": dataflow,
+        "strategy": {"kind": "composite", "stages": stages},
+        "phases": phases,
+    }
+    return metadata
+
+
+def write_multimodal_pipeline_metadata(
+    directory: str,
+    *,
+    filename: str = "inference_metadata.yaml",
+    **kwargs: Any,
+) -> str:
+    """Build and write composite multimodal metadata into ``directory``."""
+    metadata = build_multimodal_pipeline_metadata(**kwargs)
+    os.makedirs(directory, exist_ok=True)
+    path = os.path.join(directory, filename)
+    with open(path, "w", encoding="utf-8") as handle:
+        yaml.safe_dump(metadata, handle, sort_keys=False)
+    return path
 
 
 def write_diffusion_pipeline_metadata(

--- a/src/mobius/integrations/onnx_genai/inference_metadata.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata.py
@@ -565,6 +565,82 @@ def write_speech_to_text_pipeline_metadata(
     return path
 
 
+def build_audio_codec_pipeline_metadata(
+    *,
+    encoder_filename: str = "encoder.onnx",
+    decoder_filename: str = "decoder.onnx",
+    codes_dtype: str = "int64",
+) -> dict[str, Any]:
+    """Build metadata for an audio-to-audio neural codec pipeline.
+
+    This is the pure single-pass composite shape (DESIGN.md §20): an audio
+    encoder maps a waveform to ``codes``, and a decoder reconstructs a waveform
+    from those codes. Both stages run once over the shared tensor pool (there is
+    no autoregressive decode and no tokenizer), wired ``encoder.codes ->
+    decoder.codes``.
+
+    Args:
+        encoder_filename: Waveform-to-codes encoder ONNX filename.
+        decoder_filename: Codes-to-waveform decoder ONNX filename.
+        codes_dtype: Metadata dtype of the ``codes`` tensor exchanged between the
+            two stages (neural codecs typically emit ``int64`` code indices).
+
+    Returns:
+        A dict with a top-level ``pipeline`` key. No decoder capabilities are
+        emitted because the pipeline produces tensors, not tokens.
+    """
+    return {
+        "pipeline": {
+            "models": {
+                "encoder": {"filename": encoder_filename, "type": "audio_encoder"},
+                "decoder": {"filename": decoder_filename, "type": "vocoder"},
+            },
+            "dataflow": [
+                {
+                    "from": "encoder.codes",
+                    "to": "decoder.codes",
+                    "dtype": codes_dtype,
+                    "device_transfer": False,
+                }
+            ],
+            "strategy": {
+                "kind": "composite",
+                "stages": [
+                    {
+                        "name": "encode_waveform",
+                        "strategy": {"kind": "single_pass", "model": "encoder"},
+                        "run_on": "prompt_only",
+                    },
+                    {
+                        "name": "decode_waveform",
+                        "strategy": {"kind": "single_pass", "model": "decoder"},
+                        "run_on": "prompt_only",
+                    },
+                ],
+            },
+            "phases": {
+                "encoder": {"run_on": "prompt_only"},
+                "decoder": {"run_on": "prompt_only"},
+            },
+        }
+    }
+
+
+def write_audio_codec_pipeline_metadata(
+    directory: str,
+    *,
+    filename: str = "inference_metadata.yaml",
+    **kwargs: Any,
+) -> str:
+    """Build and write composite audio-codec metadata into ``directory``."""
+    metadata = build_audio_codec_pipeline_metadata(**kwargs)
+    os.makedirs(directory, exist_ok=True)
+    path = os.path.join(directory, filename)
+    with open(path, "w", encoding="utf-8") as handle:
+        yaml.safe_dump(metadata, handle, sort_keys=False)
+    return path
+
+
 def write_diffusion_pipeline_metadata(
     directory: str,
     *,

--- a/src/mobius/integrations/onnx_genai/inference_metadata.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata.py
@@ -355,6 +355,7 @@ def build_multimodal_pipeline_metadata(
     vision_encoder_filename: str | None = None,
     audio_encoder_filename: str | None = None,
     tokenizer_filename: str = "tokenizer.json",
+    activation_dtype: str = "fp32",
     decoder_metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build metadata for an encoder-to-fusion-to-decoder multimodal pipeline.
@@ -396,7 +397,7 @@ def build_multimodal_pipeline_metadata(
             {
                 "from": f"{name}.{output_name}",
                 "to": f"embedding.{output_name}",
-                "dtype": "fp32",
+                "dtype": activation_dtype,
                 "device_transfer": False,
             }
         )
@@ -436,7 +437,7 @@ def build_multimodal_pipeline_metadata(
         {
             "from": "embedding.inputs_embeds",
             "to": "decoder.inputs_embeds",
-            "dtype": "fp32",
+            "dtype": activation_dtype,
             "device_transfer": False,
         }
     )
@@ -487,6 +488,7 @@ def build_speech_to_text_pipeline_metadata(
     encoder_filename: str = "encoder/model.onnx",
     decoder_filename: str = "decoder/model.onnx",
     tokenizer_filename: str = "tokenizer.json",
+    activation_dtype: str = "fp32",
     decoder_metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build metadata for a cross-attention encoder-decoder ASR pipeline.
@@ -523,7 +525,7 @@ def build_speech_to_text_pipeline_metadata(
             {
                 "from": "encoder.encoder_hidden_states",
                 "to": "decoder.encoder_hidden_states",
-                "dtype": "fp32",
+                "dtype": activation_dtype,
                 "device_transfer": False,
             }
         ],
@@ -650,6 +652,7 @@ def build_tts_pipeline_metadata(
     pre_embedder_filename: str = "talker_step_embedder/model.onnx",
     prefill_embedder_filename: str | None = "talker_prefill_embedder/model.onnx",
     tokenizer_filename: str = "tokenizer.json",
+    activation_dtype: str = "fp32",
     decoder_metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build metadata for a pre-embedder-driven multi-decoder TTS pipeline.
@@ -718,13 +721,13 @@ def build_tts_pipeline_metadata(
         {
             "from": "talker_step_embedder.inputs_embeds",
             "to": "talker.inputs_embeds",
-            "dtype": "fp32",
+            "dtype": activation_dtype,
             "device_transfer": False,
         },
         {
             "from": "talker.last_hidden_state",
             "to": "code_predictor.inputs_embeds",
-            "dtype": "fp32",
+            "dtype": activation_dtype,
             "device_transfer": False,
         },
     ]

--- a/src/mobius/integrations/onnx_genai/inference_metadata.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata.py
@@ -732,7 +732,11 @@ def build_tts_pipeline_metadata(
         "kind": "nested_autoregressive",
         "outer": "talker",
         "inner": "code_predictor",
-        "pre_embedder": "talker_step_embedder",
+        "pre_embedder": {
+            "component": "talker_step_embedder",
+            "frame_codes_input": "frame_codes",
+            "text_embed_input": "text_embed",
+        },
         "num_code_groups": num_code_groups,
         "max_tokens": max_frames,
     }
@@ -747,10 +751,16 @@ def build_tts_pipeline_metadata(
             "filename": prefill_embedder_filename,
             "type": "embedding",
         }
-        # Runs once in the prompt phase; the runtime auto-seeds its `text_ids`
-        # with the tokenized prompt and reads prefill_embeds/trailing_text_embeds
-        # from the pool (resolved by name — no dataflow edges needed).
-        stage_strategy["prefill_embedder"] = "talker_prefill_embedder"
+        # Runs once in the prompt phase; the runtime seeds the declared
+        # `prompt_input` with the tokenized prompt and reads the two named
+        # outputs from the pool. Every port is declared explicitly (the engine
+        # never guesses tensor names).
+        stage_strategy["prefill_embedder"] = {
+            "component": "talker_prefill_embedder",
+            "prompt_input": "text_ids",
+            "prefill_output": "prefill_embeds",
+            "trailing_output": "trailing_text_embeds",
+        }
         phases["talker_prefill_embedder"] = {"run_on": "prompt_only"}
 
     metadata = dict(decoder_metadata or {})

--- a/src/mobius/integrations/onnx_genai/inference_metadata.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata.py
@@ -648,6 +648,7 @@ def build_tts_pipeline_metadata(
     talker_filename: str = "talker/model.onnx",
     code_predictor_filename: str = "code_predictor/model.onnx",
     pre_embedder_filename: str = "talker_step_embedder/model.onnx",
+    prefill_embedder_filename: str | None = "talker_prefill_embedder/model.onnx",
     tokenizer_filename: str = "tokenizer.json",
     decoder_metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -662,14 +663,20 @@ def build_tts_pipeline_metadata(
     codes by the ``talker_step_embedder`` pre-embedder (``frame_codes
     [+ text_embed] -> inputs_embeds``), keeping the engine generic.
 
-    Only the three engine-driven components are emitted (``talker``,
-    ``code_predictor``, ``talker_step_embedder``). The package's ``embedding``
-    and optional ``speaker_encoder`` models feed the trailing-text ``text_embed``
-    and prefill-embeds path, which the runtime does not yet consume (it feeds a
-    zero ``text_embed`` — see DESIGN.md §20.3); emitting them here would declare
-    models the engine cannot place, so they are deliberately omitted until that
-    follow-up lands. There is **no in-package vocoder** — the assembled
-    ``talker.output_codes`` are decoded to a waveform by a separate codec model.
+    When ``prefill_embedder_filename`` is set (the default), a
+    ``talker_prefill_embedder`` prompt-phase component is also emitted. It maps
+    the tokenized prompt ``text_ids -> prefill_embeds + trailing_text_embeds``:
+    the runtime feeds ``prefill_embeds`` to the talker on frame 0 and threads
+    ``trailing_text_embeds[:, k-1, :]`` as the pre-embedder's ``text_embed`` on
+    frames k>=1 (see the ``prefill_embedder`` field). Pass ``None`` to emit the
+    prefill-less shape (talker frame 0 + ``text_embed`` fed zeros).
+
+    The engine-driven components are emitted (``talker``, ``code_predictor``,
+    ``talker_step_embedder``, and ``talker_prefill_embedder`` when present). The
+    package's ``embedding`` and optional ``speaker_encoder`` models are internal
+    weight sources already folded into the pre-/prefill-embedders, so they are
+    not declared as pipeline models. There is **no in-package vocoder** — the
+    assembled ``talker.output_codes`` are decoded by a separate codec model.
 
     Args:
         num_code_groups: Codes collected per outer frame (RVQ residual count).
@@ -677,6 +684,8 @@ def build_tts_pipeline_metadata(
         talker_filename: Outer decoder (talker) ONNX filename.
         code_predictor_filename: Inner decoder ONNX filename.
         pre_embedder_filename: ``talker_step_embedder`` ONNX filename.
+        prefill_embedder_filename: ``talker_prefill_embedder`` ONNX filename, or
+            ``None`` to omit the prefill/trailing-text path.
         tokenizer_filename: Tokenizer filename used by the talker.
         decoder_metadata: Optional output from
             :func:`decoder_metadata_from_config`; its decoder capabilities are
@@ -690,59 +699,75 @@ def build_tts_pipeline_metadata(
     if max_frames < 1:
         raise ValueError("max_frames must be at least 1")
 
+    models: dict[str, Any] = {
+        "talker": {
+            "filename": talker_filename,
+            "type": "decoder",
+            "tokenizer": tokenizer_filename,
+        },
+        "talker_step_embedder": {
+            "filename": pre_embedder_filename,
+            "type": "embedding",
+        },
+        "code_predictor": {
+            "filename": code_predictor_filename,
+            "type": "decoder",
+        },
+    }
+    dataflow: list[dict[str, Any]] = [
+        {
+            "from": "talker_step_embedder.inputs_embeds",
+            "to": "talker.inputs_embeds",
+            "dtype": "fp32",
+            "device_transfer": False,
+        },
+        {
+            "from": "talker.last_hidden_state",
+            "to": "code_predictor.inputs_embeds",
+            "dtype": "fp32",
+            "device_transfer": False,
+        },
+    ]
+    stage_strategy: dict[str, Any] = {
+        "kind": "nested_autoregressive",
+        "outer": "talker",
+        "inner": "code_predictor",
+        "pre_embedder": "talker_step_embedder",
+        "num_code_groups": num_code_groups,
+        "max_tokens": max_frames,
+    }
+    phases: dict[str, Any] = {
+        "talker": {"run_on": "every_step"},
+        "talker_step_embedder": {"run_on": "on_demand"},
+        "code_predictor": {"run_on": "every_step"},
+    }
+
+    if prefill_embedder_filename is not None:
+        models["talker_prefill_embedder"] = {
+            "filename": prefill_embedder_filename,
+            "type": "embedding",
+        }
+        # Runs once in the prompt phase; the runtime auto-seeds its `text_ids`
+        # with the tokenized prompt and reads prefill_embeds/trailing_text_embeds
+        # from the pool (resolved by name — no dataflow edges needed).
+        stage_strategy["prefill_embedder"] = "talker_prefill_embedder"
+        phases["talker_prefill_embedder"] = {"run_on": "prompt_only"}
+
     metadata = dict(decoder_metadata or {})
     metadata["pipeline"] = {
-        "models": {
-            "talker": {
-                "filename": talker_filename,
-                "type": "decoder",
-                "tokenizer": tokenizer_filename,
-            },
-            "talker_step_embedder": {
-                "filename": pre_embedder_filename,
-                "type": "embedding",
-            },
-            "code_predictor": {
-                "filename": code_predictor_filename,
-                "type": "decoder",
-            },
-        },
-        "dataflow": [
-            {
-                "from": "talker_step_embedder.inputs_embeds",
-                "to": "talker.inputs_embeds",
-                "dtype": "fp32",
-                "device_transfer": False,
-            },
-            {
-                "from": "talker.last_hidden_state",
-                "to": "code_predictor.inputs_embeds",
-                "dtype": "fp32",
-                "device_transfer": False,
-            },
-        ],
+        "models": models,
+        "dataflow": dataflow,
         "strategy": {
             "kind": "composite",
             "stages": [
                 {
                     "name": "generate_codes",
-                    "strategy": {
-                        "kind": "nested_autoregressive",
-                        "outer": "talker",
-                        "inner": "code_predictor",
-                        "pre_embedder": "talker_step_embedder",
-                        "num_code_groups": num_code_groups,
-                        "max_tokens": max_frames,
-                    },
+                    "strategy": stage_strategy,
                     "run_on": "every_step",
                 },
             ],
         },
-        "phases": {
-            "talker": {"run_on": "every_step"},
-            "talker_step_embedder": {"run_on": "on_demand"},
-            "code_predictor": {"run_on": "every_step"},
-        },
+        "phases": phases,
     }
     return metadata
 

--- a/src/mobius/integrations/onnx_genai/inference_metadata.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata.py
@@ -641,6 +641,127 @@ def write_audio_codec_pipeline_metadata(
     return path
 
 
+def build_tts_pipeline_metadata(
+    *,
+    num_code_groups: int,
+    max_frames: int = 2000,
+    talker_filename: str = "talker/model.onnx",
+    code_predictor_filename: str = "code_predictor/model.onnx",
+    pre_embedder_filename: str = "talker_step_embedder/model.onnx",
+    tokenizer_filename: str = "tokenizer.json",
+    decoder_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build metadata for a pre-embedder-driven multi-decoder TTS pipeline.
+
+    This is the real Qwen3-TTS shape (DESIGN.md §20.3, ``nested_autoregressive``
+    with the optional ``pre_embedder`` extension): an OUTER ``talker`` AR loop
+    where each frame drives an INNER ``code_predictor`` AR loop of
+    ``num_code_groups`` steps (seeded by the talker's ``last_hidden_state``).
+    Unlike the plain nested shape, the talker is **not** driven by ``input_ids``:
+    each frame its ``inputs_embeds`` is materialized from the previous frame's
+    codes by the ``talker_step_embedder`` pre-embedder (``frame_codes
+    [+ text_embed] -> inputs_embeds``), keeping the engine generic.
+
+    Only the three engine-driven components are emitted (``talker``,
+    ``code_predictor``, ``talker_step_embedder``). The package's ``embedding``
+    and optional ``speaker_encoder`` models feed the trailing-text ``text_embed``
+    and prefill-embeds path, which the runtime does not yet consume (it feeds a
+    zero ``text_embed`` — see DESIGN.md §20.3); emitting them here would declare
+    models the engine cannot place, so they are deliberately omitted until that
+    follow-up lands. There is **no in-package vocoder** — the assembled
+    ``talker.output_codes`` are decoded to a waveform by a separate codec model.
+
+    Args:
+        num_code_groups: Codes collected per outer frame (RVQ residual count).
+        max_frames: Maximum number of outer talker frames to generate.
+        talker_filename: Outer decoder (talker) ONNX filename.
+        code_predictor_filename: Inner decoder ONNX filename.
+        pre_embedder_filename: ``talker_step_embedder`` ONNX filename.
+        tokenizer_filename: Tokenizer filename used by the talker.
+        decoder_metadata: Optional output from
+            :func:`decoder_metadata_from_config`; its decoder capabilities are
+            retained at the document top level.
+
+    Returns:
+        A dict with a top-level ``pipeline`` key and any decoder capabilities.
+    """
+    if num_code_groups < 1:
+        raise ValueError("num_code_groups must be at least 1")
+    if max_frames < 1:
+        raise ValueError("max_frames must be at least 1")
+
+    metadata = dict(decoder_metadata or {})
+    metadata["pipeline"] = {
+        "models": {
+            "talker": {
+                "filename": talker_filename,
+                "type": "decoder",
+                "tokenizer": tokenizer_filename,
+            },
+            "talker_step_embedder": {
+                "filename": pre_embedder_filename,
+                "type": "embedding",
+            },
+            "code_predictor": {
+                "filename": code_predictor_filename,
+                "type": "decoder",
+            },
+        },
+        "dataflow": [
+            {
+                "from": "talker_step_embedder.inputs_embeds",
+                "to": "talker.inputs_embeds",
+                "dtype": "fp32",
+                "device_transfer": False,
+            },
+            {
+                "from": "talker.last_hidden_state",
+                "to": "code_predictor.inputs_embeds",
+                "dtype": "fp32",
+                "device_transfer": False,
+            },
+        ],
+        "strategy": {
+            "kind": "composite",
+            "stages": [
+                {
+                    "name": "generate_codes",
+                    "strategy": {
+                        "kind": "nested_autoregressive",
+                        "outer": "talker",
+                        "inner": "code_predictor",
+                        "pre_embedder": "talker_step_embedder",
+                        "num_code_groups": num_code_groups,
+                        "max_tokens": max_frames,
+                    },
+                    "run_on": "every_step",
+                },
+            ],
+        },
+        "phases": {
+            "talker": {"run_on": "every_step"},
+            "talker_step_embedder": {"run_on": "on_demand"},
+            "code_predictor": {"run_on": "every_step"},
+        },
+    }
+    return metadata
+
+
+def write_tts_pipeline_metadata(
+    directory: str,
+    *,
+    filename: str = "inference_metadata.yaml",
+    **kwargs: Any,
+) -> str:
+    """Build and write pre-embedder-driven TTS metadata into ``directory``."""
+    metadata = build_tts_pipeline_metadata(**kwargs)
+    os.makedirs(directory, exist_ok=True)
+    path = os.path.join(directory, filename)
+    with open(path, "w", encoding="utf-8") as handle:
+        yaml.safe_dump(metadata, handle, sort_keys=False)
+    return path
+
+
 def write_diffusion_pipeline_metadata(
     directory: str,
     *,

--- a/src/mobius/integrations/onnx_genai/inference_metadata.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata.py
@@ -484,8 +484,8 @@ def write_multimodal_pipeline_metadata(
 
 def build_speech_to_text_pipeline_metadata(
     *,
-    encoder_filename: str = "encoder.onnx",
-    decoder_filename: str = "decoder.onnx",
+    encoder_filename: str = "encoder/model.onnx",
+    decoder_filename: str = "decoder/model.onnx",
     tokenizer_filename: str = "tokenizer.json",
     decoder_metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -567,8 +567,8 @@ def write_speech_to_text_pipeline_metadata(
 
 def build_audio_codec_pipeline_metadata(
     *,
-    encoder_filename: str = "encoder.onnx",
-    decoder_filename: str = "decoder.onnx",
+    encoder_filename: str = "encoder/model.onnx",
+    decoder_filename: str = "decoder/model.onnx",
     codes_dtype: str = "int64",
 ) -> dict[str, Any]:
     """Build metadata for an audio-to-audio neural codec pipeline.

--- a/src/mobius/integrations/onnx_genai/inference_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata_test.py
@@ -418,7 +418,9 @@ class TestBuildTTSPipelineMetadata:
     """Pre-embedder-driven multi-decoder TTS (Qwen3-TTS) metadata."""
 
     def test_minimal_nested_autoregressive_with_pre_embedder(self):
-        meta = build_tts_pipeline_metadata(num_code_groups=16, max_frames=1000)
+        meta = build_tts_pipeline_metadata(
+            num_code_groups=16, max_frames=1000, prefill_embedder_filename=None
+        )
         pipe = meta["pipeline"]
         assert set(pipe["models"]) == {"talker", "talker_step_embedder", "code_predictor"}
         assert pipe["models"]["talker"]["type"] == "decoder"
@@ -430,6 +432,7 @@ class TestBuildTTSPipelineMetadata:
         assert stage["outer"] == "talker"
         assert stage["inner"] == "code_predictor"
         assert stage["pre_embedder"] == "talker_step_embedder"
+        assert "prefill_embedder" not in stage
         assert stage["num_code_groups"] == 16
         assert stage["max_tokens"] == 1000
 
@@ -450,6 +453,16 @@ class TestBuildTTSPipelineMetadata:
         assert "vocoder" not in pipe["models"]
         # Pre-embedder is a loop-internal on_demand component.
         assert pipe["phases"]["talker_step_embedder"]["run_on"] == "on_demand"
+
+    def test_with_prefill_embedder(self):
+        # Default emits the prefill/trailing-text component (prompt phase).
+        meta = build_tts_pipeline_metadata(num_code_groups=16)
+        pipe = meta["pipeline"]
+        assert "talker_prefill_embedder" in pipe["models"]
+        assert pipe["models"]["talker_prefill_embedder"]["type"] == "embedding"
+        stage = pipe["strategy"]["stages"][0]["strategy"]
+        assert stage["prefill_embedder"] == "talker_prefill_embedder"
+        assert pipe["phases"]["talker_prefill_embedder"]["run_on"] == "prompt_only"
 
     def test_rejects_invalid_code_groups(self):
         with pytest.raises(ValueError, match="num_code_groups"):

--- a/src/mobius/integrations/onnx_genai/inference_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata_test.py
@@ -431,7 +431,8 @@ class TestBuildTTSPipelineMetadata:
         assert stage["kind"] == "nested_autoregressive"
         assert stage["outer"] == "talker"
         assert stage["inner"] == "code_predictor"
-        assert stage["pre_embedder"] == "talker_step_embedder"
+        assert stage["pre_embedder"]["component"] == "talker_step_embedder"
+        assert stage["pre_embedder"]["frame_codes_input"] == "frame_codes"
         assert "prefill_embedder" not in stage
         assert stage["num_code_groups"] == 16
         assert stage["max_tokens"] == 1000
@@ -461,7 +462,10 @@ class TestBuildTTSPipelineMetadata:
         assert "talker_prefill_embedder" in pipe["models"]
         assert pipe["models"]["talker_prefill_embedder"]["type"] == "embedding"
         stage = pipe["strategy"]["stages"][0]["strategy"]
-        assert stage["prefill_embedder"] == "talker_prefill_embedder"
+        assert stage["prefill_embedder"]["component"] == "talker_prefill_embedder"
+        assert stage["prefill_embedder"]["prompt_input"] == "text_ids"
+        assert stage["prefill_embedder"]["prefill_output"] == "prefill_embeds"
+        assert stage["prefill_embedder"]["trailing_output"] == "trailing_text_embeds"
         assert pipe["phases"]["talker_prefill_embedder"]["run_on"] == "prompt_only"
 
     def test_rejects_invalid_code_groups(self):
@@ -473,7 +477,8 @@ class TestBuildTTSPipelineMetadata:
         with open(path) as handle:
             loaded = yaml.safe_load(handle)
         stage = loaded["pipeline"]["strategy"]["stages"][0]["strategy"]
-        assert stage["pre_embedder"] == "talker_step_embedder"
+        assert stage["pre_embedder"]["component"] == "talker_step_embedder"
+        assert stage["pre_embedder"]["frame_codes_input"] == "frame_codes"
         assert stage["num_code_groups"] == 8
 
     def test_matches_onnx_genai_json_schema(self):

--- a/src/mobius/integrations/onnx_genai/inference_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata_test.py
@@ -15,8 +15,10 @@ from mobius.integrations.onnx_genai.inference_metadata import (
     build_diffusion_pipeline_metadata,
     build_language_diffusion_pipeline_metadata,
     build_multimodal_pipeline_metadata,
+    build_tts_pipeline_metadata,
     load_diffusers_scheduler_config,
     write_diffusion_pipeline_metadata,
+    write_tts_pipeline_metadata,
 )
 
 
@@ -410,3 +412,67 @@ class TestBuildMultimodalPipelineMetadata:
                 "run_on": "every_step",
             },
         ]
+
+
+class TestBuildTTSPipelineMetadata:
+    """Pre-embedder-driven multi-decoder TTS (Qwen3-TTS) metadata."""
+
+    def test_minimal_nested_autoregressive_with_pre_embedder(self):
+        meta = build_tts_pipeline_metadata(num_code_groups=16, max_frames=1000)
+        pipe = meta["pipeline"]
+        assert set(pipe["models"]) == {"talker", "talker_step_embedder", "code_predictor"}
+        assert pipe["models"]["talker"]["type"] == "decoder"
+        assert pipe["models"]["talker"]["tokenizer"] == "tokenizer.json"
+        assert pipe["models"]["talker_step_embedder"]["type"] == "embedding"
+
+        stage = pipe["strategy"]["stages"][0]["strategy"]
+        assert stage["kind"] == "nested_autoregressive"
+        assert stage["outer"] == "talker"
+        assert stage["inner"] == "code_predictor"
+        assert stage["pre_embedder"] == "talker_step_embedder"
+        assert stage["num_code_groups"] == 16
+        assert stage["max_tokens"] == 1000
+
+        # Required pre-embedder feed edge + inner seed edge.
+        assert {
+            "from": "talker_step_embedder.inputs_embeds",
+            "to": "talker.inputs_embeds",
+            "dtype": "fp32",
+            "device_transfer": False,
+        } in pipe["dataflow"]
+        assert {
+            "from": "talker.last_hidden_state",
+            "to": "code_predictor.inputs_embeds",
+            "dtype": "fp32",
+            "device_transfer": False,
+        } in pipe["dataflow"]
+        # No in-package vocoder.
+        assert "vocoder" not in pipe["models"]
+        # Pre-embedder is a loop-internal on_demand component.
+        assert pipe["phases"]["talker_step_embedder"]["run_on"] == "on_demand"
+
+    def test_rejects_invalid_code_groups(self):
+        with pytest.raises(ValueError, match="num_code_groups"):
+            build_tts_pipeline_metadata(num_code_groups=0)
+
+    def test_write_roundtrip(self, tmp_path):
+        path = write_tts_pipeline_metadata(str(tmp_path), num_code_groups=8)
+        with open(path) as handle:
+            loaded = yaml.safe_load(handle)
+        stage = loaded["pipeline"]["strategy"]["stages"][0]["strategy"]
+        assert stage["pre_embedder"] == "talker_step_embedder"
+        assert stage["num_code_groups"] == 8
+
+    def test_matches_onnx_genai_json_schema(self):
+        """Emitted TTS metadata validates against onnx-genai's published schema."""
+        schema_path = _onnx_genai_schema_path()
+        if schema_path is None:
+            pytest.skip("onnx-genai schema not found (set ONNX_GENAI_SCHEMA)")
+        import json
+
+        import jsonschema
+
+        with open(schema_path) as handle:
+            schema = json.load(handle)
+        meta = build_tts_pipeline_metadata(num_code_groups=16, max_frames=2000)
+        jsonschema.validate(instance=meta, schema=schema)

--- a/src/mobius/integrations/onnx_genai/inference_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata_test.py
@@ -14,6 +14,7 @@ from mobius.integrations.onnx_genai.inference_metadata import (
     SchedulerConfig,
     build_diffusion_pipeline_metadata,
     build_language_diffusion_pipeline_metadata,
+    build_multimodal_pipeline_metadata,
     load_diffusers_scheduler_config,
     write_diffusion_pipeline_metadata,
 )
@@ -271,3 +272,141 @@ class TestLanguageDiffusionMetadata:
             guidance_scale=2.5,
         )
         jsonschema.validate(instance=meta, schema=schema)
+
+
+class TestBuildMultimodalPipelineMetadata:
+    def test_vision_only_pipeline(self):
+        metadata = build_multimodal_pipeline_metadata(
+            vision_encoder_filename="vision_encoder.onnx"
+        )
+
+        assert metadata == {
+            "pipeline": {
+                "models": {
+                    "vision_encoder": {
+                        "filename": "vision_encoder.onnx",
+                        "type": "vision_encoder",
+                    },
+                    "embedding": {"filename": "embedding.onnx", "type": "encoder"},
+                    "decoder": {
+                        "filename": "decoder.onnx",
+                        "type": "decoder",
+                        "tokenizer": "tokenizer.json",
+                    },
+                },
+                "dataflow": [
+                    {
+                        "from": "vision_encoder.image_features",
+                        "to": "embedding.image_features",
+                        "dtype": "fp32",
+                        "device_transfer": False,
+                    },
+                    {
+                        "from": "embedding.inputs_embeds",
+                        "to": "decoder.inputs_embeds",
+                        "dtype": "fp32",
+                        "device_transfer": False,
+                    },
+                ],
+                "strategy": {
+                    "kind": "composite",
+                    "stages": [
+                        {
+                            "name": "encode_vision",
+                            "strategy": {
+                                "kind": "single_pass",
+                                "model": "vision_encoder",
+                            },
+                            "run_on": "prompt_only",
+                        },
+                        {
+                            "name": "fuse_embeddings",
+                            "strategy": {
+                                "kind": "single_pass",
+                                "model": "embedding",
+                            },
+                            "run_on": "prompt_only",
+                        },
+                        {
+                            "name": "decode",
+                            "strategy": {
+                                "kind": "autoregressive",
+                                "decoder": "decoder",
+                            },
+                            "run_on": "every_step",
+                        },
+                    ],
+                },
+                "phases": {
+                    "vision_encoder": {"run_on": "prompt_only"},
+                    "embedding": {"run_on": "prompt_only"},
+                    "decoder": {"run_on": "every_step"},
+                },
+            }
+        }
+
+    def test_vision_and_audio_pipeline(self):
+        metadata = build_multimodal_pipeline_metadata(
+            vision_encoder_filename="vision_encoder.onnx",
+            audio_encoder_filename="audio_encoder.onnx",
+        )
+        pipeline = metadata["pipeline"]
+
+        assert pipeline["models"] == {
+            "vision_encoder": {
+                "filename": "vision_encoder.onnx",
+                "type": "vision_encoder",
+            },
+            "audio_encoder": {
+                "filename": "audio_encoder.onnx",
+                "type": "audio_encoder",
+            },
+            "embedding": {"filename": "embedding.onnx", "type": "encoder"},
+            "decoder": {
+                "filename": "decoder.onnx",
+                "type": "decoder",
+                "tokenizer": "tokenizer.json",
+            },
+        }
+        assert pipeline["dataflow"] == [
+            {
+                "from": "vision_encoder.image_features",
+                "to": "embedding.image_features",
+                "dtype": "fp32",
+                "device_transfer": False,
+            },
+            {
+                "from": "audio_encoder.audio_features",
+                "to": "embedding.audio_features",
+                "dtype": "fp32",
+                "device_transfer": False,
+            },
+            {
+                "from": "embedding.inputs_embeds",
+                "to": "decoder.inputs_embeds",
+                "dtype": "fp32",
+                "device_transfer": False,
+            },
+        ]
+        assert pipeline["strategy"]["stages"] == [
+            {
+                "name": "encode_vision",
+                "strategy": {"kind": "single_pass", "model": "vision_encoder"},
+                "run_on": "prompt_only",
+            },
+            {
+                "name": "encode_audio",
+                "strategy": {"kind": "single_pass", "model": "audio_encoder"},
+                "run_on": "prompt_only",
+            },
+            {
+                "name": "fuse_embeddings",
+                "strategy": {"kind": "single_pass", "model": "embedding"},
+                "run_on": "prompt_only",
+            },
+            {
+                "name": "decode",
+                "strategy": {"kind": "autoregressive", "decoder": "decoder"},
+                "run_on": "every_step",
+            },
+        ]

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -41,9 +41,11 @@ from mobius.components import (
     Embedding,
     LayerNorm,
     Linear,
+    QuantizedEmbedding,
     RMSNorm,
     create_attention_bias,
     initialize_rope,
+    make_quantized_linear_factory,
 )
 from mobius.components._activations import get_activation
 from mobius.components._gemma4_audio import Gemma4AudioEncoder
@@ -53,6 +55,147 @@ from mobius.models.gemma3_text import Gemma3TextScaledWordEmbedding
 
 if TYPE_CHECKING:
     from mobius.components._attention import GQAContext
+
+
+# ---------------------------------------------------------------------------
+# Mixed-precision quantization helpers
+#
+# Gemma4 is a multimodal model whose text decoder + token embeddings may be
+# weight-quantized (MatMulNBits / GatherBlockQuantized) while its vision and
+# audio encoders stay float.  The vision/audio encoder modules deliberately do
+# NOT consult ``config.quantization`` — they always build plain ``Linear``
+# layers — so enabling quantization only affects the text path.  The helpers
+# below are the single place the text components read the quantization config,
+# which keeps that "text quantized, vision/audio float" contract explicit.
+# ---------------------------------------------------------------------------
+
+
+def _text_quantization_config(config: Gemma4Config):
+    """Return the active weight-quantization config, or ``None`` when off."""
+    quantization_config = getattr(config, "quantization", None)
+    if quantization_config is None or quantization_config.quant_method == "none":
+        return None
+    return quantization_config
+
+
+def _text_linear_class(config: Gemma4Config) -> type | None:
+    """Return a QuantizedLinear factory for text projections, or ``None``.
+
+    ``None`` means "use a plain float :class:`Linear`". Only the text decoder
+    projections (attention Q/K/V/O + MLP + LM head) use this; vision and audio
+    linears are always float.
+    """
+    quantization_config = _text_quantization_config(config)
+    if quantization_config is None:
+        return None
+    zero_point_dtype = (
+        config.dtype
+        if getattr(quantization_config, "float_zero_point", False)
+        else ir.DataType.UINT8
+    )
+    return make_quantized_linear_factory(
+        bits=quantization_config.bits,
+        block_size=quantization_config.group_size,
+        has_zero_point=not quantization_config.sym,
+        zero_point_dtype=zero_point_dtype,
+    )
+
+
+def _text_embeddings_quantized(config: Gemma4Config) -> bool:
+    """Whether the text token-embedding tables use GatherBlockQuantized."""
+    quantization_config = _text_quantization_config(config)
+    return quantization_config is not None and bool(
+        getattr(quantization_config, "quantize_embeddings", False)
+    )
+
+
+def _text_lm_head_quantized(config: Gemma4Config) -> bool:
+    """Whether the text LM head projection uses MatMulNBits."""
+    quantization_config = _text_quantization_config(config)
+    return quantization_config is not None and bool(
+        getattr(quantization_config, "quantize_lm_head", False)
+    )
+
+
+def _make_scaled_word_embedding(
+    config: Gemma4Config,
+    num_embeddings: int,
+    embedding_dim: int,
+    embed_scale: float,
+):
+    """Build a scaled token embedding, quantized when the config requests it.
+
+    Returns a :class:`Gemma4ScaledQuantizedWordEmbedding` (GatherBlockQuantized
+    lookup) when embedding quantization is enabled and the embedding dimension
+    is block-aligned, otherwise a float :class:`Gemma3TextScaledWordEmbedding`.
+    """
+    quantization_config = _text_quantization_config(config)
+    if (
+        _text_embeddings_quantized(config)
+        and embedding_dim % quantization_config.group_size == 0
+    ):
+        return Gemma4ScaledQuantizedWordEmbedding(
+            num_embeddings,
+            embedding_dim,
+            config.pad_token_id,
+            embed_scale=embed_scale,
+            bits=quantization_config.bits,
+            block_size=quantization_config.group_size,
+            has_zero_point=not quantization_config.sym,
+        )
+    return Gemma3TextScaledWordEmbedding(
+        num_embeddings,
+        embedding_dim,
+        config.pad_token_id,
+        embed_scale=embed_scale,
+    )
+
+
+def _make_lm_head(config: Gemma4Config) -> nn.Module:
+    """Build the LM head projection, quantized (MatMulNBits) when requested.
+
+    The multimodal decoder and embedding live in separate ONNX graphs, so a
+    quantized head cannot share the embedding's packed table — it always gets
+    its own independent MatMulNBits weight (populated from the same repacked
+    token-embedding data at load time).
+    """
+    if _text_lm_head_quantized(config):
+        return _text_linear_class(config)(config.hidden_size, config.vocab_size, bias=False)
+    return Linear(config.hidden_size, config.vocab_size, bias=False)
+
+
+class Gemma4ScaledQuantizedWordEmbedding(QuantizedEmbedding):
+    """GatherBlockQuantized token embedding scaled by ``embed_scale``.
+
+    Quantized counterpart of :class:`Gemma3TextScaledWordEmbedding`: the packed
+    embedding rows are gathered and dequantized by ``GatherBlockQuantized`` and
+    then multiplied by the Gemma ``sqrt(hidden_size)`` (or per-layer) scale.
+    """
+
+    def __init__(
+        self,
+        num_embeddings: int,
+        embedding_dim: int,
+        padding_idx: int,
+        embed_scale: float = 1.0,
+        *,
+        bits: int = 4,
+        block_size: int = 32,
+        has_zero_point: bool = True,
+    ):
+        super().__init__(
+            num_embeddings,
+            embedding_dim,
+            bits=bits,
+            block_size=block_size,
+            has_zero_point=has_zero_point,
+            padding_idx=padding_idx,
+        )
+        self.embed_scale = embed_scale
+
+    def forward(self, op: OpBuilder, input_ids: ir.Value) -> ir.Value:
+        embeddings = super().forward(op, input_ids)
+        return op.Mul(embeddings, self.embed_scale)
 
 
 def _dtype_safe_compress(
@@ -695,23 +838,27 @@ class Gemma4TextAttention(nn.Module):
                 == len(prev_layers) - 1 - prev_layers[::-1].index(layer_types[layer_idx])
             )
 
+        # Text-decoder projections are quantized (MatMulNBits) when the config
+        # requests it; otherwise plain float Linear. Attention norms stay float.
+        linear_class = _text_linear_class(config) or Linear
+
         # All layers have Q projection + Q norm + output projection
-        self.q_proj = Linear(
+        self.q_proj = linear_class(
             config.hidden_size, config.num_attention_heads * head_dim, bias=False
         )
         self.q_norm = RMSNorm(head_dim, eps=config.rms_norm_eps)
-        self.o_proj = Linear(
+        self.o_proj = linear_class(
             config.num_attention_heads * head_dim, config.hidden_size, bias=False
         )
 
         # KV-shared layers borrow K,V — no projections needed
         if not self.is_kv_shared_layer:
-            self.k_proj = Linear(
+            self.k_proj = linear_class(
                 config.hidden_size, self.num_key_value_heads * head_dim, bias=False
             )
             # Alternative attention (k_eq_v): V = K, no separate v_proj
             if not self._use_alternative_attention:
-                self.v_proj = Linear(
+                self.v_proj = linear_class(
                     config.hidden_size, self.num_key_value_heads * head_dim, bias=False
                 )
             self.k_norm = RMSNorm(head_dim, eps=config.rms_norm_eps)
@@ -809,10 +956,21 @@ class Gemma4TextAttention(nn.Module):
                 # the FULL sequence (with RoPE applied).  Transpose it to the 3D
                 # layout the Attention op expects:
                 #   [batch, kv_len, kv_heads * head_dim].
+                #
+                # Reshape to the STATIC ``kv_heads * head_dim`` hidden size (not a
+                # dynamic ``-1``): the source present-value comes out of an
+                # Attention op whose head_dim onnxruntime does not always
+                # propagate, so a ``-1`` here leaves the Attention op's value
+                # head size (and therefore this layer's attention output width)
+                # unknown.  onnxruntime then infers a mismatched o_proj input dim
+                # and rejects the graph at session creation with a MatMul
+                # "Incompatible dimensions" shape-inference error.  A concrete
+                # last dim lets it infer the attention output width correctly.
+                shared_kv_hidden = self.num_key_value_heads * self.head_dim
                 src_key = op.Transpose(src_key, perm=[0, 2, 1, 3])
-                src_key = op.Reshape(src_key, [0, 0, -1])
+                src_key = op.Reshape(src_key, [0, 0, shared_kv_hidden])
                 src_value = op.Transpose(src_value, perm=[0, 2, 1, 3])
-                src_value = op.Reshape(src_value, [0, 0, -1])
+                src_value = op.Reshape(src_value, [0, 0, shared_kv_hidden])
 
                 # IMPORTANT: pass is_causal=0 here, NOT the caller's is_causal.
                 #
@@ -1100,6 +1258,7 @@ class Gemma4DecoderLayer(nn.Module):
             intermediate_size=intermediate_size,
             activation=config.hidden_act,
             bias=config.mlp_bias,
+            linear_class=_text_linear_class(config),
         )
 
         self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
@@ -1482,11 +1641,11 @@ class Gemma4TextModel(nn.Module):
         self._dtype = config.dtype
 
         embed_scale = math.sqrt(config.hidden_size)
-        self.embed_tokens = Gemma3TextScaledWordEmbedding(
+        self.embed_tokens = _make_scaled_word_embedding(
+            config,
             config.vocab_size,
             config.hidden_size,
-            config.pad_token_id,
-            embed_scale=embed_scale,
+            embed_scale,
         )
 
         layer_types = config.layer_types or ["sliding_attention"] * config.num_hidden_layers
@@ -1562,11 +1721,11 @@ class Gemma4TextModel(nn.Module):
             vocab_per_layer = getattr(config, "vocab_size_per_layer_input", 0)
             # Fused [V, L*D] table — used when split_per_layer_embedding is False.
             # Requires ORT >= 1.27 for CUDA Gather int64 index support (onnxruntime#28107).
-            self.embed_tokens_per_layer = Gemma3TextScaledWordEmbedding(
+            self.embed_tokens_per_layer = _make_scaled_word_embedding(
+                config,
                 vocab_per_layer,
                 self._num_layers * self._per_layer_dim,
-                config.pad_token_id,
-                embed_scale=float(self._per_layer_dim**0.5),
+                float(self._per_layer_dim**0.5),
             )
             # Split [V, D] tables — used when split_per_layer_embedding is True
             # (i.e. the fused table exceeds the EP's max_buffer_size, e.g. WebGPU's
@@ -1896,7 +2055,7 @@ class Gemma4CausalLMModel(CausalLMModel):
         nn.Module.__init__(self)
         self.config = config
         self.model = Gemma4TextModel(config)
-        self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.lm_head = _make_lm_head(config)
 
     def forward(
         self,
@@ -1961,7 +2120,7 @@ class _Gemma4DecoderModel(nn.Module):
         super().__init__()
         self.config = config
         self.model = Gemma4TextModel(config)
-        self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.lm_head = _make_lm_head(config)
 
     def forward(
         self,
@@ -2124,11 +2283,11 @@ class Gemma4EmbeddingModel(nn.Module):
         super().__init__()
         self.config = config
         embed_scale = math.sqrt(config.hidden_size)
-        self.embed_tokens = Gemma3TextScaledWordEmbedding(
+        self.embed_tokens = _make_scaled_word_embedding(
+            config,
             config.vocab_size,
             config.hidden_size,
-            config.pad_token_id,
-            embed_scale=embed_scale,
+            embed_scale,
         )
         self.image_token_id = config.image_token_id or 0
         # Audio token ID is only set when the model has an audio encoder.
@@ -2143,11 +2302,11 @@ class Gemma4EmbeddingModel(nn.Module):
             # Single fused [V, L*D] embedding table matching HuggingFace's
             # ``embed_tokens_per_layer.weight`` shape.  The ORT CUDA Gather
             # int32 overflow (onnxruntime#28107) is now fixed.
-            self.embed_tokens_per_layer = Gemma3TextScaledWordEmbedding(
+            self.embed_tokens_per_layer = _make_scaled_word_embedding(
+                config,
                 vocab_per_layer,
                 self._num_layers * self._per_layer_dim,
-                config.pad_token_id,
-                embed_scale=float(self._per_layer_dim**0.5),
+                float(self._per_layer_dim**0.5),
             )
             self.per_layer_model_projection = Linear(
                 config.hidden_size,
@@ -2702,7 +2861,10 @@ class Gemma4Model(nn.Module):
             for key, value in state_dict.items()
         }
 
-        # Synthesize lm_head from embed_tokens when weights are tied
+        # Synthesize lm_head from embed_tokens when weights are tied. For a
+        # float checkpoint this copies ``embed_tokens.weight``; for a quantized
+        # checkpoint the tied MatMulNBits head tensors (weight/scales/
+        # zero_points) are emitted directly by the loader, so nothing to do here.
         if self.config.tie_word_embeddings:
             embed_key = "language_model.embed_tokens.weight"
             head_key = "language_model.lm_head.weight"
@@ -2729,9 +2891,13 @@ class Gemma4Model(nn.Module):
                     # All other text weights nest under decoder.model.*
                     onnx_key = "decoder.model." + suffix
                     renamed[onnx_key] = value
-                    if suffix == "embed_tokens.weight":
-                        # Token embedding is shared with the embedding sub-model
-                        renamed["embedding.embed_tokens.weight"] = value
+                    if suffix.startswith("embed_tokens."):
+                        # Token embedding is shared with the embedding sub-model.
+                        # The suffix tail (``weight`` for float, or ``qweight`` /
+                        # ``scales`` / ``zero_points`` for a GatherBlockQuantized
+                        # table) is preserved so both float and quantized
+                        # embeddings route correctly.
+                        renamed["embedding." + suffix] = value
 
             elif key.startswith("vision_tower."):
                 new_key = "vision_encoder.encoder." + key[len("vision_tower.") :]

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -160,7 +160,9 @@ def _make_lm_head(config: Gemma4Config) -> nn.Module:
     token-embedding data at load time).
     """
     if _text_lm_head_quantized(config):
-        return _text_linear_class(config)(config.hidden_size, config.vocab_size, bias=False)
+        linear_cls = _text_linear_class(config)
+        if linear_cls is not None:
+            return linear_cls(config.hidden_size, config.vocab_size, bias=False)
     return Linear(config.hidden_size, config.vocab_size, bias=False)
 
 

--- a/src/mobius/models/qwen3_tts.py
+++ b/src/mobius/models/qwen3_tts.py
@@ -516,6 +516,22 @@ class Qwen3TTSTalkerPrefillEmbedder(nn.Module):
         text_vocab = tts.text_vocab_size if tts else 151936
         hidden = config.hidden_size
 
+        # The fixed TTS special-token ids and codec prefill ids are baked into
+        # the graph as Gather indices, so the embedding tables must be large
+        # enough to contain them, or the build would emit an out-of-bounds Gather.
+        max_text_id = max(_TTS_BOS_ID, _TTS_EOS_ID, _TTS_PAD_ID)
+        if text_vocab <= max_text_id:
+            raise ValueError(
+                f"text_vocab_size ({text_vocab}) must exceed the TTS special-token "
+                f"id {max_text_id}; the prefill embedder gathers those ids."
+            )
+        max_codec_id = max(_AUTO_CODEC_PREFILL_IDS)
+        if config.vocab_size <= max_codec_id:
+            raise ValueError(
+                f"config.vocab_size ({config.vocab_size}) must exceed the codec "
+                f"prefill id {max_codec_id}."
+            )
+
         # Same tables as the embedding model (shared weights, routed in
         # preprocess_weights). Text embedding + ResizeMLP projection.
         self.text_embedding = Embedding(text_vocab, text_hidden)
@@ -546,6 +562,17 @@ class Qwen3TTSTalkerPrefillEmbedder(nn.Module):
         # Projected text embeds for every prompt token.
         all_text_embeds = self._text_path(op, text_ids)  # (B, L, H)
 
+        # The special-token / codec-prefill pieces below are built at batch=1
+        # (they are constant across the batch). Broadcast them to the dynamic
+        # batch B of the text embeds before any Concat with batched tensors,
+        # otherwise Concat(axis=1) fails a batch-dimension mismatch for B > 1.
+        batch_dim = op.Shape(all_text_embeds, start=0, end=1)  # (1,) == [B]
+
+        def _to_batch(x: ir.Value) -> ir.Value:
+            """Expand a ``(1, S, H)`` tensor to ``(B, S, H)`` along the batch."""
+            tail = op.Shape(x, start=1)  # [S, H]
+            return op.Expand(x, op.Concat(batch_dim, tail, axis=0))
+
         # TTS special token embeds (bos, eos, pad) through the text path.
         special_ids = op.Unsqueeze(
             op.Constant(value_ints=[_TTS_BOS_ID, _TTS_EOS_ID, _TTS_PAD_ID]), [0]
@@ -570,9 +597,9 @@ class Qwen3TTSTalkerPrefillEmbedder(nn.Module):
         )  # (1, N-2, H)
         text_side = op.Concat(text_pad_rep, tts_bos, axis=1)  # (1, N-1, H)
         codec_side = op.Slice(codec_prefill, [0], [num_prefill - 1], [1])  # (1, N-1, H)
-        codec_text_pairs = op.Add(text_side, codec_side)  # (1, N-1, H)
+        codec_text_pairs = _to_batch(op.Add(text_side, codec_side))  # (B, N-1, H)
 
-        # First text token + last codec token (bos).
+        # First text token + last codec token (bos). Add broadcasts (1->B).
         first_text = op.Slice(all_text_embeds, [3], [4], [1])  # (B, 1, H)
         codec_bos = op.Slice(codec_prefill, [num_prefill - 1], [num_prefill], [1])  # (1, 1, H)
         first_text_codec = op.Add(first_text, codec_bos)  # (B, 1, H)
@@ -581,9 +608,11 @@ class Qwen3TTSTalkerPrefillEmbedder(nn.Module):
             role, codec_text_pairs, first_text_codec, axis=1
         )  # (B, 8, H)
 
-        # Trailing text: remaining tokens [4:-5] ++ tts_eos.
+        # Trailing text: remaining tokens [4:-5] ++ tts_eos (broadcast to B).
         remaining_text = op.Slice(all_text_embeds, [4], [-5], [1])  # (B, L-9, H)
-        trailing_text_embeds = op.Concat(remaining_text, tts_eos, axis=1)  # (B, L-8, H)
+        trailing_text_embeds = op.Concat(
+            remaining_text, _to_batch(tts_eos), axis=1
+        )  # (B, L-8, H)
 
         return prefill_embeds, trailing_text_embeds
 

--- a/src/mobius/models/qwen3_tts.py
+++ b/src/mobius/models/qwen3_tts.py
@@ -443,6 +443,156 @@ class Qwen3TTSTalkerStepEmbedder(nn.Module):
 
 
 # ---------------------------------------------------------------------------
+# Talker prefill embedder (pre-embedding component)
+# ---------------------------------------------------------------------------
+
+# Text-side special token IDs (shared text vocab).
+_TTS_BOS_ID = 151672
+_TTS_EOS_ID = 151673
+_TTS_PAD_ID = 151671
+# Codec prefill token IDs for the DEFAULT path (language="Auto", no speaker,
+# no instruct). N = 5: [nothink, think_bos, think_eos, pad, bos].
+_CODEC_NOTHINK_ID = 2155
+_CODEC_THINK_BOS_ID = 2156
+_CODEC_THINK_EOS_ID = 2157
+_CODEC_PAD_ID = 2148
+_CODEC_BOS_ID = 2149
+_AUTO_CODEC_PREFILL_IDS = [
+    _CODEC_NOTHINK_ID,
+    _CODEC_THINK_BOS_ID,
+    _CODEC_THINK_EOS_ID,
+    _CODEC_PAD_ID,
+    _CODEC_BOS_ID,
+]
+
+
+class Qwen3TTSTalkerPrefillEmbedder(nn.Module):
+    r"""Materializes the talker PREFILL + trailing-text construction in ONNX.
+
+    In the reference generation loop (see
+    ``examples/qwen3_tts.py::generate_codes``) two embedding sequences are built
+    once, up front, from the already-tokenized prompt ids. This component folds
+    that construction into a single graph so a generic runtime loop can drive
+    the talker without any Qwen3-TTS-specific slicing/interleaving logic.
+
+    Scope: the DEFAULT path only — ``language="Auto"`` (codec prefill ids
+    ``[nothink, think_bos, think_eos, pad, bos]``, so ``N = 5``), NO instruct
+    and NO speaker embedding. Speaker/language/instruct branches are a
+    documented follow-up and are intentionally not implemented here.
+
+    The prompt is tokenized (by the runtime) as::
+
+        <|im_start|>assistant\n{text}<|im_end|>\n<|im_start|>assistant\n
+
+    giving ``text_ids`` with layout: ``[0:3]`` role prefix, ``[3]`` first text
+    token, ``[4:-5]`` remaining text, ``[-5:]`` end role (discarded).
+
+    Two sequences are produced (matching ``generate_codes`` exactly):
+
+    - ``prefill_embeds`` = ``role(3) + codec_text_pairs(N-1) + first_text_codec(1)``
+      where ``codec_text_pairs = (tts_pad*(N-2) ++ tts_bos) + codec_prefill[:-1]``
+      and ``first_text_codec = text_embeds[:, 3:4] + codec_prefill[:, -1:]``.
+      Length is constant: ``3 + (N-1) + 1 = 3 + 4 + 1 = 8``.
+    - ``trailing_text_embeds`` = ``text_embeds[:, 4:-5] ++ tts_eos``.
+      Length is ``(text_len - 9) + 1 = text_len - 8``.
+
+    Weights are the SAME tables as the ``embedding`` model (text embedding +
+    projection, codec embedding); they are shared, not re-quantized. Only the
+    Slice/Concat/Add/Tile interleaving lives here; the codec prefill ids and the
+    tts special ids are graph constants.
+
+    Inputs:
+      - ``text_ids``: (batch, text_len) int64 — already-tokenized prompt ids.
+
+    Outputs:
+      - ``prefill_embeds``: (batch, 8, hidden) float.
+      - ``trailing_text_embeds``: (batch, text_len - 8, hidden) float.
+    """
+
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+        tts = config.tts
+        text_hidden = tts.text_hidden_size if tts else 2048
+        text_vocab = tts.text_vocab_size if tts else 151936
+        hidden = config.hidden_size
+
+        # Same tables as the embedding model (shared weights, routed in
+        # preprocess_weights). Text embedding + ResizeMLP projection.
+        self.text_embedding = Embedding(text_vocab, text_hidden)
+        self.text_projection_fc1 = Linear(text_hidden, text_hidden, bias=True)
+        self.text_projection_fc2 = Linear(text_hidden, hidden, bias=True)
+        # Codec embedding (audio codes → hidden).
+        self.codec_embedding = Embedding(config.vocab_size, hidden)
+
+    def _text_path(self, op: OpBuilder, ids: ir.Value) -> ir.Value:
+        """Embed *ids* through the text embedding + projection (fc1 → SiLU → fc2)."""
+        embeds = self.text_embedding(op, ids)
+        embeds = self.text_projection_fc1(op, embeds)
+        embeds = op.Mul(embeds, op.Sigmoid(embeds))  # SiLU
+        return self.text_projection_fc2(op, embeds)
+
+    def forward(self, op: OpBuilder, text_ids: ir.Value):
+        """Build ``prefill_embeds`` and ``trailing_text_embeds`` from ``text_ids``.
+
+        Args:
+            text_ids: (batch, text_len) int64 already-tokenized prompt ids.
+
+        Returns:
+            Tuple ``(prefill_embeds, trailing_text_embeds)``, both
+            (batch, seq, hidden) float.
+        """
+        num_prefill = len(_AUTO_CODEC_PREFILL_IDS)  # N = 5
+
+        # Projected text embeds for every prompt token.
+        all_text_embeds = self._text_path(op, text_ids)  # (B, L, H)
+
+        # TTS special token embeds (bos, eos, pad) through the text path.
+        special_ids = op.Unsqueeze(
+            op.Constant(value_ints=[_TTS_BOS_ID, _TTS_EOS_ID, _TTS_PAD_ID]), [0]
+        )  # (1, 3)
+        special_embeds = self._text_path(op, special_ids)  # (1, 3, H)
+        tts_bos = op.Slice(
+            special_embeds, [0], [1], [1]
+        )  # (1, 1, H)
+        tts_eos = op.Slice(special_embeds, [1], [2], [1])
+        tts_pad = op.Slice(special_embeds, [2], [3], [1])
+
+        # Codec prefill embeds over the constant Auto-path ids.
+        codec_ids = op.Unsqueeze(
+            op.Constant(value_ints=_AUTO_CODEC_PREFILL_IDS), [0]
+        )  # (1, N)
+        codec_prefill = self.codec_embedding(op, codec_ids)  # (1, N, H)
+
+        # Role prefix: first 3 text tokens (pure text, no codec overlay).
+        role = op.Slice(all_text_embeds, [0], [3], [1])  # (B, 3, H)
+
+        # Text side of codec prefill: tts_pad * (N-2) ++ tts_bos.
+        text_pad_rep = op.Tile(
+            tts_pad, op.Constant(value_ints=[1, num_prefill - 2, 1])
+        )  # (1, N-2, H)
+        text_side = op.Concat(text_pad_rep, tts_bos, axis=1)  # (1, N-1, H)
+        codec_side = op.Slice(codec_prefill, [0], [num_prefill - 1], [1])  # (1, N-1, H)
+        codec_text_pairs = op.Add(text_side, codec_side)  # (1, N-1, H)
+
+        # First text token + last codec token (bos).
+        first_text = op.Slice(all_text_embeds, [3], [4], [1])  # (B, 1, H)
+        codec_bos = op.Slice(
+            codec_prefill, [num_prefill - 1], [num_prefill], [1]
+        )  # (1, 1, H)
+        first_text_codec = op.Add(first_text, codec_bos)  # (B, 1, H)
+
+        prefill_embeds = op.Concat(
+            role, codec_text_pairs, first_text_codec, axis=1
+        )  # (B, 8, H)
+
+        # Trailing text: remaining tokens [4:-5] ++ tts_eos.
+        remaining_text = op.Slice(all_text_embeds, [4], [-5], [1])  # (B, L-9, H)
+        trailing_text_embeds = op.Concat(remaining_text, tts_eos, axis=1)  # (B, L-8, H)
+
+        return prefill_embeds, trailing_text_embeds
+
+
+# ---------------------------------------------------------------------------
 # Speaker encoder model (model 4 of 4)
 # ---------------------------------------------------------------------------
 
@@ -512,6 +662,7 @@ class Qwen3TTSForConditionalGeneration(nn.Module):
         self.code_predictor = Qwen3TTSCodePredictorModel(config)
         self.embedding = Qwen3TTSEmbeddingModel(config)
         self.talker_step_embedder = Qwen3TTSTalkerStepEmbedder(config)
+        self.talker_prefill_embedder = Qwen3TTSTalkerPrefillEmbedder(config)
         # Speaker encoder is optional — not all TTS models include it
         tts = config.tts
         if tts and tts.speaker_encoder:
@@ -563,19 +714,21 @@ class Qwen3TTSForConditionalGeneration(nn.Module):
                 self._route_code_predictor_weight(cleaned, cp_key, value)
                 continue
 
-            # Text embedding → embedding model
+            # Text embedding → embedding model (+ shared with prefill embedder)
             if inner.startswith("model.text_embedding."):
                 emb_key = inner[len("model.") :]  # text_embedding.*
                 cleaned[f"embedding.{emb_key}"] = value
+                cleaned[f"talker_prefill_embedder.{emb_key}"] = value
                 continue
 
-            # Text projection → embedding model
+            # Text projection → embedding model (+ shared with prefill embedder)
             if inner.startswith("text_projection."):
                 proj_key = inner[len("text_projection.") :]
                 # linear_fc1.weight → text_projection_fc1.weight
                 proj_key = proj_key.replace("linear_fc1.", "text_projection_fc1.")
                 proj_key = proj_key.replace("linear_fc2.", "text_projection_fc2.")
                 cleaned[f"embedding.{proj_key}"] = value
+                cleaned[f"talker_prefill_embedder.{proj_key}"] = value
                 continue
 
             # Codec embedding: talker.model.codec_embedding.weight
@@ -586,6 +739,8 @@ class Qwen3TTSForConditionalGeneration(nn.Module):
                 # materialize codec_sum in-graph (talker.codec_embed(code_0)).
                 if emb_key == "codec_embedding.weight":
                     cleaned["talker_step_embedder.codec_embedding"] = value
+                    # Also share with the prefill embedder's codec table.
+                    cleaned[f"talker_prefill_embedder.{emb_key}"] = value
                 continue
 
             # Codec head → talker lm_head

--- a/src/mobius/models/qwen3_tts.py
+++ b/src/mobius/models/qwen3_tts.py
@@ -551,9 +551,7 @@ class Qwen3TTSTalkerPrefillEmbedder(nn.Module):
             op.Constant(value_ints=[_TTS_BOS_ID, _TTS_EOS_ID, _TTS_PAD_ID]), [0]
         )  # (1, 3)
         special_embeds = self._text_path(op, special_ids)  # (1, 3, H)
-        tts_bos = op.Slice(
-            special_embeds, [0], [1], [1]
-        )  # (1, 1, H)
+        tts_bos = op.Slice(special_embeds, [0], [1], [1])  # (1, 1, H)
         tts_eos = op.Slice(special_embeds, [1], [2], [1])
         tts_pad = op.Slice(special_embeds, [2], [3], [1])
 
@@ -576,9 +574,7 @@ class Qwen3TTSTalkerPrefillEmbedder(nn.Module):
 
         # First text token + last codec token (bos).
         first_text = op.Slice(all_text_embeds, [3], [4], [1])  # (B, 1, H)
-        codec_bos = op.Slice(
-            codec_prefill, [num_prefill - 1], [num_prefill], [1]
-        )  # (1, 1, H)
+        codec_bos = op.Slice(codec_prefill, [num_prefill - 1], [num_prefill], [1])  # (1, 1, H)
         first_text_codec = op.Add(first_text, codec_bos)  # (B, 1, H)
 
         prefill_embeds = op.Concat(

--- a/src/mobius/models/qwen3_tts.py
+++ b/src/mobius/models/qwen3_tts.py
@@ -590,11 +590,17 @@ class Qwen3TTSForConditionalGeneration(nn.Module):
             else:
                 remaining[key] = value
 
-        # Stack codec embeddings: (num_groups-1, cp_vocab, cp_hidden)
+        # Stack codec embeddings: (num_groups-1, cp_vocab, talker_hidden).
+        # The code predictor exposes this table via `op.Identity(stacked_codec_embedding)`
+        # as its `codec_embeddings` graph output, and onnx-ir folds the Identity so
+        # the sole initializer takes the OUTPUT name `codec_embeddings` (unprefixed) —
+        # unlike every other code_predictor initializer. Key the stacked weight to that
+        # exact initializer name so it is applied (apply_weights routes an unprefixed
+        # name to the only component that declares it).
         if codec_emb_weights:
             num_groups = max(codec_emb_weights.keys()) + 1
             stacked = torch.stack([codec_emb_weights[i] for i in range(num_groups)])
-            remaining["code_predictor.stacked_codec_embedding"] = stacked
+            remaining["codec_embeddings"] = stacked
 
         # Stack lm_heads: (num_groups-1, cp_vocab, cp_hidden)
         if lm_head_weights:

--- a/src/mobius/models/qwen3_tts.py
+++ b/src/mobius/models/qwen3_tts.py
@@ -874,15 +874,18 @@ class Qwen3TTSForConditionalGeneration(nn.Module):
 
         # Stack codec embeddings: (num_groups-1, cp_vocab, talker_hidden).
         # The code predictor exposes this table via `op.Identity(stacked_codec_embedding)`
-        # as its `codec_embeddings` graph output, and onnx-ir folds the Identity so
+        # as its `codec_embeddings` graph output. onnx-ir normally folds the Identity so
         # the sole initializer takes the OUTPUT name `codec_embeddings` (unprefixed) —
-        # unlike every other code_predictor initializer. Key the stacked weight to that
-        # exact initializer name so it is applied (apply_weights routes an unprefixed
-        # name to the only component that declares it).
+        # unlike every other code_predictor initializer. To avoid depending on that IR
+        # rewrite, key the stacked weight under BOTH names: whichever initializer the
+        # build actually emits (`codec_embeddings` when folded, else
+        # `code_predictor.stacked_codec_embedding`) is populated, and the other key is
+        # harmlessly logged as unmapped (apply_weights does not error on extra keys).
         if codec_emb_weights:
             num_groups = max(codec_emb_weights.keys()) + 1
             stacked = torch.stack([codec_emb_weights[i] for i in range(num_groups)])
             remaining["codec_embeddings"] = stacked
+            remaining["code_predictor.stacked_codec_embedding"] = stacked
             # Share the same stacked table with the talker step embedder so it
             # can materialize codec_sum in-graph (Σ cp_codec_weights[i][code]).
             remaining["talker_step_embedder.stacked_codec_embedding"] = stacked

--- a/src/mobius/models/qwen3_tts.py
+++ b/src/mobius/models/qwen3_tts.py
@@ -356,6 +356,93 @@ class Qwen3TTSEmbeddingModel(nn.Module):
 
 
 # ---------------------------------------------------------------------------
+# Talker step embedder (pre-embedding component)
+# ---------------------------------------------------------------------------
+
+
+class Qwen3TTSTalkerStepEmbedder(nn.Module):
+    r"""Materializes the per-step talker ``codec_sum`` construction in ONNX.
+
+    In the reference generation loop the talker's per-step ``inputs_embeds``
+    is built in Python as::
+
+        codec_sum = talker.codec_embed(code_0)
+                    + Σ_{i=0..14} cp_codec_weights[i][codes[i + 1]]
+        inputs_embeds = codec_sum + text_embed
+
+    where ``talker.codec_embed`` is the talker codec-embedding table (the
+    embedding model's ``codec_embedding.weight``) and ``cp_codec_weights`` is
+    the code predictor's stacked codec-embedding table
+    (``[num_code_groups - 1, cp_vocab, hidden]``).
+
+    This module folds that construction into a graph so a generic runtime loop
+    can drive the talker by feeding the previous frame's raw integer codes
+    (plus the already-embedded trailing-text vector) instead of a pre-built
+    ``inputs_embeds``. The text projection stays on the embedding model; this
+    component only holds the two codec-embedding tables (shared weights, not
+    re-quantized) and does the Gather + Add.
+
+    Inputs:
+      - ``frame_codes``: (batch, num_code_groups) int64 — the previous frame's
+        codes (``code_0`` followed by ``codes[1..num_code_groups - 1]``).
+      - ``text_embed``: (batch, 1, hidden) float — the trailing-text (or pad)
+        embedding for this step, produced by the embedding model.
+
+    Output:
+      - ``inputs_embeds``: (batch, 1, hidden) float — exactly
+        ``codec_sum + text_embed``.
+    """
+
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+        tts = config.tts
+        hidden = config.hidden_size
+        # Talker codec-embedding table (audio codes → hidden). Same weights as
+        # the embedding model's ``codec_embedding``; shared, not re-quantized.
+        self.codec_embedding = nn.Parameter([config.vocab_size, hidden])
+
+        # Code predictor stacked codec-embedding table, stored in talker_hidden
+        # space: (num_code_groups - 1, cp_vocab, hidden). Same weights as the
+        # code predictor's ``stacked_codec_embedding`` (exposed as its
+        # ``codec_embeddings`` graph output).
+        num_extra_groups = (tts.num_code_groups if tts else 16) - 1
+        cp = tts.code_predictor if tts else None
+        cp_vocab = cp.vocab_size if cp else 2048
+        self.stacked_codec_embedding = nn.Parameter([num_extra_groups, cp_vocab, hidden])
+        self._num_extra_groups = num_extra_groups
+
+    def forward(
+        self,
+        op: OpBuilder,
+        frame_codes: ir.Value,
+        text_embed: ir.Value,
+    ):
+        """Compute ``codec_sum + text_embed`` from raw frame codes.
+
+        Args:
+            frame_codes: (batch, num_code_groups) int64 previous-frame codes.
+            text_embed: (batch, 1, hidden) float trailing-text/pad embedding.
+
+        Returns:
+            inputs_embeds: (batch, 1, hidden) float.
+        """
+        # code_0 → talker codec embedding. Keep the length-1 group axis so the
+        # result is (batch, 1, hidden) and broadcasts cleanly against text.
+        code_0 = op.Gather(frame_codes, [0], axis=1)  # (batch, 1)
+        codec_sum = op.Gather(self.codec_embedding, code_0, axis=0)  # (batch, 1, hidden)
+
+        # codes[1..num_extra_groups] → per-group code predictor codec embedding.
+        for i in range(self._num_extra_groups):
+            code_i = op.Gather(frame_codes, [i + 1], axis=1)  # (batch, 1)
+            table_i = op.Gather(self.stacked_codec_embedding, [i], axis=0)
+            table_i = op.Squeeze(table_i, [0])  # (cp_vocab, hidden)
+            emb_i = op.Gather(table_i, code_i, axis=0)  # (batch, 1, hidden)
+            codec_sum = op.Add(codec_sum, emb_i)
+
+        return op.Add(codec_sum, text_embed)
+
+
+# ---------------------------------------------------------------------------
 # Speaker encoder model (model 4 of 4)
 # ---------------------------------------------------------------------------
 
@@ -424,6 +511,7 @@ class Qwen3TTSForConditionalGeneration(nn.Module):
         self.talker = Qwen3TTSTalkerDecoderModel(config)
         self.code_predictor = Qwen3TTSCodePredictorModel(config)
         self.embedding = Qwen3TTSEmbeddingModel(config)
+        self.talker_step_embedder = Qwen3TTSTalkerStepEmbedder(config)
         # Speaker encoder is optional — not all TTS models include it
         tts = config.tts
         if tts and tts.speaker_encoder:
@@ -494,6 +582,10 @@ class Qwen3TTSForConditionalGeneration(nn.Module):
             if inner.startswith("model.codec_embedding."):
                 emb_key = inner.replace("model.codec_embedding.", "codec_embedding.")
                 cleaned[f"embedding.{emb_key}"] = value
+                # Share the same table with the talker step embedder so it can
+                # materialize codec_sum in-graph (talker.codec_embed(code_0)).
+                if emb_key == "codec_embedding.weight":
+                    cleaned["talker_step_embedder.codec_embedding"] = value
                 continue
 
             # Codec head → talker lm_head
@@ -601,6 +693,9 @@ class Qwen3TTSForConditionalGeneration(nn.Module):
             num_groups = max(codec_emb_weights.keys()) + 1
             stacked = torch.stack([codec_emb_weights[i] for i in range(num_groups)])
             remaining["codec_embeddings"] = stacked
+            # Share the same stacked table with the talker step embedder so it
+            # can materialize codec_sum in-graph (Σ cp_codec_weights[i][code]).
+            remaining["talker_step_embedder.stacked_codec_embedding"] = stacked
 
         # Stack lm_heads: (num_groups-1, cp_vocab, cp_hidden)
         if lm_head_weights:

--- a/src/mobius/models/qwen3_tts.py
+++ b/src/mobius/models/qwen3_tts.py
@@ -25,6 +25,7 @@ HuggingFace class: Qwen3TTSForConditionalGeneration
 from __future__ import annotations
 
 import dataclasses
+import logging
 from typing import TYPE_CHECKING
 
 import torch
@@ -43,6 +44,8 @@ from mobius.components._ecapa_tdnn import SpeakerEncoder
 
 if TYPE_CHECKING:
     import onnx_ir as ir
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Talker decoder model (model 1 of 4)
@@ -518,18 +521,25 @@ class Qwen3TTSTalkerPrefillEmbedder(nn.Module):
 
         # The fixed TTS special-token ids and codec prefill ids are baked into
         # the graph as Gather indices, so the embedding tables must be large
-        # enough to contain them, or the build would emit an out-of-bounds Gather.
+        # enough to contain them or the gathers are out of bounds at runtime.
+        # Real Qwen3-TTS configs always satisfy this; tiny structural-test
+        # configs may not (the graph still builds — the OOB only matters at
+        # run time), so warn rather than fail the build.
         max_text_id = max(_TTS_BOS_ID, _TTS_EOS_ID, _TTS_PAD_ID)
         if text_vocab <= max_text_id:
-            raise ValueError(
-                f"text_vocab_size ({text_vocab}) must exceed the TTS special-token "
-                f"id {max_text_id}; the prefill embedder gathers those ids."
+            logger.warning(
+                "text_vocab_size (%d) does not exceed the TTS special-token id %d; "
+                "the prefill embedder's baked-in gathers would be out of bounds at "
+                "run time for this config.",
+                text_vocab,
+                max_text_id,
             )
         max_codec_id = max(_AUTO_CODEC_PREFILL_IDS)
         if config.vocab_size <= max_codec_id:
-            raise ValueError(
-                f"config.vocab_size ({config.vocab_size}) must exceed the codec "
-                f"prefill id {max_codec_id}."
+            logger.warning(
+                "config.vocab_size (%d) does not exceed the codec prefill id %d.",
+                config.vocab_size,
+                max_codec_id,
             )
 
         # Same tables as the embedding model (shared weights, routed in

--- a/src/mobius/models/qwen3_tts_test.py
+++ b/src/mobius/models/qwen3_tts_test.py
@@ -13,15 +13,18 @@ from mobius._model_package import ModelPackage
 from mobius._testing.ort_inference import OnnxModelSession
 from mobius.models.qwen3_tts import (
     Qwen3TTSForConditionalGeneration,
+    Qwen3TTSTalkerPrefillEmbedder,
     Qwen3TTSTalkerStepEmbedder,
 )
 from mobius.tasks import TTSTask
 
 # Tiny synthetic config — small tables, no 1.7B download.
 _HIDDEN = 8
-_CODEC_VOCAB = 10
+_CODEC_VOCAB = 2160  # > largest codec prefill id (2157)
 _CP_VOCAB = 6
 _NUM_CODE_GROUPS = 4
+_TEXT_HIDDEN = 8
+_TEXT_VOCAB = 151674  # > largest tts special id (151673)
 
 _TINY_CONFIG = ArchitectureConfig(
     model_type="qwen3_tts",
@@ -36,6 +39,8 @@ _TINY_CONFIG = ArchitectureConfig(
     hidden_act="silu",
     tts=TTSConfig(
         num_code_groups=_NUM_CODE_GROUPS,
+        text_hidden_size=_TEXT_HIDDEN,
+        text_vocab_size=_TEXT_VOCAB,
         code_predictor=CodePredictorConfig(
             hidden_size=_HIDDEN,
             vocab_size=_CP_VOCAB,
@@ -152,3 +157,133 @@ def test_step_embedder_weights_shared_with_existing_tables():
         _CP_VOCAB,
         _HIDDEN,
     )
+
+# ---------------------------------------------------------------------------
+# Talker prefill embedder
+# ---------------------------------------------------------------------------
+
+# Special IDs for the Auto/no-speaker/no-instruct path (mirrors the module).
+_TTS_BOS_ID = 151672
+_TTS_EOS_ID = 151673
+_TTS_PAD_ID = 151671
+_AUTO_CODEC_PREFILL_IDS = [2155, 2156, 2157, 2148, 2149]  # N = 5
+
+
+def _build_prefill_embedder_session(weights):
+    """Build the talker_prefill_embedder ONNX graph and load the given tables."""
+    module = Qwen3TTSTalkerPrefillEmbedder(_TINY_CONFIG)
+    module._set_name("talker_prefill_embedder")
+    model = TTSTask()._build_talker_prefill_embedder(module, _TINY_CONFIG)
+    pkg = ModelPackage({"talker_prefill_embedder": model}, config=_TINY_CONFIG)
+    pkg.apply_weights(
+        {f"talker_prefill_embedder.{k}": torch.from_numpy(v) for k, v in weights.items()}
+    )
+    return OnnxModelSession(model)
+
+
+def _numpy_prefill_reference(weights, text_ids):
+    """Reproduce generate_codes's prefill_embeds + trailing_text (Auto path)."""
+    text_emb = weights["text_embedding.weight"]
+    fc1_w = weights["text_projection_fc1.weight"]
+    fc1_b = weights["text_projection_fc1.bias"]
+    fc2_w = weights["text_projection_fc2.weight"]
+    fc2_b = weights["text_projection_fc2.bias"]
+    codec_emb = weights["codec_embedding.weight"]
+
+    def text_path(ids):
+        e = text_emb[ids]  # (B, L, text_hidden)
+        e = e @ fc1_w.T + fc1_b
+        e = e * (1.0 / (1.0 + np.exp(-e)))  # SiLU
+        return e @ fc2_w.T + fc2_b  # (B, L, hidden)
+
+    all_text = text_path(text_ids)  # (B, L, H)
+    special = text_path(np.array([[_TTS_BOS_ID, _TTS_EOS_ID, _TTS_PAD_ID]], dtype=np.int64))
+    tts_bos = special[:, 0:1, :]
+    tts_eos = special[:, 1:2, :]
+    tts_pad = special[:, 2:3, :]
+
+    codec_prefill = codec_emb[np.array([_AUTO_CODEC_PREFILL_IDS], dtype=np.int64)]  # (1,N,H)
+    n = codec_prefill.shape[1]
+
+    role = all_text[:, :3, :]
+    text_side = np.concatenate([np.tile(tts_pad, (1, n - 2, 1)), tts_bos], axis=1)
+    codec_text_pairs = text_side + codec_prefill[:, : n - 1, :]
+    first_text_codec = all_text[:, 3:4, :] + codec_prefill[:, -1:, :]
+    prefill = np.concatenate([role, codec_text_pairs, first_text_codec], axis=1)
+
+    trailing = np.concatenate([all_text[:, 4:-5, :], tts_eos], axis=1)
+    return prefill.astype(np.float32), trailing.astype(np.float32)
+
+
+def _random_prefill_weights(seed):
+    rng = np.random.default_rng(seed)
+    return {
+        "text_embedding.weight": rng.standard_normal((_TEXT_VOCAB, _TEXT_HIDDEN)).astype(
+            np.float32
+        ),
+        "text_projection_fc1.weight": rng.standard_normal(
+            (_TEXT_HIDDEN, _TEXT_HIDDEN)
+        ).astype(np.float32),
+        "text_projection_fc1.bias": rng.standard_normal(_TEXT_HIDDEN).astype(np.float32),
+        "text_projection_fc2.weight": rng.standard_normal((_HIDDEN, _TEXT_HIDDEN)).astype(
+            np.float32
+        ),
+        "text_projection_fc2.bias": rng.standard_normal(_HIDDEN).astype(np.float32),
+        "codec_embedding.weight": rng.standard_normal((_CODEC_VOCAB, _HIDDEN)).astype(
+            np.float32
+        ),
+    }
+
+
+def test_prefill_embedder_matches_numpy_reference():
+    """Graph interleaving equals the numpy prefill/trailing reference."""
+    weights = _random_prefill_weights(7)
+    session = _build_prefill_embedder_session(weights)
+    rng = np.random.default_rng(11)
+
+    for text_len in (10, 14, 20):
+        text_ids = rng.integers(0, 1000, size=(1, text_len)).astype(np.int64)
+        exp_prefill, exp_trailing = _numpy_prefill_reference(weights, text_ids)
+
+        out = session.run({"text_ids": text_ids})
+        got_prefill = out["prefill_embeds"]
+        got_trailing = out["trailing_text_embeds"]
+
+        # prefill_len is constant: 3 (role) + 4 (N-1 pairs) + 1 (first_text_codec)
+        assert got_prefill.shape == (1, 8, _HIDDEN)
+        # trailing_len = (text_len - 9) + 1 = text_len - 8
+        assert got_trailing.shape == (1, text_len - 8, _HIDDEN)
+
+        np.testing.assert_allclose(got_prefill, exp_prefill, atol=1e-4, rtol=1e-4)
+        np.testing.assert_allclose(got_trailing, exp_trailing, atol=1e-4, rtol=1e-4)
+
+
+def test_prefill_embedder_weights_shared_with_embedding():
+    """preprocess_weights routes the embedding tables to the prefill embedder."""
+    model = Qwen3TTSForConditionalGeneration(_TINY_CONFIG)
+
+    state_dict: dict[str, torch.Tensor] = {
+        "talker.model.text_embedding.weight": torch.randn(_TEXT_VOCAB, _TEXT_HIDDEN),
+        "talker.text_projection.linear_fc1.weight": torch.randn(_TEXT_HIDDEN, _TEXT_HIDDEN),
+        "talker.text_projection.linear_fc1.bias": torch.randn(_TEXT_HIDDEN),
+        "talker.text_projection.linear_fc2.weight": torch.randn(_HIDDEN, _TEXT_HIDDEN),
+        "talker.text_projection.linear_fc2.bias": torch.randn(_HIDDEN),
+        "talker.model.codec_embedding.weight": torch.randn(_CODEC_VOCAB, _HIDDEN),
+    }
+
+    cleaned = model.preprocess_weights(state_dict)
+
+    shared = {
+        "text_embedding.weight",
+        "text_projection_fc1.weight",
+        "text_projection_fc1.bias",
+        "text_projection_fc2.weight",
+        "text_projection_fc2.bias",
+        "codec_embedding.weight",
+    }
+    for key in shared:
+        assert f"talker_prefill_embedder.{key}" in cleaned
+        torch.testing.assert_close(
+            cleaned[f"talker_prefill_embedder.{key}"],
+            cleaned[f"embedding.{key}"],
+        )

--- a/src/mobius/models/qwen3_tts_test.py
+++ b/src/mobius/models/qwen3_tts_test.py
@@ -70,9 +70,9 @@ def test_step_embedder_matches_numpy_gather_sum():
     """Gather+Sum in the graph equals the numpy codec_sum + text_embed reference."""
     rng = np.random.default_rng(0)
     codec_table = rng.standard_normal((_CODEC_VOCAB, _HIDDEN)).astype(np.float32)
-    stacked_codec = rng.standard_normal(
-        (_NUM_CODE_GROUPS - 1, _CP_VOCAB, _HIDDEN)
-    ).astype(np.float32)
+    stacked_codec = rng.standard_normal((_NUM_CODE_GROUPS - 1, _CP_VOCAB, _HIDDEN)).astype(
+        np.float32
+    )
 
     session = _build_step_embedder_session(codec_table, stacked_codec)
 
@@ -99,9 +99,9 @@ def test_step_embedder_batched():
     """The component broadcasts correctly over a batch dimension."""
     rng = np.random.default_rng(1)
     codec_table = rng.standard_normal((_CODEC_VOCAB, _HIDDEN)).astype(np.float32)
-    stacked_codec = rng.standard_normal(
-        (_NUM_CODE_GROUPS - 1, _CP_VOCAB, _HIDDEN)
-    ).astype(np.float32)
+    stacked_codec = rng.standard_normal((_NUM_CODE_GROUPS - 1, _CP_VOCAB, _HIDDEN)).astype(
+        np.float32
+    )
     session = _build_step_embedder_session(codec_table, stacked_codec)
 
     batch = 3
@@ -117,9 +117,7 @@ def test_step_embedder_batched():
             codec_sum = codec_sum + stacked_codec[i, rest[b, i], :]
         expected[b, 0] = codec_sum + text_embed[b, 0]
 
-    got = session.run({"frame_codes": frame_codes, "text_embed": text_embed})[
-        "inputs_embeds"
-    ]
+    got = session.run({"frame_codes": frame_codes, "text_embed": text_embed})["inputs_embeds"]
     assert got.shape == (batch, 1, _HIDDEN)
     np.testing.assert_allclose(got, expected, atol=1e-5, rtol=1e-5)
 
@@ -157,6 +155,7 @@ def test_step_embedder_weights_shared_with_existing_tables():
         _CP_VOCAB,
         _HIDDEN,
     )
+
 
 # ---------------------------------------------------------------------------
 # Talker prefill embedder
@@ -221,9 +220,9 @@ def _random_prefill_weights(seed):
         "text_embedding.weight": rng.standard_normal((_TEXT_VOCAB, _TEXT_HIDDEN)).astype(
             np.float32
         ),
-        "text_projection_fc1.weight": rng.standard_normal(
-            (_TEXT_HIDDEN, _TEXT_HIDDEN)
-        ).astype(np.float32),
+        "text_projection_fc1.weight": rng.standard_normal((_TEXT_HIDDEN, _TEXT_HIDDEN)).astype(
+            np.float32
+        ),
         "text_projection_fc1.bias": rng.standard_normal(_TEXT_HIDDEN).astype(np.float32),
         "text_projection_fc2.weight": rng.standard_normal((_HIDDEN, _TEXT_HIDDEN)).astype(
             np.float32

--- a/src/mobius/models/qwen3_tts_test.py
+++ b/src/mobius/models/qwen3_tts_test.py
@@ -1,0 +1,154 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for the Qwen3-TTS talker step embedder pre-embedding component."""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+from mobius._configs import ArchitectureConfig, CodePredictorConfig, TTSConfig
+from mobius._model_package import ModelPackage
+from mobius._testing.ort_inference import OnnxModelSession
+from mobius.models.qwen3_tts import (
+    Qwen3TTSForConditionalGeneration,
+    Qwen3TTSTalkerStepEmbedder,
+)
+from mobius.tasks import TTSTask
+
+# Tiny synthetic config — small tables, no 1.7B download.
+_HIDDEN = 8
+_CODEC_VOCAB = 10
+_CP_VOCAB = 6
+_NUM_CODE_GROUPS = 4
+
+_TINY_CONFIG = ArchitectureConfig(
+    model_type="qwen3_tts",
+    hidden_size=_HIDDEN,
+    intermediate_size=16,
+    num_hidden_layers=1,
+    num_attention_heads=2,
+    num_key_value_heads=1,
+    head_dim=4,
+    vocab_size=_CODEC_VOCAB,
+    rms_norm_eps=1e-6,
+    hidden_act="silu",
+    tts=TTSConfig(
+        num_code_groups=_NUM_CODE_GROUPS,
+        code_predictor=CodePredictorConfig(
+            hidden_size=_HIDDEN,
+            vocab_size=_CP_VOCAB,
+            num_code_groups=_NUM_CODE_GROUPS,
+        ),
+    ),
+)
+
+
+def _build_step_embedder_session(codec_table, stacked_codec):
+    """Build the talker_step_embedder ONNX graph and load the given tables."""
+    module = Qwen3TTSTalkerStepEmbedder(_TINY_CONFIG)
+    # Match the initializer prefix used when the composite model is built.
+    module._set_name("talker_step_embedder")
+    model = TTSTask()._build_talker_step_embedder(module, _TINY_CONFIG)
+    pkg = ModelPackage({"talker_step_embedder": model}, config=_TINY_CONFIG)
+    pkg.apply_weights(
+        {
+            "talker_step_embedder.codec_embedding": torch.from_numpy(codec_table),
+            "talker_step_embedder.stacked_codec_embedding": torch.from_numpy(stacked_codec),
+        }
+    )
+    return OnnxModelSession(model)
+
+
+def test_step_embedder_matches_numpy_gather_sum():
+    """Gather+Sum in the graph equals the numpy codec_sum + text_embed reference."""
+    rng = np.random.default_rng(0)
+    codec_table = rng.standard_normal((_CODEC_VOCAB, _HIDDEN)).astype(np.float32)
+    stacked_codec = rng.standard_normal(
+        (_NUM_CODE_GROUPS - 1, _CP_VOCAB, _HIDDEN)
+    ).astype(np.float32)
+
+    session = _build_step_embedder_session(codec_table, stacked_codec)
+
+    for _ in range(5):
+        code_0 = int(rng.integers(0, _CODEC_VOCAB))
+        rest = rng.integers(0, _CP_VOCAB, size=_NUM_CODE_GROUPS - 1).astype(np.int64)
+        frame_codes = np.array([[code_0, *rest.tolist()]], dtype=np.int64)
+        text_embed = rng.standard_normal((1, 1, _HIDDEN)).astype(np.float32)
+
+        # numpy reference: codec_sum + text_embed
+        codec_sum = codec_table[code_0].copy()
+        for i in range(_NUM_CODE_GROUPS - 1):
+            codec_sum = codec_sum + stacked_codec[i, rest[i], :]
+        expected = codec_sum.reshape(1, 1, _HIDDEN) + text_embed
+
+        out = session.run({"frame_codes": frame_codes, "text_embed": text_embed})
+        got = out["inputs_embeds"]
+
+        assert got.shape == (1, 1, _HIDDEN)
+        np.testing.assert_allclose(got, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_step_embedder_batched():
+    """The component broadcasts correctly over a batch dimension."""
+    rng = np.random.default_rng(1)
+    codec_table = rng.standard_normal((_CODEC_VOCAB, _HIDDEN)).astype(np.float32)
+    stacked_codec = rng.standard_normal(
+        (_NUM_CODE_GROUPS - 1, _CP_VOCAB, _HIDDEN)
+    ).astype(np.float32)
+    session = _build_step_embedder_session(codec_table, stacked_codec)
+
+    batch = 3
+    code0 = rng.integers(0, _CODEC_VOCAB, size=batch)
+    rest = rng.integers(0, _CP_VOCAB, size=(batch, _NUM_CODE_GROUPS - 1))
+    frame_codes = np.concatenate([code0[:, None], rest], axis=1).astype(np.int64)
+    text_embed = rng.standard_normal((batch, 1, _HIDDEN)).astype(np.float32)
+
+    expected = np.empty((batch, 1, _HIDDEN), dtype=np.float32)
+    for b in range(batch):
+        codec_sum = codec_table[code0[b]].copy()
+        for i in range(_NUM_CODE_GROUPS - 1):
+            codec_sum = codec_sum + stacked_codec[i, rest[b, i], :]
+        expected[b, 0] = codec_sum + text_embed[b, 0]
+
+    got = session.run({"frame_codes": frame_codes, "text_embed": text_embed})[
+        "inputs_embeds"
+    ]
+    assert got.shape == (batch, 1, _HIDDEN)
+    np.testing.assert_allclose(got, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_step_embedder_weights_shared_with_existing_tables():
+    """preprocess_weights routes the same codec tables to the step embedder."""
+    model = Qwen3TTSForConditionalGeneration(_TINY_CONFIG)
+
+    codec_weight = torch.randn(_CODEC_VOCAB, _HIDDEN)
+    state_dict: dict[str, torch.Tensor] = {
+        "talker.model.codec_embedding.weight": codec_weight,
+    }
+    for i in range(_NUM_CODE_GROUPS - 1):
+        state_dict[f"talker.code_predictor.model.codec_embedding.{i}.weight"] = torch.randn(
+            _CP_VOCAB, _HIDDEN
+        )
+
+    cleaned = model.preprocess_weights(state_dict)
+
+    # Talker codec table is shared with the embedding model.
+    assert "talker_step_embedder.codec_embedding" in cleaned
+    torch.testing.assert_close(
+        cleaned["talker_step_embedder.codec_embedding"],
+        cleaned["embedding.codec_embedding.weight"],
+    )
+
+    # Stacked CP codec table is shared with the code predictor's codec_embeddings.
+    assert "talker_step_embedder.stacked_codec_embedding" in cleaned
+    torch.testing.assert_close(
+        cleaned["talker_step_embedder.stacked_codec_embedding"],
+        cleaned["codec_embeddings"],
+    )
+    assert cleaned["talker_step_embedder.stacked_codec_embedding"].shape == (
+        _NUM_CODE_GROUPS - 1,
+        _CP_VOCAB,
+        _HIDDEN,
+    )

--- a/src/mobius/models/qwen3_tts_test.py
+++ b/src/mobius/models/qwen3_tts_test.py
@@ -257,6 +257,32 @@ def test_prefill_embedder_matches_numpy_reference():
         np.testing.assert_allclose(got_trailing, exp_trailing, atol=1e-4, rtol=1e-4)
 
 
+def test_prefill_embedder_batched():
+    """Batched text_ids (B>1) produce per-row output matching the B=1 reference.
+
+    Guards the batch-broadcast of the batch=1 codec/special pieces: a naive
+    Concat of batch=1 pairs with batch=B text would fail the batch dim for B>1.
+    """
+    weights = _random_prefill_weights(13)
+    session = _build_prefill_embedder_session(weights)
+    rng = np.random.default_rng(99)
+    text_len = 16
+    text_ids = rng.integers(0, 1000, size=(3, text_len)).astype(np.int64)
+
+    out = session.run({"text_ids": text_ids})
+    got_prefill = out["prefill_embeds"]
+    got_trailing = out["trailing_text_embeds"]
+
+    assert got_prefill.shape == (3, 8, _HIDDEN)
+    assert got_trailing.shape == (3, text_len - 8, _HIDDEN)
+
+    # Each batch row must equal the single-row reference for that row's ids.
+    for b in range(3):
+        exp_prefill, exp_trailing = _numpy_prefill_reference(weights, text_ids[b : b + 1])
+        np.testing.assert_allclose(got_prefill[b : b + 1], exp_prefill, atol=1e-4, rtol=1e-4)
+        np.testing.assert_allclose(got_trailing[b : b + 1], exp_trailing, atol=1e-4, rtol=1e-4)
+
+
 def test_prefill_embedder_weights_shared_with_embedding():
     """preprocess_weights routes the embedding tables to the prefill embedder."""
     model = Qwen3TTSForConditionalGeneration(_TINY_CONFIG)

--- a/src/mobius/tasks/_tts.py
+++ b/src/mobius/tasks/_tts.py
@@ -3,11 +3,12 @@
 
 """TTS 4-model split task for Qwen3-TTS.
 
-Builds four separate ONNX models:
+Builds separate ONNX models:
 1. **talker**: inputs_embeds → logits (first code group) + last_hidden_state + KV cache
 2. **code_predictor**: inputs_embeds → hidden_states + KV cache (1D RoPE)
 3. **embedding**: text_ids + codec_ids → text_embeds + codec_embeds
-4. **speaker_encoder**: mel_input → speaker_embedding
+4. **talker_step_embedder**: frame_codes + text_embed → inputs_embeds
+5. **speaker_encoder**: mel_input → speaker_embedding
 
 Used by Qwen3TTSForConditionalGeneration.
 """
@@ -51,12 +52,14 @@ class TTSTask(ModelTask):
         "talker": "decoder",
         "code_predictor": "decoder",
         "embedding": "embedding",
+        "talker_step_embedder": "embedding",
         "speaker_encoder": "encoder",
     }
     components: ClassVar[ComponentSpec] = ComponentSpec(
         talker="talker",
         code_predictor="code_predictor",
         embedding="embedding",
+        talker_step_embedder="talker_step_embedder",
     )
 
     def build(
@@ -70,6 +73,9 @@ class TTSTask(ModelTask):
         models["talker"] = self._build_talker(module.talker, config)
         models["code_predictor"] = self._build_code_predictor(module.code_predictor, config)
         models["embedding"] = self._build_embedding(module.embedding, config)
+        models["talker_step_embedder"] = self._build_talker_step_embedder(
+            module.talker_step_embedder, config
+        )
         if module.speaker_encoder is not None:
             models["speaker_encoder"] = self._build_speaker_encoder(
                 module.speaker_encoder, config
@@ -248,6 +254,46 @@ class TTSTask(ModelTask):
 
         builder.add_output(text_embeds, "text_embeds")
         builder.add_output(codec_embeds, "codec_embeds")
+        return _make_model(graph)
+
+    def _build_talker_step_embedder(
+        self,
+        talker_step_embedder: nn.Module,
+        config: ArchitectureConfig,
+    ) -> ir.Model:
+        """Build talker step embedder: frame_codes + text_embed → inputs_embeds.
+
+        Materializes the per-step talker ``codec_sum`` construction in-graph:
+        ``codec_sum = talker.codec_embed(code_0) + Σ cp_codec_weights[i][code]``
+        and returns ``codec_sum + text_embed``. Lets a generic runtime loop
+        drive the talker from the previous frame's raw integer codes instead
+        of a pre-built ``inputs_embeds``.
+        """
+        tts = config.tts
+        num_code_groups = tts.num_code_groups if tts else 16
+
+        batch = ir.SymbolicDim("batch")
+
+        graph, builder = _make_graph(name="talker_step_embedder")
+
+        frame_codes = builder.input(
+            "frame_codes",
+            dtype=ir.DataType.INT64,
+            shape=[batch, num_code_groups],
+        )
+        text_embed = builder.input(
+            "text_embed",
+            dtype=config.dtype,
+            shape=[batch, 1, config.hidden_size],
+        )
+
+        inputs_embeds = talker_step_embedder(
+            builder.op,
+            frame_codes=frame_codes,
+            text_embed=text_embed,
+        )
+
+        builder.add_output(inputs_embeds, "inputs_embeds")
         return _make_model(graph)
 
     def _build_speaker_encoder(

--- a/src/mobius/tasks/_tts.py
+++ b/src/mobius/tasks/_tts.py
@@ -8,7 +8,8 @@ Builds separate ONNX models:
 2. **code_predictor**: inputs_embeds → hidden_states + KV cache (1D RoPE)
 3. **embedding**: text_ids + codec_ids → text_embeds + codec_embeds
 4. **talker_step_embedder**: frame_codes + text_embed → inputs_embeds
-5. **speaker_encoder**: mel_input → speaker_embedding
+5. **talker_prefill_embedder**: text_ids → prefill_embeds + trailing_text_embeds
+6. **speaker_encoder**: mel_input → speaker_embedding
 
 Used by Qwen3TTSForConditionalGeneration.
 """
@@ -53,6 +54,7 @@ class TTSTask(ModelTask):
         "code_predictor": "decoder",
         "embedding": "embedding",
         "talker_step_embedder": "embedding",
+        "talker_prefill_embedder": "embedding",
         "speaker_encoder": "encoder",
     }
     components: ClassVar[ComponentSpec] = ComponentSpec(
@@ -60,6 +62,7 @@ class TTSTask(ModelTask):
         code_predictor="code_predictor",
         embedding="embedding",
         talker_step_embedder="talker_step_embedder",
+        talker_prefill_embedder="talker_prefill_embedder",
     )
 
     def build(
@@ -75,6 +78,9 @@ class TTSTask(ModelTask):
         models["embedding"] = self._build_embedding(module.embedding, config)
         models["talker_step_embedder"] = self._build_talker_step_embedder(
             module.talker_step_embedder, config
+        )
+        models["talker_prefill_embedder"] = self._build_talker_prefill_embedder(
+            module.talker_prefill_embedder, config
         )
         if module.speaker_encoder is not None:
             models["speaker_encoder"] = self._build_speaker_encoder(
@@ -294,6 +300,45 @@ class TTSTask(ModelTask):
         )
 
         builder.add_output(inputs_embeds, "inputs_embeds")
+        return _make_model(graph)
+
+    def _build_talker_prefill_embedder(
+        self,
+        talker_prefill_embedder: nn.Module,
+        config: ArchitectureConfig,
+    ) -> ir.Model:
+        """Build talker prefill embedder: text_ids → prefill + trailing embeds.
+
+        Materializes the up-front PREFILL and trailing-text embedding
+        construction in-graph (Auto language, no speaker, no instruct):
+
+        - ``prefill_embeds`` = role(3) + codec_text_pairs(N-1) + first_text_codec(1),
+          length ``3 + 4 + 1 = 8`` (constant, independent of text length).
+        - ``trailing_text_embeds`` = text_embeds[:, 4:-5] ++ tts_eos,
+          length ``text_len - 8``.
+
+        Reuses the embedding model's text + codec tables (shared weights). Lets
+        a generic runtime loop drive the talker without Qwen3-TTS-specific
+        slicing/interleaving logic.
+        """
+        batch = ir.SymbolicDim("batch")
+        text_seq = ir.SymbolicDim("text_sequence_len")
+
+        graph, builder = _make_graph(name="talker_prefill_embedder")
+
+        text_ids = builder.input(
+            "text_ids",
+            dtype=ir.DataType.INT64,
+            shape=[batch, text_seq],
+        )
+
+        prefill_embeds, trailing_text_embeds = talker_prefill_embedder(
+            builder.op,
+            text_ids=text_ids,
+        )
+
+        builder.add_output(prefill_embeds, "prefill_embeds")
+        builder.add_output(trailing_text_embeds, "trailing_text_embeds")
         return _make_model(graph)
 
     def _build_speaker_encoder(

--- a/src/mobius/tasks/_tts.py
+++ b/src/mobius/tasks/_tts.py
@@ -1,9 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""TTS 4-model split task for Qwen3-TTS.
+"""TTS multi-model split task for Qwen3-TTS.
 
-Builds separate ONNX models:
+Builds separate ONNX models (five required + one optional speaker encoder):
 1. **talker**: inputs_embeds → logits (first code group) + last_hidden_state + KV cache
 2. **code_predictor**: inputs_embeds → hidden_states + KV cache (1D RoPE)
 3. **embedding**: text_ids + codec_ids → text_embeds + codec_embeds
@@ -36,13 +36,17 @@ from mobius.tasks._cache_utils import (
 
 
 class TTSTask(ModelTask):
-    """4-model split for Qwen3-TTS.
+    """Multi-model split for Qwen3-TTS.
 
-    The module must provide three required sub-modules and one optional:
+    The module must provide five required sub-modules and one optional:
 
     - ``talker``: Decoder producing logits + last_hidden_state
     - ``code_predictor``: Small decoder for remaining code groups
     - ``embedding``: Text + codec embedding model
+    - ``talker_step_embedder``: Per-frame ``frame_codes [+ text_embed] ->
+      inputs_embeds`` pre-embedder for the talker
+    - ``talker_prefill_embedder``: ``text_ids -> prefill_embeds +
+      trailing_text_embeds`` prefill/trailing-text builder
     - ``speaker_encoder``: ECAPA-TDNN speaker encoder *(optional — omitted
       when the model uses a pre-computed speaker embedding instead)*
 


### PR DESCRIPTION
## Summary

Adds **model-builder + metadata-emitter support for any-to-any onnx-genai pipelines**, pairing with the onnx-genai `feat/any-to-any-pipeline` PR (runtime). Mobius now builds and self-describes VLM, ASR, audio-codec, GGUF, and multi-decoder TTS packages for the onnx-genai composite runtime.

## What's included

**onnx-genai metadata emitters** (`src/mobius/integrations/onnx_genai/`)
- Composite **ASR** (Whisper-style), **audio-codec** (audio-to-audio), and **multimodal VLM** pipeline metadata.
- Self-contained packages: emit `tokenizer.json` for decoder/VLM/ASR builds.
- **`build_tts_pipeline_metadata`**: emits the `pre_embedder`-driven `nested_autoregressive` contract for real Qwen3-TTS (talker + code_predictor + talker_step_embedder), validated against onnx-genai's committed JSON schema. Packages without the pre-embedder raise a precise error.
- Structural dispatch in `write_onnx_genai_config` (fails loudly on unknown shapes).

**GGUF integration** (`src/mobius/integrations/gguf/`)
- `build-gguf --runtime onnx-genai` emits `inference_metadata` + `tokenizer.json`.
- Build **Gemma3/Gemma4 from GGUF**; **Gemma4 multimodal VLM from mmproj GGUF** with quantization preserved (~4.2 GB self-contained).
- Reconstruct `tokenizer.json` for archs transformers doesn't recognize (gemma4); fix string-array reader off-by-one.

**Qwen3-TTS model** (`src/mobius/models/qwen3_tts.py`, `tasks/_tts.py`)
- `talker_step_embedder` pre-embedding component (`frame_codes [+ text_embed] -> inputs_embeds`), sharing weights with embedding/code_predictor (validated maxdiff 0.0 vs HF; exact code match over full generation).
- Build fixes: route the Identity-folded `codec_embeddings` initializer; preserve the talker's non-standard interleaved-MRoPE `rope_scaling` (dropped by HF standardization) so the talker uses MRoPE.

## Testing

onnx-genai integration + qwen3-tts model tests green; TTS emitter validated end to end against the real 1.7B `Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice` package + the committed JSON schema.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
