### PR TITLE
fix(tests): release/ignore Windows ONNX temp-file lock in llada & unet parity tests

### DIFF
--- a/src/mobius/models/llada_test.py
+++ b/src/mobius/models/llada_test.py
@@ -20,6 +20,7 @@ Two properties are asserted:
 from __future__ import annotations
 
 import tempfile
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -167,11 +168,11 @@ def _build_onnx_session(config: ArchitectureConfig, state: dict[str, torch.Tenso
     model = MaskedDiffusionTask().build(module, config)["model"]
     apply_weights(model, module.preprocess_weights(state))
 
-    with tempfile.NamedTemporaryFile(suffix=".onnx") as handle:
-        onnx_ir.save(model, handle.name)
-        # onnxruntime reads the model fully at construction, so the temp file
-        # can be removed as soon as the session exists.
-        return ort.InferenceSession(handle.name)
+    # Windows keeps the ORT model file mapped; ignore cleanup errors so the dir can be removed.
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+        model_path = Path(temp_dir) / "model.onnx"
+        onnx_ir.save(model, model_path)
+        return ort.InferenceSession(model_path)
 
 
 def test_llada_matches_torch_reference():

--- a/src/mobius/models/unet_parity_test.py
+++ b/src/mobius/models/unet_parity_test.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import re
 import tempfile
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -63,9 +64,11 @@ def test_cross_attention_block_matches_diffusers():
     model = _make_model(graph)
     apply_weights(model, _remap_transformer(hf.state_dict()))
 
-    with tempfile.NamedTemporaryFile(suffix=".onnx") as handle:
-        onnx_ir.save(model, handle.name)
-        session = ort.InferenceSession(handle.name)
+    # Windows keeps the ORT model file mapped; ignore cleanup errors so the dir can be removed.
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+        model_path = Path(temp_dir) / "model.onnx"
+        onnx_ir.save(model, model_path)
+        session = ort.InferenceSession(model_path)
         actual = session.run(None, {"hidden": hidden.numpy(), "context": context.numpy()})[0]
     assert np.abs(actual - expected).max() < 1e-4
 
@@ -115,9 +118,11 @@ def test_unet_matches_diffusers():
     model = DenoisingTask().build(module, config)["model"]
     apply_weights(model, module.preprocess_weights(dict(hf.state_dict())))
 
-    with tempfile.NamedTemporaryFile(suffix=".onnx") as handle:
-        onnx_ir.save(model, handle.name)
-        session = ort.InferenceSession(handle.name)
+    # Windows keeps the ORT model file mapped; ignore cleanup errors so the dir can be removed.
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+        model_path = Path(temp_dir) / "model.onnx"
+        onnx_ir.save(model, model_path)
+        session = ort.InferenceSession(model_path)
         actual = session.run(
             None,
             {
@@ -185,9 +190,11 @@ def test_unet_sd1x_mixed_block_types_matches_diffusers():
     model = DenoisingTask().build(module, config)["model"]
     apply_weights(model, module.preprocess_weights(dict(hf.state_dict())))
 
-    with tempfile.NamedTemporaryFile(suffix=".onnx") as handle:
-        onnx_ir.save(model, handle.name)
-        session = ort.InferenceSession(handle.name)
+    # Windows keeps the ORT model file mapped; ignore cleanup errors so the dir can be removed.
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+        model_path = Path(temp_dir) / "model.onnx"
+        onnx_ir.save(model, model_path)
+        session = ort.InferenceSession(model_path)
         actual = session.run(
             None,
             {
@@ -271,9 +278,11 @@ def test_unet_lora_gate_parity():
     weights.update(remap_diffusers_unet_lora(lora_state, "test"))
     apply_weights(model, weights)
 
-    with tempfile.NamedTemporaryFile(suffix=".onnx") as handle:
-        onnx_ir.save(model, handle.name)
-        session = ort.InferenceSession(handle.name)
+    # Windows keeps the ORT model file mapped; ignore cleanup errors so the dir can be removed.
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+        model_path = Path(temp_dir) / "model.onnx"
+        onnx_ir.save(model, model_path)
+        session = ort.InferenceSession(model_path)
         feed = {
             "sample": sample.numpy(),
             "timestep": timestep.numpy().astype(np.int64),


### PR DESCRIPTION
## Summary

- use `TemporaryDirectory(ignore_cleanup_errors=True)` for every temporary ONNX model in the LLaDA and UNet parity tests
- document that ONNX Runtime keeps model files memory-mapped on Windows
- preserve all inference and parity assertions unchanged

## Root cause

ONNX Runtime can retain a memory-mapped handle to the `.onnx` model on Windows. Temporary-directory teardown then raises `PermissionError` because Windows does not allow deleting an open file, unlike POSIX.

## Verification

- `python3 -m pytest src/mobius/models/unet_parity_test.py src/mobius/models/llada_test.py -q` — 3 passed, 4 skipped
- `ruff format --check src/mobius/models/llada_test.py src/mobius/models/unet_parity_test.py`
- `ruff check src/mobius/models/llada_test.py src/mobius/models/unet_parity_test.py`

`lintrunner` was also attempted with only these paths; the installed adapter invokes an older Ruff that cannot parse the repository configuration rule `RUF067`.