### PR TITLE
Emit executable native VLM contracts

### DIFF
--- a/src/mobius/integrations/onnx_genai/inference_metadata.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata.py
@@ -110,6 +110,38 @@ def _port(value: Any) -> _Port:
     )
 
 
+def _shape_metadata(port: _Port) -> list[int | str | None]:
+    """Return a YAML-safe graph shape without losing symbolic dimensions."""
+    shape: list[int | str | None] = []
+    for dim in port.dims:
+        if isinstance(dim, int):
+            shape.append(dim)
+            continue
+        value = getattr(dim, "value", None)
+        shape.append(str(value) if value is not None else None)
+    return shape
+
+
+def _port_metadata(port: _Port) -> dict[str, Any]:
+    """Serialize one exact graph port for the executable component contract."""
+    return {
+        "name": port.name,
+        "dtype": port.dtype,
+        "rank": port.rank,
+        "shape": _shape_metadata(port),
+    }
+
+
+def _same_dim(left: Any, right: Any) -> bool:
+    if isinstance(left, int) or isinstance(right, int):
+        return left == right
+    return getattr(left, "value", None) == getattr(right, "value", None)
+
+
+def _ports_match_for_dataflow(source: _Port, target: _Port) -> bool:
+    return source.dtype == target.dtype and source.rank == target.rank
+
+
 def _is_float(port: _Port) -> bool:
     return port.dtype in {
         "fp32",
@@ -719,14 +751,15 @@ def _decoder_io(
     inputs = [_port(value) for value in decoder.graph.inputs]
     outputs = [_port(value) for value in decoder.graph.outputs]
     io: dict[str, Any] = {
-        "inputs": [port.name for port in inputs],
-        "outputs": [port.name for port in outputs],
+        "inputs": [_port_metadata(port) for port in inputs],
+        "outputs": [_port_metadata(port) for port in outputs],
     }
 
     routed = [port for port in inputs if port.name in routed_inputs]
     embedded = next((port for port in routed if _is_float(port) and port.rank == 3), None)
     if embedded is not None:
         io["inputs_embeds_input"] = embedded.name
+        io["sequence_source"] = "inputs_embeds"
 
     input_by_name = {port.name: port for port in inputs}
     output_by_name = {port.name: port for port in outputs}
@@ -741,6 +774,7 @@ def _decoder_io(
     token = input_by_name.get("input_ids")
     if token is not None:
         io["token_input"] = token.name
+        io.setdefault("sequence_source", "token_ids")
 
     logits = output_by_name.get("logits")
     if logits is None:
@@ -773,6 +807,272 @@ def _decoder_io(
 def _component_filenames(pkg: Any) -> dict[str, str]:
     multiple = len(pkg) > 1
     return {name: f"{name}/model.onnx" if multiple else "model.onnx" for name in pkg}
+
+
+def _sequence_decoder_inputs(decoder_ports: dict[str, list[_Port]]) -> set[str]:
+    """Find decoder inputs whose leading dimensions track the logits sequence."""
+    logits = next(
+        (
+            port
+            for port in decoder_ports["outputs"]
+            if port.name == "logits" and port.rank is not None and port.rank >= 2
+        ),
+        None,
+    )
+    if logits is None:
+        return set()
+    return {
+        port.name
+        for port in decoder_ports["inputs"]
+        if port.rank is not None
+        and port.rank >= 2
+        and _same_dim(port.dims[0], logits.dims[0])
+        and _same_dim(port.dims[1], logits.dims[1])
+        and _is_float(port)
+    }
+
+
+def _component_token_input(component_ports: dict[str, list[_Port]]) -> _Port | None:
+    """Resolve a single structural token stream for an upstream step component."""
+    candidates = [
+        port for port in component_ports["inputs"] if _is_integer(port) and port.rank == 2
+    ]
+    return candidates[0] if len(candidates) == 1 else None
+
+
+def _input_source_map(
+    *,
+    ports: dict[str, dict[str, list[_Port]]],
+    dataflow: list[dict[str, Any]],
+    models: dict[str, Any],
+    decoder_name: str,
+    image_endpoints: set[str],
+) -> dict[str, dict[str, Any]]:
+    incoming = {edge["to"]: edge for edge in dataflow}
+    sources: dict[str, dict[str, Any]] = {}
+    for component, component_ports in ports.items():
+        for port in component_ports["inputs"]:
+            endpoint = f"{component}.{port.name}"
+            edge = incoming.get(endpoint)
+            if edge is not None:
+                sources[endpoint] = {"kind": "dataflow", "from": edge["from"]}
+            elif endpoint in image_endpoints:
+                sources[endpoint] = {
+                    "kind": "generated",
+                    "generator": "image_preprocessing",
+                }
+            else:
+                sources[endpoint] = {"kind": "external", "input": "request"}
+
+    decoder_io = models[decoder_name]["io"]
+    generated_ports = {
+        decoder_io.get("attention_mask_input"): "attention_mask",
+        decoder_io.get("position_ids_input"): "positions",
+    }
+    for port, generator in generated_ports.items():
+        if port is not None:
+            sources[f"{decoder_name}.{port}"] = {
+                "kind": "generated",
+                "generator": generator,
+            }
+
+    for input_name, output_name in zip(
+        decoder_io.get("kv_inputs", []),
+        decoder_io.get("kv_outputs", []),
+    ):
+        sources[f"{decoder_name}.{input_name}"] = {
+            "kind": "stateful",
+            "from": f"{decoder_name}.{output_name}",
+            "update": decoder_io.get("kv_update", "append"),
+        }
+    for pair in decoder_io.get("state_pairs", []):
+        sources[f"{decoder_name}.{pair['input']}"] = {
+            "kind": "stateful",
+            "from": f"{decoder_name}.{pair['output']}",
+            "update": pair["update"],
+        }
+    return sources
+
+
+def _annotate_component_inputs(
+    models: dict[str, Any],
+    sources: dict[str, dict[str, Any]],
+) -> None:
+    for component, model in models.items():
+        for port in model["io"]["inputs"]:
+            port["source"] = sources[f"{component}.{port['name']}"]
+
+
+def _closure_error(endpoint: str, why: str, how: str) -> ValueError:
+    return ValueError(
+        f"What: executable metadata closure is invalid at '{endpoint}'. "
+        f"Why: {why} How to fix: {how}"
+    )
+
+
+def validate_executable_closure(pkg: Any, metadata: dict[str, Any]) -> None:
+    """Reject a native sidecar that cannot bind every real graph input exactly once."""
+    pipeline = metadata.get("pipeline")
+    if not isinstance(pipeline, dict):
+        raise _closure_error(
+            "pipeline.models",
+            "the metadata has no pipeline object.",
+            "emit the native multi-model pipeline contract before packaging.",
+        )
+    declared_models = pipeline.get("models")
+    if not isinstance(declared_models, dict):
+        raise _closure_error(
+            "pipeline.models",
+            "the metadata has no component declarations.",
+            "emit one pipeline.models entry for every ONNX graph.",
+        )
+
+    graph_ports = {
+        component: {
+            "inputs": {_port(value).name: _port(value) for value in model.graph.inputs},
+            "outputs": {_port(value).name: _port(value) for value in model.graph.outputs},
+        }
+        for component, model in pkg.items()
+    }
+    incoming: dict[str, list[dict[str, Any]]] = {}
+    for edge in pipeline.get("dataflow", []):
+        source_endpoint = edge.get("from")
+        target_endpoint = edge.get("to")
+        if not isinstance(source_endpoint, str) or not isinstance(target_endpoint, str):
+            raise _closure_error(
+                "pipeline.dataflow",
+                "a dataflow edge does not declare string from/to endpoints.",
+                "emit every edge as exact component.output and component.input endpoints.",
+            )
+        source_component, separator, source_name = source_endpoint.partition(".")
+        target_component, target_separator, target_name = target_endpoint.partition(".")
+        if not separator or not target_separator:
+            raise _closure_error(
+                target_endpoint,
+                "the edge endpoint is not in component.port form.",
+                "emit exact component.output and component.input endpoints.",
+            )
+        source = graph_ports.get(source_component, {}).get("outputs", {}).get(source_name)
+        target = graph_ports.get(target_component, {}).get("inputs", {}).get(target_name)
+        if source is None:
+            raise _closure_error(
+                source_endpoint,
+                "the declared producer is not an output of its ONNX graph.",
+                "regenerate dataflow from the saved graph outputs.",
+            )
+        if target is None:
+            raise _closure_error(
+                target_endpoint,
+                "the declared consumer is not an input of its ONNX graph.",
+                "regenerate dataflow from the saved graph inputs.",
+            )
+        if source.dtype != target.dtype or source.rank != target.rank:
+            raise _closure_error(
+                target_endpoint,
+                f"edge {source_endpoint} has dtype/rank {source.dtype}/{source.rank}, "
+                f"but the consumer requires {target.dtype}/{target.rank}.",
+                "insert an explicit typed transform or remove the incompatible edge.",
+            )
+        if edge.get("dtype") != source.dtype or edge.get("rank") != source.rank:
+            raise _closure_error(
+                target_endpoint,
+                f"the edge declares dtype/rank {edge.get('dtype')}/{edge.get('rank')}, "
+                f"but the ONNX ports are {source.dtype}/{source.rank}.",
+                "derive edge dtype and rank directly from the matched graph ports.",
+            )
+        incoming.setdefault(target_endpoint, []).append(edge)
+
+    for component, component_ports in graph_ports.items():
+        model = declared_models.get(component)
+        if not isinstance(model, dict) or not isinstance(model.get("io"), dict):
+            first_port = next(iter(component_ports["inputs"]), "<io>")
+            raise _closure_error(
+                f"{component}.{first_port}",
+                "the component has no explicit io contract.",
+                "emit typed inputs and outputs from ONNX graph introspection.",
+            )
+        io = model["io"]
+        input_specs = io.get("inputs")
+        output_specs = io.get("outputs")
+        if not isinstance(input_specs, list) or not isinstance(output_specs, list):
+            first_port = next(iter(component_ports["inputs"]), "<io>")
+            raise _closure_error(
+                f"{component}.{first_port}",
+                "the component io contract does not contain typed input/output lists.",
+                "emit name, dtype, rank, and shape for every real graph port.",
+            )
+        declared_inputs = {
+            spec.get("name"): spec for spec in input_specs if isinstance(spec, dict)
+        }
+        declared_outputs = {
+            spec.get("name"): spec for spec in output_specs if isinstance(spec, dict)
+        }
+        for direction, real_ports, declared in (
+            ("input", component_ports["inputs"], declared_inputs),
+            ("output", component_ports["outputs"], declared_outputs),
+        ):
+            if set(declared) != set(real_ports):
+                missing = sorted(set(real_ports) - set(declared))
+                extra = sorted(set(declared) - set(real_ports))
+                port = (missing or extra or ["<io>"])[0]
+                raise _closure_error(
+                    f"{component}.{port}",
+                    f"declared {direction} ports differ from the ONNX graph "
+                    f"(missing={missing}, extra={extra}).",
+                    "regenerate component io from the packaged ONNX graph.",
+                )
+            for name, real in real_ports.items():
+                spec = declared[name]
+                if (
+                    spec.get("dtype") != real.dtype
+                    or spec.get("rank") != real.rank
+                    or spec.get("shape") != _shape_metadata(real)
+                ):
+                    raise _closure_error(
+                        f"{component}.{name}",
+                        "the declared dtype, rank, or shape does not match the ONNX graph.",
+                        "regenerate the typed port declaration from graph introspection.",
+                    )
+
+        for name in component_ports["inputs"]:
+            endpoint = f"{component}.{name}"
+            spec = declared_inputs[name]
+            edges = incoming.get(endpoint, [])
+            source = spec.get("source")
+            if not isinstance(source, dict):
+                raise _closure_error(
+                    endpoint,
+                    "the required graph input has no declared source classification.",
+                    "classify it as external, generated, stateful, defaulted, or dataflow.",
+                )
+            kind = source.get("kind")
+            if kind == "dataflow":
+                if len(edges) != 1 or source.get("from") != edges[0]["from"]:
+                    raise _closure_error(
+                        endpoint,
+                        f"the input declares dataflow source {source.get('from')!r}, "
+                        f"but {len(edges)} matching edge(s) exist.",
+                        "emit exactly one compatible edge and reference its producer.",
+                    )
+            elif kind in {"external", "generated", "stateful", "defaulted"}:
+                if edges:
+                    raise _closure_error(
+                        endpoint,
+                        f"the input is classified as {kind!r} but also has a dataflow edge.",
+                        "keep exactly one source category for every required graph input.",
+                    )
+                if kind == "defaulted" and "value" not in source:
+                    raise _closure_error(
+                        endpoint,
+                        "a defaulted input does not declare its default value.",
+                        "emit the explicit typed default value or use another source category.",
+                    )
+            else:
+                raise _closure_error(
+                    endpoint,
+                    f"the source category {kind!r} is not executable.",
+                    "use external, generated, stateful, defaulted, or dataflow.",
+                )
 
 
 def _topological_order(
@@ -856,20 +1156,31 @@ def build_native_vlm_package_metadata(
         for name, model in pkg.items()
     }
     dataflow: list[dict[str, Any]] = []
-    for source_name, source_ports in ports.items():
-        output_by_name = {port.name: port for port in source_ports["outputs"]}
-        for target_name, target_ports in ports.items():
-            if source_name == target_name:
-                continue
-            for target_port in target_ports["inputs"]:
-                source_port = output_by_name.get(target_port.name)
-                if source_port is None or source_port.dtype != target_port.dtype:
-                    continue
+    for target_name, target_ports in ports.items():
+        for target_port in target_ports["inputs"]:
+            matches = [
+                (source_name, source_port)
+                for source_name, source_ports in ports.items()
+                if source_name != target_name
+                for source_port in source_ports["outputs"]
+                if source_port.name == target_port.name
+                and _ports_match_for_dataflow(source_port, target_port)
+            ]
+            if len(matches) > 1:
+                producers = [f"{name}.{port.name}" for name, port in matches]
+                raise _closure_error(
+                    f"{target_name}.{target_port.name}",
+                    f"multiple compatible graph outputs could feed this input: {producers}.",
+                    "declare a unique structural producer or rename the ambiguous graph ports.",
+                )
+            if matches:
+                source_name, source_port = matches[0]
                 dataflow.append(
                     {
                         "from": f"{source_name}.{source_port.name}",
                         "to": f"{target_name}.{target_port.name}",
                         "dtype": source_port.dtype,
+                        "rank": source_port.rank,
                         "device_transfer": False,
                     }
                 )
@@ -887,8 +1198,9 @@ def build_native_vlm_package_metadata(
     preprocessing_outputs = []
     processor_summaries = []
     for port, content, pad_value in image_program.bindings:
+        endpoint = f"vision_encoder.{port.name}"
         output: dict[str, Any] = {
-            "name": port.name,
+            "name": endpoint,
             "content": content,
             "dtype": port.dtype,
         }
@@ -896,15 +1208,17 @@ def build_native_vlm_package_metadata(
             output["pad_value"] = pad_value
         preprocessing_outputs.append(output)
         if content in image_program.summary_contents:
-            processor_summaries.append(port.name)
+            processor_summaries.append(endpoint)
 
     if positions is not None and positions["rank"] > 1 and processor_summaries:
         positions["processor_summaries"] = processor_summaries
 
+    sequence_decoder_inputs = _sequence_decoder_inputs(ports[decoder_name])
     downstream_to_decoder = {
         edge["from"].split(".", 1)[0]
         for edge in dataflow
         if edge["to"].startswith(f"{decoder_name}.")
+        and edge["to"].split(".", 1)[1] in sequence_decoder_inputs
     }
     models: dict[str, Any] = {}
     phases: dict[str, Any] = {}
@@ -917,16 +1231,27 @@ def build_native_vlm_package_metadata(
             role = "vision_encoder"
             run_on = "prompt_only"
             io = {
-                "inputs": [port.name for port in ports[name]["inputs"]],
-                "outputs": [port.name for port in ports[name]["outputs"]],
+                "inputs": [_port_metadata(port) for port in ports[name]["inputs"]],
+                "outputs": [_port_metadata(port) for port in ports[name]["outputs"]],
             }
         else:
-            role = "encoder"
+            role = "audio_encoder" if name == "audio_encoder" else "encoder"
             run_on = "every_step" if name in downstream_to_decoder else "prompt_only"
             io = {
-                "inputs": [port.name for port in ports[name]["inputs"]],
-                "outputs": [port.name for port in ports[name]["outputs"]],
+                "inputs": [_port_metadata(port) for port in ports[name]["inputs"]],
+                "outputs": [_port_metadata(port) for port in ports[name]["outputs"]],
             }
+            if run_on == "every_step":
+                token_input = _component_token_input(ports[name])
+                if token_input is None:
+                    raise _closure_error(
+                        f"{name}.<token_input>",
+                        "the sequence-dependent component must run every step, but its "
+                        "graph does not expose one structurally unique rank-2 integer token input.",
+                        "declare a unique token-stream input or add a structural registry entry.",
+                    )
+                io["token_input"] = token_input.name
+                io["sequence_source"] = "token_ids"
         models[name] = {
             "filename": filenames[name],
             "type": role,
@@ -935,6 +1260,18 @@ def build_native_vlm_package_metadata(
         if name == decoder_name:
             models[name]["tokenizer"] = "tokenizer.json"
         phases[name] = {"run_on": run_on}
+
+    image_endpoints = {
+        output["name"] for output in preprocessing_outputs if not output.get("optional", False)
+    }
+    sources = _input_source_map(
+        ports=ports,
+        dataflow=dataflow,
+        models=models,
+        decoder_name=decoder_name,
+        image_endpoints=image_endpoints,
+    )
+    _annotate_component_inputs(models, sources)
 
     stages = []
     for name in _topological_order(pkg.keys(), dataflow):
@@ -994,6 +1331,7 @@ def build_native_vlm_package_metadata(
     }
     if positions is not None:
         metadata["pipeline"]["positions"] = positions
+    validate_executable_closure(pkg, metadata)
     return metadata
 
 

--- a/src/mobius/integrations/onnx_genai/inference_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata_test.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import copy
 import dataclasses
 import json
 import math
@@ -26,6 +27,7 @@ from mobius.integrations.onnx_genai.inference_metadata import (
     build_tts_pipeline_metadata,
     is_native_vlm_package,
     load_diffusers_scheduler_config,
+    validate_executable_closure,
     write_diffusion_pipeline_metadata,
     write_native_vlm_package_metadata,
     write_tts_pipeline_metadata,
@@ -133,6 +135,7 @@ def _decoder_model(
     raw_token_input: bool = False,
     fixed_state: bool = False,
     equal_kv_shape: bool = False,
+    kv_head_dims: list[int] | None = None,
 ) -> ir.Model:
     inputs = [_value(name, dtype, shape) for name, dtype, shape in routed_inputs]
     inputs.extend(
@@ -147,37 +150,35 @@ def _decoder_model(
     )
     if raw_token_input:
         inputs.append(_value("input_ids", ir.DataType.INT64, ["batch", "sequence"]))
-    inputs.extend(
-        [
-            _value(
-                "past_key_values.0.key",
-                ir.DataType.FLOAT,
-                ["batch", 2, "past_sequence", 8],
-            ),
-            _value(
-                "past_key_values.0.value",
-                ir.DataType.FLOAT,
-                ["batch", 2, "past_sequence", 8],
-            ),
-        ]
-    )
-    output_specs = [
-        ("logits", ir.DataType.FLOAT, ["batch", "sequence", 128]),
-        (
-            "present.0.key",
-            ir.DataType.FLOAT,
-            ["batch", 2, "past_sequence", 8]
+    kv_head_dims = kv_head_dims or [8]
+    for layer, head_dim in enumerate(kv_head_dims):
+        inputs.extend(
+            [
+                _value(
+                    f"past_key_values.{layer}.key",
+                    ir.DataType.FLOAT,
+                    ["batch", 2, "past_sequence", head_dim],
+                ),
+                _value(
+                    f"past_key_values.{layer}.value",
+                    ir.DataType.FLOAT,
+                    ["batch", 2, "past_sequence", head_dim],
+                ),
+            ]
+        )
+    output_specs = [("logits", ir.DataType.FLOAT, ["batch", "sequence", 128])]
+    for layer, head_dim in enumerate(kv_head_dims):
+        output_shape = (
+            ["batch", 2, "past_sequence", head_dim]
             if equal_kv_shape
-            else ["batch", 2, "total_sequence", 8],
-        ),
-        (
-            "present.0.value",
-            ir.DataType.FLOAT,
-            ["batch", 2, "past_sequence", 8]
-            if equal_kv_shape
-            else ["batch", 2, "total_sequence", 8],
-        ),
-    ]
+            else ["batch", 2, "total_sequence", head_dim]
+        )
+        output_specs.extend(
+            [
+                (f"present.{layer}.key", ir.DataType.FLOAT, output_shape),
+                (f"present.{layer}.value", ir.DataType.FLOAT, output_shape),
+            ]
+        )
     if fixed_state:
         inputs.extend(
             [
@@ -253,8 +254,26 @@ def _assert_all_graph_ports_declared(
     assert set(models) == set(package)
     for name, model in package.items():
         io = models[name]["io"]
-        assert io["inputs"] == [value.name for value in model.graph.inputs]
-        assert io["outputs"] == [value.name for value in model.graph.outputs]
+        assert [port["name"] for port in io["inputs"]] == [
+            value.name for value in model.graph.inputs
+        ]
+        assert [port["name"] for port in io["outputs"]] == [
+            value.name for value in model.graph.outputs
+        ]
+        for port, value in zip(io["inputs"], model.graph.inputs):
+            assert (
+                port["dtype"]
+                == {
+                    ir.DataType.FLOAT: "fp32",
+                    ir.DataType.FLOAT16: "fp16",
+                    ir.DataType.INT64: "int64",
+                    ir.DataType.BOOL: "bool",
+                }[value.dtype]
+            )
+            assert port["rank"] == len(value.shape)
+            assert "source" in port
+        for port, value in zip(io["outputs"], model.graph.outputs):
+            assert port["rank"] == len(value.shape)
 
 
 class TestNativeVlmPackageMetadata:
@@ -291,6 +310,7 @@ class TestNativeVlmPackageMetadata:
                     ],
                     position_shape=["batch", "sequence"],
                     raw_token_input=True,
+                    kv_head_dims=[8, 16, 8],
                 ),
                 "vision_encoder": _model(
                     "vision_encoder",
@@ -326,7 +346,35 @@ class TestNativeVlmPackageMetadata:
                             ir.DataType.FLOAT,
                             ["batch", "sequence", 128],
                         ),
-                    ]
+                    ],
+                    include_audio=True,
+                ),
+                "audio_encoder": _model(
+                    "audio_encoder",
+                    [
+                        _value(
+                            "input_features",
+                            ir.DataType.FLOAT,
+                            ["batch", "time", 128],
+                        ),
+                        _value(
+                            "input_features_mask",
+                            ir.DataType.BOOL,
+                            ["batch", "time"],
+                        ),
+                    ],
+                    [
+                        (
+                            "audio_features",
+                            ir.DataType.FLOAT,
+                            ["batch", "audio_sequence", 64],
+                        ),
+                        (
+                            "audio_features_mask",
+                            ir.DataType.BOOL,
+                            ["batch", "audio_sequence"],
+                        ),
+                    ],
                 ),
             },
             config=config,
@@ -354,6 +402,7 @@ class TestNativeVlmPackageMetadata:
         metadata = build_native_vlm_package_metadata(
             package, config=config, source=str(source)
         )
+        validate_executable_closure(package, metadata)
         self._validate(metadata)
         _assert_all_graph_ports_declared(package, metadata)
         flow = metadata["pipeline"]["dataflow"]
@@ -361,15 +410,31 @@ class TestNativeVlmPackageMetadata:
             "from": "embedding.inputs_embeds",
             "to": "decoder.inputs_embeds",
             "dtype": "fp32",
+            "rank": 3,
             "device_transfer": False,
         } in flow
         assert {
             "from": "embedding.per_layer_inputs",
             "to": "decoder.per_layer_inputs",
             "dtype": "fp32",
+            "rank": 3,
             "device_transfer": False,
         } in flow
+        assert not any(edge["from"] == "audio_encoder.audio_features" for edge in flow)
+        embedding_audio = next(
+            port
+            for port in metadata["pipeline"]["models"]["embedding"]["io"]["inputs"]
+            if port["name"] == "audio_features"
+        )
+        assert embedding_audio["source"] == {"kind": "external", "input": "request"}
         assert metadata["pipeline"]["phases"]["embedding"] == {"run_on": "every_step"}
+        embedding_stage = next(
+            stage
+            for stage in metadata["pipeline"]["strategy"]["stages"]
+            if stage["strategy"].get("model") == "embedding"
+        )
+        assert embedding_stage["run_on"] == "every_step"
+        assert metadata["pipeline"]["models"]["embedding"]["io"]["token_input"] == "input_ids"
         assert metadata["pipeline"]["vision"]["token_count_source"] == "from_coordinates"
         assert metadata["pipeline"]["vision"]["token_pooling_factor"] == 9
         transforms = metadata["preprocessing"]["image"]["transforms"]
@@ -389,6 +454,46 @@ class TestNativeVlmPackageMetadata:
         )
         assert not any(transform["op"] == "normalize" for transform in transforms)
         assert metadata["model"]["io"]["token_input"] == "input_ids"
+        assert metadata["model"]["io"]["kv_inputs"] == [
+            f"past_key_values.{layer}.{role}"
+            for layer in range(3)
+            for role in ("key", "value")
+        ]
+        assert metadata["model"]["io"]["kv_outputs"] == [
+            f"present.{layer}.{role}" for layer in range(3) for role in ("key", "value")
+        ]
+        kv_inputs = {
+            port["name"]: port
+            for port in metadata["pipeline"]["models"]["decoder"]["io"]["inputs"]
+            if port["name"].startswith("past_key_values.")
+        }
+        assert kv_inputs["past_key_values.1.key"]["shape"][-1] == 16
+        image_outputs = metadata["preprocessing"]["image"]["outputs"]
+        assert image_outputs == [
+            {
+                "name": "vision_encoder.pixel_values",
+                "content": "pixels",
+                "dtype": "fp32",
+            },
+            {
+                "name": "vision_encoder.pixel_position_ids",
+                "content": "patch_coordinates",
+                "dtype": "int64",
+                "pad_value": -1,
+            },
+        ]
+
+        broken = copy.deepcopy(metadata)
+        broken["pipeline"]["dataflow"] = [
+            edge
+            for edge in broken["pipeline"]["dataflow"]
+            if edge["to"] != "decoder.per_layer_inputs"
+        ]
+        with pytest.raises(
+            ValueError,
+            match=r"What:.*decoder\.per_layer_inputs.*Why:.*How to fix:",
+        ):
+            validate_executable_closure(package, broken)
 
     def test_qwen_packed_grid_rank3_positions_sparse_and_fixed_state(self, tmp_path):
         config = _VlmConfig(
@@ -484,7 +589,7 @@ class TestNativeVlmPackageMetadata:
             "continuation": "from_grid",
             "axes": ["temporal", "height", "width"],
             "sections": [16, 24, 24],
-            "processor_summaries": ["image_grid_thw"],
+            "processor_summaries": ["vision_encoder.image_grid_thw"],
         }
         io = metadata["model"]["io"]
         assert io["kv_inputs"] == [
@@ -619,6 +724,7 @@ class TestNativeVlmPackageMetadata:
                 "from": f"embedding.{gate}",
                 "to": f"decoder.{gate}",
                 "dtype": "fp32",
+                "rank": 0,
                 "device_transfer": False,
             } in flow
         outputs = metadata["preprocessing"]["image"]["outputs"]
@@ -982,7 +1088,7 @@ class TestNativeVlmPackageMetadata:
             for output in metadata["preprocessing"]["image"]["outputs"]
             if output["content"] == "transformed_size"
         )
-        assert size_output["name"] == "image_sizes"
+        assert size_output["name"] == "vision_encoder.image_sizes"
         assert float(reference["image_attention_mask"].min()) == pytest.approx(0)
         assert float(reference["image_attention_mask"].max()) == pytest.approx(1)
 


### PR DESCRIPTION
## Summary
- emit typed graph-derived inputs/outputs for every native VLM component, including source classification and exact sparse KV ports
- route every compatible sequence edge (including `per_layer_inputs`) and run sequence-producing embedding stages on every decode step
- emit qualified typed image endpoints/transforms and validate executable closure before writing the sidecar
- reject missing/duplicate input sources and dtype/rank-incompatible edges with actionable `component.port` errors

The real Gemma4 audio output is rank 3 while the embedding input is rank 2, so the old invalid edge is no longer guessed; the embedding audio port is explicitly external until optional-modality/typed-audio transform semantics land.

## Validation
- `PYTHONPATH=$PWD/src python3 -m pytest src/mobius/integrations/onnx_genai/inference_metadata_test.py tests/cli_test.py -q` — 62 passed
- `lintrunner` 0.12.7 with repository Ruff 0.15.14 adapters — clean
- offline optimized Gemma4 E2B fp16 export — closure validator passed against all four saved ONNX graphs
- verified 15 K/V layers (30 inputs/30 outputs), mixed 256/512 head dimensions, fp16 pixels + int64 patch coordinates, both embedding→decoder edges, and embedding `every_step`