### PR TITLE
Emit Gemma4 optional audio modality contract

### DIFF
--- a/src/mobius/_pipeline_contract.py
+++ b/src/mobius/_pipeline_contract.py
@@ -1,0 +1,75 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Declarations carried by exported ONNX graphs for pipeline metadata emission."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from typing import Any
+
+import onnx_ir as ir
+
+_COMPONENT_PRESENCE = "mobius.pipeline.when_present"
+_OPTIONAL_INPUT_PRESENCE = "mobius.pipeline.optional_input.presence"
+_OPTIONAL_INPUT_ABSENT_SHAPE = "mobius.pipeline.optional_input.absent_shape"
+
+
+def declare_component_presence(graph: ir.Graph, presence: str) -> None:
+    """Declare the opaque presence key required to execute a component graph."""
+    if not presence:
+        raise ValueError("Component presence key must be non-empty")
+    graph.metadata_props[_COMPONENT_PRESENCE] = presence
+
+
+def component_presence(graph: Any) -> str | None:
+    """Return a component graph's declared presence key, if any."""
+    presence = getattr(graph, "metadata_props", {}).get(_COMPONENT_PRESENCE)
+    return presence or None
+
+
+def declare_optional_input(
+    value: ir.Value,
+    *,
+    presence: str,
+    absent_shape: Sequence[int | str],
+) -> None:
+    """Declare a zero fallback for an optional ONNX graph input."""
+    if not presence:
+        raise ValueError("Optional-input presence key must be non-empty")
+    shape = list(absent_shape)
+    if not shape or any(isinstance(dim, int) and dim < 0 for dim in shape):
+        raise ValueError("Optional-input absent shape must contain non-negative dimensions")
+    value.metadata_props[_OPTIONAL_INPUT_PRESENCE] = presence
+    value.metadata_props[_OPTIONAL_INPUT_ABSENT_SHAPE] = json.dumps(shape)
+
+
+def optional_input_contract(value: Any) -> dict[str, Any] | None:
+    """Return the executable optional-input contract declared on a graph input."""
+    metadata = getattr(value, "metadata_props", {})
+    presence = metadata.get(_OPTIONAL_INPUT_PRESENCE)
+    absent_shape = metadata.get(_OPTIONAL_INPUT_ABSENT_SHAPE)
+    if presence is None and absent_shape is None:
+        return None
+    if not presence or absent_shape is None:
+        raise ValueError(
+            f"ONNX input {value.name!r} has an incomplete optional-input declaration"
+        )
+    try:
+        shape = json.loads(absent_shape)
+    except (TypeError, json.JSONDecodeError) as error:
+        raise ValueError(
+            f"ONNX input {value.name!r} has an invalid optional-input absent shape"
+        ) from error
+    if not isinstance(shape, list) or not shape:
+        raise ValueError(
+            f"ONNX input {value.name!r} optional-input absent shape must be a non-empty list"
+        )
+    return {
+        "presence": presence,
+        "absent": {
+            "kind": "zeros",
+            "shape": shape,
+        },
+    }

--- a/src/mobius/integrations/onnx_genai/inference_metadata.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata.py
@@ -42,6 +42,8 @@ from typing import Any
 
 import yaml
 
+from mobius._pipeline_contract import component_presence, optional_input_contract
+
 _LOGGER = logging.getLogger(__name__)
 
 _RUNTIME_ASSET_NAMES = (
@@ -1257,9 +1259,18 @@ def build_native_vlm_package_metadata(
             "type": role,
             "io": io,
         }
+        optional_inputs = {
+            value.name: contract
+            for value in pkg[name].graph.inputs
+            if (contract := optional_input_contract(value)) is not None
+        }
+        if optional_inputs:
+            io["optional_inputs"] = optional_inputs
         if name == decoder_name:
             models[name]["tokenizer"] = "tokenizer.json"
         phases[name] = {"run_on": run_on}
+        if presence := component_presence(pkg[name].graph):
+            phases[name]["when_present"] = presence
 
     image_endpoints = {
         output["name"] for output in preprocessing_outputs if not output.get("optional", False)

--- a/src/mobius/integrations/onnx_genai/inference_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata_test.py
@@ -18,6 +18,10 @@ import pytest
 import yaml
 
 from mobius._model_package import ModelPackage
+from mobius._pipeline_contract import (
+    declare_component_presence,
+    declare_optional_input,
+)
 from mobius.integrations.onnx_genai.inference_metadata import (
     SchedulerConfig,
     build_diffusion_pipeline_metadata,
@@ -118,13 +122,21 @@ def _embedding_model(
     outputs: list[tuple[str, ir.DataType, list[int | str]]],
     *,
     include_audio: bool = False,
+    optional_audio: bool = False,
 ) -> ir.Model:
     inputs = [
         _value("input_ids", ir.DataType.INT64, ["batch", "sequence"]),
         _value("image_features", ir.DataType.FLOAT, ["image_tokens", 64]),
     ]
     if include_audio:
-        inputs.append(_value("audio_features", ir.DataType.FLOAT, ["audio_tokens", 64]))
+        audio_features = _value("audio_features", ir.DataType.FLOAT, ["audio_tokens", 64])
+        if optional_audio:
+            declare_optional_input(
+                audio_features,
+                presence="audio",
+                absent_shape=[0, 64],
+            )
+        inputs.append(audio_features)
     return _model("embedding", inputs, outputs)
 
 
@@ -348,6 +360,7 @@ class TestNativeVlmPackageMetadata:
                         ),
                     ],
                     include_audio=True,
+                    optional_audio=True,
                 ),
                 "audio_encoder": _model(
                     "audio_encoder",
@@ -367,7 +380,7 @@ class TestNativeVlmPackageMetadata:
                         (
                             "audio_features",
                             ir.DataType.FLOAT,
-                            ["batch", "audio_sequence", 64],
+                            ["audio_tokens", 64],
                         ),
                         (
                             "audio_features_mask",
@@ -379,6 +392,7 @@ class TestNativeVlmPackageMetadata:
             },
             config=config,
         )
+        declare_component_presence(package["audio_encoder"].graph, "audio")
 
         source = tmp_path / "gemma"
         source.mkdir()
@@ -402,6 +416,7 @@ class TestNativeVlmPackageMetadata:
         metadata = build_native_vlm_package_metadata(
             package, config=config, source=str(source)
         )
+        emitted_yaml = yaml.safe_load(yaml.safe_dump(metadata, sort_keys=False))
         validate_executable_closure(package, metadata)
         self._validate(metadata)
         _assert_all_graph_ports_declared(package, metadata)
@@ -420,13 +435,38 @@ class TestNativeVlmPackageMetadata:
             "rank": 3,
             "device_transfer": False,
         } in flow
-        assert not any(edge["from"] == "audio_encoder.audio_features" for edge in flow)
+        assert {
+            "from": "audio_encoder.audio_features",
+            "to": "embedding.audio_features",
+            "dtype": "fp32",
+            "rank": 2,
+            "device_transfer": False,
+        } in flow
         embedding_audio = next(
             port
             for port in metadata["pipeline"]["models"]["embedding"]["io"]["inputs"]
             if port["name"] == "audio_features"
         )
-        assert embedding_audio["source"] == {"kind": "external", "input": "request"}
+        assert embedding_audio["source"] == {
+            "kind": "dataflow",
+            "from": "audio_encoder.audio_features",
+        }
+        assert emitted_yaml["pipeline"]["models"]["embedding"]["io"]["optional_inputs"] == {
+            "audio_features": {
+                "presence": "audio",
+                "absent": {"kind": "zeros", "shape": [0, 64]},
+            }
+        }
+        assert emitted_yaml["pipeline"]["phases"]["audio_encoder"] == {
+            "run_on": "prompt_only",
+            "when_present": "audio",
+        }
+        audio_stage = next(
+            stage
+            for stage in metadata["pipeline"]["strategy"]["stages"]
+            if stage["strategy"].get("model") == "audio_encoder"
+        )
+        assert audio_stage["run_on"] == "prompt_only"
         assert metadata["pipeline"]["phases"]["embedding"] == {"run_on": "every_step"}
         embedding_stage = next(
             stage

--- a/src/mobius/tasks/_gemma4.py
+++ b/src/mobius/tasks/_gemma4.py
@@ -27,6 +27,10 @@ from onnxscript import GraphBuilder, nn
 from mobius._build_context import ep_capabilities
 from mobius._configs import Gemma4Config
 from mobius._model_package import ModelPackage
+from mobius._pipeline_contract import (
+    declare_component_presence,
+    declare_optional_input,
+)
 from mobius.tasks._base import (
     ModelTask,
     _make_graph,
@@ -192,9 +196,8 @@ class Gemma4Task(ModelTask):
         (``True``) vs padding (``False``), always contiguous
         (right-padded).  The mask is downsampled through two conv layers
         (stride 2 each → ``T//4``) and used to zero out padding in
-        Conformer attention.  The downsampled mask is returned as
-        ``audio_features_mask [B, T//4]`` so callers can strip padding
-        rows before scattering into text embeddings.
+        Conformer attention. The export strips padding inside the ONNX
+        graph and returns ``audio_features [num_valid, hidden_size]``.
 
     **Decoder** — standard ``attention_mask`` for KV cache padding.
         ``attention_mask [B, past+current]`` is a 1/0 int mask indicating
@@ -380,10 +383,10 @@ class Gemma4Task(ModelTask):
           positions in Conformer attention.
 
         Outputs:
-        - ``audio_features [batch, time//4, text_hidden_size]``: encoded tokens
+        - ``audio_features [num_valid, text_hidden_size]``: encoded tokens with
+          padded rows removed in batch-major order
         - ``audio_features_mask [batch, time//4]``: BOOL downsampled mask
-          indicating which output positions are valid (for stripping
-          padding rows before scattering into text embeddings)
+          retained for diagnostics and backwards compatibility
         """
         batch = ir.SymbolicDim("batch")
         time = ir.SymbolicDim("time")
@@ -408,11 +411,25 @@ class Gemma4Task(ModelTask):
             input_features,
             input_features_mask=input_features_mask,
         )
+        if downsampled_mask is None:
+            raise ValueError("Gemma4 audio encoder must return a downsampled validity mask")
+        flattened_features = op.Reshape(
+            audio_features,
+            op.Constant(value_ints=[-1, config.hidden_size]),
+        )
+        flattened_mask = op.Reshape(
+            downsampled_mask,
+            op.Constant(value_ints=[-1]),
+        )
+        flattened_features_f32 = op.Cast(flattened_features, to=ir.DataType.FLOAT)
+        audio_features = op.CastLike(
+            op.Compress(flattened_features_f32, flattened_mask, axis=0),
+            flattened_features,
+        )
         builder.add_output(audio_features, "audio_features")
+        builder.add_output(downsampled_mask, "audio_features_mask")
 
-        if downsampled_mask is not None:
-            builder.add_output(downsampled_mask, "audio_features_mask")
-
+        declare_component_presence(graph, "audio")
         return _make_model(graph)
 
     def _build_embedding(
@@ -447,6 +464,11 @@ class Gemma4Task(ModelTask):
                 "audio_features",
                 dtype=config.dtype,
                 shape=[num_audio_tokens, config.hidden_size],
+            )
+            declare_optional_input(
+                audio_features_val,
+                presence="audio",
+                absent_shape=[0, config.hidden_size],
             )
 
         result = embedding(
@@ -568,4 +590,5 @@ class Gemma4UnifiedTask(Gemma4Task):
             input_features_mask=input_features_mask,
         )
         builder.add_output(audio_features, "audio_features")
+        declare_component_presence(graph, "audio")
         return _make_model(graph)

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import re
 
+import ml_dtypes
 import numpy as np
 import onnx_ir as ir
 import pytest
@@ -1689,6 +1690,7 @@ class TestBuildGraphVisionLanguage:
         [
             (ir.DataType.FLOAT, np.float32),
             (ir.DataType.FLOAT16, np.float16),
+            (ir.DataType.BFLOAT16, ml_dtypes.bfloat16),
         ],
     )
     def test_gemma4_audio_encoder_strips_padding_in_graph(self, dtype, np_dtype):
@@ -1725,6 +1727,7 @@ class TestBuildGraphVisionLanguage:
             outputs["audio_features"],
             np.concatenate([features[0, :2], features[1, :1]], axis=0),
         )
+        assert outputs["audio_features"].dtype == np.dtype(np_dtype)
 
     def test_gemma4_unified_multimodal_graph(self):
         """Build gemma4_unified (gemma-4-12B) encoder-free multimodal model.

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -61,6 +61,7 @@ from mobius._configs import (
     VisionConfig,
 )
 from mobius._optimizations import SymbolicShapeInferencePass
+from mobius._pipeline_contract import component_presence, optional_input_contract
 from mobius._registry import registry
 from mobius.tasks import (
     CausalLMTask,
@@ -1238,7 +1239,7 @@ class TestBuildGraphVisionLanguage:
         module = model_cls(config)
         task_name = _default_task_for_model("gemma4")
         task = get_task(task_name)
-        pkg = task.build(module, config)
+        pkg = build_from_module(module, config, task=task)
 
         assert set(pkg.keys()) == {"decoder", "vision_encoder", "embedding"}, (
             f"Vision-only Gemma4 should produce 3 models, got: {set(pkg.keys())}"
@@ -1660,13 +1661,21 @@ class TestBuildGraphVisionLanguage:
         audio_input_names = {i.name for i in audio.graph.inputs}
         assert "input_features" in audio_input_names
         assert "input_features_mask" in audio_input_names
-        assert "audio_features" in {o.name for o in audio.graph.outputs}
+        audio_features = next(o for o in audio.graph.outputs if o.name == "audio_features")
+        assert len(audio_features.shape) == 2
+        assert audio_features.shape[-1] == config.hidden_size
+        assert component_presence(audio.graph) == "audio"
         # Embedding: all three inputs
         embedding = pkg["embedding"]
         emb_input_names = {i.name for i in embedding.graph.inputs}
         assert "input_ids" in emb_input_names
         assert "image_features" in emb_input_names
         assert "audio_features" in emb_input_names
+        embedding_audio = next(i for i in embedding.graph.inputs if i.name == "audio_features")
+        assert optional_input_contract(embedding_audio) == {
+            "presence": "audio",
+            "absent": {"kind": "zeros", "shape": [0, config.hidden_size]},
+        }
         assert "inputs_embeds" in {o.name for o in embedding.graph.outputs}
         # KV cache outputs: num_kv_layers = num_hidden_layers - num_kv_shared_layers = 1
         decoder_output_names = {o.name for o in decoder.graph.outputs}
@@ -1674,6 +1683,48 @@ class TestBuildGraphVisionLanguage:
         assert "present.0.value" in decoder_output_names
         assert "present.1.key" not in decoder_output_names  # shared layer excluded
         assert "present.1.value" not in decoder_output_names  # shared layer excluded
+
+    @pytest.mark.parametrize(
+        ("dtype", "np_dtype"),
+        [
+            (ir.DataType.FLOAT, np.float32),
+            (ir.DataType.FLOAT16, np.float16),
+        ],
+    )
+    def test_gemma4_audio_encoder_strips_padding_in_graph(self, dtype, np_dtype):
+        """The exported audio graph produces ordered rank-2 valid feature rows."""
+        from onnxscript import nn
+
+        from mobius._configs import Gemma4AudioConfig, Gemma4Config
+        from mobius._testing.ort_inference import OnnxModelSession
+        from mobius.tasks._gemma4 import Gemma4Task
+
+        class IdentityAudio(nn.Module):
+            def forward(self, op, input_features, input_features_mask=None):
+                return op.Identity(input_features), op.Identity(input_features_mask)
+
+        config = Gemma4Config(
+            hidden_size=4,
+            dtype=dtype,
+            audio=Gemma4AudioConfig(input_size=4),
+        )
+        model = Gemma4Task()._build_audio(IdentityAudio(), config)
+        features = np.arange(24, dtype=np_dtype).reshape(2, 3, 4)
+        mask = np.array([[True, True, False], [True, False, False]])
+
+        session = OnnxModelSession(model)
+        outputs = session.run(
+            {
+                "input_features": features,
+                "input_features_mask": mask,
+            }
+        )
+        session.close()
+
+        np.testing.assert_array_equal(
+            outputs["audio_features"],
+            np.concatenate([features[0, :2], features[1, :1]], axis=0),
+        )
 
     def test_gemma4_unified_multimodal_graph(self):
         """Build gemma4_unified (gemma-4-12B) encoder-free multimodal model.
@@ -1728,7 +1779,7 @@ class TestBuildGraphVisionLanguage:
         model_cls = registry.get("gemma4_unified")
         module = model_cls(config)
         task = get_task(_default_task_for_model("gemma4_unified"))
-        pkg = task.build(module, config)
+        pkg = build_from_module(module, config, task=task)
 
         assert set(pkg.keys()) == {
             "decoder",
@@ -1748,12 +1799,18 @@ class TestBuildGraphVisionLanguage:
         a_inputs = {i.name for i in audio.graph.inputs}
         assert a_inputs == {"input_features", "input_features_mask"}
         assert "audio_features" in {o.name for o in audio.graph.outputs}
+        assert component_presence(audio.graph) == "audio"
 
         # Embedding: fuses both modalities → inputs_embeds (no block_sequence_ids;
         # the decoder derives the bidirectional overlay from input_ids itself)
         embedding = pkg["embedding"]
         e_inputs = {i.name for i in embedding.graph.inputs}
         assert {"input_ids", "image_features", "audio_features"} <= e_inputs
+        embedding_audio = next(i for i in embedding.graph.inputs if i.name == "audio_features")
+        assert optional_input_contract(embedding_audio) == {
+            "presence": "audio",
+            "absent": {"kind": "zeros", "shape": [0, config.hidden_size]},
+        }
         e_outputs = {o.name for o in embedding.graph.outputs}
         assert "inputs_embeds" in e_outputs
         assert "block_sequence_ids" not in e_outputs


### PR DESCRIPTION
## Summary
- declare Gemma4 audio optionality on exported ONNX graph structure and emit io.optional_inputs.audio_features with the frozen audio presence key and zero fallback
- emit phases.audio_encoder.when_present: audio while keeping the strategy stage run_on: prompt_only
- adapt E2B audio features inside the exported audio encoder graph by flattening batch/time and applying the downsampled validity mask with ONNX Compress
- route the resulting rank-2 audio output directly to the rank-2 embedding input; keep gemma4_unified declarations consistent

## Contract

    optional_inputs:
      audio_features:
        presence: audio
        absent:
          kind: zeros
          shape: [0, 1536]
    phases:
      audio_encoder:
        run_on: prompt_only
        when_present: audio

## Validation
- ruff check on changed files
- ruff format --check on changed files
- python3 -m pytest src/mobius/integrations/onnx_genai/inference_metadata_test.py -q (40 passed)
- targeted Gemma4 graph/adapter tests (4 passed)
- verified an E2B-width export emits a rank-2, dtype-compatible audio_encoder.audio_features to embedding.audio_features edge

WP-B4 optional-modality exporter contract.
