### PR TITLE
Fix NeMo RNNT constant-folding overflow

### DIFF
--- a/src/mobius/models/nemo_rnnt.py
+++ b/src/mobius/models/nemo_rnnt.py
@@ -182,7 +182,7 @@ class _Conv1d(nn.Module):
         new_cache = op.Slice(
             x_cat,
             op.Constant(value_ints=[-self._left_pad]),
-            op.Constant(value_ints=[int(np.iinfo(np.int64).max)]),
+            _dim(op, x_cat, 2),
             op.Constant(value_ints=[2]),
         )
         return out, new_cache
@@ -304,7 +304,7 @@ class RelPositionMultiHeadAttention(nn.Module):
         x = op.Slice(
             x,
             op.Constant(value_ints=[1]),
-            op.Constant(value_ints=[int(np.iinfo(np.int64).max)]),
+            _dim(op, x, 2),
             op.Constant(value_ints=[2]),
         )
         # view back to (B, h, T, L)
@@ -520,7 +520,7 @@ class ConformerLayer(nn.Module):
             new_channel = op.Slice(
                 kv,
                 op.Constant(value_ints=[-cache_len]),
-                op.Constant(value_ints=[int(np.iinfo(np.int64).max)]),
+                _dim(op, kv, 1),
                 op.Constant(value_ints=[1]),
             )  # last cache_len frames of concat(cache, att_in)
         else:
@@ -767,7 +767,6 @@ class FastConformerEncoder(nn.Module):
         """
         de = self._drop_extra
         cache_size = self._cache_size
-        intmax = int(np.iinfo(np.int64).max)
         x = self.pre_encode(op, audio_signal)  # (B, T_sub, d)
         length_sub = self._subsampled_length(op, length)  # (B,)
         # Drop the leading subsampled frames corrupted by chunk-boundary padding
@@ -775,7 +774,7 @@ class FastConformerEncoder(nn.Module):
         x = op.Slice(
             x,
             op.Constant(value_ints=[de]),
-            op.Constant(value_ints=[intmax]),
+            _dim(op, x, 1),
             op.Constant(value_ints=[1]),
         )  # (B, T_out, d)
         length_sub = op.Max(


### PR DESCRIPTION
## Summary
- replace NeMo RNNT `Slice` INT64_MAX end sentinels with each input tensor's actual dynamic dimension
- prevent symbolic shape inference from deriving out-of-range int64 constants
- preserve slice-to-end semantics without pinning upstream dependencies

## Root cause
With onnxscript 0.7.1 / onnx-ir 0.2.1 / onnx 1.22.0 / numpy 2.4.6, the second cleanup pass propagated an INT64_MAX Slice end through symbolic shape arithmetic. It emitted `encoder.layers.0.self_attn.Shape_180` as a Constant with `value_ints=(9223372036854775811,)` (INT64_MAX + 4). onnxscript's `FoldConstantsPass` then attempted `np.array(..., dtype=np.int64)` and raised `OverflowError: Python int too large to convert to C long`.

Using the real dimension as the Slice end is semantically exact and avoids treating a sentinel as a concrete shape value.

## Validation
- `pytest src/mobius/models/nemo_rnnt_test.py -q`: **11 passed**
- `pytest -n auto -m "not integration and not arch_validation" -q`: **4685 passed, 334 skipped, 62 xfailed**
- `lintrunner --all-files`: **clean**
