### PR TITLE
Rename PyPI distribution from mobius-ai to mobius-onnx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,7 +193,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   intentionally skipped tensors (tokenizer, rope_freqs) from
   genuinely unmapped ones.
 - `gguf` optional dependency group in `pyproject.toml`
-  (`pip install mobius-ai[gguf]`).
+  (`pip install mobius-onnx[gguf]`).
 - 28 unit tests for GGUF reader, config mapping, tensor mapping,
   tensor processors, and CLI using synthetic GGUF files.
 

--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -7,7 +7,7 @@ from mobius import build_from_gguf
 ```
 
 > **Note**: Requires the optional `gguf` package:
-> `pip install mobius-ai[gguf]`
+> `pip install mobius-onnx[gguf]`
 
 ## Signature
 

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -257,7 +257,7 @@ mobius build --model Qwen/Qwen2.5-0.5B output_dir/ \
 
 Build an ONNX model from a GGUF file (e.g. from llama.cpp).
 
-> **Note**: Requires the optional `gguf` package: `pip install mobius-ai[gguf]`
+> **Note**: Requires the optional `gguf` package: `pip install mobius-onnx[gguf]`
 
 ### Synopsis
 

--- a/docs/design/gguf-support-proposal.md
+++ b/docs/design/gguf-support-proposal.md
@@ -465,7 +465,7 @@ Add `gguf` as an optional dependency in a new extras group:
 [project.optional-dependencies]
 gguf = ["gguf>=0.10.0"]
 # Combined:
-all = ["mobius-ai[transformers,gguf]"]
+all = ["mobius-onnx[transformers,gguf]"]
 ```
 
 The `gguf` import is lazy — users who don't use GGUF features

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@ automatic weight downloading and conversion, including bfloat16 models via
 ## Installation
 
 ```bash
-pip install mobius-ai
+pip install mobius-onnx
 ```
 
 For development and testing:
@@ -112,7 +112,7 @@ mobius build-gguf path/to/model.gguf --output output/model/
 ```
 
 > **Note**: GGUF support requires the optional `gguf` package:
-> `pip install mobius-ai[gguf]`
+> `pip install mobius-onnx[gguf]`
 
 ### Build quantized models (GPTQ/AWQ)
 

--- a/examples/diffusion.py
+++ b/examples/diffusion.py
@@ -85,7 +85,7 @@ def main():
     except ImportError:
         print(
             "Error: mobius is not installed.\n"
-            "Install with: pip install mobius-ai[transformers]",
+            "Install with: pip install mobius-onnx[transformers]",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/examples/fun_asr.py
+++ b/examples/fun_asr.py
@@ -17,7 +17,7 @@ Supports real-time microphone input and audio file input.
 
 Prerequisites::
 
-    pip install mobius-ai[transformers] sounddevice torchaudio pyyaml
+    pip install mobius-onnx[transformers] sounddevice torchaudio pyyaml
 
 Usage::
 

--- a/examples/gemma4_12b_text_ort_genai.py
+++ b/examples/gemma4_12b_text_ort_genai.py
@@ -40,7 +40,7 @@ Japan is" -> " Tokyo.").
 
 Requirements::
 
-    pip install mobius-ai[ort-genai] transformers
+    pip install mobius-onnx[ort-genai] transformers
     # plus a per-layer-KV-aware onnxruntime-genai build
 
 Usage::

--- a/examples/gemma4_genai.py
+++ b/examples/gemma4_genai.py
@@ -14,7 +14,7 @@ automatically wraps prompts in the Gemma chat template.
 
 Requirements::
 
-    pip install mobius-ai[transformers] onnxruntime-genai
+    pip install mobius-onnx[transformers] onnxruntime-genai
 
 Usage::
 

--- a/examples/gemma4_multimodal.py
+++ b/examples/gemma4_multimodal.py
@@ -36,7 +36,7 @@ are used (vision and audio encoders run once per generation).
 
 Prerequisites::
 
-    pip install mobius-ai[transformers]
+    pip install mobius-onnx[transformers]
     pip install torchaudio pillow  # for audio and image loading
 
 Usage::

--- a/examples/gemma4_ort_genai.py
+++ b/examples/gemma4_ort_genai.py
@@ -16,7 +16,7 @@ build of ORT GenAI that supports the ``gemma4`` type.
 
 Requirements::
 
-    pip install mobius-ai[ort-genai]
+    pip install mobius-onnx[ort-genai]
 
 Usage::
 

--- a/examples/gemma4_unified_ort_genai.py
+++ b/examples/gemma4_unified_ort_genai.py
@@ -65,7 +65,7 @@ artifacts).
 
 Requirements::
 
-    pip install mobius-ai[ort-genai] transformers pillow librosa
+    pip install mobius-onnx[ort-genai] transformers pillow librosa
     # plus a per-layer-KV-aware onnxruntime-genai build (see caveat 1)
 
 Usage::

--- a/examples/mms.py
+++ b/examples/mms.py
@@ -34,7 +34,7 @@ segment as it is ready.  Press Ctrl-C to stop.
 
 Prerequisites::
 
-    pip install mobius-ai[transformers] torchaudio
+    pip install mobius-onnx[transformers] torchaudio
     pip install sounddevice   # for --mic, --live, or audio playback
 
 Usage::

--- a/examples/model_builder_comparison.py
+++ b/examples/model_builder_comparison.py
@@ -1200,7 +1200,7 @@ def _expected_counts(model_id: str) -> dict[str, int] | None:
 
 def _mobius_version() -> str:
     try:
-        return importlib.metadata.version("mobius-ai")
+        return importlib.metadata.version("mobius-onnx")
     except importlib.metadata.PackageNotFoundError:
         pass
     try:

--- a/examples/nemotron_fastconformer_rnnt.py
+++ b/examples/nemotron_fastconformer_rnnt.py
@@ -24,12 +24,12 @@ is *not* required at runtime.
 
 Prerequisites::
 
-    pip install mobius-ai onnxruntime onnxruntime-easy librosa soundfile sentencepiece
+    pip install mobius-onnx onnxruntime onnxruntime-easy librosa soundfile sentencepiece
     pip install sounddevice          # only for microphone input
 
 The example runs ONNX models through ``mobius._testing.ort_inference``,
 which depends on ``onnxruntime`` and ``onnxruntime-easy`` (these are not
-pulled in by the ``mobius-ai`` core package). ``torch`` is a core mobius
+pulled in by the ``mobius-onnx`` core package). ``torch`` is a core mobius
 dependency and is installed automatically.
 
 Tested on Linux/x86-64 (CPU and CUDA). On Apple Silicon / other platforms

--- a/examples/olive/ministral-3-3b-vlm/requirements.txt
+++ b/examples/olive/ministral-3-3b-vlm/requirements.txt
@@ -1,7 +1,7 @@
 # Mobius (ONNX model construction) — install from this repo:
 #   pip install -e '.[transformers]'
 # Or from PyPI/git:
-#   pip install mobius-ai[transformers]
+#   pip install mobius-onnx[transformers]
 
 torch>=2.10.0,<2.11.0
 transformers>=4.57.0

--- a/examples/personaplex/moshi_ort.py
+++ b/examples/personaplex/moshi_ort.py
@@ -29,7 +29,7 @@ audio stream is fed as the 8 "other" codebooks (``k = 9..16``); the assistant
 
 Prerequisites::
 
-    pip install mobius-ai onnxruntime numpy soundfile
+    pip install mobius-onnx onnxruntime numpy soundfile
 
 CUDA note: on H200 / Ampere+ GPUs ORT defaults to TF32 for fp32 matmul, which
 can flip greedy sampling. ``--device cuda`` sets ``use_tf32=0`` for fp32

--- a/examples/phi4mm_multimodal.py
+++ b/examples/phi4mm_multimodal.py
@@ -32,7 +32,7 @@ only the embedding and decoder sessions are used (no vision/speech).
 
 Prerequisites::
 
-    pip install mobius-ai[transformers] torchaudio
+    pip install mobius-onnx[transformers] torchaudio
 
 Usage::
 

--- a/examples/phi4mm_ort_genai.py
+++ b/examples/phi4mm_ort_genai.py
@@ -17,7 +17,7 @@ The model is split into 4 ONNX graphs:
 
 Requirements::
 
-    pip install mobius-ai[ort-genai] torchaudio
+    pip install mobius-onnx[ort-genai] torchaudio
 
 Usage::
 

--- a/examples/qwen25_vl_ort_genai.py
+++ b/examples/qwen25_vl_ort_genai.py
@@ -10,7 +10,7 @@ text generation — with or without an image.
 
 Requirements::
 
-    pip install mobius-ai[ort-genai]
+    pip install mobius-onnx[ort-genai]
 
 Usage::
 

--- a/examples/qwen35_vl_ort_genai.py
+++ b/examples/qwen35_vl_ort_genai.py
@@ -20,7 +20,7 @@ onnxruntime-genai providing the tokenizer.
 
 Requirements::
 
-    pip install mobius-ai[ort-genai]
+    pip install mobius-onnx[ort-genai]
 
 Usage::
 

--- a/examples/qwen3_6_35b_a3b_ort_genai.py
+++ b/examples/qwen3_6_35b_a3b_ort_genai.py
@@ -22,7 +22,7 @@ sessions with onnxruntime-genai providing only the tokenizer.
 
 Requirements::
 
-    pip install mobius-ai[ort-genai]
+    pip install mobius-onnx[ort-genai]
     # For INT4 quantization (Olive from source recommended):
     pip install -e /path/to/Olive cupy-cuda12x
 

--- a/examples/qwen3_asr.py
+++ b/examples/qwen3_asr.py
@@ -13,7 +13,7 @@ Supports real-time microphone input and audio file input.
 
 Prerequisites::
 
-    pip install mobius-ai[transformers] sounddevice
+    pip install mobius-onnx[transformers] sounddevice
 
 Usage::
 

--- a/examples/qwen3_forced_aligner.py
+++ b/examples/qwen3_forced_aligner.py
@@ -13,7 +13,7 @@ head. The classifier output is interpreted as alignment probabilities.
 
 Prerequisites::
 
-    pip install mobius-ai[transformers] torchaudio
+    pip install mobius-onnx[transformers] torchaudio
 
 Usage::
 

--- a/examples/qwen3_tts.py
+++ b/examples/qwen3_tts.py
@@ -18,7 +18,7 @@ Architecture:
 
 Prerequisites::
 
-    pip install mobius-ai[transformers] sounddevice soundfile
+    pip install mobius-onnx[transformers] sounddevice soundfile
 
 Usage::
 

--- a/examples/qwen3_tts_voice_clone.py
+++ b/examples/qwen3_tts_voice_clone.py
@@ -15,7 +15,7 @@ Architecture:
 
 Prerequisites::
 
-    pip install mobius-ai[transformers] sounddevice soundfile librosa
+    pip install mobius-onnx[transformers] sounddevice soundfile librosa
 
 Usage::
 

--- a/examples/qwen3_vl_ort_genai.py
+++ b/examples/qwen3_vl_ort_genai.py
@@ -10,8 +10,8 @@ using raw ONNX Runtime sessions with HuggingFace preprocessing.
 
 Requirements::
 
-    pip install mobius-ai[ort-genai] onnxruntime-gpu  # for CUDA
-    pip install mobius-ai[ort-genai] onnxruntime       # for CPU only
+    pip install mobius-onnx[ort-genai] onnxruntime-gpu  # for CUDA
+    pip install mobius-onnx[ort-genai] onnxruntime       # for CPU only
 
 Supported dtype/EP combinations::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "mobius-ai"
+name = "mobius-onnx"
 dynamic = ["version"]
 description = "ONNX model definitions for GenAI using onnxscript.nn"
 authors = [

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -412,7 +412,7 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
         from mobius.integrations.gguf import build_from_gguf
     except ImportError:
         print(
-            "GGUF support requires the gguf package. Install with: pip install mobius-ai[gguf]"
+            "GGUF support requires the gguf package. Install with: pip install mobius-onnx[gguf]"
         )
         raise SystemExit(1)
 

--- a/tests/ort_genai_test.py
+++ b/tests/ort_genai_test.py
@@ -7,7 +7,7 @@ Verifies that exported ONNX models work end-to-end with the
 onnxruntime-genai inference runtime. Requires the ``ort-genai``
 extra to be installed::
 
-    pip install mobius-ai[ort-genai]
+    pip install mobius-onnx[ort-genai]
 
 Run::
 


### PR DESCRIPTION
## Summary

The project was renamed, so this updates the **PyPI/distribution name** from `mobius-ai` to `mobius-onnx`.

Only the distribution name changes:
- The **import package stays `mobius`** (`import mobius`, the `mobius` console script, and internal imports are all unchanged).
- The dynamic version still resolves from `mobius.__version__` (`[tool.setuptools.dynamic]`).

## Changes

- `pyproject.toml`: `name = "mobius-onnx"`
- Updated every user-facing `pip install mobius-ai[...]` reference → `mobius-onnx[...]` across docs, examples, tests, and the CHANGELOG.
- `src/mobius/__main__.py`: GGUF install hint in `mobius build-gguf`.
- `examples/model_builder_comparison.py`: `importlib.metadata.version("mobius-onnx")`.

30 files changed, 33 insertions(+), 33 deletions(-). Ruff clean.

## Follow-up (out of scope for this PR)

The `mobius-onnx` name must be claimed/registered on PyPI and the publish workflow's credentials/name updated before the next release.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>