### PR TITLE
Add PyPI publish workflow (trusted publishing)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -324,27 +324,3 @@ jobs:
       - name: Build wheels
         run: |
           python -m build
-      - name: Upload wheels
-        uses: actions/upload-artifact@v7
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        with:
-          name: dist
-          path: dist
-
-  release:
-    name: Release
-    environment: release
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    needs: [test, build]
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          name: dist
-          path: dist
-      - name: Publish package
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          attestations: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,65 @@
+name: Publish
+
+# Publishes the `mobius-onnx` distribution to PyPI via Trusted Publishing
+# (OIDC — no API token). The PyPI trusted publisher is configured for this
+# repository with workflow `publish.yml` and environment `pypi`; both must
+# match exactly for the upload to be authorized.
+#
+# Triggers:
+#   * pushing a version tag (``v*``) — the normal release path, and
+#   * manual ``workflow_dispatch`` — publishes the version currently declared
+#     in ``mobius.__version__``.
+#
+# The built version comes from ``mobius.__version__`` (setuptools dynamic
+# version), so tag the commit whose ``__version__`` matches the tag.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install build dependencies
+        run: pip install build twine
+      - name: Build sdist and wheel
+        run: python -m build
+      - name: Verify distribution metadata
+        run: twine check dist/*
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist
+
+  publish:
+    name: Publish to PyPI
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true


### PR DESCRIPTION
## This is temporary until we set up esrp

## Summary

Adds a dedicated **`publish.yml`** that builds and uploads `mobius-onnx` to PyPI via **Trusted Publishing** (OIDC — no API token), matching the PyPI trusted-publisher config for this repo:

- **Repository:** `onnxruntime/mobius`
- **Workflow:** `publish.yml`
- **Environment:** `pypi`

**Triggers:** version tag push (`v*`) and manual `workflow_dispatch`.

## Also

Removes the old `release` job from `main.yml`. It used `environment: release`, which no longer matches the trusted publisher, so on a tag push it would fail OIDC authorization. Its tag-only dist artifact upload is dropped too (publishing is now self-contained in `publish.yml`). The CI `build` job still builds the wheel on every push/PR to validate packaging.

## Notes

- Version is `mobius.__version__` (setuptools dynamic) — currently `0.1.0`. Verified locally: `python -m build` produces `mobius_onnx-0.1.0.tar.gz` and `mobius_onnx-0.1.0-py3-none-any.whl`.
- After merge, tagging `v0.1.0` (or dispatching the workflow) publishes `mobius-onnx==0.1.0`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>