### PR TITLE
Add PyPI and Ruff badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # mobius
 
+[![PyPI](https://img.shields.io/pypi/v/mobius-onnx)](https://pypi.org/project/mobius-onnx/)
 [![CI](https://github.com/onnxruntime/mobius/actions/workflows/main.yml/badge.svg)](https://github.com/onnxruntime/mobius/actions/workflows/main.yml)
 [![L4: Golden Checkpoint Parity (GPU)](https://github.com/onnxruntime/mobius/actions/workflows/gpu_l4_golden_parity.yml/badge.svg)](https://github.com/onnxruntime/mobius/actions/workflows/gpu_l4_golden_parity.yml)
 [![L5: End-to-End Generation (GPU)](https://github.com/onnxruntime/mobius/actions/workflows/gpu_l5_generation_e2e.yml/badge.svg)](https://github.com/onnxruntime/mobius/actions/workflows/gpu_l5_generation_e2e.yml)
 [![Nightly L2 Architecture Validation](https://github.com/onnxruntime/mobius/actions/workflows/nightly_l2.yml/badge.svg)](https://github.com/onnxruntime/mobius/actions/workflows/nightly_l2.yml)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 ONNX model definitions for GenAI using the `onnxscript.nn` API.
 


### PR DESCRIPTION
Adds two badges to the README badge row:

- **PyPI version** — `img.shields.io/pypi/v/mobius-onnx`, linking to https://pypi.org/project/mobius-onnx/ (now that `mobius-onnx` 0.1.0 is published).
- **Ruff** — the official Ruff style badge, linking to the Ruff repo.

Both endpoints verified reachable (HTTP 200).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>