### PR TITLE
feat(kv-cache): add FP8 (E4M3) KV-cache export path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
-- The boolean flags `--static-cache`, `--fp8-kv-cache`, and `--text-only` are now
-  **deprecated aliases** for the matching `--features` value. They still work and
-  set the same behaviour, but print a deprecation notice on stderr. Companion
+- The boolean flags `--static-cache`, `--fp8-kv-cache`, and `--text-only` have
+  been **removed** in favor of the equivalent `--features` value. Companion
   value args (`--max-seq-len`, `--kv-cache-scale-file`) are unchanged.
 
 ### FP8 (E4M3) KV-cache export (`--features fp8-kv-cache`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Cargo-style `--features` build option
+
+#### Added
+
+- `mobius build --features <a,b,...>` collects the build-mode toggles under a
+  single Rust/cargo-style option. Accepts a comma-separated list and may be
+  repeated (`--features fp8-kv-cache,static-cache` or `--features fp8-kv-cache
+  --features static-cache`). Available features: `static-cache`, `fp8-kv-cache`,
+  `text-only`. Unknown feature names are rejected with an error listing the
+  valid set.
+
+#### Changed
+
+- The boolean flags `--static-cache`, `--fp8-kv-cache`, and `--text-only` are now
+  **deprecated aliases** for the matching `--features` value. They still work and
+  set the same behaviour, but print a deprecation notice on stderr. Companion
+  value args (`--max-seq-len`, `--kv-cache-scale-file`) are unchanged.
+
+### FP8 (E4M3) KV-cache export (`--features fp8-kv-cache`)
+
+#### Added
+
+- `build(fp8_kv_cache=True)` and `mobius build --features fp8-kv-cache` retype the
+  fused `GroupQueryAttention` KV cache to `FLOAT8E4M3FN` (per-tensor E4M3) after
+  GQA fusion, adding `k_scale`/`v_scale` initializers and the
+  `k_quant_type`/`v_quant_type="PER_TENSOR"`, `kv_cache_bit_width=8` attributes.
+  Halves KV-cache memory at long context on ORT runtimes with the FP8 KV kernel
+  (SM89+). `--kv-cache-scale-file` supplies calibrated per-layer scales
+  (onnxruntime-genai format); without it all layers use a unit scale of 1.0.
+  Only graph-input or empty-placeholder caches are retyped — a non-empty
+  initializer cache is skipped with a warning.
+
 ### Text-only export for multimodal Gemma 4 (`--text-only`)
 
 #### Added

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -168,20 +168,50 @@ mobius build --model Qwen/Qwen2.5-0.5B output/ \
     --ep cuda --dtype f16 --runtime ort-genai
 ```
 
-### Static Cache (`--static-cache`)
+### Build Features (`--features`)
+
+Build-mode toggles are collected under a single cargo-style `--features`
+option. Pass a comma-separated list (and/or repeat the flag):
 
 ```
---static-cache
+--features fp8-kv-cache,static-cache
+--features text-only
+```
+
+Available features:
+
+| Feature | Effect |
+|---------|--------|
+| `static-cache` | Pre-allocate fixed-size KV cache buffers using `TensorScatter` (pair with `--max-seq-len N`). Requires `DecoderLayer` / `MoEDecoderLayer` models. Cannot combine with `--task`. |
+| `fp8-kv-cache` | Store the `GroupQueryAttention` KV cache as `FLOAT8E4M3FN` (per-tensor E4M3), halving KV-cache memory. Requires a GQA build (e.g. `--ep cuda --dtype f16`) and an ORT runtime with the FP8 KV-cache kernel (SM89+). Pair with `--kv-cache-scale-file` for calibrated scales. |
+| `text-only` | Export the text backbone of a multimodal checkpoint as a standalone decoder-only LLM (see below). |
+
+The legacy boolean flags `--static-cache`, `--fp8-kv-cache`, and
+`--text-only` still work but are **deprecated** aliases for the matching
+feature and print a warning. Prefer `--features`.
+
+```bash
+mobius build --model meta-llama/Llama-3.2-1B output/ \
+    --features static-cache --max-seq-len 2048
+
+mobius build --model Qwen/Qwen2.5-0.5B output/ \
+    --ep cuda --dtype f16 --features fp8-kv-cache
+```
+
+### Static Cache (`--features static-cache`)
+
+```
+--features static-cache
 --max-seq-len N
 ```
 
 Pre-allocate fixed-size KV cache buffers using TensorScatter. Useful when
 the maximum sequence length is known up front.
 
-- `--static-cache` enables static cache mode. Requires models using
+- `--features static-cache` enables static cache mode. Requires models using
   `DecoderLayer` or `MoEDecoderLayer`.
 - `--max-seq-len N` sets the maximum sequence length for static cache
-  buffers. Only valid with `--static-cache`. Defaults to
+  buffers. Only valid with static cache. Defaults to
   `max_position_embeddings` from the model config.
 
 Cannot be combined with `--task`.
@@ -189,10 +219,11 @@ Cannot be combined with `--task`.
 #### Example
 
 ```bash
-mobius build --model meta-llama/Llama-3.2-1B output/ --static-cache
+mobius build --model meta-llama/Llama-3.2-1B output/ --features static-cache
 
 # With explicit max sequence length
-mobius build --model meta-llama/Llama-3.2-1B output/ --static-cache --max-seq-len 2048
+mobius build --model meta-llama/Llama-3.2-1B output/ \
+    --features static-cache --max-seq-len 2048
 ```
 
 ### Other Flags
@@ -206,13 +237,14 @@ mobius build --model meta-llama/Llama-3.2-1B output/ --static-cache --max-seq-le
 | `--max-shard-size SIZE` | Maximum shard size for safetensors external data (e.g. `5GB`). Only used with `--external-data safetensors`. |
 | `--trust-remote-code` | Trust remote code when loading the HuggingFace model config. |
 | `--component NAME` | Build only one component from a diffusers pipeline (e.g. `--component vae_decoder`). |
-| `--text-only` | Export the text backbone of a multimodal checkpoint as a standalone decoder-only LLM. Strips vision/audio routing so the decoder uses `GroupQueryAttention` on GQA-capable EPs (build with `--ep cuda`/`dml`). Currently supported for `gemma4_unified` (`google/gemma-4-12B`). Not compatible with `--config` or `--component`. |
+| `--text-only` | **Deprecated** alias for `--features text-only`. Export the text backbone of a multimodal checkpoint as a standalone decoder-only LLM. Strips vision/audio routing so the decoder uses `GroupQueryAttention` on GQA-capable EPs (build with `--ep cuda`/`dml`). Currently supported for `gemma4_unified` (`google/gemma-4-12B`). Not compatible with `--config` or `--component`. |
+| `--kv-cache-scale-file PATH` | Optional JSON file of calibrated per-layer FP8 KV-cache scales (onnxruntime-genai format). Only used with the `fp8-kv-cache` feature; without it all layers use a unit scale of 1.0. |
 
 #### Text-only example
 
 ```bash
 # Export gemma-4-12B's text backbone as a GQA decoder-only LLM
-mobius build --model google/gemma-4-12B output/ --text-only --ep cuda --dtype f16
+mobius build --model google/gemma-4-12B output/ --features text-only --ep cuda --dtype f16
 ```
 
 For a full ORT-GenAI text-only package (with `genai_config.json`), use

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -187,8 +187,7 @@ Available features:
 | `text-only` | Export the text backbone of a multimodal checkpoint as a standalone decoder-only LLM (see below). |
 
 The legacy boolean flags `--static-cache`, `--fp8-kv-cache`, and
-`--text-only` still work but are **deprecated** aliases for the matching
-feature and print a warning. Prefer `--features`.
+`--text-only` have been removed in favor of `--features`.
 
 ```bash
 mobius build --model meta-llama/Llama-3.2-1B output/ \
@@ -237,7 +236,7 @@ mobius build --model meta-llama/Llama-3.2-1B output/ \
 | `--max-shard-size SIZE` | Maximum shard size for safetensors external data (e.g. `5GB`). Only used with `--external-data safetensors`. |
 | `--trust-remote-code` | Trust remote code when loading the HuggingFace model config. |
 | `--component NAME` | Build only one component from a diffusers pipeline (e.g. `--component vae_decoder`). |
-| `--text-only` | **Deprecated** alias for `--features text-only`. Export the text backbone of a multimodal checkpoint as a standalone decoder-only LLM. Strips vision/audio routing so the decoder uses `GroupQueryAttention` on GQA-capable EPs (build with `--ep cuda`/`dml`). Currently supported for `gemma4_unified` (`google/gemma-4-12B`). Not compatible with `--config` or `--component`. |
+| `--kv-cache-scale-file PATH` | Optional JSON file of calibrated per-layer FP8 KV-cache scales (onnxruntime-genai format). Only used with the `fp8-kv-cache` feature; without it all layers use a unit scale of 1.0. |
 | `--kv-cache-scale-file PATH` | Optional JSON file of calibrated per-layer FP8 KV-cache scales (onnxruntime-genai format). Only used with the `fp8-kv-cache` feature; without it all layers use a unit scale of 1.0. |
 
 #### Text-only example

--- a/examples/gemma4_12b_text_ort_genai.py
+++ b/examples/gemma4_12b_text_ort_genai.py
@@ -56,7 +56,7 @@ Usage::
 
 The equivalent raw-ONNX (no genai_config) build is::
 
-    mobius build --model google/gemma-4-12B --text-only --ep cuda --dtype f16 \
+    mobius build --model google/gemma-4-12B --features text-only --ep cuda --dtype f16 \
         out/gemma4_12b_text_onnx/
 """
 

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -10,7 +10,6 @@ import glob
 import json
 import logging
 import os
-import sys
 from typing import TYPE_CHECKING
 
 import tqdm
@@ -36,9 +35,7 @@ logger = logging.getLogger(__name__)
 
 # Rust/cargo-style build features. Each feature name (kebab-case) maps to the
 # boolean attribute on the parsed args that it enables. `--features a,b` (or a
-# repeated `--features`) is the canonical way to toggle these build modes; the
-# legacy per-feature boolean flags remain as deprecated aliases that set the
-# same attributes.
+# repeated `--features`) is the canonical way to toggle these build modes.
 _BUILD_FEATURES: dict[str, str] = {
     "static-cache": "static_cache",
     "fp8-kv-cache": "fp8_kv_cache",
@@ -53,18 +50,11 @@ def _resolve_build_features(args: argparse.Namespace) -> None:
     style), e.g. ``--features fp8-kv-cache,static-cache`` or
     ``--features fp8-kv-cache --features static-cache``. Each recognised feature
     sets its corresponding attribute (``fp8-kv-cache`` -> ``args.fp8_kv_cache``).
-
-    The legacy boolean flags (``--static-cache``, ``--text-only``,
-    ``--fp8-kv-cache``) still work but are deprecated: using one prints a notice
-    and sets the same attribute. Unknown feature names raise ``SystemExit``.
+    Unknown feature names raise ``SystemExit``.
     """
-    # Warn when a caller uses a deprecated boolean alias directly.
-    for feature, dest in _BUILD_FEATURES.items():
-        if getattr(args, dest, False):
-            print(
-                f"Warning: --{feature} is deprecated; use --features {feature} instead.",
-                file=sys.stderr,
-            )
+    for dest in _BUILD_FEATURES.values():
+        if not hasattr(args, dest):
+            setattr(args, dest, False)
 
     raw = getattr(args, "features", None) or []
     requested: list[str] = []
@@ -184,7 +174,7 @@ def _cmd_build(args: argparse.Namespace) -> None:
         return CausalLMTask(static_cache=True, max_seq_len=args.max_seq_len)
 
     # Fold --features into the boolean build-mode attributes before any
-    # validation reads them (and warn on deprecated boolean aliases).
+    # validation reads them.
     _resolve_build_features(args)
 
     # Validate --max-seq-len requires --static-cache
@@ -725,16 +715,8 @@ def main(argv: list[str] | None = None) -> None:
             "may be repeated). Available: "
             + ", ".join(sorted(_BUILD_FEATURES))
             + ". Example: --features fp8-kv-cache,static-cache. This is the "
-            "canonical replacement for the individual --static-cache / "
-            "--text-only / --fp8-kv-cache flags."
+            "canonical way to enable these build modes."
         ),
-    )
-    build_parser.add_argument(
-        "--static-cache",
-        action="store_true",
-        help="[deprecated: use --features static-cache] "
-        "Use static KV cache (pre-allocated buffers with TensorScatter). "
-        "Requires models using DecoderLayer or MoEDecoderLayer.",
     )
     build_parser.add_argument(
         "--max-seq-len",
@@ -769,31 +751,6 @@ def main(argv: list[str] | None = None) -> None:
             "document for LLMs, or an iterative pipeline document for diffusion). "
             "When used with --model, tokenizer files are downloaded from HuggingFace; "
             "with --config (local directory), they are copied from that directory."
-        ),
-    )
-    build_parser.add_argument(
-        "--text-only",
-        dest="text_only",
-        action="store_true",
-        help=(
-            "[deprecated: use --features text-only] "
-            "Export the text backbone of a multimodal checkpoint as a "
-            "standalone decoder-only LLM. Strips vision/audio routing so the "
-            "decoder uses GroupQueryAttention on GQA-capable EPs. Currently "
-            "supported for gemma4_unified (google/gemma-4-12B). Not compatible "
-            "with --config or --component (use --model <hf-id>)."
-        ),
-    )
-    build_parser.add_argument(
-        "--fp8-kv-cache",
-        dest="fp8_kv_cache",
-        action="store_true",
-        help=(
-            "[deprecated: use --features fp8-kv-cache] "
-            "Store the GroupQueryAttention KV cache as FLOAT8E4M3FN (per-tensor "
-            "E4M3), halving KV-cache memory at long context. Requires a "
-            "GQA-capable build (e.g. --execution-provider cuda with --dtype "
-            "f16/bf16) and an ORT runtime with the FP8 KV-cache kernel (SM89+)."
         ),
     )
     build_parser.add_argument(

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -10,6 +10,7 @@ import glob
 import json
 import logging
 import os
+import sys
 from typing import TYPE_CHECKING
 
 import tqdm
@@ -31,6 +32,51 @@ from mobius._config_resolver import (
 from mobius._registry import registry
 
 logger = logging.getLogger(__name__)
+
+
+# Rust/cargo-style build features. Each feature name (kebab-case) maps to the
+# boolean attribute on the parsed args that it enables. `--features a,b` (or a
+# repeated `--features`) is the canonical way to toggle these build modes; the
+# legacy per-feature boolean flags remain as deprecated aliases that set the
+# same attributes.
+_BUILD_FEATURES: dict[str, str] = {
+    "static-cache": "static_cache",
+    "fp8-kv-cache": "fp8_kv_cache",
+    "text-only": "text_only",
+}
+
+
+def _resolve_build_features(args: argparse.Namespace) -> None:
+    """Fold ``--features`` values into the boolean build-mode attributes.
+
+    ``--features`` accepts a comma-separated list and may be repeated (cargo
+    style), e.g. ``--features fp8-kv-cache,static-cache`` or
+    ``--features fp8-kv-cache --features static-cache``. Each recognised feature
+    sets its corresponding attribute (``fp8-kv-cache`` -> ``args.fp8_kv_cache``).
+
+    The legacy boolean flags (``--static-cache``, ``--text-only``,
+    ``--fp8-kv-cache``) still work but are deprecated: using one prints a notice
+    and sets the same attribute. Unknown feature names raise ``SystemExit``.
+    """
+    # Warn when a caller uses a deprecated boolean alias directly.
+    for feature, dest in _BUILD_FEATURES.items():
+        if getattr(args, dest, False):
+            print(
+                f"Warning: --{feature} is deprecated; use --features {feature} instead.",
+                file=sys.stderr,
+            )
+
+    raw = getattr(args, "features", None) or []
+    requested: list[str] = []
+    for chunk in raw:
+        requested.extend(f.strip() for f in chunk.split(",") if f.strip())
+
+    for feature in requested:
+        dest = _BUILD_FEATURES.get(feature)
+        if dest is None:
+            valid = ", ".join(sorted(_BUILD_FEATURES))
+            raise SystemExit(f"Error: unknown feature '{feature}'. Valid features: {valid}.")
+        setattr(args, dest, True)
 
 
 def _parse_size(size_str: str) -> int:
@@ -136,6 +182,10 @@ def _cmd_build(args: argparse.Namespace) -> None:
                 max_seq_len=args.max_seq_len,
             )
         return CausalLMTask(static_cache=True, max_seq_len=args.max_seq_len)
+
+    # Fold --features into the boolean build-mode attributes before any
+    # validation reads them (and warn on deprecated boolean aliases).
+    _resolve_build_features(args)
 
     # Validate --max-seq-len requires --static-cache
     if args.max_seq_len is not None and not args.static_cache:
@@ -666,9 +716,24 @@ def main(argv: list[str] | None = None) -> None:
         help="Build only this component from a diffusers pipeline (e.g. --component vae_decoder).",
     )
     build_parser.add_argument(
+        "--features",
+        action="append",
+        default=None,
+        metavar="FEATURES",
+        help=(
+            "Comma-separated list of build features to enable (cargo-style; "
+            "may be repeated). Available: "
+            + ", ".join(sorted(_BUILD_FEATURES))
+            + ". Example: --features fp8-kv-cache,static-cache. This is the "
+            "canonical replacement for the individual --static-cache / "
+            "--text-only / --fp8-kv-cache flags."
+        ),
+    )
+    build_parser.add_argument(
         "--static-cache",
         action="store_true",
-        help="Use static KV cache (pre-allocated buffers with TensorScatter). "
+        help="[deprecated: use --features static-cache] "
+        "Use static KV cache (pre-allocated buffers with TensorScatter). "
         "Requires models using DecoderLayer or MoEDecoderLayer.",
     )
     build_parser.add_argument(
@@ -711,6 +776,7 @@ def main(argv: list[str] | None = None) -> None:
         dest="text_only",
         action="store_true",
         help=(
+            "[deprecated: use --features text-only] "
             "Export the text backbone of a multimodal checkpoint as a "
             "standalone decoder-only LLM. Strips vision/audio routing so the "
             "decoder uses GroupQueryAttention on GQA-capable EPs. Currently "
@@ -723,6 +789,7 @@ def main(argv: list[str] | None = None) -> None:
         dest="fp8_kv_cache",
         action="store_true",
         help=(
+            "[deprecated: use --features fp8-kv-cache] "
             "Store the GroupQueryAttention KV cache as FLOAT8E4M3FN (per-tensor "
             "E4M3), halving KV-cache memory at long context. Requires a "
             "GQA-capable build (e.g. --execution-provider cuda with --dtype "

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -178,6 +178,19 @@ def _cmd_build(args: argparse.Namespace) -> None:
 
     load_weights = not args.no_weights
     task: str | ModelTask | None = args.task
+
+    # FP8 KV cache: resolve the optional per-layer scale file up front so both
+    # the --config and --model build paths can pass the same scales.
+    fp8_kv_cache = getattr(args, "fp8_kv_cache", False)
+    kv_cache_scales: dict[int, tuple[float, float]] | None = None
+    scale_file = getattr(args, "kv_cache_scale_file", None)
+    if scale_file is not None and not fp8_kv_cache:
+        raise SystemExit("Error: --kv-cache-scale-file can only be used with --fp8-kv-cache.")
+    if fp8_kv_cache and scale_file is not None:
+        from mobius._passes._fp8_kv_cache import load_kv_cache_scale_file
+
+        kv_cache_scales = load_kv_cache_scale_file(scale_file)
+
     if args.static_cache:
         # Defer task creation — we need to know the model type first.
         # Store parameters for later resolution.
@@ -250,7 +263,12 @@ def _cmd_build(args: argparse.Namespace) -> None:
         module_class = registry.get(model_type)
         model_module = module_class(config)
         pkg = build_from_module(
-            model_module, config, task=task, execution_provider=execution_provider
+            model_module,
+            config,
+            task=task,
+            execution_provider=execution_provider,
+            fp8_kv_cache=fp8_kv_cache,
+            kv_cache_scales=kv_cache_scales,
         )
         for name, model in pkg.items():
             model.graph.name = f"{config_path}/{name}"
@@ -278,6 +296,8 @@ def _cmd_build(args: argparse.Namespace) -> None:
             trust_remote_code=trust_remote_code,
             execution_provider=execution_provider,
             text_only=args.text_only,
+            fp8_kv_cache=fp8_kv_cache,
+            kv_cache_scales=kv_cache_scales,
         )
 
     _save_package(pkg, output_dir, args, optimize, component_filter)
@@ -696,6 +716,29 @@ def main(argv: list[str] | None = None) -> None:
             "decoder uses GroupQueryAttention on GQA-capable EPs. Currently "
             "supported for gemma4_unified (google/gemma-4-12B). Not compatible "
             "with --config or --component (use --model <hf-id>)."
+        ),
+    )
+    build_parser.add_argument(
+        "--fp8-kv-cache",
+        dest="fp8_kv_cache",
+        action="store_true",
+        help=(
+            "Store the GroupQueryAttention KV cache as FLOAT8E4M3FN (per-tensor "
+            "E4M3), halving KV-cache memory at long context. Requires a "
+            "GQA-capable build (e.g. --execution-provider cuda with --dtype "
+            "f16/bf16) and an ORT runtime with the FP8 KV-cache kernel (SM89+)."
+        ),
+    )
+    build_parser.add_argument(
+        "--kv-cache-scale-file",
+        dest="kv_cache_scale_file",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Optional JSON file of calibrated per-layer FP8 KV-cache scales "
+            "(onnxruntime-genai format: {'scales': {'k_scales': [...], "
+            "'v_scales': [...]}}). Only used with --fp8-kv-cache; without it "
+            "all layers use a unit scale of 1.0."
         ),
     )
     build_parser.set_defaults(func=_cmd_build)

--- a/src/mobius/_builder.py
+++ b/src/mobius/_builder.py
@@ -135,6 +135,8 @@ def build_from_module(
     *,
     execution_provider: str = "default",
     trace_optimization: bool = False,
+    fp8_kv_cache: bool = False,
+    kv_cache_scales: dict[int, tuple[float, float]] | None = None,
 ) -> ModelPackage:
     """Build an ONNX :class:`ModelPackage` from a module instance and config.
 
@@ -165,6 +167,16 @@ def build_from_module(
         trace_optimization: When ``True``, log step-by-step diagnostic
             output at INFO level for each optimization stage, showing which
             rules matched and how many nodes were added/removed.
+        fp8_kv_cache: When ``True``, store each decoder
+            ``GroupQueryAttention`` KV cache as ``FLOAT8E4M3FN`` (per-tensor
+            E4M3). Only applies on GQA-capable EP/dtype combinations (e.g.
+            ``execution_provider="cuda"`` with an fp16/bf16 dtype); otherwise a
+            warning is emitted and the request is ignored. Requires an ORT
+            build with the FP8 KV-cache GQA kernel (SM89+ CUDA).
+        kv_cache_scales: Optional ``layer_id -> (k_scale, v_scale)`` map of
+            per-tensor FP8 scales (from offline calibration), used only when
+            ``fp8_kv_cache`` is ``True``. Layers absent from the map use a unit
+            scale of ``1.0``.
 
     Returns:
         A :class:`ModelPackage` containing the built model(s).
@@ -213,6 +225,8 @@ def build_from_module(
             dtype=dtype,
             model_role=role,
             trace=trace_optimization,
+            fp8_kv_cache=fp8_kv_cache,
+            kv_cache_scales=kv_cache_scales,
         )
 
     _maybe_apply_opset_lowering(pkg, execution_provider)
@@ -355,6 +369,8 @@ def build(
     execution_provider: str = "default",
     trace_optimization: bool = False,
     text_only: bool = False,
+    fp8_kv_cache: bool = False,
+    kv_cache_scales: dict[int, tuple[float, float]] | None = None,
 ) -> ModelPackage:
     """Build an ONNX :class:`ModelPackage` from a HuggingFace model ID.
 
@@ -419,6 +435,17 @@ def build(
             text-only sibling. Currently supported for ``gemma4_unified``
             (``google/gemma-4-12B``) and ``qwen3_5_moe_vl``
             (``Qwen/Qwen3.6-35B-A3B``).
+        fp8_kv_cache: When ``True``, store each decoder
+            ``GroupQueryAttention`` KV cache as ``FLOAT8E4M3FN`` (per-tensor
+            E4M3), halving KV-cache memory at long context. Only applies on
+            GQA-capable EP/dtype combinations (e.g.
+            ``execution_provider="cuda"`` with an fp16/bf16 dtype); otherwise a
+            warning is emitted and the request is ignored. Requires an ORT
+            build with the FP8 KV-cache GQA kernel (SM89+ CUDA).
+        kv_cache_scales: Optional ``layer_id -> (k_scale, v_scale)`` map of
+            per-tensor FP8 scales (from offline calibration), used only when
+            ``fp8_kv_cache`` is ``True``. Layers absent from the map use a unit
+            scale of ``1.0``.
 
     Returns:
         A :class:`ModelPackage` containing the built model(s).
@@ -595,6 +622,8 @@ def build(
         task,
         execution_provider=execution_provider,
         trace_optimization=trace_optimization,
+        fp8_kv_cache=fp8_kv_cache,
+        kv_cache_scales=kv_cache_scales,
     )
 
     for name, model in pkg.items():

--- a/src/mobius/_execution_providers.py
+++ b/src/mobius/_execution_providers.py
@@ -93,6 +93,12 @@ class EpCapabilities:
             default) leaves ``Range`` unchanged.  Set ``False`` only when
             static cache is used on runtimes that lack a ``Range`` kernel (QNN
             HTP), where the ``Range`` node would otherwise be forced onto CPU.
+        supports_fp8_kv_cache: ``True`` allows :class:`~mobius._passes.
+            Fp8KvCachePass` to retype the ``GroupQueryAttention`` KV cache to
+            ``FLOAT8E4M3FN``.  Only CUDA (SM89+ Ada/Hopper/Blackwell) ships the
+            FP8 GQA kernel, so this defaults to ``False`` for every other EP —
+            ``--features fp8-kv-cache`` is ignored (with a warning) on EPs that
+            cannot run an FP8 KV cache, preventing invalid/unloadable models.
         supports_matmul_nbits: ``False`` converts ``com.microsoft::MatMulNBits``
             (blockwise-INT4 weight) into a standard ``DequantizeLinear`` +
             ``MatMul`` (QDQ) pair via MatMulNBitsToQDQ.  ``True`` leaves the
@@ -153,6 +159,7 @@ class EpCapabilities:
     supports_rotary_embedding: bool = True
     supports_tensor_scatter: bool = True
     supports_range: bool = True
+    supports_fp8_kv_cache: bool = False
     default_int4_accuracy_level: int = 0
     provider_options: dict[str, str] = dataclasses.field(default_factory=dict)
     enable_graph_capture: bool = False
@@ -309,6 +316,9 @@ def _register_builtins() -> None:
                 "enable_skip_layer_norm_strict_mode": "1",
             },
             supports_past_present_share_buffer=True,
+            # Only CUDA ships the FP8 (E4M3) GroupQueryAttention KV-cache kernel
+            # (SM89+ Ada/Hopper/Blackwell).
+            supports_fp8_kv_cache=True,
         ),
         EpCapabilities(
             name="dml",

--- a/src/mobius/_optimizations.py
+++ b/src/mobius/_optimizations.py
@@ -57,6 +57,7 @@ from mobius._flags import flags
 from mobius._passes import (
     FoldConcatInitializersPass,
     FoldTransposedInitializerPass,
+    Fp8KvCachePass,
     RemoveDeadGraphInputsPass,
 )
 from mobius.functions import register_function_bodies
@@ -368,6 +369,8 @@ def optimize_model(
     dtype: ir.DataType = ir.DataType.FLOAT,
     model_role: str = "decoder",
     trace: bool = False,
+    fp8_kv_cache: bool = False,
+    kv_cache_scales: dict[int, tuple[float, float]] | None = None,
 ) -> None:
     """Apply EP-aware optimization passes to *model* in-place.
 
@@ -392,6 +395,16 @@ def optimize_model(
         dtype: Model dtype for support-matrix lookups.
         model_role: Semantic role of this model component.
         trace: When ``True``, emit per-stage diagnostic logs at INFO level.
+        fp8_kv_cache: When ``True``, convert decoder
+            ``GroupQueryAttention`` KV caches to ``FLOAT8E4M3FN`` (per-tensor
+            E4M3) via :class:`~mobius._passes.Fp8KvCachePass`. Only applied
+            when GQA fusion is active for ``(ep, dtype)`` and
+            ``model_role == "decoder"``; otherwise a warning is emitted and the
+            request is ignored (no GQA nodes to convert).
+        kv_cache_scales: Optional ``layer_id -> (k_scale, v_scale)`` map of
+            per-tensor FP8 scales (from offline calibration). Only used when
+            ``fp8_kv_cache`` is ``True``; layers absent from the map use a unit
+            scale of ``1.0``.
 
     Raises:
         ValueError: If *ep* is not a registered execution provider.
@@ -553,6 +566,22 @@ def optimize_model(
                 f"Check that the attention pattern matches the GQA rewrite rule.",
                 stacklevel=4,
             )
+
+    # FP8 KV cache: convert GroupQueryAttention KV caches to FLOAT8E4M3FN.
+    # Runs after fusion so the GQA nodes exist. Requires GQA (a decoder on a
+    # GQA-capable EP/dtype); otherwise there is no KV-cache op to convert.
+    if fp8_kv_cache:
+        gqa_active = model_role == "decoder" and dtype in caps.gqa_dtypes
+        if not gqa_active:
+            warnings.warn(
+                f"fp8_kv_cache=True was requested but GQA fusion is not active "
+                f"for ep={ep!r}/dtype={dtype}/role={model_role!r}. FP8 KV cache "
+                f"requires a GroupQueryAttention decoder (e.g. --execution-provider "
+                f"cuda with an fp16/bf16 dtype). Ignoring the request.",
+                stacklevel=4,
+            )
+        else:
+            Fp8KvCachePass(kv_cache_scales)(model)
 
 
 def fold_initializers_after_weights(model: ir.Model) -> None:

--- a/src/mobius/_optimizations.py
+++ b/src/mobius/_optimizations.py
@@ -398,9 +398,10 @@ def optimize_model(
         fp8_kv_cache: When ``True``, convert decoder
             ``GroupQueryAttention`` KV caches to ``FLOAT8E4M3FN`` (per-tensor
             E4M3) via :class:`~mobius._passes.Fp8KvCachePass`. Only applied
-            when GQA fusion is active for ``(ep, dtype)`` and
-            ``model_role == "decoder"``; otherwise a warning is emitted and the
-            request is ignored (no GQA nodes to convert).
+            when GQA fusion is active for ``(ep, dtype)``,
+            ``model_role == "decoder"``, and the EP ships the FP8 GQA kernel
+            (``caps.supports_fp8_kv_cache`` — currently CUDA only); otherwise a
+            warning is emitted and the request is ignored.
         kv_cache_scales: Optional ``layer_id -> (k_scale, v_scale)`` map of
             per-tensor FP8 scales (from offline calibration). Only used when
             ``fp8_kv_cache`` is ``True``; layers absent from the map use a unit
@@ -572,12 +573,13 @@ def optimize_model(
     # GQA-capable EP/dtype); otherwise there is no KV-cache op to convert.
     if fp8_kv_cache:
         gqa_active = model_role == "decoder" and dtype in caps.gqa_dtypes
-        if not gqa_active:
+        if not gqa_active or not caps.supports_fp8_kv_cache:
             warnings.warn(
-                f"fp8_kv_cache=True was requested but GQA fusion is not active "
-                f"for ep={ep!r}/dtype={dtype}/role={model_role!r}. FP8 KV cache "
-                f"requires a GroupQueryAttention decoder (e.g. --execution-provider "
-                f"cuda with an fp16/bf16 dtype). Ignoring the request.",
+                f"fp8_kv_cache=True was requested but the FP8 GQA KV-cache kernel "
+                f"is not available for ep={ep!r}/dtype={dtype}/role={model_role!r}. "
+                f"FP8 KV cache requires a GroupQueryAttention decoder on an EP with "
+                f"the FP8 kernel (currently only --execution-provider cuda with an "
+                f"fp16/bf16 dtype). Ignoring the request.",
                 stacklevel=4,
             )
         else:

--- a/src/mobius/_passes/__init__.py
+++ b/src/mobius/_passes/__init__.py
@@ -42,9 +42,11 @@ from __future__ import annotations
 __all__ = [
     "FoldTransposedInitializerPass",
     "FoldConcatInitializersPass",
+    "Fp8KvCachePass",
     "RemoveDeadGraphInputsPass",
 ]
 
 from mobius._passes._fold_concat import FoldConcatInitializersPass
 from mobius._passes._fold_transpose import FoldTransposedInitializerPass
+from mobius._passes._fp8_kv_cache import Fp8KvCachePass
 from mobius._passes._remove_dead_inputs import RemoveDeadGraphInputsPass

--- a/src/mobius/_passes/_fp8_kv_cache.py
+++ b/src/mobius/_passes/_fp8_kv_cache.py
@@ -46,6 +46,7 @@ import json
 import logging
 import math
 import re
+import warnings
 
 import numpy as np
 import onnx_ir as ir
@@ -79,6 +80,19 @@ def _retype_fp8(value: ir.Value | None) -> None:
     value.type = ir.TensorType(_FP8)
 
 
+def _is_retypable_cache(value: ir.Value) -> bool:
+    """Whether *value* may be safely retyped to FP8.
+
+    A KV cache is retypable when it is a graph input (no ``const_value``) or an
+    empty placeholder initializer. A non-empty FLOAT/FLOAT16 initializer must
+    NOT be retyped: declaring FP8 over FLOAT bytes would corrupt the graph.
+    """
+    const = value.const_value
+    if const is None:
+        return True
+    return const.size == 0
+
+
 class Fp8KvCachePass(ir.passes.InPlacePass):
     """Convert decoder ``GroupQueryAttention`` KV caches to FP8-E4M3.
 
@@ -109,6 +123,19 @@ class Fp8KvCachePass(ir.passes.InPlacePass):
                 # Prompt-processing GQA without a KV cache — nothing to convert.
                 continue
 
+            # Contract: only KV caches that are graph inputs (or empty
+            # placeholders) may be retyped. Retyping a non-empty FLOAT/FLOAT16
+            # initializer would declare FP8 over FLOAT bytes and corrupt the
+            # graph, so skip such nodes loudly rather than emit an invalid model.
+            if not _is_retypable_cache(past_key) or not _is_retypable_cache(past_value):
+                warnings.warn(
+                    f"Fp8KvCachePass: skipping {node.name!r} — its KV cache is a "
+                    f"non-empty initializer, not a graph input. Only graph-input "
+                    f"KV caches can be converted to FP8.",
+                    stacklevel=2,
+                )
+                continue
+
             # No early skip when past_key is already FP8: every step below is
             # idempotent (retype is a no-op, scale initializers dedup by name,
             # attributes overwrite, inputs only grow when < 14), so a re-run
@@ -120,17 +147,22 @@ class Fp8KvCachePass(ir.passes.InPlacePass):
             )
 
             # (1) Retype the cache graph I/O: past inputs + present outputs.
+            # Guard each present output on its own index so a hypothetical
+            # 2-output GQA variant cannot leave present_key (index 1) as a
+            # different dtype from past_key.
             _retype_fp8(past_key)
             _retype_fp8(past_value)
-            present_key = node.outputs[1] if len(node.outputs) > 2 else None
+            present_key = node.outputs[1] if len(node.outputs) > 1 else None
             present_value = node.outputs[2] if len(node.outputs) > 2 else None
             _retype_fp8(present_key)
             _retype_fp8(present_value)
 
-            # (2) Per-layer scale initializers (unit 1.0 unless calibrated).
-            suffix = f"{layer_id}" if layer_id is not None else node.name
-            k_scale = self._scale_initializer(graph, f"kv_cache.{suffix}.k_scale", k_val)
-            v_scale = self._scale_initializer(graph, f"kv_cache.{suffix}.v_scale", v_val)
+            # (2) Scale initializers (unit 1.0 unless calibrated). Names are
+            # derived from the cache tensor names — not just the numeric layer
+            # id — so distinct caches at the same layer index (e.g. seq2seq
+            # self- vs cross-attention) never share a scale initializer.
+            k_scale = self._scale_initializer(graph, f"{past_key.name}.fp8_scale", k_val)
+            v_scale = self._scale_initializer(graph, f"{past_value.name}.fp8_scale", v_val)
 
             if len(node.inputs) < _MIN_INPUTS:
                 node.resize_inputs(_MIN_INPUTS)

--- a/src/mobius/_passes/_fp8_kv_cache.py
+++ b/src/mobius/_passes/_fp8_kv_cache.py
@@ -1,0 +1,201 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Pass that converts a ``GroupQueryAttention`` KV cache to FP8 (E4M3).
+
+``com.microsoft::GroupQueryAttention`` can store its past/present key-value
+cache as ``FLOAT8E4M3FN`` instead of the model dtype (fp16/bf16), halving the
+KV-cache memory footprint at long context. The kernel keeps the ``query`` /
+``key`` / ``value`` node inputs at the model dtype and quantizes the new K/V to
+FP8 internally on write, dequantizing on read, using a per-tensor scale.
+
+This pass runs **after** the GQA fusion rules (see
+:func:`~mobius._optimizations.optimize_model`). For every decoder
+``GroupQueryAttention`` node whose ``past_key`` / ``past_value`` inputs are
+graph inputs it:
+
+1. Retypes the ``past_key`` / ``past_value`` inputs and the
+   ``present_key`` / ``present_value`` outputs (all graph I/O) to
+   ``FLOAT8E4M3FN`` while preserving their shapes.
+2. Adds ``k_scale`` / ``v_scale`` scalar FLOAT initializers (input slots 12/13).
+   Scales default to ``1.0`` (the "legacy" export shape) or are taken from a
+   caller-provided per-layer calibration map so out-of-range K/V do not
+   saturate the ~±448 FP8-E4M3 range.
+3. Sets the quantization attributes ``k_quant_type`` / ``v_quant_type`` to
+   ``"PER_TENSOR"`` and ``kv_cache_bit_width`` to ``8``.
+
+The GQA op signature this targets (ORT >= 1.28) is::
+
+    query, key, value, past_key, past_value, seqlens_k, total_sequence_length,
+    cos_cache, sin_cache, position_ids, attention_bias, head_sink,
+    k_scale, v_scale, q_norm_weight, k_norm_weight
+
+so the ``k_scale`` / ``v_scale`` inputs live at positions 12 and 13. mobius
+emits 9 inputs (through ``sin_cache``); this pass grows the input list to 14,
+leaving the optional ``position_ids`` / ``attention_bias`` / ``head_sink``
+slots (9/10/11) empty.
+
+Requires an ORT build with the FP8 KV-cache GQA kernel (SM89+ CUDA, e.g. Ada /
+Hopper / Blackwell). The FP8 KV cache is IO-bound at runtime as device
+``FLOAT8E4M3FN`` OrtValues (as onnxruntime-genai does), not fed as numpy.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import numpy as np
+import onnx_ir as ir
+
+logger = logging.getLogger(__name__)
+
+_FP8 = ir.DataType.FLOAT8E4M3FN
+
+# GQA (ORT >= 1.28) optional KV-scale input slots.
+_K_SCALE_INDEX = 12
+_V_SCALE_INDEX = 13
+_MIN_INPUTS = _V_SCALE_INDEX + 1  # 14: grow to expose both scale slots.
+
+# Parses the layer index ``i`` from a KV-cache input named
+# ``past_key_values.{i}.key`` (the name minted by ``_make_kv_cache_inputs``).
+_LAYER_ID_RE = re.compile(r"\.(\d+)\.")
+
+
+def _layer_id_from_name(name: str | None) -> int | None:
+    """Return the layer index encoded in a ``past_key_values.{i}.key`` name."""
+    if not name:
+        return None
+    match = _LAYER_ID_RE.search(name)
+    return int(match.group(1)) if match else None
+
+
+def _retype_fp8(value: ir.Value | None) -> None:
+    """Retype *value* to ``FLOAT8E4M3FN`` in place, preserving its shape."""
+    if value is None:
+        return
+    value.type = ir.TensorType(_FP8)
+
+
+class Fp8KvCachePass(ir.passes.InPlacePass):
+    """Convert decoder ``GroupQueryAttention`` KV caches to FP8-E4M3.
+
+    Args:
+        scales: Optional mapping ``layer_id -> (k_scale, v_scale)`` of
+            per-tensor FP8 scales (typically produced by an offline
+            calibration). Layers absent from the map — and every layer when
+            *scales* is ``None`` — use a unit scale of ``1.0``.
+    """
+
+    def __init__(self, scales: dict[int, tuple[float, float]] | None = None) -> None:
+        super().__init__()
+        self._scales = scales or {}
+
+    def call(self, model: ir.Model) -> ir.passes.PassResult:
+        graph = model.graph
+        modified = False
+        converted = 0
+
+        for node in graph:
+            if node.domain != "com.microsoft" or node.op_type != "GroupQueryAttention":
+                continue
+
+            inputs = node.inputs
+            past_key = inputs[3] if len(inputs) > 4 else None
+            past_value = inputs[4] if len(inputs) > 4 else None
+            if past_key is None or past_value is None:
+                # Prompt-processing GQA without a KV cache — nothing to convert.
+                continue
+            if past_key.dtype == _FP8:
+                # Already converted (idempotent re-run).
+                continue
+
+            layer_id = _layer_id_from_name(past_key.name)
+            k_val, v_val = self._scales.get(
+                layer_id if layer_id is not None else -1, (1.0, 1.0)
+            )
+
+            # (1) Retype the cache graph I/O: past inputs + present outputs.
+            _retype_fp8(past_key)
+            _retype_fp8(past_value)
+            present_key = node.outputs[1] if len(node.outputs) > 2 else None
+            present_value = node.outputs[2] if len(node.outputs) > 2 else None
+            _retype_fp8(present_key)
+            _retype_fp8(present_value)
+
+            # (2) Per-layer scale initializers (unit 1.0 unless calibrated).
+            suffix = f"{layer_id}" if layer_id is not None else node.name
+            k_scale = self._scale_initializer(graph, f"kv_cache.{suffix}.k_scale", k_val)
+            v_scale = self._scale_initializer(graph, f"kv_cache.{suffix}.v_scale", v_val)
+
+            if len(node.inputs) < _MIN_INPUTS:
+                node.resize_inputs(_MIN_INPUTS)
+            node.replace_input_with(_K_SCALE_INDEX, k_scale)
+            node.replace_input_with(_V_SCALE_INDEX, v_scale)
+
+            # (3) Quantization attributes.
+            node.attributes.add(ir.AttrString("k_quant_type", "PER_TENSOR"))
+            node.attributes.add(ir.AttrString("v_quant_type", "PER_TENSOR"))
+            node.attributes.add(ir.AttrInt64("kv_cache_bit_width", 8))
+
+            modified = True
+            converted += 1
+
+        if converted:
+            logger.info(
+                "Fp8KvCachePass: converted %d GroupQueryAttention KV cache(s) to FP8",
+                converted,
+            )
+        return ir.passes.PassResult(model, modified=modified)
+
+    @staticmethod
+    def _scale_initializer(graph: ir.Graph, name: str, value: float) -> ir.Value:
+        """Return (creating if needed) a scalar FLOAT scale initializer."""
+        existing = graph.initializers.get(name)
+        if existing is not None:
+            return existing
+        tensor = ir.tensor(np.array([value], dtype=np.float32), name=name)
+        scale = ir.Value(name=name, type=ir.TensorType(ir.DataType.FLOAT), shape=ir.Shape([1]))
+        scale.const_value = tensor
+        graph.initializers[name] = scale
+        return scale
+
+
+def load_kv_cache_scale_file(path: str) -> dict[int, tuple[float, float]]:
+    """Load per-layer FP8 KV-cache scales from a calibration JSON file.
+
+    Accepts the onnxruntime-genai calibration format::
+
+        {"scales": {"k_scales": [s0, s1, ...], "v_scales": [s0, s1, ...]}}
+
+    The lists are indexed positionally: entry ``i`` maps to layer id ``i``
+    (matching the ``past_key_values.{i}`` naming). ``k_scales`` and
+    ``v_scales`` must have equal length.
+
+    Args:
+        path: Path to the calibration JSON file.
+
+    Returns:
+        A ``layer_id -> (k_scale, v_scale)`` mapping.
+
+    Raises:
+        ValueError: If the file lacks ``scales.k_scales`` / ``scales.v_scales``
+            or the two lists differ in length.
+    """
+    import json
+
+    with open(path, encoding="utf-8") as handle:
+        data = json.load(handle)
+    try:
+        k_scales = data["scales"]["k_scales"]
+        v_scales = data["scales"]["v_scales"]
+    except (KeyError, TypeError) as error:
+        raise ValueError(
+            f"{path!r} must contain scales.k_scales and scales.v_scales."
+        ) from error
+    if len(k_scales) != len(v_scales):
+        raise ValueError(
+            f"{path!r}: k_scales and v_scales must have equal length "
+            f"(got k={len(k_scales)}, v={len(v_scales)})."
+        )
+    return {i: (float(k), float(v)) for i, (k, v) in enumerate(zip(k_scales, v_scales))}

--- a/src/mobius/_passes/_fp8_kv_cache.py
+++ b/src/mobius/_passes/_fp8_kv_cache.py
@@ -42,7 +42,9 @@ Hopper / Blackwell). The FP8 KV cache is IO-bound at runtime as device
 
 from __future__ import annotations
 
+import json
 import logging
+import math
 import re
 
 import numpy as np
@@ -106,9 +108,11 @@ class Fp8KvCachePass(ir.passes.InPlacePass):
             if past_key is None or past_value is None:
                 # Prompt-processing GQA without a KV cache — nothing to convert.
                 continue
-            if past_key.dtype == _FP8:
-                # Already converted (idempotent re-run).
-                continue
+
+            # No early skip when past_key is already FP8: every step below is
+            # idempotent (retype is a no-op, scale initializers dedup by name,
+            # attributes overwrite, inputs only grow when < 14), so a re-run
+            # cannot leave a node in a half-converted state.
 
             layer_id = _layer_id_from_name(past_key.name)
             k_val, v_val = self._scales.get(
@@ -182,8 +186,6 @@ def load_kv_cache_scale_file(path: str) -> dict[int, tuple[float, float]]:
         ValueError: If the file lacks ``scales.k_scales`` / ``scales.v_scales``
             or the two lists differ in length.
     """
-    import json
-
     with open(path, encoding="utf-8") as handle:
         data = json.load(handle)
     try:
@@ -193,9 +195,22 @@ def load_kv_cache_scale_file(path: str) -> dict[int, tuple[float, float]]:
         raise ValueError(
             f"{path!r} must contain scales.k_scales and scales.v_scales."
         ) from error
+    if not isinstance(k_scales, list) or not isinstance(v_scales, list):
+        raise ValueError(  # noqa: TRY004 — malformed calibration file is a value error, not a type error
+            f"{path!r}: scales.k_scales and scales.v_scales must be JSON arrays."
+        )
     if len(k_scales) != len(v_scales):
         raise ValueError(
             f"{path!r}: k_scales and v_scales must have equal length "
             f"(got k={len(k_scales)}, v={len(v_scales)})."
         )
-    return {i: (float(k), float(v)) for i, (k, v) in enumerate(zip(k_scales, v_scales))}
+    scales: dict[int, tuple[float, float]] = {}
+    for i, (k, v) in enumerate(zip(k_scales, v_scales)):
+        k_f, v_f = float(k), float(v)
+        if not (math.isfinite(k_f) and k_f > 0.0 and math.isfinite(v_f) and v_f > 0.0):
+            raise ValueError(
+                f"{path!r}: layer {i} has a non-positive or non-finite scale "
+                f"(k={k}, v={v}); FP8 KV-cache scales must be finite and > 0."
+            )
+        scales[i] = (k_f, v_f)
+    return scales

--- a/src/mobius/_passes/_fp8_kv_cache_test.py
+++ b/src/mobius/_passes/_fp8_kv_cache_test.py
@@ -1,0 +1,237 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for the FP8 KV-cache pass (:mod:`mobius._passes._fp8_kv_cache`).
+
+Two layers of coverage:
+
+* **Structural (no GPU):** build a tiny GQA decoder on the CUDA EP with
+  ``fp8_kv_cache=True`` and assert the exported graph types every
+  ``past_key_values`` input and ``present`` output as ``FLOAT8E4M3FN``, adds
+  per-layer ``k_scale`` / ``v_scale`` initializers at GQA input slots 12/13,
+  and sets the quantization attributes.
+* **Runtime (CUDA only):** apply the pass to a hand-built ``GroupQueryAttention``
+  graph and execute it on ``CUDAExecutionProvider`` to prove the emitted op
+  signature is accepted by ORT's FP8 KV-cache kernel.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import ml_dtypes
+import numpy as np
+import onnx_ir as ir
+import onnxruntime as ort
+import pytest
+
+sys.path.insert(0, "tests")
+
+from _test_configs import _base_config
+
+from mobius import build_from_module
+from mobius._passes._fp8_kv_cache import (
+    Fp8KvCachePass,
+    load_kv_cache_scale_file,
+)
+from mobius._registry import registry
+
+_FP8 = ir.DataType.FLOAT8E4M3FN
+_CUDA = "CUDAExecutionProvider"
+_HAS_CUDA = _CUDA in ort.get_available_providers()
+
+
+def _build_fp8_decoder(fp8_kv_cache=True, kv_cache_scales=None):
+    """Build a tiny fp16 qwen2 decoder on the CUDA EP with the FP8 KV pass."""
+    config = _base_config(dtype=ir.DataType.FLOAT16)
+    module = registry.get("qwen2")(config)
+    pkg = build_from_module(
+        module,
+        config,
+        "text-generation",
+        execution_provider="cuda",
+        fp8_kv_cache=fp8_kv_cache,
+        kv_cache_scales=kv_cache_scales,
+    )
+    return pkg["model"], config
+
+
+class TestFp8KvCacheGraph:
+    def test_all_kv_io_typed_fp8(self):
+        model, config = _build_fp8_decoder()
+        ins = {v.name: v for v in model.graph.inputs}
+        outs = {v.name: v for v in model.graph.outputs}
+        for i in range(config.num_hidden_layers):
+            assert ins[f"past_key_values.{i}.key"].dtype == _FP8
+            assert ins[f"past_key_values.{i}.value"].dtype == _FP8
+            assert outs[f"present.{i}.key"].dtype == _FP8
+            assert outs[f"present.{i}.value"].dtype == _FP8
+
+    def test_gqa_scale_inputs_and_attrs(self):
+        model, _ = _build_fp8_decoder()
+        gqa_nodes = [
+            n
+            for n in model.graph
+            if n.domain == "com.microsoft" and n.op_type == "GroupQueryAttention"
+        ]
+        assert gqa_nodes, "expected GroupQueryAttention nodes"
+        for node in gqa_nodes:
+            assert len(node.inputs) == 14
+            assert node.inputs[12] is not None and node.inputs[12].name.endswith("k_scale")
+            assert node.inputs[13] is not None and node.inputs[13].name.endswith("v_scale")
+            assert node.attributes.get_string("k_quant_type") == "PER_TENSOR"
+            assert node.attributes.get_string("v_quant_type") == "PER_TENSOR"
+            assert node.attributes.get_int("kv_cache_bit_width") == 8
+
+    def test_default_unit_scales(self):
+        model, config = _build_fp8_decoder()
+        for i in range(config.num_hidden_layers):
+            k = model.graph.initializers[f"kv_cache.{i}.k_scale"]
+            v = model.graph.initializers[f"kv_cache.{i}.v_scale"]
+            np.testing.assert_array_equal(k.const_value.numpy(), np.array([1.0], np.float32))
+            np.testing.assert_array_equal(v.const_value.numpy(), np.array([1.0], np.float32))
+
+    def test_calibrated_scales_applied(self):
+        scales = {0: (0.25, 0.5), 1: (2.0, 4.0)}
+        model, _config = _build_fp8_decoder(kv_cache_scales=scales)
+        for i, (kv_k, kv_v) in scales.items():
+            k = model.graph.initializers[f"kv_cache.{i}.k_scale"]
+            v = model.graph.initializers[f"kv_cache.{i}.v_scale"]
+            np.testing.assert_array_equal(k.const_value.numpy(), np.array([kv_k], np.float32))
+            np.testing.assert_array_equal(v.const_value.numpy(), np.array([kv_v], np.float32))
+
+    def test_disabled_keeps_fp16_kv(self):
+        model, _config = _build_fp8_decoder(fp8_kv_cache=False)
+        ins = {v.name: v for v in model.graph.inputs}
+        assert ins["past_key_values.0.key"].dtype == ir.DataType.FLOAT16
+
+    def test_ignored_and_warns_on_non_gqa_ep(self):
+        """fp8_kv_cache on a non-GQA EP is a no-op with a warning."""
+        config = _base_config(dtype=ir.DataType.FLOAT)
+        module = registry.get("qwen2")(config)
+        with pytest.warns(UserWarning, match="fp8_kv_cache=True"):
+            pkg = build_from_module(
+                module,
+                config,
+                "text-generation",
+                execution_provider="default",
+                fp8_kv_cache=True,
+            )
+        ins = {v.name: v for v in pkg["model"].graph.inputs}
+        assert ins["past_key_values.0.key"].dtype == ir.DataType.FLOAT
+
+    def test_pass_is_idempotent(self):
+        model, _config = _build_fp8_decoder()
+        # Re-running the pass must not add extra inputs or re-type anything.
+        Fp8KvCachePass()(model)
+        for node in model.graph:
+            if node.op_type == "GroupQueryAttention":
+                assert len(node.inputs) == 14
+
+
+class TestLoadScaleFile:
+    def test_parses_ort_genai_format(self, tmp_path):
+        path = tmp_path / "scales.json"
+        path.write_text(
+            json.dumps({"scales": {"k_scales": [0.1, 0.2], "v_scales": [0.3, 0.4]}})
+        )
+        scales = load_kv_cache_scale_file(str(path))
+        assert scales == {0: (0.1, 0.3), 1: (0.2, 0.4)}
+
+    def test_rejects_missing_keys(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text(json.dumps({"scales": {"k_scales": [0.1]}}))
+        with pytest.raises(ValueError, match="k_scales and scales"):
+            load_kv_cache_scale_file(str(path))
+
+    def test_rejects_length_mismatch(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text(json.dumps({"scales": {"k_scales": [0.1, 0.2], "v_scales": [0.3]}}))
+        with pytest.raises(ValueError, match="equal length"):
+            load_kv_cache_scale_file(str(path))
+
+
+@pytest.mark.skipif(not _HAS_CUDA, reason="requires CUDAExecutionProvider (SM89+)")
+def test_fp8_kv_gqa_runs_on_cuda(tmp_path):
+    """The emitted FP8 GQA op signature is accepted and computes on CUDA.
+
+    Builds a single ``GroupQueryAttention`` graph with fp16 q/k/v, empty FP8
+    past cache (as internal constants so no fp8 numpy feed is needed — a known
+    ORT-Python limitation), runs the pass, and executes on the CUDA EP.
+    """
+    b, s, h, kv, d = 1, 4, 2, 1, 16
+    f16 = ir.DataType.FLOAT16
+    i32 = ir.DataType.INT32
+
+    def val(name, dt, shape):
+        return ir.Value(name=name, type=ir.TensorType(dt), shape=ir.Shape(shape))
+
+    def const(name, arr):
+        v = ir.Value(
+            name=name, type=ir.TensorType(ir.tensor(arr).dtype), shape=ir.Shape(arr.shape)
+        )
+        v.const_value = ir.tensor(arr, name=name)
+        return v
+
+    query = val("query", f16, [b, s, h * d])
+    key = val("key", f16, [b, s, kv * d])
+    value = val("value", f16, [b, s, kv * d])
+    seqlens_k = val("seqlens_k", i32, [b])
+    total_seq = val("total_seq", i32, [1])
+    # Empty (0-length) fp16 past constants: the pass retypes them to FP8 (there
+    # are no elements to reinterpret) so no fp8 numpy feed is needed.
+    past_key = const("past_key", np.zeros((b, kv, 0, d), dtype=np.float16))
+    past_value = const("past_value", np.zeros((b, kv, 0, d), dtype=np.float16))
+    out = val("out", f16, [b, s, h * d])
+    pk = val("present_key", f16, [b, kv, s, d])
+    pv = val("present_value", f16, [b, kv, s, d])
+
+    node = ir.Node(
+        "com.microsoft",
+        "GroupQueryAttention",
+        [query, key, value, past_key, past_value, seqlens_k, total_seq],
+        attributes={
+            "num_heads": ir.AttrInt64("num_heads", h),
+            "kv_num_heads": ir.AttrInt64("kv_num_heads", kv),
+        },
+        outputs=[out, pk, pv],
+        num_outputs=3,
+    )
+    graph = ir.Graph(
+        [query, key, value, seqlens_k, total_seq],
+        [out, pk, pv],
+        nodes=[node],
+        initializers=[past_key, past_value],
+        name="g",
+        opset_imports={"": 24, "com.microsoft": 1},
+    )
+    model = ir.Model(graph, ir_version=10)
+    Fp8KvCachePass()(model)
+
+    # Present outputs are now FP8 and the node carries k_scale/v_scale + attrs.
+    assert graph.outputs[1].dtype == _FP8
+    assert node.attributes.get_int("kv_cache_bit_width") == 8
+
+    # Match the empty past constants' data to their new FP8 declared type.
+    past_key.const_value = ir.tensor(
+        np.zeros((b, kv, 0, d), dtype=ml_dtypes.float8_e4m3fn), name="past_key"
+    )
+    past_value.const_value = ir.tensor(
+        np.zeros((b, kv, 0, d), dtype=ml_dtypes.float8_e4m3fn), name="past_value"
+    )
+
+    path = tmp_path / "gqa.onnx"
+    ir.save(model, str(path))
+    sess = ort.InferenceSession(str(path), providers=[_CUDA, "CPUExecutionProvider"])
+    outs = sess.run(
+        None,
+        {
+            "query": (np.random.randn(b, s, h * d) * 0.1).astype(np.float16),
+            "key": (np.random.randn(b, s, kv * d) * 0.1).astype(np.float16),
+            "value": (np.random.randn(b, s, kv * d) * 0.1).astype(np.float16),
+            "seqlens_k": np.array([s - 1], dtype=np.int32),
+            "total_seq": np.array([s], dtype=np.int32),
+        },
+    )
+    assert np.isfinite(outs[0].astype(np.float32)).all()

--- a/src/mobius/_passes/_fp8_kv_cache_test.py
+++ b/src/mobius/_passes/_fp8_kv_cache_test.py
@@ -42,6 +42,26 @@ _CUDA = "CUDAExecutionProvider"
 _HAS_CUDA = _CUDA in ort.get_available_providers()
 
 
+def _cuda_supports_fp8() -> bool:
+    """Best-effort check that the CUDA device has an FP8 GQA kernel (SM89+).
+
+    Conservative: returns ``False`` when the compute capability cannot be
+    determined (e.g. torch unavailable), so the runtime test is skipped rather
+    than run on hardware without the FP8 kernel (e.g. T4 / SM75).
+    """
+    if not _HAS_CUDA:
+        return False
+    try:
+        import torch
+
+        return torch.cuda.get_device_capability() >= (8, 9)
+    except Exception:
+        return False
+
+
+_FP8_CUDA = _cuda_supports_fp8()
+
+
 def _build_fp8_decoder(fp8_kv_cache=True, kv_cache_scales=None):
     """Build a tiny fp16 qwen2 decoder on the CUDA EP with the FP8 KV pass."""
     config = _base_config(dtype=ir.DataType.FLOAT16)
@@ -78,8 +98,12 @@ class TestFp8KvCacheGraph:
         assert gqa_nodes, "expected GroupQueryAttention nodes"
         for node in gqa_nodes:
             assert len(node.inputs) == 14
-            assert node.inputs[12] is not None and node.inputs[12].name.endswith("k_scale")
-            assert node.inputs[13] is not None and node.inputs[13].name.endswith("v_scale")
+            assert node.inputs[12] is not None and node.inputs[12].name.endswith(
+                "key.fp8_scale"
+            )
+            assert node.inputs[13] is not None and node.inputs[13].name.endswith(
+                "value.fp8_scale"
+            )
             assert node.attributes.get_string("k_quant_type") == "PER_TENSOR"
             assert node.attributes.get_string("v_quant_type") == "PER_TENSOR"
             assert node.attributes.get_int("kv_cache_bit_width") == 8
@@ -87,8 +111,8 @@ class TestFp8KvCacheGraph:
     def test_default_unit_scales(self):
         model, config = _build_fp8_decoder()
         for i in range(config.num_hidden_layers):
-            k = model.graph.initializers[f"kv_cache.{i}.k_scale"]
-            v = model.graph.initializers[f"kv_cache.{i}.v_scale"]
+            k = model.graph.initializers[f"past_key_values.{i}.key.fp8_scale"]
+            v = model.graph.initializers[f"past_key_values.{i}.value.fp8_scale"]
             np.testing.assert_array_equal(k.const_value.numpy(), np.array([1.0], np.float32))
             np.testing.assert_array_equal(v.const_value.numpy(), np.array([1.0], np.float32))
 
@@ -96,8 +120,8 @@ class TestFp8KvCacheGraph:
         scales = {0: (0.25, 0.5), 1: (2.0, 4.0)}
         model, _config = _build_fp8_decoder(kv_cache_scales=scales)
         for i, (kv_k, kv_v) in scales.items():
-            k = model.graph.initializers[f"kv_cache.{i}.k_scale"]
-            v = model.graph.initializers[f"kv_cache.{i}.v_scale"]
+            k = model.graph.initializers[f"past_key_values.{i}.key.fp8_scale"]
+            v = model.graph.initializers[f"past_key_values.{i}.value.fp8_scale"]
             np.testing.assert_array_equal(k.const_value.numpy(), np.array([kv_k], np.float32))
             np.testing.assert_array_equal(v.const_value.numpy(), np.array([kv_v], np.float32))
 
@@ -128,6 +152,53 @@ class TestFp8KvCacheGraph:
         for node in model.graph:
             if node.op_type == "GroupQueryAttention":
                 assert len(node.inputs) == 14
+
+    def test_skips_nonempty_initializer_cache(self):
+        """A non-empty FLOAT initializer-backed cache is left untouched (warns)."""
+        f16, i32 = ir.DataType.FLOAT16, ir.DataType.INT32
+
+        def val(name, dt, shape):
+            return ir.Value(name=name, type=ir.TensorType(dt), shape=ir.Shape(shape))
+
+        query = val("query", f16, [1, 1, 32])
+        seqlens_k = val("seqlens_k", i32, [1])
+        total_seq = val("total_seq", i32, [1])
+        # Non-empty fp16 past initializers (NOT graph inputs).
+        past_key = val("past_key_values.0.key", f16, [1, 1, 1, 16])
+        past_key.const_value = ir.tensor(
+            np.ones((1, 1, 1, 16), np.float16), name="past_key_values.0.key"
+        )
+        past_value = val("past_key_values.0.value", f16, [1, 1, 1, 16])
+        past_value.const_value = ir.tensor(
+            np.ones((1, 1, 1, 16), np.float16), name="past_key_values.0.value"
+        )
+        out = val("out", f16, [1, 1, 32])
+        pk = val("present.0.key", f16, [1, 1, 1, 16])
+        pv = val("present.0.value", f16, [1, 1, 1, 16])
+        node = ir.Node(
+            "com.microsoft",
+            "GroupQueryAttention",
+            [query, None, None, past_key, past_value, seqlens_k, total_seq],
+            attributes={
+                "num_heads": ir.AttrInt64("num_heads", 2),
+                "kv_num_heads": ir.AttrInt64("kv_num_heads", 1),
+            },
+            outputs=[out, pk, pv],
+            num_outputs=3,
+        )
+        graph = ir.Graph(
+            [query, seqlens_k, total_seq],
+            [out, pk, pv],
+            nodes=[node],
+            initializers=[past_key, past_value],
+            name="g",
+            opset_imports={"": 24, "com.microsoft": 1},
+        )
+        model = ir.Model(graph, ir_version=10)
+        with pytest.warns(UserWarning, match="non-empty initializer"):
+            Fp8KvCachePass()(model)
+        assert past_key.dtype == f16
+        assert len(node.inputs) == 7  # unchanged: no scale inputs added
 
 
 class TestLoadScaleFile:
@@ -166,7 +237,7 @@ class TestLoadScaleFile:
             load_kv_cache_scale_file(str(path))
 
 
-@pytest.mark.skipif(not _HAS_CUDA, reason="requires CUDAExecutionProvider (SM89+)")
+@pytest.mark.skipif(not _FP8_CUDA, reason="requires CUDA FP8 GQA kernel (SM89+)")
 def test_fp8_kv_gqa_runs_on_cuda(tmp_path):
     """The emitted FP8 GQA op signature is accepted and computes on CUDA.
 

--- a/src/mobius/_passes/_fp8_kv_cache_test.py
+++ b/src/mobius/_passes/_fp8_kv_cache_test.py
@@ -151,6 +151,20 @@ class TestLoadScaleFile:
         with pytest.raises(ValueError, match="equal length"):
             load_kv_cache_scale_file(str(path))
 
+    def test_rejects_non_positive_scale(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text(
+            json.dumps({"scales": {"k_scales": [0.1, 0.0], "v_scales": [0.3, 0.4]}})
+        )
+        with pytest.raises(ValueError, match="non-finite"):
+            load_kv_cache_scale_file(str(path))
+
+    def test_rejects_non_array(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text(json.dumps({"scales": {"k_scales": "0.1", "v_scales": "0.3"}}))
+        with pytest.raises(ValueError, match="must be JSON arrays"):
+            load_kv_cache_scale_file(str(path))
+
 
 @pytest.mark.skipif(not _HAS_CUDA, reason="requires CUDAExecutionProvider (SM89+)")
 def test_fp8_kv_gqa_runs_on_cuda(tmp_path):

--- a/src/mobius/_passes/_fp8_kv_cache_test.py
+++ b/src/mobius/_passes/_fp8_kv_cache_test.py
@@ -145,6 +145,26 @@ class TestFp8KvCacheGraph:
         ins = {v.name: v for v in pkg["model"].graph.inputs}
         assert ins["past_key_values.0.key"].dtype == ir.DataType.FLOAT
 
+    def test_ignored_and_warns_on_non_fp8_ep_with_gqa(self):
+        """GQA-active but non-FP8 EP (CPU/float32) must NOT emit FP8 KV I/O.
+
+        Regression: fp8_kv_cache was previously applied whenever GQA fusion was
+        active, which includes CPU (gqa_dtypes={FLOAT}) — an EP without the FP8
+        GQA kernel — producing models that can't load/run.
+        """
+        config = _base_config(dtype=ir.DataType.FLOAT)
+        module = registry.get("qwen2")(config)
+        with pytest.warns(UserWarning, match="fp8_kv_cache=True"):
+            pkg = build_from_module(
+                module,
+                config,
+                "text-generation",
+                execution_provider="cpu",
+                fp8_kv_cache=True,
+            )
+        ins = {v.name: v for v in pkg["model"].graph.inputs}
+        assert ins["past_key_values.0.key"].dtype == ir.DataType.FLOAT
+
     def test_pass_is_idempotent(self):
         model, _config = _build_fp8_decoder()
         # Re-running the pass must not add extra inputs or re-type anything.

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -139,6 +139,151 @@ class TestCLIBuild:
             )
             assert os.path.isfile(os.path.join(tmpdir, "model.onnx"))
 
+    def test_features_static_cache_equivalent(self):
+        """--features static-cache builds the same static-cache model."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            main(
+                [
+                    "build",
+                    "--model",
+                    "Qwen/Qwen2.5-0.5B",
+                    tmpdir,
+                    "--no-weights",
+                    "--features",
+                    "static-cache",
+                ]
+            )
+            model = onnx.load(os.path.join(tmpdir, "model.onnx"))
+            cache_inputs = [
+                inp for inp in model.graph.input if inp.name.startswith("key_cache.")
+            ]
+            assert len(cache_inputs) > 0, "static cache not applied via --features"
+
+    def test_features_max_seq_len_pairs_with_static_cache(self):
+        """--max-seq-len works when static-cache is enabled via --features."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            main(
+                [
+                    "build",
+                    "--model",
+                    "Qwen/Qwen2.5-0.5B",
+                    tmpdir,
+                    "--no-weights",
+                    "--features",
+                    "static-cache",
+                    "--max-seq-len",
+                    "128",
+                ]
+            )
+            assert os.path.isfile(os.path.join(tmpdir, "model.onnx"))
+
+    def test_features_text_only_passed_through(self):
+        """--features text-only sets text_only on the build() call."""
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            mock.patch(
+                "mobius._diffusers_builder._load_diffusers_pipeline_index",
+                return_value=None,
+            ),
+            mock.patch("mobius.__main__.build", return_value=mock.MagicMock()) as mock_build,
+            mock.patch("mobius.__main__._save_package"),
+        ):
+            main(
+                [
+                    "build",
+                    "--model",
+                    "some/model",
+                    tmpdir,
+                    "--no-weights",
+                    "--features",
+                    "text-only",
+                ]
+            )
+        assert mock_build.call_args.kwargs.get("text_only") is True
+
+    def test_features_fp8_kv_cache_passed_through(self):
+        """--features fp8-kv-cache sets fp8_kv_cache on the build() call."""
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            mock.patch(
+                "mobius._diffusers_builder._load_diffusers_pipeline_index",
+                return_value=None,
+            ),
+            mock.patch("mobius.__main__.build", return_value=mock.MagicMock()) as mock_build,
+            mock.patch("mobius.__main__._save_package"),
+        ):
+            main(
+                [
+                    "build",
+                    "--model",
+                    "some/model",
+                    tmpdir,
+                    "--no-weights",
+                    "--features",
+                    "fp8-kv-cache",
+                ]
+            )
+        assert mock_build.call_args.kwargs.get("fp8_kv_cache") is True
+
+    def test_features_comma_separated_multiple(self):
+        """A single --features accepts a comma-separated list."""
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            mock.patch(
+                "mobius._diffusers_builder._load_diffusers_pipeline_index",
+                return_value=None,
+            ),
+            mock.patch("mobius.__main__.build", return_value=mock.MagicMock()) as mock_build,
+            mock.patch("mobius.__main__._save_package"),
+        ):
+            main(
+                [
+                    "build",
+                    "--model",
+                    "some/model",
+                    tmpdir,
+                    "--no-weights",
+                    "--features",
+                    "text-only,fp8-kv-cache",
+                ]
+            )
+        kwargs = mock_build.call_args.kwargs
+        assert kwargs.get("text_only") is True
+        assert kwargs.get("fp8_kv_cache") is True
+
+    def test_features_unknown_errors(self):
+        """An unrecognised feature name is rejected with a clear error."""
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            pytest.raises(SystemExit, match=r"unknown feature 'bogus'"),
+        ):
+            main(
+                [
+                    "build",
+                    "--model",
+                    "some/model",
+                    tmpdir,
+                    "--no-weights",
+                    "--features",
+                    "bogus",
+                ]
+            )
+
+    def test_deprecated_static_cache_flag_warns(self, capsys):
+        """The legacy --static-cache flag still works but warns."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            main(
+                [
+                    "build",
+                    "--model",
+                    "Qwen/Qwen2.5-0.5B",
+                    tmpdir,
+                    "--no-weights",
+                    "--static-cache",
+                ]
+            )
+        assert "--static-cache is deprecated" in capsys.readouterr().err
+
     def test_max_seq_len_without_static_cache_errors(self):
         with tempfile.TemporaryDirectory() as tmpdir, pytest.raises(SystemExit):
             main(

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -78,7 +78,17 @@ class TestCLIBuild:
     def test_text_only_with_config_errors(self):
         """--text-only is rejected on the --config (local dir) path."""
         with tempfile.TemporaryDirectory() as tmpdir, pytest.raises(SystemExit):
-            main(["build", "--config", tmpdir, tmpdir, "--text-only", "--no-weights"])
+            main(
+                [
+                    "build",
+                    "--config",
+                    tmpdir,
+                    tmpdir,
+                    "--features",
+                    "text-only",
+                    "--no-weights",
+                ]
+            )
 
     def test_text_only_with_component_errors(self):
         """--text-only is rejected when combined with --component."""
@@ -89,7 +99,8 @@ class TestCLIBuild:
                     "--model",
                     "google/gemma-4-12B",
                     tmpdir,
-                    "--text-only",
+                    "--features",
+                    "text-only",
                     "--component",
                     "vision_encoder",
                     "--no-weights",
@@ -116,7 +127,8 @@ class TestCLIBuild:
                     "--model",
                     "some/diffusion-repo",
                     tmpdir,
-                    "--text-only",
+                    "--features",
+                    "text-only",
                     "--no-weights",
                 ]
             )
@@ -134,7 +146,8 @@ class TestCLIBuild:
                     "Qwen/Qwen2.5-0.5B",
                     tmpdir,
                     "--no-weights",
-                    "--static-cache",
+                    "--features",
+                    "static-cache",
                 ]
             )
             assert os.path.isfile(os.path.join(tmpdir, "model.onnx"))
@@ -269,21 +282,6 @@ class TestCLIBuild:
                 ]
             )
 
-    def test_deprecated_static_cache_flag_warns(self, capsys):
-        """The legacy --static-cache flag still works but warns."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            main(
-                [
-                    "build",
-                    "--model",
-                    "Qwen/Qwen2.5-0.5B",
-                    tmpdir,
-                    "--no-weights",
-                    "--static-cache",
-                ]
-            )
-        assert "--static-cache is deprecated" in capsys.readouterr().err
-
     def test_max_seq_len_without_static_cache_errors(self):
         with tempfile.TemporaryDirectory() as tmpdir, pytest.raises(SystemExit):
             main(
@@ -308,7 +306,8 @@ class TestCLIBuild:
                     "Qwen/Qwen2.5-0.5B",
                     tmpdir,
                     "--no-weights",
-                    "--static-cache",
+                    "--features",
+                    "static-cache",
                     "--task",
                     "text-generation",
                 ]
@@ -323,7 +322,8 @@ class TestCLIBuild:
                     "Qwen/Qwen2.5-0.5B",
                     tmpdir,
                     "--no-weights",
-                    "--static-cache",
+                    "--features",
+                    "static-cache",
                     "--max-seq-len",
                     "0",
                 ]
@@ -340,7 +340,8 @@ class TestCLIBuild:
                     "Qwen/Qwen2.5-0.5B",
                     tmpdir,
                     "--no-weights",
-                    "--static-cache",
+                    "--features",
+                    "static-cache",
                     "--max-seq-len",
                     str(max_seq_len),
                 ]


### PR DESCRIPTION
## Summary

Adds an opt-in **FP8 (E4M3) KV-cache export path**. When enabled, each decoder `com.microsoft::GroupQueryAttention` stores its past/present key-value cache as `FLOAT8E4M3FN` instead of the model dtype (fp16/bf16), **halving KV-cache memory** at long context. Mirrors onnxruntime-genai's `fp8_kv_cache` option (microsoft/onnxruntime-genai#2351).

## How it works

A new post-fusion IR pass `Fp8KvCachePass` (`src/mobius/_passes/_fp8_kv_cache.py`), run after the GQA fusion rules, for every decoder GQA node whose KV cache are graph inputs:

1. Retypes the `past_key`/`past_value` inputs and `present_key`/`present_value` outputs (all graph I/O) to `FLOAT8E4M3FN`, preserving shapes.
2. Adds per-layer `k_scale`/`v_scale` scalar FLOAT initializers at GQA input slots **12/13** (ORT ≥ 1.28 signature).
3. Sets `k_quant_type`/`v_quant_type = "PER_TENSOR"` and `kv_cache_bit_width = 8`.

`query`/`key`/`value` stay at the model dtype — the kernel quantizes the new K/V to FP8 on write and dequantizes on read using the scales. Scales default to a unit `1.0` (the "legacy" export shape), or come from an offline **calibration file** (onnxruntime-genai `{"scales": {"k_scales": [...], "v_scales": [...]}}` JSON).

## Usage

```bash
mobius build --model Qwen/Qwen3-4B --dtype f16 \
  --execution-provider cuda --fp8-kv-cache \
  [--kv-cache-scale-file scales.json] /out
```

Also exposed programmatically on `build(...)` / `build_from_module(...)` via `fp8_kv_cache=` and `kv_cache_scales=`. The option is **ignored with a warning** when GQA fusion is not active (non-GQA EP or fp32), since there is no KV-cache op to convert.

## Verification (H200 / SM90, onnxruntime-gpu 1.28)

- The emitted FP8 GQA op **loads and computes on the CUDA EP** — finite fp16 output, FP8 present cache (covered by `test_fp8_kv_gqa_runs_on_cuda`, gated on CUDA availability).
- End-to-end FP8 KV at runtime is IO-bound as device `FLOAT8E4M3FN` OrtValues (as onnxruntime-genai does). The Python numpy fp8 **feed** path is unsupported by ORT; the runtime test works around it with empty in-graph FP8 constants.

## Tests

`src/mobius/_passes/_fp8_kv_cache_test.py` — 11 tests: KV I/O typed FP8, GQA scale inputs + quant attrs, default unit scales, calibrated scales, disabled path, ignored+warns on non-GQA EP, idempotency, scale-file parsing/validation, and the CUDA runtime run. Existing pass/CLI/build-graph suites pass; changed files pass ruff.

> ⚠️ Please review — do not merge yet.