### PR TITLE
feat(models): add NVIDIA Cosmos3-Edge vision-language model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### NVIDIA Cosmos 3 Edge text reasoner (`cosmos3_edge`)
+
+#### Added
+
+- Support for the **text reasoner backbone** of the `cosmos3_edge`
+  vision-language checkpoint (`nvidia/Cosmos3-Edge`). The language tower is a
+  grouped-query-attention decoder with a **non-gated squared-ReLU FFN**
+  (`hidden_act="relu2"`, `up_proj → relu2 → down_proj`) and 3D multimodal RoPE
+  (`mrope_section=[24, 20, 20]`, equivalent to 1D RoPE for text-only). Mapped
+  onto the standard `CausalLMModel` backbone + `FCMLP`; `preprocess_weights`
+  renames the `self_attn.to_{q,k,v,out}` projections, nests the top-level text
+  tower under `model.`, and drops the vision encoder, projector, and the
+  generator-tower `k_norm_und_for_gen` key-norm. Registered as `cosmos3_edge`
+  / `cosmos3_edge_text`; L1 graph-build tested. The `cosmos3_omni` variants
+  (`Cosmos3-Nano`/`-Super`) are two-tower diffusion world models and remain out
+  of scope for this decoder-only path.
+
 ### Cargo-style `--features` build option
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### NVIDIA Cosmos 3 Edge text reasoner (`cosmos3_edge`)
+### NVIDIA Cosmos 3 Edge vision-language model (`cosmos3_edge`)
 
 #### Added
 
-- Support for the **text reasoner backbone** of the `cosmos3_edge`
-  vision-language checkpoint (`nvidia/Cosmos3-Edge`). The language tower is a
-  grouped-query-attention decoder with a **non-gated squared-ReLU FFN**
-  (`hidden_act="relu2"`, `up_proj → relu2 → down_proj`) and 3D multimodal RoPE
-  (`mrope_section=[24, 20, 20]`, equivalent to 1D RoPE for text-only). Mapped
-  onto the standard `CausalLMModel` backbone + `FCMLP`; `preprocess_weights`
-  renames the `self_attn.to_{q,k,v,out}` projections, nests the top-level text
-  tower under `model.`, and drops the vision encoder, projector, and the
-  generator-tower `k_norm_und_for_gen` key-norm. Registered as `cosmos3_edge`
-  / `cosmos3_edge_text`; L1 graph-build tested. The `cosmos3_omni` variants
-  (`Cosmos3-Nano`/`-Super`) are two-tower diffusion world models and remain out
-  of scope for this decoder-only path.
+- Support for the **full `cosmos3_edge` vision-language model**
+  (`nvidia/Cosmos3-Edge`, `Cosmos3EdgeForConditionalGeneration`) as a 3-model
+  onnxruntime-genai split (`decoder` + `vision_encoder` + `embedding`):
+  - **decoder**: grouped-query-attention text reasoner with a **non-gated
+    squared-ReLU FFN** (`hidden_act="relu2"`, `up_proj → relu2 → down_proj`)
+    and 3D multimodal RoPE (`mrope_section=[24, 20, 20]`); takes
+    `inputs_embeds`.
+  - **vision_encoder**: SigLIP vision tower + a new
+    `Cosmos3EdgeMultiModalProjector` (pre-shuffle `LayerNorm` → 2×2
+    pixel-shuffle → `linear_fc1` → GELU → `linear_fc2`).
+  - **embedding**: token embedding + image-feature fusion at
+    `image_token_id=19`.
+  `preprocess_weights` routes the single HF checkpoint to the three
+  sub-models: `model.visual.*` / `model.projector.*` → vision (with SigLIP
+  `mlp.fc1/fc2` → `up_proj/down_proj`), `embed_tokens` → embedding, the
+  top-level text tower (`layers.*` / `norm` / `lm_head`) → decoder (renaming
+  `self_attn.to_{q,k,v,out}` → `{q,k,v,o}_proj`), and drops the
+  generator-tower `k_norm_und_for_gen` key-norm. Built via a new
+  `Cosmos3EdgeVLTask` (`cosmos3-edge-vl`). The decoder-only text reasoner
+  remains available as `cosmos3_edge_text`.
+- **L1 graph-build tested only.** NVIDIA does not publish modeling code for
+  `cosmos3_edge` (not in `transformers`, no remote-code module), so the exact
+  pixel-shuffle ordering and numerical parity are unverifiable; L4/L5 parity
+  is deferred. The `cosmos3_omni` variants (`Cosmos3-Nano`/`-Super`) are
+  two-tower diffusion world models tracked separately.
 
 ### Cargo-style `--features` build option
 

--- a/src/mobius/_configs/_sub_configs.py
+++ b/src/mobius/_configs/_sub_configs.py
@@ -74,6 +74,10 @@ class VisionConfig:
     pooling_kernel_size: int | None = None
     # MLP activation for vision encoder layers (e.g. "gelu_pytorch_tanh" for Gemma4 SigLIP)
     hidden_act: str | None = None
+    # Cosmos3-Edge pixel-shuffle projector intermediate size
+    # (HF: projector_config.merger_intermediate_size). ``None`` means the model
+    # does not use a Cosmos-style merger projector.
+    projector_intermediate_size: int | None = None
     # CLIP-style feature extraction: which ``hidden_states`` index to output
     # (HuggingFace convention, e.g. -2 for Phi-3.5-Vision). ``None`` means use
     # the final hidden state (all layers + post_layernorm).

--- a/src/mobius/_configs/per_model/__init__.py
+++ b/src/mobius/_configs/per_model/__init__.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 # defaults run separately as an explicit first pass, so `ruff` / `isort`
 # may freely re-sort this block.
 from mobius._configs.per_model import (  # noqa: F401
+    _cosmos3_edge_vision,
     _gemma4_audio,
     _gemma4_unified_audio,
     _gemma4_unified_vision,

--- a/src/mobius/_configs/per_model/_cosmos3_edge_vision.py
+++ b/src/mobius/_configs/per_model/_cosmos3_edge_vision.py
@@ -1,0 +1,62 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Vision extractor hook for NVIDIA Cosmos3-Edge.
+
+Cosmos3-Edge (``cosmos3_edge`` / ``Cosmos3EdgeForConditionalGeneration``) pairs
+a SigLIP-style vision encoder (``cosmos3_edge_vision``) with a pixel-shuffle
+merger projector (``cosmos3_edge_projector``). Two config quirks need bridging
+into :class:`~mobius._configs.VisionConfig`:
+
+- The vision config declares ``num_patches`` (256) instead of ``image_size``.
+  The standard :class:`~mobius.components.PatchEmbedding` derives the patch
+  count from ``image_size // patch_size``, so we reconstruct
+  ``image_size = sqrt(num_patches) * patch_size`` (16 * 16 = 256).
+- The projector's intermediate width lives in a sibling ``projector_config``
+  (``merger_intermediate_size``), not in ``vision_config``.
+"""
+
+from __future__ import annotations
+
+import math
+
+from mobius._configs._extractors import register_vision_hook
+
+
+@register_vision_hook("cosmos3_edge", "cosmos3_edge_vision")
+def _cosmos3_edge_vision(config, parent_config, model_type: str, fields: dict):
+    vision_source = parent_config or config
+    hf_vision = getattr(vision_source, "vision_config", None) or getattr(
+        config, "vision_config", None
+    )
+
+    # Reconstruct image_size from num_patches (256 -> 16x16 grid -> 256 px).
+    if fields.get("image_size") is None and hf_vision is not None:
+        num_patches = getattr(hf_vision, "num_patches", None)
+        patch_size = getattr(hf_vision, "patch_size", None) or fields.get("patch_size")
+        if num_patches is not None and patch_size is not None:
+            grid = round(math.sqrt(num_patches))
+            fields["image_size"] = grid * patch_size
+
+    # Pixel-shuffle projector intermediate size from projector_config.
+    projector_cfg = getattr(vision_source, "projector_config", None) or getattr(
+        config, "projector_config", None
+    )
+    if projector_cfg is not None:
+        get = (
+            projector_cfg.get
+            if isinstance(projector_cfg, dict)
+            else lambda k, d=None: getattr(projector_cfg, k, d)
+        )
+        fields["projector_intermediate_size"] = get("merger_intermediate_size")
+        # out_hidden_size drives the projector output (text hidden size).
+        if fields.get("out_hidden_size") is None:
+            fields["out_hidden_size"] = get("out_hidden_size")
+        merge = get("spatial_merge_size")
+        if merge is not None:
+            fields["spatial_merge_size"] = merge
+
+    # Cosmos3-Edge places image_token_id at the top level (default 19).
+    if fields.get("image_token_id") is None:
+        fields["image_token_id"] = getattr(vision_source, "image_token_id", 19)
+    return None

--- a/src/mobius/_configs/per_model/_cosmos3_edge_vision.py
+++ b/src/mobius/_configs/per_model/_cosmos3_edge_vision.py
@@ -35,7 +35,12 @@ def _cosmos3_edge_vision(config, parent_config, model_type: str, fields: dict):
         num_patches = getattr(hf_vision, "num_patches", None)
         patch_size = getattr(hf_vision, "patch_size", None) or fields.get("patch_size")
         if num_patches is not None and patch_size is not None:
-            grid = round(math.sqrt(num_patches))
+            grid = math.isqrt(num_patches)
+            if grid * grid != num_patches:
+                raise ValueError(
+                    "Cosmos3-Edge vision num_patches must form a square grid, "
+                    f"got {num_patches}"
+                )
             fields["image_size"] = grid * patch_size
 
     # Pixel-shuffle projector intermediate size from projector_config.

--- a/src/mobius/_registry.py
+++ b/src/mobius/_registry.py
@@ -35,6 +35,7 @@ from mobius.models import (
     ArceeCausalLMModel,
     CausalLMModel,
     ChatGLMCausalLMModel,
+    Cosmos3EdgeTextModel,
     Cosmos3OmniReasonerModel,
     DeepSeekOCR2CausalLMModel,
     DeepSeekV3CausalLMModel,
@@ -399,6 +400,8 @@ _REGISTRATIONS: dict[str, ModelRegistration] = {
     "codegen": ModelRegistration(CodeGenCausalLMModel),
     "cohere": ModelRegistration(CohereCausalLMModel),
     "cohere2": ModelRegistration(CohereCausalLMModel),
+    "cosmos3_edge": ModelRegistration(Cosmos3EdgeTextModel),
+    "cosmos3_edge_text": ModelRegistration(Cosmos3EdgeTextModel),
     "cosmos3_omni": ModelRegistration(
         Cosmos3OmniReasonerModel, task="qwen-vl", family="cosmos", variant="reasoner"
     ),
@@ -824,6 +827,8 @@ _TEST_MODEL_IDS: dict[str, str] = {
     "qwen2": "Qwen/Qwen2.5-0.5B",
     "cohere": "CohereForAI/c4ai-command-r7b-12-2024",
     "cohere2": "CohereForAI/c4ai-command-r7b-12-2024",
+    "cosmos3_edge": "nvidia/Cosmos3-Edge",
+    "cosmos3_edge_text": "nvidia/Cosmos3-Edge",
     "exaone": "LGAI-EXAONE/EXAONE-3.0-7.8B-Instruct",
     "glm": "THUDM/glm-4-9b-chat-hf",
     "glm4": "THUDM/glm-4-9b-chat-hf",

--- a/src/mobius/_registry.py
+++ b/src/mobius/_registry.py
@@ -36,6 +36,7 @@ from mobius.models import (
     CausalLMModel,
     ChatGLMCausalLMModel,
     Cosmos3EdgeTextModel,
+    Cosmos3EdgeVLModel,
     Cosmos3OmniReasonerModel,
     DeepSeekOCR2CausalLMModel,
     DeepSeekV3CausalLMModel,
@@ -400,7 +401,7 @@ _REGISTRATIONS: dict[str, ModelRegistration] = {
     "codegen": ModelRegistration(CodeGenCausalLMModel),
     "cohere": ModelRegistration(CohereCausalLMModel),
     "cohere2": ModelRegistration(CohereCausalLMModel),
-    "cosmos3_edge": ModelRegistration(Cosmos3EdgeTextModel),
+    "cosmos3_edge": ModelRegistration(Cosmos3EdgeVLModel),
     "cosmos3_edge_text": ModelRegistration(Cosmos3EdgeTextModel),
     "cosmos3_omni": ModelRegistration(
         Cosmos3OmniReasonerModel, task="qwen-vl", family="cosmos", variant="reasoner"

--- a/src/mobius/components/__init__.py
+++ b/src/mobius/components/__init__.py
@@ -47,6 +47,7 @@ __all__ = [
     "LoRALinear",
     "MLP",
     "MLPMultiModalProjector",
+    "Cosmos3EdgeMultiModalProjector",
     "MoELayer",
     "OffsetRMSNorm",
     "PatchEmbed",
@@ -168,6 +169,9 @@ from mobius.components._moe import (
     SoftmaxTopKGate,
     SparseMixerGate,
     TopKGate,
+)
+from mobius.components._multimodal import (
+    Cosmos3EdgeMultiModalProjector as Cosmos3EdgeMultiModalProjector,
 )
 from mobius.components._multimodal import (
     Gemma3MultiModalProjector as Gemma3MultiModalProjector,

--- a/src/mobius/components/_multimodal.py
+++ b/src/mobius/components/_multimodal.py
@@ -148,6 +148,15 @@ class Cosmos3EdgeMultiModalProjector(nn.Module):
         norm_eps: float = 1e-6,
     ):
         super().__init__()
+        if grid_size <= 0:
+            raise ValueError(f"grid_size must be positive, got {grid_size}")
+        if spatial_merge_size <= 0:
+            raise ValueError(f"spatial_merge_size must be positive, got {spatial_merge_size}")
+        if grid_size % spatial_merge_size != 0:
+            raise ValueError(
+                f"grid_size ({grid_size}) must be divisible by "
+                f"spatial_merge_size ({spatial_merge_size})"
+            )
         self._grid = grid_size
         self._ms = spatial_merge_size
         self._vision_hidden = vision_hidden_size

--- a/src/mobius/components/_multimodal.py
+++ b/src/mobius/components/_multimodal.py
@@ -23,6 +23,7 @@ from onnxscript import OpBuilder, nn
 
 from mobius.components._common import Linear
 from mobius.components._rms_norm import RMSNorm
+from mobius.components._vision import VisionLayerNorm
 
 if TYPE_CHECKING:
     import onnx_ir as ir
@@ -115,6 +116,81 @@ class MLPMultiModalProjector(nn.Module):
         hidden = op.Gelu(hidden)
         hidden = self.linear_2(op, hidden)
         return hidden
+
+
+class Cosmos3EdgeMultiModalProjector(nn.Module):
+    """Cosmos3-Edge pixel-shuffle merger projector.
+
+    ``LayerNorm → spatial 2x2 pixel-shuffle → Linear(fc1) → GELU → Linear(fc2)``
+
+    The SigLIP vision encoder emits a fixed ``grid x grid`` patch grid
+    (``num_patches`` patches, e.g. 16x16 = 256). ``use_postshuffle_norm=false``
+    means the ``LayerNorm`` is applied on the raw ``vision_hidden_size`` (1152)
+    features **before** the spatial merge. The merge concatenates each
+    ``spatial_merge_size x spatial_merge_size`` block of adjacent patches into a
+    single ``spatial_merge_size**2 * vision_hidden_size`` (4608) vector, which
+    ``linear_fc1`` maps to ``intermediate_size`` (11520) and ``linear_fc2`` maps
+    to ``text_hidden_size`` (2048).
+
+    HF weights (``model.projector.*``):
+    - ``norm.{weight,bias}`` (pre-shuffle LayerNorm)
+    - ``linear_fc1.{weight,bias}``
+    - ``linear_fc2.{weight,bias}``
+    """
+
+    def __init__(
+        self,
+        vision_hidden_size: int,
+        text_hidden_size: int,
+        intermediate_size: int,
+        grid_size: int,
+        spatial_merge_size: int = 2,
+        norm_eps: float = 1e-6,
+    ):
+        super().__init__()
+        self._grid = grid_size
+        self._ms = spatial_merge_size
+        self._vision_hidden = vision_hidden_size
+        merged_dim = vision_hidden_size * spatial_merge_size * spatial_merge_size
+        # Pre-shuffle LayerNorm over the raw vision hidden size.
+        self.norm = VisionLayerNorm(vision_hidden_size, eps=norm_eps)
+        self.linear_fc1 = Linear(merged_dim, intermediate_size, bias=True)
+        self.linear_fc2 = Linear(intermediate_size, text_hidden_size, bias=True)
+
+    def forward(self, op: OpBuilder, vision_features: ir.Value):
+        # vision_features: [batch, grid*grid, vision_hidden]
+        ms = self._ms
+        g = self._grid
+        gm = g // ms
+        d = self._vision_hidden
+
+        # Pre-shuffle LayerNorm (use_postshuffle_norm=false).
+        x = self.norm(op, vision_features)
+
+        batch = op.Shape(vision_features, start=0, end=1)  # dynamic [1]
+
+        # [B, g*g, D] -> [B, g/ms, ms, g/ms, ms, D]
+        shape_6d = op.Concat(
+            batch,
+            op.Constant(value_ints=[gm, ms, gm, ms, d]),
+            axis=0,
+        )
+        x = op.Reshape(x, shape_6d)
+        # Group hidden dim outermost per merged block (HF F.unfold ordering):
+        # [B, g/ms, ms, g/ms, ms, D] -> [B, g/ms, g/ms, D, ms, ms]
+        x = op.Transpose(x, perm=[0, 1, 3, 5, 2, 4])
+        # Flatten to [B, (g/ms)^2, D*ms*ms]
+        shape_3d = op.Concat(
+            batch,
+            op.Constant(value_ints=[gm * gm, d * ms * ms]),
+            axis=0,
+        )
+        x = op.Reshape(x, shape_3d)
+
+        x = self.linear_fc1(op, x)
+        x = op.Gelu(x)
+        x = self.linear_fc2(op, x)
+        return x
 
 
 class LinearMultiModalProjector(nn.Module):

--- a/src/mobius/models/__init__.py
+++ b/src/mobius/models/__init__.py
@@ -24,6 +24,7 @@ __all__ = [
     "CohereCausalLMModel",
     "ControlNetModel",
     "Cosmos3EdgeTextModel",
+    "Cosmos3EdgeVLModel",
     "Cosmos3OmniReasonerModel",
     "DeepSeekOCR2CausalLMModel",
     "DeepSeekV3CausalLMModel",
@@ -168,7 +169,7 @@ from mobius.models.clip import CLIPVisionModel, SigLIPVisionModel
 from mobius.models.cogvideox import CogVideoXTransformer3DModel
 from mobius.models.cohere import CohereCausalLMModel
 from mobius.models.controlnet import ControlNetModel
-from mobius.models.cosmos import Cosmos3EdgeTextModel
+from mobius.models.cosmos import Cosmos3EdgeTextModel, Cosmos3EdgeVLModel
 from mobius.models.cosmos3_omni import Cosmos3OmniReasonerModel
 from mobius.models.ctrl import CTRLCausalLMModel
 from mobius.models.deepseek import DeepSeekV3CausalLMModel

--- a/src/mobius/models/__init__.py
+++ b/src/mobius/models/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "CogVideoXTransformer3DModel",
     "CohereCausalLMModel",
     "ControlNetModel",
+    "Cosmos3EdgeTextModel",
     "Cosmos3OmniReasonerModel",
     "DeepSeekOCR2CausalLMModel",
     "DeepSeekV3CausalLMModel",
@@ -167,6 +168,7 @@ from mobius.models.clip import CLIPVisionModel, SigLIPVisionModel
 from mobius.models.cogvideox import CogVideoXTransformer3DModel
 from mobius.models.cohere import CohereCausalLMModel
 from mobius.models.controlnet import ControlNetModel
+from mobius.models.cosmos import Cosmos3EdgeTextModel
 from mobius.models.cosmos3_omni import Cosmos3OmniReasonerModel
 from mobius.models.ctrl import CTRLCausalLMModel
 from mobius.models.deepseek import DeepSeekV3CausalLMModel

--- a/src/mobius/models/cosmos.py
+++ b/src/mobius/models/cosmos.py
@@ -3,47 +3,83 @@
 
 """NVIDIA Cosmos 3 model support.
 
-Currently supports the **text reasoner backbone** of the ``cosmos3_edge``
-checkpoint (``nvidia/Cosmos3-Edge``, ``Cosmos3EdgeForConditionalGeneration``).
+Supports the ``cosmos3_edge`` checkpoint (``nvidia/Cosmos3-Edge``,
+``Cosmos3EdgeForConditionalGeneration``) both as a full vision-language model
+(:class:`Cosmos3EdgeVLModel`, 3-model onnxruntime-genai split) and as a
+standalone text reasoner (:class:`Cosmos3EdgeTextModel`).
 
-Cosmos3-Edge is a vision-language model whose language tower is a standard
-grouped-query-attention decoder with two Cosmos-specific traits:
+Cosmos3-Edge is a LLaVA-style VLM built from three towers:
 
-- **Non-gated feed-forward network** — ``down_proj(relu2(up_proj(x)))`` using
-  a squared-ReLU activation (``hidden_act="relu2"``), rather than the
-  GLU-style gated MLP used by Llama/Qwen. This maps onto :class:`FCMLP`.
-- **3D multimodal RoPE** (``mrope_section=[24, 20, 20]``). For text-only
-  inference the three sections are identical, so it reduces to standard 1D
-  RoPE (same simplification used by the Qwen-VL text decoders).
+- **Text reasoner** — a grouped-query-attention decoder with two
+  Cosmos-specific traits:
+
+  - **Non-gated feed-forward network** — ``down_proj(relu2(up_proj(x)))`` using
+    a squared-ReLU activation (``hidden_act="relu2"``), rather than the
+    GLU-style gated MLP used by Llama/Qwen. This maps onto :class:`FCMLP`.
+  - **3D multimodal RoPE** (``mrope_section=[24, 20, 20]``). For text-only
+    inference the three sections use the same positions, so it reduces to
+    standard 1D RoPE (same simplification used by the Qwen-VL text decoders).
+
+- **Vision encoder** — a SigLIP-style patch-embedding + transformer tower
+  (``model.visual.*``).
+- **Merger projector** — a pixel-shuffle projector
+  (:class:`Cosmos3EdgeMultiModalProjector`, ``model.projector.*``) that merges
+  each 2x2 patch block and projects to the text hidden size.
 
 The HuggingFace weights use ``self_attn.to_{q,k,v,out}`` projection names and
 place the text tower at the top level (``layers.*``, ``embed_tokens``,
 ``norm``, ``lm_head``) with the vision encoder and projector under
-``model.visual.*`` / ``model.projector.*``. :meth:`preprocess_weights` renames
-the projections, prefixes the text tower with ``model.`` and drops the
-vision/projector weights.
+``model.visual.*`` / ``model.projector.*``. The VLM's
+:meth:`Cosmos3EdgeVLModel.preprocess_weights` routes these to the three
+sub-models; the text-only :meth:`Cosmos3EdgeTextModel.preprocess_weights`
+drops the vision/projector weights.
 
 The ``k_norm_und_for_gen`` per-layer key-norm weight is an artifact of the
 two-tower (Mixture-of-Transformers) design: it normalizes the *understanding*
 tower's keys for consumption by the *generator* (diffusion) tower, and is not
 applied in the reasoner's own causal self-attention. It is therefore dropped
-for the standalone text decoder.
+for both paths.
+
+.. note::
+   NVIDIA does not publish modeling code for ``cosmos3_edge`` (it is not in
+   ``transformers`` and the repo ships no remote-code module), so exact
+   pixel-shuffle ordering and numerical parity are unverifiable. These builds
+   are validated at graph-construction (L1) confidence only.
 
 The ``cosmos3_omni`` variants (``nvidia/Cosmos3-Nano`` / ``-Super``) are
-two-tower diffusion world models exported as diffusers pipelines and are out
-of scope for this decoder-only path.
+two-tower diffusion world models exported as diffusers pipelines and are
+tracked separately.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from onnxscript import OpBuilder, nn
+
 from mobius._configs import ArchitectureConfig
-from mobius.components import FCMLP
-from mobius.models.base import CausalLMModel
+from mobius.components import (
+    FCMLP,
+    Cosmos3EdgeMultiModalProjector,
+    Embedding,
+    Linear,
+    VisionModel,
+)
+from mobius.models.base import CausalLMModel, TextModel
 
 if TYPE_CHECKING:
+    import onnx_ir as ir
     import torch
+
+
+def _rename_cosmos_text_key(key: str) -> str:
+    """Rename a Cosmos3-Edge attention projection key to mobius conventions."""
+    return (
+        key.replace("self_attn.to_q.", "self_attn.q_proj.")
+        .replace("self_attn.to_k.", "self_attn.k_proj.")
+        .replace("self_attn.to_v.", "self_attn.v_proj.")
+        .replace("self_attn.to_out.", "self_attn.o_proj.")
+    )
 
 
 class Cosmos3EdgeTextModel(CausalLMModel):
@@ -80,12 +116,7 @@ class Cosmos3EdgeTextModel(CausalLMModel):
             if "k_norm_und_for_gen" in key:
                 continue
 
-            new_key = (
-                key.replace("self_attn.to_q.", "self_attn.q_proj.")
-                .replace("self_attn.to_k.", "self_attn.k_proj.")
-                .replace("self_attn.to_v.", "self_attn.v_proj.")
-                .replace("self_attn.to_out.", "self_attn.o_proj.")
-            )
+            new_key = _rename_cosmos_text_key(key)
             # The text tower is stored at the top level; the mobius backbone
             # nests it under ``model.``. ``lm_head`` stays at the top level.
             if new_key == "lm_head.weight":
@@ -95,3 +126,250 @@ class Cosmos3EdgeTextModel(CausalLMModel):
 
             renamed[new_key] = value
         return super().preprocess_weights(renamed)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Cosmos3-Edge vision-language model (3-model split)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class _Cosmos3EdgeDecoderModel(nn.Module):
+    """Cosmos3-Edge text decoder taking ``inputs_embeds``.
+
+    Reuses the reasoner backbone (:class:`TextModel` with GQA) but swaps in a
+    non-gated squared-ReLU :class:`FCMLP` and is driven through
+    :class:`Cosmos3EdgeVLTask`, which feeds ``inputs_embeds`` (from the
+    embedding sub-model) instead of ``input_ids``. The unused ``embed_tokens``
+    initializer is pruned at build time, so the decoder only owns
+    ``model.layers.*``, ``model.norm`` and ``lm_head``.
+    """
+
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+        self.config = config
+        self.model = TextModel(config)
+        # Non-gated squared-ReLU FFN (up_proj -> relu2 -> down_proj).
+        for layer in self.model.layers:
+            layer.mlp = FCMLP(
+                config.hidden_size,
+                config.intermediate_size,
+                activation=config.hidden_act or "relu2",
+                bias=config.mlp_bias,
+            )
+        self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def forward(
+        self,
+        op: OpBuilder,
+        inputs_embeds: ir.Value,
+        attention_mask: ir.Value,
+        position_ids: ir.Value,
+        past_key_values: list | None = None,
+    ):
+        hidden_states, present_key_values = self.model(
+            op,
+            input_ids=None,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+        )
+        logits = self.lm_head(op, hidden_states)
+        return logits, present_key_values
+
+    def preprocess_weights(
+        self, state_dict: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        # state_dict here is the decoder-routed slice (text tower only): keys
+        # such as ``layers.N.self_attn.to_q.weight``, ``norm.weight`` and
+        # ``lm_head.weight`` at the HF top level (no ``model.`` prefix).
+        renamed: dict[str, torch.Tensor] = {}
+        for key, value in state_dict.items():
+            new_key = _rename_cosmos_text_key(key)
+            if new_key == "lm_head.weight":
+                pass
+            elif new_key.startswith(("layers.", "embed_tokens.")) or new_key == "norm.weight":
+                new_key = f"model.{new_key}"
+            renamed[new_key] = value
+        return renamed
+
+
+class _Cosmos3EdgeVisionEncoderModel(nn.Module):
+    """Cosmos3-Edge vision encoder: SigLIP tower + pixel-shuffle projector.
+
+    ``pixel_values [B, 3, H, W]`` → SigLIP encoder → ``[B, num_patches, D]``
+    → :class:`Cosmos3EdgeMultiModalProjector` → ``[B, num_merged, text_hidden]``.
+    """
+
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+        vc = config.vision
+        assert vc is not None, "Cosmos3-Edge requires a VisionConfig"
+        assert vc.image_size is not None and vc.patch_size is not None
+        assert vc.hidden_size is not None
+        assert vc.projector_intermediate_size is not None, (
+            "Cosmos3-Edge projector requires projector_intermediate_size"
+        )
+        self.vision_tower = VisionModel(config)
+        # Fixed square patch grid (image_size // patch_size), e.g. 256 -> 16.
+        grid_size = vc.image_size // vc.patch_size
+        self.multi_modal_projector = Cosmos3EdgeMultiModalProjector(
+            vision_hidden_size=vc.hidden_size,
+            text_hidden_size=config.hidden_size,
+            intermediate_size=vc.projector_intermediate_size,
+            grid_size=grid_size,
+            spatial_merge_size=vc.spatial_merge_size,
+            norm_eps=vc.norm_eps,
+        )
+
+    def forward(self, op: OpBuilder, pixel_values: ir.Value):
+        vision_features = self.vision_tower(op, pixel_values)
+        return self.multi_modal_projector(op, vision_features)
+
+    def preprocess_weights(
+        self, state_dict: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        # state_dict here is the vision-routed slice: ``model.visual.*`` (SigLIP
+        # tower) and ``model.projector.*`` (merger projector).
+        renamed: dict[str, torch.Tensor] = {}
+        for key, value in state_dict.items():
+            if key.startswith("model.visual."):
+                new_key = "vision_tower.vision_model." + key[len("model.visual.") :]
+                # SigLIP MLP: fc1/fc2 -> up_proj/down_proj (FCMLP convention).
+                new_key = new_key.replace(".mlp.fc1.", ".mlp.up_proj.").replace(
+                    ".mlp.fc2.", ".mlp.down_proj."
+                )
+                renamed[new_key] = value
+            elif key.startswith("model.projector."):
+                new_key = "multi_modal_projector." + key[len("model.projector.") :]
+                renamed[new_key] = value
+        return renamed
+
+
+class _Cosmos3EdgeEmbeddingModel(nn.Module):
+    """Cosmos3-Edge embedding: token lookup + image feature fusion.
+
+    Scatters projected vision features into the text embedding sequence at
+    ``image_token_id`` (19) positions, matching the LLaVA embedding contract.
+    """
+
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+        self.config = config
+        self.embed_tokens = Embedding(
+            config.vocab_size, config.hidden_size, config.pad_token_id
+        )
+        self.image_token_id = config.image_token_id or 0
+
+    def forward(self, op: OpBuilder, input_ids: ir.Value, image_features: ir.Value):
+        text_embeds = self.embed_tokens(op, input_ids)
+
+        image_mask = op.Equal(input_ids, op.Constant(value_int=self.image_token_id))
+        image_mask_3d = op.Unsqueeze(image_mask, [-1])
+
+        mask_int = op.Cast(image_mask, to=7)
+        cumsum = op.CumSum(mask_int, 1)
+        indices = op.Sub(cumsum, op.Constant(value_int=1))
+        indices = op.Clip(indices, op.Constant(value_int=0))
+
+        # Pad image_features with one zero row so Gather stays in-bounds for
+        # text-only input (num_image_tokens == 0); the mask discards it.
+        pad_row = op.Expand(
+            op.CastLike(0.0, image_features),
+            op.Concat(
+                op.Constant(value_ints=[1]),
+                op.Shape(image_features, start=1, end=2),
+                axis=0,
+            ),
+        )
+        padded_features = op.Concat(image_features, pad_row, axis=0)
+
+        gathered = op.Gather(padded_features, indices, axis=0)
+        return op.Where(image_mask_3d, gathered, text_embeds)
+
+    def preprocess_weights(
+        self, state_dict: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        # HF stores the shared token table at the top level as
+        # ``embed_tokens.weight``; keep it unchanged for the local Embedding.
+        return {k: v for k, v in state_dict.items() if "embed_tokens" in k}
+
+
+class Cosmos3EdgeVLModel(nn.Module):
+    """NVIDIA Cosmos3-Edge vision-language model (3-model split).
+
+    ``model_type: cosmos3_edge`` / ``Cosmos3EdgeForConditionalGeneration``.
+
+    Builds three ONNX models for onnxruntime-genai deployment:
+
+    - **decoder**: squared-ReLU GQA text reasoner taking ``inputs_embeds``.
+    - **vision_encoder**: SigLIP vision tower + pixel-shuffle merger projector.
+    - **embedding**: token embedding + image feature fusion at
+      ``image_token_id`` (19).
+
+    HuggingFace weight layout (single checkpoint, no ``language_model.``
+    prefix):
+
+    - ``model.visual.*`` → vision tower (SigLIP)
+    - ``model.projector.*`` → merger projector
+    - ``embed_tokens.weight`` → embedding
+    - ``layers.*`` / ``norm.weight`` / ``lm_head.weight`` → decoder
+    - ``*k_norm_und_for_gen*`` → dropped (generator-tower artifact; see the
+      module docstring)
+
+    .. note::
+       NVIDIA does not publish modeling code for ``cosmos3_edge`` (it is not in
+       ``transformers`` and the repo ships no remote-code module), so the exact
+       pixel-shuffle ordering and numerical parity are unverifiable. This build
+       is validated at graph-construction (L1) confidence only.
+    """
+
+    default_task: str = "cosmos3-edge-vl"
+    category: str = "Multimodal"
+
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+        self.config = config
+        self.decoder = _Cosmos3EdgeDecoderModel(config)
+        self.vision_encoder = _Cosmos3EdgeVisionEncoderModel(config)
+        self.embedding = _Cosmos3EdgeEmbeddingModel(config)
+
+    def forward(self, op: OpBuilder, **kwargs):
+        raise NotImplementedError(
+            "Cosmos3EdgeVLModel uses Cosmos3EdgeVLTask, which builds the "
+            "decoder, vision_encoder and embedding sub-models separately."
+        )
+
+    def preprocess_weights(
+        self, state_dict: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        """Route HF weights to the three sub-models and prefix by component.
+
+        Sub-module parameters retain their root-relative names
+        (``decoder.*`` / ``vision_encoder.*`` / ``embedding.*``), so the
+        prefixed keys line up with each component graph's initializers when
+        :meth:`ModelPackage.apply_weights` matches by name.
+        """
+        vision_sd: dict[str, torch.Tensor] = {}
+        embedding_sd: dict[str, torch.Tensor] = {}
+        decoder_sd: dict[str, torch.Tensor] = {}
+
+        for key, value in state_dict.items():
+            # Generator-tower key-norm is not used by the reasoner (see docstring).
+            if "k_norm_und_for_gen" in key:
+                continue
+            if key.startswith(("model.visual.", "model.projector.")):
+                vision_sd[key] = value
+            elif "embed_tokens" in key:
+                embedding_sd[key] = value
+            else:
+                decoder_sd[key] = value
+
+        result: dict[str, torch.Tensor] = {}
+        for k, v in self.vision_encoder.preprocess_weights(vision_sd).items():
+            result[f"vision_encoder.{k}"] = v
+        for k, v in self.embedding.preprocess_weights(embedding_sd).items():
+            result[f"embedding.{k}"] = v
+        for k, v in self.decoder.preprocess_weights(decoder_sd).items():
+            result[f"decoder.{k}"] = v
+        return result

--- a/src/mobius/models/cosmos.py
+++ b/src/mobius/models/cosmos.py
@@ -218,6 +218,11 @@ class _Cosmos3EdgeVisionEncoderModel(nn.Module):
                 "Cosmos3-Edge projector output must match the text hidden size, "
                 f"got {vc.out_hidden_size} != {config.hidden_size}"
             )
+        if vc.image_size % vc.patch_size != 0:
+            raise ValueError(
+                f"image_size ({vc.image_size}) must be divisible by "
+                f"patch_size ({vc.patch_size})"
+            )
         self.vision_tower = VisionModel(config)
         # Fixed square patch grid (image_size // patch_size), e.g. 256 -> 16.
         grid_size = vc.image_size // vc.patch_size

--- a/src/mobius/models/cosmos.py
+++ b/src/mobius/models/cosmos.py
@@ -1,0 +1,97 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""NVIDIA Cosmos 3 model support.
+
+Currently supports the **text reasoner backbone** of the ``cosmos3_edge``
+checkpoint (``nvidia/Cosmos3-Edge``, ``Cosmos3EdgeForConditionalGeneration``).
+
+Cosmos3-Edge is a vision-language model whose language tower is a standard
+grouped-query-attention decoder with two Cosmos-specific traits:
+
+- **Non-gated feed-forward network** — ``down_proj(relu2(up_proj(x)))`` using
+  a squared-ReLU activation (``hidden_act="relu2"``), rather than the
+  GLU-style gated MLP used by Llama/Qwen. This maps onto :class:`FCMLP`.
+- **3D multimodal RoPE** (``mrope_section=[24, 20, 20]``). For text-only
+  inference the three sections are identical, so it reduces to standard 1D
+  RoPE (same simplification used by the Qwen-VL text decoders).
+
+The HuggingFace weights use ``self_attn.to_{q,k,v,out}`` projection names and
+place the text tower at the top level (``layers.*``, ``embed_tokens``,
+``norm``, ``lm_head``) with the vision encoder and projector under
+``model.visual.*`` / ``model.projector.*``. :meth:`preprocess_weights` renames
+the projections, prefixes the text tower with ``model.`` and drops the
+vision/projector weights.
+
+The ``k_norm_und_for_gen`` per-layer key-norm weight is an artifact of the
+two-tower (Mixture-of-Transformers) design: it normalizes the *understanding*
+tower's keys for consumption by the *generator* (diffusion) tower, and is not
+applied in the reasoner's own causal self-attention. It is therefore dropped
+for the standalone text decoder.
+
+The ``cosmos3_omni`` variants (``nvidia/Cosmos3-Nano`` / ``-Super``) are
+two-tower diffusion world models exported as diffusers pipelines and are out
+of scope for this decoder-only path.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mobius._configs import ArchitectureConfig
+from mobius.components import FCMLP
+from mobius.models.base import CausalLMModel
+
+if TYPE_CHECKING:
+    import torch
+
+
+class Cosmos3EdgeTextModel(CausalLMModel):
+    """Cosmos3-Edge text reasoner backbone (decoder-only).
+
+    Extracts the language tower from the ``cosmos3_edge`` vision-language
+    checkpoint. Replaces the gated MLP with a non-gated squared-ReLU
+    :class:`FCMLP` and renames/strips weights so the standard
+    :class:`CausalLMModel` backbone can consume them.
+    """
+
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__(config)
+        # Cosmos3-Edge uses a non-gated FFN (up_proj -> relu2 -> down_proj),
+        # unlike the GLU-style gated MLP of the base CausalLMModel.
+        for layer in self.model.layers:
+            layer.mlp = FCMLP(
+                config.hidden_size,
+                config.intermediate_size,
+                activation=config.hidden_act or "relu2",
+                bias=config.mlp_bias,
+            )
+
+    def preprocess_weights(
+        self, state_dict: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        renamed: dict[str, torch.Tensor] = {}
+        for key, value in state_dict.items():
+            # Drop the vision encoder and multimodal projector — this is the
+            # standalone text decoder.
+            if key.startswith(("model.visual.", "model.projector.")):
+                continue
+            # Drop the generator-tower key-norm (see module docstring).
+            if "k_norm_und_for_gen" in key:
+                continue
+
+            new_key = (
+                key.replace("self_attn.to_q.", "self_attn.q_proj.")
+                .replace("self_attn.to_k.", "self_attn.k_proj.")
+                .replace("self_attn.to_v.", "self_attn.v_proj.")
+                .replace("self_attn.to_out.", "self_attn.o_proj.")
+            )
+            # The text tower is stored at the top level; the mobius backbone
+            # nests it under ``model.``. ``lm_head`` stays at the top level.
+            if new_key == "lm_head.weight":
+                pass
+            elif new_key.startswith(("layers.", "embed_tokens.")) or new_key == "norm.weight":
+                new_key = f"model.{new_key}"
+
+            renamed[new_key] = value
+        return super().preprocess_weights(renamed)

--- a/src/mobius/models/cosmos.py
+++ b/src/mobius/models/cosmos.py
@@ -73,12 +73,15 @@ if TYPE_CHECKING:
 
 
 def _rename_cosmos_text_key(key: str) -> str:
-    """Rename a Cosmos3-Edge attention projection key to mobius conventions."""
+    """Rename Cosmos3-Edge attention and QK-norm keys to mobius conventions."""
     return (
-        key.replace("self_attn.to_q.", "self_attn.q_proj.")
+        key.replace("self_attn.to_out.0.", "self_attn.o_proj.")
+        .replace("self_attn.to_q.", "self_attn.q_proj.")
         .replace("self_attn.to_k.", "self_attn.k_proj.")
         .replace("self_attn.to_v.", "self_attn.v_proj.")
         .replace("self_attn.to_out.", "self_attn.o_proj.")
+        .replace("self_attn.norm_q.", "self_attn.q_norm.")
+        .replace("self_attn.norm_k.", "self_attn.k_norm.")
     )
 
 
@@ -210,6 +213,11 @@ class _Cosmos3EdgeVisionEncoderModel(nn.Module):
         assert vc.projector_intermediate_size is not None, (
             "Cosmos3-Edge projector requires projector_intermediate_size"
         )
+        if vc.out_hidden_size is not None:
+            assert vc.out_hidden_size == config.hidden_size, (
+                "Cosmos3-Edge projector output must match the text hidden size, "
+                f"got {vc.out_hidden_size} != {config.hidden_size}"
+            )
         self.vision_tower = VisionModel(config)
         # Fixed square patch grid (image_size // patch_size), e.g. 256 -> 16.
         grid_size = vc.image_size // vc.patch_size
@@ -218,7 +226,7 @@ class _Cosmos3EdgeVisionEncoderModel(nn.Module):
             text_hidden_size=config.hidden_size,
             intermediate_size=vc.projector_intermediate_size,
             grid_size=grid_size,
-            spatial_merge_size=vc.spatial_merge_size,
+            spatial_merge_size=vc.spatial_merge_size or 2,
             norm_eps=vc.norm_eps,
         )
 
@@ -364,6 +372,14 @@ class Cosmos3EdgeVLModel(nn.Module):
                 embedding_sd[key] = value
             else:
                 decoder_sd[key] = value
+
+        if self.config.tie_word_embeddings:
+            embed_weight = next(iter(embedding_sd.values()), None)
+            head_weight = decoder_sd.get("lm_head.weight")
+            if embed_weight is None and head_weight is not None:
+                embedding_sd["embed_tokens.weight"] = head_weight
+            elif head_weight is None and embed_weight is not None:
+                decoder_sd["lm_head.weight"] = embed_weight
 
         result: dict[str, torch.Tensor] = {}
         for k, v in self.vision_encoder.preprocess_weights(vision_sd).items():

--- a/src/mobius/models/cosmos_test.py
+++ b/src/mobius/models/cosmos_test.py
@@ -5,15 +5,19 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
 from mobius._configs import ArchitectureConfig, VisionConfig
+from mobius._configs.per_model._cosmos3_edge_vision import _cosmos3_edge_vision
 from mobius.models.cosmos import (
     Cosmos3EdgeTextModel,
     Cosmos3EdgeVLModel,
     _Cosmos3EdgeVisionEncoderModel,
 )
+from mobius.tasks import Cosmos3EdgeVLTask
 
 
 def _tiny_config(
@@ -21,6 +25,8 @@ def _tiny_config(
     tie_word_embeddings: bool = False,
     spatial_merge_size: int | None = 2,
     out_hidden_size: int | None = 64,
+    image_size: int = 28,
+    patch_size: int = 14,
 ) -> ArchitectureConfig:
     return ArchitectureConfig(
         model_type="cosmos3_edge",
@@ -41,8 +47,8 @@ def _tiny_config(
             intermediate_size=64,
             num_hidden_layers=1,
             num_attention_heads=2,
-            image_size=28,
-            patch_size=14,
+            image_size=image_size,
+            patch_size=patch_size,
             spatial_merge_size=spatial_merge_size,
             out_hidden_size=out_hidden_size,
             projector_intermediate_size=64,
@@ -100,3 +106,39 @@ def test_vision_encoder_defaults_missing_spatial_merge_size():
 def test_vision_encoder_rejects_projector_width_mismatch():
     with pytest.raises(AssertionError, match="projector output must match"):
         _Cosmos3EdgeVisionEncoderModel(_tiny_config(out_hidden_size=32))
+
+
+def test_vl_task_vision_output_matches_embedding_input():
+    config = _tiny_config()
+    package = Cosmos3EdgeVLTask().build(Cosmos3EdgeVLModel(config), config)
+
+    pixel_values = package["vision_encoder"].graph.inputs[0]
+    image_features = package["vision_encoder"].graph.outputs[0]
+    embedding_features = next(
+        value for value in package["embedding"].graph.inputs if value.name == "image_features"
+    )
+
+    assert pixel_values.shape[0] == 1
+    assert len(image_features.shape) == 2
+    assert len(embedding_features.shape) == 2
+    assert image_features.shape[-1] == embedding_features.shape[-1] == config.hidden_size
+
+
+def test_vision_encoder_rejects_non_integral_patch_grid():
+    with pytest.raises(ValueError, match=r"image_size .* divisible by patch_size"):
+        _Cosmos3EdgeVisionEncoderModel(_tiny_config(image_size=30, patch_size=14))
+
+
+def test_vision_encoder_rejects_unmergeable_patch_grid():
+    with pytest.raises(ValueError, match=r"grid_size .* divisible"):
+        _Cosmos3EdgeVisionEncoderModel(
+            _tiny_config(image_size=42, patch_size=14, spatial_merge_size=2)
+        )
+
+
+def test_vision_config_rejects_non_square_num_patches():
+    vision_config = SimpleNamespace(num_patches=255, patch_size=16)
+    config = SimpleNamespace(vision_config=vision_config)
+
+    with pytest.raises(ValueError, match="num_patches must form a square grid"):
+        _cosmos3_edge_vision(config, None, "cosmos3_edge", {"image_size": None})

--- a/src/mobius/models/cosmos_test.py
+++ b/src/mobius/models/cosmos_test.py
@@ -1,0 +1,102 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Unit tests for Cosmos3-Edge weight routing and projector configuration."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from mobius._configs import ArchitectureConfig, VisionConfig
+from mobius.models.cosmos import (
+    Cosmos3EdgeTextModel,
+    Cosmos3EdgeVLModel,
+    _Cosmos3EdgeVisionEncoderModel,
+)
+
+
+def _tiny_config(
+    *,
+    tie_word_embeddings: bool = False,
+    spatial_merge_size: int | None = 2,
+    out_hidden_size: int | None = 64,
+) -> ArchitectureConfig:
+    return ArchitectureConfig(
+        model_type="cosmos3_edge",
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        vocab_size=256,
+        max_position_embeddings=128,
+        hidden_act="relu2",
+        rms_norm_eps=1e-6,
+        attn_qk_norm=True,
+        tie_word_embeddings=tie_word_embeddings,
+        vision=VisionConfig(
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            image_size=28,
+            patch_size=14,
+            spatial_merge_size=spatial_merge_size,
+            out_hidden_size=out_hidden_size,
+            projector_intermediate_size=64,
+        ),
+    )
+
+
+def test_text_attention_weights_map_to_mobius_names():
+    module = Cosmos3EdgeTextModel(_tiny_config())
+    weights = {
+        "layers.0.self_attn.to_q.weight": torch.zeros(1),
+        "layers.0.self_attn.to_k.weight": torch.zeros(1),
+        "layers.0.self_attn.to_v.weight": torch.zeros(1),
+        "layers.0.self_attn.to_out.0.weight": torch.zeros(1),
+        "layers.0.self_attn.norm_q.weight": torch.zeros(1),
+        "layers.0.self_attn.norm_k.weight": torch.zeros(1),
+    }
+
+    result = module.preprocess_weights(weights)
+
+    assert "model.layers.0.self_attn.q_proj.weight" in result
+    assert "model.layers.0.self_attn.k_proj.weight" in result
+    assert "model.layers.0.self_attn.v_proj.weight" in result
+    assert "model.layers.0.self_attn.o_proj.weight" in result
+    assert "model.layers.0.self_attn.q_norm.weight" in result
+    assert "model.layers.0.self_attn.k_norm.weight" in result
+
+
+def test_vl_tied_embedding_populates_decoder_lm_head():
+    module = Cosmos3EdgeVLModel(_tiny_config(tie_word_embeddings=True))
+    weight = torch.randn(256, 64)
+
+    result = module.preprocess_weights({"embed_tokens.weight": weight})
+
+    assert result["embedding.embed_tokens.weight"] is weight
+    assert result["decoder.lm_head.weight"] is weight
+
+
+def test_vl_tied_lm_head_populates_embedding():
+    module = Cosmos3EdgeVLModel(_tiny_config(tie_word_embeddings=True))
+    weight = torch.randn(256, 64)
+
+    result = module.preprocess_weights({"lm_head.weight": weight})
+
+    assert result["decoder.lm_head.weight"] is weight
+    assert result["embedding.embed_tokens.weight"] is weight
+
+
+def test_vision_encoder_defaults_missing_spatial_merge_size():
+    module = _Cosmos3EdgeVisionEncoderModel(_tiny_config(spatial_merge_size=None))
+
+    assert module.multi_modal_projector._ms == 2
+
+
+def test_vision_encoder_rejects_projector_width_mismatch():
+    with pytest.raises(AssertionError, match="projector output must match"):
+        _Cosmos3EdgeVisionEncoderModel(_tiny_config(out_hidden_size=32))

--- a/src/mobius/tasks/__init__.py
+++ b/src/mobius/tasks/__init__.py
@@ -41,6 +41,7 @@ __all__ = [
     "Gemma4UnifiedTask",
     "Gemma4TextCausalLMTask",
     "HybridCausalLMTask",
+    "Cosmos3EdgeVLTask",
     "HybridQwenVLTask",
     "ImageClassificationTask",
     "ModelTask",
@@ -120,6 +121,7 @@ from mobius.tasks._vae import VAETask
 from mobius.tasks._video_denoising import VideoDenoisingTask
 from mobius.tasks._vision_language import Qwen3VLVisionLanguageTask
 from mobius.tasks._vision_language_3model import (
+    Cosmos3EdgeVLTask,
     HybridQwenVLTask,
     MllamaVisionLanguageTask,
     PixtralVLTask,
@@ -156,6 +158,7 @@ TASK_REGISTRY: dict[str, type[ModelTask]] = {
     "vae": VAETask,
     "qwen-image-vae": QwenImageVAETask,
     "vision-language": VisionLanguageTask,
+    "cosmos3-edge-vl": Cosmos3EdgeVLTask,
     "pixtral-vl": PixtralVLTask,
     "mllama-vision-language": MllamaVisionLanguageTask,
     "qwen-vl": QwenVLTask,

--- a/src/mobius/tasks/_vision_language_3model.py
+++ b/src/mobius/tasks/_vision_language_3model.py
@@ -98,12 +98,11 @@ class VisionLanguageTask(ModelTask):
 class Cosmos3EdgeVLTask(VisionLanguageTask):
     """NVIDIA Cosmos3-Edge VL 3-model split.
 
-    Identical to the base :class:`VisionLanguageTask` (SigLIP vision encoder
-    with a dense ``pixel_values [B, 3, H, W]`` input, pixel-shuffle merger
-    projector) but builds the text decoder with 3D multimodal RoPE
+    Builds the text decoder with 3D multimodal RoPE
     (``mrope_section=[24, 20, 20]``), so ``position_ids`` has shape
-    ``[3, batch, seq]``. The vision tower keeps the standard SigLIP contract,
-    so only ``build`` is overridden.
+    ``[3, batch, seq]``. The vision runtime processes one image at a time and
+    removes the image batch dimension so its output matches the embedding
+    model's rank-2 ``[num_image_tokens, hidden]`` input contract.
     """
 
     def build(
@@ -122,6 +121,26 @@ class Cosmos3EdgeVLTask(VisionLanguageTask):
             feature_dim=config.hidden_size,
         )
         return ModelPackage(models, config=config)
+
+    def _build_vision(
+        self,
+        vision: nn.Module,
+        config: ArchitectureConfig,
+    ) -> ir.Model:
+        """Build the single-image vision encoder with rank-2 feature output."""
+        image_size = (config.vision.image_size if config.vision else None) or 224
+
+        graph, builder = _make_graph(name="vision_encoder")
+        pixel_values = builder.input(
+            "pixel_values",
+            dtype=config.dtype,
+            shape=[1, 3, image_size, image_size],
+        )
+        image_features = vision(builder.op, pixel_values=pixel_values)
+        image_features = builder.op.Squeeze(image_features, [0])
+
+        builder.add_output(image_features, "image_features")
+        return _make_model(graph)
 
 
 class QwenVLTask(VisionLanguageTask):

--- a/src/mobius/tasks/_vision_language_3model.py
+++ b/src/mobius/tasks/_vision_language_3model.py
@@ -95,6 +95,35 @@ class VisionLanguageTask(ModelTask):
         return _make_model(graph)
 
 
+class Cosmos3EdgeVLTask(VisionLanguageTask):
+    """NVIDIA Cosmos3-Edge VL 3-model split.
+
+    Identical to the base :class:`VisionLanguageTask` (SigLIP vision encoder
+    with a dense ``pixel_values [B, 3, H, W]`` input, pixel-shuffle merger
+    projector) but builds the text decoder with 3D multimodal RoPE
+    (``mrope_section=[24, 20, 20]``), so ``position_ids`` has shape
+    ``[3, batch, seq]``. The vision tower keeps the standard SigLIP contract,
+    so only ``build`` is overridden.
+    """
+
+    def build(
+        self,
+        module: nn.Module,
+        config: ArchitectureConfig,
+    ) -> ModelPackage:
+        self._validate_components(module)
+        models: dict[str, ir.Model] = {}
+        models["decoder"] = build_decoder_from_embeds(module.decoder, config, mrope=True)
+        models["vision_encoder"] = self._build_vision(module.vision_encoder, config)
+        models["embedding"] = build_embedding_from_features(
+            module.embedding,
+            config,
+            feature_name="image_features",
+            feature_dim=config.hidden_size,
+        )
+        return ModelPackage(models, config=config)
+
+
 class QwenVLTask(VisionLanguageTask):
     """Qwen-family VL 3-model split with packed-attention vision and MRoPE.
 

--- a/tests/_test_configs.py
+++ b/tests/_test_configs.py
@@ -111,6 +111,11 @@ CAUSAL_LM_CONFIGS: list[tuple[str, dict, bool]] = [
     ("qwen2", {}, True),
     ("cohere", {"tie_word_embeddings": True, "logit_scale": 0.0625}, True),
     ("cohere2", {"tie_word_embeddings": True, "logit_scale": 0.0625}, False),
+    (
+        "cosmos3_edge",
+        {"hidden_act": "relu2", "mlp_bias": False, "mrope_section": [24, 20, 20]},
+        True,
+    ),
     ("diffllama", {}, False),
     ("doge", {}, False),
     (

--- a/tests/_test_configs.py
+++ b/tests/_test_configs.py
@@ -112,7 +112,7 @@ CAUSAL_LM_CONFIGS: list[tuple[str, dict, bool]] = [
     ("cohere", {"tie_word_embeddings": True, "logit_scale": 0.0625}, True),
     ("cohere2", {"tie_word_embeddings": True, "logit_scale": 0.0625}, False),
     (
-        "cosmos3_edge",
+        "cosmos3_edge_text",
         {"hidden_act": "relu2", "mlp_bias": False, "mrope_section": [24, 20, 20]},
         True,
     ),
@@ -2090,6 +2090,20 @@ _TINY_QWEN3_VL_VISION = VisionConfig(
 )
 
 
+_TINY_COSMOS3_EDGE_VISION = VisionConfig(
+    hidden_size=32,
+    intermediate_size=64,
+    num_hidden_layers=1,
+    num_attention_heads=2,
+    image_size=28,
+    patch_size=14,
+    norm_eps=1e-6,
+    spatial_merge_size=2,
+    out_hidden_size=64,
+    projector_intermediate_size=64,
+)
+
+
 # ---------------------------------------------------------------------------
 # Vision-Language configs  (task: vision-language and variants)
 # ---------------------------------------------------------------------------
@@ -2099,6 +2113,17 @@ _TINY_QWEN3_VL_VISION = VisionConfig(
 VL_CONFIGS: list[tuple[str, dict, bool]] = [
     # --- LLaVA family (vision-language, 3-model split) ---
     ("llava", {"vision": _TINY_VISION, "image_token_id": 32000}, True),
+    (
+        "cosmos3_edge",
+        {
+            "vision": _TINY_COSMOS3_EDGE_VISION,
+            "image_token_id": 19,
+            "hidden_act": "relu2",
+            "mlp_bias": False,
+            "mrope_section": [24, 20, 20],
+        },
+        True,
+    ),
     ("aya_vision", {"vision": _TINY_VISION, "image_token_id": 32000}, False),
     ("chameleon", {"vision": _TINY_VISION, "image_token_id": 32000}, False),
     ("cohere2_vision", {"vision": _TINY_VISION, "image_token_id": 32000}, False),

--- a/tests/model_coverage_test.py
+++ b/tests/model_coverage_test.py
@@ -158,6 +158,10 @@ _COVERAGE_SKIP: dict[str, str] = {
     "shieldgemma2": "Alias for gemma2 — covered by gemma2",
     "yi": "Alias for llama — covered by llama",
     # --- VL text-decoder submodels (tested via their parent VL model) ---
+    "cosmos3_edge": "Cosmos3-Edge text reasoner backbone — L1 graph-build only; "
+    "L4/L5 parity needs NVIDIA's custom edge modeling code (not in transformers)",
+    "cosmos3_edge_text": "Alias for cosmos3_edge text reasoner — L1 graph-build only; "
+    "L4/L5 parity needs NVIDIA's custom edge modeling code (not in transformers)",
     "glm4v_moe_text": "VL text decoder — tested via glm4v_moe",
     "glm4v_text": "VL text decoder — tested via glm4v",
     "qwen2_5_vl_text": "VL text decoder — tested via qwen2_5_vl",

--- a/tests/model_coverage_test.py
+++ b/tests/model_coverage_test.py
@@ -157,11 +157,12 @@ _COVERAGE_SKIP: dict[str, str] = {
     "seed_oss": "Internal model — no public HF checkpoint",
     "shieldgemma2": "Alias for gemma2 — covered by gemma2",
     "yi": "Alias for llama — covered by llama",
-    # --- VL text-decoder submodels (tested via their parent VL model) ---
-    "cosmos3_edge": "Cosmos3-Edge text reasoner backbone — L1 graph-build only; "
-    "L4/L5 parity needs NVIDIA's custom edge modeling code (not in transformers)",
-    "cosmos3_edge_text": "Alias for cosmos3_edge text reasoner — L1 graph-build only; "
-    "L4/L5 parity needs NVIDIA's custom edge modeling code (not in transformers)",
+    # --- VL models / text-decoder submodels (L1 graph-build only) ---
+    "cosmos3_edge": "Cosmos3-Edge VLM (SigLIP + pixel-shuffle projector + "
+    "squared-ReLU GQA decoder) — L1 graph-build only; L4/L5 parity needs "
+    "NVIDIA's custom edge modeling code (not in transformers)",
+    "cosmos3_edge_text": "Cosmos3-Edge standalone text reasoner — L1 graph-build "
+    "only; L4/L5 parity needs NVIDIA's custom edge modeling code (not in transformers)",
     "glm4v_moe_text": "VL text decoder — tested via glm4v_moe",
     "glm4v_text": "VL text decoder — tested via glm4v",
     "qwen2_5_vl_text": "VL text decoder — tested via qwen2_5_vl",


### PR DESCRIPTION
## Summary

Adds the full **NVIDIA Cosmos3-Edge** vision-language model
(`nvidia/Cosmos3-Edge`, `Cosmos3EdgeForConditionalGeneration`) to mobius as a
LLaVA-style **3-model onnxruntime-genai split** (`decoder` + `vision_encoder` +
`embedding`), building on the text reasoner backbone from the first commit.

### Architecture

- **decoder** — grouped-query-attention text reasoner with a **non-gated
  squared-ReLU FFN** (`hidden_act="relu2"`, `up_proj → relu2 → down_proj`) and
  3D multimodal RoPE (`mrope_section=[24, 20, 20]`); takes `inputs_embeds`.
- **vision_encoder** — SigLIP vision tower + new
  `Cosmos3EdgeMultiModalProjector` (pre-shuffle `LayerNorm` → 2x2 pixel-shuffle
  → `linear_fc1` → GELU → `linear_fc2`).
- **embedding** — token embedding + image-feature fusion at `image_token_id=19`.

Built through a new `Cosmos3EdgeVLTask` (`cosmos3-edge-vl`). The decoder-only
text reasoner remains available as `cosmos3_edge_text`.

### Weight routing (`preprocess_weights`)

Single HF checkpoint → three sub-models:
- `model.visual.*` / `model.projector.*` → vision (SigLIP `mlp.fc1/fc2` → `up_proj/down_proj`)
- `embed_tokens` → embedding
- top-level text tower (`layers.*` / `norm` / `lm_head`) → decoder (`self_attn.to_{q,k,v,out}` → `{q,k,v,o}_proj`)
- `k_norm_und_for_gen` (generator-tower key-norm) → dropped

Verified against the real `nvidia/Cosmos3-Edge` safetensors index: every produced
weight key lands on a graph initializer, and every weight-bearing initializer is
covered (only computed RoPE/const tensors are unmatched, as expected).

### Confidence

**L1 (graph-build) only.** NVIDIA does not publish modeling code for `cosmos3_edge`
(not in `transformers`, no remote-code module), so the exact pixel-shuffle ordering
and numerical parity are **unverifiable**; L4/L5 parity is deferred. The
`cosmos3_omni` variants (`Cosmos3-Nano`/`-Super`) are two-tower diffusion world
models tracked separately.

### Testing

- `tests/build_graph_test.py -k cosmos3` — all pass (text + VLM 3-model split).
- Full `build_graph_test.py` + `model_coverage_test.py` + `cli_test.py` suites pass.
- `ruff format` + `ruff check` clean.

🤖 Do not merge — awaiting review.
