### PR TITLE
Fix Bamba synthetic parity CI tolerance

### DIFF
--- a/tests/synthetic_parity_test.py
+++ b/tests/synthetic_parity_test.py
@@ -108,6 +108,10 @@ _ATOL_OVERRIDES: dict[str, float] = {
     # dispatch, plus Mamba1 SSM single-token decode FP path differences.
     # Argmax correct, cosine=0.998 — model is functionally correct.
     "jamba": 0.04,
+    # Bamba's hybrid Mamba2 + attention path differs slightly in FP accumulation
+    # order from HuggingFace. Both deterministic seeds keep the same argmax and
+    # cosine >= 0.999996 with max absolute error below 0.0017.
+    "bamba": 0.002,
     # ModernBERT decoder has a 3-component LM head (dense→norm→decoder) whose
     # FP accumulation differs from PyTorch → ~0.043 max diff.
     # Argmax correct, cosine=0.996 — model is functionally correct.


### PR DESCRIPTION
## Summary

- add a Bamba-specific `atol=0.002` override for L3 synthetic parity
- document the stable hybrid Mamba2/attention floating-point accumulation difference
- preserve the existing argmax and cosine correctness gates

## Root cause

Both deterministic Bamba seeds exceed the generic `1e-3` threshold under the CI dependency set:

| Seed | Max abs diff | Cosine | Argmax |
|---|---:|---:|---|
| 0 | 0.001375 | 0.999997 | match |
| 1 | 0.001662 | 0.999996 | match |

The same failures occur on unrelated PRs, confirming this is a baseline tolerance issue rather than a model change regression.

## Validation

- `pytest tests/synthetic_parity_test.py -q --models bamba --tb=short`: `2 passed, 201 skipped`
- reproduced the exact CI failures before the change