### PR TITLE
Fix prefill pruning for Gemma 4 models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single Rust/cargo-style option. Accepts a comma-separated list and may be
   repeated (`--features fp8-kv-cache,static-cache` or `--features fp8-kv-cache
   --features static-cache`). Available features: `static-cache`, `fp8-kv-cache`,
-  `prune-lm-head`, `text-only`. Unknown feature names are rejected with an error
+  `prune-prefill-prefix`, `text-only`. Unknown feature names are rejected with an error
   listing the valid set.
 
 #### Changed
@@ -54,16 +54,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   been **removed** in favor of the equivalent `--features` value. Companion
   value args (`--max-seq-len`, `--kv-cache-scale-file`) are unchanged.
 
-### Final-token LM-head pruning (`--features prune-lm-head`)
+### Prefill token-prefix pruning (`--features prune-prefill-prefix`)
 
 #### Added
 
-- `build(prune_lm_head=True)` and `mobius build --features prune-lm-head`
-  select the final hidden-state position before the LM-head projection, reducing
-  prefill logits from `[B, S, vocab]` to `[B, 1, vocab]`. This avoids computing
-  unused per-token logits for single-token autoregressive generation. Models
-  with custom forward paths that do not support pre-projection pruning fail
-  explicitly instead of silently producing an unoptimized graph.
+- `build(prune_prefill_prefix=True)` and
+  `mobius build --features prune-prefill-prefix` discard prefill token positions
+  before the final token after required KV states have been produced. Generic
+  causal models prune immediately before the LM head; Gemma 4 also prunes its
+  KV-sharing layer suffix and per-layer inputs.
 
 ### FP8 (E4M3) KV-cache export (`--features fp8-kv-cache`)
 

--- a/README.md
+++ b/README.md
@@ -113,12 +113,12 @@ mobius build --model openai/whisper-tiny output_dir/
 ```
 
 Build-mode toggles use the cargo-style `--features` option. Available features
-are `static-cache`, `fp8-kv-cache`, `prune-lm-head`, and `text-only`. Pass them
+are `static-cache`, `fp8-kv-cache`, `prune-prefill-prefix`, and `text-only`. Pass them
 as a comma-separated list or repeat the option:
 
 ```sh
 mobius build --model meta-llama/Llama-3.2-1B output_dir/ \
-    --features static-cache,prune-lm-head --max-seq-len 2048
+      --features static-cache,prune-prefill-prefix --max-seq-len 2048
 ```
 
 See the [CLI Reference](https://onnxruntime.github.io/mobius/cli_reference.html) for all subcommands and flags.

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -175,7 +175,7 @@ option. Pass a comma-separated list (and/or repeat the flag):
 
 ```
 --features fp8-kv-cache,static-cache
---features prune-lm-head
+--features prune-prefill-prefix
 --features text-only
 ```
 
@@ -185,7 +185,7 @@ Available features:
 |---------|--------|
 | `static-cache` | Pre-allocate fixed-size KV cache buffers using `TensorScatter` (pair with `--max-seq-len N`). Requires `DecoderLayer` / `MoEDecoderLayer` models. Cannot combine with `--task`. |
 | `fp8-kv-cache` | Store the `GroupQueryAttention` KV cache as `FLOAT8E4M3FN` (per-tensor E4M3), halving KV-cache memory. Requires a GQA build (e.g. `--ep cuda --dtype f16`) and an ORT runtime with the FP8 KV-cache kernel (SM89+). Pair with `--kv-cache-scale-file` for calibrated scales. |
-| `prune-lm-head` | Select the final hidden-state position before the LM-head projection and emit logits shaped `[B, 1, vocab]`. Supported by models using the base `CausalLMModel.forward()` path; unsupported custom forwards fail explicitly. Use only when the downstream workflow does not need per-token logits. |
+| `prune-prefill-prefix` | After required KV states are produced, discard prefill token positions before the final token from the remaining decoder computation. Emits logits shaped `[B, 1, vocab]`; Gemma 4 also prunes its KV-sharing layers and per-layer inputs. |
 | `text-only` | Export the text backbone of a multimodal checkpoint as a standalone decoder-only LLM (see below). |
 
 The legacy boolean flags `--static-cache`, `--fp8-kv-cache`, and
@@ -199,7 +199,7 @@ mobius build --model Qwen/Qwen2.5-0.5B output/ \
     --ep cuda --dtype f16 --features fp8-kv-cache
 
 mobius build --model meta-llama/Llama-3.2-1B output/ \
-    --features prune-lm-head
+    --features prune-prefill-prefix
 ```
 
 ### Static Cache (`--features static-cache`)

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -185,7 +185,7 @@ Available features:
 |---------|--------|
 | `static-cache` | Pre-allocate fixed-size KV cache buffers using `TensorScatter` (pair with `--max-seq-len N`). Requires `DecoderLayer` / `MoEDecoderLayer` models. Cannot combine with `--task`. |
 | `fp8-kv-cache` | Store the `GroupQueryAttention` KV cache as `FLOAT8E4M3FN` (per-tensor E4M3), halving KV-cache memory. Requires a GQA build (e.g. `--ep cuda --dtype f16`) and an ORT runtime with the FP8 KV-cache kernel (SM89+). Pair with `--kv-cache-scale-file` for calibrated scales. |
-| `prune-prefill-prefix` | After required KV states are produced, discard prefill token positions before the final token from the remaining decoder computation. Emits logits shaped `[B, 1, vocab]`; Gemma 4 also prunes its KV-sharing layers and per-layer inputs. |
+| `prune-prefill-prefix` | Emit logits shaped `[B, 1, vocab]` by selecting the final token before the LM head. Gemma 4 also prunes its KV-sharing layer suffix and per-layer inputs to reduce prefill compute. |
 | `text-only` | Export the text backbone of a multimodal checkpoint as a standalone decoder-only LLM (see below). |
 
 The legacy boolean flags `--static-cache`, `--fp8-kv-cache`, and

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 _BUILD_FEATURES: dict[str, str] = {
     "static-cache": "static_cache",
     "fp8-kv-cache": "fp8_kv_cache",
-    "prune-lm-head": "prune_lm_head",
+    "prune-prefill-prefix": "prune_prefill_prefix",
     "text-only": "text_only",
 }
 
@@ -223,7 +223,7 @@ def _cmd_build(args: argparse.Namespace) -> None:
     # FP8 KV cache: resolve the optional per-layer scale file up front so both
     # the --config and --model build paths can pass the same scales.
     fp8_kv_cache = getattr(args, "fp8_kv_cache", False)
-    prune_lm_head = getattr(args, "prune_lm_head", False)
+    prune_prefill_prefix = getattr(args, "prune_prefill_prefix", False)
     kv_cache_scales: dict[int, tuple[float, float]] | None = None
     scale_file = getattr(args, "kv_cache_scale_file", None)
     if scale_file is not None and not fp8_kv_cache:
@@ -313,7 +313,7 @@ def _cmd_build(args: argparse.Namespace) -> None:
             execution_provider=execution_provider,
             fp8_kv_cache=fp8_kv_cache,
             kv_cache_scales=kv_cache_scales,
-            prune_lm_head=prune_lm_head,
+            prune_prefill_prefix=prune_prefill_prefix,
         )
         for name, model in pkg.items():
             model.graph.name = f"{config_path}/{name}"
@@ -343,7 +343,7 @@ def _cmd_build(args: argparse.Namespace) -> None:
             text_only=args.text_only,
             fp8_kv_cache=fp8_kv_cache,
             kv_cache_scales=kv_cache_scales,
-            prune_lm_head=prune_lm_head,
+            prune_prefill_prefix=prune_prefill_prefix,
         )
 
     _save_package(pkg, output_dir, args, optimize, component_filter)

--- a/src/mobius/_build_context.py
+++ b/src/mobius/_build_context.py
@@ -35,8 +35,8 @@ __all__ = [
     "build_context",
     "ep_capabilities",
     "get_build_dtype",
-    "is_lm_head_pruning_enabled",
-    "lm_head_pruning",
+    "is_prefill_prefix_pruning_enabled",
+    "prefill_prefix_pruning",
 ]
 
 _DEFAULT_CAPABILITIES = EpCapabilities(name="default")
@@ -47,8 +47,8 @@ _current_ep: contextvars.ContextVar[EpCapabilities] = contextvars.ContextVar(
 _current_dtype: contextvars.ContextVar[ir.DataType] = contextvars.ContextVar(
     "mobius_build_dtype", default=ir.DataType.FLOAT
 )
-_prune_lm_head: contextvars.ContextVar[bool] = contextvars.ContextVar(
-    "mobius_prune_lm_head", default=False
+_prune_prefill_prefix: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "mobius_prune_prefill_prefix", default=False
 )
 
 
@@ -121,15 +121,15 @@ def get_build_dtype() -> ir.DataType:
 
 
 @contextmanager
-def lm_head_pruning(enabled: bool) -> Iterator[None]:
-    """Enable or disable pre-projection LM-head pruning during graph construction."""
-    token = _prune_lm_head.set(enabled)
+def prefill_prefix_pruning(enabled: bool) -> Iterator[None]:
+    """Enable or disable prefill token-prefix pruning during graph construction."""
+    token = _prune_prefill_prefix.set(enabled)
     try:
         yield
     finally:
-        _prune_lm_head.reset(token)
+        _prune_prefill_prefix.reset(token)
 
 
-def is_lm_head_pruning_enabled() -> bool:
-    """Return whether the active causal-LM task requests final-token logits only."""
-    return _prune_lm_head.get()
+def is_prefill_prefix_pruning_enabled() -> bool:
+    """Return whether the active task discards prefill tokens before the final token."""
+    return _prune_prefill_prefix.get()

--- a/src/mobius/_build_context_test.py
+++ b/src/mobius/_build_context_test.py
@@ -12,8 +12,8 @@ from mobius._build_context import (
     build_context,
     ep_capabilities,
     get_build_dtype,
-    is_lm_head_pruning_enabled,
-    lm_head_pruning,
+    is_prefill_prefix_pruning_enabled,
+    prefill_prefix_pruning,
 )
 from mobius._execution_providers import EpCapabilities, ep_registry
 
@@ -37,8 +37,8 @@ class TestBuildContextDefaults:
         """No context active → returns FLOAT."""
         assert get_build_dtype() == ir.DataType.FLOAT
 
-    def test_lm_head_pruning_is_disabled(self):
-        assert not is_lm_head_pruning_enabled()
+    def test_prefill_prefix_pruning_is_disabled(self):
+        assert not is_prefill_prefix_pruning_enabled()
 
     def test_default_capabilities_has_no_fusions(self):
         """Default EP has no GQA dtypes (portable ONNX)."""
@@ -74,10 +74,10 @@ class TestBuildContextScoping:
         assert ep_capabilities().name == "default"
         assert get_build_dtype() == ir.DataType.FLOAT
 
-    def test_lm_head_pruning_restored_after_context(self):
-        with lm_head_pruning(True):
-            assert is_lm_head_pruning_enabled()
-        assert not is_lm_head_pruning_enabled()
+    def test_prefill_prefix_pruning_restored_after_context(self):
+        with prefill_prefix_pruning(True):
+            assert is_prefill_prefix_pruning_enabled()
+        assert not is_prefill_prefix_pruning_enabled()
 
 
 class TestBuildContextNesting:

--- a/src/mobius/_builder.py
+++ b/src/mobius/_builder.py
@@ -106,24 +106,45 @@ def _cast_module_dtype(module: nn.Module, dtype: ir.DataType) -> None:
             param.const_value = tensor_adapters.TorchTensor(cast_tensor)
 
 
-def _enable_pruned_lm_head_task(task: str | ModelTask) -> str | ModelTask:
-    """Return a task equivalent to *task* with LM-head pruning enabled."""
-    from mobius.tasks import CausalLMTask, HybridCausalLMTask
+def _enable_prefill_prefix_pruning_task(task: str | ModelTask) -> str | ModelTask:
+    """Return a task equivalent to *task* with prefill-prefix pruning enabled."""
+    from mobius.tasks import (
+        CausalLMTask,
+        Gemma4Task,
+        Gemma4TextCausalLMTask,
+        HybridCausalLMTask,
+    )
 
     if task == "text-generation":
-        return CausalLMTask(prune_lm_head=True)
+        return CausalLMTask(prune_prefill_prefix=True)
     if task == "hybrid-text-generation":
-        return HybridCausalLMTask(prune_lm_head=True)
+        return HybridCausalLMTask(prune_prefill_prefix=True)
+    if task == "gemma4-text-generation":
+        return Gemma4TextCausalLMTask(prune_prefill_prefix=True)
+    if task == "gemma4":
+        return Gemma4Task(prune_prefill_prefix=True)
     if isinstance(task, CausalLMTask):
         return CausalLMTask(
             static_cache=getattr(task, "_static_cache", False),
             max_seq_len=getattr(task, "_max_seq_len", None),
-            prune_lm_head=True,
+            prune_prefill_prefix=True,
         )
     if isinstance(task, HybridCausalLMTask):
-        return HybridCausalLMTask(prune_lm_head=True)
+        return HybridCausalLMTask(prune_prefill_prefix=True)
+    if isinstance(task, Gemma4TextCausalLMTask):
+        return Gemma4TextCausalLMTask(
+            static_cache=getattr(task, "_static_cache", False),
+            max_seq_len=getattr(task, "_max_seq_len", None),
+            prune_prefill_prefix=True,
+        )
+    if isinstance(task, Gemma4Task):
+        return Gemma4Task(
+            static_cache=getattr(task, "_static_cache", False),
+            max_seq_len=getattr(task, "_max_seq_len", None),
+            prune_prefill_prefix=True,
+        )
     raise ValueError(
-        "prune_lm_head=True is only supported for text-generation and "
+        "prune_prefill_prefix=True is only supported for text-generation and "
         "hybrid-text-generation tasks."
     )
 
@@ -159,7 +180,7 @@ def build_from_module(
     trace_optimization: bool = False,
     fp8_kv_cache: bool = False,
     kv_cache_scales: dict[int, tuple[float, float]] | None = None,
-    prune_lm_head: bool = False,
+    prune_prefill_prefix: bool = False,
 ) -> ModelPackage:
     """Build an ONNX :class:`ModelPackage` from a module instance and config.
 
@@ -200,10 +221,9 @@ def build_from_module(
             per-tensor FP8 scales (from offline calibration), used only when
             ``fp8_kv_cache`` is ``True``. Layers absent from the map use a unit
             scale of ``1.0``.
-        prune_lm_head: When ``True``, reduce decoder logits to the final token
-            via the causal-LM task so runtimes can avoid full prefill LM-head
-            projection. Only supported by ``text-generation`` and
-            ``hybrid-text-generation`` tasks.
+        prune_prefill_prefix: When ``True``, discard prefill token positions
+            before the final token from the remaining decoder computation and
+            logits. Only supported by causal generation tasks.
 
     Returns:
         A :class:`ModelPackage` containing the built model(s).
@@ -237,8 +257,8 @@ def build_from_module(
     # are included — their graph inputs are kept at f32 (matching GenAI's
     # image processor output) with a Cast at the graph entry.
     _cast_module_dtype(module, dtype)
-    if prune_lm_head:
-        task = _enable_pruned_lm_head_task(task)
+    if prune_prefill_prefix:
+        task = _enable_prefill_prefix_pruning_task(task)
     resolved_task = get_task(task)
     capabilities = ep_registry.require(execution_provider)
     with build_context(capabilities, dtype):
@@ -400,7 +420,7 @@ def build(
     text_only: bool = False,
     fp8_kv_cache: bool = False,
     kv_cache_scales: dict[int, tuple[float, float]] | None = None,
-    prune_lm_head: bool = False,
+    prune_prefill_prefix: bool = False,
 ) -> ModelPackage:
     """Build an ONNX :class:`ModelPackage` from a HuggingFace model ID.
 
@@ -476,7 +496,7 @@ def build(
             per-tensor FP8 scales (from offline calibration), used only when
             ``fp8_kv_cache`` is ``True``. Layers absent from the map use a unit
             scale of ``1.0``.
-        prune_lm_head: When ``True``, build supported causal-LM tasks so the
+        prune_prefill_prefix: When ``True``, build supported causal-LM tasks so the
             exported ``logits`` output contains only the final token
             (``[B, 1, vocab]``). This is intended for single-token
             autoregressive generation and is incompatible with workflows that
@@ -659,7 +679,7 @@ def build(
         trace_optimization=trace_optimization,
         fp8_kv_cache=fp8_kv_cache,
         kv_cache_scales=kv_cache_scales,
-        prune_lm_head=prune_lm_head,
+        prune_prefill_prefix=prune_prefill_prefix,
     )
 
     for name, model in pkg.items():

--- a/src/mobius/_builder.py
+++ b/src/mobius/_builder.py
@@ -144,8 +144,8 @@ def _enable_prefill_prefix_pruning_task(task: str | ModelTask) -> str | ModelTas
             prune_prefill_prefix=True,
         )
     raise ValueError(
-        "prune_prefill_prefix=True is only supported for text-generation and "
-        "hybrid-text-generation tasks."
+        "prune_prefill_prefix=True is only supported for text-generation, "
+        "hybrid-text-generation, gemma4-text-generation, and gemma4 tasks."
     )
 
 

--- a/src/mobius/_builder.py
+++ b/src/mobius/_builder.py
@@ -221,9 +221,10 @@ def build_from_module(
             per-tensor FP8 scales (from offline calibration), used only when
             ``fp8_kv_cache`` is ``True``. Layers absent from the map use a unit
             scale of ``1.0``.
-        prune_prefill_prefix: When ``True``, discard prefill token positions
-            before the final token from the remaining decoder computation and
-            logits. Only supported by causal generation tasks.
+        prune_prefill_prefix: When ``True``, retain only the final sequence position
+            before the LM head so ``logits`` is shaped ``[B, 1, vocab]``. Some
+            models (e.g. Gemma 4) additionally prune decoder suffix computation
+            during prefill. Only supported by causal generation tasks.
 
     Returns:
         A :class:`ModelPackage` containing the built model(s).

--- a/src/mobius/_builder_test.py
+++ b/src/mobius/_builder_test.py
@@ -13,7 +13,12 @@ from __future__ import annotations
 import onnx_ir as ir
 import pytest
 
-from mobius._builder import _graph_requires_opset24, _maybe_apply_opset_lowering, flags
+from mobius._builder import (
+    _enable_prefill_prefix_pruning_task,
+    _graph_requires_opset24,
+    _maybe_apply_opset_lowering,
+    flags,
+)
 from mobius._model_package import ModelPackage
 
 
@@ -55,6 +60,16 @@ def _static_cache_nodes() -> list[ir.Node]:
 
 def _standard_nodes() -> list[ir.Node]:
     return [ir.Node("", "Reshape", inputs=[_make_value("x"), _make_value("shape")])]
+
+
+def test_prefill_prefix_pruning_error_lists_supported_tasks() -> None:
+    with pytest.raises(
+        ValueError,
+        match=(
+            "text-generation, hybrid-text-generation, gemma4-text-generation, and gemma4 tasks"
+        ),
+    ):
+        _enable_prefill_prefix_pruning_task("feature-extraction")
 
 
 def test_graph_requires_opset24_tensor_scatter() -> None:

--- a/src/mobius/integrations/ort_genai/genai_config_test.py
+++ b/src/mobius/integrations/ort_genai/genai_config_test.py
@@ -232,6 +232,31 @@ class TestGenaiConfigGeneratorLLM:
         assert webgpu["enableGraphCapture"] == "1"
         assert webgpu["validationMode"] == "disabled"
 
+    def test_webgpu_graph_capture_is_decoder_only_for_multimodal(self):
+        gen = GenaiConfigGenerator(
+            "gemma4",
+            vocab_size=256,
+            hidden_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=1,
+            head_dim=16,
+            ep="webgpu",
+        )
+        config = gen.with_vision(image_token_id=255999).with_audio().generate()
+
+        model = config["model"]
+        decoder_webgpu = model["decoder"]["session_options"]["provider_options"][0][
+            "webgpu"
+        ]
+        assert decoder_webgpu["enableGraphCapture"] == "1"
+        for component in ("vision", "embedding", "speech"):
+            webgpu = model[component]["session_options"]["provider_options"][0][
+                "webgpu"
+            ]
+            assert webgpu["enableGraphCapture"] == "0"
+            assert webgpu["validationMode"] == "basic"
+
     def test_search_params_custom_ep_with_share_buffer(self):
         """A custom EP registered with supports_past_present_share_buffer=True gets the flag set.
 

--- a/src/mobius/integrations/ort_genai/genai_config_test.py
+++ b/src/mobius/integrations/ort_genai/genai_config_test.py
@@ -246,14 +246,10 @@ class TestGenaiConfigGeneratorLLM:
         config = gen.with_vision(image_token_id=255999).with_audio().generate()
 
         model = config["model"]
-        decoder_webgpu = model["decoder"]["session_options"]["provider_options"][0][
-            "webgpu"
-        ]
+        decoder_webgpu = model["decoder"]["session_options"]["provider_options"][0]["webgpu"]
         assert decoder_webgpu["enableGraphCapture"] == "1"
         for component in ("vision", "embedding", "speech"):
-            webgpu = model[component]["session_options"]["provider_options"][0][
-                "webgpu"
-            ]
+            webgpu = model[component]["session_options"]["provider_options"][0]["webgpu"]
             assert webgpu["enableGraphCapture"] == "0"
             assert webgpu["validationMode"] == "basic"
 

--- a/src/mobius/models/_models_test.py
+++ b/src/mobius/models/_models_test.py
@@ -280,9 +280,7 @@ class TestPrunePrefillPrefix:
 
         config = make_config()
         with pytest.raises(ValueError, match="does not support prune_prefill_prefix"):
-            build_from_module(
-                UnsupportedCausalLM(config), config, prune_prefill_prefix=True
-            )
+            build_from_module(UnsupportedCausalLM(config), config, prune_prefill_prefix=True)
 
 
 class TestDeepStackCaptureOrdering:

--- a/src/mobius/models/_models_test.py
+++ b/src/mobius/models/_models_test.py
@@ -137,10 +137,10 @@ class TestBuildFromModule:
         assert isinstance(model, ir.Model)
         assert model.graph.num_nodes() > 0
 
-    def test_build_with_prune_lm_head_feature(self):
+    def test_build_with_prune_prefill_prefix_feature(self):
         config = make_config()
         module = CausalLMModel(config)
-        model = build_from_module(module, config, prune_lm_head=True)["model"]
+        model = build_from_module(module, config, prune_prefill_prefix=True)["model"]
 
         logits = next(v for v in model.graph.outputs if v.name == "logits")
         assert len(logits.shape) == 3
@@ -191,23 +191,23 @@ class TestTextModelOutputHiddenStates:
         assert model.output_layer_indices == [0, 3]
 
 
-class TestPruneLmHead:
-    """Tests for the ``prune_lm_head`` option in :class:`CausalLMTask`.
+class TestPrunePrefillPrefix:
+    """Tests for the ``prune_prefill_prefix`` option in :class:`CausalLMTask`.
 
     When ``True``, a ``Gather + Unsqueeze`` is inserted after the LM head
     so logits are produced for only the last sequence position.
-    Mirrors onnxruntime-genai Model Builder's ``prune_lm_head`` opt-in.
+    The generic causal task applies the optimization immediately before the LM head.
     """
 
-    def _build(self, prune_lm_head: bool = False) -> ir.Model:
+    def _build(self, prune_prefill_prefix: bool = False) -> ir.Model:
         config = make_config()
         module = CausalLMModel(config)
-        task = CausalLMTask(prune_lm_head=prune_lm_head)
+        task = CausalLMTask(prune_prefill_prefix=prune_prefill_prefix)
         return build_from_module(module, config, task=task)["model"]
 
-    def test_default_emits_no_lm_head_pruning(self):
-        """Default (prune_lm_head=False): graph emits full [B, S, vocab] logits."""
-        model = self._build(prune_lm_head=False)
+    def test_default_emits_no_prefill_prefix_pruning(self):
+        """Default graph emits full [B, S, vocab] logits."""
+        model = self._build(prune_prefill_prefix=False)
 
         logits = next(v for v in model.graph.outputs if v.name == "logits")
         # Logits must remain rank-3 [B, S, vocab]
@@ -226,7 +226,7 @@ class TestPruneLmHead:
 
     def test_prune_emits_gather_on_logits(self):
         """Pruning selects the final hidden state before the LM-head MatMul."""
-        model = self._build(prune_lm_head=True)
+        model = self._build(prune_prefill_prefix=True)
 
         logits = next(v for v in model.graph.outputs if v.name == "logits")
         # Logits must still be rank-3 [B, 1, vocab] (NOT rank-4 [B, 1, 1, V])
@@ -253,7 +253,7 @@ class TestPruneLmHead:
         input_ids still has dynamic sequence_length
         so the model accepts arbitrary prompts.
         """
-        model = self._build(prune_lm_head=True)
+        model = self._build(prune_prefill_prefix=True)
 
         input_ids = next(v for v in model.graph.inputs if v.name == "input_ids")
         # input dim 1 (sequence_length) should still be dynamic, not 1
@@ -279,8 +279,10 @@ class TestPruneLmHead:
                 return self.lm_head(op, hidden_states), present
 
         config = make_config()
-        with pytest.raises(ValueError, match="does not support prune_lm_head"):
-            build_from_module(UnsupportedCausalLM(config), config, prune_lm_head=True)
+        with pytest.raises(ValueError, match="does not support prune_prefill_prefix"):
+            build_from_module(
+                UnsupportedCausalLM(config), config, prune_prefill_prefix=True
+            )
 
 
 class TestDeepStackCaptureOrdering:

--- a/src/mobius/models/base.py
+++ b/src/mobius/models/base.py
@@ -22,7 +22,7 @@ from onnxscript import OpBuilder, nn
 from mobius._build_context import (
     ep_capabilities,
     get_build_dtype,
-    is_lm_head_pruning_enabled,
+    is_prefill_prefix_pruning_enabled,
 )
 from mobius._configs import ArchitectureConfig, CausalLMConfig
 from mobius._flags import flags
@@ -448,11 +448,11 @@ class CausalLMModel(nn.Module):
         )
         if len(result) == 3:
             hidden_states, present_key_values, intermediate_hidden_states = result
-            hidden_states = _prune_lm_head_hidden_states(op, hidden_states)
+            hidden_states = _retain_last_sequence_token(op, hidden_states)
             logits = self.lm_head(op, hidden_states)
             return logits, present_key_values, intermediate_hidden_states
         hidden_states, present_key_values = result
-        hidden_states = _prune_lm_head_hidden_states(op, hidden_states)
+        hidden_states = _retain_last_sequence_token(op, hidden_states)
         logits = self.lm_head(op, hidden_states)
         return logits, present_key_values
 
@@ -499,9 +499,9 @@ class CausalLMModel(nn.Module):
         return state_dict
 
 
-def _prune_lm_head_hidden_states(op: OpBuilder, hidden_states: ir.Value) -> ir.Value:
-    """Select the final sequence position before the LM-head projection."""
-    if not is_lm_head_pruning_enabled():
+def _retain_last_sequence_token(op: OpBuilder, hidden_states: ir.Value) -> ir.Value:
+    """Retain only the final sequence position when prefill-prefix pruning is active."""
+    if not is_prefill_prefix_pruning_enabled():
         return hidden_states
     last_hidden = op.Gather(hidden_states, op.Constant(value_int=-1), axis=1)
     return op.Unsqueeze(last_hidden, op.Constant(value_ints=[1]))

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -50,7 +50,7 @@ from mobius.components import (
 from mobius.components._activations import get_activation
 from mobius.components._gemma4_audio import Gemma4AudioEncoder
 from mobius.components._mlp import GatedMLP
-from mobius.models.base import CausalLMModel
+from mobius.models.base import CausalLMModel, _retain_last_sequence_token
 from mobius.models.gemma3_text import Gemma3TextScaledWordEmbedding
 
 if TYPE_CHECKING:
@@ -68,6 +68,44 @@ if TYPE_CHECKING:
 # below are the single place the text components read the quantization config,
 # which keeps that "text quantized, vision/audio float" contract explicit.
 # ---------------------------------------------------------------------------
+
+
+def _split_per_layer_projection_weight(
+    state_dict: dict[str, torch.Tensor],
+    prefix: str,
+    config: Gemma4Config,
+) -> None:
+    """Split the packed PLE projection at the first KV-sharing layer."""
+    shared_layers = config.num_kv_shared_layers
+    per_layer_dim = config.hidden_size_per_layer_input
+    if not shared_layers or not per_layer_dim:
+        return
+
+    weight_key = f"{prefix}per_layer_model_projection.weight"
+    weight = state_dict.get(weight_key)
+    if weight is None:
+        return
+
+    expected_rows = config.num_hidden_layers * per_layer_dim
+    if weight.shape[0] != expected_rows:
+        raise ValueError(
+            f"{weight_key} dim 0 expected {expected_rows}, got {weight.shape[0]}"
+        )
+    producer_rows = (config.num_hidden_layers - shared_layers) * per_layer_dim
+    producer, consumer = weight.split(
+        [producer_rows, expected_rows - producer_rows], dim=0
+    )
+    state_dict[weight_key] = producer.contiguous()
+    state_dict[f"{prefix}per_layer_model_projection_consumer.weight"] = (
+        consumer.contiguous()
+    )
+
+
+def _typed_scalar_constant(
+    op: OpBuilder, value: float, dtype: ir.DataType
+) -> ir.Value:
+    """Create a scalar constant directly in the model compute dtype."""
+    return op.Constant(value=ir.tensor(np.asarray(value, dtype=dtype.numpy())))
 
 
 def _text_quantization_config(config: Gemma4Config):
@@ -143,7 +181,7 @@ def _make_scaled_word_embedding(
             block_size=quantization_config.group_size,
             has_zero_point=not quantization_config.sym,
         )
-    return Gemma3TextScaledWordEmbedding(
+    return Gemma4ScaledWordEmbedding(
         num_embeddings,
         embedding_dim,
         config.pad_token_id,
@@ -164,6 +202,19 @@ def _make_lm_head(config: Gemma4Config) -> nn.Module:
         if linear_cls is not None:
             return linear_cls(config.hidden_size, config.vocab_size, bias=False)
     return Linear(config.hidden_size, config.vocab_size, bias=False)
+
+
+class Gemma4ScaledWordEmbedding(Gemma3TextScaledWordEmbedding):
+    """Gemma embedding with a typed scale constant suitable for graph capture."""
+
+    def forward(self, op: OpBuilder, input_ids: ir.Value) -> ir.Value:
+        embeddings = Embedding.forward(self, op, input_ids)
+        scale = op.Constant(
+            value=ir.tensor(
+                np.asarray(self.embed_scale, dtype=self.weight.dtype.numpy())
+            )
+        )
+        return op.Mul(embeddings, scale)
 
 
 class Gemma4ScaledQuantizedWordEmbedding(QuantizedEmbedding):
@@ -197,7 +248,12 @@ class Gemma4ScaledQuantizedWordEmbedding(QuantizedEmbedding):
 
     def forward(self, op: OpBuilder, input_ids: ir.Value) -> ir.Value:
         embeddings = super().forward(op, input_ids)
-        return op.Mul(embeddings, self.embed_scale)
+        scale = op.Constant(
+            value=ir.tensor(
+                np.asarray(self.embed_scale, dtype=self.scales.dtype.numpy())
+            )
+        )
+        return op.Mul(embeddings, scale)
 
 
 def _dtype_safe_compress(
@@ -1773,6 +1829,10 @@ class Gemma4TextModel(nn.Module):
         # embedding model and passed as per_layer_inputs. In single-model
         # (text-only) mode, they are computed here from input_ids.
         self._per_layer_dim = getattr(config, "hidden_size_per_layer_input", 0)
+        self._num_layers = config.num_hidden_layers
+        self._first_kv_shared_layer = (
+            self._num_layers - config.num_kv_shared_layers
+        )
         self._hidden_size = config.hidden_size
         self._image_token_id: int = config.image_token_id or 0
         # The vision-block overlay keys on image_token_id. A 0/None id means the
@@ -1785,7 +1845,6 @@ class Gemma4TextModel(nn.Module):
             config.audio.audio_token_id if config.audio is not None else None
         )
         if self._per_layer_dim:
-            self._num_layers = config.num_hidden_layers
             vocab_per_layer = getattr(config, "vocab_size_per_layer_input", 0)
             # Fused [V, L*D] table — used when split_per_layer_embedding is False.
             # Requires ORT >= 1.27 for CUDA Gather int64 index support (onnxruntime#28107).
@@ -1802,7 +1861,7 @@ class Gemma4TextModel(nn.Module):
             # ONNX initializer, so the unused one adds no graph weight.
             self.embed_tokens_per_layer_split = nn.ModuleList(
                 [
-                    Gemma3TextScaledWordEmbedding(
+                    Gemma4ScaledWordEmbedding(
                         vocab_per_layer,
                         self._per_layer_dim,
                         config.pad_token_id,
@@ -1813,9 +1872,16 @@ class Gemma4TextModel(nn.Module):
             )
             self.per_layer_model_projection = Linear(
                 config.hidden_size,
-                config.num_hidden_layers * self._per_layer_dim,
+                self._first_kv_shared_layer * self._per_layer_dim,
                 bias=False,
             )
+            if self._first_kv_shared_layer < self._num_layers:
+                self.per_layer_model_projection_consumer = Linear(
+                    config.hidden_size,
+                    (self._num_layers - self._first_kv_shared_layer)
+                    * self._per_layer_dim,
+                    bias=False,
+                )
             self.per_layer_projection_norm = RMSNorm(
                 self._per_layer_dim, eps=config.rms_norm_eps
             )
@@ -1859,12 +1925,26 @@ class Gemma4TextModel(nn.Module):
         inputs_embeds: ir.Value,
     ) -> list[ir.Value]:
         """Compute per-layer input embeddings for single-model (text-only) mode."""
-        proj = self.per_layer_model_projection(op, inputs_embeds)
-        proj = op.Mul(proj, float(self._hidden_size**-0.5))
-        proj = op.Reshape(
-            proj, op.Constant(value_ints=[0, 0, self._num_layers, self._per_layer_dim])
+        producer_count = self._first_kv_shared_layer
+        producer_proj = self.per_layer_model_projection(op, inputs_embeds)
+        producer_proj = op.Mul(producer_proj, float(self._hidden_size**-0.5))
+        producer_proj = op.Reshape(
+            producer_proj,
+            op.Constant(value_ints=[0, 0, producer_count, self._per_layer_dim]),
         )
-        proj = self.per_layer_projection_norm(op, proj)
+        producer_proj = self.per_layer_projection_norm(op, producer_proj)
+
+        consumer_count = self._num_layers - producer_count
+        consumer_proj: ir.Value | None = None
+        if consumer_count:
+            consumer_inputs = _retain_last_sequence_token(op, inputs_embeds)
+            consumer_proj = self.per_layer_model_projection_consumer(op, consumer_inputs)
+            consumer_proj = op.Mul(consumer_proj, float(self._hidden_size**-0.5))
+            consumer_proj = op.Reshape(
+                consumer_proj,
+                op.Constant(value_ints=[0, 0, consumer_count, self._per_layer_dim]),
+            )
+            consumer_proj = self.per_layer_projection_norm(op, consumer_proj)
 
         pad = op.Constant(value_int=0)
         masked_ids = input_ids
@@ -1884,25 +1964,54 @@ class Gemma4TextModel(nn.Module):
         if self.config.split_per_layer_embedding:
             # L separate Gathers on [V, D] tables — each fits within the EP's
             # max_buffer_size (e.g. WebGPU's 256 MiB limit).
-            per_layer_embs = [
-                op.Unsqueeze(self.embed_tokens_per_layer_split[i](op, masked_ids), [2])
-                for i in range(self._num_layers)
-            ]
-            fused_emb = op.Concat(*per_layer_embs, axis=2)  # [B, S, L, D]
+            per_layer_embs = []
+            for layer_idx in range(self._num_layers):
+                embedding = self.embed_tokens_per_layer_split[layer_idx](op, masked_ids)
+                if layer_idx >= producer_count:
+                    embedding = _retain_last_sequence_token(op, embedding)
+                per_layer_embs.append(op.Unsqueeze(embedding, [2]))
+            producer_emb = op.Concat(*per_layer_embs[:producer_count], axis=2)
+            consumer_emb = (
+                op.Concat(*per_layer_embs[producer_count:], axis=2)
+                if consumer_count
+                else None
+            )
         else:
             fused_emb = self.embed_tokens_per_layer(op, masked_ids)
             fused_emb = op.Reshape(
                 fused_emb,
                 op.Constant(value_ints=[0, 0, self._num_layers, self._per_layer_dim]),
             )
+            producer_emb = op.Slice(
+                fused_emb, starts=[0], ends=[producer_count], axes=[2]
+            )
+            consumer_emb = None
+            if consumer_count:
+                consumer_emb = op.Slice(
+                    fused_emb,
+                    starts=[producer_count],
+                    ends=[self._num_layers],
+                    axes=[2],
+                )
+                consumer_emb = _retain_last_sequence_token(op, consumer_emb)
 
-        combined = op.Add(proj, fused_emb)
-        combined = op.Mul(combined, float(0.5**0.5))
-
-        return [
-            op.Gather(combined, op.Constant(value_int=i), axis=2)
-            for i in range(self._num_layers)
+        producer_combined = op.Mul(
+            op.Add(producer_proj, producer_emb), float(0.5**0.5)
+        )
+        per_layer_inputs = [
+            op.Gather(producer_combined, op.Constant(value_int=i), axis=2)
+            for i in range(producer_count)
         ]
+        if consumer_count:
+            assert consumer_proj is not None and consumer_emb is not None
+            consumer_combined = op.Mul(
+                op.Add(consumer_proj, consumer_emb), float(0.5**0.5)
+            )
+            per_layer_inputs.extend(
+                op.Gather(consumer_combined, op.Constant(value_int=i), axis=2)
+                for i in range(consumer_count)
+            )
+        return per_layer_inputs
 
     def forward(
         self,
@@ -1934,6 +2043,10 @@ class Gemma4TextModel(nn.Module):
                 op.Squeeze(op.Slice(per_layer_4d, starts=[i], ends=[i + 1], axes=[2]), [2])
                 for i in range(num_layers)
             ]
+            for layer_idx in range(self._first_kv_shared_layer, num_layers):
+                per_layer_list[layer_idx] = _retain_last_sequence_token(
+                    op, per_layer_list[layer_idx]
+                )
         elif self._per_layer_dim and input_ids is not None:
             # Text-only: compute per-layer inputs from input_ids
             per_layer_list = self._compute_per_layer_inputs(op, input_ids, hidden_states)
@@ -2013,20 +2126,12 @@ class Gemma4TextModel(nn.Module):
                 op.Sub(reduce_sum, one_i32),
                 to=ir.DataType.INT32,
             )
-            if caps.requires_graph_capture_rewrite:
-                # Support graph capture for shared-KV layer models on WebGPU EP.
-                # Derive total_seq_len from reduce_sum (already computed) as a
-                # scalar INT32 via Gather index 0 (valid because graph capture
-                # requires batch=1).
-                total_seq_len = op.Gather(
-                    op.Cast(reduce_sum, to=ir.DataType.INT32),
-                    op.Constant(value_int=0),
-                )
-            else:
-                total_seq_len = op.Cast(
-                    op.Gather(op.Shape(attention_mask), 1),
-                    to=ir.DataType.INT32,
-                )
+            # Graph capture requires batch=1, so the first reduced sequence
+            # length is also the scalar total sequence length expected by GQA.
+            total_seq_len = op.Gather(
+                op.Cast(reduce_sum, to=ir.DataType.INT32),
+                op.Constant(value_int=0),
+            )
 
             # Per-layer-type GQA contexts with appropriate cos/sin caches
             # and local_window_size for sliding layers.
@@ -2157,6 +2262,8 @@ class Gemma4TextModel(nn.Module):
         for i, (layer, layer_type, past_kv) in enumerate(
             zip(self.layers, self.layer_types, past_kvs)
         ):
+            if i == self._first_kv_shared_layer and i < len(self.layers):
+                hidden_states = _retain_last_sequence_token(op, hidden_states)
             per_layer_input = per_layer_list[i] if per_layer_list is not None else None
 
             # Per-layer cache/attention dispatch:
@@ -2243,12 +2350,12 @@ class Gemma4CausalLMModel(CausalLMModel):
             past_key_values=past_key_values,
             inputs_embeds=inputs_embeds,
         )
+        hidden_states = _retain_last_sequence_token(op, hidden_states)
         logits = self.lm_head(op, hidden_states)
         # Optional final logit soft-capping (tanh scaled): logit_cap * tanh(x / logit_cap)
         if self.config.final_logit_softcapping:
-            cap = op.CastLike(
-                self.config.final_logit_softcapping,
-                logits,
+            cap = _typed_scalar_constant(
+                op, self.config.final_logit_softcapping, self.config.dtype
             )
             logits = op.Mul(op.Tanh(op.Div(logits, cap)), cap)
         return logits, present_key_values
@@ -2268,6 +2375,7 @@ class Gemma4CausalLMModel(CausalLMModel):
         # (For WebGPU, splitting is handled by _Gemma4DecoderModel.preprocess_weights.)
         # Map HF expert weight names and fold router scale
         _remap_moe_expert_weights(state_dict, self.config)
+        _split_per_layer_projection_weight(state_dict, "model.", self.config)
         return super().preprocess_weights(state_dict)
 
     def static_kv_cache_specs(self) -> list[tuple[int, int]]:
@@ -2321,12 +2429,12 @@ class _Gemma4DecoderModel(nn.Module):
             per_layer_inputs=per_layer_inputs,
             block_sequence_ids=block_sequence_ids,
         )
+        hidden_states = _retain_last_sequence_token(op, hidden_states)
         logits = self.lm_head(op, hidden_states)
         # Gemma4 applies final logit soft-capping: logit_cap * tanh(x / logit_cap)
         if self.config.final_logit_softcapping:
-            cap = op.CastLike(
-                self.config.final_logit_softcapping,
-                logits,
+            cap = _typed_scalar_constant(
+                op, self.config.final_logit_softcapping, self.config.dtype
             )
             logits = op.Mul(op.Tanh(op.Div(logits, cap)), cap)
         return logits, present_key_values
@@ -2335,6 +2443,7 @@ class _Gemma4DecoderModel(nn.Module):
         self, state_dict: dict[str, torch.Tensor]
     ) -> dict[str, torch.Tensor]:
         state_dict = vlm_decoder_weights(state_dict, tie=self.config.tie_word_embeddings)
+        _split_per_layer_projection_weight(state_dict, "model.", self.config)
         # For WebGPU: split the fused [V, L*D] per-layer embedding into L separate [V, D] tables.
         per_layer_dim = self.config.hidden_size_per_layer_input
         if per_layer_dim and self.config.split_per_layer_embedding:
@@ -3160,6 +3269,9 @@ class Gemma4Model(nn.Module):
                     )
                 ):
                     renamed[k.replace("embedding.", "decoder.model.", 1)] = renamed.pop(k)
+            _split_per_layer_projection_weight(
+                renamed, "decoder.model.", self.config
+            )
 
         return renamed
 

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -2103,12 +2103,18 @@ class Gemma4TextModel(nn.Module):
                 op.Sub(reduce_sum, one_i32),
                 to=ir.DataType.INT32,
             )
-            # Graph capture requires batch=1, so the first reduced sequence
-            # length is also the scalar total sequence length expected by GQA.
-            total_seq_len = op.Gather(
-                op.Cast(reduce_sum, to=ir.DataType.INT32),
-                op.Constant(value_int=0),
-            )
+            if caps.requires_graph_capture_rewrite:
+                # Graph capture requires batch=1, so the first reduced sequence
+                # length is also the scalar total sequence length expected by GQA.
+                total_seq_len = op.Gather(
+                    op.Cast(reduce_sum, to=ir.DataType.INT32),
+                    op.Constant(value_int=0),
+                )
+            else:
+                total_seq_len = op.Cast(
+                    op.Gather(op.Shape(attention_mask), 1),
+                    to=ir.DataType.INT32,
+                )
 
             # Per-layer-type GQA contexts with appropriate cos/sin caches
             # and local_window_size for sliding layers.

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -88,22 +88,14 @@ def _split_per_layer_projection_weight(
 
     expected_rows = config.num_hidden_layers * per_layer_dim
     if weight.shape[0] != expected_rows:
-        raise ValueError(
-            f"{weight_key} dim 0 expected {expected_rows}, got {weight.shape[0]}"
-        )
+        raise ValueError(f"{weight_key} dim 0 expected {expected_rows}, got {weight.shape[0]}")
     producer_rows = (config.num_hidden_layers - shared_layers) * per_layer_dim
-    producer, consumer = weight.split(
-        [producer_rows, expected_rows - producer_rows], dim=0
-    )
+    producer, consumer = weight.split([producer_rows, expected_rows - producer_rows], dim=0)
     state_dict[weight_key] = producer.contiguous()
-    state_dict[f"{prefix}per_layer_model_projection_consumer.weight"] = (
-        consumer.contiguous()
-    )
+    state_dict[f"{prefix}per_layer_model_projection_consumer.weight"] = consumer.contiguous()
 
 
-def _typed_scalar_constant(
-    op: OpBuilder, value: float, dtype: ir.DataType
-) -> ir.Value:
+def _typed_scalar_constant(op: OpBuilder, value: float, dtype: ir.DataType) -> ir.Value:
     """Create a scalar constant directly in the model compute dtype."""
     return op.Constant(value=ir.tensor(np.asarray(value, dtype=dtype.numpy())))
 
@@ -210,9 +202,7 @@ class Gemma4ScaledWordEmbedding(Gemma3TextScaledWordEmbedding):
     def forward(self, op: OpBuilder, input_ids: ir.Value) -> ir.Value:
         embeddings = Embedding.forward(self, op, input_ids)
         scale = op.Constant(
-            value=ir.tensor(
-                np.asarray(self.embed_scale, dtype=self.weight.dtype.numpy())
-            )
+            value=ir.tensor(np.asarray(self.embed_scale, dtype=self.weight.dtype.numpy()))
         )
         return op.Mul(embeddings, scale)
 
@@ -249,9 +239,7 @@ class Gemma4ScaledQuantizedWordEmbedding(QuantizedEmbedding):
     def forward(self, op: OpBuilder, input_ids: ir.Value) -> ir.Value:
         embeddings = super().forward(op, input_ids)
         scale = op.Constant(
-            value=ir.tensor(
-                np.asarray(self.embed_scale, dtype=self.scales.dtype.numpy())
-            )
+            value=ir.tensor(np.asarray(self.embed_scale, dtype=self.scales.dtype.numpy()))
         )
         return op.Mul(embeddings, scale)
 
@@ -1830,9 +1818,7 @@ class Gemma4TextModel(nn.Module):
         # (text-only) mode, they are computed here from input_ids.
         self._per_layer_dim = getattr(config, "hidden_size_per_layer_input", 0)
         self._num_layers = config.num_hidden_layers
-        self._first_kv_shared_layer = (
-            self._num_layers - config.num_kv_shared_layers
-        )
+        self._first_kv_shared_layer = self._num_layers - config.num_kv_shared_layers
         self._hidden_size = config.hidden_size
         self._image_token_id: int = config.image_token_id or 0
         # The vision-block overlay keys on image_token_id. A 0/None id means the
@@ -1878,8 +1864,7 @@ class Gemma4TextModel(nn.Module):
             if self._first_kv_shared_layer < self._num_layers:
                 self.per_layer_model_projection_consumer = Linear(
                     config.hidden_size,
-                    (self._num_layers - self._first_kv_shared_layer)
-                    * self._per_layer_dim,
+                    (self._num_layers - self._first_kv_shared_layer) * self._per_layer_dim,
                     bias=False,
                 )
             self.per_layer_projection_norm = RMSNorm(
@@ -1972,9 +1957,7 @@ class Gemma4TextModel(nn.Module):
                 per_layer_embs.append(op.Unsqueeze(embedding, [2]))
             producer_emb = op.Concat(*per_layer_embs[:producer_count], axis=2)
             consumer_emb = (
-                op.Concat(*per_layer_embs[producer_count:], axis=2)
-                if consumer_count
-                else None
+                op.Concat(*per_layer_embs[producer_count:], axis=2) if consumer_count else None
             )
         else:
             fused_emb = self.embed_tokens_per_layer(op, masked_ids)
@@ -1982,9 +1965,7 @@ class Gemma4TextModel(nn.Module):
                 fused_emb,
                 op.Constant(value_ints=[0, 0, self._num_layers, self._per_layer_dim]),
             )
-            producer_emb = op.Slice(
-                fused_emb, starts=[0], ends=[producer_count], axes=[2]
-            )
+            producer_emb = op.Slice(fused_emb, starts=[0], ends=[producer_count], axes=[2])
             consumer_emb = None
             if consumer_count:
                 consumer_emb = op.Slice(
@@ -1995,18 +1976,14 @@ class Gemma4TextModel(nn.Module):
                 )
                 consumer_emb = _retain_last_sequence_token(op, consumer_emb)
 
-        producer_combined = op.Mul(
-            op.Add(producer_proj, producer_emb), float(0.5**0.5)
-        )
+        producer_combined = op.Mul(op.Add(producer_proj, producer_emb), float(0.5**0.5))
         per_layer_inputs = [
             op.Gather(producer_combined, op.Constant(value_int=i), axis=2)
             for i in range(producer_count)
         ]
         if consumer_count:
             assert consumer_proj is not None and consumer_emb is not None
-            consumer_combined = op.Mul(
-                op.Add(consumer_proj, consumer_emb), float(0.5**0.5)
-            )
+            consumer_combined = op.Mul(op.Add(consumer_proj, consumer_emb), float(0.5**0.5))
             per_layer_inputs.extend(
                 op.Gather(consumer_combined, op.Constant(value_int=i), axis=2)
                 for i in range(consumer_count)
@@ -3269,9 +3246,7 @@ class Gemma4Model(nn.Module):
                     )
                 ):
                     renamed[k.replace("embedding.", "decoder.model.", 1)] = renamed.pop(k)
-            _split_per_layer_projection_weight(
-                renamed, "decoder.model.", self.config
-            )
+            _split_per_layer_projection_weight(renamed, "decoder.model.", self.config)
 
         return renamed
 

--- a/src/mobius/tasks/_causal_lm.py
+++ b/src/mobius/tasks/_causal_lm.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import onnx_ir as ir
 from onnxscript import GraphBuilder, nn
 
-from mobius._build_context import lm_head_pruning
+from mobius._build_context import prefill_prefix_pruning
 from mobius._configs import ArchitectureConfig
 from mobius._model_package import ModelPackage
 from mobius.components._attention import StaticCacheState
@@ -76,7 +76,7 @@ class CausalLMTask(ModelTask):
         max_seq_len: Maximum sequence length for static cache buffers.
             Only used when ``static_cache=True``.  Defaults to
             ``config.max_position_embeddings``.
-        prune_lm_head: If ``True``, insert ``Gather(axis=1, index=-1)``
+        prune_prefill_prefix: If ``True``, insert ``Gather(axis=1, index=-1)``
             before the LM head so only the last token's hidden state is
             projected to logits.  Output logits shape becomes ``[B, 1,
             vocab]`` instead of ``[B, S, vocab]``, reducing prefill cost
@@ -84,8 +84,7 @@ class CausalLMTask(ModelTask):
             runtime only needs the final token's logits (single-token
             autoregressive generation).  Breaks workflows that require
             per-token logits (logprob scoring, speculative decoding,
-            multi-token generation).  Mirrors the ``prune_lm_head`` extra
-            option in onnxruntime-genai's Model Builder.
+            multi-token generation).
     """
 
     def __init__(
@@ -93,11 +92,11 @@ class CausalLMTask(ModelTask):
         *,
         static_cache: bool = False,
         max_seq_len: int | None = None,
-        prune_lm_head: bool = False,
+        prune_prefill_prefix: bool = False,
     ):
         self._static_cache = static_cache
         self._max_seq_len = max_seq_len
-        self._prune_lm_head = prune_lm_head
+        self._prune_prefill_prefix = prune_prefill_prefix
 
     def build(
         self,
@@ -189,7 +188,7 @@ class CausalLMTask(ModelTask):
                 value_head_dim=kv_value_head_dim,
             )
 
-        with lm_head_pruning(self._prune_lm_head):
+        with prefill_prefix_pruning(self._prune_prefill_prefix):
             result = module(
                 op,
                 input_ids=input_ids,
@@ -203,7 +202,7 @@ class CausalLMTask(ModelTask):
         else:
             logits, present_key_values = result
 
-        _validate_pruned_logits(logits, self._prune_lm_head, module)
+        _validate_pruned_logits(logits, self._prune_prefill_prefix, module)
 
         builder.add_output(logits, "logits")
 
@@ -258,13 +257,13 @@ class HybridCausalLMTask(ModelTask):
         - present.{i}.{key|value|conv_state|recurrent_state}: FLOAT
 
     Args:
-        prune_lm_head: If ``True``, insert ``Gather(axis=1, index=-1)``
+        prune_prefill_prefix: If ``True``, insert ``Gather(axis=1, index=-1)``
             before the LM head so only the last token's logits are emitted.
             See :class:`CausalLMTask` for full documentation.
     """
 
-    def __init__(self, *, prune_lm_head: bool = False):
-        self._prune_lm_head = prune_lm_head
+    def __init__(self, *, prune_prefill_prefix: bool = False):
+        self._prune_prefill_prefix = prune_prefill_prefix
 
     def build(
         self,
@@ -296,7 +295,7 @@ class HybridCausalLMTask(ModelTask):
             past_seq_len,
         )
 
-        with lm_head_pruning(self._prune_lm_head):
+        with prefill_prefix_pruning(self._prune_prefill_prefix):
             result = module(
                 op,
                 input_ids=input_ids,
@@ -310,7 +309,7 @@ class HybridCausalLMTask(ModelTask):
         else:
             logits, present_key_values = result
 
-        _validate_pruned_logits(logits, self._prune_lm_head, module)
+        _validate_pruned_logits(logits, self._prune_prefill_prefix, module)
 
         builder.add_output(logits, "logits")
         _register_hybrid_cache_outputs(
@@ -331,16 +330,16 @@ class HybridCausalLMTask(ModelTask):
 
 def _validate_pruned_logits(
     logits: ir.Value,
-    prune_lm_head: bool,
+    prune_prefill_prefix: bool,
     module: nn.Module,
 ) -> None:
     """Fail when a custom model forward ignores the task's pruning request."""
-    if not prune_lm_head:
+    if not prune_prefill_prefix:
         return
     shape = logits.shape
     if shape is None or len(shape) != 3 or shape[1] != 1:
         raise ValueError(
-            f"{type(module).__name__} does not support prune_lm_head. "
+            f"{type(module).__name__} does not support prune_prefill_prefix. "
             "The model must select the final hidden state before its LM-head projection."
         )
 

--- a/src/mobius/tasks/_gemma4.py
+++ b/src/mobius/tasks/_gemma4.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import onnx_ir as ir
 from onnxscript import GraphBuilder, nn
 
-from mobius._build_context import ep_capabilities
+from mobius._build_context import ep_capabilities, prefill_prefix_pruning
 from mobius._configs import Gemma4Config
 from mobius._model_package import ModelPackage
 from mobius._pipeline_contract import (
@@ -276,9 +276,11 @@ class Gemma4TextCausalLMTask(ModelTask):
         *,
         static_cache: bool = False,
         max_seq_len: int | None = None,
+        prune_prefill_prefix: bool = False,
     ):
         self._static_cache = static_cache
         self._max_seq_len = max_seq_len
+        self._prune_prefill_prefix = prune_prefill_prefix
 
     def build(
         self,
@@ -351,13 +353,14 @@ class Gemma4TextCausalLMTask(ModelTask):
                 past_seq_len,
             )
 
-        logits, present_key_values = module(
-            op,
-            input_ids=input_ids,
-            attention_mask=attention_mask,
-            position_ids=position_ids,
-            past_key_values=past_key_values,
-        )
+        with prefill_prefix_pruning(self._prune_prefill_prefix):
+            logits, present_key_values = module(
+                op,
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+            )
         builder.add_output(logits, "logits")
 
         if static:
@@ -416,9 +419,11 @@ class Gemma4Task(ModelTask):
         *,
         static_cache: bool = False,
         max_seq_len: int | None = None,
+        prune_prefill_prefix: bool = False,
     ):
         self._static_cache = static_cache
         self._max_seq_len = max_seq_len
+        self._prune_prefill_prefix = prune_prefill_prefix
 
     def build(
         self,
@@ -551,15 +556,16 @@ class Gemma4Task(ModelTask):
                 past_seq_len,
             )
 
-        logits, present_key_values = decoder(
-            op,
-            inputs_embeds=inputs_embeds,
-            attention_mask=attention_mask,
-            position_ids=position_ids,
-            per_layer_inputs=per_layer_inputs_val,
-            past_key_values=past_key_values,
-            input_ids=input_ids_val,
-        )
+        with prefill_prefix_pruning(self._prune_prefill_prefix):
+            logits, present_key_values = decoder(
+                op,
+                inputs_embeds=inputs_embeds,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                per_layer_inputs=per_layer_inputs_val,
+                past_key_values=past_key_values,
+                input_ids=input_ids_val,
+            )
 
         builder.add_output(logits, "logits")
         if static:

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -244,8 +244,8 @@ class TestCLIBuild:
             )
         assert mock_build.call_args.kwargs.get("fp8_kv_cache") is True
 
-    def test_features_prune_lm_head_passed_through(self):
-        """--features prune-lm-head sets prune_lm_head on the build() call."""
+    def test_features_prune_prefill_prefix_passed_through(self):
+        """--features prune-prefill-prefix sets the build option."""
         with (
             tempfile.TemporaryDirectory() as tmpdir,
             mock.patch(
@@ -263,10 +263,10 @@ class TestCLIBuild:
                     tmpdir,
                     "--no-weights",
                     "--features",
-                    "prune-lm-head",
+                    "prune-prefill-prefix",
                 ]
             )
-        assert mock_build.call_args.kwargs.get("prune_lm_head") is True
+        assert mock_build.call_args.kwargs.get("prune_prefill_prefix") is True
 
     def test_features_comma_separated_multiple(self):
         """A single --features accepts a comma-separated list."""
@@ -287,13 +287,13 @@ class TestCLIBuild:
                     tmpdir,
                     "--no-weights",
                     "--features",
-                    "text-only,fp8-kv-cache,prune-lm-head",
+                    "text-only,fp8-kv-cache,prune-prefill-prefix",
                 ]
             )
         kwargs = mock_build.call_args.kwargs
         assert kwargs.get("text_only") is True
         assert kwargs.get("fp8_kv_cache") is True
-        assert kwargs.get("prune_lm_head") is True
+        assert kwargs.get("prune_prefill_prefix") is True
 
     def test_features_unknown_errors(self):
         """An unrecognised feature name is rejected with a clear error."""

--- a/tests/gemma4_prefill_prefix_test.py
+++ b/tests/gemma4_prefill_prefix_test.py
@@ -1,0 +1,139 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from __future__ import annotations
+
+import torch
+
+from mobius import build_from_module
+from mobius._configs import Gemma4Config, VisionConfig
+from mobius._registry import registry
+from mobius.models.gemma4 import _split_per_layer_projection_weight
+
+
+def _make_config(*, with_vision: bool = False) -> Gemma4Config:
+    return Gemma4Config(
+        num_hidden_layers=4,
+        hidden_size=64,
+        intermediate_size=128,
+        num_attention_heads=4,
+        num_key_value_heads=1,
+        head_dim=16,
+        vocab_size=256,
+        rms_norm_eps=1e-6,
+        hidden_act="silu",
+        attn_qk_norm=True,
+        layer_types=[
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+            "full_attention",
+        ],
+        sliding_window=8,
+        global_head_dim=16,
+        global_rope_theta=10_000.0,
+        global_partial_rotary_factor=0.25,
+        final_logit_softcapping=30.0,
+        hidden_size_per_layer_input=8,
+        vocab_size_per_layer_input=64,
+        split_per_layer_embedding=True,
+        image_token_id=255999 if with_vision else None,
+        pad_token_id=0,
+        tie_word_embeddings=False,
+        num_kv_shared_layers=2,
+        vision=(
+            VisionConfig(
+                hidden_size=32,
+                intermediate_size=64,
+                num_hidden_layers=1,
+                num_attention_heads=2,
+                patch_size=16,
+                norm_eps=1e-6,
+            )
+            if with_vision
+            else None
+        ),
+    )
+
+
+def test_prunes_gemma4_shared_layer_prefix() -> None:
+    config = _make_config()
+    module = registry.get("gemma4_text")(config)
+    model = build_from_module(
+        module,
+        config,
+        task="gemma4-text-generation",
+        execution_provider="webgpu",
+        prune_prefill_prefix=True,
+    )["model"]
+
+    producer = next(
+        node
+        for node in model.graph
+        if node.op_type == "MatMul" and "/per_layer_model_projection/" in node.name
+    )
+    consumer = next(
+        node
+        for node in model.graph
+        if node.op_type == "MatMul"
+        and "/per_layer_model_projection_consumer/" in node.name
+    )
+    assert producer.outputs[0].shape[1] != 1
+    assert producer.outputs[0].shape[2] == 16
+    assert consumer.inputs[0].shape[1:] == (1, 64)
+    assert consumer.outputs[0].shape[1:] == (1, 16)
+
+    first_shared_norm = next(
+        node for node in model.graph if "layers.2/input_layernorm" in node.name
+    )
+    assert first_shared_norm.inputs[0].shape[1:] == (1, 64)
+    logits = next(value for value in model.graph.outputs if value.name == "logits")
+    assert logits.shape[1:] == (1, config.vocab_size)
+
+    consumer_embedding_scale = next(
+        node
+        for node in model.graph
+        if node.op_type == "Mul" and "embed_tokens_per_layer_split.2" in node.name
+    )
+    assert any(
+        node.op_type == "Gather"
+        and any(
+            input_value is consumer_embedding_scale.outputs[0]
+            for input_value in node.inputs
+        )
+        for node in model.graph
+    )
+    assert not any(node.op_type == "CastLike" for node in model.graph)
+
+
+def test_multimodal_task_prunes_decoder_prefix() -> None:
+    config = _make_config(with_vision=True)
+    module = registry.get("gemma4")(config)
+    package = build_from_module(
+        module,
+        config,
+        task="gemma4",
+        execution_provider="webgpu",
+        prune_prefill_prefix=True,
+    )
+
+    logits = next(
+        value for value in package["decoder"].graph.outputs if value.name == "logits"
+    )
+    assert logits.shape[1:] == (1, config.vocab_size)
+
+
+def test_splits_per_layer_projection_weight() -> None:
+    config = _make_config()
+    original = torch.arange(32 * 64, dtype=torch.float32).reshape(32, 64)
+    state_dict = {"model.per_layer_model_projection.weight": original.clone()}
+
+    _split_per_layer_projection_weight(state_dict, "model.", config)
+
+    assert torch.equal(
+        state_dict["model.per_layer_model_projection.weight"], original[:16]
+    )
+    assert torch.equal(
+        state_dict["model.per_layer_model_projection_consumer.weight"],
+        original[16:],
+    )

--- a/tests/gemma4_prefill_prefix_test.py
+++ b/tests/gemma4_prefill_prefix_test.py
@@ -75,8 +75,7 @@ def test_prunes_gemma4_shared_layer_prefix() -> None:
     consumer = next(
         node
         for node in model.graph
-        if node.op_type == "MatMul"
-        and "/per_layer_model_projection_consumer/" in node.name
+        if node.op_type == "MatMul" and "/per_layer_model_projection_consumer/" in node.name
     )
     assert producer.outputs[0].shape[1] != 1
     assert producer.outputs[0].shape[2] == 16
@@ -98,8 +97,7 @@ def test_prunes_gemma4_shared_layer_prefix() -> None:
     assert any(
         node.op_type == "Gather"
         and any(
-            input_value is consumer_embedding_scale.outputs[0]
-            for input_value in node.inputs
+            input_value is consumer_embedding_scale.outputs[0] for input_value in node.inputs
         )
         for node in model.graph
     )
@@ -130,9 +128,7 @@ def test_splits_per_layer_projection_weight() -> None:
 
     _split_per_layer_projection_weight(state_dict, "model.", config)
 
-    assert torch.equal(
-        state_dict["model.per_layer_model_projection.weight"], original[:16]
-    )
+    assert torch.equal(state_dict["model.per_layer_model_projection.weight"], original[:16])
     assert torch.equal(
         state_dict["model.per_layer_model_projection_consumer.weight"],
         original[16:],


### PR DESCRIPTION
Gemma 4 models have shared KV cache

For the E2B model the KV cache of the first 15 layers are shared with the remaining 20 layers.
This means during prefill there is no need to compute beyond 15 layers, only decode needs to run the full graph. Effectively 2B model is a 0.6B model for prefill purposes.
Without this optimization prefill perf will suffer on CPU/GPU.
This change extends the prune_lm_head concept, now instead of pruning at the lm_head level - gemma models prune at a much higher layer, at level 15 onwards.
The brings the prefill TTFT from 845ms on a Nvidia 4070 to 183ms.

Mobius is also fixed to generate graph capture compatible models for Gemma 4.