### PR TITLE
Use fused Swish ops

### DIFF
--- a/src/mobius/components/_activations.py
+++ b/src/mobius/components/_activations.py
@@ -13,8 +13,8 @@ if TYPE_CHECKING:
 
 
 def silu(op: OpBuilder, x):
-    """SiLU (Swish) activation: x * sigmoid(x)."""
-    return op.Mul(x, op.Sigmoid(x))
+    """SiLU (Swish) activation."""
+    return op.Swish(x)
 
 
 def gelu(op: OpBuilder, x):

--- a/src/mobius/components/_activations_test.py
+++ b/src/mobius/components/_activations_test.py
@@ -32,8 +32,9 @@ class TestActivations:
         x = create_test_input(builder, "x", [2, 3, 64])
         result = silu(op, x)
         assert result is not None
-        assert count_op_type(graph, "Sigmoid") >= 1
-        assert count_op_type(graph, "Mul") >= 1
+        assert count_op_type(graph, "Swish") == 1
+        assert count_op_type(graph, "Sigmoid") == 0
+        assert count_op_type(graph, "Mul") == 0
 
     def test_relu(self):
         builder, op, graph = create_test_builder()

--- a/src/mobius/components/_audio.py
+++ b/src/mobius/components/_audio.py
@@ -27,8 +27,8 @@ if TYPE_CHECKING:
 
 
 def _swish(op: OpBuilder, x):
-    """Swish activation: x * sigmoid(x)."""
-    return op.Mul(x, op.Sigmoid(x))
+    """Swish activation."""
+    return op.Swish(x)
 
 
 # ---------------------------------------------------------------------------
@@ -40,7 +40,7 @@ class _SwishModule(nn.Module):
     """Swish activation as an nn.Module (no parameters)."""
 
     def forward(self, op: OpBuilder, x: ir.Value):
-        return op.Mul(x, op.Sigmoid(x))
+        return op.Swish(x)
 
 
 class _ReLUModule(nn.Module):

--- a/src/mobius/components/_audio.py
+++ b/src/mobius/components/_audio.py
@@ -26,11 +26,6 @@ if TYPE_CHECKING:
     import onnx_ir as ir
 
 
-def _swish(op: OpBuilder, x):
-    """Swish activation."""
-    return op.Swish(x)
-
-
 # ---------------------------------------------------------------------------
 # Private helper modules
 # ---------------------------------------------------------------------------
@@ -133,7 +128,7 @@ class _GLULinear(nn.Module):
     def forward(self, op: OpBuilder, x: ir.Value):
         x = self.linear(op, x)  # [B, T, output_dim * 2]
         first, second = op.Split(x, axis=-1, num_outputs=2, _outputs=2)
-        return op.Mul(first, _swish(op, second))
+        return op.Mul(first, op.Swish(second))
 
 
 class _GLUPointWiseConv(nn.Module):
@@ -155,7 +150,7 @@ class _GLUPointWiseConv(nn.Module):
         first, second = op.Split(glu_out, axis=1, num_outputs=2, _outputs=2)
         first = op.Add(first, self.b1)
         second = op.Add(second, self.b2)
-        return op.Mul(first, _swish(op, second))
+        return op.Mul(first, op.Swish(second))
 
 
 class _DepthwiseSepConv(nn.Module):
@@ -355,7 +350,7 @@ class ConformerConvModule(nn.Module):
         x = self.dw_sep_conv_1d(op, x)
 
         # Swish + final pointwise conv
-        x = _swish(op, x)
+        x = op.Swish(x)
         x = self.ext_pw_conv_1d(op, x)
 
         return op.Transpose(x, perm=[0, 2, 1])  # [B, T, C]

--- a/src/mobius/components/_gemma4_audio.py
+++ b/src/mobius/components/_gemma4_audio.py
@@ -73,8 +73,8 @@ def _glu(op: OpBuilder, x: ir.Value) -> ir.Value:
 
 
 def _swish(op: OpBuilder, x: ir.Value) -> ir.Value:
-    """SiLU/Swish activation: x * sigmoid(x)."""
-    return op.Mul(x, op.Sigmoid(x))
+    """SiLU/Swish activation."""
+    return op.Swish(x)
 
 
 # ---------------------------------------------------------------------------

--- a/src/mobius/components/_gemma4_audio.py
+++ b/src/mobius/components/_gemma4_audio.py
@@ -72,11 +72,6 @@ def _glu(op: OpBuilder, x: ir.Value) -> ir.Value:
     return op.Mul(a, op.Sigmoid(b))
 
 
-def _swish(op: OpBuilder, x: ir.Value) -> ir.Value:
-    """SiLU/Swish activation."""
-    return op.Swish(x)
-
-
 # ---------------------------------------------------------------------------
 # Public components
 # ---------------------------------------------------------------------------
@@ -311,7 +306,7 @@ class Gemma4FeedForward(nn.Module):
         x = _gradient_clip(op, x, self._gradient_clipping)
         x = self.pre_layer_norm(op, x)
         x = self.ffw_layer_1(op, x)  # [B, T, 4h]
-        x = _swish(op, x)
+        x = op.Swish(x)
         x = self.ffw_layer_2(op, x)  # [B, T, h]
         x = _gradient_clip(op, x, self._gradient_clipping)
         x = self.post_layer_norm(op, x)
@@ -374,7 +369,7 @@ class Gemma4LightConv1d(nn.Module):
 
         x = _gradient_clip(op, x, self._gradient_clipping)
         x = self.conv_norm(op, x)
-        x = _swish(op, x)
+        x = op.Swish(x)
         x = self.linear_end(op, x)  # [B, T, h]
         return op.Add(x, residual)
 

--- a/src/mobius/components/_lightning_attention.py
+++ b/src/mobius/components/_lightning_attention.py
@@ -115,7 +115,7 @@ class LightningAttention(nn.Module):
         # Fused QKV: project then apply SiLU before split (matches HF)
         # qkv: (B, T, 3 * num_heads * head_dim)
         qkv = self.qkv_proj(op, hidden_states)
-        qkv = op.Mul(qkv, op.Sigmoid(qkv))  # SiLU: x * sigmoid(x)
+        qkv = op.Swish(qkv)
 
         # Split into Q, K, V: each (B, T, num_heads * head_dim)
         head_total = self.num_heads * self.head_dim

--- a/src/mobius/components/_mamba_block.py
+++ b/src/mobius/components/_mamba_block.py
@@ -151,7 +151,7 @@ class MambaBlock(nn.Module):
         conv_out = self.conv1d(op, conv_input)
 
         # --- Step 3: SiLU activation ---
-        conv_out = op.Mul(conv_out, op.Sigmoid(conv_out))
+        conv_out = op.Swish(conv_out)
 
         # Transpose back: (batch, 1, d_inner)
         x_ssm = op.Transpose(conv_out, perm=[0, 2, 1])
@@ -161,7 +161,7 @@ class MambaBlock(nn.Module):
         # y: (batch, 1, d_inner)
 
         # --- Step 5: Output gating: y * SiLU(z) ---
-        z_activated = op.Mul(z_gate, op.Sigmoid(z_gate))
+        z_activated = op.Swish(z_gate)
         gated = op.Mul(y, z_activated)
 
         # --- Step 6: Output projection ---

--- a/src/mobius/components/_mamba_block_test.py
+++ b/src/mobius/components/_mamba_block_test.py
@@ -99,8 +99,8 @@ class TestMambaBlock:
         # Two splits: in_proj (x/z) and SSM x_proj (dt/B/C)
         assert count_op_type(graph, "Split") >= 2
 
-    def test_silu_activation_via_sigmoid(self):
-        """SiLU (x * sigmoid(x)) produces Sigmoid + Mul ops."""
+    def test_silu_activation_uses_fused_swish(self):
+        """Both SiLU activations use the fused Swish op."""
         block = MambaBlock(d_model=32, d_inner=64, d_state=8)
         test_builder, op, graph = create_test_builder()
         hidden = create_test_input(test_builder, "hidden_states", [1, 1, 32])
@@ -109,8 +109,9 @@ class TestMambaBlock:
 
         block(op, hidden, conv_state, ssm_state)
 
-        # SiLU appears in conv path + z gating = at least 2 Sigmoid ops
-        assert count_op_type(graph, "Sigmoid") >= 2
+        # SiLU appears in the convolution path and output gate.
+        assert count_op_type(graph, "Swish") == 2
+        assert count_op_type(graph, "Sigmoid") == 0
 
     def test_matmul_ops_for_projections(self):
         """Graph contains MatMul ops for linear projections."""

--- a/src/mobius/components/_mlp_test.py
+++ b/src/mobius/components/_mlp_test.py
@@ -70,8 +70,8 @@ class TestMLP:
         x = create_test_input(builder, "x", [1, 8, 64])
 
         mlp(op, x)
-        # SiLU = x * sigmoid(x): Sigmoid + Mul
-        assert count_op_type(graph, "Sigmoid") >= 1
+        assert count_op_type(graph, "Swish") == 1
+        assert count_op_type(graph, "Sigmoid") == 0
 
     def test_gelu_activation(self):
         config = make_config(hidden_act="gelu")
@@ -195,9 +195,9 @@ class TestGatedMLP:
         builder, op, graph = create_test_builder()
         x = create_test_input(builder, "x", [1, 8, 64])
         mlp(op, x)
-        # SiLU = x * sigmoid(x): Sigmoid + Mul (gate) + Mul (gate*up)
-        assert count_op_type(graph, "Sigmoid") >= 1
-        assert count_op_type(graph, "Mul") >= 2
+        assert count_op_type(graph, "Swish") == 1
+        assert count_op_type(graph, "Sigmoid") == 0
+        assert count_op_type(graph, "Mul") >= 1
 
     def test_gelu_activation(self):
         mlp = GatedMLP(hidden_size=64, intermediate_size=128, activation="gelu")
@@ -267,8 +267,8 @@ class TestFusedGateUpMLP:
         builder, op, graph = create_test_builder()
         x = create_test_input(builder, "x", [1, 8, 64])
         mlp(op, x)
-        # SiLU = x * sigmoid(x)
-        assert count_op_type(graph, "Sigmoid") >= 1
+        assert count_op_type(graph, "Swish") == 1
+        assert count_op_type(graph, "Sigmoid") == 0
 
     def test_linear_class_applied(self):
         from mobius.components._common import Linear

--- a/src/mobius/components/_rms_norm.py
+++ b/src/mobius/components/_rms_norm.py
@@ -77,7 +77,7 @@ class GatedRMSNorm(nn.Module):
         # SiLU gating in fp32 for precision, matching HF.
         h_f32 = op.Cast(hidden_states, to=ir.DataType.FLOAT)
         g_f32 = op.Cast(gate, to=ir.DataType.FLOAT)
-        gate_activated = op.Mul(g_f32, op.Sigmoid(g_f32))
+        gate_activated = op.Swish(g_f32)
         gated = op.Mul(h_f32, gate_activated)
 
         if self.group_size is not None and self.group_size < self.hidden_size:
@@ -204,7 +204,7 @@ class PostGatedRMSNorm(nn.Module):
         # Apply gate in fp32: normed * SiLU(gate), then cast back.
         # Matches HF Qwen3_5RMSNormGated which does gate.to(float32).
         g_f32 = op.Cast(gate, to=ir.DataType.FLOAT)
-        gate_activated = op.Mul(g_f32, op.Sigmoid(g_f32))
+        gate_activated = op.Swish(g_f32)
         result = op.Mul(op.Cast(normed, to=ir.DataType.FLOAT), gate_activated)
         return op.CastLike(result, hidden_states)
 

--- a/src/mobius/functions/causal_conv.py
+++ b/src/mobius/functions/causal_conv.py
@@ -128,7 +128,7 @@ def causal_conv_nd_with_state(
 
         # Step 5: Apply activation.
         if activation in ("silu", "swish"):
-            output = op.Mul(conv_out, op.Sigmoid(conv_out))
+            output = op.Swish(conv_out)
         elif activation == "none":
             output = conv_out
         else:

--- a/src/mobius/functions/causal_conv_test.py
+++ b/src/mobius/functions/causal_conv_test.py
@@ -53,8 +53,10 @@ class TestCausalConvNdWithState:
         )
         op_types = [node.op_type for node in func.graph]
         if activation in ("silu", "swish"):
-            assert "Sigmoid" in op_types
+            assert "Swish" in op_types
+            assert "Sigmoid" not in op_types
         else:
+            assert "Swish" not in op_types
             assert "Sigmoid" not in op_types
 
     def test_invalid_ndim_raises(self):

--- a/src/mobius/models/deepseek.py
+++ b/src/mobius/models/deepseek.py
@@ -328,8 +328,7 @@ class _SharedExpertMLP(nn.Module):
 
     def forward(self, op: OpBuilder, hidden_states: ir.Value):
         gate_out = self.gate_proj(op, hidden_states)
-        # SiLU = x * sigmoid(x)
-        gate = op.Mul(gate_out, op.Sigmoid(gate_out))
+        gate = op.Swish(gate_out)
         up = self.up_proj(op, hidden_states)
         return self.down_proj(op, op.Mul(gate, up))
 

--- a/src/mobius/models/deepseek_v4.py
+++ b/src/mobius/models/deepseek_v4.py
@@ -199,7 +199,7 @@ class _DeepSeekV4Expert(nn.Module):
         if self.limit > 0:
             gate = op.Clip(gate, None, self.limit)
             up = op.Clip(up, -self.limit, self.limit)
-        return self.down_proj(op, op.Mul(op.Mul(gate, op.Sigmoid(gate)), up))
+        return self.down_proj(op, op.Mul(op.Swish(gate), up))
 
 
 class DeepSeekV4MoE(nn.Module):

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -1605,9 +1605,8 @@ class Gemma4DecoderLayer(nn.Module):
             half = op.Shape(fc2, start=1, end=2)  # [moe_inter]
             gate = op.Slice(proj, [0], half, [1])  # [T, moe_inter] first half
             up = op.Slice(proj, half, op.Shape(proj, start=1, end=2), [1])  # second half
-            # SiLU(gate) = gate * sigmoid(gate)
             expert_out = op.MatMul(
-                op.Mul(op.Mul(gate, op.Sigmoid(gate)), up),  # [T, moe_inter]
+                op.Mul(op.Swish(gate), up),  # [T, moe_inter]
                 op.Transpose(fc2),  # → [T, H]
             )
 

--- a/src/mobius/models/moshi.py
+++ b/src/mobius/models/moshi.py
@@ -314,7 +314,7 @@ class _DepformerLayer(nn.Module):
         h2 = self.norm2(op, x)
         gate_up = self.gating_in(op, h2, substep_index)  # (B, 1, 2 * hidden)
         gate, up = op.Split(gate_up, axis=-1, num_outputs=2, _outputs=2)
-        ff = op.Mul(op.Mul(gate, op.Sigmoid(gate)), up)  # silu(gate) * up
+        ff = op.Mul(op.Swish(gate), up)  # silu(gate) * up
         ff = self.gating_out(op, ff, substep_index)  # (B, 1, 1024)
         x = op.Add(x, ff)  # residual (no layer_scale)
         return x, present_key, present_value

--- a/src/mobius/models/qwen3_tts.py
+++ b/src/mobius/models/qwen3_tts.py
@@ -349,7 +349,7 @@ class Qwen3TTSEmbeddingModel(nn.Module):
         # Text: embed → project (fc1 → SiLU → fc2)
         text_embeds = self.text_embedding(op, text_ids)
         text_embeds = self.text_projection_fc1(op, text_embeds)
-        text_embeds = op.Mul(text_embeds, op.Sigmoid(text_embeds))  # SiLU
+        text_embeds = op.Swish(text_embeds)
         text_embeds = self.text_projection_fc2(op, text_embeds)
 
         # Codec: simple embedding lookup
@@ -554,7 +554,7 @@ class Qwen3TTSTalkerPrefillEmbedder(nn.Module):
         """Embed *ids* through the text embedding + projection (fc1 → SiLU → fc2)."""
         embeds = self.text_embedding(op, ids)
         embeds = self.text_projection_fc1(op, embeds)
-        embeds = op.Mul(embeds, op.Sigmoid(embeds))  # SiLU
+        embeds = op.Swish(embeds)
         return self.text_projection_fc2(op, embeds)
 
     def forward(self, op: OpBuilder, text_ids: ir.Value):

--- a/src/mobius/models/qwen_image.py
+++ b/src/mobius/models/qwen_image.py
@@ -51,7 +51,7 @@ class _TimestepMLP(nn.Module):
 
     def forward(self, op: OpBuilder, sample: ir.Value):
         sample = self.linear_1(op, sample)
-        sample = op.Mul(sample, op.Sigmoid(sample))  # SiLU
+        sample = op.Swish(sample)
         sample = self.linear_2(op, sample)
         return sample
 
@@ -82,7 +82,7 @@ class _AdaLayerNormOutput(nn.Module):
         self.linear = _Linear(hidden_size, hidden_size * 2)
 
     def forward(self, op: OpBuilder, hidden_states: ir.Value, timestep_emb: ir.Value):
-        emb = op.Mul(timestep_emb, op.Sigmoid(timestep_emb))  # SiLU
+        emb = op.Swish(timestep_emb)
         emb = self.linear(op, emb)
         shift, scale = op.Split(emb, num_outputs=2, axis=-1, _outputs=2)
         one = 1.0

--- a/src/mobius/rewrite_rules/_qmoe_fusion.py
+++ b/src/mobius/rewrite_rules/_qmoe_fusion.py
@@ -133,13 +133,14 @@ class _ExpertProjections:
 def _trace_expert(down: ir.Node) -> _ExpertProjections | None:
     """Walk back from a ``down_proj`` ``MatMulNBits`` to its gate/up projections.
 
-    Expert MLP shape (SwiGLU): ``down(  (gate*sigmoid(gate)) * up  )``.
+    Expert MLP shape (SwiGLU): ``down(Swish(gate) * up)``. The legacy
+    ``gate * Sigmoid(gate)`` decomposition remains accepted for imported graphs.
     """
     act_mul = _require_producer(down.inputs[0], "Mul")
     if act_mul is None:
         return None
     a, b = act_mul.inputs[0], act_mul.inputs[1]
-    # one operand is the up projection (MatMulNBits), the other the SiLU Mul.
+    # One operand is the up projection (MatMulNBits), the other the SiLU activation.
     if a.producer() and a.producer().op_type == "MatMulNBits":
         up_out, silu_out = a, b
     elif b.producer() and b.producer().op_type == "MatMulNBits":
@@ -148,17 +149,30 @@ def _trace_expert(down: ir.Node) -> _ExpertProjections | None:
         return None
     up = up_out.producer()
     silu = silu_out.producer()
-    if silu is None or silu.op_type != "Mul":
+    if silu is None:
         return None
+    if silu.op_type == "Swish":
+        gate = silu.inputs[0].producer()
+        if gate is None or gate.op_type != "MatMulNBits":
+            return None
+        return _ExpertProjections(gate, up, down)
+    if silu.op_type != "Mul":
+        return None
+
+    # Accept the legacy gate * Sigmoid(gate) decomposition.
     x, y = silu.inputs[0], silu.inputs[1]
-    # gate_out feeds both the SiLU Mul directly and a Sigmoid.
-    if x.producer() and x.producer().op_type == "MatMulNBits":
-        gate = x.producer()
-    elif y.producer() and y.producer().op_type == "MatMulNBits":
-        gate = y.producer()
-    else:
-        return None
-    return _ExpertProjections(gate, up, down)
+    for gate_out, sigmoid_out in ((x, y), (y, x)):
+        gate = gate_out.producer()
+        sigmoid = sigmoid_out.producer()
+        if (
+            gate is not None
+            and gate.op_type == "MatMulNBits"
+            and sigmoid is not None
+            and sigmoid.op_type == "Sigmoid"
+            and sigmoid.inputs[0] is gate_out
+        ):
+            return _ExpertProjections(gate, up, down)
+    return None
 
 
 def _router_gate(logits: ir.Value) -> ir.Node | None:

--- a/src/mobius/rewrite_rules/_qmoe_fusion_test.py
+++ b/src/mobius/rewrite_rules/_qmoe_fusion_test.py
@@ -9,6 +9,7 @@ import numpy as np
 import onnx_ir as ir
 import pytest
 
+from mobius._constants import OPSET_VERSION
 from mobius.rewrite_rules import fuse_dense_moe_to_qmoe
 from mobius.rewrite_rules._qmoe_fusion import _qmoe_abi_supported
 
@@ -294,7 +295,7 @@ def _build_dense_graph() -> tuple[ir.Model, dict[str, _Quant], np.ndarray]:
     graph.outputs.append(final.outputs[0])
 
     model = ir.Model(graph, ir_version=10, producer_name="test")
-    model.opset_imports[""] = 21
+    model.opset_imports[""] = OPSET_VERSION
     model.opset_imports["com.microsoft"] = 1
     return model, quants, rng.standard_normal((5, H)).astype(np.float32)
 

--- a/src/mobius/rewrite_rules/_qmoe_fusion_test.py
+++ b/src/mobius/rewrite_rules/_qmoe_fusion_test.py
@@ -223,12 +223,7 @@ def _build_dense_graph() -> tuple[ir.Model, dict[str, _Quant], np.ndarray]:
 
         gate = _matmulnbits(f"expert{e}.gate_proj", hidden, q(f"g{e}", INTER, H), graph)
         nodes.append(gate.producer())
-        sig = ir.node("Sigmoid", inputs=[gate], num_outputs=1, name=f"expert{e}.sigmoid")
-        sig.outputs[0].name = f"expert{e}.sigmoid.out"
-        nodes.append(sig)
-        silu = ir.node(
-            "Mul", inputs=[gate, sig.outputs[0]], num_outputs=1, name=f"expert{e}.silu"
-        )
+        silu = ir.node("Swish", inputs=[gate], num_outputs=1, name=f"expert{e}.silu")
         silu.outputs[0].name = f"expert{e}.silu.out"
         nodes.append(silu)
         up = _matmulnbits(f"expert{e}.up_proj", hidden, q(f"u{e}", INTER, H), graph)


### PR DESCRIPTION
## Summary
- replace exact `x * sigmoid(x)` decompositions with the opset-24 `Swish` operator
- cover shared activation paths and model-specific implementations, including Muse Glimmer
- teach QMoE fusion to recognize fused Swish while retaining support for legacy decomposed graphs
- update graph-shape tests to prevent regressions

## Testing
- `python -m pytest src/mobius/rewrite_rules/_qmoe_fusion_test.py src/mobius/rewrite_rules/_group_query_attention_test.py src/mobius/components/_activations_test.py src/mobius/components/_mamba_block_test.py src/mobius/components/_mlp_test.py src/mobius/functions/causal_conv_test.py -q --tb=short`
- full non-integration suite: 3823 passed, with four obsolete graph-shape assertions subsequently updated and covered by the targeted run