### PR TITLE
Guard unsupported Nemotron 3.5 GGUF conversion

### DIFF
--- a/.agents/skills/onnx-export-quantization/SKILL.md
+++ b/.agents/skills/onnx-export-quantization/SKILL.md
@@ -96,6 +96,36 @@ output/
 └── genai_config.json
 ```
 
+### Direct GGUF import acceptance
+
+Do not infer a GGUF's quantization from its filename. Presets such as
+`Q4_K_M`, `MXFP4_MOE`, and Unsloth Dynamic variants can contain large tensors
+in different per-tensor formats (for example Q5_0, Q5_1, Q8_0, and MXFP4).
+Before implementing or claiming a direct conversion:
+
+1. Pin the GGUF repository revision, filename, file size, and LFS SHA-256.
+2. Inspect the GGUF metadata and complete tensor table (names, logical shapes,
+   and quantization types) without downloading tensor payloads when range
+   requests are available.
+3. Compare the layer schedule and tensor shapes with a separately pinned
+   official config and safetensors headers. `block_count` may include auxiliary
+   MTP/draft blocks rather than decoder backbone layers.
+4. Classify every large tensor as byte-preserved native blocks, lossless affine
+   repacking, or dequantize/requantize. If any large tensor takes the third
+   path, the conversion does **not** preserve the source quantization.
+5. Reject split GGUF shards unless the importer explicitly assembles every
+   shard. Reading one shard can build a plausible but incomplete model.
+6. Compare embedded tokenizer special-token IDs and chat template with the
+   pinned upstream tokenizer. A self-contained package is invalid when padding,
+   EOS, or BOS semantics disagree.
+7. Require real-weight full-logit parity and deterministic multi-token
+   generation through both ONNX Runtime and the declared GenAI runtime. Graph,
+   config, and session creation are not acceptance evidence.
+
+Use Hub GGUF architecture metadata to fail before downloading multi-gigabyte
+unsupported files, then repeat the guard from the local GGUF header so local
+paths receive the same actionable error.
+
 ## Quantization with Olive
 
 ### Installation

--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -18,6 +18,10 @@ def build_from_gguf(
     task: str | None = None,
     dtype: str | None = None,
     keep_quantized: bool = False,
+    execution_provider: str = "default",
+    mmproj: str | Path | None = None,
+    static_cache: bool = False,
+    max_seq_len: int | None = None,
 ) -> ModelPackage:
 ```
 
@@ -25,10 +29,14 @@ def build_from_gguf(
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `gguf_path` | `str \| Path` | (required) | Path to a `.gguf` model file. |
+| `gguf_path` | `str \| Path` | (required) | Local `.gguf` path or `owner/repo:filename.gguf` Hub reference. |
 | `task` | `str \| None` | `None` | Override the model task (e.g. `"text-generation"`). When `None`, the task is auto-detected from the model type. |
 | `dtype` | `str \| None` | `None` | Override model dtype (e.g. `"f16"`). When `None`, defaults to float32. |
-| `keep_quantized` | `bool` | `False` | When `True`, preserve quantization for supported GGUF types (Q4_0, Q4_1, Q8_0) by repacking linear-layer weights into MatMulNBits format. Unsupported types are dequantized to float. |
+| `keep_quantized` | `bool` | `False` | Preserve supported affine blocks as `MatMulNBits` and supported IQ/MXFP4 blocks in the onnx-genai native format. A mixed preset may still require dequantization/requantization. |
+| `execution_provider` | `str` | `"default"` | Target EP for EP-aware graph optimization. |
+| `mmproj` | `str \| Path \| None` | `None` | Optional companion multimodal-projector GGUF. |
+| `static_cache` | `bool` | `False` | Build a fixed-width KV cache when the architecture supports it. |
+| `max_seq_len` | `int \| None` | `None` | Static-cache sequence limit. |
 
 ## Returns
 
@@ -71,3 +79,167 @@ mobius build-gguf llama-3.2-1b-q4_0.gguf --output output/llama/
 The GGUF builder maps GGUF architecture names (e.g. `llama`, `qwen2`,
 `gemma`) to the same model classes used by `build()`. Most decoder-only
 LLM architectures are supported.
+
+Sharded GGUF files are rejected. A single shard has only part of the tensor
+table, and treating it as a complete checkpoint would create a corrupt model.
+
+## NVIDIA Nemotron 3.5 Lightning waiver
+
+Direct conversion of GGUF architecture `nemotron_h_moe` is intentionally
+disabled. The following evidence is pinned:
+
+- GGUF repository:
+  `unsloth/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-GGUF` at
+  `f2d3fe3694501008786e81e5f20360cbf715496a`.
+- Official BF16 comparison:
+  `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16` at
+  `d468880b6ad3c6e0d21377ce7242adaea4cc884d`.
+- The official backbone has exactly 52 layers: 23 Mamba, 23 MoE, and
+  6 attention layers. GGUF block 52 is a separate combined attention+MoE MTP
+  auxiliary block, so `block_count=53` cannot be aliased to the backbone.
+
+### Quantization findings
+
+| GGUF file | Relevant tensor inventory | Direct preservation |
+|---|---|---|
+| `...-Q8_0.gguf` | 32.904B parameters in `Q8_0` | Qtype-compatible, but blocked by architecture and semantic validation |
+| `...-MXFP4_MOE.gguf` | 14.687B `MXFP4`, 12.772B `Q5_1`, 5.445B `Q8_0` | No; the 5-bit expert weights require a quantization-changing float round-trip |
+| `...-UD-Q4_K_M.gguf` | 15.326B `Q5_0`, 12.772B `Q5_1`, 4.806B `Q8_0` | No; the preset name does not describe its actual per-tensor types |
+| `BF16/...-0000*-of-00002.gguf` | 329 tensors in shard 1 and 88 in shard 2 | No; Mobius does not assemble GGUF shards |
+
+The GGUF embeds GPT-2/Pixtral BPE metadata with BOS 1 and EOS 11, but declares
+padding ID 999 (`<SPECIAL_999>`). The pinned official tokenizer declares
+`<|im_end|>` (ID 11) as padding. The GGUF also names the BF16 base repository
+without recording its immutable source commit. Both discrepancies must be
+resolved before a self-contained runtime package can be accepted.
+
+The guard also reflects missing semantic evidence: Nemotron-H Mamba2 synthetic
+full-logit parity is not passing, and no real-weight ORT or ORT GenAI generation
+has passed. Graph creation, config emission, or session creation is not a
+substitute for generation.
+
+### Reproduce the guard with a pinned download
+
+The `Q8_0` file is the only practical candidate whose large quantized tensors
+all use a currently repackable type. Download it explicitly so the source does
+not move:
+
+```powershell
+$repo = "unsloth/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-GGUF"
+$revision = "f2d3fe3694501008786e81e5f20360cbf715496a"
+$file = "NVIDIA-Nemotron-3.5-Lightning-30B-A3B-Q8_0.gguf"
+
+python -m pip install `
+  --index-url https://packagefeedproxy.microsoft.io/pypi/simple `
+  huggingface_hub
+hf download $repo $file --revision $revision --local-dir .\nemotron-gguf
+
+# Expected: fail-fast NotImplementedError; no ONNX package is emitted.
+python -m mobius build-gguf ".\nemotron-gguf\$file" `
+  --keep-quantized --ep cpu `
+  --external-data safetensors --output .\nemotron-gguf-onnx
+```
+
+`mobius build-gguf --runtime ort-genai` is rejected separately. The GGUF CLI
+does not emit `genai_config.json` until a selected architecture's cache and
+tokenizer contracts have passed real ORT GenAI generation.
+
+To execute the pinned GGUF without changing its quantization, use current
+llama.cpp instead:
+
+```powershell
+.\llama-cli.exe `
+  --model ".\nemotron-gguf\$file" `
+  --temp 0.6 --top-p 0.95 --min-p 0.01
+```
+
+### Option A: official BF16, then Olive
+
+Option A is the ONNX route because it preserves authoritative config,
+tokenizer, and weight provenance. It is still a candidate until Nemotron-H
+semantic tests pass, and currently targets direct ONNX Runtime rather than
+ORT GenAI:
+
+```powershell
+$repo = "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16"
+$revision = "d468880b6ad3c6e0d21377ce7242adaea4cc884d"
+
+hf download $repo --revision $revision --local-dir .\nemotron-bf16
+python -m mobius build `
+  --config .\nemotron-bf16 `
+  --dtype bf16 --ep cuda `
+  --external-data safetensors --max-shard-size 5GB `
+  .\nemotron-bf16-onnx
+```
+
+After the BF16 package passes full-logit and generation parity, quantize its
+decoder with an initialized Olive environment:
+
+```json
+{
+  "input_model": {
+    "type": "OnnxModel",
+    "model_path": "nemotron-bf16-onnx/model.onnx"
+  },
+  "passes": {
+    "int4": {
+      "type": "OnnxKQuantQuantization",
+      "bits": 4,
+      "block_size": 32
+    }
+  },
+  "output_dir": "nemotron-int4-onnx"
+}
+```
+
+```powershell
+python -m pip install `
+  --index-url https://packagefeedproxy.microsoft.io/pypi/simple `
+  olive-ai onnxruntime
+olive run --config .\olive-int4.json
+Copy-Item .\nemotron-bf16\tokenizer* .\nemotron-int4-onnx\
+Copy-Item .\nemotron-bf16\special_tokens_map.json .\nemotron-int4-onnx\
+Copy-Item .\nemotron-bf16\chat_template.jinja .\nemotron-int4-onnx\
+```
+
+The candidate can be checked for direct ORT session loading:
+
+```python
+import onnxruntime as ort
+
+session = ort.InferenceSession(
+    r".\nemotron-int4-onnx\model.onnx",
+    providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+)
+print(session.get_providers())
+print([(value.name, value.shape, value.type) for value in session.get_inputs()])
+```
+
+Session loading is not generation evidence. There is intentionally no ORT
+GenAI generation command for this model at the pinned revisions:
+
+- ORT GenAI 0.15.2 does not register model type `nemotron_h`.
+- The generated generic decoder config does not bind the graph's Mamba
+  `conv_state` and `recurrent_state` cache inputs.
+- The official `generation_config.json` uses EOS IDs `[2, 11]`, while the
+  architecture config alone supplies EOS 2.
+
+Do not publish the package unless BF16 full logits match the pinned reference,
+direct-ORT greedy generation is coherent and deterministic through an
+independently validated hybrid-cache loop, the quantized package remains
+non-degenerate, and ORT GenAI model/cache/token support is implemented before
+claiming ORT GenAI compatibility.
+
+### Prerequisites for revisiting direct GGUF conversion
+
+1. Map the 52-layer schedule exactly and model block 52 as MTP, or explicitly
+   exclude it with generation evidence.
+2. Fix Nemotron-H Mamba2 full-logit parity before testing quantized output.
+3. Preserve every large source qtype. For Q5 variants this requires a validated
+   5-bit runtime kernel and repacker; dequantize/requantize is not direct
+   preservation.
+4. Resolve the GGUF padding-token mismatch and record an immutable upstream
+   BF16 source revision.
+5. Pass real-weight prefill, cached decode, deterministic multi-token
+   generation, ORT load/inference, and ORT GenAI package generation on each
+   claimed EP.

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -311,9 +311,13 @@ mobius build-gguf GGUF_PATH [options]
 | Option | Description |
 |--------|-------------|
 | `--output DIR`, `-o DIR` | Output directory. Default: `<gguf_stem>_onnx/`. |
-| `--keep-quantized` | Preserve GGUF quantization as `MatMulNBits` (Q4_0/Q4_1/Q8_0). |
+| `--keep-quantized` | Preserve supported affine blocks as `MatMulNBits` and supported native IQ/MXFP4 blocks. Mixed presets may still require requantization. |
 | `--dtype DTYPE` | Target dtype for model weights: `f16`, `bf16`, `f32`. |
 | `--external-data FORMAT` | External data format: `onnx` (default) or `safetensors`. |
+| `--ep EP` | Target execution provider for EP-aware optimization. |
+| `--runtime RUNTIME` | `onnx-genai` emits supported runtime metadata. `ort-genai` is rejected until GGUF cache/tokenizer generation coverage exists. |
+| `--static-cache` | Build a fixed-width cache where supported. |
+| `--max-seq-len N` | Set the fixed cache length; requires `--static-cache`. |
 
 ### Examples
 
@@ -327,6 +331,12 @@ mobius build-gguf model.gguf --output output/ --keep-quantized
 # Convert with specific dtype
 mobius build-gguf model.gguf --output output/ --dtype f16
 ```
+
+Sharded GGUF inputs are rejected because a single shard has an incomplete
+tensor table. `nemotron_h_moe` is also rejected until its MTP block, Mamba2
+parity, mixed expert quantization, tokenizer provenance, and real ORT/ORT GenAI
+generation are validated. See
+[`build_from_gguf()`](api/build_from_gguf.md#nvidia-nemotron-35-lightning-waiver).
 
 ---
 

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -504,6 +504,15 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
         )
         raise SystemExit(1)
 
+    if getattr(args, "runtime", None) == "ort-genai":
+        raise SystemExit(
+            "Error: mobius build-gguf does not yet support --runtime ort-genai. "
+            "The command cannot emit a valid genai_config.json until the selected "
+            "GGUF architecture's cache and tokenizer contracts have passed real "
+            "ORT GenAI generation. Use --runtime onnx-genai where supported, or "
+            "omit --runtime and run the ONNX model directly."
+        )
+
     mmproj_path = getattr(args, "mmproj", None)
 
     if args.keep_quantized:
@@ -862,8 +871,8 @@ def main(argv: list[str] | None = None) -> None:
             "Generate runtime-specific config files after building. "
             "'onnx-genai' writes inference_metadata.yaml plus a tokenizer.json "
             "reconstructed from the GGUF's embedded tokenizer metadata; "
-            "'ort-genai' writes genai_config.json + copies tokenizer files. "
-            "Either way the quantized model runs directly in the target runtime."
+            "'ort-genai' is currently rejected until GGUF cache/tokenizer "
+            "contracts have runtime generation coverage."
         ),
     )
     gguf_parser.add_argument(

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 __all__ = ["build_from_gguf"]
 
 import logging
+import re
 from collections import Counter
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -29,10 +31,167 @@ from huggingface_hub import HfApi, hf_hub_download
 
 from mobius._model_package import ModelPackage
 
+_HUB_PREFLIGHT_TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (OSError,)
+try:
+    from httpx import TransportError as _HttpxTransportError
+except ImportError:
+    pass
+else:
+    _HUB_PREFLIGHT_TRANSPORT_ERRORS += (_HttpxTransportError,)
+
 if TYPE_CHECKING:
     from mobius.tasks import ModelTask
 
 logger = logging.getLogger(__name__)
+
+_GGUF_SHARD_FILENAME_RE = re.compile(
+    r"-(?P<index>\d{5})-of-(?P<count>\d{5})\.gguf$",
+    re.IGNORECASE,
+)
+_NEMOTRON_H_MOE_ARCHITECTURE = "nemotron_h_moe"
+
+
+def _summarize_nemotron_h_moe_layout(
+    tensor_names: Iterable[str],
+) -> tuple[Counter[str], tuple[int, ...], dict[int, frozenset[str]]]:
+    """Summarize base-layer and MTP mixer types from Nemotron-H GGUF names."""
+    layer_kinds: dict[int, set[str]] = {}
+    mtp_blocks: set[int] = set()
+    for name in tensor_names:
+        match = re.match(r"^blk\.(\d+)\.(.+)$", name)
+        if match is None:
+            continue
+        block_index = int(match.group(1))
+        suffix = match.group(2)
+        kinds = layer_kinds.setdefault(block_index, set())
+        if suffix.startswith("nextn."):
+            mtp_blocks.add(block_index)
+        elif suffix.startswith("ssm_"):
+            kinds.add("mamba")
+        elif suffix.startswith(("ffn_", "exp_probs_")):
+            kinds.add("moe")
+        elif suffix.startswith(("attn_q.", "attn_k.", "attn_v.", "attn_output.")):
+            kinds.add("attention")
+
+    base_counts: Counter[str] = Counter()
+    for block_index, kinds in layer_kinds.items():
+        if block_index not in mtp_blocks:
+            base_counts.update(kinds)
+    mtp_kinds = {
+        block_index: frozenset(layer_kinds.get(block_index, set()))
+        for block_index in sorted(mtp_blocks)
+    }
+    return base_counts, tuple(sorted(mtp_blocks)), mtp_kinds
+
+
+def _raise_for_unsupported_gguf_architecture(
+    architecture: str,
+    *,
+    source: str,
+    tensor_names: Iterable[str] | None = None,
+) -> None:
+    """Reject GGUF architectures that do not have semantic conversion evidence."""
+    if architecture != _NEMOTRON_H_MOE_ARCHITECTURE:
+        return
+
+    layout = ""
+    if tensor_names is not None:
+        counts, mtp_blocks, mtp_kinds = _summarize_nemotron_h_moe_layout(tensor_names)
+        mtp_kind_names = {index: sorted(kinds) for index, kinds in mtp_kinds.items()}
+        layout = (
+            " Detected base schedule: "
+            f"{counts['mamba']} Mamba + {counts['moe']} MoE + "
+            f"{counts['attention']} attention layers; auxiliary MTP blocks: "
+            f"{list(mtp_blocks)} with mixer types {mtp_kind_names}."
+        )
+
+    raise NotImplementedError(
+        "Direct GGUF conversion for architecture 'nemotron_h_moe' is intentionally "
+        f"disabled for {source!r}.{layout} GGUF block_count includes a combined "
+        "attention+MoE MTP auxiliary block, so aliasing it to the 52-layer "
+        "'nemotron_h' backbone would build the wrong graph. The current Nemotron-H "
+        "Mamba2 path also lacks passing full-logit/generation parity, and common "
+        "GGUF presets contain Q5_0/Q5_1 expert tensors that cannot be preserved by "
+        "MatMulNBits. No ONNX artifacts were emitted. Use llama.cpp/Unsloth to run "
+        "the GGUF without changing its quantization, or start from the official "
+        "pinned BF16 Hugging Face checkpoint and quantize the validated ONNX export "
+        "with Olive only after L4/L5 semantic generation passes. See "
+        "docs/api/build_from_gguf.md for the pinned recipe and waiver."
+    )
+
+
+def _raise_for_sharded_gguf(
+    *,
+    source: str,
+    filename: str | None = None,
+    split_count: int | None = None,
+) -> None:
+    """Reject one-shard inputs before they can produce an incomplete model."""
+    shard_index: int | None = None
+    if filename is not None:
+        match = _GGUF_SHARD_FILENAME_RE.search(filename)
+        if match is not None:
+            shard_index = int(match.group("index"))
+            split_count = int(match.group("count"))
+    if split_count is None or split_count <= 1:
+        return
+
+    shard_detail = f" shard {shard_index} of {split_count}" if shard_index else ""
+    raise NotImplementedError(
+        f"Sharded GGUF input is not supported: {source!r} is{shard_detail}. "
+        "The GGUF builder reads one file and cannot assemble split tensor tables; "
+        "continuing would emit an incomplete ONNX model. Select a single-file GGUF "
+        "variant, join the shards with a GGUF-aware tool, or build from the original "
+        "Hugging Face checkpoint."
+    )
+
+
+def _preflight_hf_gguf(api: HfApi, repo_id: str, filename: str) -> None:
+    """Use Hub metadata to reject known-bad inputs before a multi-GB download."""
+    source = f"{repo_id}:{filename}"
+    _raise_for_sharded_gguf(source=source, filename=filename)
+    try:
+        info = api.model_info(repo_id, expand=["gguf"])
+    except TypeError as error:
+        if "expand" not in str(error):
+            raise
+        logger.info(
+            "Skipping Hub GGUF architecture preflight for %s because this "
+            "huggingface_hub version has no model_info(expand=...) support; "
+            "the downloaded or cached local header will still be validated.",
+            source,
+        )
+        return
+    except _HUB_PREFLIGHT_TRANSPORT_ERRORS as error:
+        logger.warning(
+            "Hub GGUF architecture preflight failed for %s (%s); continuing to "
+            "hf_hub_download so an authenticated or cached file can still be used. "
+            "The local header will be validated before graph construction.",
+            source,
+            error,
+        )
+        return
+    gguf_metadata = getattr(info, "gguf", None)
+    if isinstance(gguf_metadata, Mapping):
+        architecture = gguf_metadata.get("architecture")
+    else:
+        architecture = getattr(gguf_metadata, "architecture", None)
+    if isinstance(architecture, str):
+        _raise_for_unsupported_gguf_architecture(
+            architecture,
+            source=source,
+        )
+
+
+def _validate_gguf_model(gguf_model, *, source: str) -> None:
+    """Validate a parsed GGUF before config extraction or graph construction."""
+    split_count = int(gguf_model.get_metadata("split.count", 1))
+    _raise_for_sharded_gguf(source=source, split_count=split_count)
+    _raise_for_unsupported_gguf_architecture(
+        gguf_model.architecture,
+        source=source,
+        tensor_names=gguf_model.tensor_names,
+    )
 
 
 def _looks_like_hf_repo_id(value: str) -> bool:
@@ -65,8 +224,9 @@ def _resolve_gguf_path(gguf_path: str | Path) -> str:
         # FileNotFoundError with the original path.
         return raw
 
+    api = HfApi()
     if not filename:
-        files = [f for f in HfApi().list_repo_files(repo_id) if f.endswith(".gguf")]
+        files = [f for f in api.list_repo_files(repo_id) if f.endswith(".gguf")]
         if not files:
             raise FileNotFoundError(f"No *.gguf files found in HF repo {repo_id!r}")
         if len(files) > 1:
@@ -76,6 +236,7 @@ def _resolve_gguf_path(gguf_path: str | Path) -> str:
             )
         filename = files[0]
 
+    _preflight_hf_gguf(api, repo_id, filename)
     logger.info("Downloading %s from %s", filename, repo_id)
     return hf_hub_download(repo_id=repo_id, filename=filename)
 
@@ -194,6 +355,7 @@ def build_from_gguf(
     # 1. Parse GGUF file (auto-download from HF Hub when given "owner/repo[:filename]")
     gguf_path = _resolve_gguf_path(gguf_path)
     gguf_model = GGUFModel(gguf_path)
+    _validate_gguf_model(gguf_model, source=str(gguf_path))
     gguf_arch = gguf_model.architecture
     logger.info("Loaded GGUF file: %s (arch=%s)", gguf_path, gguf_arch)
 

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -6,11 +6,15 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
 
+import httpx
 import numpy as np
 import onnx_ir as ir
 import onnxruntime as ort
 import pytest
+from huggingface_hub.utils import OfflineModeIsEnabled
 
 
 def _run_gather_block_quantized(
@@ -77,6 +81,7 @@ def _run_gather_block_quantized(
 def _write_quantized_gguf(
     path: Path,
     *,
+    architecture: str = "llama",
     hidden_size: int = 64,
     num_layers: int = 1,
     num_heads: int = 4,
@@ -98,7 +103,7 @@ def _write_quantized_gguf(
     """
     from gguf import GGMLQuantizationType, GGUFWriter
 
-    writer = GGUFWriter(str(path), "llama")
+    writer = GGUFWriter(str(path), architecture)
     writer.add_context_length(512)
     writer.add_embedding_length(hidden_size)
     writer.add_feed_forward_length(intermediate_size)
@@ -754,3 +759,181 @@ class TestRawTensorIterator:
         expected = model.get_tensor(name)
         actual = model.dequantize_raw_tensor(raw, qtype, shape)
         np.testing.assert_array_equal(actual, expected)
+
+
+class TestGGUFPreflightGuards:
+    """Unsupported layouts fail before graph construction or large downloads."""
+
+    def test_nemotron_layout_excludes_combined_mtp_block(self):
+        from mobius.integrations.gguf._builder import (
+            _summarize_nemotron_h_moe_layout,
+        )
+
+        # Pinned NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16 schedule:
+        # 52 backbone layers followed by one combined attention+MoE MTP block.
+        backbone_schedule = (
+            "mamba",
+            "moe",
+            "mamba",
+            "moe",
+            "mamba",
+            "attention",
+            "moe",
+            "mamba",
+            "moe",
+            "mamba",
+            "moe",
+            "mamba",
+            "attention",
+            "moe",
+            "mamba",
+            "moe",
+            "mamba",
+            "moe",
+            "mamba",
+            "attention",
+            "moe",
+            "mamba",
+            "moe",
+            "mamba",
+            "moe",
+            "mamba",
+            "attention",
+            "moe",
+            "mamba",
+            "moe",
+            "mamba",
+            "moe",
+            "mamba",
+            "attention",
+            "moe",
+            "mamba",
+            "moe",
+            "mamba",
+            "moe",
+            "mamba",
+            "moe",
+            "mamba",
+            "attention",
+            "moe",
+            "mamba",
+            "moe",
+            "mamba",
+            "moe",
+            "mamba",
+            "moe",
+            "mamba",
+            "moe",
+        )
+        assert len(backbone_schedule) == 52
+
+        representative_tensor = {
+            "mamba": "ssm_in.weight",
+            "moe": "ffn_up_exps.weight",
+            "attention": "attn_q.weight",
+        }
+        tensor_names = [
+            f"blk.{index}.{representative_tensor[layer_type]}"
+            for index, layer_type in enumerate(backbone_schedule)
+        ]
+        tensor_names.extend(
+            [
+                "blk.52.nextn.eh_proj.weight",
+                "blk.52.attn_q.weight",
+                "blk.52.ffn_up_exps.weight",
+            ]
+        )
+
+        counts, mtp_blocks, mtp_kinds = _summarize_nemotron_h_moe_layout(tensor_names)
+
+        assert dict(counts) == {"mamba": 23, "moe": 23, "attention": 6}
+        assert mtp_blocks == (52,)
+        assert mtp_kinds == {52: frozenset({"attention", "moe"})}
+
+    def test_local_nemotron_h_moe_fails_before_graph_build(self, tmp_path: Path):
+        from mobius.integrations.gguf import build_from_gguf
+
+        path = tmp_path / "nemotron-h-moe-q8.gguf"
+        _write_quantized_gguf(path, architecture="nemotron_h_moe")
+
+        with pytest.raises(NotImplementedError) as exc_info:
+            build_from_gguf(path, keep_quantized=True)
+
+        message = str(exc_info.value)
+        assert "intentionally disabled" in message
+        assert "MTP auxiliary block" in message
+        assert "Q5_0/Q5_1" in message
+        assert "llama.cpp/Unsloth" in message
+        assert "Olive" in message
+
+    def test_remote_nemotron_h_moe_fails_before_download(self):
+        from mobius.integrations.gguf._builder import _resolve_gguf_path
+
+        filename = "NVIDIA-Nemotron-3.5-Lightning-30B-A3B-Q8_0.gguf"
+        with (
+            mock.patch("mobius.integrations.gguf._builder.HfApi") as api_type,
+            mock.patch("mobius.integrations.gguf._builder.hf_hub_download") as download,
+            pytest.raises(NotImplementedError, match="nemotron_h_moe"),
+        ):
+            api_type.return_value.model_info.return_value = SimpleNamespace(
+                gguf={"architecture": "nemotron_h_moe"}
+            )
+            _resolve_gguf_path(f"unsloth/nemotron:{filename}")
+
+        api_type.return_value.model_info.assert_called_once_with(
+            "unsloth/nemotron", expand=["gguf"]
+        )
+        download.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "preflight_error",
+        [
+            pytest.param(
+                OfflineModeIsEnabled("offline"),
+                id="offline-cache",
+            ),
+            pytest.param(
+                TypeError("model_info() got an unexpected keyword argument 'expand'"),
+                id="older-huggingface-hub",
+            ),
+            pytest.param(
+                httpx.ConnectError("disconnected"),
+                id="transport-error",
+            ),
+        ],
+    )
+    def test_unavailable_hub_preflight_falls_back_to_download(self, preflight_error):
+        from mobius.integrations.gguf._builder import _resolve_gguf_path
+
+        with (
+            mock.patch("mobius.integrations.gguf._builder.HfApi") as api_type,
+            mock.patch(
+                "mobius.integrations.gguf._builder.hf_hub_download",
+                return_value="cached-model.gguf",
+            ) as download,
+        ):
+            api_type.return_value.model_info.side_effect = preflight_error
+            result = _resolve_gguf_path("owner/repo:model.gguf")
+
+        assert result == "cached-model.gguf"
+        download.assert_called_once_with(repo_id="owner/repo", filename="model.gguf")
+
+    def test_remote_shard_fails_before_hub_calls(self):
+        from mobius.integrations.gguf._builder import _resolve_gguf_path
+
+        filename = "BF16/model-00001-of-00002.gguf"
+        with (
+            mock.patch("mobius.integrations.gguf._builder.HfApi") as api_type,
+            mock.patch("mobius.integrations.gguf._builder.hf_hub_download") as download,
+            pytest.raises(NotImplementedError, match="shard 1 of 2"),
+        ):
+            _resolve_gguf_path(f"owner/repo:{filename}")
+
+        api_type.return_value.model_info.assert_not_called()
+        download.assert_not_called()
+
+    def test_local_split_metadata_is_rejected(self):
+        from mobius.integrations.gguf._builder import _raise_for_sharded_gguf
+
+        with pytest.raises(NotImplementedError, match="cannot assemble split tensor tables"):
+            _raise_for_sharded_gguf(source="model-00001-of-00002.gguf", split_count=2)

--- a/src/mobius/integrations/gguf/_mmproj.py
+++ b/src/mobius/integrations/gguf/_mmproj.py
@@ -363,13 +363,17 @@ def build_gemma4_vlm_from_gguf(
     import dataclasses
 
     from mobius._builder import resolve_dtype
+    from mobius.integrations.gguf._builder import _validate_gguf_model
     from mobius.integrations.gguf._config_mapping import gguf_to_config
     from mobius.integrations.gguf._reader import GGUFModel
     from mobius.models.gemma4 import Gemma4Model
     from mobius.tasks._gemma4 import Gemma4Task
 
     text_gguf = GGUFModel(_resolve_local_path(text_gguf_path))
+    _validate_gguf_model(text_gguf, source=str(text_gguf_path))
+
     mmproj_gguf = GGUFModel(_resolve_local_path(mmproj_gguf_path))
+    _validate_gguf_model(mmproj_gguf, source=str(mmproj_gguf_path))
     if mmproj_gguf.architecture != "clip":
         raise ValueError(
             f"Expected a 'clip' mmproj GGUF, got architecture "

--- a/src/mobius/integrations/gguf/_mmproj_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_test.py
@@ -11,6 +11,7 @@ encoder build+run path end-to-end on CPU.
 from __future__ import annotations
 
 from pathlib import Path
+from unittest import mock
 
 import numpy as np
 import pytest
@@ -98,11 +99,65 @@ def _write_clip_mmproj_gguf(path: Path, *, with_audio: bool = True) -> None:
     writer.close()
 
 
+def _write_minimal_gguf(
+    path: Path,
+    architecture: str,
+    *,
+    split_count: int = 1,
+) -> None:
+    """Write only enough GGUF structure to exercise pre-config guards."""
+    from gguf import GGUFWriter
+
+    writer = GGUFWriter(str(path), architecture)
+    if split_count > 1:
+        writer.add_uint16("split.no", 0)
+        writer.add_uint16("split.count", split_count)
+        writer.add_uint64("split.tensors.count", 1)
+    writer.add_tensor("sentinel", np.zeros((1,), dtype=np.float32))
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_tensors_to_file()
+    writer.close()
+
+
 @pytest.fixture
 def clip_mmproj_gguf(tmp_path: Path) -> Path:
     path = tmp_path / "mmproj.gguf"
     _write_clip_mmproj_gguf(path)
     return path
+
+
+class TestMultimodalPreflightGuards:
+    def test_rejects_unsupported_text_architecture_before_config(
+        self,
+        tmp_path: Path,
+    ):
+        from mobius.integrations.gguf._mmproj import build_gemma4_vlm_from_gguf
+
+        text_path = tmp_path / "nemotron-h-moe.gguf"
+        _write_minimal_gguf(text_path, "nemotron_h_moe")
+
+        with (
+            mock.patch(
+                "mobius.integrations.gguf._mmproj._resolve_local_path",
+                side_effect=[str(text_path)],
+            ) as resolve,
+            pytest.raises(NotImplementedError, match="nemotron_h_moe"),
+        ):
+            build_gemma4_vlm_from_gguf(text_path, "owner/repo:mmproj.gguf")
+
+        assert resolve.call_count == 1
+
+    def test_rejects_split_mmproj_before_config(self, tmp_path: Path):
+        from mobius.integrations.gguf._mmproj import build_gemma4_vlm_from_gguf
+
+        text_path = tmp_path / "gemma4.gguf"
+        mmproj_path = tmp_path / "mmproj-00001-of-00002.gguf"
+        _write_minimal_gguf(text_path, "gemma4")
+        _write_minimal_gguf(mmproj_path, "clip", split_count=2)
+
+        with pytest.raises(NotImplementedError, match="cannot assemble split tensor tables"):
+            build_gemma4_vlm_from_gguf(text_path, mmproj_path)
 
 
 class TestReadVisionConfig:

--- a/tests/gguf_test.py
+++ b/tests/gguf_test.py
@@ -508,3 +508,21 @@ class TestCLIBuildGGUF:
         path = _create_tiny_gguf(tmp_path / "test.gguf")
         with pytest.raises((SystemExit, ValueError)):
             main(["build-gguf", path, "--keep-quantized"])
+
+    def test_ort_genai_runtime_is_rejected_before_artifacts(self, tmp_path):
+        """build-gguf must not silently ignore an ORT GenAI runtime request."""
+        from mobius.__main__ import main
+
+        output_dir = tmp_path / "output"
+        with pytest.raises(SystemExit, match="does not yet support --runtime ort-genai"):
+            main(
+                [
+                    "build-gguf",
+                    str(tmp_path / "not-downloaded.gguf"),
+                    "--runtime",
+                    "ort-genai",
+                    "--output",
+                    str(output_dir),
+                ]
+            )
+        assert not output_dir.exists()


### PR DESCRIPTION
## Summary

- Fail fast for `nemotron_h_moe` GGUFs before remote multi-GB downloads (when Hub metadata is available) and again from the local header before graph construction.
- Reject split GGUF shards, including text/mmproj paths, rather than emitting incomplete weights.
- Reject `mobius build-gguf --runtime ort-genai` before artifacts because that path cannot yet emit a valid cache/tokenizer contract.
- Document the pinned Nemotron 3.5 GGUF/BF16 evidence, exact file-selection commands, Option A direct-ORT recipe, acceptance gates, and waiver; refine the quantization skill with reusable direct-GGUF checks.

## Pinned evidence

- GGUF: `unsloth/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-GGUF@f2d3fe3694501008786e81e5f20360cbf715496a`
- Official BF16: `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16@d468880b6ad3c6e0d21377ce7242adaea4cc884d`
- Backbone schedule: 23 Mamba + 23 MoE + 6 attention layers; GGUF block 52 is the separate combined attention+MoE MTP block.
- `Q8_0` is qtype-compatible, but lacks semantic acceptance. `MXFP4_MOE` contains 12.772B Q5_1 parameters; `UD-Q4_K_M` contains 15.326B Q5_0 + 12.772B Q5_1 parameters, so neither preserves quantization end to end.
- GGUF padding ID 999 conflicts with the official `<|im_end|>` padding token (ID 11), and the GGUF records no immutable upstream BF16 commit.

## Validation

- Rebased linearly onto repaired main commit `2073725840e007c1fba59ce3cb1f06e4ad9fe75a`; the #484 fixes are inherited, not duplicated.
- `86 passed`: GGUF builder/mmproj/CLI plus quantization integration regression suites.
- Canonical non-integration suite: `3,933 passed, 58 skipped`.
- Live Hub metadata preflight rejected the pinned 35 GB Q8 file before download.
- Initialized `lintrunner -a` and `git diff --check` pass; the worktree is clean.
- Independent release review found no remaining significant issues.
- Refreshed CI passes Lint, all Ubuntu/Windows test jobs, Build, L1 smoke, Architecture Diff, benchmarks, CodeQL, affected-model detection, CLA, and lintrunner.
- Self-hosted `Integration (fast)`: `16 passed, 4 skipped, 2 failed`, exclusively the same two DeepSeek parity failures as #484's repaired-main job (`test_deepseek_v2_lite_prefill_logits_match` and `test_deepseek_non_mla_decoder_prefill_logits_match`). This PR changes no DeepSeek code.

## Waivers

- No Nemotron GGUF ONNX artifact, ORT load, ORT GenAI load, or generation is claimed: the new guard intentionally prevents unsupported artifacts. Current Nemotron-H synthetic parity is skipped/xfail (expert shape transfer mismatch and Mamba2 recurrence divergence).
- Foundry Local and L4/L5 generation are waived until architecture parity, MTP handling, tokenizer provenance, and runtime cache bindings are implemented.
- The inherited DeepSeek GPU parity failures are outside this focused PR; fixing them here would mix unrelated model work.

Tracks #483.