### PR TITLE
docs(skill): stop recommending onnx.save into an existing external-data blob

### DIFF
--- a/.agents/skills/mobius-onnx-export-gotchas/SKILL.md
+++ b/.agents/skills/mobius-onnx-export-gotchas/SKILL.md
@@ -88,16 +88,49 @@ fp16 and re-save. **Gotcha when re-saving with external data:** if you save with
 then rename the file, the references inside `model.onnx` still point to `X.data`. Either save directly
 with `location="model.onnx.data"`, or rewrite each initializer's `external_data` `location` entry.
 
+**Do not re-save with `onnx.save(..., save_as_external_data=True)` into an existing `.data` file.**
+`onnx.save_model` reaches `onnx.external_data_helper.save_external_data`, which opens the target
+`"r+b"` and then `seek(0, 2)` — it **appends**. The previous copy of the weights is never truncated,
+the offsets in `model.onnx` are rewritten to point at the newly appended copy, and the original copy
+stays on disk referenced by nothing. The model still loads and still produces byte-identical output,
+so nothing fails; the file is simply twice the size it should be. A Qwen2.5-14B int4 export was
+measured at 16.652 GB of which only 8.330 GB (50.02%) was referenced, in a single contiguous
+orphaned prefix `[0, 8322547712)`. That cost 2x disk and download, 2x pinned host RAM on
+memory-mapped weight paths, and produced a wrong weight-budget figure downstream in a consumer that
+reasonably sized from file length (justinchuby/onnx-genai#853).
+
+Use `ir.save`, which is what the rest of mobius uses. It writes the blob with `"wb"` and overwrites
+unconditionally, so there is no second copy to orphan:
+
 ```python
-import onnx, numpy as np
-from onnx import numpy_helper, TensorProto
-m = onnx.load("model.onnx", load_external_data=True)
-for init in m.graph.initializer:
-    if init.data_type == TensorProto.FLOAT:
-        arr = numpy_helper.to_array(init).astype(np.float16)
-        init.CopyFrom(numpy_helper.from_array(arr, init.name))
-onnx.save(m, "model.onnx", save_as_external_data=True, all_tensors_to_one_file=True,
-          location="model.onnx.data", size_threshold=1024, convert_attribute=False)
+import numpy as np
+import onnx_ir as ir
+
+model = ir.load("model.onnx")
+for name, value in model.graph.initializers.items():
+    if value.const_value is not None and value.const_value.dtype == ir.DataType.FLOAT:
+        value.const_value = ir.tensor(value.const_value.numpy().astype(np.float16), name=name)
+ir.save(model, "model.onnx", external_data="model.onnx.data")
+```
+
+Note `ir.save` invalidates any existing external tensor that references the path it is writing, so
+load the values you intend to keep before saving over their backing file.
+
+Because this failure is silent, assert the post-condition rather than eyeballing the file size:
+
+```python
+import onnx, pathlib
+
+m = onnx.load("model.onnx", load_external_data=False)
+referenced = sum(
+    int(dict((kv.key, kv.value) for kv in t.external_data)["length"])
+    for t in m.graph.initializer
+    if t.data_location == onnx.TensorProto.EXTERNAL
+)
+size = pathlib.Path("model.onnx.data").stat().st_size
+assert referenced >= 0.99 * size, (
+    f"external data blob is {size:,} bytes but only {referenced:,} are referenced"
+)
 ```
 
 ## 4. Always validate the export in ORT before profiling


### PR DESCRIPTION
The salvage recipe in the ONNX export gotchas skill re-saves with `onnx.save(..., save_as_external_data=True, location="model.onnx.data")`. When that file already exists, `onnx.save_model` reaches `onnx.external_data_helper.save_external_data`, which does:

```python
with os.fdopen(fd, "r+b") as data_file:
    data_file.seek(0, 2)          # seek to END, then write
```

It **appends**. The previous copy of the weights is never truncated, the offsets in `model.onnx` are rewritten to point at the newly appended copy, and the original copy stays on disk referenced by nothing.

Nothing fails when this happens — the model loads and produces byte-identical output. The file is simply twice the size it should be, which is exactly why it survives review.

## Measured

A 512×512 fixture, saved fp32 with external data, then put through each recipe (cast FLOAT32 → fp16, re-save into the same `location`):

```
onnx.save: blob 1,050,624 -> 1,575,936   referenced 525,312   orphaned 1,050,624 (66.7%)
   ir.save: blob 1,050,624 ->   525,312   referenced 525,312   orphaned         0 ( 0.0%)
```

Both produce `FLOAT16` initializers, so the recipes are equivalent in outcome; only one of them leaves a dead copy behind.

## Why `ir.save`

`save_as_external_data` appears in exactly **one** place in this repository — this skill file. Everything under `src/` already uses `ir.save`, which writes the blob with `"wb"` and overwrites unconditionally. The skill was last touched 2026-06-12 (#351) and appears to predate that convergence, so this brings it in line with the rest of the codebase rather than introducing a new dependency.

The added note about `ir.save` invalidating existing external tensors that reference the path it is writing comes from its own docstring, and matters here because the recipe loads from the file it then saves over.

## The assert

A silent failure deserves an assertion rather than a reader remembering to look at a file size, so the fix adds the post-condition:

```python
referenced = sum(
    int(dict((kv.key, kv.value) for kv in t.external_data)["length"])
    for t in m.graph.initializer
    if t.data_location == onnx.TensorProto.EXTERNAL
)
assert referenced >= 0.99 * pathlib.Path("model.onnx.data").stat().st_size
```

## Scope

Context in #488. To be explicit about what this PR does **not** claim: I hit a real mobius-produced artifact with a 50.02% orphaned blob (16.652 GB, of which 8.330 GB referenced), and I do **not** know that this recipe produced it — the arithmetic actually argues against it, since the two generations in that file are the same size to within 0.088% and this recipe involves an fp32→fp16 cast that would shrink the second one. That investigation is still open in #488. This PR fixes a documented recipe that is unsafe on its own terms.

Docs only.
