### PR TITLE
Fix Olive quantized-weight suffix mismatch in preprocess_olive_weights

### DIFF
--- a/src/mobius/_weight_utils.py
+++ b/src/mobius/_weight_utils.py
@@ -716,19 +716,29 @@ def preprocess_olive_weights(
 ) -> dict[str, torch.Tensor]:
     """Rename and reshape Olive-packed quantized weights.
 
-    Olive stores quantized weights with uint8 packing:
-      - ``*.qweight``: [N, packed_K] uint8
-      - ``*.scales``: [N, n_blocks]
-      - ``*.qzeros``: [N, ceil(n_blocks * bits / 8)] uint8, asymmetric only
+    Olive stores the quantized state of a parameter named ``<pname>`` (e.g.
+    ``"weight"`` for ``nn.Linear``/``nn.Embedding``, or ``"gate_up_proj"`` for
+    a fused-3D MoE expert parameter) as sibling buffers on the owning module,
+    using an *underscore* suffix convention (see Olive's
+    ``olive/common/quant/state_dict.py``) — **not** a dotted one:
+      - ``<pname>_qweight``: [N, packed_K] uint8 (always present)
+      - ``<pname>_scales``: [N, n_blocks] (always present)
+      - ``<pname>_qzeros``: [N, ceil(n_blocks * bits / 8)] uint8 (asymmetric only)
+
+    e.g. ``model.layers.0.mlp.gate_proj.weight_qweight`` (regular ``nn.Linear``)
+    or ``model.layers.0.mlp.experts.gate_up_proj_qweight`` (fused MoE param,
+    no ``.weight`` component since the parameter itself has no nested Linear).
 
     Linear projections target ``MatMulNBits``, which expects ``weight`` as
     [N, n_blocks, blob_size]; scales and zero-points already match the
     expected orientation, so they are renamed but not transposed.
 
-    The input embedding table (``*.embed_tokens.qweight``) instead targets
-    ``GatherBlockQuantized``, which consumes the **2-D** uint8 ``qweight``
-    directly — so it is kept as-is (only ``qzeros`` is renamed to
-    ``zero_points``).
+    The input embedding table (``*.embed_tokens.weight_qweight``) instead
+    targets ``GatherBlockQuantized``, which consumes the **2-D** uint8
+    ``qweight`` directly — so it is renamed to ``*.embed_tokens.qweight``
+    (dropping only the redundant ``weight`` component, not the ``qweight``
+    name itself); ``qzeros``/``scales`` are renamed the same way as the
+    general case below.
 
     Tied LM head: Olive RTN drops ``lm_head.*`` when the head is tied. When the
     head is **quantized**, no ``lm_head`` weights are produced here — the model
@@ -751,9 +761,27 @@ def preprocess_olive_weights(
     blob_size = group_size * bits // 8
     result: dict[str, torch.Tensor] = {}
 
+    def _rename(key: str, raw_suffix: str, dotted_name: str) -> str:
+        """Convert an Olive ``<owner>[.weight]{raw_suffix}`` key to ``<owner>.<dotted_name>``.
+
+        Olive's ``pname`` is either the bare ``"weight"`` parameter of an
+        ``nn.Linear``/``nn.Embedding`` (so the raw key carries a redundant
+        ``.weight`` component before the suffix, e.g. ``...gate_proj.weight_qweight``)
+        or a fused MoE parameter with no nested Linear (e.g.
+        ``...experts.gate_up_proj_qweight``). Strip the suffix, drop a
+        trailing ``.weight`` if present, then append ``.<dotted_name>`` so
+        both shapes land on a single canonical ``<owner>.<dotted_name>`` key.
+        """
+        stem = key[: -len(raw_suffix)]
+        if stem.endswith(".weight"):
+            stem = stem[: -len(".weight")]
+        return f"{stem}.{dotted_name}"
+
     for key, value in state_dict.items():
-        if key.endswith("embed_tokens.qweight"):
-            # GatherBlockQuantized consumes the 2-D uint8 table directly.
+        if key.endswith("embed_tokens.weight_qweight"):
+            # GatherBlockQuantized consumes the 2-D uint8 table directly, so
+            # this keeps the ``qweight`` name (unlike MatMulNBits linears,
+            # which rename to ``weight`` below).
             if value.dtype != torch.uint8:
                 raise ValueError(
                     f"Olive embedding qweight must be uint8 for {key}, got {value.dtype}"
@@ -763,16 +791,16 @@ def preprocess_olive_weights(
                     f"Olive embedding qweight packed dimension for {key} "
                     f"({value.shape[-1]}) must be divisible by blob_size ({blob_size})"
                 )
-            result[key] = value.contiguous()
-        elif key.endswith("embed_tokens.qzeros"):
+            result[key[: -len("weight_qweight")] + "qweight"] = value.contiguous()
+        elif key.endswith("embed_tokens.weight_qzeros"):
             if value.dtype != torch.uint8:
                 raise ValueError(
                     f"Olive embedding qzeros must be uint8 for {key}, got {value.dtype}"
                 )
-            result[key.replace(".qzeros", ".zero_points")] = value.contiguous()
-        elif key.endswith("embed_tokens.scales"):
-            result[key] = value
-        elif key.endswith(".qweight"):
+            result[key[: -len("weight_qzeros")] + "zero_points"] = value.contiguous()
+        elif key.endswith("embed_tokens.weight_scales"):
+            result[key[: -len("weight_scales")] + "scales"] = value
+        elif key.endswith("_qweight"):
             if value.dtype != torch.uint8:
                 raise ValueError(f"Olive qweight must be uint8 for {key}, got {value.dtype}")
             if value.shape[-1] % blob_size != 0:
@@ -780,17 +808,20 @@ def preprocess_olive_weights(
                     f"Olive qweight packed dimension for {key} ({value.shape[-1]}) "
                     f"must be divisible by blob_size ({blob_size})"
                 )
-            new_key = key.replace(".qweight", ".weight")
+            new_key = _rename(key, "_qweight", "weight")
             # Preserve all leading dims so fused expert-major tensors
             # ``[E, N, packed_K]`` reshape to ``[E, N, n_blocks, blob_size]``
             # for the QMoE repacker; 2-D linears ``[N, packed_K]`` are
             # unchanged (``[N, n_blocks, blob_size]``).
             result[new_key] = value.reshape(*value.shape[:-1], -1, blob_size).contiguous()
-        elif key.endswith(".qzeros"):
+        elif key.endswith("_qzeros"):
             if value.dtype != torch.uint8:
                 raise ValueError(f"Olive qzeros must be uint8 for {key}, got {value.dtype}")
-            new_key = key.replace(".qzeros", ".zero_points")
+            new_key = _rename(key, "_qzeros", "zero_points")
             result[new_key] = value.contiguous()
+        elif key.endswith("_scales"):
+            new_key = _rename(key, "_scales", "scales")
+            result[new_key] = value
         else:
             result[key] = value
 

--- a/src/mobius/_weight_utils_test.py
+++ b/src/mobius/_weight_utils_test.py
@@ -574,21 +574,43 @@ class TestPreprocessOliveWeights:
 
     def test_qweight_renamed_and_reshaped_to_matmulnbits_weight(self):
         sd = {
-            "q_proj.qweight": torch.randint(0, 255, (self.N, self.PACKED_K), dtype=torch.uint8)
+            "q_proj.weight_qweight": torch.randint(
+                0, 255, (self.N, self.PACKED_K), dtype=torch.uint8
+            )
         }
 
         result = preprocess_olive_weights(sd, bits=self.BITS, group_size=self.GROUP_SIZE)
 
         assert "q_proj.weight" in result
-        assert "q_proj.qweight" not in result
+        assert "q_proj.weight_qweight" not in result
         assert result["q_proj.weight"].shape == (self.N, self.N_BLOCKS, self.BLOB_SIZE)
         assert result["q_proj.weight"].dtype == torch.uint8
+
+    def test_fused_moe_qweight_renamed_and_reshaped(self):
+        """Fused MoE expert params (no nested ``.weight``) get ``.weight`` appended."""
+        num_experts = 4
+        sd = {
+            "mlp.experts.gate_up_proj_qweight": torch.randint(
+                0, 255, (num_experts, self.N, self.PACKED_K), dtype=torch.uint8
+            )
+        }
+
+        result = preprocess_olive_weights(sd, bits=self.BITS, group_size=self.GROUP_SIZE)
+
+        assert "mlp.experts.gate_up_proj.weight" in result
+        assert "mlp.experts.gate_up_proj_qweight" not in result
+        assert result["mlp.experts.gate_up_proj.weight"].shape == (
+            num_experts,
+            self.N,
+            self.N_BLOCKS,
+            self.BLOB_SIZE,
+        )
 
     def test_scales_orientation_is_preserved(self):
         scales = torch.randn(self.N, self.N_BLOCKS)
 
         result = preprocess_olive_weights(
-            {"q_proj.scales": scales}, bits=self.BITS, group_size=self.GROUP_SIZE
+            {"q_proj.weight_scales": scales}, bits=self.BITS, group_size=self.GROUP_SIZE
         )
 
         assert result["q_proj.scales"] is scales
@@ -597,11 +619,11 @@ class TestPreprocessOliveWeights:
         qzeros = torch.randint(0, 255, (self.N, self.N_BLOCKS // 2), dtype=torch.uint8)
 
         result = preprocess_olive_weights(
-            {"q_proj.qzeros": qzeros}, bits=self.BITS, group_size=self.GROUP_SIZE
+            {"q_proj.weight_qzeros": qzeros}, bits=self.BITS, group_size=self.GROUP_SIZE
         )
 
         assert "q_proj.zero_points" in result
-        assert "q_proj.qzeros" not in result
+        assert "q_proj.weight_qzeros" not in result
         assert torch.equal(result["q_proj.zero_points"], qzeros)
 
     def test_non_quantized_keys_pass_through(self):
@@ -615,7 +637,9 @@ class TestPreprocessOliveWeights:
 
     def test_non_uint8_qweight_raises(self):
         sd = {
-            "q_proj.qweight": torch.randint(0, 255, (self.N, self.PACKED_K), dtype=torch.int32)
+            "q_proj.weight_qweight": torch.randint(
+                0, 255, (self.N, self.PACKED_K), dtype=torch.int32
+            )
         }
 
         with pytest.raises(ValueError, match="Olive qweight must be uint8"):
@@ -623,7 +647,7 @@ class TestPreprocessOliveWeights:
 
     def test_non_uint8_qzeros_raises(self):
         sd = {
-            "q_proj.qzeros": torch.randint(
+            "q_proj.weight_qzeros": torch.randint(
                 0, 255, (self.N, self.N_BLOCKS // 2), dtype=torch.int32
             )
         }
@@ -635,10 +659,10 @@ class TestPreprocessOliveWeights:
     V = 64  # vocab size for embedding tests
 
     def test_embed_qweight_kept_2d(self):
-        """embed_tokens.qweight targets GatherBlockQuantized: keep 2-D uint8."""
+        """embed_tokens.weight_qweight targets GatherBlockQuantized: keep 2-D uint8."""
         qweight = torch.randint(0, 255, (self.V, self.PACKED_K), dtype=torch.uint8)
         result = preprocess_olive_weights(
-            {"model.embed_tokens.qweight": qweight},
+            {"model.embed_tokens.weight_qweight": qweight},
             bits=self.BITS,
             group_size=self.GROUP_SIZE,
             quantize_embeddings=True,
@@ -650,17 +674,17 @@ class TestPreprocessOliveWeights:
     def test_embed_qzeros_renamed_to_zero_points(self):
         qzeros = torch.randint(0, 255, (self.V, self.N_BLOCKS // 2), dtype=torch.uint8)
         result = preprocess_olive_weights(
-            {"model.embed_tokens.qzeros": qzeros},
+            {"model.embed_tokens.weight_qzeros": qzeros},
             bits=self.BITS,
             group_size=self.GROUP_SIZE,
             quantize_embeddings=True,
         )
         assert "model.embed_tokens.zero_points" in result
-        assert "model.embed_tokens.qzeros" not in result
+        assert "model.embed_tokens.weight_qzeros" not in result
 
     def test_embed_non_uint8_qweight_raises(self):
         sd = {
-            "model.embed_tokens.qweight": torch.randint(
+            "model.embed_tokens.weight_qweight": torch.randint(
                 0, 255, (self.V, self.PACKED_K), dtype=torch.int32
             )
         }
@@ -669,7 +693,7 @@ class TestPreprocessOliveWeights:
 
     def test_embed_non_uint8_qzeros_raises(self):
         sd = {
-            "model.embed_tokens.qzeros": torch.randint(
+            "model.embed_tokens.weight_qzeros": torch.randint(
                 0, 255, (self.V, self.N_BLOCKS // 2), dtype=torch.int32
             )
         }
@@ -688,9 +712,9 @@ class TestPreprocessOliveWeights:
         qzeros = torch.randint(0, 255, (self.V, self.N_BLOCKS // 2), dtype=torch.uint8)
         result = preprocess_olive_weights(
             {
-                "model.embed_tokens.qweight": qweight,
-                "model.embed_tokens.scales": scales,
-                "model.embed_tokens.qzeros": qzeros,
+                "model.embed_tokens.weight_qweight": qweight,
+                "model.embed_tokens.weight_scales": scales,
+                "model.embed_tokens.weight_qzeros": qzeros,
             },
             bits=self.BITS,
             group_size=self.GROUP_SIZE,
@@ -714,13 +738,13 @@ class TestPreprocessOliveWeights:
         assert result["lm_head.weight"] is embed
 
     def test_untied_quantized_lm_head_not_overwritten(self):
-        """A present lm_head.qweight must not be replaced by embed synthesis."""
+        """A present lm_head.weight_qweight must not be replaced by embed synthesis."""
         lm_head = torch.randint(0, 255, (self.V, self.PACKED_K), dtype=torch.uint8)
         embed = torch.randint(0, 255, (self.V, self.PACKED_K), dtype=torch.uint8)
         result = preprocess_olive_weights(
             {
-                "lm_head.qweight": lm_head,
-                "model.embed_tokens.qweight": embed,
+                "lm_head.weight_qweight": lm_head,
+                "model.embed_tokens.weight_qweight": embed,
             },
             bits=self.BITS,
             group_size=self.GROUP_SIZE,

--- a/src/mobius/components/_moe_test.py
+++ b/src/mobius/components/_moe_test.py
@@ -301,12 +301,12 @@ class TestMoELayer:
         fc2_zp = torch.randint(0, 16, (num_experts, hidden_size, fc2_blocks))
 
         raw = {
-            "model.layers.1.mlp.experts.gate_up_proj.qweight": _to_olive_qweight(fc1_codes),
-            "model.layers.1.mlp.experts.gate_up_proj.scales": fc1_scales,
-            "model.layers.1.mlp.experts.gate_up_proj.qzeros": _to_olive_qzeros(fc1_zp),
-            "model.layers.1.mlp.experts.down_proj.qweight": _to_olive_qweight(fc2_codes),
-            "model.layers.1.mlp.experts.down_proj.scales": fc2_scales,
-            "model.layers.1.mlp.experts.down_proj.qzeros": _to_olive_qzeros(fc2_zp),
+            "model.layers.1.mlp.experts.gate_up_proj_qweight": _to_olive_qweight(fc1_codes),
+            "model.layers.1.mlp.experts.gate_up_proj_scales": fc1_scales,
+            "model.layers.1.mlp.experts.gate_up_proj_qzeros": _to_olive_qzeros(fc1_zp),
+            "model.layers.1.mlp.experts.down_proj_qweight": _to_olive_qweight(fc2_codes),
+            "model.layers.1.mlp.experts.down_proj_scales": fc2_scales,
+            "model.layers.1.mlp.experts.down_proj_qzeros": _to_olive_qzeros(fc2_zp),
         }
         packed = pack_qmoe_expert_weights(
             preprocess_olive_weights(raw, bits=4, group_size=block_size),

--- a/src/mobius/models/qwen35.py
+++ b/src/mobius/models/qwen35.py
@@ -388,7 +388,7 @@ class Qwen35MoECausalLMModel(CausalLMModel):
 
             # Unpack fused float expert weights into per-expert tensors for the
             # dense fallback. When ``use_qmoe`` is set the fused quantized
-            # tensors arrive as ``.qweight``/``.scales``/``.qzeros`` (which do
+            # tensors arrive as ``_qweight``/``_scales``/``_qzeros`` (which do
             # not match these suffixes) and are kept expert-major for
             # ``pack_qmoe_expert_weights`` below.
             # HF format: [num_experts, fused_dim, hidden] with gate+up fused

--- a/src/mobius/models/qwen35_test.py
+++ b/src/mobius/models/qwen35_test.py
@@ -41,21 +41,28 @@ def _moe_config(quantization: QuantizationConfig | None) -> object:
 
 
 def _olive_expert_state_dict() -> dict[str, torch.Tensor]:
-    """Synthetic HF-style fused Olive-quantized MoE expert tensors."""
+    """Synthetic HF-style fused Olive-quantized MoE expert tensors.
+
+    Olive's on-disk suffix convention is an *underscore* suffix directly on
+    the parameter name (``<pname>_qweight``/``_scales``/``_qzeros``), not a
+    dotted one -- see ``olive/common/quant/state_dict.py``. For a fused MoE
+    parameter like ``gate_up_proj`` (no nested ``nn.Linear``), this means
+    ``experts.gate_up_proj_qweight``, not ``experts.gate_up_proj.qweight``.
+    """
     p = "model.language_model.layers.0.mlp."
     return {
-        p + "experts.gate_up_proj.qweight": torch.randint(
+        p + "experts.gate_up_proj_qweight": torch.randint(
             0, 256, (_E, _FC1_OUT, _H * _BITS // 8), dtype=torch.uint8
         ),
-        p + "experts.gate_up_proj.scales": torch.rand(_E, _FC1_OUT, _H // _BLK),
-        p + "experts.gate_up_proj.qzeros": torch.randint(
+        p + "experts.gate_up_proj_scales": torch.rand(_E, _FC1_OUT, _H // _BLK),
+        p + "experts.gate_up_proj_qzeros": torch.randint(
             0, 256, (_E, _FC1_OUT, 1), dtype=torch.uint8
         ),
-        p + "experts.down_proj.qweight": torch.randint(
+        p + "experts.down_proj_qweight": torch.randint(
             0, 256, (_E, _H, _INT * _BITS // 8), dtype=torch.uint8
         ),
-        p + "experts.down_proj.scales": torch.rand(_E, _H, _INT // _BLK),
-        p + "experts.down_proj.qzeros": torch.randint(0, 256, (_E, _H, 1), dtype=torch.uint8),
+        p + "experts.down_proj_scales": torch.rand(_E, _H, _INT // _BLK),
+        p + "experts.down_proj_qzeros": torch.randint(0, 256, (_E, _H, 1), dtype=torch.uint8),
         p + "gate.weight": torch.rand(_E, _H),
     }
 


### PR DESCRIPTION
## Problem

`preprocess_olive_weights()` in `_weight_utils.py` assumed Olive's quantized checkpoints use a **dotted** suffix convention (`<pname>.qweight` / `.scales` / `.qzeros`). Olive actually uses an **underscore** suffix appended directly to the owning parameter name — e.g. `model.layers.0.mlp.gate_proj.weight_qweight`, or for fused MoE parameters with no nested `Linear`, `model.layers.0.mlp.experts.gate_up_proj_qweight` (see `olive/common/quant/state_dict.py`, `QWEIGHT_SUFFIX = "_qweight"` etc.).

Because of this mismatch, every `endswith`/`replace` check in the function silently failed to match, so real Olive-quantized checkpoints fell through to the "pass through unchanged" branch instead of being renamed/reshaped for `MatMulNBits` / `GatherBlockQuantized` / `QMoE` consumption. This surfaced as `"N initializer(s) without weights"` errors when trying to load an Olive `Rtn`/`Gptq`-quantized checkpoint into a Mobius-built graph.

This exact mismatch was flagged narrowly in #427 (for a defensive `ndim==2` guard on the older `moe=True` 3-D path) and left unresolved ("parked"). #451 added QMoE emission for Qwen3.5/3.6-MoE on top of the same incorrect dotted-suffix assumption, so it also never actually exercised a real Olive checkpoint end-to-end.

## Repro

Chaining Olive's `Rtn(moe=true)` -> `MobiusBuilder` against `yujiepan/qwen3.5-moe-tiny-random` (or `optimum-intel-internal-testing/tiny-random-qwen3.5-moe`) reproduces the failure directly.

## Fix

- Added a `_rename()` helper that strips the underscore suffix, drops a redundant trailing `.weight` component (present for regular `nn.Linear`/`nn.Embedding` params, absent for bare fused-MoE params like `gate_up_proj`), and appends the correct dotted target name.
- Kept the `embed_tokens` special case separate (its packed weight keeps the `qweight` name, not `weight`, since `QuantizedEmbedding`/`GatherBlockQuantized` consume it directly).
- Added a previously-missing `_scales` rename branch for the general (non-embedding) case.
- Updated `_weight_utils_test.py`, `models/qwen35_test.py`, and `components/_moe_test.py` fixtures, which had been written against the same incorrect dotted-suffix convention.

## Scope / what this does NOT fix

This fixes weight **naming**, not quantization **coverage**. `Qwen35Attention`, `GatedDeltaNet`, and the `MLP(config)` call site in `Qwen35DecoderLayer` still hardcode plain `Linear` regardless of `config.quantization` — only the MoE fused-expert path (added in #451) threads quantization through for this model family. So a quantized Qwen3.5/3.6 checkpoint will still fail with a shape mismatch on `self_attn`/`linear_attn`/dense `mlp` weights after this fix (confirmed via the same repro, isolated with `modules_to_not_convert`). That's a separate, larger gap — will file a follow-up issue for it.

## Testing

- `pytest src/mobius/_weight_utils_test.py src/mobius/models/qwen35_test.py src/mobius/models/deepseek_test.py src/mobius/components/_moe_test.py` — 117 passed.
- `ruff check` on all changed files — clean.
- Repro confirmed to now get past the suffix/rename stage and fail only at the (separately tracked) `linear_class` gap.