### PR TITLE
Thread linear_class through Qwen3.5 self_attn/linear_attn/shared_expert

### DIFF
--- a/src/mobius/components/_attention.py
+++ b/src/mobius/components/_attention.py
@@ -467,13 +467,23 @@ class Qwen35Attention(nn.Module):
     - Per-head Q/K RMSNorm with +1 offset (OffsetRMSNorm)
     - Partial RoPE (rotary_embedding_dim < head_dim)
     - Output gating: attn_output * sigmoid(gate)
+
+    Args:
+        config: Architecture configuration.
+        linear_class: Factory callable ``(in_features, out_features, bias=...)``
+            for creating projection layers. Defaults to ``Linear``. Pass a
+            quantized-linear factory (see ``make_quantized_linear_factory``)
+            to emit ``MatMulNBits`` for q/k/v/o projections instead.
     """
 
     def __init__(
         self,
         config: ArchitectureConfig,
+        linear_class: type | None = None,
     ):
         super().__init__()
+        if linear_class is None:
+            linear_class = Linear
         self.hidden_size = config.hidden_size
         self.head_dim = config.head_dim
         self.num_attention_heads = config.num_attention_heads
@@ -486,22 +496,22 @@ class Qwen35Attention(nn.Module):
         self._rope_interleave = config.rope_interleave
 
         q_dim = self.num_attention_heads * self.head_dim
-        self.q_proj = Linear(
+        self.q_proj = linear_class(
             self.hidden_size,
             q_dim * 2,
             bias=config.attn_qkv_bias,
         )
-        self.k_proj = Linear(
+        self.k_proj = linear_class(
             self.hidden_size,
             self.num_key_value_heads * self.head_dim,
             bias=config.attn_qkv_bias,
         )
-        self.v_proj = Linear(
+        self.v_proj = linear_class(
             self.hidden_size,
             self.num_key_value_heads * self.head_dim,
             bias=config.attn_qkv_bias,
         )
-        self.o_proj = Linear(
+        self.o_proj = linear_class(
             q_dim,
             self.hidden_size,
             bias=config.attn_o_bias,

--- a/src/mobius/components/_gated_deltanet.py
+++ b/src/mobius/components/_gated_deltanet.py
@@ -102,10 +102,23 @@ class GatedDeltaNet(nn.Module):
     The forward pass is a clean sequence of op calls.
 
     The recurrent state replaces the KV cache for these layers.
+
+    Args:
+        config: Architecture configuration.
+        linear_class: Factory callable ``(in_features, out_features, bias=...)``
+            for creating the ``in_proj_qkv``/``in_proj_z``/``in_proj_b``/
+            ``in_proj_a``/``out_proj`` projections. Defaults to ``Linear``.
+            Pass a quantized-linear factory (see
+            ``make_quantized_linear_factory``) to emit ``MatMulNBits`` for
+            these projections instead. ``dt_bias``, ``A_log``, and
+            ``conv1d.weight`` are small recurrent-state parameters and are
+            never quantized regardless of this argument.
     """
 
-    def __init__(self, config: ArchitectureConfig):
+    def __init__(self, config: ArchitectureConfig, linear_class: type | None = None):
         super().__init__()
+        if linear_class is None:
+            linear_class = Linear
         self.hidden_size = config.hidden_size
         self._dtype = config.dtype
         self.num_v_heads = config.linear_num_value_heads
@@ -118,17 +131,17 @@ class GatedDeltaNet(nn.Module):
         self.conv_dim = self.key_dim * 2 + self.value_dim
 
         # QKV projection (fused: Q, K, V in one linear)
-        self.in_proj_qkv = Linear(
+        self.in_proj_qkv = linear_class(
             self.hidden_size,
             self.key_dim * 2 + self.value_dim,
             bias=False,
         )
         # Gating projection (z for silu gating in output norm)
-        self.in_proj_z = Linear(self.hidden_size, self.value_dim, bias=False)
+        self.in_proj_z = linear_class(self.hidden_size, self.value_dim, bias=False)
         # Beta projection (forget gate)
-        self.in_proj_b = Linear(self.hidden_size, self.num_v_heads, bias=False)
+        self.in_proj_b = linear_class(self.hidden_size, self.num_v_heads, bias=False)
         # Alpha projection (decay control)
-        self.in_proj_a = Linear(self.hidden_size, self.num_v_heads, bias=False)
+        self.in_proj_a = linear_class(self.hidden_size, self.num_v_heads, bias=False)
 
         # Causal depthwise Conv1D
         self.conv1d = _DepthwiseConv1d(self.conv_dim, self.conv_kernel_size)
@@ -141,7 +154,7 @@ class GatedDeltaNet(nn.Module):
         self.norm = PostGatedRMSNorm(self.head_v_dim, eps=config.rms_norm_eps)
 
         # Output projection
-        self.out_proj = Linear(self.value_dim, self.hidden_size, bias=False)
+        self.out_proj = linear_class(self.value_dim, self.hidden_size, bias=False)
 
     def forward(
         self,

--- a/src/mobius/models/moe.py
+++ b/src/mobius/models/moe.py
@@ -278,16 +278,23 @@ class Qwen2MoELayer(MoELayer):
     Replicates HuggingFace ``Qwen2MoeSparseMoeBlock``.
     """
 
-    def __init__(self, config: ArchitectureConfig, gate: nn.Module | None = None):
+    def __init__(
+        self,
+        config: ArchitectureConfig,
+        gate: nn.Module | None = None,
+        linear_class: type | None = None,
+    ):
         super().__init__(config, gate=gate)
         assert config.shared_expert_intermediate_size is not None, (
             "Qwen2MoELayer requires config.shared_expert_intermediate_size"
         )
+        if linear_class is None:
+            linear_class = Linear
         shared_config = dataclasses.replace(
             config, intermediate_size=config.shared_expert_intermediate_size
         )
-        self.shared_expert = MLP(shared_config)
-        self.shared_expert_gate = Linear(config.hidden_size, 1, bias=False)
+        self.shared_expert = MLP(shared_config, linear_class=linear_class)
+        self.shared_expert_gate = linear_class(config.hidden_size, 1, bias=False)
 
     def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # Routing expert output: top-k weighted sum  [B, S, H]

--- a/src/mobius/models/qwen35.py
+++ b/src/mobius/models/qwen35.py
@@ -3,8 +3,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
+import onnx_ir as ir
 import torch
 from onnxscript import OpBuilder, nn
 
@@ -19,6 +18,7 @@ from mobius.components._common import (
 from mobius.components._gated_deltanet import GatedDeltaNet
 from mobius.components._mlp import MLP
 from mobius.components._moe import _supported_qmoe_quantization
+from mobius.components._quantized_linear import make_quantized_linear_factory
 from mobius.components._rms_norm import OffsetRMSNorm
 from mobius.components._rotary_embedding import initialize_rope
 from mobius.models.base import CausalLMModel
@@ -30,12 +30,29 @@ from mobius.models.qwen_vl import (
     split_deepstack_embeds,
 )
 
-if TYPE_CHECKING:
-    import onnx_ir as ir
-
 # ---------------------------------------------------------------------------
 # Qwen3.5 — hybrid linear/full attention
 # ---------------------------------------------------------------------------
+
+
+def _linear_factory(config: ArchitectureConfig) -> type | None:
+    """Build a quantized-linear factory from ``config.quantization``, or None.
+
+    Returns ``None`` (meaning "use plain ``Linear``") when the model is
+    unquantized. Shared by the dense (:class:`Qwen35DecoderLayer`) and MoE
+    (:class:`Qwen35MoEDecoderLayer`) variants so ``self_attn``/``linear_attn``/
+    ``mlp``/``shared_expert`` are all quantized consistently.
+    """
+    quantization = config.quantization
+    if quantization is None or quantization.quant_method == "none":
+        return None
+    zero_point_dtype = config.dtype if quantization.float_zero_point else ir.DataType.UINT8
+    return make_quantized_linear_factory(
+        bits=quantization.bits,
+        block_size=quantization.group_size,
+        has_zero_point=not quantization.sym,
+        zero_point_dtype=zero_point_dtype,
+    )
 
 
 class Qwen35DecoderLayer(nn.Module):
@@ -47,6 +64,12 @@ class Qwen35DecoderLayer(nn.Module):
 
     Both variants use :class:`OffsetRMSNorm` (the *1 + weight* variant)
     for pre-attention and post-attention normalization.
+
+    When ``config.quantization`` is set, ``self_attn``/``linear_attn``/``mlp``
+    projections are built with a quantized-linear factory (see
+    :func:`_linear_factory`) so quantized checkpoints (e.g. Olive
+    RTN/GPTQ) load correctly instead of hitting a dense-vs-packed shape
+    mismatch.
     """
 
     def __init__(self, config: ArchitectureConfig, layer_idx: int):
@@ -55,13 +78,14 @@ class Qwen35DecoderLayer(nn.Module):
         self.layer_type: str = (
             layer_types[layer_idx] if layer_idx < len(layer_types) else "full_attention"
         )
+        linear_class = _linear_factory(config)
 
         if self.layer_type == "linear_attention":
-            self.linear_attn = GatedDeltaNet(config)
+            self.linear_attn = GatedDeltaNet(config, linear_class=linear_class)
         else:
-            self.self_attn = Qwen35Attention(config)
+            self.self_attn = Qwen35Attention(config, linear_class=linear_class)
 
-        self.mlp = MLP(config)
+        self.mlp = MLP(config, linear_class=linear_class)
         self.input_layernorm = OffsetRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = OffsetRMSNorm(
             config.hidden_size, eps=config.rms_norm_eps
@@ -247,11 +271,18 @@ class Qwen35MoEDecoderLayer(Qwen35DecoderLayer):
     Same hybrid DeltaNet/full-attention architecture as
     :class:`Qwen35DecoderLayer`, but replaces the dense MLP with a
     :class:`Qwen35MoEBlock`.
+
+    The routed experts are quantized via the fused ``com.microsoft::QMoE``
+    path (see :class:`~mobius.components._moe.MoELayer`), driven directly
+    by ``config.quantization``. The always-active ``shared_expert``/
+    ``shared_expert_gate`` are not part of that fused op, so they are
+    quantized separately via the same ``linear_class`` factory used for
+    ``self_attn``/``linear_attn``/dense ``mlp`` (see :func:`_linear_factory`).
     """
 
     def __init__(self, config: ArchitectureConfig, layer_idx: int):
         super().__init__(config, layer_idx)
-        self.mlp = Qwen35MoEBlock(config)
+        self.mlp = Qwen35MoEBlock(config, linear_class=_linear_factory(config))
 
 
 class Qwen35MoETextModel(nn.Module):


### PR DESCRIPTION
## Stacked on #491

This PR is stacked on #491 (the Olive suffix fix) — its base branch is `fix/olive-suffix-mismatch`, not `main`. Please merge #491 first; this diff will shrink to just this PR's own commit once that lands and the base is retargeted to `main`.

## Problem (#492)

For Qwen3.5/3.6's hybrid DeltaNet + full-attention MoE architecture, only the fused MoE expert path had real quantization wiring. Three call sites hardcoded plain `Linear` regardless of `config.quantization`, unlike the generic `Attention`/`MLP` classes used elsewhere in Mobius:

- `Qwen35Attention` (full-attention layers): `q_proj`/`k_proj`/`v_proj`/`o_proj`
- `GatedDeltaNet` (linear-attention layers): `in_proj_qkv`/`in_proj_z`/`in_proj_b`/`in_proj_a`/`out_proj`
- `Qwen2MoELayer`'s `shared_expert`/`shared_expert_gate` (reused by `Qwen35MoEBlock`) — the always-active shared expert isn't part of the fused QMoE op, so it needs its own quantization wiring separate from the routed experts

Since Mobius rebuilds the ONNX graph from scratch (rather than tracing the PyTorch model), the initializer slots for these modules were always built expecting dense float weights, so a quantized checkpoint's packed weights could never load — surfacing as a shape mismatch (e.g. `model.layers.3.self_attn.k_proj.weight: model expects [16, 32], got [16, 2, 8]`).

## Fix

- Added an optional `linear_class` constructor parameter to `Qwen35Attention` and `GatedDeltaNet`, matching the pattern already used by the generic `Attention`/`MLP` classes. `GatedDeltaNet`'s `dt_bias`/`A_log`/`conv1d.weight` are small recurrent-state parameters and are intentionally left unquantized regardless of this argument (open design question from #492, resolved here: always float).
- Added an optional `linear_class` parameter to `Qwen2MoELayer` for `shared_expert`/`shared_expert_gate`. Defaults to `None` (plain `Linear`), so existing `Qwen2MoEDecoderLayer` (Qwen2-MoE) callers are unaffected.
- Added a `_linear_factory(config)` helper in `qwen35.py` (mirrors the existing pattern already used in `deepseek.py`) and threaded it through `Qwen35DecoderLayer`/`Qwen35MoEDecoderLayer`'s `self_attn`/`linear_attn`/`mlp` construction.

## Testing

- `pytest src/mobius/models/qwen35_test.py src/mobius/models/_qwen35_mtp_test.py src/mobius/components/_attention_test.py src/mobius/components/_gated_deltanet_test.py src/mobius/components/_moe_test.py src/mobius/components/_mlp_test.py src/mobius/_weight_utils_test.py src/mobius/models/deepseek_test.py` — 198 passed.
- `ruff check` on all changed files — clean.
- **End-to-end**: Olive `Rtn(bits=4, group_size=16, sym=true, moe=true)` -> `MobiusBuilder` against `optimum-intel-internal-testing/tiny-random-qwen3.5-moe`, **without** excluding `linear_attn`/`shared_expert` via `modules_to_not_convert`, now succeeds end-to-end: `self_attn`/`linear_attn`/`shared_expert` weights save as quantized `u8` tensors, and a full ONNX model + `genai_config.json` are produced.

Closes #492.