### PR TITLE
Fix QMoE gate scoping, router dtype/shape, swiglu layout, and hybrid-recurrent past_present_share_buffer

### DIFF
--- a/src/mobius/components/_moe.py
+++ b/src/mobius/components/_moe.py
@@ -15,6 +15,45 @@ from mobius._configs import ArchitectureConfig, QuantizationConfig
 from mobius.components._mlp import MLP
 
 
+def _interleave_gate_up_rows(
+    op: OpBuilder, tensor: ir.Value, num_experts: int, fc1_out: int
+) -> ir.Value:
+    """Reorder fc1 gate/up rows from HF-concatenated to QMoE-interleaved layout.
+
+    mobius stores ``fc1_*`` parameters chunked as ``[E, 2*inter, ...]`` with
+    the first ``inter`` rows holding the gate projection and the next
+    ``inter`` rows holding the up projection (matching HuggingFace
+    ``experts.gate_up_proj``). ``swiglu_fusion=1`` requires the interleaved
+    layout ``[g_0, u_0, g_1, u_1, ...]`` instead -- it is the only layout the
+    CPU QMoE kernel supports (``contrib_ops/cpu/moe/moe_quantization_cpu.cc``).
+    Reshape/transpose/reshape the row dimension to reorder it; this operates
+    on a constant initializer so ORT folds it away at session load (mirrors
+    the unquantized-MoE interleave in ``gemma4.py``).
+    """
+    half = fc1_out // 2
+    trailing = op.Shape(tensor, start=2)
+    split_shape = op.Concat(op.Constant(value_ints=[num_experts, 2, half]), trailing, axis=0)
+    reshaped = op.Reshape(tensor, split_shape)
+    transposed = op.Transpose(reshaped, perm=[0, 2, 1, 3])
+    merge_shape = op.Concat(op.Constant(value_ints=[num_experts, fc1_out]), trailing, axis=0)
+    return op.Reshape(transposed, merge_shape)
+
+
+def _flatten_to_2d(op: OpBuilder, tensor: ir.Value) -> ir.Value:
+    """Flatten leading (batch, sequence, ...) dims into one, keeping the last.
+
+    QMoE's ``router_probs`` and ``router_weights`` inputs require a strictly
+    2D ``(num_tokens, num_experts)`` shape (unlike ``input``/hidden_states,
+    which accepts 2D or 3D) -- see ``contrib_defs.cc``. Router logits are
+    computed from a possibly-3D ``hidden_states`` (``batch, seq, hidden``),
+    so collapse everything but the last dim.
+    """
+    last_dim = op.Shape(tensor, start=-1)
+    flat_shape = op.Concat(op.Constant(value_ints=[-1]), last_dim, axis=0)
+    return op.Reshape(tensor, flat_shape)
+
+
+
 class TopKGate(nn.Module):
     """Standard top-k expert routing gate.
 
@@ -56,7 +95,10 @@ class TopKGate(nn.Module):
         """
         weight_t = op.Transpose(self.weight, perm=[1, 0])
         router_logits = op.MatMul(hidden_states, weight_t)
-        router_logits = op.Cast(router_logits, to=ir.DataType.FLOAT.value)
+        # QMoE's ``router_probs`` input shares type constraint "T" with
+        # ``input`` (see contrib_defs.cc), so it must match hidden_states'
+        # dtype rather than a fixed float32.
+        router_logits = op.CastLike(router_logits, hidden_states)
         return router_logits, None, True, 1.0
 
 
@@ -92,7 +134,7 @@ class SoftmaxTopKGate(nn.Module):
     def qmoe_routing(self, op: OpBuilder, hidden_states: ir.Value):
         """Return selection and aggregation tensors for QMoE.
 
-        ``router_probs`` (QMoE input 1) is the raw float32 logits and the
+        ``router_probs`` (QMoE input 1) is the raw logits (cast to hidden_states's dtype) and the
         pre-softmaxed probabilities are passed as ``router_weights`` (input
         14). CUDA QMoE ignores ``router_weights`` and applies softmax-top-k on
         ``router_probs``, so feeding logits reproduces ``forward`` exactly
@@ -105,7 +147,10 @@ class SoftmaxTopKGate(nn.Module):
         """
         weight_t = op.Transpose(self.weight, perm=[1, 0])
         router_logits = op.MatMul(hidden_states, weight_t)
-        router_logits = op.Cast(router_logits, to=ir.DataType.FLOAT.value)
+        # QMoE's ``router_probs`` input shares type constraint "T" with
+        # ``input`` (see contrib_defs.cc), so it must match hidden_states'
+        # dtype rather than a fixed float32.
+        router_logits = op.CastLike(router_logits, hidden_states)
         routing_probs = op.Softmax(router_logits, axis=-1)
         return router_logits, routing_probs, self.norm_topk_prob, 1.0
 
@@ -154,7 +199,7 @@ class SigmoidTopKGate(nn.Module):
         """Return selection and aggregation tensors for QMoE.
 
         The sigmoid-activated probabilities are passed as ``router_weights``
-        (QMoE input 14) while the raw float32 logits are passed as
+        (QMoE input 14) while the raw logits (cast to hidden_states's dtype) are passed as
         ``router_probs`` (input 1). CPU QMoE selects the top-k over
         ``router_probs`` (sigmoid is monotonic, so logits give the same
         selection) and gathers ``router_weights`` at the selected experts,
@@ -164,7 +209,10 @@ class SigmoidTopKGate(nn.Module):
         """
         weight_t = op.Transpose(self.weight, perm=[1, 0])
         router_logits = op.MatMul(hidden_states, weight_t)
-        router_logits = op.Cast(router_logits, to=ir.DataType.FLOAT.value)
+        # QMoE's ``router_probs`` input shares type constraint "T" with
+        # ``input`` (see contrib_defs.cc), so it must match hidden_states'
+        # dtype rather than a fixed float32.
+        router_logits = op.CastLike(router_logits, hidden_states)
         routing_probs = op.Sigmoid(router_logits)
         return (
             router_logits,
@@ -298,6 +346,7 @@ class MoELayer(nn.Module):
         block_size = quantization.group_size
         bits = quantization.bits
         fc1_out = 2 * intermediate_size
+        self._fc1_out = fc1_out
         if hidden_size % block_size or intermediate_size % block_size:
             raise ValueError(
                 "QMoE dimensions must be divisible by the quantization group size"
@@ -341,14 +390,48 @@ class MoELayer(nn.Module):
     def _qmoe_forward(self, op: OpBuilder, hidden_states: ir.Value):
         quantization = self._qmoe_quantization
         assert quantization is not None
-        router_probs, router_weights, normalize, output_scale = self.gate.qmoe_routing(
-            op, hidden_states
+        # ``qmoe_routing`` is called directly (not via ``self.gate(op, ...)``)
+        # because it returns multiple routing tensors rather than following
+        # the standard forward() signature. ``Module.__call__`` only realizes
+        # parameters (qualifying their initializer names, e.g.
+        # "<prefix>.gate.weight") for the module actually invoked through
+        # ``__call__`` -- see onnxscript/nn/_module.py -- so bypassing it here
+        # would leave ``self.gate.weight`` registered as a bare, unqualified
+        # "weight" initializer. Manually push the gate's module scope and
+        # realize its parameters first, mirroring the pattern used for the
+        # sparse LM head in gemma4_assistant.py.
+        op.builder.push_module(self.gate.name or "gate", type(self.gate).__qualname__)
+        try:
+            for param in self.gate.parameters():
+                param._realize(op.builder)  # pylint: disable=protected-access
+            router_probs, router_weights, normalize, output_scale = self.gate.qmoe_routing(
+                op, hidden_states
+            )
+        finally:
+            op.builder.pop_module()
+
+        router_probs = _flatten_to_2d(op, router_probs)
+        if router_weights is not None:
+            router_weights = _flatten_to_2d(op, router_weights)
+
+        fc1_experts_weights = _interleave_gate_up_rows(
+            op, self.fc1_experts_weights, self.num_experts, self._fc1_out
+        )
+        fc1_scales = _interleave_gate_up_rows(
+            op, self.fc1_scales, self.num_experts, self._fc1_out
+        )
+        fc1_experts_zero_points = (
+            _interleave_gate_up_rows(
+                op, self.fc1_experts_zero_points, self.num_experts, self._fc1_out
+            )
+            if self.fc1_experts_zero_points is not None
+            else None
         )
         result = op.QMoE(
             hidden_states,
             router_probs,
-            self.fc1_experts_weights,
-            self.fc1_scales,
+            fc1_experts_weights,
+            fc1_scales,
             None,
             self.fc2_experts_weights,
             self.fc2_scales,
@@ -356,7 +439,7 @@ class MoELayer(nn.Module):
             None,
             None,
             None,
-            self.fc1_experts_zero_points,
+            fc1_experts_zero_points,
             self.fc2_experts_zero_points,
             None,
             router_weights,
@@ -365,7 +448,7 @@ class MoELayer(nn.Module):
             k=self.top_k,
             expert_weight_bits=quantization.bits,
             block_size=quantization.group_size,
-            swiglu_fusion=2,
+            swiglu_fusion=1,
             quant_type="int",
             weights_prepacked=0,
             _domain="com.microsoft",

--- a/src/mobius/components/_moe_test.py
+++ b/src/mobius/components/_moe_test.py
@@ -158,7 +158,7 @@ class TestMoELayer:
         qmoe = qmoe_nodes[0]
         assert qmoe.attributes["k"].value == 6
         assert qmoe.attributes["block_size"].value == 32
-        assert qmoe.attributes["swiglu_fusion"].value == 2
+        assert qmoe.attributes["swiglu_fusion"].value == 1
         assert qmoe.attributes["expert_weight_bits"].value == 4
         assert qmoe.attributes["quant_type"].value == "int"
         assert qmoe.attributes["weights_prepacked"].value == 0
@@ -210,7 +210,7 @@ class TestMoELayer:
         qmoe = qmoe_nodes[0]
         assert qmoe.attributes["k"].value == 6
         assert qmoe.attributes["block_size"].value == 32
-        assert qmoe.attributes["swiglu_fusion"].value == 2
+        assert qmoe.attributes["swiglu_fusion"].value == 1
         assert qmoe.attributes["quant_type"].value == "int"
         assert qmoe.attributes["weights_prepacked"].value == 0
         assert layer.fc1_experts_weights.shape == ir.Shape([64, 64, 32])

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -1009,13 +1009,26 @@ def _write_genai_config(
     # shared buffer. Introspect the graph: if there is at least one GQA
     # node, the model supports shared-buffer mode; otherwise force it off
     # regardless of the EP capability flag.
+    #
+    # ``com.microsoft.LinearAttention`` (linear/recurrent-attention layers,
+    # e.g. Qwen3.5's GatedDeltaNet) is a separate, *mandatory* case: its
+    # recurrent state requires ``past_present_share_buffer=True`` regardless
+    # of whether any other layer uses GQA (ORT GenAI raises "RecurrentState
+    # requires past_present_share_buffer=true" otherwise). Hybrid models mix
+    # LinearAttention layers with standard (non-GQA) ``Attention`` layers, so
+    # this flag must win over the "no GQA" default-off heuristic above.
     decoder_model = pkg.get(decoder_key)
     supports_in_place_kv_cache: bool | None = None
     if decoder_model is not None:
-        supports_in_place_kv_cache = any(
+        has_gqa = any(
             node.op_type == "GroupQueryAttention" and node.domain == "com.microsoft"
             for node in decoder_model.graph
         )
+        has_recurrent_state = any(
+            node.op_type == "LinearAttention" and node.domain == "com.microsoft"
+            for node in decoder_model.graph
+        )
+        supports_in_place_kv_cache = has_gqa or has_recurrent_state
 
     generator = GenaiConfigGenerator.from_config(
         config,


### PR DESCRIPTION
## Summary

While validating that an Olive-quantized (RTN, `moe=true`) Qwen3.5-MoE export
actually *runs* under `onnxruntime-genai` (not just structurally exports —
see discussion on #492), five independent, pre-existing bugs surfaced in the
QMoE fused-expert path and `genai_config.json` generation. None of these are
related to #491 or #493 — this PR is based directly on `main`.

Each bug was fixed one at a time and re-verified against actual
`onnxruntime_genai.Model(...)` load + generation on a tiny Qwen3.5-MoE test
model (Olive `Rtn(bits=4, group_size=16, sym=true, moe=true)` →
`MobiusBuilder`), confirming execution progressed further after each fix.

### 1. Router gate weight orphaned as unqualified `"weight"` graph input

`MoELayer._qmoe_forward()` called `self.gate.qmoe_routing(op, ...)` directly
instead of through `self.gate(op, ...)`, bypassing `Module.__call__`'s
parameter-realization step (which qualifies `weight` into e.g.
`model.layers.0.mlp.gate.weight`). This left a bare, unqualified `"weight"`
node input in the graph, which `onnxruntime_genai` rejected at load:
`Node input 'weight' is not a graph input, initializer, or output of a
previous node.`

Fixed by manually pushing the gate's module scope and realizing its
parameters before calling `qmoe_routing`, mirroring the existing pattern
used for the sparse LM head in `gemma4_assistant.py`.

### 2. `router_probs` hard-cast to float32 instead of matching hidden_states' dtype

QMoE's `router_probs` input shares type constraint `T` with the `input`
(hidden_states) tensor per `contrib_defs.cc` — it must match hidden_states'
actual dtype (e.g. fp16), not a fixed float32. The previous code did
`op.Cast(router_logits, to=ir.DataType.FLOAT.value)` unconditionally, which
produced: `Type Error: Type parameter (T) of Optype (QMoE) bound to
different types (tensor(float16) and tensor(float))`.

Fixed with `op.CastLike(router_logits, hidden_states)` in all three gate
classes' `qmoe_routing()` (`TopKGate`, `SoftmaxTopKGate`, `SigmoidTopKGate`).

### 3. `swiglu_fusion=2` (concatenated) unsupported by the CPU QMoE kernel

`swiglu_fusion=2` tells QMoE the fc1 gate/up rows are concatenated
(`[gate_rows; up_rows]`, matching HF's `experts.gate_up_proj` layout as-is).
The CPU QMoE kernel in this ORT build only supports `swiglu_fusion=1`
(interleaved `[g_0, u_0, g_1, u_1, ...]`):
`CPU QMoE only supports interleaved SwiGLU format. Please set
swiglu_fusion=1.` This also matches the official `onnxruntime-genai`
reference builders, which always emit the interleaved layout.

Fixed by adding `_interleave_gate_up_rows()`, which reorders
`fc1_experts_weights` / `fc1_scales` / `fc1_experts_zero_points` from the
concatenated to the interleaved row layout via a graph-level
reshape/transpose/reshape. Since this operates on constant initializers, ORT
folds it away at session load — this mirrors the existing unquantized-MoE
interleave already used for `swiglu_fusion=1` in `gemma4.py`.

### 4. `router_probs`/`router_weights` left 3D instead of required 2D

QMoE's `router_probs` and `router_weights` inputs require a strictly 2D
`(num_tokens, num_experts)` shape (unlike `input`/hidden_states, which
accepts 2D *or* 3D per the op schema). Router logits computed from a 3D
`hidden_states` (`batch, seq, hidden`) were passed through unflattened,
producing: `Input 'router_probs' is expected to have 2 dimensions, got 3`.

Fixed by adding `_flatten_to_2d()`, which collapses all leading dims into
one before the `QMoE` call (applied to both `router_probs` and
`router_weights` when present).

### 5. `past_present_share_buffer` auto-detection ignores `LinearAttention`

`auto_export.py`'s heuristic for `past_present_share_buffer` only checked
for `GroupQueryAttention` nodes, defaulting the flag to `False` when absent
— correct for models using only standard (non-GQA) `Attention`, but wrong
for hybrid models that mix `com.microsoft.LinearAttention` (recurrent state,
e.g. Qwen3.5's GatedDeltaNet linear-attention layers) with standard
`Attention` layers for full self-attention. `LinearAttention`'s recurrent
state requires `past_present_share_buffer=True` *unconditionally*,
regardless of whether any other layer uses GQA — otherwise
`onnxruntime_genai` fails at load: `RecurrentState requires
past_present_share_buffer=true.`

Fixed by also checking for `LinearAttention` nodes and OR-ing that into the
detection result.

## Testing

- `pytest src/mobius/components/_moe_test.py
  src/mobius/integrations/ort_genai/` — 203 passed.
- `ruff check` on all changed files — clean.
- End-to-end verification: re-ran the Olive RTN + MobiusBuilder export after
  each fix and re-attempted `onnxruntime_genai.Model(...)` load +
  generation; execution progressed past each bug in turn (orphaned weight →
  type mismatch → CPU-kernel rejection → shape-rank error →
  past_present_share_buffer load failure) until reaching a separate,
  unrelated limitation specific to the tiny test model's abnormally small
  `head_dim` (GQA's rotary-cache-size kernel constraint), which is a test-model
  scale artifact rather than a design bug.

## Not in scope

- `rewrite_rules/_qmoe_fusion.py` has the same `swiglu_fusion=2` +
  float32-router-cast pattern in its dense-fallback-to-QMoE rewrite rule, but
  that module isn't wired into `MobiusBuilder`'s default pipeline (not
  invoked anywhere outside its own tests), so it's left untouched here as a
  possible future follow-up.
- `deepseek.py`'s `qmoe_routing()` does its own float32 upcasting for
  numerical stability in sigmoid/scoring, independent of this PR's scope.