### PR TITLE
Fix Qwen3.5-MoE Olive->Mobius export: suffix mismatch, linear_class threading, QMoE routing/layout, and genai_config detection

### DIFF
--- a/src/mobius/_weight_utils.py
+++ b/src/mobius/_weight_utils.py
@@ -716,19 +716,29 @@ def preprocess_olive_weights(
 ) -> dict[str, torch.Tensor]:
     """Rename and reshape Olive-packed quantized weights.
 
-    Olive stores quantized weights with uint8 packing:
-      - ``*.qweight``: [N, packed_K] uint8
-      - ``*.scales``: [N, n_blocks]
-      - ``*.qzeros``: [N, ceil(n_blocks * bits / 8)] uint8, asymmetric only
+    Olive stores the quantized state of a parameter named ``<pname>`` (e.g.
+    ``"weight"`` for ``nn.Linear``/``nn.Embedding``, or ``"gate_up_proj"`` for
+    a fused-3D MoE expert parameter) as sibling buffers on the owning module,
+    using an *underscore* suffix convention (see Olive's
+    ``olive/common/quant/state_dict.py``) — **not** a dotted one:
+      - ``<pname>_qweight``: [N, packed_K] uint8 (always present)
+      - ``<pname>_scales``: [N, n_blocks] (always present)
+      - ``<pname>_qzeros``: [N, ceil(n_blocks * bits / 8)] uint8 (asymmetric only)
+
+    e.g. ``model.layers.0.mlp.gate_proj.weight_qweight`` (regular ``nn.Linear``)
+    or ``model.layers.0.mlp.experts.gate_up_proj_qweight`` (fused MoE param,
+    no ``.weight`` component since the parameter itself has no nested Linear).
 
     Linear projections target ``MatMulNBits``, which expects ``weight`` as
     [N, n_blocks, blob_size]; scales and zero-points already match the
     expected orientation, so they are renamed but not transposed.
 
-    The input embedding table (``*.embed_tokens.qweight``) instead targets
-    ``GatherBlockQuantized``, which consumes the **2-D** uint8 ``qweight``
-    directly — so it is kept as-is (only ``qzeros`` is renamed to
-    ``zero_points``).
+    The input embedding table (``*.embed_tokens.weight_qweight``) instead
+    targets ``GatherBlockQuantized``, which consumes the **2-D** uint8
+    ``qweight`` directly — so it is renamed to ``*.embed_tokens.qweight``
+    (dropping only the redundant ``weight`` component, not the ``qweight``
+    name itself); ``qzeros``/``scales`` are renamed the same way as the
+    general case below.
 
     Tied LM head: Olive RTN drops ``lm_head.*`` when the head is tied. When the
     head is **quantized**, no ``lm_head`` weights are produced here — the model
@@ -751,9 +761,27 @@ def preprocess_olive_weights(
     blob_size = group_size * bits // 8
     result: dict[str, torch.Tensor] = {}
 
+    def _rename(key: str, raw_suffix: str, dotted_name: str) -> str:
+        """Convert an Olive ``<owner>[.weight]{raw_suffix}`` key to ``<owner>.<dotted_name>``.
+
+        Olive's ``pname`` is either the bare ``"weight"`` parameter of an
+        ``nn.Linear``/``nn.Embedding`` (so the raw key carries a redundant
+        ``.weight`` component before the suffix, e.g. ``...gate_proj.weight_qweight``)
+        or a fused MoE parameter with no nested Linear (e.g.
+        ``...experts.gate_up_proj_qweight``). Strip the suffix, drop a
+        trailing ``.weight`` if present, then append ``.<dotted_name>`` so
+        both shapes land on a single canonical ``<owner>.<dotted_name>`` key.
+        """
+        stem = key[: -len(raw_suffix)]
+        if stem.endswith(".weight"):
+            stem = stem[: -len(".weight")]
+        return f"{stem}.{dotted_name}"
+
     for key, value in state_dict.items():
-        if key.endswith("embed_tokens.qweight"):
-            # GatherBlockQuantized consumes the 2-D uint8 table directly.
+        if key.endswith("embed_tokens.weight_qweight"):
+            # GatherBlockQuantized consumes the 2-D uint8 table directly, so
+            # this keeps the ``qweight`` name (unlike MatMulNBits linears,
+            # which rename to ``weight`` below).
             if value.dtype != torch.uint8:
                 raise ValueError(
                     f"Olive embedding qweight must be uint8 for {key}, got {value.dtype}"
@@ -763,16 +791,16 @@ def preprocess_olive_weights(
                     f"Olive embedding qweight packed dimension for {key} "
                     f"({value.shape[-1]}) must be divisible by blob_size ({blob_size})"
                 )
-            result[key] = value.contiguous()
-        elif key.endswith("embed_tokens.qzeros"):
+            result[key[: -len("weight_qweight")] + "qweight"] = value.contiguous()
+        elif key.endswith("embed_tokens.weight_qzeros"):
             if value.dtype != torch.uint8:
                 raise ValueError(
                     f"Olive embedding qzeros must be uint8 for {key}, got {value.dtype}"
                 )
-            result[key.replace(".qzeros", ".zero_points")] = value.contiguous()
-        elif key.endswith("embed_tokens.scales"):
-            result[key] = value
-        elif key.endswith(".qweight"):
+            result[key[: -len("weight_qzeros")] + "zero_points"] = value.contiguous()
+        elif key.endswith("embed_tokens.weight_scales"):
+            result[key[: -len("weight_scales")] + "scales"] = value
+        elif key.endswith("_qweight"):
             if value.dtype != torch.uint8:
                 raise ValueError(f"Olive qweight must be uint8 for {key}, got {value.dtype}")
             if value.shape[-1] % blob_size != 0:
@@ -780,17 +808,20 @@ def preprocess_olive_weights(
                     f"Olive qweight packed dimension for {key} ({value.shape[-1]}) "
                     f"must be divisible by blob_size ({blob_size})"
                 )
-            new_key = key.replace(".qweight", ".weight")
+            new_key = _rename(key, "_qweight", "weight")
             # Preserve all leading dims so fused expert-major tensors
             # ``[E, N, packed_K]`` reshape to ``[E, N, n_blocks, blob_size]``
             # for the QMoE repacker; 2-D linears ``[N, packed_K]`` are
             # unchanged (``[N, n_blocks, blob_size]``).
             result[new_key] = value.reshape(*value.shape[:-1], -1, blob_size).contiguous()
-        elif key.endswith(".qzeros"):
+        elif key.endswith("_qzeros"):
             if value.dtype != torch.uint8:
                 raise ValueError(f"Olive qzeros must be uint8 for {key}, got {value.dtype}")
-            new_key = key.replace(".qzeros", ".zero_points")
+            new_key = _rename(key, "_qzeros", "zero_points")
             result[new_key] = value.contiguous()
+        elif key.endswith("_scales"):
+            new_key = _rename(key, "_scales", "scales")
+            result[new_key] = value
         else:
             result[key] = value
 

--- a/src/mobius/_weight_utils.py
+++ b/src/mobius/_weight_utils.py
@@ -778,7 +778,25 @@ def preprocess_olive_weights(
         return f"{stem}.{dotted_name}"
 
     for key, value in state_dict.items():
-        if key.endswith("embed_tokens.weight_qweight"):
+        is_embed_qweight = key.endswith("embed_tokens.weight_qweight")
+        is_embed_qzeros = key.endswith("embed_tokens.weight_qzeros")
+        is_embed_scales = key.endswith("embed_tokens.weight_scales")
+        if (
+            is_embed_qweight or is_embed_qzeros or is_embed_scales
+        ) and not quantize_embeddings:
+            # These Olive keys only exist when the embedding table itself was
+            # quantized; ``quantize_embeddings=False`` means the caller
+            # expects a float embedding, so a packed embedding key showing up
+            # anyway indicates a caller/config mismatch rather than a case to
+            # silently reroute through the generic Linear renaming below
+            # (which would wrongly 3-D reshape ``qweight`` and break
+            # ``GatherBlockQuantized``'s 2-D contract).
+            raise ValueError(
+                f"Found packed embedding quantization key {key!r} but "
+                "quantize_embeddings=False; the caller's quantize_embeddings "
+                "flag doesn't match the state dict."
+            )
+        if is_embed_qweight and quantize_embeddings:
             # GatherBlockQuantized consumes the 2-D uint8 table directly, so
             # this keeps the ``qweight`` name (unlike MatMulNBits linears,
             # which rename to ``weight`` below).
@@ -792,13 +810,13 @@ def preprocess_olive_weights(
                     f"({value.shape[-1]}) must be divisible by blob_size ({blob_size})"
                 )
             result[key[: -len("weight_qweight")] + "qweight"] = value.contiguous()
-        elif key.endswith("embed_tokens.weight_qzeros"):
+        elif is_embed_qzeros and quantize_embeddings:
             if value.dtype != torch.uint8:
                 raise ValueError(
                     f"Olive embedding qzeros must be uint8 for {key}, got {value.dtype}"
                 )
             result[key[: -len("weight_qzeros")] + "zero_points"] = value.contiguous()
-        elif key.endswith("embed_tokens.weight_scales"):
+        elif is_embed_scales and quantize_embeddings:
             result[key[: -len("weight_scales")] + "scales"] = value
         elif key.endswith("_qweight"):
             if value.dtype != torch.uint8:

--- a/src/mobius/_weight_utils_test.py
+++ b/src/mobius/_weight_utils_test.py
@@ -574,21 +574,43 @@ class TestPreprocessOliveWeights:
 
     def test_qweight_renamed_and_reshaped_to_matmulnbits_weight(self):
         sd = {
-            "q_proj.qweight": torch.randint(0, 255, (self.N, self.PACKED_K), dtype=torch.uint8)
+            "q_proj.weight_qweight": torch.randint(
+                0, 255, (self.N, self.PACKED_K), dtype=torch.uint8
+            )
         }
 
         result = preprocess_olive_weights(sd, bits=self.BITS, group_size=self.GROUP_SIZE)
 
         assert "q_proj.weight" in result
-        assert "q_proj.qweight" not in result
+        assert "q_proj.weight_qweight" not in result
         assert result["q_proj.weight"].shape == (self.N, self.N_BLOCKS, self.BLOB_SIZE)
         assert result["q_proj.weight"].dtype == torch.uint8
+
+    def test_fused_moe_qweight_renamed_and_reshaped(self):
+        """Fused MoE expert params (no nested ``.weight``) get ``.weight`` appended."""
+        num_experts = 4
+        sd = {
+            "mlp.experts.gate_up_proj_qweight": torch.randint(
+                0, 255, (num_experts, self.N, self.PACKED_K), dtype=torch.uint8
+            )
+        }
+
+        result = preprocess_olive_weights(sd, bits=self.BITS, group_size=self.GROUP_SIZE)
+
+        assert "mlp.experts.gate_up_proj.weight" in result
+        assert "mlp.experts.gate_up_proj_qweight" not in result
+        assert result["mlp.experts.gate_up_proj.weight"].shape == (
+            num_experts,
+            self.N,
+            self.N_BLOCKS,
+            self.BLOB_SIZE,
+        )
 
     def test_scales_orientation_is_preserved(self):
         scales = torch.randn(self.N, self.N_BLOCKS)
 
         result = preprocess_olive_weights(
-            {"q_proj.scales": scales}, bits=self.BITS, group_size=self.GROUP_SIZE
+            {"q_proj.weight_scales": scales}, bits=self.BITS, group_size=self.GROUP_SIZE
         )
 
         assert result["q_proj.scales"] is scales
@@ -597,11 +619,11 @@ class TestPreprocessOliveWeights:
         qzeros = torch.randint(0, 255, (self.N, self.N_BLOCKS // 2), dtype=torch.uint8)
 
         result = preprocess_olive_weights(
-            {"q_proj.qzeros": qzeros}, bits=self.BITS, group_size=self.GROUP_SIZE
+            {"q_proj.weight_qzeros": qzeros}, bits=self.BITS, group_size=self.GROUP_SIZE
         )
 
         assert "q_proj.zero_points" in result
-        assert "q_proj.qzeros" not in result
+        assert "q_proj.weight_qzeros" not in result
         assert torch.equal(result["q_proj.zero_points"], qzeros)
 
     def test_non_quantized_keys_pass_through(self):
@@ -615,7 +637,9 @@ class TestPreprocessOliveWeights:
 
     def test_non_uint8_qweight_raises(self):
         sd = {
-            "q_proj.qweight": torch.randint(0, 255, (self.N, self.PACKED_K), dtype=torch.int32)
+            "q_proj.weight_qweight": torch.randint(
+                0, 255, (self.N, self.PACKED_K), dtype=torch.int32
+            )
         }
 
         with pytest.raises(ValueError, match="Olive qweight must be uint8"):
@@ -623,7 +647,7 @@ class TestPreprocessOliveWeights:
 
     def test_non_uint8_qzeros_raises(self):
         sd = {
-            "q_proj.qzeros": torch.randint(
+            "q_proj.weight_qzeros": torch.randint(
                 0, 255, (self.N, self.N_BLOCKS // 2), dtype=torch.int32
             )
         }
@@ -635,10 +659,10 @@ class TestPreprocessOliveWeights:
     V = 64  # vocab size for embedding tests
 
     def test_embed_qweight_kept_2d(self):
-        """embed_tokens.qweight targets GatherBlockQuantized: keep 2-D uint8."""
+        """embed_tokens.weight_qweight targets GatherBlockQuantized: keep 2-D uint8."""
         qweight = torch.randint(0, 255, (self.V, self.PACKED_K), dtype=torch.uint8)
         result = preprocess_olive_weights(
-            {"model.embed_tokens.qweight": qweight},
+            {"model.embed_tokens.weight_qweight": qweight},
             bits=self.BITS,
             group_size=self.GROUP_SIZE,
             quantize_embeddings=True,
@@ -650,17 +674,17 @@ class TestPreprocessOliveWeights:
     def test_embed_qzeros_renamed_to_zero_points(self):
         qzeros = torch.randint(0, 255, (self.V, self.N_BLOCKS // 2), dtype=torch.uint8)
         result = preprocess_olive_weights(
-            {"model.embed_tokens.qzeros": qzeros},
+            {"model.embed_tokens.weight_qzeros": qzeros},
             bits=self.BITS,
             group_size=self.GROUP_SIZE,
             quantize_embeddings=True,
         )
         assert "model.embed_tokens.zero_points" in result
-        assert "model.embed_tokens.qzeros" not in result
+        assert "model.embed_tokens.weight_qzeros" not in result
 
     def test_embed_non_uint8_qweight_raises(self):
         sd = {
-            "model.embed_tokens.qweight": torch.randint(
+            "model.embed_tokens.weight_qweight": torch.randint(
                 0, 255, (self.V, self.PACKED_K), dtype=torch.int32
             )
         }
@@ -669,7 +693,7 @@ class TestPreprocessOliveWeights:
 
     def test_embed_non_uint8_qzeros_raises(self):
         sd = {
-            "model.embed_tokens.qzeros": torch.randint(
+            "model.embed_tokens.weight_qzeros": torch.randint(
                 0, 255, (self.V, self.N_BLOCKS // 2), dtype=torch.int32
             )
         }
@@ -688,9 +712,9 @@ class TestPreprocessOliveWeights:
         qzeros = torch.randint(0, 255, (self.V, self.N_BLOCKS // 2), dtype=torch.uint8)
         result = preprocess_olive_weights(
             {
-                "model.embed_tokens.qweight": qweight,
-                "model.embed_tokens.scales": scales,
-                "model.embed_tokens.qzeros": qzeros,
+                "model.embed_tokens.weight_qweight": qweight,
+                "model.embed_tokens.weight_scales": scales,
+                "model.embed_tokens.weight_qzeros": qzeros,
             },
             bits=self.BITS,
             group_size=self.GROUP_SIZE,
@@ -714,13 +738,13 @@ class TestPreprocessOliveWeights:
         assert result["lm_head.weight"] is embed
 
     def test_untied_quantized_lm_head_not_overwritten(self):
-        """A present lm_head.qweight must not be replaced by embed synthesis."""
+        """A present lm_head.weight_qweight must not be replaced by embed synthesis."""
         lm_head = torch.randint(0, 255, (self.V, self.PACKED_K), dtype=torch.uint8)
         embed = torch.randint(0, 255, (self.V, self.PACKED_K), dtype=torch.uint8)
         result = preprocess_olive_weights(
             {
-                "lm_head.qweight": lm_head,
-                "model.embed_tokens.qweight": embed,
+                "lm_head.weight_qweight": lm_head,
+                "model.embed_tokens.weight_qweight": embed,
             },
             bits=self.BITS,
             group_size=self.GROUP_SIZE,

--- a/src/mobius/_weight_utils_test.py
+++ b/src/mobius/_weight_utils_test.py
@@ -689,7 +689,9 @@ class TestPreprocessOliveWeights:
             )
         }
         with pytest.raises(ValueError, match="Olive embedding qweight must be uint8"):
-            preprocess_olive_weights(sd, bits=self.BITS, group_size=self.GROUP_SIZE)
+            preprocess_olive_weights(
+                sd, bits=self.BITS, group_size=self.GROUP_SIZE, quantize_embeddings=True
+            )
 
     def test_embed_non_uint8_qzeros_raises(self):
         sd = {
@@ -698,7 +700,28 @@ class TestPreprocessOliveWeights:
             )
         }
         with pytest.raises(ValueError, match="Olive embedding qzeros must be uint8"):
-            preprocess_olive_weights(sd, bits=self.BITS, group_size=self.GROUP_SIZE)
+            preprocess_olive_weights(
+                sd, bits=self.BITS, group_size=self.GROUP_SIZE, quantize_embeddings=True
+            )
+
+    def test_embed_qweight_with_quantize_embeddings_false_raises(self):
+        """quantize_embeddings=False must not silently accept a packed embedding key.
+
+        Regression test: previously this branch matched on key suffix alone
+        and ignored ``quantize_embeddings`` entirely, so a caller/config
+        mismatch (a packed embedding key present while the caller declares
+        the embedding float) would either sneak through unnoticed or, worse,
+        get incorrectly reshaped/renamed via the generic Linear branch.
+        """
+        sd = {
+            "model.embed_tokens.weight_qweight": torch.randint(
+                0, 255, (self.V, self.PACKED_K), dtype=torch.uint8
+            )
+        }
+        with pytest.raises(ValueError, match="quantize_embeddings=False"):
+            preprocess_olive_weights(
+                sd, bits=self.BITS, group_size=self.GROUP_SIZE, quantize_embeddings=False
+            )
 
     # --- Tied LM head synthesis ---
 

--- a/src/mobius/components/_attention.py
+++ b/src/mobius/components/_attention.py
@@ -467,13 +467,23 @@ class Qwen35Attention(nn.Module):
     - Per-head Q/K RMSNorm with +1 offset (OffsetRMSNorm)
     - Partial RoPE (rotary_embedding_dim < head_dim)
     - Output gating: attn_output * sigmoid(gate)
+
+    Args:
+        config: Architecture configuration.
+        linear_class: Factory callable ``(in_features, out_features, bias=...)``
+            for creating projection layers. Defaults to ``Linear``. Pass a
+            quantized-linear factory (see ``make_quantized_linear_factory``)
+            to emit ``MatMulNBits`` for q/k/v/o projections instead.
     """
 
     def __init__(
         self,
         config: ArchitectureConfig,
+        linear_class: type | None = None,
     ):
         super().__init__()
+        if linear_class is None:
+            linear_class = Linear
         self.hidden_size = config.hidden_size
         self.head_dim = config.head_dim
         self.num_attention_heads = config.num_attention_heads
@@ -486,22 +496,22 @@ class Qwen35Attention(nn.Module):
         self._rope_interleave = config.rope_interleave
 
         q_dim = self.num_attention_heads * self.head_dim
-        self.q_proj = Linear(
+        self.q_proj = linear_class(
             self.hidden_size,
             q_dim * 2,
             bias=config.attn_qkv_bias,
         )
-        self.k_proj = Linear(
+        self.k_proj = linear_class(
             self.hidden_size,
             self.num_key_value_heads * self.head_dim,
             bias=config.attn_qkv_bias,
         )
-        self.v_proj = Linear(
+        self.v_proj = linear_class(
             self.hidden_size,
             self.num_key_value_heads * self.head_dim,
             bias=config.attn_qkv_bias,
         )
-        self.o_proj = Linear(
+        self.o_proj = linear_class(
             q_dim,
             self.hidden_size,
             bias=config.attn_o_bias,

--- a/src/mobius/components/_gated_deltanet.py
+++ b/src/mobius/components/_gated_deltanet.py
@@ -102,10 +102,23 @@ class GatedDeltaNet(nn.Module):
     The forward pass is a clean sequence of op calls.
 
     The recurrent state replaces the KV cache for these layers.
+
+    Args:
+        config: Architecture configuration.
+        linear_class: Factory callable ``(in_features, out_features, bias=...)``
+            for creating the ``in_proj_qkv``/``in_proj_z``/``in_proj_b``/
+            ``in_proj_a``/``out_proj`` projections. Defaults to ``Linear``.
+            Pass a quantized-linear factory (see
+            ``make_quantized_linear_factory``) to emit ``MatMulNBits`` for
+            these projections instead. ``dt_bias``, ``A_log``, and
+            ``conv1d.weight`` are small recurrent-state parameters and are
+            never quantized regardless of this argument.
     """
 
-    def __init__(self, config: ArchitectureConfig):
+    def __init__(self, config: ArchitectureConfig, linear_class: type | None = None):
         super().__init__()
+        if linear_class is None:
+            linear_class = Linear
         self.hidden_size = config.hidden_size
         self._dtype = config.dtype
         self.num_v_heads = config.linear_num_value_heads
@@ -118,17 +131,17 @@ class GatedDeltaNet(nn.Module):
         self.conv_dim = self.key_dim * 2 + self.value_dim
 
         # QKV projection (fused: Q, K, V in one linear)
-        self.in_proj_qkv = Linear(
+        self.in_proj_qkv = linear_class(
             self.hidden_size,
             self.key_dim * 2 + self.value_dim,
             bias=False,
         )
         # Gating projection (z for silu gating in output norm)
-        self.in_proj_z = Linear(self.hidden_size, self.value_dim, bias=False)
+        self.in_proj_z = linear_class(self.hidden_size, self.value_dim, bias=False)
         # Beta projection (forget gate)
-        self.in_proj_b = Linear(self.hidden_size, self.num_v_heads, bias=False)
+        self.in_proj_b = linear_class(self.hidden_size, self.num_v_heads, bias=False)
         # Alpha projection (decay control)
-        self.in_proj_a = Linear(self.hidden_size, self.num_v_heads, bias=False)
+        self.in_proj_a = linear_class(self.hidden_size, self.num_v_heads, bias=False)
 
         # Causal depthwise Conv1D
         self.conv1d = _DepthwiseConv1d(self.conv_dim, self.conv_kernel_size)
@@ -141,7 +154,7 @@ class GatedDeltaNet(nn.Module):
         self.norm = PostGatedRMSNorm(self.head_v_dim, eps=config.rms_norm_eps)
 
         # Output projection
-        self.out_proj = Linear(self.value_dim, self.hidden_size, bias=False)
+        self.out_proj = linear_class(self.value_dim, self.hidden_size, bias=False)
 
     def forward(
         self,

--- a/src/mobius/components/_moe.py
+++ b/src/mobius/components/_moe.py
@@ -53,7 +53,6 @@ def _flatten_to_2d(op: OpBuilder, tensor: ir.Value) -> ir.Value:
     return op.Reshape(tensor, flat_shape)
 
 
-
 class TopKGate(nn.Module):
     """Standard top-k expert routing gate.
 
@@ -315,7 +314,12 @@ class MoELayer(nn.Module):
     and compatibility path, not the grouped-expert performance representation.
     """
 
-    def __init__(self, config: ArchitectureConfig, gate: nn.Module | None = None):
+    def __init__(
+        self,
+        config: ArchitectureConfig,
+        gate: nn.Module | None = None,
+        linear_class: type | None = None,
+    ):
         super().__init__()
         assert config.num_local_experts is not None
         assert config.num_experts_per_tok is not None
@@ -336,7 +340,17 @@ class MoELayer(nn.Module):
             self.experts = None
             self._init_qmoe_parameters(expert_config)
         else:
-            self.experts = nn.ModuleList([MLP(expert_config) for _ in range(self.num_experts)])
+            # ``linear_class`` also drives the dense loop-over-experts
+            # fallback (e.g. when the quantization config doesn't match the
+            # native QMoE ABI). Without threading it here, this fallback
+            # path would silently lose quantization for every per-expert
+            # MLP even though the caller requested a quantized linear_class.
+            self.experts = nn.ModuleList(
+                [
+                    MLP(expert_config, linear_class=linear_class)
+                    for _ in range(self.num_experts)
+                ]
+            )
 
     def _init_qmoe_parameters(self, expert_config: ArchitectureConfig) -> None:
         quantization = self._qmoe_quantization
@@ -402,7 +416,12 @@ class MoELayer(nn.Module):
         # sparse LM head in gemma4_assistant.py.
         op.builder.push_module(self.gate.name or "gate", type(self.gate).__qualname__)
         try:
-            for param in self.gate.parameters():
+            # ``recurse=False``: mirror ``Module.__call__``'s direct-only
+            # realization. Gate classes are currently leaf modules with no
+            # child modules, but recursing here would double-register any
+            # nested module's parameters under this pushed scope if one were
+            # ever added.
+            for param in self.gate.parameters(recurse=False):
                 param._realize(op.builder)  # pylint: disable=protected-access
             router_probs, router_weights, normalize, output_scale = self.gate.qmoe_routing(
                 op, hidden_states

--- a/src/mobius/components/_moe.py
+++ b/src/mobius/components/_moe.py
@@ -15,6 +15,45 @@ from mobius._configs import ArchitectureConfig, QuantizationConfig
 from mobius.components._mlp import MLP
 
 
+def _interleave_gate_up_rows(
+    op: OpBuilder, tensor: ir.Value, num_experts: int, fc1_out: int
+) -> ir.Value:
+    """Reorder fc1 gate/up rows from HF-concatenated to QMoE-interleaved layout.
+
+    mobius stores ``fc1_*`` parameters chunked as ``[E, 2*inter, ...]`` with
+    the first ``inter`` rows holding the gate projection and the next
+    ``inter`` rows holding the up projection (matching HuggingFace
+    ``experts.gate_up_proj``). ``swiglu_fusion=1`` requires the interleaved
+    layout ``[g_0, u_0, g_1, u_1, ...]`` instead -- it is the only layout the
+    CPU QMoE kernel supports (``contrib_ops/cpu/moe/moe_quantization_cpu.cc``).
+    Reshape/transpose/reshape the row dimension to reorder it; this operates
+    on a constant initializer so ORT folds it away at session load (mirrors
+    the unquantized-MoE interleave in ``gemma4.py``).
+    """
+    half = fc1_out // 2
+    trailing = op.Shape(tensor, start=2)
+    split_shape = op.Concat(op.Constant(value_ints=[num_experts, 2, half]), trailing, axis=0)
+    reshaped = op.Reshape(tensor, split_shape)
+    transposed = op.Transpose(reshaped, perm=[0, 2, 1, 3])
+    merge_shape = op.Concat(op.Constant(value_ints=[num_experts, fc1_out]), trailing, axis=0)
+    return op.Reshape(transposed, merge_shape)
+
+
+def _flatten_to_2d(op: OpBuilder, tensor: ir.Value) -> ir.Value:
+    """Flatten leading (batch, sequence, ...) dims into one, keeping the last.
+
+    QMoE's ``router_probs`` and ``router_weights`` inputs require a strictly
+    2D ``(num_tokens, num_experts)`` shape (unlike ``input``/hidden_states,
+    which accepts 2D or 3D) -- see ``contrib_defs.cc``. Router logits are
+    computed from a possibly-3D ``hidden_states`` (``batch, seq, hidden``),
+    so collapse everything but the last dim.
+    """
+    last_dim = op.Shape(tensor, start=-1)
+    flat_shape = op.Concat(op.Constant(value_ints=[-1]), last_dim, axis=0)
+    return op.Reshape(tensor, flat_shape)
+
+
+
 class TopKGate(nn.Module):
     """Standard top-k expert routing gate.
 
@@ -56,7 +95,10 @@ class TopKGate(nn.Module):
         """
         weight_t = op.Transpose(self.weight, perm=[1, 0])
         router_logits = op.MatMul(hidden_states, weight_t)
-        router_logits = op.Cast(router_logits, to=ir.DataType.FLOAT.value)
+        # QMoE's ``router_probs`` input shares type constraint "T" with
+        # ``input`` (see contrib_defs.cc), so it must match hidden_states'
+        # dtype rather than a fixed float32.
+        router_logits = op.CastLike(router_logits, hidden_states)
         return router_logits, None, True, 1.0
 
 
@@ -92,7 +134,7 @@ class SoftmaxTopKGate(nn.Module):
     def qmoe_routing(self, op: OpBuilder, hidden_states: ir.Value):
         """Return selection and aggregation tensors for QMoE.
 
-        ``router_probs`` (QMoE input 1) is the raw float32 logits and the
+        ``router_probs`` (QMoE input 1) is the raw logits (cast to hidden_states's dtype) and the
         pre-softmaxed probabilities are passed as ``router_weights`` (input
         14). CUDA QMoE ignores ``router_weights`` and applies softmax-top-k on
         ``router_probs``, so feeding logits reproduces ``forward`` exactly
@@ -105,7 +147,10 @@ class SoftmaxTopKGate(nn.Module):
         """
         weight_t = op.Transpose(self.weight, perm=[1, 0])
         router_logits = op.MatMul(hidden_states, weight_t)
-        router_logits = op.Cast(router_logits, to=ir.DataType.FLOAT.value)
+        # QMoE's ``router_probs`` input shares type constraint "T" with
+        # ``input`` (see contrib_defs.cc), so it must match hidden_states'
+        # dtype rather than a fixed float32.
+        router_logits = op.CastLike(router_logits, hidden_states)
         routing_probs = op.Softmax(router_logits, axis=-1)
         return router_logits, routing_probs, self.norm_topk_prob, 1.0
 
@@ -154,7 +199,7 @@ class SigmoidTopKGate(nn.Module):
         """Return selection and aggregation tensors for QMoE.
 
         The sigmoid-activated probabilities are passed as ``router_weights``
-        (QMoE input 14) while the raw float32 logits are passed as
+        (QMoE input 14) while the raw logits (cast to hidden_states's dtype) are passed as
         ``router_probs`` (input 1). CPU QMoE selects the top-k over
         ``router_probs`` (sigmoid is monotonic, so logits give the same
         selection) and gathers ``router_weights`` at the selected experts,
@@ -164,7 +209,10 @@ class SigmoidTopKGate(nn.Module):
         """
         weight_t = op.Transpose(self.weight, perm=[1, 0])
         router_logits = op.MatMul(hidden_states, weight_t)
-        router_logits = op.Cast(router_logits, to=ir.DataType.FLOAT.value)
+        # QMoE's ``router_probs`` input shares type constraint "T" with
+        # ``input`` (see contrib_defs.cc), so it must match hidden_states'
+        # dtype rather than a fixed float32.
+        router_logits = op.CastLike(router_logits, hidden_states)
         routing_probs = op.Sigmoid(router_logits)
         return (
             router_logits,
@@ -298,6 +346,7 @@ class MoELayer(nn.Module):
         block_size = quantization.group_size
         bits = quantization.bits
         fc1_out = 2 * intermediate_size
+        self._fc1_out = fc1_out
         if hidden_size % block_size or intermediate_size % block_size:
             raise ValueError(
                 "QMoE dimensions must be divisible by the quantization group size"
@@ -341,14 +390,48 @@ class MoELayer(nn.Module):
     def _qmoe_forward(self, op: OpBuilder, hidden_states: ir.Value):
         quantization = self._qmoe_quantization
         assert quantization is not None
-        router_probs, router_weights, normalize, output_scale = self.gate.qmoe_routing(
-            op, hidden_states
+        # ``qmoe_routing`` is called directly (not via ``self.gate(op, ...)``)
+        # because it returns multiple routing tensors rather than following
+        # the standard forward() signature. ``Module.__call__`` only realizes
+        # parameters (qualifying their initializer names, e.g.
+        # "<prefix>.gate.weight") for the module actually invoked through
+        # ``__call__`` -- see onnxscript/nn/_module.py -- so bypassing it here
+        # would leave ``self.gate.weight`` registered as a bare, unqualified
+        # "weight" initializer. Manually push the gate's module scope and
+        # realize its parameters first, mirroring the pattern used for the
+        # sparse LM head in gemma4_assistant.py.
+        op.builder.push_module(self.gate.name or "gate", type(self.gate).__qualname__)
+        try:
+            for param in self.gate.parameters():
+                param._realize(op.builder)  # pylint: disable=protected-access
+            router_probs, router_weights, normalize, output_scale = self.gate.qmoe_routing(
+                op, hidden_states
+            )
+        finally:
+            op.builder.pop_module()
+
+        router_probs = _flatten_to_2d(op, router_probs)
+        if router_weights is not None:
+            router_weights = _flatten_to_2d(op, router_weights)
+
+        fc1_experts_weights = _interleave_gate_up_rows(
+            op, self.fc1_experts_weights, self.num_experts, self._fc1_out
+        )
+        fc1_scales = _interleave_gate_up_rows(
+            op, self.fc1_scales, self.num_experts, self._fc1_out
+        )
+        fc1_experts_zero_points = (
+            _interleave_gate_up_rows(
+                op, self.fc1_experts_zero_points, self.num_experts, self._fc1_out
+            )
+            if self.fc1_experts_zero_points is not None
+            else None
         )
         result = op.QMoE(
             hidden_states,
             router_probs,
-            self.fc1_experts_weights,
-            self.fc1_scales,
+            fc1_experts_weights,
+            fc1_scales,
             None,
             self.fc2_experts_weights,
             self.fc2_scales,
@@ -356,7 +439,7 @@ class MoELayer(nn.Module):
             None,
             None,
             None,
-            self.fc1_experts_zero_points,
+            fc1_experts_zero_points,
             self.fc2_experts_zero_points,
             None,
             router_weights,
@@ -365,7 +448,7 @@ class MoELayer(nn.Module):
             k=self.top_k,
             expert_weight_bits=quantization.bits,
             block_size=quantization.group_size,
-            swiglu_fusion=2,
+            swiglu_fusion=1,
             quant_type="int",
             weights_prepacked=0,
             _domain="com.microsoft",

--- a/src/mobius/components/_moe_test.py
+++ b/src/mobius/components/_moe_test.py
@@ -301,12 +301,12 @@ class TestMoELayer:
         fc2_zp = torch.randint(0, 16, (num_experts, hidden_size, fc2_blocks))
 
         raw = {
-            "model.layers.1.mlp.experts.gate_up_proj.qweight": _to_olive_qweight(fc1_codes),
-            "model.layers.1.mlp.experts.gate_up_proj.scales": fc1_scales,
-            "model.layers.1.mlp.experts.gate_up_proj.qzeros": _to_olive_qzeros(fc1_zp),
-            "model.layers.1.mlp.experts.down_proj.qweight": _to_olive_qweight(fc2_codes),
-            "model.layers.1.mlp.experts.down_proj.scales": fc2_scales,
-            "model.layers.1.mlp.experts.down_proj.qzeros": _to_olive_qzeros(fc2_zp),
+            "model.layers.1.mlp.experts.gate_up_proj_qweight": _to_olive_qweight(fc1_codes),
+            "model.layers.1.mlp.experts.gate_up_proj_scales": fc1_scales,
+            "model.layers.1.mlp.experts.gate_up_proj_qzeros": _to_olive_qzeros(fc1_zp),
+            "model.layers.1.mlp.experts.down_proj_qweight": _to_olive_qweight(fc2_codes),
+            "model.layers.1.mlp.experts.down_proj_scales": fc2_scales,
+            "model.layers.1.mlp.experts.down_proj_qzeros": _to_olive_qzeros(fc2_zp),
         }
         packed = pack_qmoe_expert_weights(
             preprocess_olive_weights(raw, bits=4, group_size=block_size),

--- a/src/mobius/components/_moe_test.py
+++ b/src/mobius/components/_moe_test.py
@@ -98,6 +98,27 @@ class TestMoELayer:
         layer = MoELayer(config)
         assert len(layer.experts) == 8
 
+    def test_moe_layer_linear_class_used_for_dense_expert_fallback(self):
+        # When the config doesn't match the native QMoE ABI (e.g. no
+        # quantization here), MoELayer falls back to per-expert dense MLPs.
+        # linear_class must be threaded through to that fallback, not just
+        # to the fused QMoE path -- otherwise quantized dense-fallback
+        # experts would silently lose quantization.
+        from mobius.components._common import Linear
+
+        created = []
+
+        class TrackingLinear(Linear):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                created.append(self)
+
+        config = make_config(num_local_experts=4, num_experts_per_tok=2)
+        layer = MoELayer(config, linear_class=TrackingLinear)
+        assert layer.experts is not None
+        assert len(created) > 0
+        assert all(isinstance(p, TrackingLinear) for p in created)
+
     def test_moe_layer_forward(self):
         config = make_config(num_local_experts=4, num_experts_per_tok=2)
         layer = MoELayer(config)

--- a/src/mobius/components/_moe_test.py
+++ b/src/mobius/components/_moe_test.py
@@ -158,7 +158,7 @@ class TestMoELayer:
         qmoe = qmoe_nodes[0]
         assert qmoe.attributes["k"].value == 6
         assert qmoe.attributes["block_size"].value == 32
-        assert qmoe.attributes["swiglu_fusion"].value == 2
+        assert qmoe.attributes["swiglu_fusion"].value == 1
         assert qmoe.attributes["expert_weight_bits"].value == 4
         assert qmoe.attributes["quant_type"].value == "int"
         assert qmoe.attributes["weights_prepacked"].value == 0
@@ -210,7 +210,7 @@ class TestMoELayer:
         qmoe = qmoe_nodes[0]
         assert qmoe.attributes["k"].value == 6
         assert qmoe.attributes["block_size"].value == 32
-        assert qmoe.attributes["swiglu_fusion"].value == 2
+        assert qmoe.attributes["swiglu_fusion"].value == 1
         assert qmoe.attributes["quant_type"].value == "int"
         assert qmoe.attributes["weights_prepacked"].value == 0
         assert layer.fc1_experts_weights.shape == ir.Shape([64, 64, 32])

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -1009,13 +1009,26 @@ def _write_genai_config(
     # shared buffer. Introspect the graph: if there is at least one GQA
     # node, the model supports shared-buffer mode; otherwise force it off
     # regardless of the EP capability flag.
+    #
+    # ``com.microsoft.LinearAttention`` (linear/recurrent-attention layers,
+    # e.g. Qwen3.5's GatedDeltaNet) is a separate, *mandatory* case: its
+    # recurrent state requires ``past_present_share_buffer=True`` regardless
+    # of whether any other layer uses GQA (ORT GenAI raises "RecurrentState
+    # requires past_present_share_buffer=true" otherwise). Hybrid models mix
+    # LinearAttention layers with standard (non-GQA) ``Attention`` layers, so
+    # this flag must win over the "no GQA" default-off heuristic above.
     decoder_model = pkg.get(decoder_key)
     supports_in_place_kv_cache: bool | None = None
     if decoder_model is not None:
-        supports_in_place_kv_cache = any(
+        has_gqa = any(
             node.op_type == "GroupQueryAttention" and node.domain == "com.microsoft"
             for node in decoder_model.graph
         )
+        has_recurrent_state = any(
+            node.op_type == "LinearAttention" and node.domain == "com.microsoft"
+            for node in decoder_model.graph
+        )
+        supports_in_place_kv_cache = has_gqa or has_recurrent_state
 
     generator = GenaiConfigGenerator.from_config(
         config,

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -1014,9 +1014,21 @@ def _write_genai_config(
     # e.g. Qwen3.5's GatedDeltaNet) is a separate, *mandatory* case: its
     # recurrent state requires ``past_present_share_buffer=True`` regardless
     # of whether any other layer uses GQA (ORT GenAI raises "RecurrentState
-    # requires past_present_share_buffer=true" otherwise). Hybrid models mix
-    # LinearAttention layers with standard (non-GQA) ``Attention`` layers, so
-    # this flag must win over the "no GQA" default-off heuristic above.
+    # requires past_present_share_buffer=true" otherwise).
+    #
+    # Hybrid models mix LinearAttention layers with full-attention layers,
+    # which may lower to GQA *or* to the standard (non-GQA) ``Attention`` op
+    # depending on EP/dtype (e.g. the CPU EP only lowers to GQA for fp32;
+    # fp16 falls back to standard Attention -- see ``_execution_providers.py``
+    # ``gqa_dtypes``). If a hybrid graph has LinearAttention but its
+    # full-attention layers are still standard (non-GQA) Attention, forcing
+    # ``past_present_share_buffer=True`` produces an unrunnable config: the
+    # recurrent state requires it, but standard Attention's dynamic-shape KV
+    # concat cannot honor a pre-allocated shared buffer, which fails at
+    # generation time with an ``attn_mask``/``total_sequence_length``
+    # mismatch rather than at load time. Rather than silently emit a broken
+    # config, raise a clear error so the caller picks an EP/dtype combination
+    # (e.g. fp32 on CPU) that lowers full attention to GQA.
     decoder_model = pkg.get(decoder_key)
     supports_in_place_kv_cache: bool | None = None
     if decoder_model is not None:
@@ -1028,6 +1040,21 @@ def _write_genai_config(
             node.op_type == "LinearAttention" and node.domain == "com.microsoft"
             for node in decoder_model.graph
         )
+        has_standard_attention = any(
+            node.op_type == "Attention" and node.domain in ("", "ai.onnx")
+            for node in decoder_model.graph
+        )
+        if has_recurrent_state and has_standard_attention and not has_gqa:
+            raise ValueError(
+                "This decoder graph mixes com.microsoft.LinearAttention "
+                "(recurrent state, requires past_present_share_buffer=True) "
+                "with standard (non-GQA) Attention (incompatible with "
+                "past_present_share_buffer=True), and no GroupQueryAttention "
+                "node was found. This EP/dtype combination cannot produce a "
+                "runnable genai_config -- pick an EP/dtype that lowers full "
+                "attention to GroupQueryAttention instead (e.g. fp32 on the "
+                "CPU EP)."
+            )
         supports_in_place_kv_cache = has_gqa or has_recurrent_state
 
     generator = GenaiConfigGenerator.from_config(

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -1044,16 +1044,21 @@ def _write_genai_config(
             node.op_type == "Attention" and node.domain in ("", "ai.onnx")
             for node in decoder_model.graph
         )
-        if has_recurrent_state and has_standard_attention and not has_gqa:
+        if has_recurrent_state and has_standard_attention:
+            # A GQA node elsewhere in the graph does NOT make a co-existing
+            # standard Attention node compatible with a shared buffer --
+            # each op instance is independently (in)compatible, so this
+            # must reject on the mere presence of standard Attention, not
+            # only when GQA is completely absent (partial GQA fusion still
+            # leaves the unfused standard Attention layers broken).
             raise ValueError(
                 "This decoder graph mixes com.microsoft.LinearAttention "
                 "(recurrent state, requires past_present_share_buffer=True) "
                 "with standard (non-GQA) Attention (incompatible with "
-                "past_present_share_buffer=True), and no GroupQueryAttention "
-                "node was found. This EP/dtype combination cannot produce a "
-                "runnable genai_config -- pick an EP/dtype that lowers full "
-                "attention to GroupQueryAttention instead (e.g. fp32 on the "
-                "CPU EP)."
+                "past_present_share_buffer=True). This EP/dtype combination "
+                "cannot produce a runnable genai_config -- pick an EP/dtype "
+                "that lowers *all* full-attention layers to "
+                "GroupQueryAttention instead (e.g. fp32 on the CPU EP)."
             )
         supports_in_place_kv_cache = has_gqa or has_recurrent_state
 

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -2234,6 +2234,93 @@ class TestPixtralGenaiConfig:
         assert data["model"]["image_token_id"] == 10
 
 
+class TestHybridAttentionShareBufferGuard:
+    """Tests for the LinearAttention/GQA past_present_share_buffer guard.
+
+    See the comment above ``supports_in_place_kv_cache`` in
+    ``_write_genai_config``: recurrent-state layers (LinearAttention)
+    mandate ``past_present_share_buffer=True``, but standard (non-GQA)
+    Attention is incompatible with it. A hybrid graph with both, and no
+    GQA node to lower the standard Attention layers to, must raise a clear
+    build-time error rather than silently emit a broken config.
+    """
+
+    @staticmethod
+    def _make_pkg(node_op_types: list[tuple[str, str]]):
+        """Build a fake decoder pkg whose graph has the given (op_type, domain) nodes."""
+        import dataclasses
+
+        from mobius._model_package import ModelPackage
+
+        @dataclasses.dataclass
+        class FakeConfig:
+            model_type: str = "qwen35_moe"
+            vocab_size: int = 256
+            hidden_size: int = 64
+            num_hidden_layers: int = 2
+            num_attention_heads: int = 4
+            num_key_value_heads: int = 2
+            head_dim: int = 16
+            max_position_embeddings: int = 128
+
+        nodes = [
+            ir.Node(op_type=op_type, domain=domain, inputs=[], num_outputs=1)
+            for op_type, domain in node_op_types
+        ]
+        graph = ir.Graph(
+            inputs=[ir.Value(name="input_ids")],
+            outputs=[ir.Value(name="logits")],
+            nodes=nodes,
+            name="decoder",
+        )
+        decoder = ir.Model(graph, ir_version=10)
+        return ModelPackage({"model": decoder}, config=FakeConfig())
+
+    def _write(self, pkg, tmp_path):
+        return _write_genai_config(
+            pkg.config,
+            str(tmp_path),
+            pkg=pkg,
+            ort_model_type="qwen35_moe",
+            ep="cpu",
+            context_length=4096,
+            bos_token_id=1,
+            eos_token_id=2,
+            pad_token_id=0,
+            is_vlm=False,
+            has_speech=False,
+        )
+
+    def test_recurrent_state_with_standard_attention_and_no_gqa_raises(self, tmp_path):
+        """LinearAttention + standard Attention + no GQA is an unrunnable config."""
+        pkg = self._make_pkg(
+            [("LinearAttention", "com.microsoft"), ("Attention", "")],
+        )
+        with pytest.raises(ValueError, match="past_present_share_buffer"):
+            self._write(pkg, tmp_path)
+
+    def test_recurrent_state_with_gqa_does_not_raise(self, tmp_path):
+        """LinearAttention + GQA (no standard Attention) is a valid hybrid config."""
+        pkg = self._make_pkg(
+            [
+                ("LinearAttention", "com.microsoft"),
+                ("GroupQueryAttention", "com.microsoft"),
+            ],
+        )
+        path = self._write(pkg, tmp_path)
+        with open(path) as f:
+            data = json.load(f)
+        assert data["search"]["past_present_share_buffer"] is True
+
+    def test_recurrent_state_only_does_not_raise(self, tmp_path):
+        """LinearAttention with no full-attention layers at all is unaffected."""
+        pkg = self._make_pkg([("LinearAttention", "com.microsoft")])
+        path = self._write(pkg, tmp_path)
+        with open(path) as f:
+            data = json.load(f)
+        assert data["search"]["past_present_share_buffer"] is True
+
+
 class TestGraphInputNames:
     """Tests for _graph_input_names() helper."""
 

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -2312,6 +2312,26 @@ class TestHybridAttentionShareBufferGuard:
             data = json.load(f)
         assert data["search"]["past_present_share_buffer"] is True
 
+    def test_recurrent_state_with_standard_attention_and_gqa_raises(self, tmp_path):
+        """Partial GQA fusion still leaves an incompatible standard Attention node.
+
+        Regression test: the guard previously read
+        ``has_recurrent_state and has_standard_attention and not has_gqa``, so
+        a GQA node present *anywhere* in the graph would short-circuit the
+        check even though a separate, unfused standard Attention node
+        coexists. A GQA node on one layer doesn't make a standard Attention
+        node on another layer safe for ``past_present_share_buffer=True``.
+        """
+        pkg = self._make_pkg(
+            [
+                ("LinearAttention", "com.microsoft"),
+                ("GroupQueryAttention", "com.microsoft"),
+                ("Attention", ""),
+            ],
+        )
+        with pytest.raises(ValueError, match="past_present_share_buffer"):
+            self._write(pkg, tmp_path)
+
     def test_recurrent_state_only_does_not_raise(self, tmp_path):
         """LinearAttention with no full-attention layers at all is unaffected."""
         pkg = self._make_pkg([("LinearAttention", "com.microsoft")])

--- a/src/mobius/models/deepseek.py
+++ b/src/mobius/models/deepseek.py
@@ -110,9 +110,14 @@ class DeepSeekMoEGate(nn.Module):
     def qmoe_routing(self, op: OpBuilder, hidden_states: ir.Value):
         """Return distinct expert-selection and aggregation scores for QMoE."""
         scores, scores_for_choice = self._routing_scores(op, hidden_states)
+        # QMoE's router_probs/router_weights inputs share type constraint "T"
+        # with hidden_states (see contrib_defs.cc). _routing_scores computes
+        # in float32 for numerical stability (matching HF's fp32 routing), so
+        # cast back to hidden_states' dtype before returning -- otherwise
+        # QMoE rejects a fp16/bf16 model with a mismatched-T type error.
         return (
-            scores_for_choice,
-            scores,
+            op.CastLike(scores_for_choice, hidden_states),
+            op.CastLike(scores, hidden_states),
             self.norm_topk_prob,
             float(self.routed_scaling_factor),
         )

--- a/src/mobius/models/deepseek_test.py
+++ b/src/mobius/models/deepseek_test.py
@@ -10,7 +10,7 @@ import pytest
 from onnxscript import GraphBuilder
 
 from mobius._constants import OPSET_VERSION
-from mobius._testing import make_config
+from mobius._testing import create_test_builder, create_test_input, make_config
 from mobius.models.deepseek import DeepSeekMoEGate, _DeepSeekMoEFFN
 
 
@@ -127,6 +127,38 @@ def test_noaux_tc_supports_single_expert_groups():
 
     assert output is not None
     assert any(node.op_type == "TopK" for node in graph)
+
+
+def test_qmoe_routing_casts_scores_back_to_hidden_states_dtype():
+    """qmoe_routing()'s router_probs/router_weights must match hidden_states' dtype.
+
+    QMoE's contrib-op schema binds router_probs/router_weights to the same
+    type constraint ("T") as hidden_states. _routing_scores() computes in
+    FLOAT32 for numerical stability (matching HF's fp32 routing), so
+    qmoe_routing() must cast the result back to hidden_states' dtype --
+    otherwise a fp16/bf16 model export would hit a QMoE type-mismatch error.
+    """
+    config = make_config(
+        hidden_size=4,
+        num_local_experts=4,
+        num_experts_per_tok=2,
+        n_group=1,
+        topk_group=1,
+        scoring_func="softmax",
+        topk_method="greedy",
+        norm_topk_prob=True,
+        routed_scaling_factor=1.0,
+    )
+    gate = DeepSeekMoEGate(config)
+    builder, op, _graph = create_test_builder()
+    hidden = create_test_input(
+        builder, "hidden", [1, 2, config.hidden_size], ir.DataType.FLOAT16
+    )
+
+    router_probs, router_weights, _normalize, _scale = gate.qmoe_routing(op, hidden)
+
+    assert router_probs.dtype == ir.DataType.FLOAT16
+    assert router_weights.dtype == ir.DataType.FLOAT16
 
 
 def test_grouped_routing_rejects_non_divisible_expert_count():

--- a/src/mobius/models/moe.py
+++ b/src/mobius/models/moe.py
@@ -275,6 +275,13 @@ class Qwen2MoELayer(MoELayer):
 
     Forward: ``routing_output + sigmoid(shared_gate(h)) * shared_expert(h)``
 
+    ``linear_class``, when provided, is used for the shared expert's MLP and
+    gate, and is threaded through to :class:`MoELayer` so it also drives the
+    dense loop-over-experts fallback (used when the config doesn't match the
+    native QMoE ABI). It has no effect on the fused QMoE path, whose
+    quantized parameters are constructed directly by
+    :meth:`MoELayer._init_qmoe_parameters`.
+
     Replicates HuggingFace ``Qwen2MoeSparseMoeBlock``.
     """
 
@@ -284,7 +291,7 @@ class Qwen2MoELayer(MoELayer):
         gate: nn.Module | None = None,
         linear_class: type | None = None,
     ):
-        super().__init__(config, gate=gate)
+        super().__init__(config, gate=gate, linear_class=linear_class)
         assert config.shared_expert_intermediate_size is not None, (
             "Qwen2MoELayer requires config.shared_expert_intermediate_size"
         )

--- a/src/mobius/models/moe.py
+++ b/src/mobius/models/moe.py
@@ -278,16 +278,23 @@ class Qwen2MoELayer(MoELayer):
     Replicates HuggingFace ``Qwen2MoeSparseMoeBlock``.
     """
 
-    def __init__(self, config: ArchitectureConfig, gate: nn.Module | None = None):
+    def __init__(
+        self,
+        config: ArchitectureConfig,
+        gate: nn.Module | None = None,
+        linear_class: type | None = None,
+    ):
         super().__init__(config, gate=gate)
         assert config.shared_expert_intermediate_size is not None, (
             "Qwen2MoELayer requires config.shared_expert_intermediate_size"
         )
+        if linear_class is None:
+            linear_class = Linear
         shared_config = dataclasses.replace(
             config, intermediate_size=config.shared_expert_intermediate_size
         )
-        self.shared_expert = MLP(shared_config)
-        self.shared_expert_gate = Linear(config.hidden_size, 1, bias=False)
+        self.shared_expert = MLP(shared_config, linear_class=linear_class)
+        self.shared_expert_gate = linear_class(config.hidden_size, 1, bias=False)
 
     def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # Routing expert output: top-k weighted sum  [B, S, H]

--- a/src/mobius/models/qwen35.py
+++ b/src/mobius/models/qwen35.py
@@ -395,6 +395,40 @@ class Qwen35MoECausalLMModel(CausalLMModel):
         # instead of un-fusing into per-expert MLPs. Uses the same predicate
         # as MoELayer so the weights and the emitted graph never disagree.
         use_qmoe = _supported_qmoe_quantization(self.config.quantization) is not None
+        if not use_qmoe:
+            # The dense per-expert fallback (MoELayer.experts) only knows how
+            # to consume *unquantized* fused expert tensors -- the split
+            # below un-fuses a bare float [num_experts, ...] tensor into
+            # per-expert nn.Linear-shaped weights. If quantization produced
+            # packed Olive tensors here (suffixed "_qweight"/"_scales"/
+            # "_qzeros", see preprocess_olive_weights) but the quantization
+            # config doesn't match the native QMoE ABI, there is no code path
+            # that splits a *packed* fused expert tensor into per-expert
+            # quantized Linear initializers -- silently falling through would
+            # emit a graph whose per-expert Linear modules request
+            # "experts.N.{gate,up}_proj.weight_qweight" keys that were never
+            # produced, since the packed tensor stays fused under
+            # "experts.gate_up_proj_qweight" instead. Reject explicitly
+            # rather than emit an unloadable graph.
+            packed_expert_keys = [
+                key
+                for key in state_dict
+                if ".mlp.experts." in key
+                and any(key.endswith(suffix) for suffix in ("_qweight", "_scales", "_qzeros"))
+            ]
+            if packed_expert_keys:
+                raise ValueError(
+                    "Quantized MoE expert weights were found "
+                    f"(e.g. {packed_expert_keys[0]!r}) but this quantization "
+                    "config doesn't match the native QMoE ABI "
+                    "(_supported_qmoe_quantization returned None). The dense "
+                    "loop-over-experts fallback only supports unquantized "
+                    "fused expert tensors, not packed quantized ones -- "
+                    "there is no path to un-fuse a packed expert tensor into "
+                    "per-expert quantized Linear initializers. Use a "
+                    "QMoE-ABI-compatible quantization config (see "
+                    "_supported_qmoe_quantization) for MoE models instead."
+                )
         cleaned: dict[str, torch.Tensor] = {}
         for key, value in state_dict.items():
             if key.startswith(("mtp_", "mtp.")):

--- a/src/mobius/models/qwen35.py
+++ b/src/mobius/models/qwen35.py
@@ -388,7 +388,7 @@ class Qwen35MoECausalLMModel(CausalLMModel):
 
             # Unpack fused float expert weights into per-expert tensors for the
             # dense fallback. When ``use_qmoe`` is set the fused quantized
-            # tensors arrive as ``.qweight``/``.scales``/``.qzeros`` (which do
+            # tensors arrive as ``_qweight``/``_scales``/``_qzeros`` (which do
             # not match these suffixes) and are kept expert-major for
             # ``pack_qmoe_expert_weights`` below.
             # HF format: [num_experts, fused_dim, hidden] with gate+up fused

--- a/src/mobius/models/qwen35.py
+++ b/src/mobius/models/qwen35.py
@@ -3,8 +3,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
+import onnx_ir as ir
 import torch
 from onnxscript import OpBuilder, nn
 
@@ -19,6 +18,7 @@ from mobius.components._common import (
 from mobius.components._gated_deltanet import GatedDeltaNet
 from mobius.components._mlp import MLP
 from mobius.components._moe import _supported_qmoe_quantization
+from mobius.components._quantized_linear import make_quantized_linear_factory
 from mobius.components._rms_norm import OffsetRMSNorm
 from mobius.components._rotary_embedding import initialize_rope
 from mobius.models.base import CausalLMModel
@@ -30,12 +30,29 @@ from mobius.models.qwen_vl import (
     split_deepstack_embeds,
 )
 
-if TYPE_CHECKING:
-    import onnx_ir as ir
-
 # ---------------------------------------------------------------------------
 # Qwen3.5 — hybrid linear/full attention
 # ---------------------------------------------------------------------------
+
+
+def _linear_factory(config: ArchitectureConfig) -> type | None:
+    """Build a quantized-linear factory from ``config.quantization``, or None.
+
+    Returns ``None`` (meaning "use plain ``Linear``") when the model is
+    unquantized. Shared by the dense (:class:`Qwen35DecoderLayer`) and MoE
+    (:class:`Qwen35MoEDecoderLayer`) variants so ``self_attn``/``linear_attn``/
+    ``mlp``/``shared_expert`` are all quantized consistently.
+    """
+    quantization = config.quantization
+    if quantization is None or quantization.quant_method == "none":
+        return None
+    zero_point_dtype = config.dtype if quantization.float_zero_point else ir.DataType.UINT8
+    return make_quantized_linear_factory(
+        bits=quantization.bits,
+        block_size=quantization.group_size,
+        has_zero_point=not quantization.sym,
+        zero_point_dtype=zero_point_dtype,
+    )
 
 
 class Qwen35DecoderLayer(nn.Module):
@@ -47,6 +64,12 @@ class Qwen35DecoderLayer(nn.Module):
 
     Both variants use :class:`OffsetRMSNorm` (the *1 + weight* variant)
     for pre-attention and post-attention normalization.
+
+    When ``config.quantization`` is set, ``self_attn``/``linear_attn``/``mlp``
+    projections are built with a quantized-linear factory (see
+    :func:`_linear_factory`) so quantized checkpoints (e.g. Olive
+    RTN/GPTQ) load correctly instead of hitting a dense-vs-packed shape
+    mismatch.
     """
 
     def __init__(self, config: ArchitectureConfig, layer_idx: int):
@@ -55,13 +78,14 @@ class Qwen35DecoderLayer(nn.Module):
         self.layer_type: str = (
             layer_types[layer_idx] if layer_idx < len(layer_types) else "full_attention"
         )
+        linear_class = _linear_factory(config)
 
         if self.layer_type == "linear_attention":
-            self.linear_attn = GatedDeltaNet(config)
+            self.linear_attn = GatedDeltaNet(config, linear_class=linear_class)
         else:
-            self.self_attn = Qwen35Attention(config)
+            self.self_attn = Qwen35Attention(config, linear_class=linear_class)
 
-        self.mlp = MLP(config)
+        self.mlp = MLP(config, linear_class=linear_class)
         self.input_layernorm = OffsetRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = OffsetRMSNorm(
             config.hidden_size, eps=config.rms_norm_eps
@@ -247,11 +271,18 @@ class Qwen35MoEDecoderLayer(Qwen35DecoderLayer):
     Same hybrid DeltaNet/full-attention architecture as
     :class:`Qwen35DecoderLayer`, but replaces the dense MLP with a
     :class:`Qwen35MoEBlock`.
+
+    The routed experts are quantized via the fused ``com.microsoft::QMoE``
+    path (see :class:`~mobius.components._moe.MoELayer`), driven directly
+    by ``config.quantization``. The always-active ``shared_expert``/
+    ``shared_expert_gate`` are not part of that fused op, so they are
+    quantized separately via the same ``linear_class`` factory used for
+    ``self_attn``/``linear_attn``/dense ``mlp`` (see :func:`_linear_factory`).
     """
 
     def __init__(self, config: ArchitectureConfig, layer_idx: int):
         super().__init__(config, layer_idx)
-        self.mlp = Qwen35MoEBlock(config)
+        self.mlp = Qwen35MoEBlock(config, linear_class=_linear_factory(config))
 
 
 class Qwen35MoETextModel(nn.Module):

--- a/src/mobius/models/qwen35_test.py
+++ b/src/mobius/models/qwen35_test.py
@@ -41,21 +41,28 @@ def _moe_config(quantization: QuantizationConfig | None) -> object:
 
 
 def _olive_expert_state_dict() -> dict[str, torch.Tensor]:
-    """Synthetic HF-style fused Olive-quantized MoE expert tensors."""
+    """Synthetic HF-style fused Olive-quantized MoE expert tensors.
+
+    Olive's on-disk suffix convention is an *underscore* suffix directly on
+    the parameter name (``<pname>_qweight``/``_scales``/``_qzeros``), not a
+    dotted one -- see ``olive/common/quant/state_dict.py``. For a fused MoE
+    parameter like ``gate_up_proj`` (no nested ``nn.Linear``), this means
+    ``experts.gate_up_proj_qweight``, not ``experts.gate_up_proj.qweight``.
+    """
     p = "model.language_model.layers.0.mlp."
     return {
-        p + "experts.gate_up_proj.qweight": torch.randint(
+        p + "experts.gate_up_proj_qweight": torch.randint(
             0, 256, (_E, _FC1_OUT, _H * _BITS // 8), dtype=torch.uint8
         ),
-        p + "experts.gate_up_proj.scales": torch.rand(_E, _FC1_OUT, _H // _BLK),
-        p + "experts.gate_up_proj.qzeros": torch.randint(
+        p + "experts.gate_up_proj_scales": torch.rand(_E, _FC1_OUT, _H // _BLK),
+        p + "experts.gate_up_proj_qzeros": torch.randint(
             0, 256, (_E, _FC1_OUT, 1), dtype=torch.uint8
         ),
-        p + "experts.down_proj.qweight": torch.randint(
+        p + "experts.down_proj_qweight": torch.randint(
             0, 256, (_E, _H, _INT * _BITS // 8), dtype=torch.uint8
         ),
-        p + "experts.down_proj.scales": torch.rand(_E, _H, _INT // _BLK),
-        p + "experts.down_proj.qzeros": torch.randint(0, 256, (_E, _H, 1), dtype=torch.uint8),
+        p + "experts.down_proj_scales": torch.rand(_E, _H, _INT // _BLK),
+        p + "experts.down_proj_qzeros": torch.randint(0, 256, (_E, _H, 1), dtype=torch.uint8),
         p + "gate.weight": torch.rand(_E, _H),
     }
 

--- a/src/mobius/models/qwen35_test.py
+++ b/src/mobius/models/qwen35_test.py
@@ -126,3 +126,28 @@ class TestQwen35MoEQMoEExport:
             _INT,
         )
         assert not any("fc1_experts_weights" in k for k in out)
+
+    def test_unsupported_qmoe_quantization_with_packed_experts_raises(self):
+        """Packed quantized expert weights + an unsupported QMoE ABI must raise.
+
+        Regression test: ``group_size=24`` (not a power of two) makes
+        ``_supported_qmoe_quantization`` reject the config, so
+        ``preprocess_weights`` takes the dense-fallback branch. But that
+        branch's fused-tensor unfuser only knows how to split *unquantized*
+        float ``experts.gate_up_proj``/``experts.down_proj`` tensors -- there
+        is no code path that splits packed ``_qweight``/``_scales``/
+        ``_qzeros`` fused-expert tensors into per-expert quantized Linear
+        initializers. Previously this silently fell through to
+        ``cleaned[key] = value`` and produced a graph whose per-expert
+        Linear modules expect keys that were never generated.
+        """
+        config = _moe_config(
+            QuantizationConfig(bits=8, group_size=_BLK, quant_method="olive", sym=False)
+        )
+        model = Qwen35MoECausalLMModel(config)
+        try:
+            model.preprocess_weights(_olive_expert_state_dict())
+        except ValueError as e:
+            assert "QMoE ABI" in str(e)
+        else:
+            raise AssertionError("expected ValueError for unsupported QMoE + packed experts")

--- a/src/mobius/rewrite_rules/_group_query_attention_test.py
+++ b/src/mobius/rewrite_rules/_group_query_attention_test.py
@@ -321,14 +321,20 @@ class TestGroupQueryAttentionRules:
         assert counts.get("GroupQueryAttention", 0) == 0
         assert counts.get("Attention", 0) == num_layers
         for node in (node for node in model.graph if node.op_type == "QMoE"):
+            # router_probs (index 1) and router_weights (index 14) share
+            # QMoE's "T" type constraint with hidden_states, so they are
+            # cast back to the model dtype (FLOAT16 here) after being
+            # computed in FLOAT32 for routing-score numerical stability.
             assert node.inputs[1] is not None
-            assert node.inputs[1].dtype == ir.DataType.FLOAT
+            assert node.inputs[1].dtype == ir.DataType.FLOAT16
+            # fc1_scales/fc2_scales (indices 3, 6) are quantization scale
+            # tensors, independent of the hidden_states/router dtype.
             assert node.inputs[3] is not None
             assert node.inputs[3].dtype == ir.DataType.FLOAT
             assert node.inputs[6] is not None
             assert node.inputs[6].dtype == ir.DataType.FLOAT
             assert node.inputs[14] is not None
-            assert node.inputs[14].dtype == ir.DataType.FLOAT
+            assert node.inputs[14].dtype == ir.DataType.FLOAT16
 
         input_names = [
             value.name


### PR DESCRIPTION
## Summary

Consolidates #491, #493, and #494 into a single PR (closing all three) to
simplify review. This is the full chain of fixes needed to take an
Olive-quantized (RTN, ``moe=true``) Qwen3.5-MoE checkpoint all the way
through ``MobiusBuilder`` export and **actually run** the result with
``onnxruntime-genai`` — not just structurally export it.

Three commits, each independently tested and lint-clean:

### 1. Fix Olive quantized-weight suffix mismatch (was #491)

``preprocess_olive_weights`` matched Olive's dotted quantized-weight suffix
convention (``.qweight``/``.qzeros``/``.scales``), but Olive actually emits
an underscore convention. Fixes weight loading for any Olive-quantized
checkpoint.

### 2. Thread `linear_class` through Qwen3.5 self_attn/linear_attn/shared_expert (was #493, closes #492)

`Qwen35Attention`, `GatedDeltaNet`, and `Qwen2MoELayer` (`shared_expert`/
`shared_expert_gate`) didn't accept a `linear_class` parameter, so
quantization couldn't be threaded into them the way it is for other
components. Added `linear_class` params and a `_linear_factory()` helper in
`qwen35.py` (mirroring `deepseek.py`'s existing pattern), verified against a
tiny Qwen3.5-MoE model with RTN quantization (no `modules_to_not_convert`
exclusions needed).

`qwen3_next.py` (Qwen3-Coder-Next, reusing the same `Qwen35Attention`/
`GatedDeltaNet` components) intentionally not touched — no regression since
`linear_class` defaults to `None`, and its `Qwen3NextMoEBlock` has no QMoE
wiring at all (separate, larger gap, noted as a possible follow-up).

### 3. Fix QMoE routing/layout bugs + genai_config detection (was #494)

Actually loading/running the exported model with `onnxruntime_genai`
(rather than just checking that MobiusBuilder could structurally export it)
surfaced five further bugs, fixed one at a time and re-verified by re-running
inference after each:

- **Router gate weight orphaned as unqualified `"weight"` graph input** —
  `MoELayer._qmoe_forward()` called `self.gate.qmoe_routing()` directly,
  bypassing `Module.__call__`'s parameter-realization step. Fixed by
  manually pushing the gate's module scope first (mirrors the existing
  pattern in `gemma4_assistant.py`).
- **`router_probs` hard-cast to float32** instead of matching
  hidden_states' dtype (QMoE's `router_probs` shares type constraint `T`
  with `input` per `contrib_defs.cc`). Fixed with `CastLike`.
- **`swiglu_fusion=2` (concatenated) unsupported by the CPU QMoE kernel**
  in this ORT build (only `swiglu_fusion=1`, interleaved, works). Fixed by
  reordering fc1 gate/up rows into the interleaved layout via a
  graph-level reshape/transpose/reshape (folded away at session load since
  it operates on a constant initializer), matching the existing pattern
  already used for unquantized MoE in `gemma4.py`.
- **`router_probs`/`router_weights` left 3D** when QMoE requires strictly
  2D. Added `_flatten_to_2d()`.
- **`past_present_share_buffer` auto-detection ignored `LinearAttention`**
  (recurrent state, e.g. Qwen3.5's GatedDeltaNet), defaulting to `False` for
  hybrid models and causing a hard load failure (`RecurrentState requires
  past_present_share_buffer=true`). Fixed by also detecting `LinearAttention`
  nodes.

## Testing

- `pytest` across all affected suites (`qwen35_test.py`,
  `_qwen35_mtp_test.py`, `_attention_test.py`, `_gated_deltanet_test.py`,
  `_moe_test.py`, `_mlp_test.py`, `_weight_utils_test.py`, `deepseek_test.py`,
  `integrations/ort_genai/`) — **381 passed**.
- `ruff check` on all changed files — clean.
- End-to-end: Olive `Rtn(bits=4, group_size=16, sym=true, moe=true)` →
  `MobiusBuilder` export of a tiny Qwen3.5-MoE test model, followed by
  actually loading and generating with `onnxruntime_genai.Model(...)`.
  Execution progressed past each of the 5 QMoE/genai_config bugs above in
  turn as they were fixed, confirming the full weight-loading → QMoE →
  LinearAttention pipeline is now structurally and semantically correct up
  to a separate, unrelated limitation specific to the tiny test model's
  abnormally small `head_dim` (a GQA rotary-cache-size kernel constraint —
  a test-model-scale artifact, not a design bug).

## Not in scope

- `rewrite_rules/_qmoe_fusion.py` has the same `swiglu_fusion=2` +
  float32-router-cast pattern in its dense-fallback-to-QMoE rewrite rule, but
  that module isn't wired into `MobiusBuilder`'s default pipeline, so it's
  left untouched as a possible future follow-up.
- `deepseek.py`'s `qmoe_routing()` does its own float32 upcasting for
  numerical stability, independent of this PR's scope.

Closes #492.