### PR TITLE
Make GGUF imports quantized by default

### DIFF
--- a/.agents/skills/onnx-export-quantization/SKILL.md
+++ b/.agents/skills/onnx-export-quantization/SKILL.md
@@ -96,6 +96,37 @@ output/
 └── genai_config.json
 ```
 
+### Direct GGUF import
+
+Direct GGUF conversion preserves supported quantization by default because the
+usual intent is a quantized ONNX model:
+
+```bash
+mobius build-gguf model.gguf --output output/
+```
+
+The equivalent API call is:
+
+```python
+from mobius import build_from_gguf
+
+package = build_from_gguf("model.gguf")
+```
+
+Use `mobius build-gguf model.gguf --dequantize` or
+`build_from_gguf("model.gguf", keep_quantized=False)` to request a fully float
+model. The older `--keep-quantized` CLI flag remains a compatibility alias for
+the default and must not be combined with `--dequantize`. F32-, F16-, and
+BF16-only GGUFs build through the float path because they have no quantized
+tensors to preserve.
+
+Preservation does not mean every source tensor remains byte-identical. In
+text-only builds, runtime-native IQ/MXFP4 projection blocks can retain their
+bytes. Supported affine blocks are repacked, but the conversion can be lossy
+for source types such as Q4_1 and Q4_K. Multimodal, mixed, or unsupported source
+qtypes may be dequantized and requantized or rejected. Apply the classification
+and acceptance checks below before making preservation claims.
+
 ### Direct GGUF import acceptance
 
 Do not infer a GGUF's quantization from its filename. Presets such as
@@ -110,9 +141,10 @@ Before implementing or claiming a direct conversion:
 3. Compare the layer schedule and tensor shapes with a separately pinned
    official config and safetensors headers. `block_count` may include auxiliary
    MTP/draft blocks rather than decoder backbone layers.
-4. Classify every large tensor as byte-preserved native blocks, lossless affine
-   repacking, or dequantize/requantize. If any large tensor takes the third
-   path, the conversion does **not** preserve the source quantization.
+4. Classify every large tensor as byte-preserved native blocks, affine
+   repacking (lossless or lossy, with numerical validation), or
+   dequantize/requantize. If any large tensor takes the third path, the
+   conversion does **not** preserve the source quantization.
 5. Reject split GGUF shards unless the importer explicitly assembles every
    shard. Reading one shard can build a plausible but incomplete model.
 6. Compare embedded tokenizer special-token IDs and chat template with the

--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -17,7 +17,7 @@ def build_from_gguf(
     *,
     task: str | None = None,
     dtype: str | None = None,
-    keep_quantized: bool = False,
+    keep_quantized: bool = True,
     execution_provider: str = "default",
     mmproj: str | Path | None = None,
     static_cache: bool = False,
@@ -32,7 +32,7 @@ def build_from_gguf(
 | `gguf_path` | `str \| Path` | (required) | Local `.gguf` path or `owner/repo:filename.gguf` Hub reference. |
 | `task` | `str \| None` | `None` | Override the model task (e.g. `"text-generation"`). When `None`, the task is auto-detected from the model type. |
 | `dtype` | `str \| None` | `None` | Override model dtype (e.g. `"f16"`). When `None`, defaults to float32. |
-| `keep_quantized` | `bool` | `False` | Preserve supported affine blocks as `MatMulNBits` and supported IQ/MXFP4 blocks in the onnx-genai native format. A mixed preset may still require dequantization/requantization. |
+| `keep_quantized` | `bool` | `True` | Preserve quantization when present. Supported affine blocks are repacked as `MatMulNBits`; in text-only builds, supported native IQ/MXFP4 projection blocks retain their bytes. Multimodal and mixed presets may require dequantization/requantization. Set to `False` to dequantize all weights. |
 | `execution_provider` | `str` | `"default"` | Target EP for EP-aware graph optimization. |
 | `mmproj` | `str \| Path \| None` | `None` | Optional companion multimodal-projector GGUF. |
 | `static_cache` | `bool` | `False` | Build a fixed-width KV cache when the architecture supports it. |
@@ -47,15 +47,15 @@ def build_from_gguf(
 ```python
 from mobius import build_from_gguf
 
-# Basic conversion (dequantizes to float)
+# Basic conversion preserves supported quantization by default
 pkg = build_from_gguf("llama-3.2-1b-q4_0.gguf")
 pkg.save("output/llama/")
 ```
 
 ```python
-# Preserve quantization (Q4_0/Q4_1/Q8_0 → MatMulNBits)
-pkg = build_from_gguf("llama-3.2-1b-q4_0.gguf", keep_quantized=True)
-pkg.save("output/llama-q4/")
+# Explicitly dequantize every weight to float
+pkg = build_from_gguf("llama-3.2-1b-q4_0.gguf", keep_quantized=False)
+pkg.save("output/llama-float/")
 ```
 
 ```bash
@@ -67,12 +67,16 @@ mobius build-gguf llama-3.2-1b-q4_0.gguf --output output/llama/
 
 1. Reads GGUF metadata to detect architecture and config
 2. Maps GGUF tensor names to HuggingFace weight names
-3. Dequantizes quantized tensors to float (or repacks into MatMulNBits
-   when `keep_quantized=True`)
+3. Preserves supported quantized tensors by default, using repacking,
+   text-only native-block retention, or dequantize/requantize according to the
+   source qtype and build path; `keep_quantized=False` dequantizes every tensor
 4. Applies architecture-specific tensor processors (e.g. Q/K permute)
 5. Builds the ONNX graph using the same pipeline as `build()`
 6. Runs `preprocess_weights()` (HF → ONNX name mapping)
 7. Applies weights to the graph
+
+F32-, F16-, and BF16-only GGUFs use the normal float import path even though
+`keep_quantized=True` is the default: there is no quantization to preserve.
 
 ## Supported GGUF Architectures
 
@@ -136,7 +140,7 @@ hf download $repo $file --revision $revision --local-dir .\nemotron-gguf
 
 # Expected: fail-fast NotImplementedError; no ONNX package is emitted.
 python -m mobius build-gguf ".\nemotron-gguf\$file" `
-  --keep-quantized --ep cpu `
+  --ep cpu `
   --external-data safetensors --output .\nemotron-gguf-onnx
 ```
 

--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -77,6 +77,10 @@ mobius build-gguf llama-3.2-1b-q4_0.gguf --output output/llama/
 
 F32-, F16-, and BF16-only GGUFs use the normal float import path even though
 `keep_quantized=True` is the default: there is no quantization to preserve.
+Quantized GGUFs containing only qtypes with no supported preservation target
+(for example, pure Q6_K or Q5_K weights) fail with an actionable error rather
+than silently becoming float. Pass `keep_quantized=False` to request that float
+conversion explicitly.
 
 ## Supported GGUF Architectures
 

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -291,6 +291,9 @@ mobius build --model Qwen/Qwen2.5-0.5B output_dir/ \
 ## `mobius build-gguf`
 
 Build an ONNX model from a GGUF file (e.g. from llama.cpp).
+Supported GGUF quantization is preserved by default. This can involve
+byte-preserving native blocks in text-only builds, affine repacking, or
+dequantize/requantize for multimodal and mixed source qtypes.
 
 > **Note**: Requires the optional `gguf` package: `pip install mobius-onnx[gguf]`
 
@@ -311,7 +314,8 @@ mobius build-gguf GGUF_PATH [options]
 | Option | Description |
 |--------|-------------|
 | `--output DIR`, `-o DIR` | Output directory. Default: `<gguf_stem>_onnx/`. |
-| `--keep-quantized` | Preserve supported affine blocks as `MatMulNBits` and supported native IQ/MXFP4 blocks. Mixed presets may still require requantization. |
+| `--dequantize` | Explicitly dequantize all GGUF weights to float. |
+| `--keep-quantized` | Deprecated compatibility alias for the default quantization-preserving behavior. Cannot be combined with `--dequantize`. |
 | `--dtype DTYPE` | Target dtype for model weights: `f16`, `bf16`, `f32`. |
 | `--external-data FORMAT` | External data format: `onnx` (default) or `safetensors`. |
 | `--ep EP` | Target execution provider for EP-aware optimization. |
@@ -322,15 +326,18 @@ mobius build-gguf GGUF_PATH [options]
 ### Examples
 
 ```bash
-# Basic GGUF conversion
+# Basic GGUF conversion (preserves supported quantization)
 mobius build-gguf model.gguf --output output/
 
-# Preserve quantization
-mobius build-gguf model.gguf --output output/ --keep-quantized
+# Explicitly dequantize all weights
+mobius build-gguf model.gguf --output output-float/ --dequantize
 
 # Convert with specific dtype
 mobius build-gguf model.gguf --output output/ --dtype f16
 ```
+
+F32-, F16-, and BF16-only files build normally as float models because they
+contain no quantization to preserve.
 
 Sharded GGUF inputs are rejected because a single shard has an incomplete
 tensor table. `nemotron_h_moe` is also rejected until its MTP block, Mamba2

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -338,6 +338,9 @@ mobius build-gguf model.gguf --output output/ --dtype f16
 
 F32-, F16-, and BF16-only files build normally as float models because they
 contain no quantization to preserve.
+Quantized files containing only qtypes with no supported preservation target
+(for example, pure Q6_K or Q5_K weights) fail instead of silently becoming
+float. Re-run with `--dequantize` to request explicit float conversion.
 
 Sharded GGUF inputs are rejected because a single shard has an incomplete
 tensor table. `nemotron_h_moe` is also rejected until its MTP block, Mamba2

--- a/docs/design/gguf-support-proposal.md
+++ b/docs/design/gguf-support-proposal.md
@@ -1,6 +1,6 @@
 # GGUF Support Proposal for mobius
 
-**Status**: Draft — awaiting go/no-go decision
+**Status**: Implemented; exploratory QDQ sections are retained as historical design context
 **Author**: Architect (Agent 029c7dd2)
 **Date**: 2026-02-27
 
@@ -13,13 +13,12 @@ Ollama, LM Studio, etc.). By supporting GGUF import, we let users bring
 quantized community models directly into the ONNX Runtime ecosystem without
 needing to find the original HuggingFace checkpoint.
 
-**Key insight**: We do NOT need to parse or dequantize GGUF weights
-ourselves. HuggingFace Transformers already has full GGUF loading support
-(`AutoModelForCausalLM.from_pretrained(repo, gguf_file=...)`) that
-dequantizes GGUF tensors to fp32 PyTorch state dicts. Our value-add is
-the **second path**: keeping weights quantized using either standard ONNX
-**QDQ** (DequantizeLinear + MatMul) for cross-runtime portability, or
-ORT's **MatMulNBits** for maximum ORT performance (see Section 8).
+**Implemented approach**: Mobius reads GGUF metadata and tensors directly.
+Supported affine weights are repacked for `MatMulNBits`; supported native
+IQ/MXFP4 blocks can remain byte-preserved in text-only builds; multimodal and
+mixed source qtypes can require dequantization/requantization. QDQ alternatives
+discussed in Section 8 are historical design exploration, not a currently
+selectable import format.
 
 ## 1. What is GGUF?
 
@@ -250,28 +249,20 @@ pkg.apply_weights(state_dict)
 
 #### 3.3.1 Quantization Format Mapping
 
-| GGUF Type | ORT Mapping | Approach |
-|-----------|-------------|----------|
-| `F32` | Standard `float32` | Direct copy |
-| `F16` | Standard `float16` | Direct copy |
-| `BF16` | Standard `bfloat16` | Direct copy |
-| `Q8_0` | `MatMulNBits(bits=8, block_size=32)` | Repack: extract scale + int8 data |
-| `Q4_0` | `MatMulNBits(bits=4, block_size=32)` | Repack: symmetric, no zero-point |
-| `Q4_1` | `MatMulNBits(bits=4, block_size=32)` | Repack: asymmetric, has zero-point |
-| `Q5_0` | Dequantize → `float16` | 5-bit not supported by MatMulNBits |
-| `Q5_1` | Dequantize → `float16` | 5-bit not supported by MatMulNBits |
-| `Q4_K` | `MatMulNBits(bits=4, block_size=32)` | Repack sub-blocks; super-block scale applied to sub-scales |
-| `Q5_K` | Dequantize → `float16` | 5-bit not supported |
-| `Q6_K` | Dequantize → `float16` | 6-bit not supported |
-| `Q2_K` | Dequantize → `float16` | 2-bit not supported |
-| `Q3_K` | Dequantize → `float16` | 3-bit not supported |
-| `IQ4_NL` | Dequantize → lookup → `MatMulNBits(4,32)` | Apply lookup table then repack |
-| `IQ4_XS` | Dequantize → lookup → `MatMulNBits(4,256)` | Apply lookup table then repack |
+| GGUF Type | Text-only default | Multimodal default |
+|-----------|-------------------|--------------------|
+| `F32`/`F16`/`BF16` | Float path (BF16 is decoded to float32) | Float path |
+| `Q8_0` | Exact affine repack to `MatMulNBits(8,32)` | Common affine target |
+| `Q4_0` | Exact affine repack to `MatMulNBits(4,32)` with explicit zero-point | Common affine target |
+| `Q4_1` | Affine repack with rounded integer zero-point (lossy) | Common affine target |
+| `Q4_K` | Dequantize/requantize to `MatMulNBits(4,32)` (lossy) | Common affine target |
+| `Q2_K`/`Q3_K`/`Q5_*`/`Q6_K` | Dequantize/requantize when the selected target is supported; otherwise reject | Dequantize/requantize to the common affine target |
+| Supported IQ/MXFP4 native blocks | Retain bytes for `BlockQuantizedMatMul` | Dequantize/requantize to the common affine target |
 
-**Key constraint**: ORT's `MatMulNBits` only supports 4-bit and 8-bit
-quantization. GGUF types that don't map cleanly (Q2_K, Q3_K, Q5_*,
-Q6_K) must be dequantized to fp16. This is a mixed-precision model —
-most layers at 4/8-bit, unsupported layers at fp16.
+**Key constraint**: preserving quantization does not imply preserving every
+source encoding. Only supported native blocks in text-only builds retain their
+bytes; other types are repacked, requantized, or rejected according to the
+selected common target.
 
 #### 3.3.2 Repacking Q4_0 to MatMulNBits
 
@@ -409,26 +400,25 @@ src/mobius/
 ### 4.2 Public API
 
 ```python
-# Phase 1: Dequantize path
 from mobius.integrations.gguf import build_from_gguf
 
+# Default: preserve supported quantization
 pkg = build_from_gguf("path/to/model.gguf")
-# Returns ModelPackage with fp32/fp16 ONNX model
+# Returns quantized ONNX ops when quantized tensors are present
 
-# Phase 2: Quantized path
-pkg = build_from_gguf("path/to/model.gguf", keep_quantized=True)
-# Returns ModelPackage with MatMulNBits ONNX model
+# Explicit float path
+pkg = build_from_gguf("path/to/model.gguf", keep_quantized=False)
+# Returns ModelPackage with fp32/fp16 ONNX model
 ```
 
 ### 4.3 CLI Integration
 
 ```bash
-# Phase 1
-mobius build --gguf path/to/model.gguf --output model.onnx
+# Default: preserve supported quantization
+mobius build-gguf path/to/model.gguf --output model-onnx/
 
-# Phase 2 (preserve quantization)
-mobius build --gguf path/to/model.gguf --keep-quantized \
-    --output model.onnx
+# Explicit float path
+mobius build-gguf path/to/model.gguf --dequantize --output model-float-onnx/
 ```
 
 ### 4.4 Integration with Existing Pipeline
@@ -796,9 +786,9 @@ the fp16/fp32 activation, `B` is the packed uint8 weight blob.
    control), AVX2/AVX512/VNNI CPU kernels. ORT's own quantization
    pipeline (GPTQ, AWQ, RTN) all target MatMulNBits.
 
-3. **Direct GGUF mapping**: Q4_0/Q4_1/Q8_0 block structure maps
-   directly to MatMulNBits' `(N, n_blocks, blob_size)` layout with
-   minimal repacking (extract scale, transpose, repack nibbles).
+3. **GGUF mapping**: Q4_0 and Q8_0 map exactly to MatMulNBits with
+   minimal repacking. Q4_1 uses the same target layout but rounds its
+   effective zero-point and is therefore lossy.
 
 4. **Proven in production**: mobius already uses
    `QuantizedLinear` (our existing component) which emits MatMulNBits.
@@ -821,34 +811,21 @@ the fp16/fp32 activation, `B` is the packed uint8 weight blob.
    runtime-specific checks.
 
 3. **Limited bit-widths**: Only 4 and 8-bit. No 2-bit, 3-bit, 5-bit,
-   6-bit. This means Q2_K, Q3_K, Q5_K, Q6_K GGUF types must all be
-   dequantized even in the "keep quantized" path.
+   6-bit. The importer can dequantize/requantize those source types into a
+   supported common target or reject an unsupported target.
 
 4. **No standard evolution path**: If ONNX standardizes a native fused
    quantized matmul op, MatMulNBits models won't benefit automatically.
    Migration would require graph rewriting.
 
-### 8.5 GGUF Type → ONNX Representation Mapping
+### 8.5 GGUF Type → Implemented ONNX Representation
 
-| GGUF Type | QDQ Mapping | MatMulNBits Mapping | Recommended |
-|---|---|---|---|
-| `F32`/`F16`/`BF16` | N/A (use as-is) | N/A (use as-is) | Standard fp ops |
-| **`Q4_0`** | DQ(int4, scale, block=32) sym | MMNB(bits=4, block=32) sym | **Both work cleanly** |
-| **`Q4_1`** | DQ(uint4, scale+zp, block=32) asym | MMNB(bits=4, block=32) + zp | **Both work cleanly** |
-| **`Q8_0`** | DQ(int8, scale, block=32) sym | MMNB(bits=8, block=32) sym | **Both work cleanly** |
-| `Q5_0`/`Q5_1` | DQ(int8, ...) with 5→8 padding | ❌ Must dequantize | QDQ with int8 or dequantize |
-| `Q4_K` | DQ(int4, flattened_scale, block=32) | MMNB(4,32) + flattened scale | Both lossy, QDQ preferred |
-| `Q5_K` | DQ(int8, flattened_scale, block=32) | ❌ Must dequantize | QDQ with int8 or dequantize |
-| `Q6_K` | DQ(int8, flattened_scale, block=32) | ❌ Must dequantize | QDQ with int8 or dequantize |
-| `Q2_K` | DQ(int4, ...) lossy 2→4 promotion | ❌ Must dequantize | Dequantize to fp16 |
-| `Q3_K` | DQ(int4, ...) lossy 3→4 promotion | ❌ Must dequantize | Dequantize to fp16 |
-| `IQ4_NL` | ❌ Non-linear, no QDQ mapping | ❌ Non-linear | **Dequantize only** |
-| `IQ4_XS` | ❌ Non-linear, no QDQ mapping | ❌ Non-linear | **Dequantize only** |
-
-**Key insight**: Q4_0, Q4_1, and Q8_0 are the only GGUF types that map
-cleanly to _both_ representations. These are also the simplest and most
-common non-K-quant types. Q4_K (the most popular K-quant) requires
-lossy super-block flattening regardless of representation.
+The implemented mapping is summarized in
+[Section 3.3.1](#331-quantization-format-mapping). In particular, Q4_1 rounds
+its effective zero-point, Q4_K uses lossy dequantize/requantize, and supported
+IQ/MXFP4 blocks are byte-retained only for text-only
+`BlockQuantizedMatMul` builds. Multimodal builds normalize quantized text
+projections to a common affine `MatMulNBits` target.
 
 ### 8.6 Limitations of Both Representations
 
@@ -877,51 +854,31 @@ Neither QDQ nor MatMulNBits can natively represent:
    promotion to int8 (wasting storage), but there's no native 5-bit or
    6-bit ONNX type. MatMulNBits doesn't support these at all.
 
-### 8.7 Recommendation: Dual-Path Strategy
+### 8.7 Implemented Direct-Import Policy
 
-We recommend **QDQ as the primary representation** with **MatMulNBits
-as an ORT-specific optimization option**:
+Direct GGUF import preserves supported quantization by default, with an
+explicit fully float path:
 
 ```python
-# Default: portable QDQ model (works everywhere)
-pkg = build_from_gguf("model.gguf", keep_quantized=True)
+# Default: preserve supported quantization
+pkg = build_from_gguf("model.gguf")
 
-# ORT-optimized: MatMulNBits model (best ORT performance)
-pkg = build_from_gguf("model.gguf", keep_quantized=True,
-                       quant_format="matmulnbits")
+# Explicitly dequantize all weights
+pkg = build_from_gguf("model.gguf", keep_quantized=False)
 ```
 
-**Rationale**:
+The quantized path is classified per tensor: supported affine blocks are
+repacked for `MatMulNBits`; in text-only builds, supported native IQ/MXFP4
+projection blocks retain their bytes for `BlockQuantizedMatMul`; and multimodal
+or mixed source qtypes may require dequantization/requantization or produce a
+clear unsupported-layout error. F32-, F16-, and BF16-only files use the float
+path automatically because there is no quantization to preserve.
 
-1. **QDQ first** because portability is the primary value proposition
-   of ONNX. If a user converts GGUF → ONNX but can only run on ORT,
-   we've reduced the value of the conversion (they could use llama.cpp
-   directly). QDQ unlocks TensorRT, OpenVINO, QNN — the real
-   differentiator.
+### 8.8 Historical Alternative: QDQLinear (Not Implemented)
 
-2. **MatMulNBits as opt-in** for users who know they're targeting ORT
-   and want guaranteed fused-kernel performance without relying on EP
-   fusion. This is our existing `QuantizedLinear` component — zero new
-   code for the graph construction side.
-
-3. **Rewrite rule** (future): A `QDQ_to_MatMulNBits` rewrite rule could
-   convert QDQ models to MatMulNBits for ORT deployment, decoupling the
-   "how we represent" question from "how we export." This is consistent
-   with our rewrite rule architecture.
-
-**Implementation impact on Path B phasing**:
-
-| Phase | Path B: Keep Quantized |
-|---|---|
-| Phase 2a | QDQ for Q4_0/Q4_1/Q8_0 (clean mapping, portable) |
-| Phase 2b | MatMulNBits alternative via `quant_format=` flag |
-| Phase 2c | QDQ for Q4_K (flattened super-blocks, lossy but usable) |
-| Phase 3 | Q5_K/Q6_K via QDQ int8 promotion (storage-inefficient) |
-
-### 8.8 New Component: QDQLinear
-
-To support the QDQ path, we need a `QDQLinear` component alongside the
-existing `QuantizedLinear` (MatMulNBits):
+The proposal considered a `QDQLinear` component alongside the existing
+`QuantizedLinear` (MatMulNBits), but direct GGUF import does not currently
+implement or expose this path:
 
 ```python
 class QDQLinear(nn.Module):
@@ -1041,15 +998,15 @@ variant.
 
 ### 8.10 Summary Decision Matrix
 
-| Scenario | Recommended Representation |
+| Scenario | Implemented representation |
 |---|---|
-| GGUF Q4_0/Q8_0 → portable ONNX | **QDQ** (DequantizeLinear + MatMul) |
-| GGUF Q4_0/Q8_0 → ORT-only deployment | **MatMulNBits** (maximum perf) |
-| GGUF Q4_K → any runtime | **QDQ** with flattened scales (lossy) |
-| GGUF Q5_*/Q6_K → any runtime | **Dequantize to fp16** (no clean quantized mapping) |
-| GGUF IQ4_* → any runtime | **Dequantize to fp16** (non-linear) |
-| GPTQ/AWQ models (existing) | **MatMulNBits** (status quo, works well) |
-| New quantization methods | **QDQ first**, MatMulNBits rewrite rule |
+| F32/F16/BF16-only GGUF | Float import path |
+| Q4_0/Q8_0 text-only GGUF | Exact affine repack to `MatMulNBits` |
+| Q4_1 text-only GGUF | Lossy affine repack to `MatMulNBits` |
+| Q4_K or mixed affine GGUF | Dequantize/requantize to a supported common target, or reject |
+| Supported IQ/MXFP4 text-only GGUF | Byte-retained `BlockQuantizedMatMul` |
+| Supported IQ/MXFP4 multimodal text backbone | Dequantize/requantize to common `MatMulNBits` target |
+| `keep_quantized=False` / `--dequantize` | Fully float import path |
 
 ## 9. Risk Analysis
 
@@ -1060,7 +1017,7 @@ variant.
 | K-quant repacking precision loss | Medium | Benchmark perplexity: GGUF-direct vs GGUF→ONNX. Accept if <0.5 PPL increase. |
 | `gguf` package API instability | Low | Pin to `>=0.10.0`, use only stable APIs (`GGUFReader`, `dequantize`). |
 | Architecture coverage gaps | Low | Start with Llama (90% of GGUF models). Add others incrementally. |
-| QDQ INT4 EP fusion gaps | Medium | Benchmark QDQ vs MatMulNBits per-EP; provide `quant_format` flag for user choice. |
+| Runtime support for emitted quantized ops | Medium | Downstream runtimes decide support for `MatMulNBits`, `GatherBlockQuantized`, and `BlockQuantizedMatMul`; Mobius does not add a model/runtime gate. |
 | Tensor permutation bugs | Medium | Validate against HF's GGUF loading (they've battle-tested these transforms). |
 
 ### 9.2 Product Risks

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,7 +96,8 @@ pkg = build("facebook/wav2vec2-base")
 
 ### Build from a GGUF file
 
-Convert a GGUF model (e.g. from llama.cpp) to ONNX:
+Convert a GGUF model (e.g. from llama.cpp) to ONNX. Supported quantization is
+preserved by default:
 
 ```python
 from mobius import build_from_gguf
@@ -110,6 +111,10 @@ Or via CLI:
 ```bash
 mobius build-gguf path/to/model.gguf --output output/model/
 ```
+
+Pass `--dequantize` on the CLI, or `keep_quantized=False` to
+`build_from_gguf()`, when a fully float ONNX model is required. F32-, F16-, and
+BF16-only GGUFs automatically use the float path.
 
 > **Note**: GGUF support requires the optional `gguf` package:
 > `pip install mobius-onnx[gguf]`

--- a/docs/model-catalog.md
+++ b/docs/model-catalog.md
@@ -267,9 +267,11 @@ All decoder-only LLMs and MoE models support quantized weight loading:
 | **AWQ** | HuggingFace (e.g. `-AWQ` suffix models) | `build("TheBloke/Llama-2-7B-AWQ")` |
 | **GGUF** | Local `.gguf` files | `build_from_gguf("model.gguf")` |
 
-GGUF support (Phase 1) dequantizes weights to float before building the
-ONNX graph. Phase 2 (`--keep-quantized`) preserves quantization using
-MatMulNBits ops.
+GGUF import preserves supported quantization by default using affine repacking
+or, for supported text-only inputs, native quantized ops. Multimodal and mixed
+source qtypes can require dequantization/requantization, so this does not imply
+byte preservation for every tensor. Use `--dequantize` for an explicitly float
+model.
 
 ## Summary
 

--- a/examples/hy_mt1_5.py
+++ b/examples/hy_mt1_5.py
@@ -96,7 +96,8 @@ def _build_q1_0(gguf_ref: str, output_dir: Path) -> None:
     # past_present_share_buffer mode cannot be used; mobius's
     # write_ort_genai_config inspects the resulting graph and turns
     # share_buffer off automatically when GQA is absent.
-    pkg = build_from_gguf(gguf_ref, keep_quantized=True, dtype="f32", execution_provider="cpu")
+    # Direct GGUF conversion preserves supported quantization by default.
+    pkg = build_from_gguf(gguf_ref, dtype="f32", execution_provider="cpu")
     pkg.save(str(output_dir))
     write_ort_genai_config(pkg, str(output_dir), hf_model_id=HF_MODEL_ID, ep="cpu")
     print("  genai_config.json + tokenizer files written")

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -514,12 +514,12 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
         )
 
     mmproj_path = getattr(args, "mmproj", None)
+    keep_quantized = not args.dequantize
 
-    if args.keep_quantized:
-        print(
-            "Quantized mode: preserving GGUF quantization as "
-            "MatMulNBits/GatherBlockQuantized..."
-        )
+    if keep_quantized:
+        print("Preserving supported GGUF quantization (float-only inputs stay float)...")
+    else:
+        print("Dequantized mode: converting GGUF weights to float...")
 
     gguf_path = args.gguf_path
     output_dir = args.output or os.path.splitext(gguf_path)[0] + "_onnx"
@@ -536,7 +536,7 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
         gguf_path,
         mmproj=mmproj_path,
         dtype=args.dtype,
-        keep_quantized=args.keep_quantized,
+        keep_quantized=keep_quantized,
         execution_provider=args.execution_provider,
         static_cache=args.static_cache,
         max_seq_len=args.max_seq_len,
@@ -831,12 +831,18 @@ def main(argv: list[str] | None = None) -> None:
             "Currently supports Gemma4 vision; audio is experimental."
         ),
     )
-    gguf_parser.add_argument(
+    quantization_group = gguf_parser.add_mutually_exclusive_group()
+    quantization_group.add_argument(
+        "--dequantize",
+        action="store_true",
+        help="Dequantize all GGUF weights to float instead of preserving quantization.",
+    )
+    quantization_group.add_argument(
         "--keep-quantized",
         action="store_true",
         help=(
-            "Preserve supported projection, output-head, and embedding "
-            "quantization via MatMulNBits/GatherBlockQuantized."
+            "Deprecated compatibility alias; supported GGUF quantization is "
+            "preserved by default."
         ),
     )
     gguf_parser.add_argument(

--- a/src/mobius/integrations/gguf/__init__.py
+++ b/src/mobius/integrations/gguf/__init__.py
@@ -12,6 +12,8 @@ Usage::
 
     # Text-only model
     pkg = build_from_gguf("path/to/model.gguf")
+    # Supported quantization is preserved by default; pass
+    # keep_quantized=False for a fully float model.
 
     # Multimodal (text + companion mmproj vision/audio encoder)
     pkg = build_from_gguf("path/to/model.gguf", mmproj="path/to/mmproj.gguf")

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -4,15 +4,14 @@
 """GGUF → ONNX build pipeline.
 
 Converts ``.gguf`` model files to ONNX using the standard build
-pipeline.  Two modes:
-
-- **Dequantized** (default): All quantized tensors are dequantized to
-  float.  Simple, but loses the compression benefit of quantization.
-- **Quantized** (``keep_quantized=True``): Affine linear-layer weights are
-  repacked into MatMulNBits format and token embeddings into
-  GatherBlockQuantized format. Runtime-supported native IQ/MXFP4 projection
-  blocks are preserved for BlockQuantizedMatMul. Mixed presets such as Q4_K_M are
-  normalized to one affine layout. Other tensors are dequantized.
+pipeline. Quantized preservation is the default: affine linear-layer weights
+are repacked into MatMulNBits format and token embeddings into
+GatherBlockQuantized format. For text-only builds, runtime-supported native
+IQ/MXFP4 projection blocks are preserved for BlockQuantizedMatMul. Multimodal
+text backbones and mixed presets such as Q4_K_M are normalized to one affine
+layout, so not every source tensor is byte-preserved. Other tensors are
+dequantized. Set ``keep_quantized=False`` to dequantize all weights to float
+explicitly.
 """
 
 from __future__ import annotations
@@ -246,7 +245,7 @@ def build_from_gguf(
     *,
     task: str | None = None,
     dtype: str | None = None,
-    keep_quantized: bool = False,
+    keep_quantized: bool = True,
     execution_provider: str = "default",
     mmproj: str | Path | None = None,
     static_cache: bool = False,
@@ -263,9 +262,12 @@ def build_from_gguf(
     7. Run ``preprocess_weights()`` (HF → ONNX name mapping)
     8. Apply weights to the ONNX model
 
-    When *keep_quantized* is ``True``, supported affine tensors are repacked
-    into MatMulNBits format, while runtime-supported native IQ/MXFP4 projection
-    blocks are retained byte-for-byte for BlockQuantizedMatMul.
+    By default, supported affine tensors are repacked into MatMulNBits format.
+    For text-only builds, runtime-supported native IQ/MXFP4 projection blocks
+    are retained byte-for-byte for BlockQuantizedMatMul. Multimodal text
+    backbones normalize quantized projections to a common affine layout. GGUFs
+    containing only F32, F16, or BF16 weights use the float path because there
+    is no quantization to preserve.
 
     Args:
         gguf_path: Path to the ``.gguf`` file, *or* a HuggingFace Hub
@@ -279,9 +281,12 @@ def build_from_gguf(
             model type.
         dtype: Override model dtype (e.g. ``"f16"``). When ``None``,
             defaults to float32.
-        keep_quantized: When ``True``, preserve quantized linear-layer
-            weights in MatMulNBits format. Mixed Q4_K_M source types are
-            normalized to 4-bit, block-32 weights.
+        keep_quantized: Preserve quantization when quantized tensors are
+            present. This is the default. Supported affine blocks are repacked,
+            text-only runtime-supported native IQ/MXFP4 projection blocks
+            retain their bytes, and mixed or multimodal source types can be
+            normalized to a common affine layout. Set to ``False`` to
+            dequantize all weights.
         execution_provider: Target execution provider for EP-aware
             optimisations (e.g. ``"cpu"`` to apply the
             GroupQueryAttention rewrite). Defaults to ``"default"``
@@ -358,6 +363,9 @@ def build_from_gguf(
     _validate_gguf_model(gguf_model, source=str(gguf_path))
     gguf_arch = gguf_model.architecture
     logger.info("Loaded GGUF file: %s (arch=%s)", gguf_path, gguf_arch)
+    preserve_quantization = keep_quantized and _has_quantized_weights(gguf_model, gguf_arch)
+    if keep_quantized and not preserve_quantization:
+        logger.info("GGUF contains no mapped quantized weights; using the float import path")
 
     # 2. Extract config from GGUF metadata
     config = gguf_to_config(gguf_model)
@@ -371,7 +379,7 @@ def build_from_gguf(
             config = dataclasses.replace(config, dtype=resolved)
 
     # 3. Quantized path: detect dominant type and set config
-    if keep_quantized:
+    if preserve_quantization:
         from mobius._configs import QuantizationConfig
         from mobius._flags import flags
         from mobius.integrations.gguf._tencent_q1_0 import is_tencent_q1_0_layout
@@ -428,7 +436,7 @@ def build_from_gguf(
 
     # 5. Build ONNX graph
     module = module_class(config)
-    if keep_quantized:
+    if preserve_quantization:
         _replace_native_block_linears(module, gguf_model, gguf_arch)
     pkg = build_from_module(
         module, config, resolved_task, execution_provider=execution_provider
@@ -440,7 +448,7 @@ def build_from_gguf(
     )
 
     # 6. Load tensors from GGUF → state_dict
-    if keep_quantized:
+    if preserve_quantization:
         state_dict = _load_quantized_state_dict(gguf_model, gguf_arch, module, config)
     else:
         state_dict = _load_dequantized_state_dict(gguf_model, gguf_arch)
@@ -454,7 +462,7 @@ def build_from_gguf(
     # For the quantized path, only float tensors go through
     # process_tensors; quantized Q/K tensors were permuted in
     # _load_quantized_state_dict already.
-    if keep_quantized:
+    if preserve_quantization:
         float_keys = {
             k
             for k in state_dict
@@ -668,6 +676,28 @@ def _normalize_gguf_weights(
         result[key] = value
 
     return result
+
+
+def _has_quantized_weights(gguf_model, gguf_arch: str) -> bool:
+    """Return whether a GGUF has mapped weights with a quantized tensor type."""
+    from gguf import GGMLQuantizationType
+
+    from mobius.integrations.gguf._tensor_mapping import map_gguf_to_hf_names
+
+    float_types = {
+        GGMLQuantizationType.F32,
+        GGMLQuantizationType.F16,
+        GGMLQuantizationType.BF16,
+    }
+    f64_type = getattr(GGMLQuantizationType, "F64", None)
+    if f64_type is not None:
+        float_types.add(f64_type)
+
+    for name, _raw, qtype, _shape in gguf_model.tensor_items_raw():
+        hf_name = map_gguf_to_hf_names(name, gguf_arch)
+        if hf_name is not None and hf_name.endswith(".weight") and qtype not in float_types:
+            return True
+    return False
 
 
 def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, int, bool]:

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -268,6 +268,8 @@ def build_from_gguf(
     backbones normalize quantized projections to a common affine layout. GGUFs
     containing only F32, F16, or BF16 weights use the float path because there
     is no quantization to preserve.
+    Quantized files with no supported preservation target raise an actionable
+    error instead of silently falling back to a float model.
 
     Args:
         gguf_path: Path to the ``.gguf`` file, *or* a HuggingFace Hub
@@ -314,7 +316,8 @@ def build_from_gguf(
         ImportError: If the ``gguf`` package is not installed.
         FileNotFoundError: If the GGUF file does not exist.
         KeyError: If the GGUF architecture is not in the registry.
-        ValueError: If *static_cache* is combined with an explicit *task*.
+        ValueError: If *static_cache* is combined with an explicit *task*, or
+            if a quantized input has no supported preservation target.
     """
     import dataclasses
 
@@ -796,9 +799,13 @@ def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, int, bool]:
             }
         )
         if not repackable_counts:
+            source_types = ", ".join(
+                sorted({getattr(qtype, "name", str(qtype)) for qtype in counts})
+            )
             raise ValueError(
-                "No repackable quantized tensors found in GGUF file. "
-                "Use keep_quantized=False for dequantized import."
+                "No supported quantized preservation target for GGUF weight "
+                f"types: {source_types}. Use keep_quantized=False (API) or "
+                "--dequantize (CLI) for explicit float import."
             )
         dominant = repackable_counts.most_common(1)[0][0]
     dominant_value = dominant.value if hasattr(dominant, "value") else dominant

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -5,7 +5,7 @@
 
 Converts ``.gguf`` model files to ONNX using the standard build
 pipeline. Quantized preservation is the default: affine linear-layer weights
-are repacked into MatMulNBits format and token embeddings into
+are repacked into MatMulNBits format and compatible token embeddings into
 GatherBlockQuantized format. For text-only builds, runtime-supported native
 IQ/MXFP4 projection blocks are preserved for BlockQuantizedMatMul. Multimodal
 text backbones and mixed presets such as Q4_K_M are normalized to one affine
@@ -1016,10 +1016,11 @@ def _load_quantized_state_dict(
     """Load tensors, preserving native blocks or normalizing to MatMulNBits.
 
     Projection weights (Q/K/V/O, MLP, and a quantized output head) are
-    converted to the graph's common MatMulNBits format, and token embeddings
-    to GatherBlockQuantized format. Mixed or unsupported source types are
-    dequantized and requantized when they do not match that target. Norms
-    and other non-linear tensors remain dequantized.
+    converted to the graph's common MatMulNBits format, and compatible token
+    embeddings to GatherBlockQuantized format. Mixed or unsupported source
+    types are dequantized and requantized when they do not match that target.
+    Incompatible embeddings, norms, and other non-linear tensors remain
+    dequantized.
 
     For llama-family models, quantized Q/K weights receive the
     row-level reverse-permutation that ``process_tensors`` would

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -94,6 +94,7 @@ def _write_quantized_gguf(
     value_projection_quantization: str | None = None,
     output_quantization: str | None = None,
     tie_embeddings: bool = False,
+    float_type: str = "f32",
 ) -> None:
     """Write a GGUF file with quantized projection weights.
 
@@ -118,6 +119,21 @@ def _write_quantized_gguf(
 
     def _add_f32(name: str, shape: tuple[int, ...]) -> None:
         writer.add_tensor(name, np.random.randn(*shape).astype(np.float32))
+
+    def _add_f16(name: str, shape: tuple[int, ...]) -> None:
+        writer.add_tensor(name, np.random.randn(*shape).astype(np.float16))
+
+    def _add_bf16(name: str, shape: tuple[int, ...]) -> None:
+        values = np.random.randn(*shape).astype(np.float32)
+        raw = (values.view(np.uint32) >> 16).astype(np.uint16)
+        writer.add_tensor(
+            name,
+            raw,
+            raw_shape=shape,
+            raw_dtype=GGMLQuantizationType.BF16,
+        )
+
+    add_float = {"f32": _add_f32, "f16": _add_f16, "bf16": _add_bf16}[float_type]
 
     def _add_q4_0(name: str, n_out: int, k_in: int) -> None:
         """Write a Q4_0-quantized weight tensor."""
@@ -204,13 +220,18 @@ def _write_quantized_gguf(
     elif embedding_quantization == "q8_0":
         _add_q8_0("token_embd.weight", vocab_size, hidden_size)
     else:
-        _add_f32("token_embd.weight", (vocab_size, hidden_size))
+        add_float("token_embd.weight", (vocab_size, hidden_size))
 
     if projection_quantization in {"q4_0", "q8_0"}:
         add_projection = {
             "q4_0": _add_q4_0,
             "q8_0": _add_q8_0,
         }[projection_quantization]
+    elif projection_quantization in {"f32", "f16", "bf16"}:
+
+        def add_projection(name: str, n_out: int, k_in: int) -> None:
+            add_float(name, (n_out, k_in))
+
     else:
 
         def add_projection(name: str, n_out: int, k_in: int) -> None:
@@ -245,18 +266,18 @@ def _write_quantized_gguf(
         add_projection(f"blk.{i}.ffn_up.weight", intermediate_size, hidden_size)
         add_projection(f"blk.{i}.ffn_down.weight", hidden_size, intermediate_size)
         # Norms (float32)
-        _add_f32(f"blk.{i}.attn_norm.weight", (hidden_size,))
-        _add_f32(f"blk.{i}.ffn_norm.weight", (hidden_size,))
+        add_float(f"blk.{i}.attn_norm.weight", (hidden_size,))
+        add_float(f"blk.{i}.ffn_norm.weight", (hidden_size,))
 
     # Output norm + optional untied lm_head
-    _add_f32("output_norm.weight", (hidden_size,))
+    add_float("output_norm.weight", (hidden_size,))
     if not tie_embeddings:
         if output_quantization == "q4_0":
             _add_q4_0("output.weight", vocab_size, hidden_size)
         elif output_quantization == "q8_0":
             _add_q8_0("output.weight", vocab_size, hidden_size)
         else:
-            _add_f32("output.weight", (vocab_size, hidden_size))
+            add_float("output.weight", (vocab_size, hidden_size))
 
     writer.write_header_to_file()
     writer.write_kv_data_to_file()
@@ -269,6 +290,19 @@ def q4_0_gguf(tmp_path: Path) -> Path:
     """Create a Q4_0 quantized GGUF test file."""
     path = tmp_path / "test_q4_0.gguf"
     _write_quantized_gguf(path)
+    return path
+
+
+@pytest.fixture(params=["f32", "f16", "bf16"])
+def float_only_gguf(tmp_path: Path, request) -> Path:
+    """Create a GGUF with only unquantized tensor types."""
+    float_type = request.param
+    path = tmp_path / f"test_{float_type}.gguf"
+    _write_quantized_gguf(
+        path,
+        projection_quantization=float_type,
+        float_type=float_type,
+    )
     return path
 
 
@@ -357,27 +391,55 @@ def mixed_native_q5_q8_gguf(tmp_path: Path) -> Path:
 
 
 class TestBuildQuantizedGguf:
-    """Tests for build_from_gguf(keep_quantized=True)."""
+    """Tests for the default quantization-preserving GGUF build."""
 
     def test_produces_model_package(self, q4_0_gguf: Path):
         """Quantized build returns a valid ModelPackage."""
         from mobius.integrations.gguf import build_from_gguf
 
-        pkg = build_from_gguf(q4_0_gguf, keep_quantized=True)
+        pkg = build_from_gguf(q4_0_gguf)
         assert "model" in pkg
         assert pkg["model"].graph is not None
 
     def test_model_has_matmulnbits_ops(self, q4_0_gguf: Path):
-        """Quantized model uses MatMulNBits instead of MatMul."""
+        """The API default uses MatMulNBits instead of float MatMul weights."""
         from mobius.integrations.gguf import build_from_gguf
 
-        pkg = build_from_gguf(q4_0_gguf, keep_quantized=True)
+        pkg = build_from_gguf(q4_0_gguf)
         model = pkg["model"]
 
         op_types = {node.op_type for node in model.graph if node.op_type}
         assert "MatMulNBits" in op_types, (
             f"Expected MatMulNBits in ops, got: {sorted(op_types)}"
         )
+
+    def test_default_quantized_package_save_reload(self, q4_0_gguf: Path, tmp_path: Path):
+        """Default quantized ops and weights survive ModelPackage persistence."""
+        from mobius._model_package import ModelPackage
+        from mobius.integrations.gguf import build_from_gguf
+
+        output_dir = tmp_path / "saved"
+        build_from_gguf(q4_0_gguf).save(str(output_dir), progress_bar=False)
+        reloaded = ModelPackage.load(str(output_dir))
+
+        op_types = {node.op_type for node in reloaded["model"].graph}
+        assert "MatMulNBits" in op_types
+        assert (
+            reloaded["model"]
+            .graph.initializers["model.layers.0.self_attn.q_proj.weight"]
+            .const_value
+            is not None
+        )
+
+    def test_float_only_default_uses_float_path(self, float_only_gguf: Path):
+        """F32/BF16-only GGUFs do not fail when preservation is the default."""
+        from mobius.integrations.gguf import build_from_gguf
+
+        model = build_from_gguf(float_only_gguf)["model"]
+        op_types = {node.op_type for node in model.graph}
+        assert "MatMulNBits" not in op_types
+        assert "GatherBlockQuantized" not in op_types
+        assert "BlockQuantizedMatMul" not in op_types
 
     def test_q4_0_matmulnbits_has_explicit_zero_points(self, q4_0_gguf: Path):
         """GGUF Q4_0 projections explicitly encode zp=8 instead of EP defaults."""
@@ -561,7 +623,7 @@ class TestBuildQuantizedGguf:
                 )
 
     def test_dequantized_path_no_matmulnbits(self, q4_0_gguf: Path):
-        """Without keep_quantized, no MatMulNBits ops."""
+        """Explicit API dequantization emits no quantized projection ops."""
         from mobius.integrations.gguf import build_from_gguf
 
         pkg = build_from_gguf(q4_0_gguf, keep_quantized=False)
@@ -569,6 +631,7 @@ class TestBuildQuantizedGguf:
 
         op_types = {node.op_type for node in model.graph if node.op_type}
         assert "MatMulNBits" not in op_types
+        assert "BlockQuantizedMatMul" not in op_types
 
     def test_detect_quant_params(self, q4_0_gguf: Path):
         """_detect_quant_params finds Q4_0 as dominant type."""
@@ -710,6 +773,31 @@ class TestBuildGgufStaticCache:
                 static_cache=True,
                 task="text-generation",
             )
+
+
+class TestMultimodalQuantizationDefault:
+    @pytest.mark.parametrize("keep_quantized", [True, False])
+    def test_build_from_gguf_forwards_quantization_policy_to_mmproj(
+        self, keep_quantized: bool
+    ):
+        from mobius.integrations.gguf import build_from_gguf
+
+        expected = mock.sentinel.package
+        with mock.patch(
+            "mobius.integrations.gguf._mmproj.build_gemma4_vlm_from_gguf",
+            return_value=expected,
+        ) as build_multimodal:
+            kwargs = {} if keep_quantized else {"keep_quantized": False}
+            actual = build_from_gguf("text.gguf", mmproj="mmproj.gguf", **kwargs)
+
+        assert actual is expected
+        build_multimodal.assert_called_once_with(
+            "text.gguf",
+            "mmproj.gguf",
+            dtype=None,
+            execution_provider="default",
+            keep_quantized=keep_quantized,
+        )
 
 
 class TestRawTensorIterator:

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -702,6 +702,31 @@ class TestBuildQuantizedGguf:
         bits, block_size, is_sym = _detect_quant_params(_MixedModel(), "llama")
         assert (bits, block_size, is_sym) == (4, 32, False)
 
+    def test_pure_q6_k_requires_explicit_dequantization(self):
+        """Unsupported quantized inputs fail instead of silently becoming float."""
+        from gguf import GGMLQuantizationType
+
+        from mobius.integrations.gguf._builder import _detect_quant_params
+
+        class _UnsupportedModel:
+            def tensor_items_raw(self):
+                yield (
+                    "blk.0.ffn_down.weight",
+                    np.empty(0, dtype=np.uint8),
+                    GGMLQuantizationType.Q6_K,
+                    (64, 128),
+                )
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"No supported quantized preservation target for GGUF weight "
+                r"types: Q6_K. Use keep_quantized=False \(API\) or "
+                r"--dequantize \(CLI\) for explicit float import."
+            ),
+        ):
+            _detect_quant_params(_UnsupportedModel(), "llama")
+
     def test_runtime_unsupported_format_does_not_select_native_op(self):
         """A GGUF type outside the runtime contract remains on the fallback."""
         from gguf import GGMLQuantizationType

--- a/src/mobius/integrations/gguf/_mmproj.py
+++ b/src/mobius/integrations/gguf/_mmproj.py
@@ -214,14 +214,15 @@ def _text_gguf_to_hf_multimodal_quantized(
     block_size: int,
     symmetric: bool,
 ) -> dict:
-    """Load text-backbone GGUF tensors, quantizing the decoder + token embeddings.
+    """Load text GGUF tensors, quantizing the decoder and compatible embeddings.
 
     Mirrors :func:`_text_gguf_to_hf_multimodal` but keeps the text decoder
     projections in MatMulNBits form (``.weight`` uint8 + ``.scales`` [+
-    ``.zero_points``]) and the token-embedding tables in GatherBlockQuantized
-    form (``.qweight`` + ``.scales`` [+ ``.zero_points``]).  Norms and the
-    float per-layer projections stay dequantized.  Vision/audio weights are
-    loaded separately and always stay float.
+    ``.zero_points``]) and compatible token-embedding tables in
+    GatherBlockQuantized form (``.qweight`` + ``.scales`` [+
+    ``.zero_points``]). Incompatible token embeddings, norms, and float
+    per-layer projections stay dequantized. Vision/audio weights are loaded
+    separately and always stay float.
 
     Names are the HF multimodal ``language_model.*`` names that
     :meth:`Gemma4Model.preprocess_weights` expects.
@@ -230,6 +231,7 @@ def _text_gguf_to_hf_multimodal_quantized(
 
     from mobius.integrations.gguf._builder import repack_gguf_weight_to_target
 
+    quantize_embeddings = bool(getattr(config.quantization, "quantize_embeddings", False))
     quantize_lm_head = bool(getattr(config.quantization, "quantize_lm_head", False))
     tie_word_embeddings = bool(config.tie_word_embeddings)
 
@@ -255,7 +257,7 @@ def _text_gguf_to_hf_multimodal_quantized(
         is_quant_linear = hf_name.endswith(_QUANTIZED_LINEAR_SUFFIXES) or (
             quantize_lm_head and hf_name == "language_model.lm_head.weight"
         )
-        is_quant_embedding = hf_name in _QUANTIZED_EMBEDDING_NAMES
+        is_quant_embedding = quantize_embeddings and hf_name in _QUANTIZED_EMBEDDING_NAMES
 
         if (is_quant_linear or is_quant_embedding) and len(np_shape) == 2:
             repacked = repack_gguf_weight_to_target(
@@ -342,13 +344,14 @@ def build_gemma4_vlm_from_gguf(
             encoder. Off by default — see the module docstring.
         keep_quantized: Preserve the text backbone's GGUF quantization when
             present. This is the default: decoder projections become
-            MatMulNBits and token-embedding tables become GatherBlockQuantized.
-            Quantized projection source types, including native IQ/MXFP4
-            blocks, are normalized to the common affine layout rather than
-            retained byte-for-byte. Set to ``False`` to dequantize all text
-            weights. The vision (and audio) encoder always stays float because
-            its weights come from the mmproj as F16 — see the "Mixed precision"
-            note below.
+            MatMulNBits and compatible token-embedding tables become
+            GatherBlockQuantized. Incompatible embedding qtypes or shapes stay
+            float. Quantized projection source types, including native
+            IQ/MXFP4 blocks, are normalized to the common affine layout rather
+            than retained byte-for-byte. Set to ``False`` to dequantize all
+            text weights. The vision (and audio) encoder always stays float
+            because its weights come from the mmproj as F16 — see the "Mixed
+            precision" note below.
 
     Returns:
         A :class:`ModelPackage` with ``decoder`` + ``vision_encoder`` +
@@ -417,8 +420,8 @@ def build_gemma4_vlm_from_gguf(
             config = dataclasses.replace(config, dtype=resolved)
 
     # 1b. Quantized mode: set the module-global quantization config from the
-    # text GGUF BEFORE building so the text graph emits MatMulNBits /
-    # GatherBlockQuantized. The vision/audio encoders ignore it and stay float.
+    # text GGUF BEFORE building so the text graph emits MatMulNBits and, when
+    # compatible, GatherBlockQuantized. The vision/audio encoders stay float.
     quant_params: tuple[int, int, bool] | None = None
     if preserve_quantization:
         from mobius._configs import QuantizationConfig

--- a/src/mobius/integrations/gguf/_mmproj.py
+++ b/src/mobius/integrations/gguf/_mmproj.py
@@ -326,7 +326,7 @@ def build_gemma4_vlm_from_gguf(
     execution_provider: str = "default",
     image_token_id: int | None = None,
     include_audio: bool = False,
-    keep_quantized: bool = False,
+    keep_quantized: bool = True,
 ) -> ModelPackage:
     """Build a full Gemma4 multimodal ONNX package from text + mmproj GGUFs.
 
@@ -340,20 +340,23 @@ def build_gemma4_vlm_from_gguf(
             value carried by the text config is used (if any).
         include_audio: When ``True``, also build the (experimental) audio
             encoder. Off by default — see the module docstring.
-        keep_quantized: When ``True``, preserve the text backbone's GGUF
-            quantization: the decoder projections become MatMulNBits and the
-            token-embedding tables become GatherBlockQuantized (int4), roughly
-            an 8x size reduction over the dequantized package. The
-            vision (and audio) encoder always stay float because their weights
-            come from the mmproj as F16 — see the "Mixed precision" note below.
+        keep_quantized: Preserve the text backbone's GGUF quantization when
+            present. This is the default: decoder projections become
+            MatMulNBits and token-embedding tables become GatherBlockQuantized.
+            Quantized projection source types, including native IQ/MXFP4
+            blocks, are normalized to the common affine layout rather than
+            retained byte-for-byte. Set to ``False`` to dequantize all text
+            weights. The vision (and audio) encoder always stays float because
+            its weights come from the mmproj as F16 — see the "Mixed precision"
+            note below.
 
     Returns:
         A :class:`ModelPackage` with ``decoder`` + ``vision_encoder`` +
         ``embedding`` components (plus ``audio_encoder`` if ``include_audio``).
 
     Mixed precision:
-        ``keep_quantized`` yields a mixed-precision package. Only the Gemma4
-        *text* components read ``config.quantization`` (see
+        Quantized text weights yield a mixed-precision package. Only the
+        Gemma4 *text* components read ``config.quantization`` (see
         :func:`mobius.models.gemma4._text_linear_class`); the vision/audio
         encoder modules always build float ``Linear`` layers, so a single
         module-global :class:`QuantizationConfig` quantizes the decoder +
@@ -363,7 +366,10 @@ def build_gemma4_vlm_from_gguf(
     import dataclasses
 
     from mobius._builder import resolve_dtype
-    from mobius.integrations.gguf._builder import _validate_gguf_model
+    from mobius.integrations.gguf._builder import (
+        _has_quantized_weights,
+        _validate_gguf_model,
+    )
     from mobius.integrations.gguf._config_mapping import gguf_to_config
     from mobius.integrations.gguf._reader import GGUFModel
     from mobius.models.gemma4 import Gemma4Model
@@ -371,6 +377,12 @@ def build_gemma4_vlm_from_gguf(
 
     text_gguf = GGUFModel(_resolve_local_path(text_gguf_path))
     _validate_gguf_model(text_gguf, source=str(text_gguf_path))
+
+    preserve_quantization = keep_quantized and _has_quantized_weights(text_gguf, "gemma4")
+    if keep_quantized and not preserve_quantization:
+        logger.info(
+            "Text GGUF contains no mapped quantized weights; using the float import path"
+        )
 
     mmproj_gguf = GGUFModel(_resolve_local_path(mmproj_gguf_path))
     _validate_gguf_model(mmproj_gguf, source=str(mmproj_gguf_path))
@@ -408,7 +420,7 @@ def build_gemma4_vlm_from_gguf(
     # text GGUF BEFORE building so the text graph emits MatMulNBits /
     # GatherBlockQuantized. The vision/audio encoders ignore it and stay float.
     quant_params: tuple[int, int, bool] | None = None
-    if keep_quantized:
+    if preserve_quantization:
         from mobius._configs import QuantizationConfig
         from mobius.integrations.gguf._builder import (
             _can_quantize_embedding,
@@ -463,7 +475,7 @@ def build_gemma4_vlm_from_gguf(
 
     # 3. Assemble the combined HF-multimodal state dict from both GGUFs. The
     #    text backbone is quantized when requested; vision/audio always float.
-    if keep_quantized:
+    if preserve_quantization:
         bits, block_size, is_symmetric = quant_params
         state_dict = _text_gguf_to_hf_multimodal_quantized(
             text_gguf,

--- a/src/mobius/integrations/gguf/_mmproj_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_test.py
@@ -120,6 +120,92 @@ def _write_minimal_gguf(
     writer.close()
 
 
+def _write_quantized_gemma4_text_gguf(path: Path) -> None:
+    """Write a tiny Gemma4 text GGUF with Q4 projections and a float embedding."""
+    from gguf import GGMLQuantizationType, GGUFWriter
+
+    hidden_size = 32
+    intermediate_size = 64
+    vocab_size = 64
+    num_layers = 2
+    num_heads = 4
+    num_kv_heads = 1
+    head_dim = hidden_size // num_heads
+
+    writer = GGUFWriter(str(path), "gemma4")
+    writer.add_context_length(128)
+    writer.add_embedding_length(hidden_size)
+    writer.add_feed_forward_length(intermediate_size)
+    writer.add_block_count(num_layers)
+    writer.add_head_count(num_heads)
+    writer.add_head_count_kv(num_kv_heads)
+    writer.add_key_length(head_dim)
+    writer.add_key_length_swa(head_dim)
+    writer.add_rope_dimension_count(head_dim)
+    writer.add_rope_dimension_count_swa(head_dim)
+    writer.add_rope_freq_base(10_000.0)
+    writer.add_rope_freq_base_swa(10_000.0)
+    writer.add_layer_norm_rms_eps(1e-6)
+    writer.add_vocab_size(vocab_size)
+    writer.add_array(
+        "gemma4.attention.sliding_window_pattern",
+        [True] * num_layers,
+    )
+
+    def _f32(name: str, shape: tuple[int, ...]) -> None:
+        writer.add_tensor(name, np.random.randn(*shape).astype(np.float32))
+
+    def _q4_0(name: str, n_out: int, k_in: int) -> None:
+        block_size = 32
+        block_bytes = 18
+        raw = np.zeros((n_out, k_in // block_size * block_bytes), dtype=np.uint8)
+        for row in range(n_out):
+            for block in range(k_in // block_size):
+                offset = block * block_bytes
+                raw[row, offset : offset + 2] = np.array(
+                    [np.random.uniform(0.01, 1.0)],
+                    dtype=np.float16,
+                ).view(np.uint8)
+                raw[row, offset + 2 : offset + block_bytes] = np.random.randint(
+                    0,
+                    256,
+                    size=block_bytes - 2,
+                    dtype=np.uint8,
+                )
+        writer.add_tensor(name, raw, raw_dtype=GGMLQuantizationType.Q4_0)
+
+    # The float embedding is deliberately incompatible with the projection
+    # Q4_0 target, so the graph must retain a normal float embedding initializer.
+    _f32("token_embd.weight", (vocab_size, hidden_size))
+    _q4_0("output.weight", vocab_size, hidden_size)
+    _f32("output_norm.weight", (hidden_size,))
+
+    for layer in range(num_layers):
+        prefix = f"blk.{layer}"
+        _q4_0(f"{prefix}.attn_q.weight", num_heads * head_dim, hidden_size)
+        _q4_0(f"{prefix}.attn_k.weight", num_kv_heads * head_dim, hidden_size)
+        _q4_0(f"{prefix}.attn_v.weight", num_kv_heads * head_dim, hidden_size)
+        _q4_0(f"{prefix}.attn_output.weight", hidden_size, num_heads * head_dim)
+        _q4_0(f"{prefix}.ffn_gate.weight", intermediate_size, hidden_size)
+        _q4_0(f"{prefix}.ffn_up.weight", intermediate_size, hidden_size)
+        _q4_0(f"{prefix}.ffn_down.weight", hidden_size, intermediate_size)
+        for norm in (
+            "attn_norm",
+            "post_attention_norm",
+            "ffn_norm",
+            "post_ffw_norm",
+        ):
+            _f32(f"{prefix}.{norm}.weight", (hidden_size,))
+        for norm in ("attn_q_norm", "attn_k_norm"):
+            _f32(f"{prefix}.{norm}.weight", (head_dim,))
+        _f32(f"{prefix}.layer_output_scale.weight", (1,))
+
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_tensors_to_file()
+    writer.close()
+
+
 @pytest.fixture
 def clip_mmproj_gguf(tmp_path: Path) -> Path:
     path = tmp_path / "mmproj.gguf"
@@ -369,6 +455,44 @@ class TestKeepQuantizedMixedPrecision:
         # The mmproj-sourced vision encoder is float — no quantized ops.
         assert "MatMulNBits" not in vision_ops
         assert "GatherBlockQuantized" not in vision_ops
+
+    def test_incompatible_embedding_stays_float_and_package_round_trips(
+        self,
+        clip_mmproj_gguf: Path,
+        tmp_path: Path,
+    ):
+        from mobius._model_package import ModelPackage
+        from mobius.integrations.gguf import build_gemma4_vlm_from_gguf
+
+        text_gguf = tmp_path / "gemma4-q4-f32-embedding.gguf"
+        _write_quantized_gemma4_text_gguf(text_gguf)
+
+        package = build_gemma4_vlm_from_gguf(text_gguf, clip_mmproj_gguf)
+        assert "MatMulNBits" in _component_op_types(package["decoder"])
+        assert "GatherBlockQuantized" not in _component_op_types(package["embedding"])
+        float_embedding = package["embedding"].graph.initializers[
+            "embedding.embed_tokens.weight"
+        ]
+        assert float_embedding.const_value is not None
+        assert list(float_embedding.shape) == [64, 32]
+
+        missing = [
+            f"{component}:{name}"
+            for component, model in package.items()
+            for name, initializer in model.graph.initializers.items()
+            if initializer.const_value is None
+        ]
+        assert missing == []
+
+        output_dir = tmp_path / "saved"
+        package.save(str(output_dir), progress_bar=False)
+        reloaded = ModelPackage.load(str(output_dir))
+        assert set(reloaded) == {"decoder", "vision_encoder", "embedding"}
+        assert all(
+            initializer.const_value is not None
+            for model in reloaded.values()
+            for initializer in model.graph.initializers.values()
+        )
 
     def test_quantized_decoder_loads_in_onnxruntime(
         self, clip_mmproj_gguf: Path, tmp_path: Path

--- a/src/mobius/integrations/gguf/_mmproj_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_test.py
@@ -299,6 +299,14 @@ class TestKeepQuantizedMixedPrecision:
     builder uses, without needing a full quantized text GGUF.
     """
 
+    def test_multimodal_builder_preserves_quantization_by_default(self):
+        import inspect
+
+        from mobius.integrations.gguf import build_gemma4_vlm_from_gguf
+
+        parameter = inspect.signature(build_gemma4_vlm_from_gguf).parameters["keep_quantized"]
+        assert parameter.default is True
+
     def test_decoder_and_embedding_quantized_vision_stays_float(self, clip_mmproj_gguf: Path):
         import dataclasses
 

--- a/tests/gguf_test.py
+++ b/tests/gguf_test.py
@@ -9,6 +9,8 @@ test the full pipeline without network downloads.
 
 from __future__ import annotations
 
+from unittest import mock
+
 import numpy as np
 import pytest
 import torch
@@ -31,6 +33,7 @@ def _create_tiny_gguf(
     heads: int = 2,
     vocab: int = 256,
     ffn_size: int | None = None,
+    float_type: str = "f32",
 ) -> str:
     """Create a minimal GGUF file with fp32 weights for testing.
 
@@ -48,61 +51,41 @@ def _create_tiny_gguf(
     writer.add_head_count_kv(heads)
     writer.add_context_length(128)
     writer.add_feed_forward_length(ffn_size)
+    writer.add_vocab_size(vocab)
 
-    # Tensors — fp32 random weights
+    # Tensors — unquantized random weights
     rng = np.random.default_rng(42)
 
-    writer.add_tensor(
-        "token_embd.weight",
-        rng.standard_normal((vocab, hidden), dtype=np.float32),
-    )
-    writer.add_tensor(
-        "output_norm.weight",
-        rng.standard_normal((hidden,), dtype=np.float32),
-    )
-    writer.add_tensor(
-        "output.weight",
-        rng.standard_normal((vocab, hidden), dtype=np.float32),
-    )
+    def add_float(name, shape):
+        values = rng.standard_normal(shape, dtype=np.float32)
+        if float_type == "bf16":
+            raw = (values.view(np.uint32) >> 16).astype(np.uint16)
+            writer.add_tensor(
+                name,
+                raw,
+                raw_shape=shape,
+                raw_dtype=gguf_lib.GGMLQuantizationType.BF16,
+            )
+        elif float_type == "f16":
+            writer.add_tensor(name, values.astype(np.float16))
+        else:
+            writer.add_tensor(name, values)
+
+    add_float("token_embd.weight", (vocab, hidden))
+    add_float("output_norm.weight", (hidden,))
+    add_float("output.weight", (vocab, hidden))
 
     for i in range(layers):
         prefix = f"blk.{i}"
-        writer.add_tensor(
-            f"{prefix}.attn_q.weight",
-            rng.standard_normal((hidden, hidden), dtype=np.float32),
-        )
-        writer.add_tensor(
-            f"{prefix}.attn_k.weight",
-            rng.standard_normal((hidden, hidden), dtype=np.float32),
-        )
-        writer.add_tensor(
-            f"{prefix}.attn_v.weight",
-            rng.standard_normal((hidden, hidden), dtype=np.float32),
-        )
-        writer.add_tensor(
-            f"{prefix}.attn_output.weight",
-            rng.standard_normal((hidden, hidden), dtype=np.float32),
-        )
-        writer.add_tensor(
-            f"{prefix}.ffn_gate.weight",
-            rng.standard_normal((ffn_size, hidden), dtype=np.float32),
-        )
-        writer.add_tensor(
-            f"{prefix}.ffn_up.weight",
-            rng.standard_normal((ffn_size, hidden), dtype=np.float32),
-        )
-        writer.add_tensor(
-            f"{prefix}.ffn_down.weight",
-            rng.standard_normal((hidden, ffn_size), dtype=np.float32),
-        )
-        writer.add_tensor(
-            f"{prefix}.attn_norm.weight",
-            rng.standard_normal((hidden,), dtype=np.float32),
-        )
-        writer.add_tensor(
-            f"{prefix}.ffn_norm.weight",
-            rng.standard_normal((hidden,), dtype=np.float32),
-        )
+        add_float(f"{prefix}.attn_q.weight", (hidden, hidden))
+        add_float(f"{prefix}.attn_k.weight", (hidden, hidden))
+        add_float(f"{prefix}.attn_v.weight", (hidden, hidden))
+        add_float(f"{prefix}.attn_output.weight", (hidden, hidden))
+        add_float(f"{prefix}.ffn_gate.weight", (ffn_size, hidden))
+        add_float(f"{prefix}.ffn_up.weight", (ffn_size, hidden))
+        add_float(f"{prefix}.ffn_down.weight", (hidden, ffn_size))
+        add_float(f"{prefix}.attn_norm.weight", (hidden,))
+        add_float(f"{prefix}.ffn_norm.weight", (hidden,))
 
     writer.write_header_to_file()
     writer.write_kv_data_to_file()
@@ -492,7 +475,8 @@ class TestCLIBuildGGUF:
         with pytest.raises(SystemExit):
             main(["build-gguf", "--help"])
         out = capsys.readouterr().out
-        assert "GGUF" in out or "gguf" in out
+        assert "--dequantize" in out
+        assert "preserved by default" in out
 
     def test_missing_gguf_path_errors(self):
         """build-gguf requires a gguf_path argument."""
@@ -501,13 +485,64 @@ class TestCLIBuildGGUF:
         with pytest.raises(SystemExit):
             main(["build-gguf"])
 
-    def test_keep_quantized_no_quantized_tensors(self, tmp_path):
-        """--keep-quantized on F32 GGUF raises ValueError."""
+    @pytest.mark.parametrize("float_type", ["f32", "f16", "bf16"])
+    def test_default_float_only_input_builds_and_reloads(self, tmp_path, float_type):
+        """The quantized-by-default CLI accepts F32/F16/BF16-only GGUFs."""
+        from mobius.__main__ import main
+        from mobius._model_package import ModelPackage
+
+        path = _create_tiny_gguf(tmp_path / f"test-{float_type}.gguf", float_type=float_type)
+        output_dir = tmp_path / f"output-{float_type}"
+        main(["build-gguf", path, "--output", str(output_dir)])
+
+        package = ModelPackage.load(str(output_dir))
+        op_types = {node.op_type for node in package["model"].graph}
+        assert "MatMulNBits" not in op_types
+        assert "BlockQuantizedMatMul" not in op_types
+
+    @pytest.mark.parametrize(
+        ("extra_args", "expected"),
+        [
+            ([], True),
+            (["--keep-quantized"], True),
+            (["--dequantize"], False),
+        ],
+    )
+    def test_quantization_flag_parsing(self, tmp_path, extra_args, expected):
+        """Default, compatibility alias, and explicit opt-out map to the API."""
         from mobius.__main__ import main
 
-        path = _create_tiny_gguf(tmp_path / "test.gguf")
-        with pytest.raises((SystemExit, ValueError)):
-            main(["build-gguf", path, "--keep-quantized"])
+        package = mock.MagicMock()
+        package.__iter__.return_value = iter(())
+        with mock.patch(
+            "mobius.integrations.gguf.build_from_gguf",
+            return_value=package,
+        ) as build:
+            main(
+                [
+                    "build-gguf",
+                    str(tmp_path / "model.gguf"),
+                    "--output",
+                    str(tmp_path / "output"),
+                    *extra_args,
+                ]
+            )
+
+        assert build.call_args.kwargs["keep_quantized"] is expected
+
+    def test_contradictory_quantization_flags_error(self, tmp_path):
+        from mobius.__main__ import main
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(
+                [
+                    "build-gguf",
+                    str(tmp_path / "model.gguf"),
+                    "--keep-quantized",
+                    "--dequantize",
+                ]
+            )
+        assert exc_info.value.code == 2
 
     def test_ort_genai_runtime_is_rejected_before_artifacts(self, tmp_path):
         """build-gguf must not silently ignore an ORT GenAI runtime request."""


### PR DESCRIPTION
## Summary

- preserve supported GGUF quantization by default in `build_from_gguf`, the Gemma4 multimodal builder, and `mobius build-gguf`
- add `--dequantize` as the explicit CLI opt-out while retaining `--keep-quantized` as a silent compatibility alias and rejecting contradictory flags
- route F32/F16/BF16-only GGUFs through the normal float path, and document text-only native retention versus multimodal/mixed repacking or requantization
- add API, CLI, graph-op, multimodal delegation, float-only, and save/reload coverage; update docs, examples, and the quantization skill

## Validation

- `python -m pytest src/mobius/integrations/gguf/_builder_test.py src/mobius/integrations/gguf/_mmproj_test.py tests/gguf_test.py -q --tb=short` (93 passed)
- `python -m pytest tests/build_graph_test.py tests/cli_test.py src/ -q -k "not phi4mm and not apply_weights_unknown" --tb=short -n auto` (3937 passed, 61 skipped)
- `lintrunner f --output oneline --all-files` (repository-wide formatter completed in Windows-safe path batches after the single invocation hit the Windows command-length limit)
- `lintrunner -a`
- `git diff --check`
- independent code review completed with no remaining findings

Closes #483