### PR TITLE
Parallelize ONNX external-data saves by default

### DIFF
--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -185,6 +185,8 @@ def _cmd_build(args: argparse.Namespace) -> None:
     # Validate --max-seq-len is positive
     if args.max_seq_len is not None and args.max_seq_len <= 0:
         raise SystemExit("Error: --max-seq-len must be a positive integer.")
+    if args.max_workers <= 0:
+        raise SystemExit("Error: --max-workers must be a positive integer.")
 
     max_length = getattr(args, "max_length", None)
     if max_length is not None and args.runtime != "onnx-genai":
@@ -394,6 +396,7 @@ def _save_package(
         output_dir,
         external_data=args.external_data,
         max_shard_size_bytes=max_shard_size_bytes,
+        max_workers=args.max_workers,
         components=components,
         check_weights=not args.no_weights,
     )
@@ -529,6 +532,8 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
         raise SystemExit("Error: --max-seq-len can only be used with --static-cache.")
     if args.max_seq_len is not None and args.max_seq_len <= 0:
         raise SystemExit("Error: --max-seq-len must be a positive integer.")
+    if args.max_workers <= 0:
+        raise SystemExit("Error: --max-workers must be a positive integer.")
     if mmproj_path is not None and args.static_cache:
         raise SystemExit("Error: --static-cache cannot be used with --mmproj.")
 
@@ -545,6 +550,7 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
     pkg.save(
         output_dir,
         external_data=args.external_data,
+        max_workers=args.max_workers,
     )
     for name in pkg:
         use_subfolders = len(pkg) > 1
@@ -708,6 +714,13 @@ def main(argv: list[str] | None = None) -> None:
         help="Maximum external-data shard size (e.g. '5GB'). Used by both ONNX and safetensors.",
     )
     build_parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=8,
+        metavar="N",
+        help="Number of threads used to write ONNX external data (default: 8; use 1 for serial saves).",
+    )
+    build_parser.add_argument(
         "--no-weights",
         action="store_true",
         help="Do not include weights in the output ONNX model.",
@@ -856,6 +869,13 @@ def main(argv: list[str] | None = None) -> None:
         choices=["onnx", "safetensors"],
         default="onnx",
         help="External data format (default: onnx).",
+    )
+    gguf_parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=8,
+        metavar="N",
+        help="Number of threads used to write ONNX external data (default: 8; use 1 for serial saves).",
     )
     gguf_parser.add_argument(
         "--ep",

--- a/src/mobius/_model_package.py
+++ b/src/mobius/_model_package.py
@@ -20,11 +20,13 @@ from __future__ import annotations
 
 __all__ = ["ModelPackage"]
 
+import inspect
 import logging
 import os
 import threading
 from collections import UserDict
 from collections.abc import Callable
+from typing import Any
 
 import onnx_ir as ir
 import torch
@@ -72,6 +74,7 @@ class ModelPackage(UserDict[str, ir.Model]):
         *,
         external_data: str = "onnx",
         max_shard_size_bytes: int | None = None,
+        max_workers: int = 8,
         components: Callable[[str], bool] | None = None,
         progress_bar: bool = True,
         check_weights: bool = True,
@@ -108,6 +111,10 @@ class ModelPackage(UserDict[str, ir.Model]):
                 Used by both ONNX and safetensors external-data formats. A
                 single tensor larger than this value is written in its own
                 oversized shard.
+            max_workers: Number of threads used to write ONNX external data.
+                Defaults to 8. Set to 1 to save serially. Older ``onnx_ir``
+                versions that do not support concurrent saves fall back to
+                serial behavior.
             components: Optional predicate ``(name) -> bool`` that selects
                 which components to save.  When ``None`` (default), all
                 components are saved.  Examples::
@@ -125,14 +132,17 @@ class ModelPackage(UserDict[str, ir.Model]):
 
         Raises:
             ValueError: If *external_data* is not ``"onnx"`` or
-                ``"safetensors"``, or if *check_weights* is ``True`` and
-                any initializer is missing its ``const_value``.
+                ``"safetensors"``, if *max_workers* is not positive, or if
+                *check_weights* is ``True`` and any initializer is missing its
+                ``const_value``.
         """
         if external_data not in {"onnx", "safetensors"}:
             raise ValueError(
                 f"Unknown external_data format {external_data!r}. "
                 "Expected 'onnx' or 'safetensors'."
             )
+        if max_workers <= 0:
+            raise ValueError(f"max_workers must be positive, got {max_workers}.")
         os.makedirs(directory, exist_ok=True)
         selected = {
             name: model
@@ -159,13 +169,14 @@ class ModelPackage(UserDict[str, ir.Model]):
                     callback=callback,
                 )
             else:
-                ir.save(
-                    model,
-                    path,
-                    external_data="model.onnx.data",
-                    max_shard_size_bytes=max_shard_size_bytes,
-                    callback=callback,
-                )
+                save_kwargs: dict[str, Any] = {
+                    "external_data": "model.onnx.data",
+                    "max_shard_size_bytes": max_shard_size_bytes,
+                    "callback": callback,
+                }
+                if "max_workers" in inspect.signature(ir.save).parameters:
+                    save_kwargs["max_workers"] = max_workers
+                ir.save(model, path, **save_kwargs)
 
     @classmethod
     def load(cls, directory: str) -> ModelPackage:

--- a/src/mobius/_model_package_test.py
+++ b/src/mobius/_model_package_test.py
@@ -125,6 +125,77 @@ class TestOnnxShardedSave:
         loaded = ModelPackage.load(str(tmp_path))
         assert set(loaded.data) == {"model"}
 
+    def test_defaults_to_eight_workers_when_supported(self, tmp_path, monkeypatch):
+        calls = []
+
+        def save(
+            model,
+            path,
+            *,
+            external_data,
+            max_shard_size_bytes,
+            callback,
+            max_workers,
+        ):
+            calls.append(max_workers)
+
+        monkeypatch.setattr(ir, "save", save)
+
+        ModelPackage({"m": _make_simple_model()}).save(
+            str(tmp_path), progress_bar=False, check_weights=False
+        )
+
+        assert calls == [8]
+
+    def test_forwards_serial_worker_override(self, tmp_path, monkeypatch):
+        calls = []
+
+        def save(
+            model,
+            path,
+            *,
+            external_data,
+            max_shard_size_bytes,
+            callback,
+            max_workers,
+        ):
+            calls.append(max_workers)
+
+        monkeypatch.setattr(ir, "save", save)
+
+        ModelPackage({"m": _make_simple_model()}).save(
+            str(tmp_path),
+            max_workers=1,
+            progress_bar=False,
+            check_weights=False,
+        )
+
+        assert calls == [1]
+
+    def test_omits_max_workers_for_onnx_ir_1_0(self, tmp_path, monkeypatch):
+        calls = []
+
+        def save(model, path, *, external_data, max_shard_size_bytes, callback):
+            calls.append((model, path))
+
+        monkeypatch.setattr(ir, "save", save)
+
+        ModelPackage({"m": _make_simple_model()}).save(
+            str(tmp_path), progress_bar=False, check_weights=False
+        )
+
+        assert len(calls) == 1
+
+    @pytest.mark.parametrize("max_workers", [0, -1])
+    def test_rejects_non_positive_max_workers(self, tmp_path, max_workers):
+        with pytest.raises(ValueError, match="max_workers must be positive"):
+            ModelPackage({"m": _make_simple_model()}).save(
+                str(tmp_path),
+                max_workers=max_workers,
+                progress_bar=False,
+                check_weights=False,
+            )
+
 
 class TestProgressCallback:
     class _Tensor:

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -65,6 +65,56 @@ class TestCLIBuild:
             )
             assert os.path.isfile(os.path.join(tmpdir, "model.onnx"))
 
+    def test_max_workers_defaults_to_eight(self):
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            mock.patch(
+                "mobius._diffusers_builder._load_diffusers_pipeline_index",
+                return_value=None,
+            ),
+            mock.patch("mobius.__main__.build", return_value=mock.MagicMock()),
+            mock.patch("mobius.__main__._save_package") as save_package,
+        ):
+            main(["build", "--model", "Qwen/Qwen2.5-0.5B", tmpdir, "--no-weights"])
+
+        assert save_package.call_args.args[2].max_workers == 8
+
+    def test_max_workers_override_reaches_model_package_save(self):
+        pkg = mock.MagicMock()
+        pkg.items.return_value = []
+        pkg.__iter__.return_value = iter(())
+        args = SimpleNamespace(
+            max_shard_size=None,
+            max_workers=1,
+            external_data="onnx",
+            execution_provider="cpu",
+            no_weights=True,
+            runtime=None,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _save_package(pkg, tmpdir, args, None, None)
+
+        assert pkg.save.call_args.kwargs["max_workers"] == 1
+
+    @pytest.mark.parametrize("max_workers", [0, -1])
+    def test_non_positive_max_workers_errors(self, max_workers):
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            pytest.raises(SystemExit, match=r"--max-workers must be a positive integer"),
+        ):
+            main(
+                [
+                    "build",
+                    "--model",
+                    "Qwen/Qwen2.5-0.5B",
+                    tmpdir,
+                    "--no-weights",
+                    "--max-workers",
+                    str(max_workers),
+                ]
+            )
+
     def test_build_encoder_decoder_produces_separate_files(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             main(["build", "--model", "facebook/bart-base", tmpdir, "--no-weights"])
@@ -514,6 +564,7 @@ class TestCLIBuildRuntime:
         pkg.config = object()
         args = SimpleNamespace(
             max_shard_size=None,
+            max_workers=8,
             external_data="onnx",
             execution_provider="cpu",
             no_weights=True,
@@ -553,6 +604,7 @@ class TestCLIBuildRuntime:
         pkg.config = object()
         args = SimpleNamespace(
             max_shard_size=None,
+            max_workers=8,
             external_data="onnx",
             execution_provider="cpu",
             no_weights=True,


### PR DESCRIPTION
## Summary

- add `max_workers` to `ModelPackage.save`, defaulting to 8
- expose `--max-workers` on `mobius build` and `mobius build-gguf`, with `1` restoring serial saves
- forward the setting to `onnx_ir.save` when supported while retaining `onnx_ir` 1.0 compatibility through signature-based feature detection
- reject non-positive worker counts and document the behavior

## Validation

- `python -m pytest src/mobius/_model_package_test.py tests/cli_test.py -q --tb=short` (75 passed)
- `lintrunner f --output oneline --all-files`