### PR TITLE
Add native MiniMax Music 3 pipeline support

### DIFF
--- a/src/mobius/_diffusers_builder.py
+++ b/src/mobius/_diffusers_builder.py
@@ -46,6 +46,7 @@ _PIPELINE_COMPONENT_TASK_OVERRIDES: dict[str, dict[str, str]] = {
 }
 
 _PIPELINE_MODEL_TYPES: dict[str, str] = {
+    "MiniMaxMusic3ModularPipeline": "minimax_music3",
     "QwenImageEditPlusPipeline": "qwen_image_edit",
 }
 
@@ -58,6 +59,11 @@ def _init_diffusers_class_map() -> None:
     from mobius._diffusers_configs import (
         CLIPTextConfig,
         CogVideoXConfig,
+        MiniMaxMusic3ConditionConfig,
+        MiniMaxMusic3LanguageConfig,
+        MiniMaxMusic3RVQConfig,
+        MiniMaxMusic3TransformerConfig,
+        MiniMaxMusic3VocoderConfig,
         QwenImageConfig,
         QwenImageTextEncoderConfig,
         QwenImageVAEConfig,
@@ -76,6 +82,13 @@ def _init_diffusers_class_map() -> None:
         SD3Transformer2DModel,
     )
     from mobius.models.hunyuan_dit import HunyuanDiT2DModel, HunyuanDiTConfig
+    from mobius.models.minimax_music3 import (
+        MiniMaxMusic3ConditionEncoder,
+        MiniMaxMusic3LanguageModel,
+        MiniMaxMusic3RVQDepthDecoder,
+        MiniMaxMusic3Transformer1DModel,
+        MiniMaxMusic3Vocoder,
+    )
     from mobius.models.qwen_image import QwenImageTransformer2DModel
     from mobius.models.qwen_image_vae import AutoencoderKLQwenImageModel
     from mobius.models.qwen_vl import Qwen25VLCausalLMModel
@@ -124,6 +137,31 @@ def _init_diffusers_class_map() -> None:
                 CogVideoXConfig,
                 "video-denoising",
             ),
+            "Qwen3ForCausalLM": (
+                MiniMaxMusic3LanguageModel,
+                MiniMaxMusic3LanguageConfig,
+                "minimax-music3-language",
+            ),
+            "MiniMaxMusic3RVQDepthDecoder": (
+                MiniMaxMusic3RVQDepthDecoder,
+                MiniMaxMusic3RVQConfig,
+                "minimax-music3-rvq",
+            ),
+            "MiniMaxMusic3ConditionEncoder": (
+                MiniMaxMusic3ConditionEncoder,
+                MiniMaxMusic3ConditionConfig,
+                "minimax-music3-condition",
+            ),
+            "MiniMaxMusic3Transformer1DModel": (
+                MiniMaxMusic3Transformer1DModel,
+                MiniMaxMusic3TransformerConfig,
+                "minimax-music3-denoising",
+            ),
+            "MiniMaxMusic3Vocoder": (
+                MiniMaxMusic3Vocoder,
+                MiniMaxMusic3VocoderConfig,
+                "minimax-music3-vocoder",
+            ),
         }
     )
 
@@ -136,15 +174,20 @@ def _load_diffusers_pipeline_index(
     Returns the parsed JSON dict, or ``None`` if not found.
     """
     from huggingface_hub import hf_hub_download
+    from huggingface_hub.utils import EntryNotFoundError
 
-    try:
-        path = hf_hub_download(
-            repo_id=model_id,
-            filename="model_index.json",
-            revision=revision,
-        )
-    except (OSError, ValueError) as e:
-        logger.debug("Failed to download model_index.json for %s: %s", model_id, e)
+    path = None
+    for filename in ("model_index.json", "modular_model_index.json"):
+        try:
+            path = hf_hub_download(
+                repo_id=model_id,
+                filename=filename,
+                revision=revision,
+            )
+            break
+        except (EntryNotFoundError, OSError, ValueError) as e:
+            logger.debug("Failed to download %s for %s: %s", filename, model_id, e)
+    if path is None:
         return None
 
     with open(path) as f:
@@ -156,6 +199,7 @@ def _download_diffusers_component_weights(
     component_name: str,
     *,
     revision: str | None = None,
+    subfolder: str | None = None,
 ) -> dict[str, torch.Tensor]:
     """Download weights for a specific component of a diffusers pipeline.
 
@@ -168,7 +212,8 @@ def _download_diffusers_component_weights(
     from huggingface_hub import hf_hub_download
     from huggingface_hub.utils import EntryNotFoundError
 
-    prefix = f"{component_name}/"
+    resolved_subfolder = component_name if subfolder is None else subfolder
+    prefix = f"{resolved_subfolder}/" if resolved_subfolder else ""
     # Diffusers uses two naming conventions for the weight basename, and either
     # safetensors (preferred) or PyTorch .bin serialization. Some real repos
     # (e.g. OFA-Sys/small-stable-diffusion-v0) ship only .bin.
@@ -234,26 +279,61 @@ def _load_diffusers_component_config(
     component_name: str,
     *,
     revision: str | None = None,
+    subfolder: str | None = None,
 ) -> dict:
     """Load the config.json for a specific diffusers pipeline component."""
     from huggingface_hub import hf_hub_download
 
+    resolved_subfolder = component_name if subfolder is None else subfolder
+    filename = f"{resolved_subfolder}/config.json" if resolved_subfolder else "config.json"
     path = hf_hub_download(
         repo_id=model_id,
-        filename=f"{component_name}/config.json",
+        filename=filename,
         revision=revision,
     )
     with open(path) as f:
         return json.load(f)
 
 
-def _load_optional_diffusers_json(model_id: str, filename: str) -> dict:
+def _resolve_diffusers_component_source(
+    root_model_id: str,
+    root_revision: str | None,
+    component_name: str,
+    component_info: list,
+) -> tuple[str, str | None, str | None]:
+    """Resolve a modular component's repository, revision, and subfolder.
+
+    Legacy two-item entries always use ``root_model_id/component_name`` at the
+    caller's revision. For modular three-item entries, an external repository
+    uses its metadata revision independently of the root pin. A component that
+    still references the root repository uses the explicit caller revision when
+    supplied, otherwise its metadata revision.
+    """
+    if len(component_info) == 2 or not isinstance(component_info[2], dict):
+        return root_model_id, root_revision, component_name
+
+    metadata = component_info[2]
+    component_model_id = metadata.get("pretrained_model_name_or_path") or root_model_id
+    metadata_revision = metadata.get("revision")
+    if component_model_id == root_model_id:
+        component_revision = root_revision if root_revision is not None else metadata_revision
+    else:
+        component_revision = metadata_revision
+    subfolder = metadata.get("subfolder") if "subfolder" in metadata else component_name
+    if subfolder is None:
+        subfolder = ""
+    return component_model_id, component_revision, subfolder
+
+
+def _load_optional_diffusers_json(
+    model_id: str, filename: str, *, revision: str | None = None
+) -> dict:
     """Load optional non-neural pipeline metadata without failing the build."""
     from huggingface_hub import hf_hub_download
     from huggingface_hub.utils import EntryNotFoundError
 
     try:
-        path = hf_hub_download(repo_id=model_id, filename=filename)
+        path = hf_hub_download(repo_id=model_id, filename=filename, revision=revision)
     except EntryNotFoundError:
         return {}
     with open(path) as f:
@@ -347,10 +427,18 @@ def build_diffusers_pipeline(
             continue
         if components is not None and component_name not in components:
             continue
-        if not isinstance(component_info, list) or len(component_info) != 2:
+        if not isinstance(component_info, list) or len(component_info) not in (2, 3):
             continue
 
-        library, class_name = component_info
+        library, class_name = component_info[:2]
+        component_model_id, component_revision, component_subfolder = (
+            _resolve_diffusers_component_source(
+                model_id,
+                revision,
+                component_name,
+                component_info,
+            )
+        )
         if class_name not in _DIFFUSERS_CLASS_MAP:
             logger.info(
                 "Skipping diffusers component '%s' (class '%s' from '%s' is not registered).",
@@ -367,10 +455,13 @@ def build_diffusers_pipeline(
             class_name,
         )
 
+        component_source_kwargs = {"revision": component_revision}
+        if len(component_info) == 3 and isinstance(component_info[2], dict):
+            component_source_kwargs["subfolder"] = component_subfolder
         component_config_dict = _load_diffusers_component_config(
-            model_id,
+            component_model_id,
             component_name,
-            revision=revision,
+            **component_source_kwargs,
         )
         component_configs[component_name] = component_config_dict
         config = config_class.from_diffusers(component_config_dict)
@@ -415,9 +506,9 @@ def build_diffusers_pipeline(
 
         if load_weights:
             state_dict = _download_diffusers_component_weights(
-                model_id,
+                component_model_id,
                 component_name,
-                revision=revision,
+                **component_source_kwargs,
             )
             if hasattr(model_module, "preprocess_weights"):
                 state_dict = model_module.preprocess_weights(state_dict)
@@ -435,17 +526,36 @@ def build_diffusers_pipeline(
 
     from mobius._diffusers_configs import DiffusersPipelineConfig
 
+    def load_optional_component_json(component_name: str, filename: str) -> dict:
+        component_info = pipeline_index.get(component_name)
+        if not isinstance(component_info, list) or len(component_info) not in (2, 3):
+            return {}
+        source_model_id, source_revision, source_subfolder = (
+            _resolve_diffusers_component_source(
+                model_id,
+                revision,
+                component_name,
+                component_info,
+            )
+        )
+        component_filename = f"{source_subfolder}/{filename}" if source_subfolder else filename
+        return _load_optional_diffusers_json(
+            source_model_id,
+            component_filename,
+            revision=source_revision,
+        )
+
     package.config = DiffusersPipelineConfig(
         source_model_id=model_id,
         pipeline_class=pipeline_class,
         component_configs=component_configs,
         scheduler_config=(
-            _load_optional_diffusers_json(model_id, "scheduler/scheduler_config.json")
+            load_optional_component_json("scheduler", "scheduler_config.json")
             if "scheduler" in pipeline_index
             else {}
         ),
         processor_config=(
-            _load_optional_diffusers_json(model_id, "processor/preprocessor_config.json")
+            load_optional_component_json("processor", "preprocessor_config.json")
             if "processor" in pipeline_index
             else {}
         ),

--- a/src/mobius/_diffusers_builder_test.py
+++ b/src/mobius/_diffusers_builder_test.py
@@ -16,6 +16,7 @@ from mobius._diffusers_builder import (
     _init_diffusers_class_map,
     _load_diffusers_component_config,
     _load_diffusers_pipeline_index,
+    _resolve_diffusers_component_source,
     build_diffusers_pipeline,
 )
 from mobius._model_package import ModelPackage
@@ -63,6 +64,11 @@ class TestInitDiffusersClassMap:
             "AutoencoderKLQwenImage",
             "AutoencoderKLCogVideoX",
             "CogVideoXTransformer3DModel",
+            "MiniMaxMusic3ConditionEncoder",
+            "MiniMaxMusic3RVQDepthDecoder",
+            "MiniMaxMusic3Transformer1DModel",
+            "MiniMaxMusic3Vocoder",
+            "Qwen3ForCausalLM",
         }
         assert expected_keys == set(_DIFFUSERS_CLASS_MAP.keys())
 
@@ -89,6 +95,11 @@ class TestInitDiffusersClassMap:
             "qwen-image-text-encoding",
             "video-denoising",
             "feature-extraction",
+            "minimax-music3-condition",
+            "minimax-music3-denoising",
+            "minimax-music3-language",
+            "minimax-music3-rvq",
+            "minimax-music3-vocoder",
         }
         for class_name, (_, _, task_name) in _DIFFUSERS_CLASS_MAP.items():
             assert task_name in valid_tasks, f"Unknown task '{task_name}' for {class_name}"
@@ -174,6 +185,21 @@ class TestDiffusersHubRevision:
             revision="pinned-revision",
         )
 
+    @patch("huggingface_hub.hf_hub_download", return_value="config.json")
+    def test_component_config_uses_resolved_external_subfolder(self, mock_download):
+        with patch("builtins.open", mock_open(read_data='{"in_channels": 3}')):
+            _load_diffusers_component_config(
+                "external/component-repo",
+                "transformer",
+                revision="component-revision",
+                subfolder="nested/transformer",
+            )
+        mock_download.assert_called_once_with(
+            repo_id="external/component-repo",
+            filename="nested/transformer/config.json",
+            revision="component-revision",
+        )
+
     @patch("mobius._diffusers_builder._parallel_download", return_value=[])
     @patch("huggingface_hub.hf_hub_download", return_value="weights.index.json")
     def test_component_weight_downloads_use_revision(
@@ -202,6 +228,95 @@ class TestDiffusersHubRevision:
             desc="vae weights",
         )
 
+    @patch("mobius._diffusers_builder._parallel_download", return_value=[])
+    @patch("huggingface_hub.hf_hub_download", return_value="weights.index.json")
+    def test_component_weights_use_resolved_external_subfolder(
+        self,
+        mock_download,
+        mock_parallel_download,
+    ):
+        index = '{"weight_map": {"weight": "model-00001-of-00001.safetensors"}}'
+        with patch("builtins.open", mock_open(read_data=index)):
+            _download_diffusers_component_weights(
+                "external/component-repo",
+                "transformer",
+                revision="component-revision",
+                subfolder="nested/transformer",
+            )
+        mock_download.assert_called_once_with(
+            repo_id="external/component-repo",
+            filename=("nested/transformer/diffusion_pytorch_model.safetensors.index.json"),
+            revision="component-revision",
+        )
+        mock_parallel_download.assert_called_once_with(
+            "external/component-repo",
+            ["nested/transformer/model-00001-of-00001.safetensors"],
+            revision="component-revision",
+            desc="transformer weights",
+        )
+
+    def test_component_source_revision_precedence(self):
+        root_entry = [
+            "diffusers",
+            "MiniMaxMusic3ConditionEncoder",
+            {
+                "pretrained_model_name_or_path": "root/music",
+                "revision": "metadata-revision",
+                "subfolder": "condition_encoder",
+            },
+        ]
+        assert _resolve_diffusers_component_source(
+            "root/music", "caller-revision", "condition_encoder", root_entry
+        ) == ("root/music", "caller-revision", "condition_encoder")
+        assert _resolve_diffusers_component_source(
+            "root/music", None, "condition_encoder", root_entry
+        ) == ("root/music", "metadata-revision", "condition_encoder")
+
+        external_entry = [
+            "diffusers",
+            "MiniMaxMusic3ConditionEncoder",
+            {
+                "pretrained_model_name_or_path": "external/components",
+                "revision": "external-revision",
+                "subfolder": None,
+            },
+        ]
+        assert _resolve_diffusers_component_source(
+            "root/music", "caller-revision", "condition_encoder", external_entry
+        ) == ("external/components", "external-revision", "")
+
+    @patch("huggingface_hub.hf_hub_download", return_value="scheduler.json")
+    def test_optional_metadata_download_uses_revision(self, mock_download):
+        from mobius._diffusers_builder import _load_optional_diffusers_json
+
+        with patch("builtins.open", mock_open(read_data='{"shift": 3.0}')):
+            result = _load_optional_diffusers_json(
+                "fake/model",
+                "scheduler/scheduler_config.json",
+                revision="pinned-revision",
+            )
+        assert result == {"shift": 3.0}
+        mock_download.assert_called_once_with(
+            repo_id="fake/model",
+            filename="scheduler/scheduler_config.json",
+            revision="pinned-revision",
+        )
+
+    @patch("huggingface_hub.hf_hub_download")
+    def test_falls_back_to_modular_model_index(self, mock_download):
+        from huggingface_hub.utils import EntryNotFoundError
+
+        mock_download.side_effect = [
+            EntryNotFoundError("missing"),
+            "modular_model_index.json",
+        ]
+        with patch(
+            "builtins.open",
+            mock_open(read_data='{"_class_name": "MiniMaxMusic3ModularPipeline"}'),
+        ):
+            result = _load_diffusers_pipeline_index("fake/model", revision="pinned-revision")
+        assert result["_class_name"] == "MiniMaxMusic3ModularPipeline"
+
 
 # ── build_diffusers_pipeline component filtering ─────────────────────────
 
@@ -226,6 +341,64 @@ class TestBuildDiffusersPipelineFiltering:
             build_diffusers_pipeline("fake/model", load_weights=False)
         # _load_diffusers_component_config should never be called
         mock_load_config.assert_not_called()
+
+    @patch("mobius._diffusers_builder._load_optional_diffusers_json", return_value={})
+    @patch(
+        "mobius._diffusers_builder._load_diffusers_component_config",
+        return_value={
+            "condition_hidden_dim": 16,
+            "num_condition_layers": 2,
+            "out_dim": 8,
+            "input_sampling_rate": 24000,
+            "input_hop_length": 960,
+            "output_sampling_rate": 44100,
+            "output_hop_length": 512,
+        },
+    )
+    @patch(
+        "mobius._diffusers_builder._load_diffusers_pipeline_index",
+        return_value={
+            "_class_name": "MiniMaxMusic3ModularPipeline",
+            "condition_encoder": [
+                "diffusers",
+                "MiniMaxMusic3ConditionEncoder",
+                {
+                    "pretrained_model_name_or_path": "fake/music3",
+                    "revision": None,
+                    "subfolder": "condition_encoder",
+                },
+            ],
+            "scheduler": [
+                "diffusers",
+                "FlowMatchEulerDiscreteScheduler",
+                {
+                    "pretrained_model_name_or_path": "external/scheduler",
+                    "revision": "scheduler-revision",
+                    "subfolder": "flow",
+                },
+            ],
+        },
+    )
+    def test_builds_modular_index_entry_with_metadata(
+        self, _mock_index, _mock_config, _mock_optional
+    ):
+        package = build_diffusers_pipeline(
+            "fake/music3", revision="root-revision", load_weights=False
+        )
+        assert set(package) == {"condition_encoder"}
+        assert package.config.model_type == "minimax_music3"
+        assert package.config.pipeline_class == "MiniMaxMusic3ModularPipeline"
+        _mock_config.assert_called_once_with(
+            "fake/music3",
+            "condition_encoder",
+            revision="root-revision",
+            subfolder="condition_encoder",
+        )
+        _mock_optional.assert_called_once_with(
+            "external/scheduler",
+            "flow/scheduler_config.json",
+            revision="scheduler-revision",
+        )
 
     @patch(
         "mobius._diffusers_builder._load_diffusers_component_config",
@@ -252,11 +425,11 @@ class TestBuildDiffusersPipelineFiltering:
         "mobius._diffusers_builder._load_diffusers_pipeline_index",
     )
     def test_skips_lists_with_wrong_length(self, mock_load_index, mock_load_config):
-        """Lists that don't have exactly 2 elements are skipped."""
+        """Lists that don't have two elements or two plus metadata are skipped."""
         mock_load_index.return_value = {
             "_class_name": "FluxPipeline",
             "single": ["only_one"],
-            "triple": ["a", "b", "c"],
+            "quadruple": ["a", "b", {}, "extra"],
             "empty": [],
         }
         with pytest.raises(ValueError, match="No supported neural network"):

--- a/src/mobius/_diffusers_configs.py
+++ b/src/mobius/_diffusers_configs.py
@@ -13,6 +13,12 @@ import onnx_ir as ir
 if TYPE_CHECKING:
     from mobius._configs import ArchitectureConfig
 
+MINIMAX_MUSIC3_AUDIO_END_TOKEN_ID = 151670
+MINIMAX_MUSIC3_AUDIO_CODE_OFFSET = 151675
+MINIMAX_MUSIC3_SEMANTIC_VOCAB_SIZE = 16384
+MINIMAX_MUSIC3_NUM_CODEBOOKS = 8
+MINIMAX_MUSIC3_FEEDBACK_SCALE = MINIMAX_MUSIC3_NUM_CODEBOOKS**-0.5
+
 
 class CLIPTextConfig:
     """Adapter that builds an :class:`ArchitectureConfig` for a CLIP text encoder.
@@ -76,6 +82,24 @@ class QwenImageTextEncoderConfig:
         return ArchitectureConfig.from_transformers(text_config, parent_config=hf_config)
 
 
+class MiniMaxMusic3LanguageConfig:
+    """Adapter for the Qwen3 global language model bundled with Music 3."""
+
+    @classmethod
+    def from_diffusers(cls, config: dict) -> ArchitectureConfig:
+        import transformers
+
+        from mobius._configs import ArchitectureConfig
+
+        fields = dict(config)
+        fields.pop("architectures", None)
+        fields.pop("transformers_version", None)
+        fields.pop("dtype", None)
+        model_type = fields.pop("model_type", "qwen3")
+        hf_config = transformers.AutoConfig.for_model(model_type, **fields)
+        return ArchitectureConfig.from_transformers(hf_config)
+
+
 @dataclasses.dataclass
 class DiffusersPipelineConfig:
     """Non-neural diffusers pipeline metadata retained on a ModelPackage."""
@@ -86,6 +110,102 @@ class DiffusersPipelineConfig:
     scheduler_config: dict
     processor_config: dict
     model_type: str = "diffusers"
+
+
+@dataclasses.dataclass
+class MiniMaxMusic3RVQConfig:
+    """Configuration for the MiniMax Music 3 residual-codebook depth decoder."""
+
+    hidden_size: int = 4096
+    num_layers: int = 4
+    num_attention_heads: int = 16
+    intermediate_size: int = 6144
+    audio_vocab_size: int = 1024
+    num_codebooks: int = 8
+    max_position_embeddings: int = 16
+    dtype: ir.DataType = ir.DataType.FLOAT
+
+    @classmethod
+    def from_diffusers(cls, config: dict) -> MiniMaxMusic3RVQConfig:
+        return cls(
+            **{
+                field.name: config[field.name]
+                for field in dataclasses.fields(cls)
+                if field.name in config
+            }
+        )
+
+
+@dataclasses.dataclass
+class MiniMaxMusic3ConditionConfig:
+    """Configuration for the MiniMax Music 3 frame-condition encoder."""
+
+    condition_hidden_dim: int = 4096
+    num_condition_layers: int = 8
+    out_dim: int = 2048
+    input_sampling_rate: int = 24000
+    input_hop_length: int = 960
+    output_sampling_rate: int = 44100
+    output_hop_length: int = 512
+    dtype: ir.DataType = ir.DataType.FLOAT
+
+    @classmethod
+    def from_diffusers(cls, config: dict) -> MiniMaxMusic3ConditionConfig:
+        return cls(
+            **{
+                field.name: config[field.name]
+                for field in dataclasses.fields(cls)
+                if field.name in config
+            }
+        )
+
+
+@dataclasses.dataclass
+class MiniMaxMusic3TransformerConfig:
+    """Configuration for the MiniMax Music 3 1D flow-matching transformer."""
+
+    in_channels: int = 128
+    condition_dim: int = 2048
+    num_layers: int = 36
+    num_attention_heads: int = 32
+    attention_head_dim: int = 64
+    ff_inner_dim: int = 8192
+    rotary_dim: int = 32
+    fourier_embedding_dim: int = 256
+    dtype: ir.DataType = ir.DataType.FLOAT
+
+    @classmethod
+    def from_diffusers(cls, config: dict) -> MiniMaxMusic3TransformerConfig:
+        return cls(
+            **{
+                field.name: config[field.name]
+                for field in dataclasses.fields(cls)
+                if field.name in config
+            }
+        )
+
+
+@dataclasses.dataclass
+class MiniMaxMusic3VocoderConfig:
+    """Configuration for the MiniMax Music 3 stereo DAC-style vocoder."""
+
+    latent_channels: int = 128
+    decoder_input_dim: int = 1024
+    decoder_hidden_dim: int = 1536
+    upsampling_ratios: tuple[int, ...] = (8, 8, 4, 2)
+    sampling_rate: int = 44100
+    dtype: ir.DataType = ir.DataType.FLOAT
+
+    @classmethod
+    def from_diffusers(cls, config: dict) -> MiniMaxMusic3VocoderConfig:
+        values = {
+            field.name: config[field.name]
+            for field in dataclasses.fields(cls)
+            if field.name in config
+        }
+        if "upsampling_ratios" in values:
+            values["upsampling_ratios"] = tuple(values["upsampling_ratios"])
+        return cls(**values)
 
 
 @dataclasses.dataclass

--- a/src/mobius/models/__init__.py
+++ b/src/mobius/models/__init__.py
@@ -90,6 +90,11 @@ __all__ = [
     "MimiModel",
     "MoshiDepformerModel",
     "MoshiTemporalModel",
+    "MiniMaxMusic3ConditionEncoder",
+    "MiniMaxMusic3LanguageModel",
+    "MiniMaxMusic3RVQDepthDecoder",
+    "MiniMaxMusic3Transformer1DModel",
+    "MiniMaxMusic3Vocoder",
     "MoECausalLMModel",
     "NanoChatCausalLMModel",
     "NemotronCausalLMModel",
@@ -238,6 +243,13 @@ from mobius.models.mamba import Mamba2CausalLMModel, MambaCausalLMModel
 from mobius.models.mimi import MimiModel, mimi_default_config
 from mobius.models.minicpmv4_6 import MiniCPMV46ForConditionalGeneration
 from mobius.models.minimax import MiniMaxCausalLMModel
+from mobius.models.minimax_music3 import (
+    MiniMaxMusic3ConditionEncoder,
+    MiniMaxMusic3LanguageModel,
+    MiniMaxMusic3RVQDepthDecoder,
+    MiniMaxMusic3Transformer1DModel,
+    MiniMaxMusic3Vocoder,
+)
 from mobius.models.moe import (
     Ernie45MoECausalLMModel,
     Glm4MoECausalLMModel,

--- a/src/mobius/models/minimax_music3.py
+++ b/src/mobius/models/minimax_music3.py
@@ -105,7 +105,8 @@ class _DepthAttention(nn.Module):
             op.MatMul(query, op.Transpose(key, perm=[0, 1, 3, 2])),
             self._head_dim**-0.5,
         )
-        scores = op.Where(causal_mask, scores, float("-inf"))
+        neg_inf = op.CastLike(float("-inf"), scores)
+        scores = op.Where(causal_mask, scores, neg_inf)
         attended = op.MatMul(op.Softmax(scores, axis=-1), value)
         attended = op.Transpose(attended, perm=[0, 2, 1, 3])
         attended = op.Reshape(

--- a/src/mobius/models/minimax_music3.py
+++ b/src/mobius/models/minimax_music3.py
@@ -1,0 +1,555 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Native neural components for the MiniMax Music 3 modular diffusion pipeline."""
+
+from __future__ import annotations
+
+import math
+
+import onnx_ir as ir
+import torch
+from onnxscript import OpBuilder, nn
+
+from mobius._diffusers_configs import (
+    MiniMaxMusic3ConditionConfig,
+    MiniMaxMusic3RVQConfig,
+    MiniMaxMusic3TransformerConfig,
+    MiniMaxMusic3VocoderConfig,
+)
+from mobius.components import Embedding, LayerNorm, Linear, RMSNorm, TimestepEmbedding
+from mobius.models.qwen import Qwen3CausalLMModel
+
+
+class _Conv1d(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        *,
+        stride: int = 1,
+        padding: int = 0,
+        dilation: int = 1,
+        bias: bool = True,
+    ):
+        super().__init__()
+        self.weight = nn.Parameter([out_channels, in_channels, kernel_size])
+        self.bias = nn.Parameter([out_channels]) if bias else None
+        self._kernel_size = kernel_size
+        self._stride = stride
+        self._padding = padding
+        self._dilation = dilation
+
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
+        args = (hidden_states, self.weight)
+        if self.bias is not None:
+            args += (self.bias,)
+        return op.Conv(
+            *args,
+            kernel_shape=[self._kernel_size],
+            strides=[self._stride],
+            pads=[self._padding, self._padding],
+            dilations=[self._dilation],
+        )
+
+
+class _ConvTranspose1d(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int, stride: int):
+        super().__init__()
+        self.weight = nn.Parameter([in_channels, out_channels, 2 * stride])
+        self.bias = nn.Parameter([out_channels])
+        self._stride = stride
+
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
+        padding = math.ceil(self._stride / 2)
+        return op.ConvTranspose(
+            hidden_states,
+            self.weight,
+            self.bias,
+            kernel_shape=[2 * self._stride],
+            strides=[self._stride],
+            pads=[padding, padding],
+        )
+
+
+class _DepthAttention(nn.Module):
+    def __init__(self, dim: int, heads: int):
+        super().__init__()
+        self.to_q = Linear(dim, dim, bias=False)
+        self.to_k = Linear(dim, dim, bias=False)
+        self.to_v = Linear(dim, dim, bias=False)
+        self.to_out = Linear(dim, dim, bias=False)
+        self._heads = heads
+        self._head_dim = dim // heads
+
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
+        query = self.to_q(op, hidden_states)
+        key = self.to_k(op, hidden_states)
+        value = self.to_v(op, hidden_states)
+        seq_len = op.Squeeze(op.Shape(hidden_states, start=1, end=2), [0])
+        positions = op.Range(op.Constant(value_int=0), seq_len, op.Constant(value_int=1))
+        query_positions = op.Unsqueeze(positions, [1])
+        key_positions = op.Unsqueeze(positions, [0])
+        causal_mask = op.LessOrEqual(key_positions, query_positions)
+        shape = op.Shape(query, start=0, end=2)
+        qkv_shape = op.Concat(
+            shape,
+            op.Constant(value_ints=[self._heads, self._head_dim]),
+            axis=0,
+        )
+        query = op.Transpose(op.Reshape(query, qkv_shape), perm=[0, 2, 1, 3])
+        key = op.Transpose(op.Reshape(key, qkv_shape), perm=[0, 2, 1, 3])
+        value = op.Transpose(op.Reshape(value, qkv_shape), perm=[0, 2, 1, 3])
+        scores = op.Mul(
+            op.MatMul(query, op.Transpose(key, perm=[0, 1, 3, 2])),
+            self._head_dim**-0.5,
+        )
+        scores = op.Where(causal_mask, scores, float("-inf"))
+        attended = op.MatMul(op.Softmax(scores, axis=-1), value)
+        attended = op.Transpose(attended, perm=[0, 2, 1, 3])
+        attended = op.Reshape(
+            attended,
+            op.Concat(
+                shape,
+                op.Constant(value_ints=[self._heads * self._head_dim]),
+                axis=0,
+            ),
+        )
+        return self.to_out(op, attended)
+
+
+class _DepthDecoderBlock(nn.Module):
+    def __init__(self, config: MiniMaxMusic3RVQConfig):
+        super().__init__()
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=1e-6)
+        self.attn = _DepthAttention(config.hidden_size, config.num_attention_heads)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=1e-6)
+        self.gate_proj = Linear(config.hidden_size, config.intermediate_size, bias=False)
+        self.up_proj = Linear(config.hidden_size, config.intermediate_size, bias=False)
+        self.down_proj = Linear(config.intermediate_size, config.hidden_size, bias=False)
+
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
+        residual = hidden_states
+        hidden_states = self.input_layernorm(op, hidden_states)
+        hidden_states = op.Add(residual, self.attn(op, hidden_states))
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(op, hidden_states)
+        gate = self.gate_proj(op, hidden_states)
+        gate = op.Mul(gate, op.Sigmoid(gate))
+        hidden_states = self.down_proj(op, op.Mul(gate, self.up_proj(op, hidden_states)))
+        return op.Add(residual, hidden_states)
+
+
+class MiniMaxMusic3RVQDepthDecoder(nn.Module):
+    """Local causal decoder rerun at growing lengths 2..8 for residual RVQ codes."""
+
+    default_task = "minimax-music3-rvq"
+    category = "Audio"
+
+    def __init__(self, config: MiniMaxMusic3RVQConfig):
+        super().__init__()
+        self.audio_embeddings = Embedding(
+            config.audio_vocab_size * (config.num_codebooks - 1), config.hidden_size
+        )
+        self.projection = Linear(config.hidden_size, config.hidden_size, bias=False)
+        self.pos_embedding = Embedding(config.max_position_embeddings, config.hidden_size)
+        self.layers = nn.ModuleList(
+            [_DepthDecoderBlock(config) for _ in range(config.num_layers)]
+        )
+        self.norm = RMSNorm(config.hidden_size, eps=1e-6)
+        self.audio_heads = nn.ModuleList(
+            [
+                Linear(config.hidden_size, config.audio_vocab_size, bias=False)
+                for _ in range(config.num_codebooks - 1)
+            ]
+        )
+
+    def forward(self, op: OpBuilder, inputs_embeds: ir.Value):
+        # Add learned positions to the projected within-frame sequence.
+        seq_len = op.Shape(inputs_embeds, start=1, end=2)
+        positions = op.Range(
+            op.Constant(value_int=0),
+            op.Squeeze(seq_len, [0]),
+            op.Constant(value_int=1),
+        )
+        hidden_states = op.Add(
+            inputs_embeds, op.Unsqueeze(self.pos_embedding(op, positions), [0])
+        )
+        for layer in self.layers:
+            hidden_states = layer(op, hidden_states)
+        return self.norm(op, hidden_states)
+
+
+class MiniMaxMusic3ConditionEncoder(nn.Module):
+    """Mix one global-final plus seven RVQ-step hiddens onto the Flow-VAE timeline."""
+
+    default_task = "minimax-music3-condition"
+    category = "Audio"
+
+    def __init__(self, config: MiniMaxMusic3ConditionConfig):
+        super().__init__()
+        self.layer_weight_logits = nn.Parameter([config.num_condition_layers])
+        self.layer_scale = nn.Parameter([1])
+        self.proj = _Conv1d(config.condition_hidden_dim, config.out_dim, 3, padding=1)
+        self._config = config
+
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
+        # [B, frames, layers*hidden] -> [B, layers, hidden, frames].
+        batch = op.Shape(hidden_states, start=0, end=1)
+        frames = op.Shape(hidden_states, start=1, end=2)
+        hidden_states = op.Transpose(hidden_states, perm=[0, 2, 1])
+        target_shape = op.Concat(
+            batch,
+            op.Constant(
+                value_ints=[
+                    self._config.num_condition_layers,
+                    self._config.condition_hidden_dim,
+                ]
+            ),
+            frames,
+            axis=0,
+        )
+        hidden_states = op.Reshape(hidden_states, target_shape)
+        weights = op.Softmax(self.layer_weight_logits, axis=0)
+        weights = op.Unsqueeze(weights, op.Constant(value_ints=[0, 2, 3]))
+        hidden_states = op.ReduceSum(
+            op.Mul(hidden_states, weights),
+            op.Constant(value_ints=[1]),
+            keepdims=0,
+        )
+        hidden_states = self.proj(op, op.Mul(hidden_states, self.layer_scale))
+
+        # Match Python int() exactly with positive integer arithmetic (floor).
+        numerator = self._config.output_sampling_rate * self._config.input_hop_length
+        denominator = self._config.input_sampling_rate * self._config.output_hop_length
+        latent_length = op.Div(
+            op.Mul(frames, op.Constant(value_int=numerator)),
+            op.Constant(value_int=denominator),
+        )
+        latent_length = op.Max(latent_length, op.Constant(value_int=1))
+        hidden_states = op.Resize(
+            hidden_states,
+            None,
+            None,
+            op.Concat(op.Shape(hidden_states, start=0, end=2), latent_length, axis=0),
+            mode="nearest",
+            coordinate_transformation_mode="asymmetric",
+            nearest_mode="floor",
+        )
+        return op.Transpose(hidden_states, perm=[0, 2, 1])
+
+
+class _FourierEmbedding(nn.Module):
+    def __init__(self, embedding_dim: int):
+        super().__init__()
+        self.weight = nn.Parameter([embedding_dim // 2, 1])
+
+    def forward(self, op: OpBuilder, timestep: ir.Value):
+        angles = op.Mul(
+            op.MatMul(op.Unsqueeze(timestep, [-1]), op.Transpose(self.weight)),
+            2.0 * math.pi,
+        )
+        return op.Concat(op.Cos(angles), op.Sin(angles), axis=-1)
+
+
+def _partial_rope(
+    op: OpBuilder,
+    hidden_states: ir.Value,
+    cos: ir.Value,
+    sin: ir.Value,
+    *,
+    heads: int,
+    head_dim: int,
+    rotary_dim: int,
+):
+    batch_seq = op.Shape(hidden_states, start=0, end=2)
+    states = op.Reshape(
+        hidden_states,
+        op.Concat(batch_seq, op.Constant(value_ints=[heads, head_dim]), axis=0),
+    )
+    rotated, passthrough = op.Split(
+        states,
+        op.Constant(value_ints=[rotary_dim, head_dim - rotary_dim]),
+        axis=3,
+        _outputs=2,
+    )
+    first, second = op.Split(rotated, num_outputs=2, axis=3, _outputs=2)
+    rotate_half = op.Concat(op.Neg(second), first, axis=3)
+    cos = op.CastLike(op.Unsqueeze(cos, op.Constant(value_ints=[0, 2])), rotated)
+    sin = op.CastLike(op.Unsqueeze(sin, op.Constant(value_ints=[0, 2])), rotated)
+    states = op.Concat(
+        op.Add(op.Mul(rotated, cos), op.Mul(rotate_half, sin)), passthrough, axis=3
+    )
+    return op.Reshape(
+        states, op.Concat(batch_seq, op.Constant(value_ints=[heads * head_dim]), axis=0)
+    )
+
+
+class _FlowAttention(nn.Module):
+    def __init__(self, config: MiniMaxMusic3TransformerConfig):
+        super().__init__()
+        dim = config.num_attention_heads * config.attention_head_dim
+        self.to_q = Linear(dim, dim, bias=False)
+        self.to_k = Linear(dim, dim, bias=False)
+        self.to_v = Linear(dim, dim, bias=False)
+        self.to_out = nn.ModuleList([Linear(dim, dim, bias=False)])
+        self._heads = config.num_attention_heads
+        self._head_dim = config.attention_head_dim
+        self._rotary_dim = config.rotary_dim
+
+    def forward(self, op: OpBuilder, hidden_states: ir.Value, cos: ir.Value, sin: ir.Value):
+        query = _partial_rope(
+            op,
+            self.to_q(op, hidden_states),
+            cos,
+            sin,
+            heads=self._heads,
+            head_dim=self._head_dim,
+            rotary_dim=self._rotary_dim,
+        )
+        key = _partial_rope(
+            op,
+            self.to_k(op, hidden_states),
+            cos,
+            sin,
+            heads=self._heads,
+            head_dim=self._head_dim,
+            rotary_dim=self._rotary_dim,
+        )
+        value = self.to_v(op, hidden_states)
+        attended = op.Attention(
+            query,
+            key,
+            value,
+            q_num_heads=self._heads,
+            kv_num_heads=self._heads,
+        )
+        return self.to_out[0](op, attended)
+
+
+class _TransformerBlock(nn.Module):
+    def __init__(self, config: MiniMaxMusic3TransformerConfig):
+        super().__init__()
+        dim = config.num_attention_heads * config.attention_head_dim
+        self.norm1 = LayerNorm(dim, eps=1e-5)
+        self.attn = _FlowAttention(config)
+        self.norm2 = LayerNorm(dim, eps=1e-5)
+        self.ff_in = Linear(dim, config.ff_inner_dim * 2)
+        self.ff_out = Linear(config.ff_inner_dim, dim)
+
+    def forward(self, op: OpBuilder, hidden_states: ir.Value, cos: ir.Value, sin: ir.Value):
+        hidden_states = op.Add(
+            hidden_states, self.attn(op, self.norm1(op, hidden_states), cos, sin)
+        )
+        gate_states, gate = op.Split(
+            self.ff_in(op, self.norm2(op, hidden_states)),
+            num_outputs=2,
+            axis=-1,
+            _outputs=2,
+        )
+        gate = op.Mul(gate, op.Sigmoid(gate))
+        return op.Add(hidden_states, self.ff_out(op, op.Mul(gate_states, gate)))
+
+
+class MiniMaxMusic3Transformer1DModel(nn.Module):
+    """Bidirectional 1D flow transformer used by MiniMax Music 3."""
+
+    default_task = "minimax-music3-denoising"
+    category = "Diffusion"
+
+    def __init__(self, config: MiniMaxMusic3TransformerConfig):
+        super().__init__()
+        inner_dim = config.num_attention_heads * config.attention_head_dim
+        concat_channels = 2 * config.in_channels + config.condition_dim
+        self.time_proj = _FourierEmbedding(config.fourier_embedding_dim)
+        self.time_embed = TimestepEmbedding(config.fourier_embedding_dim, inner_dim)
+        self.preprocess_conv = _Conv1d(concat_channels, concat_channels, 1, bias=False)
+        self.proj_in = Linear(concat_channels, inner_dim, bias=False)
+        self.transformer_blocks = nn.ModuleList(
+            [_TransformerBlock(config) for _ in range(config.num_layers)]
+        )
+        self.proj_out = Linear(inner_dim, config.in_channels, bias=False)
+        self.postprocess_conv = _Conv1d(config.in_channels, config.in_channels, 1, bias=False)
+        self._config = config
+
+    def forward(
+        self,
+        op: OpBuilder,
+        hidden_states: ir.Value,
+        timestep: ir.Value,
+        encoder_hidden_states: ir.Value,
+    ):
+        condition = op.Transpose(encoder_hidden_states, perm=[0, 2, 1])
+        hidden_states = op.Concat(hidden_states, op.Mul(hidden_states, 0.0), condition, axis=1)
+        hidden_states = op.Add(hidden_states, self.preprocess_conv(op, hidden_states))
+        hidden_states = self.proj_in(op, op.Transpose(hidden_states, perm=[0, 2, 1]))
+        temb = op.Unsqueeze(self.time_embed(op, self.time_proj(op, timestep)), [1])
+        hidden_states = op.Concat(temb, hidden_states, axis=1)
+
+        seq_len = op.Squeeze(op.Shape(hidden_states, start=1, end=2))
+        steps = op.Cast(
+            op.Range(
+                op.Constant(value_int=0),
+                seq_len,
+                op.Constant(value_int=1),
+            ),
+            to=ir.DataType.FLOAT,
+        )
+        inv_idx = op.Cast(
+            op.Range(
+                op.Constant(value_int=0),
+                op.Constant(value_int=self._config.rotary_dim),
+                op.Constant(value_int=2),
+            ),
+            to=ir.DataType.FLOAT,
+        )
+        inv_freq = op.Reciprocal(
+            op.Pow(10000.0, op.Div(inv_idx, float(self._config.rotary_dim)))
+        )
+        freqs = op.Mul(
+            op.Unsqueeze(steps, op.Constant(value_ints=[1])),
+            op.Unsqueeze(inv_freq, op.Constant(value_ints=[0])),
+        )
+        freqs = op.Concat(freqs, freqs, axis=-1)
+        cos, sin = op.Cos(freqs), op.Sin(freqs)
+        for block in self.transformer_blocks:
+            hidden_states = block(op, hidden_states, cos, sin)
+
+        hidden_states = op.Slice(
+            hidden_states,
+            op.Constant(value_ints=[1]),
+            op.Constant(value_ints=[9223372036854775807]),
+            op.Constant(value_ints=[1]),
+        )
+        hidden_states = op.Transpose(self.proj_out(op, hidden_states), perm=[0, 2, 1])
+        return op.Add(hidden_states, self.postprocess_conv(op, hidden_states))
+
+
+class _Snake1d(nn.Module):
+    def __init__(self, channels: int):
+        super().__init__()
+        self.alpha = nn.Parameter([1, channels, 1])
+
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
+        angle = op.Mul(self.alpha, hidden_states)
+        return op.Add(
+            hidden_states,
+            op.Mul(op.Reciprocal(op.Add(self.alpha, 1e-9)), op.Pow(op.Sin(angle), 2.0)),
+        )
+
+
+class _VocoderResidualUnit(nn.Module):
+    def __init__(self, dim: int, dilation: int):
+        super().__init__()
+        self.snake1 = _Snake1d(dim)
+        self.conv1 = _Conv1d(dim, dim, 7, padding=3 * dilation, dilation=dilation)
+        self.snake2 = _Snake1d(dim)
+        self.conv2 = _Conv1d(dim, dim, 1)
+
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
+        residual = self.conv2(
+            op, self.snake2(op, self.conv1(op, self.snake1(op, hidden_states)))
+        )
+        return op.Add(hidden_states, residual)
+
+
+class _VocoderBlock(nn.Module):
+    def __init__(self, input_dim: int, output_dim: int, stride: int):
+        super().__init__()
+        self.snake1 = _Snake1d(input_dim)
+        self.conv_t1 = _ConvTranspose1d(input_dim, output_dim, stride)
+        self.res_unit1 = _VocoderResidualUnit(output_dim, 1)
+        self.res_unit2 = _VocoderResidualUnit(output_dim, 3)
+        self.res_unit3 = _VocoderResidualUnit(output_dim, 9)
+
+    def forward(self, op: OpBuilder, hidden_states: ir.Value):
+        hidden_states = self.conv_t1(op, self.snake1(op, hidden_states))
+        hidden_states = self.res_unit1(op, hidden_states)
+        hidden_states = self.res_unit2(op, hidden_states)
+        return self.res_unit3(op, hidden_states)
+
+
+class MiniMaxMusic3Vocoder(nn.Module):
+    """Stereo DAC-style waveform decoder used by MiniMax Music 3."""
+
+    default_task = "minimax-music3-vocoder"
+    category = "Audio"
+
+    def __init__(self, config: MiniMaxMusic3VocoderConfig):
+        super().__init__()
+        self.dec_in_proj = _Conv1d(config.latent_channels // 2, config.decoder_input_dim, 1)
+        self.conv_in = _Conv1d(
+            config.decoder_input_dim, config.decoder_hidden_dim, 7, padding=3
+        )
+        blocks = []
+        output_dim = config.decoder_hidden_dim
+        for index, stride in enumerate(config.upsampling_ratios):
+            input_dim = config.decoder_hidden_dim // (2**index)
+            output_dim = config.decoder_hidden_dim // (2 ** (index + 1))
+            blocks.append(_VocoderBlock(input_dim, output_dim, stride))
+        self.blocks = nn.ModuleList(blocks)
+        self.snake_out = _Snake1d(output_dim)
+        self.conv_out = _Conv1d(output_dim, 1, 7, padding=3)
+        self._latent_channels = config.latent_channels
+
+    def forward(self, op: OpBuilder, latents: ir.Value):
+        batch = op.Shape(latents, start=0, end=1)
+        length = op.Shape(latents, start=2, end=3)
+        folded_shape = op.Concat(
+            op.Mul(batch, op.Constant(value_int=2)),
+            op.Constant(value_ints=[self._latent_channels // 2]),
+            length,
+            axis=0,
+        )
+        hidden_states = op.Reshape(latents, folded_shape)
+        hidden_states = self.conv_in(op, self.dec_in_proj(op, hidden_states))
+        for block in self.blocks:
+            hidden_states = block(op, hidden_states)
+        waveform = op.Tanh(self.conv_out(op, self.snake_out(op, hidden_states)))
+        output_shape = op.Concat(batch, op.Constant(value_ints=[2, -1]), axis=0)
+        return op.Reshape(waveform, output_shape)
+
+    def preprocess_weights(
+        self, state_dict: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        """Fold PyTorch weight-normalization tensors into ordinary convolution weights."""
+        result = dict(state_dict)
+        for name in list(state_dict):
+            if not name.endswith(".weight_v"):
+                continue
+            base = name[: -len("_v")]
+            g_name = f"{base}_g"
+            value = state_dict[name]
+            scale = state_dict[g_name] / torch.linalg.vector_norm(
+                value, dim=tuple(range(1, value.ndim)), keepdim=True
+            )
+            result[base] = value * scale
+            del result[name]
+            del result[g_name]
+        return result
+
+
+class MiniMaxMusic3LanguageModel(Qwen3CausalLMModel):
+    """Qwen3 global language model exposing normalized hidden states for Music 3."""
+
+    default_task = "minimax-music3-language"
+    category = "Audio"
+
+    def forward(
+        self,
+        op: OpBuilder,
+        inputs_embeds: ir.Value,
+        attention_mask: ir.Value,
+        position_ids: ir.Value,
+        past_key_values: list | None = None,
+    ):
+        hidden_states, present_key_values = self.model(
+            op,
+            input_ids=inputs_embeds,
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+        )
+        return self.lm_head(op, hidden_states), hidden_states, present_key_values

--- a/src/mobius/models/minimax_music3.py
+++ b/src/mobius/models/minimax_music3.py
@@ -545,7 +545,7 @@ class MiniMaxMusic3LanguageModel(Qwen3CausalLMModel):
         position_ids: ir.Value,
         past_key_values: list | None = None,
     ):
-        hidden_states, present_key_values = self.model(
+        result = self.model(
             op,
             input_ids=inputs_embeds,
             inputs_embeds=inputs_embeds,
@@ -553,4 +553,8 @@ class MiniMaxMusic3LanguageModel(Qwen3CausalLMModel):
             position_ids=position_ids,
             past_key_values=past_key_values,
         )
+        if len(result) == 3:
+            hidden_states, present_key_values, _ = result
+        else:
+            hidden_states, present_key_values = result
         return self.lm_head(op, hidden_states), hidden_states, present_key_values

--- a/src/mobius/models/minimax_music3_test.py
+++ b/src/mobius/models/minimax_music3_test.py
@@ -1,0 +1,310 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from __future__ import annotations
+
+import numpy as np
+import onnx_ir as ir
+import torch
+
+from mobius import build_from_module
+from mobius._diffusers_configs import (
+    MINIMAX_MUSIC3_AUDIO_CODE_OFFSET,
+    MINIMAX_MUSIC3_AUDIO_END_TOKEN_ID,
+    MINIMAX_MUSIC3_FEEDBACK_SCALE,
+    MINIMAX_MUSIC3_SEMANTIC_VOCAB_SIZE,
+    MiniMaxMusic3ConditionConfig,
+    MiniMaxMusic3LanguageConfig,
+    MiniMaxMusic3RVQConfig,
+    MiniMaxMusic3TransformerConfig,
+    MiniMaxMusic3VocoderConfig,
+)
+from mobius._testing.ort_inference import OnnxModelSession
+from mobius._weight_loading import apply_weights
+from mobius.models.minimax_music3 import (
+    MiniMaxMusic3ConditionEncoder,
+    MiniMaxMusic3LanguageModel,
+    MiniMaxMusic3RVQDepthDecoder,
+    MiniMaxMusic3Transformer1DModel,
+    MiniMaxMusic3Vocoder,
+)
+
+
+def _initialize(model) -> None:
+    state = {
+        name: torch.full(tuple(value.shape), 0.01, dtype=torch.float32)
+        for name, value in model.graph.initializers.items()
+        if value.const_value is None
+    }
+    apply_weights(model, state)
+
+
+def test_rvq_depth_decoder_builds_all_pipeline_contracts():
+    config = MiniMaxMusic3RVQConfig(
+        hidden_size=32,
+        num_layers=1,
+        num_attention_heads=4,
+        intermediate_size=64,
+        audio_vocab_size=16,
+        num_codebooks=3,
+        max_position_embeddings=8,
+    )
+    package = build_from_module(
+        MiniMaxMusic3RVQDepthDecoder(config), config, "minimax-music3-rvq"
+    )
+    assert set(package) == {
+        "model",
+        "projection",
+        "embedding",
+        "feedback_embedding",
+        "heads",
+    }
+
+    for model in package.values():
+        _initialize(model)
+    session = OnnxModelSession(package["model"])
+    for steps in (2, 8):
+        output = session.run({"inputs_embeds": np.ones((1, steps, 32), np.float32)})
+        assert output["hidden_states"].shape == (1, steps, 32)
+
+
+def test_condition_encoder_runtime_uses_exact_upstream_length_rounding():
+    config = MiniMaxMusic3ConditionConfig(
+        condition_hidden_dim=4,
+        num_condition_layers=8,
+        out_dim=8,
+    )
+    package = build_from_module(
+        MiniMaxMusic3ConditionEncoder(config), config, "minimax-music3-condition"
+    )
+    _initialize(package["model"])
+    session = OnnxModelSession(package["model"])
+    # Each frame is [global final hidden, seven growing-depth-step hiddens].
+    output = session.run({"hidden_states": np.ones((1, 5, 32), np.float32)})
+    # int(5 * 44100 / 24000 * 960 / 512) == 17
+    assert output["encoder_hidden_states"].shape == (1, 17, 8)
+
+
+def test_transformer_runtime_preserves_latent_shape():
+    config = MiniMaxMusic3TransformerConfig(
+        in_channels=4,
+        condition_dim=8,
+        num_layers=1,
+        num_attention_heads=2,
+        attention_head_dim=8,
+        ff_inner_dim=32,
+        rotary_dim=4,
+        fourier_embedding_dim=8,
+    )
+    package = build_from_module(
+        MiniMaxMusic3Transformer1DModel(config),
+        config,
+        "minimax-music3-denoising",
+    )
+    _initialize(package["model"])
+    session = OnnxModelSession(package["model"])
+    output = session.run(
+        {
+            "hidden_states": np.ones((1, 4, 3), np.float32),
+            "timestep": np.array([0.5], np.float32),
+            "encoder_hidden_states": np.ones((1, 3, 8), np.float32),
+        }
+    )
+    assert output["sample"].shape == (1, 4, 3)
+    assert np.isfinite(output["sample"]).all()
+
+
+def test_transformer_bfloat16_partial_rope_has_no_mixed_mul_types():
+    config = MiniMaxMusic3TransformerConfig(
+        in_channels=4,
+        condition_dim=8,
+        num_layers=1,
+        num_attention_heads=2,
+        attention_head_dim=8,
+        ff_inner_dim=32,
+        rotary_dim=4,
+        fourier_embedding_dim=8,
+        dtype=ir.DataType.BFLOAT16,
+    )
+    model = build_from_module(
+        MiniMaxMusic3Transformer1DModel(config),
+        config,
+        "minimax-music3-denoising",
+    )["model"]
+    rotary_muls = [
+        node
+        for node in model.graph
+        if node.op_type == "Mul" and "/attn/Mul_node_" in node.name
+    ]
+    assert len(rotary_muls) == 4
+    for node in rotary_muls:
+        assert {value.dtype for value in node.inputs} == {ir.DataType.BFLOAT16}
+
+
+def test_vocoder_runtime_decodes_stereo_and_upsamples():
+    config = MiniMaxMusic3VocoderConfig(
+        latent_channels=8,
+        decoder_input_dim=16,
+        decoder_hidden_dim=32,
+        upsampling_ratios=(2, 2),
+    )
+    module = MiniMaxMusic3Vocoder(config)
+    package = build_from_module(module, config, "minimax-music3-vocoder")
+    _initialize(package["model"])
+    session = OnnxModelSession(package["model"])
+    output = session.run({"latents": np.ones((1, 8, 3), np.float32)})
+    assert output["waveform"].shape == (1, 2, 12)
+    assert np.max(np.abs(output["waveform"])) <= 1.0
+
+
+def test_vocoder_preprocess_folds_checkpoint_weight_norm():
+    module = MiniMaxMusic3Vocoder(
+        MiniMaxMusic3VocoderConfig(
+            latent_channels=8,
+            decoder_input_dim=16,
+            decoder_hidden_dim=32,
+            upsampling_ratios=(2,),
+        )
+    )
+    value = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4) + 1
+    scale = torch.tensor([[[2.0]], [[3.0]]])
+    result = module.preprocess_weights(
+        {"conv.weight_v": value, "conv.weight_g": scale, "conv.bias": torch.zeros(2)}
+    )
+    expected = value * scale / torch.linalg.vector_norm(value, dim=(1, 2), keepdim=True)
+    torch.testing.assert_close(result["conv.weight"], expected)
+    assert "conv.weight_v" not in result
+    assert "conv.weight_g" not in result
+
+
+def test_pinned_configs_parse_exact_architecture_values():
+    condition = MiniMaxMusic3ConditionConfig.from_diffusers(
+        {
+            "condition_hidden_dim": 4096,
+            "num_condition_layers": 8,
+            "out_dim": 2048,
+            "input_sampling_rate": 24000,
+            "input_hop_length": 960,
+            "output_sampling_rate": 44100,
+            "output_hop_length": 512,
+        }
+    )
+    transformer = MiniMaxMusic3TransformerConfig.from_diffusers(
+        {
+            "in_channels": 128,
+            "condition_dim": 2048,
+            "num_layers": 36,
+            "num_attention_heads": 32,
+            "attention_head_dim": 64,
+            "ff_inner_dim": 8192,
+            "rotary_dim": 32,
+            "fourier_embedding_dim": 256,
+        }
+    )
+    vocoder = MiniMaxMusic3VocoderConfig.from_diffusers({"upsampling_ratios": [8, 8, 4, 2]})
+    assert condition.output_sampling_rate == 44100
+    assert transformer.num_layers == 36
+    assert transformer.rotary_dim == 32
+    assert vocoder.upsampling_ratios == (8, 8, 4, 2)
+
+
+def test_language_model_reuses_qwen3_and_exposes_music_pipeline_outputs():
+    config = MiniMaxMusic3LanguageConfig.from_diffusers(
+        {
+            "model_type": "qwen3",
+            "vocab_size": 64,
+            "hidden_size": 32,
+            "intermediate_size": 64,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 8,
+            "max_position_embeddings": 32,
+            "rms_norm_eps": 1e-6,
+            "rope_parameters": {"rope_theta": 1_000_000, "rope_type": "default"},
+            "tie_word_embeddings": False,
+            "hidden_act": "silu",
+        }
+    )
+    package = build_from_module(
+        MiniMaxMusic3LanguageModel(config), config, "minimax-music3-language"
+    )
+    assert set(package) == {"model", "embedding", "semantic_embedding"}
+    output_names = {value.name for value in package["model"].graph.outputs}
+    assert {"logits", "last_hidden_state"} <= output_names
+    assert "model.embed_tokens.weight" in package["embedding"].graph.initializers
+
+
+def test_feedback_embedding_contract_uses_exact_offsets_and_scale():
+    language_config = MiniMaxMusic3LanguageConfig.from_diffusers(
+        {
+            "model_type": "qwen3",
+            "vocab_size": 151675 + 16384,
+            "hidden_size": 8,
+            "intermediate_size": 16,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 4,
+            "max_position_embeddings": 16,
+            "rms_norm_eps": 1e-6,
+            "rope_parameters": {"rope_theta": 1_000_000, "rope_type": "default"},
+            "tie_word_embeddings": False,
+            "hidden_act": "silu",
+        }
+    )
+    language = build_from_module(
+        MiniMaxMusic3LanguageModel(language_config),
+        language_config,
+        "minimax-music3-language",
+    )
+    rvq_config = MiniMaxMusic3RVQConfig(
+        hidden_size=8,
+        num_layers=1,
+        num_attention_heads=2,
+        intermediate_size=16,
+        audio_vocab_size=4,
+        num_codebooks=8,
+        max_position_embeddings=8,
+    )
+    rvq = build_from_module(
+        MiniMaxMusic3RVQDepthDecoder(rvq_config),
+        rvq_config,
+        "minimax-music3-rvq",
+    )
+    _initialize(language["semantic_embedding"])
+    _initialize(rvq["feedback_embedding"])
+    semantic = OnnxModelSession(language["semantic_embedding"]).run(
+        {"semantic_codes": np.array([[0]], np.int64)}
+    )["semantic_feedback_embedding"]
+    acoustic = OnnxModelSession(rvq["feedback_embedding"]).run(
+        {"acoustic_codes": np.zeros((1, 1, 7), np.int64)}
+    )["acoustic_feedback_embedding"]
+    np.testing.assert_allclose(
+        semantic + acoustic,
+        np.full((1, 1, 8), 0.08 * MINIMAX_MUSIC3_FEEDBACK_SCALE, np.float32),
+    )
+    assert MINIMAX_MUSIC3_AUDIO_CODE_OFFSET == 151675
+    assert MINIMAX_MUSIC3_SEMANTIC_VOCAB_SIZE == 16384
+    assert MINIMAX_MUSIC3_AUDIO_END_TOKEN_ID == 151670
+
+
+def test_component_parameter_names_match_pinned_checkpoint_layouts():
+    rvq_config = MiniMaxMusic3RVQConfig(
+        hidden_size=32,
+        num_layers=1,
+        num_attention_heads=4,
+        intermediate_size=64,
+        audio_vocab_size=16,
+        num_codebooks=3,
+        max_position_embeddings=4,
+    )
+    rvq = build_from_module(
+        MiniMaxMusic3RVQDepthDecoder(rvq_config),
+        rvq_config,
+        "minimax-music3-rvq",
+    )
+    names = set().union(*(model.graph.initializers for model in rvq.values()))
+    assert "layers.0.attn.to_q.weight" in names
+    assert "audio_embeddings.weight" in names
+    assert "audio_heads.1.weight" in names

--- a/src/mobius/tasks/__init__.py
+++ b/src/mobius/tasks/__init__.py
@@ -54,6 +54,11 @@ __all__ = [
     "MaskedDiffusionTask",
     "MoshiDepformerTask",
     "MoshiTemporalTask",
+    "MiniMaxMusic3ConditionTask",
+    "MiniMaxMusic3DenoisingTask",
+    "MiniMaxMusic3LanguageTask",
+    "MiniMaxMusic3RVQTask",
+    "MiniMaxMusic3VocoderTask",
     "MultiModalTask",
     "OPSET_VERSION",
     "ObjectDetectionTask",
@@ -116,6 +121,13 @@ from mobius.tasks._gemma4_assistant import Gemma4AssistantTask
 from mobius.tasks._hunyuan_vl_mot import HunYuanVLMoTTask
 from mobius.tasks._image_classification import ImageClassificationTask
 from mobius.tasks._masked_diffusion import MaskedDiffusionTask
+from mobius.tasks._minimax_music3 import (
+    MiniMaxMusic3ConditionTask,
+    MiniMaxMusic3DenoisingTask,
+    MiniMaxMusic3LanguageTask,
+    MiniMaxMusic3RVQTask,
+    MiniMaxMusic3VocoderTask,
+)
 from mobius.tasks._moshi import MoshiDepformerTask, MoshiTemporalTask
 from mobius.tasks._multimodal import MultiModalTask
 from mobius.tasks._object_detection import ObjectDetectionTask
@@ -163,6 +175,11 @@ TASK_REGISTRY: dict[str, type[ModelTask]] = {
     "diarization": DiarizationTask,
     "feature-extraction": FeatureExtractionTask,
     "masked-diffusion": MaskedDiffusionTask,
+    "minimax-music3-condition": MiniMaxMusic3ConditionTask,
+    "minimax-music3-denoising": MiniMaxMusic3DenoisingTask,
+    "minimax-music3-language": MiniMaxMusic3LanguageTask,
+    "minimax-music3-rvq": MiniMaxMusic3RVQTask,
+    "minimax-music3-vocoder": MiniMaxMusic3VocoderTask,
     "image-classification": ImageClassificationTask,
     "object-detection": ObjectDetectionTask,
     "seq2seq": Seq2SeqTask,

--- a/src/mobius/tasks/_minimax_music3.py
+++ b/src/mobius/tasks/_minimax_music3.py
@@ -1,0 +1,280 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Graph contracts for MiniMax Music 3 neural components."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import onnx_ir as ir
+from onnxscript import nn
+
+from mobius._diffusers_configs import (
+    MINIMAX_MUSIC3_AUDIO_CODE_OFFSET,
+    MINIMAX_MUSIC3_FEEDBACK_SCALE,
+)
+from mobius._model_package import ModelPackage
+from mobius.components import Embedding
+from mobius.tasks._base import ModelTask, _make_graph, _make_model
+from mobius.tasks._cache_utils import (
+    _make_kv_cache_inputs,
+    _register_kv_cache_outputs,
+)
+
+
+class _EmbeddingHolder(nn.Module):
+    def __init__(self, embedding):
+        super().__init__()
+        self.embed_tokens = embedding
+
+    def forward(self, op, input_ids):
+        return self.embed_tokens(op, input_ids)
+
+
+class _LanguageEmbeddingModel(nn.Module):
+    def __init__(self, embedding):
+        super().__init__()
+        self.model = _EmbeddingHolder(embedding)
+
+    def forward(self, op, input_ids):
+        return self.model(op, input_ids)
+
+
+class _AudioEmbeddingModel(nn.Module):
+    def __init__(self, vocab_size: int, hidden_size: int):
+        super().__init__()
+        self.audio_embeddings = Embedding(vocab_size, hidden_size)
+
+    def forward(self, op, code_ids):
+        return self.audio_embeddings(op, code_ids)
+
+
+class MiniMaxMusic3LanguageTask(ModelTask):
+    """Build Qwen3 embedding and decoder graphs required by the autoregressive loop."""
+
+    model_roles: ClassVar[dict[str, str]] = {
+        "model": "decoder",
+        "embedding": "embedding",
+        "semantic_embedding": "embedding",
+    }
+
+    def build(self, module, config) -> ModelPackage:
+        batch = ir.SymbolicDim("batch")
+        seq_len = ir.SymbolicDim("sequence_length")
+        past_len = ir.SymbolicDim("past_sequence_length")
+
+        graph, builder = _make_graph()
+        inputs_embeds = builder.input(
+            "inputs_embeds", dtype=config.dtype, shape=[batch, seq_len, config.hidden_size]
+        )
+        attention_mask = builder.input(
+            "attention_mask",
+            dtype=ir.DataType.INT64,
+            shape=[batch, "past_sequence_length + sequence_length"],
+        )
+        position_ids = builder.input(
+            "position_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len]
+        )
+        past = _make_kv_cache_inputs(
+            builder,
+            config.num_hidden_layers,
+            config.num_key_value_heads,
+            config.head_dim,
+            config.dtype,
+            batch,
+            past_len,
+        )
+        logits, hidden_states, present = module(
+            builder.op,
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past,
+        )
+        builder.add_output(logits, "logits")
+        builder.add_output(hidden_states, "last_hidden_state")
+        _register_kv_cache_outputs(builder, present)
+        decoder = _make_model(graph)
+
+        graph, builder = _make_graph(name="embedding")
+        input_ids = builder.input("input_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len])
+        embeddings = _LanguageEmbeddingModel(Embedding(config.vocab_size, config.hidden_size))(
+            builder.op, input_ids
+        )
+        builder.add_output(embeddings, "inputs_embeds")
+        embedding = _make_model(graph)
+
+        # Semantic frame codes occupy a dedicated 16,384-token range beginning
+        # at 151675. Scale this contribution by 1/sqrt(8); the RVQ feedback
+        # graph applies the same scale to the sum of seven acoustic embeddings.
+        graph, builder = _make_graph(name="semantic_embedding")
+        semantic_codes = builder.input(
+            "semantic_codes", dtype=ir.DataType.INT64, shape=[batch, seq_len]
+        )
+        semantic_ids = builder.op.Add(
+            semantic_codes, builder.op.Constant(value_int=MINIMAX_MUSIC3_AUDIO_CODE_OFFSET)
+        )
+        semantic_embedding = _LanguageEmbeddingModel(
+            Embedding(config.vocab_size, config.hidden_size)
+        )(builder.op, semantic_ids)
+        semantic_embedding = builder.op.Mul(semantic_embedding, MINIMAX_MUSIC3_FEEDBACK_SCALE)
+        builder.add_output(semantic_embedding, "semantic_feedback_embedding")
+        return ModelPackage(
+            {
+                "model": decoder,
+                "embedding": embedding,
+                "semantic_embedding": _make_model(graph),
+            },
+            config=config,
+        )
+
+
+class MiniMaxMusic3RVQTask(ModelTask):
+    """Build the local depth decoder and expose its pipeline-owned heads/tables."""
+
+    model_roles: ClassVar[dict[str, str]] = {
+        "model": "decoder",
+        "projection": "embedding",
+        "embedding": "embedding",
+        "feedback_embedding": "embedding",
+        "heads": "decoder",
+    }
+
+    def build(self, module, config) -> ModelPackage:
+        graph, builder = _make_graph()
+        inputs_embeds = builder.input(
+            "inputs_embeds",
+            dtype=config.dtype,
+            shape=["batch", "steps", config.hidden_size],
+        )
+        hidden_states = module(builder.op, inputs_embeds)
+        builder.add_output(hidden_states, "hidden_states")
+        decoder = _make_model(graph)
+
+        graph, builder = _make_graph(name="projection")
+        projection_input = builder.input(
+            "hidden_states",
+            dtype=config.dtype,
+            shape=["batch", "steps", config.hidden_size],
+        )
+        builder.add_output(module.projection(builder.op, projection_input), "projected_states")
+        projection = _make_model(graph)
+
+        graph, builder = _make_graph(name="embedding")
+        code_ids = builder.input("code_ids", dtype=ir.DataType.INT64, shape=["batch", "steps"])
+        embedding_module = _AudioEmbeddingModel(
+            config.audio_vocab_size * (config.num_codebooks - 1), config.hidden_size
+        )
+        builder.add_output(embedding_module(builder.op, code_ids), "code_embeddings")
+        embedding = _make_model(graph)
+
+        # Complete-frame feedback sums all seven residual-codebook embeddings.
+        # Each codebook owns a contiguous audio_vocab_size slice in the table.
+        graph, builder = _make_graph(name="feedback_embedding")
+        acoustic_codes = builder.input(
+            "acoustic_codes",
+            dtype=ir.DataType.INT64,
+            shape=["batch", "frames", config.num_codebooks - 1],
+        )
+        offsets = builder.op.Constant(
+            value_ints=[
+                index * config.audio_vocab_size for index in range(config.num_codebooks - 1)
+            ]
+        )
+        acoustic_ids = builder.op.Add(acoustic_codes, offsets)
+        feedback_embedding_module = _AudioEmbeddingModel(
+            config.audio_vocab_size * (config.num_codebooks - 1), config.hidden_size
+        )
+        acoustic_embeddings = feedback_embedding_module(builder.op, acoustic_ids)
+        acoustic_embeddings = builder.op.ReduceSum(
+            acoustic_embeddings,
+            builder.op.Constant(value_ints=[2]),
+            keepdims=0,
+        )
+        acoustic_embeddings = builder.op.Mul(
+            acoustic_embeddings, MINIMAX_MUSIC3_FEEDBACK_SCALE
+        )
+        builder.add_output(acoustic_embeddings, "acoustic_feedback_embedding")
+        feedback_embedding = _make_model(graph)
+
+        graph, builder = _make_graph(name="heads")
+        head_input = builder.input(
+            "hidden_states",
+            dtype=config.dtype,
+            shape=["batch", "steps", config.hidden_size],
+        )
+        all_logits = [
+            builder.op.Unsqueeze(head(builder.op, head_input), [0])
+            for head in module.audio_heads
+        ]
+        builder.add_output(builder.op.Concat(*all_logits, axis=0), "all_codebook_logits")
+        heads = _make_model(graph)
+
+        return ModelPackage(
+            {
+                "model": decoder,
+                "projection": projection,
+                "embedding": embedding,
+                "feedback_embedding": feedback_embedding,
+                "heads": heads,
+            },
+            config=config,
+        )
+
+
+class MiniMaxMusic3ConditionTask(ModelTask):
+    """Mix global-final + seven RVQ-step slices and resample with floor rounding."""
+
+    def build(self, module, config) -> ModelPackage:
+        graph, builder = _make_graph()
+        hidden_states = builder.input(
+            "hidden_states",
+            dtype=config.dtype,
+            shape=[
+                "batch",
+                "frames",
+                config.num_condition_layers * config.condition_hidden_dim,
+            ],
+        )
+        condition = module(builder.op, hidden_states)
+        builder.add_output(condition, "encoder_hidden_states")
+        return ModelPackage({"model": _make_model(graph)}, config=config)
+
+
+class MiniMaxMusic3DenoisingTask(ModelTask):
+    """Build the 1D flow-matching velocity predictor."""
+
+    def build(self, module, config) -> ModelPackage:
+        graph, builder = _make_graph()
+        hidden_states = builder.input(
+            "hidden_states",
+            dtype=config.dtype,
+            shape=["batch", config.in_channels, "latent_length"],
+        )
+        timestep = builder.input("timestep", dtype=config.dtype, shape=["batch"])
+        encoder_hidden_states = builder.input(
+            "encoder_hidden_states",
+            dtype=config.dtype,
+            shape=["batch", "latent_length", config.condition_dim],
+        )
+        sample = module(builder.op, hidden_states, timestep, encoder_hidden_states)
+        builder.add_output(sample, "sample")
+        return ModelPackage({"model": _make_model(graph)}, config=config)
+
+
+class MiniMaxMusic3VocoderTask(ModelTask):
+    """Build the stereo latent-to-waveform decoder."""
+
+    model_roles: ClassVar[dict[str, str]] = {"model": "decoder"}
+
+    def build(self, module, config) -> ModelPackage:
+        graph, builder = _make_graph()
+        latents = builder.input(
+            "latents",
+            dtype=config.dtype,
+            shape=["batch", config.latent_channels, "latent_length"],
+        )
+        waveform = module(builder.op, latents)
+        builder.add_output(waveform, "waveform")
+        return ModelPackage({"model": _make_model(graph)}, config=config)

--- a/testdata/cases/diffusion/minimax-music3.yaml
+++ b/testdata/cases/diffusion/minimax-music3.yaml
@@ -1,0 +1,18 @@
+model_id: "MiniMaxAI/MiniMax-Music3"
+model_type: "minimax_music3"
+revision: "fbdf52fbaaca799592917417eb05f1899f1255ec"
+task_type: "audio-to-audio"
+dtype: "bfloat16"
+level: "L4+L5"
+skip_reason: >
+  L3/L4/L5 and a full weighted CLI export are waived: the pinned modular pipeline is
+  approximately 11.7B parameters, and its reference implementation requires the
+  unmerged diffusers modular API from PR #14456. Native tiny float32 graph/runtime,
+  config, builder, and weight-alignment tests cover the supported neural components;
+  no end-to-end pipeline runtime or generation support is claimed.
+notes: >
+  L2 pinned-config case for MiniMaxMusic3ModularPipeline. Mobius exports the Qwen3
+  language model, RVQ depth decoder, condition encoder, 1D flow transformer, and
+  stereo DAC-style vocoder as separate neural graphs. The condition slices are the
+  global final hidden plus seven growing-depth-step hiddens; feedback uses semantic
+  offset 151675 plus seven acoustic embeddings, all scaled together by 1/sqrt(8).


### PR DESCRIPTION
## Summary
- recognize MiniMax-Music3 modular diffusers indexes and resolve component repository, revision, and subfolder metadata
- export the Qwen3 language model, RVQ depth decoder, condition encoder, 1D flow transformer, and stereo vocoder as native ONNX graphs
- add exact BF16-safe partial RoPE, RVQ feedback, floor-rate interpolation, Snake activation, and weight-normalization fusion
- add tiny runtime, graph, config, weight-alignment, builder, and schema coverage

## Validation
- `python3 -m pytest src/mobius/models/minimax_music3_test.py src/mobius/_diffusers_builder_test.py tests/yaml_schema_test.py -q --tb=short` (339 affected tests passed in the implementation worktree)
- expanded independent selection: 292 passed, 1396 deselected
- repository-wide non-integration suite: 3980 passed, 60 skipped; 3 unrelated failures reproduced unchanged on `main` (Gemma3n/Gemma4 missing inferred audio output shapes and unavailable cached Gemma4 config)
- Ruff 0.16.2 formatting and lint checks pass for all changed Python files
- two-pass specialist review completed; BF16 RoPE and modular external-component metadata findings resolved

## Waivers
- L3/L4/L5 and full weighted CLI export are waived: the checkpoint is approximately 11.7B parameters and its reference diffusers implementation remains in unmerged PR #14456. The pinned L2 case records these limits.
- End-to-end scheduler orchestration and audio generation are not claimed; this PR provides faithful neural component exports and pipeline metadata.

Pinned model revision: `fbdf52fbaaca799592917417eb05f1899f1255ec`.
Pinned diffusers source: `9cdd65902a576493acea190d6bc115afb41d4709`.