### PR TITLE
Support muse-glimmer GGUF conversion (text + mmproj vision)

### DIFF
--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -841,7 +841,8 @@ def main(argv: list[str] | None = None) -> None:
             "Path to a companion 'clip' mmproj GGUF (vision/audio encoder). "
             "When set, builds a full multimodal package (decoder + "
             "vision_encoder + embedding) instead of a text-only model. "
-            "Currently supports Gemma4 vision; audio is experimental."
+            "Currently supports Gemma4 and Muse Glimmer vision; audio is "
+            "experimental."
         ),
     )
     quantization_group = gguf_parser.add_mutually_exclusive_group()

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -327,9 +327,9 @@ def build_from_gguf(
     if mmproj is not None:
         if static_cache:
             raise ValueError("static_cache=True is not supported with a companion mmproj.")
-        from mobius.integrations.gguf._mmproj import build_gemma4_vlm_from_gguf
+        from mobius.integrations.gguf._mmproj import build_vlm_from_gguf
 
-        return build_gemma4_vlm_from_gguf(
+        return build_vlm_from_gguf(
             gguf_path,
             mmproj,
             dtype=dtype,

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -809,7 +809,7 @@ class TestMultimodalQuantizationDefault:
 
         expected = mock.sentinel.package
         with mock.patch(
-            "mobius.integrations.gguf._mmproj.build_gemma4_vlm_from_gguf",
+            "mobius.integrations.gguf._mmproj.build_vlm_from_gguf",
             return_value=expected,
         ) as build_multimodal:
             kwargs = {} if keep_quantized else {"keep_quantized": False}

--- a/src/mobius/integrations/gguf/_config_mapping.py
+++ b/src/mobius/integrations/gguf/_config_mapping.py
@@ -28,7 +28,12 @@ from typing import Any
 
 import numpy as np
 
-from mobius._configs import ArchitectureConfig, Gemma4Config
+from mobius._configs import (
+    ArchitectureConfig,
+    Gemma4Config,
+    MuseGlimmerConfig,
+    _shallow_fields,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +66,8 @@ GGUF_ARCH_TO_MODEL_TYPE: dict[str, str] = {
     "hunyuan-dense": "hunyuan_v1_dense",
     "deepseek4": "deepseek_v4",
     "deci": "llama",  # DeciLM uses Llama architecture
+    "muse-glimmer": "muse_glimmer_text",
+    "muse_glimmer": "muse_glimmer_text",
 }
 
 
@@ -92,6 +99,11 @@ _DEFAULT_KEY_MAP: dict[str, str] = {
 }
 
 _ARCH_KEY_MAPS: dict[str, dict[str, str]] = {
+    # Muse Glimmer has no rope.dimension_count; head_dim comes from key_length.
+    "muse-glimmer": {
+        "attention.key_length": "head_dim",
+        "attention.sliding_window": "sliding_window",
+    },
     "deepseek4": {
         "attention.key_length": "head_dim",
         "rope.dimension_count": "qk_rope_head_dim",
@@ -115,7 +127,7 @@ _ARCH_KEY_MAPS: dict[str, dict[str, str]] = {
         "hyper_connection.sinkhorn_iterations": "hc_sinkhorn_iters",
         "hyper_connection.epsilon": "hc_eps",
         "hash_layer_count": "num_hash_layers",
-    }
+    },
 }
 
 
@@ -443,9 +455,11 @@ def gguf_to_config(
 
     # Apply architecture-specific postprocessing to produce the correct
     # config subclass (e.g. Gemma4Config instead of plain ArchitectureConfig).
+    # Postprocessors take the GGUF model too, because a few architectures store
+    # config scalars inside tensors rather than in the key-value metadata.
     postprocessor = _CONFIG_POSTPROCESSORS.get(model_type)
     if postprocessor is not None:
-        config = postprocessor(config, metadata)
+        config = postprocessor(config, metadata, model)
         config._gguf_model_type = model_type
         config.model_type = model_type
 
@@ -466,6 +480,7 @@ def gguf_to_config(
 def _gemma4_postprocess(
     config: ArchitectureConfig,
     metadata: dict[str, Any],
+    model: Any = None,
 ) -> Gemma4Config:
     """Convert a base config to Gemma4Config with architecture-specific fields.
 
@@ -680,6 +695,7 @@ _GEMMA3_DEFAULT_SLIDING_WINDOW_PATTERN = 6
 def _gemma3_postprocess(
     config: ArchitectureConfig,
     metadata: dict[str, Any],
+    model: Any = None,
 ) -> ArchitectureConfig:
     """Populate Gemma3 fields that GGUF omits.
 
@@ -719,12 +735,135 @@ def _gemma3_postprocess(
     return config
 
 
+def _muse_glimmer_postprocess(
+    config: ArchitectureConfig,
+    metadata: dict[str, Any],
+    model: Any = None,
+) -> MuseGlimmerConfig:
+    """Convert a base config to :class:`MuseGlimmerConfig`.
+
+    GGUF key mapping (``muse-glimmer.`` prefix omitted for readability):
+
+    ===================================  ====================================
+    GGUF key                             MuseGlimmerConfig field
+    ===================================  ====================================
+    logit_scale                          output_multiplier
+    final_logit_softcapping              final_logit_softcapping
+    attention.sliding_window             sliding_window
+    attention.sliding_window_pattern     layer_types, layer_rope_theta
+    ===================================  ====================================
+
+    Two values are not in the metadata at all:
+
+    ``qk_scale_factor``
+        Recovered from the ``blk.0.attn_q_norm`` tensor. Muse Glimmer's QK
+        normalization is scale-free, so llama.cpp materializes the constant as
+        a head_dim-wide vector rather than storing a scalar in the metadata.
+
+    ``post_norm_eps``
+        Not represented in GGUF; the dataclass default (1e-8, matching the
+        published checkpoints) is kept.
+    """
+    arch = "muse-glimmer"
+
+    # --- Layer types and NoPE layers from the sliding-window pattern ---
+    # Unlike Gemma 4, which stores a per-layer bool array, Muse Glimmer stores a
+    # single stride: every `pattern`-th layer is a full-attention layer and the
+    # rest are sliding. Full-attention layers are also the NoPE layers -- the HF
+    # checkpoint expresses this as layer_rope_theta[i] == 0.
+    pattern = metadata.get(f"{arch}.attention.sliding_window_pattern")
+    if pattern is not None:
+        pattern = int(pattern)
+        if pattern <= 0:
+            raise ValueError(
+                f"GGUF metadata {arch}.attention.sliding_window_pattern must be "
+                f"positive, got {pattern}."
+            )
+        layer_types = [
+            "full_attention" if (index + 1) % pattern == 0 else "sliding_attention"
+            for index in range(config.num_hidden_layers)
+        ]
+        layer_rope_theta: list[float | int] = [
+            0 if layer_type == "full_attention" else config.rope_theta
+            for layer_type in layer_types
+        ]
+        config = dataclasses.replace(
+            config,
+            layer_types=layer_types,
+            no_rope_layers=[
+                index for index, theta in enumerate(layer_rope_theta) if theta == 0
+            ],
+        )
+    else:
+        layer_rope_theta = None
+
+    sliding_window = metadata.get(f"{arch}.attention.sliding_window")
+    if sliding_window is not None:
+        config = dataclasses.replace(config, sliding_window=int(sliding_window))
+
+    config = dataclasses.replace(config, attn_qk_norm=True)
+
+    defaults = MuseGlimmerConfig()
+    softcapping = metadata.get(f"{arch}.final_logit_softcapping")
+    logit_scale = metadata.get(f"{arch}.logit_scale")
+
+    return MuseGlimmerConfig(
+        **_shallow_fields(config),
+        qk_scale_factor=_muse_glimmer_qk_scale_factor(model, defaults.qk_scale_factor),
+        output_multiplier=(
+            float(logit_scale) if logit_scale is not None else defaults.output_multiplier
+        ),
+        final_logit_softcapping=(
+            float(softcapping) if softcapping is not None else defaults.final_logit_softcapping
+        ),
+        post_norm_eps=defaults.post_norm_eps,
+        layer_rope_theta=layer_rope_theta,
+    )
+
+
+def _muse_glimmer_qk_scale_factor(model: Any, default: float) -> float:
+    """Read Muse Glimmer's ``qk_scale_factor`` out of ``blk.0.attn_q_norm``.
+
+    Muse Glimmer normalizes Q and K without a learned scale and then multiplies
+    Q by a single constant. llama.cpp has no place for that constant in the
+    metadata, so it broadcasts it across a head_dim-wide ``attn_q_norm`` tensor
+    (``attn_k_norm`` is the matching all-ones vector). Reading element 0 back is
+    therefore the only way to recover the value from a GGUF file.
+
+    Falls back to *default* when the tensor is missing, and rejects a tensor
+    that is not constant, because a non-constant vector would mean the file
+    carries a genuine per-channel norm this importer would silently drop.
+    """
+    if model is None:
+        return default
+    try:
+        weight = model.get_tensor("blk.0.attn_q_norm.weight")
+    except (KeyError, ValueError):
+        logger.warning(
+            "Muse Glimmer GGUF has no blk.0.attn_q_norm tensor; "
+            "falling back to qk_scale_factor=%s",
+            default,
+        )
+        return default
+    values = np.asarray(weight, dtype=np.float32).reshape(-1)
+    if values.size == 0:
+        return default
+    if not np.allclose(values, values[0]):
+        raise ValueError(
+            "Muse Glimmer blk.0.attn_q_norm is not a constant vector "
+            f"(min={values.min()}, max={values.max()}), so it carries a real "
+            "per-channel QK norm that this importer does not model."
+        )
+    return float(values[0])
+
+
 # Architecture-specific config postprocessors.
 # Each takes a base ArchitectureConfig + raw metadata and returns
 # an architecture-specific config subclass.
 _CONFIG_POSTPROCESSORS: dict[str, Any] = {
     "gemma3_text": _gemma3_postprocess,
     "gemma4_text": _gemma4_postprocess,
+    "muse_glimmer_text": _muse_glimmer_postprocess,
 }
 
 

--- a/src/mobius/integrations/gguf/_config_mapping.py
+++ b/src/mobius/integrations/gguf/_config_mapping.py
@@ -775,31 +775,34 @@ def _muse_glimmer_postprocess(
     # single stride: every `pattern`-th layer is a full-attention layer and the
     # rest are sliding. Full-attention layers are also the NoPE layers -- the HF
     # checkpoint expresses this as layer_rope_theta[i] == 0.
-    pattern = metadata.get(f"{arch}.attention.sliding_window_pattern")
-    if pattern is not None:
-        pattern = int(pattern)
-        if pattern <= 0:
-            raise ValueError(
-                f"GGUF metadata {arch}.attention.sliding_window_pattern must be "
-                f"positive, got {pattern}."
-            )
-        layer_types = [
-            "full_attention" if (index + 1) % pattern == 0 else "sliding_attention"
-            for index in range(config.num_hidden_layers)
-        ]
-        layer_rope_theta: list[float | int] = [
-            0 if layer_type == "full_attention" else config.rope_theta
-            for layer_type in layer_types
-        ]
-        config = dataclasses.replace(
-            config,
-            layer_types=layer_types,
-            no_rope_layers=[
-                index for index, theta in enumerate(layer_rope_theta) if theta == 0
-            ],
+    #
+    # There is no defensible fallback if the stride is missing. Guessing leaves
+    # every layer sliding and rotated, which is a different architecture that
+    # happens to load, so refuse the conversion instead of emitting one.
+    key = f"{arch}.attention.sliding_window_pattern"
+    pattern = metadata.get(key)
+    if pattern is None:
+        raise ValueError(
+            f"GGUF metadata is missing {key}. Muse Glimmer needs it to place "
+            f"the full-attention and NoPE layers; without it the converted "
+            f"model would silently be a different architecture."
         )
-    else:
-        layer_rope_theta = None
+    pattern = int(pattern)
+    if pattern <= 0:
+        raise ValueError(f"GGUF metadata {key} must be positive, got {pattern}.")
+    layer_types = [
+        "full_attention" if (index + 1) % pattern == 0 else "sliding_attention"
+        for index in range(config.num_hidden_layers)
+    ]
+    layer_rope_theta: list[float | int] = [
+        0 if layer_type == "full_attention" else config.rope_theta
+        for layer_type in layer_types
+    ]
+    config = dataclasses.replace(
+        config,
+        layer_types=layer_types,
+        no_rope_layers=[index for index, theta in enumerate(layer_rope_theta) if theta == 0],
+    )
 
     sliding_window = metadata.get(f"{arch}.attention.sliding_window")
     if sliding_window is not None:

--- a/src/mobius/integrations/gguf/_config_mapping.py
+++ b/src/mobius/integrations/gguf/_config_mapping.py
@@ -98,12 +98,16 @@ _DEFAULT_KEY_MAP: dict[str, str] = {
     "ssm.conv_kernel": "linear_conv_kernel_dim",
 }
 
+# Muse Glimmer has no rope.dimension_count; head_dim comes from key_length.
+_MUSE_GLIMMER_KEY_MAP = {
+    "attention.key_length": "head_dim",
+    "attention.sliding_window": "sliding_window",
+}
+
 _ARCH_KEY_MAPS: dict[str, dict[str, str]] = {
-    # Muse Glimmer has no rope.dimension_count; head_dim comes from key_length.
-    "muse-glimmer": {
-        "attention.key_length": "head_dim",
-        "attention.sliding_window": "sliding_window",
-    },
+    # Both spellings are accepted wherever muse-glimmer is recognized.
+    "muse-glimmer": _MUSE_GLIMMER_KEY_MAP,
+    "muse_glimmer": _MUSE_GLIMMER_KEY_MAP,
     "deepseek4": {
         "attention.key_length": "head_dim",
         "rope.dimension_count": "qk_rope_head_dim",
@@ -764,7 +768,7 @@ def _muse_glimmer_postprocess(
         Not represented in GGUF; the dataclass default (1e-8, matching the
         published checkpoints) is kept.
     """
-    arch = "muse-glimmer"
+    arch = getattr(model, "architecture", None) or "muse-glimmer"
 
     # --- Layer types and NoPE layers from the sliding-window pattern ---
     # Unlike Gemma 4, which stores a per-layer bool array, Muse Glimmer stores a

--- a/src/mobius/integrations/gguf/_config_mapping_test.py
+++ b/src/mobius/integrations/gguf/_config_mapping_test.py
@@ -262,3 +262,31 @@ class TestMuseGlimmerPostprocess:
                 self._metadata(),
                 self._FakeModel([3.87] * 127 + [1.0]),
             )
+
+    def test_underscore_spelled_architecture_is_read_the_same_way(self) -> None:
+        """Both ``muse-glimmer`` and ``muse_glimmer`` name the same architecture.
+
+        The metadata prefix follows whatever the file calls itself, so the
+        postprocessor has to take the prefix from the model rather than assume
+        the hyphenated spelling.
+        """
+        from mobius.integrations.gguf._config_mapping import (
+            _ARCH_KEY_MAPS,
+            _muse_glimmer_postprocess,
+        )
+
+        model = self._FakeModel([3.87] * 128)
+        model.architecture = "muse_glimmer"
+        metadata = {
+            key.replace("muse-glimmer.", "muse_glimmer."): value
+            for key, value in self._metadata().items()
+        }
+
+        result = _muse_glimmer_postprocess(self._base_config(), metadata, model)
+
+        assert result.sliding_window == 2048
+        assert result.no_rope_layers == [3, 7]
+        assert result.output_multiplier == pytest.approx(0.19611613513818404)
+        # The key map is what turns attention.key_length into head_dim, so it
+        # has to answer to both spellings too.
+        assert _ARCH_KEY_MAPS["muse_glimmer"] == _ARCH_KEY_MAPS["muse-glimmer"]

--- a/src/mobius/integrations/gguf/_config_mapping_test.py
+++ b/src/mobius/integrations/gguf/_config_mapping_test.py
@@ -290,3 +290,19 @@ class TestMuseGlimmerPostprocess:
         # The key map is what turns attention.key_length into head_dim, so it
         # has to answer to both spellings too.
         assert _ARCH_KEY_MAPS["muse_glimmer"] == _ARCH_KEY_MAPS["muse-glimmer"]
+
+    def test_a_missing_sliding_window_pattern_is_rejected(self) -> None:
+        """Guessing the stride would yield a different architecture.
+
+        Without it every layer is left sliding and rotated, which loads and
+        runs and is not Muse Glimmer. Refusing is the only honest answer.
+        """
+        from mobius.integrations.gguf._config_mapping import _muse_glimmer_postprocess
+
+        metadata = self._metadata()
+        del metadata["muse-glimmer.attention.sliding_window_pattern"]
+
+        with pytest.raises(ValueError, match="sliding_window_pattern"):
+            _muse_glimmer_postprocess(
+                self._base_config(), metadata, self._FakeModel([3.87] * 128)
+            )

--- a/src/mobius/integrations/gguf/_config_mapping_test.py
+++ b/src/mobius/integrations/gguf/_config_mapping_test.py
@@ -145,3 +145,120 @@ class TestDefaultActivation:
         from mobius.integrations.gguf._config_mapping import _default_activation
 
         assert _default_activation(model_type) == "silu"
+
+
+class TestMuseGlimmerPostprocess:
+    """Muse Glimmer config postprocessing.
+
+    Ground truth is the published Muse-Glimmer-30B text config: a stride-4
+    sliding-window pattern, NoPE on the full-attention layers,
+    ``qk_scale_factor`` 3.87 and ``output_multiplier`` 0.19611613513818404.
+    """
+
+    @staticmethod
+    def _base_config():
+        from mobius._configs import ArchitectureConfig
+
+        return ArchitectureConfig(
+            hidden_size=6656,
+            num_hidden_layers=8,
+            num_attention_heads=32,
+            num_key_value_heads=2,
+            vocab_size=202048,
+            intermediate_size=19968,
+            rope_theta=500000.0,
+        )
+
+    @staticmethod
+    def _metadata():
+        return {
+            "muse-glimmer.attention.sliding_window": 2048,
+            "muse-glimmer.attention.sliding_window_pattern": 4,
+            "muse-glimmer.final_logit_softcapping": 20.0,
+            "muse-glimmer.logit_scale": 0.1961161345243454,
+        }
+
+    class _FakeModel:
+        """Stands in for GGUFModel, exposing only what the mapping reads."""
+
+        def __init__(self, q_norm):
+            self._q_norm = q_norm
+
+        def get_tensor(self, name: str):
+            import numpy as np
+
+            if name == "blk.0.attn_q_norm.weight":
+                if self._q_norm is None:
+                    raise KeyError(name)
+                return np.asarray(self._q_norm, dtype=np.float32)
+            raise KeyError(name)
+
+    def test_layer_types_and_nope_layers_follow_the_stride(self) -> None:
+        from mobius.integrations.gguf._config_mapping import _muse_glimmer_postprocess
+
+        result = _muse_glimmer_postprocess(
+            self._base_config(),
+            self._metadata(),
+            self._FakeModel([3.87] * 128),
+        )
+
+        assert result.layer_types == [
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+        ]
+        # Full-attention layers are the NoPE layers.
+        assert result.no_rope_layers == [3, 7]
+        assert result.layer_rope_theta == [
+            500000.0,
+            500000.0,
+            500000.0,
+            0,
+            500000.0,
+            500000.0,
+            500000.0,
+            0,
+        ]
+        assert result.sliding_window == 2048
+
+    def test_scalars_come_from_metadata_and_the_q_norm_tensor(self) -> None:
+        from mobius.integrations.gguf._config_mapping import _muse_glimmer_postprocess
+
+        result = _muse_glimmer_postprocess(
+            self._base_config(),
+            self._metadata(),
+            self._FakeModel([3.87] * 128),
+        )
+
+        assert result.qk_scale_factor == pytest.approx(3.87)
+        assert result.output_multiplier == pytest.approx(0.19611613513818404)
+        assert result.final_logit_softcapping == pytest.approx(20.0)
+        # GGUF has no key for post_norm_eps; the checkpoint default stands.
+        assert result.post_norm_eps == pytest.approx(1e-8)
+        assert result.attn_qk_norm is True
+
+    def test_missing_q_norm_falls_back_to_the_default_scale(self) -> None:
+        from mobius.integrations.gguf._config_mapping import _muse_glimmer_postprocess
+
+        result = _muse_glimmer_postprocess(
+            self._base_config(),
+            self._metadata(),
+            self._FakeModel(None),
+        )
+
+        assert result.qk_scale_factor == pytest.approx(3.87)
+
+    def test_non_constant_q_norm_is_rejected(self) -> None:
+        from mobius.integrations.gguf._config_mapping import _muse_glimmer_postprocess
+
+        with pytest.raises(ValueError, match="not a constant vector"):
+            _muse_glimmer_postprocess(
+                self._base_config(),
+                self._metadata(),
+                self._FakeModel([3.87] * 127 + [1.0]),
+            )

--- a/src/mobius/integrations/gguf/_mmproj.py
+++ b/src/mobius/integrations/gguf/_mmproj.py
@@ -41,6 +41,7 @@ __all__ = [
 ]
 
 import logging
+import math
 from pathlib import Path
 from typing import Any
 
@@ -60,11 +61,35 @@ _DEFAULT_POOLING_KERNEL_SIZE = 4
 # Muse Glimmer's vision tower uses ordinary 2D RoPE. The mmproj stores no
 # rope.freq_base, so use the published vision config value.
 _MUSE_GLIMMER_VISION_ROPE_THETA = 10_000.0
-# Temporal patch depth (video frames folded into one patch). Not represented in
-# the clip metadata; the published checkpoints use 2.
-_MUSE_GLIMMER_TEMPORAL_PATCH_SIZE = 2
 # Full-attention stride: every 4th block is global, and so is the last block.
 _MUSE_GLIMMER_VISION_FULL_ATTENTION_STRIDE = 4
+
+
+def _muse_glimmer_temporal_patch_size(patch_embd: Any, *, patch_size: int) -> int:
+    """Recover the temporal patch depth from the patch-embedding weight.
+
+    ``clip.vision.*`` metadata carries no temporal depth. HF checkpoints fold
+    ``temporal_patch_size`` frames into a single Conv3d kernel, but a converter
+    is free to collapse that axis (llama.cpp emits a plain Conv2d kernel of
+    ``[out, in_channels, patch, patch]``, which is exactly the image-only case
+    with both frames summed). Trusting a hard-coded 2 therefore builds a tower
+    whose patch embedding is twice as wide as the weight it is about to load,
+    so derive the depth from the weight itself.
+    """
+    shape = tuple(int(dim) for dim in patch_embd.shape)
+    if len(shape) < 2:
+        raise ValueError(
+            f"Muse Glimmer patch embedding must be at least 2D, got shape {shape}."
+        )
+    in_channels = shape[1]
+    per_frame = in_channels * patch_size * patch_size
+    elements = math.prod(shape[1:])
+    if per_frame == 0 or elements % per_frame != 0:
+        raise ValueError(
+            f"Muse Glimmer patch embedding of shape {shape} is not divisible into "
+            f"{in_channels}x{patch_size}x{patch_size} frames."
+        )
+    return elements // per_frame
 
 
 def read_mmproj_muse_glimmer_vision_config(gguf_model: Any):
@@ -127,7 +152,9 @@ def read_mmproj_muse_glimmer_vision_config(gguf_model: Any):
         norm_eps=float(md.get("clip.vision.attention.layer_norm_epsilon", 1e-5)),
         in_channels=int(patch_embd.shape[1]),
         spatial_merge_size=merge_size,
-        temporal_patch_size=_MUSE_GLIMMER_TEMPORAL_PATCH_SIZE,
+        temporal_patch_size=_muse_glimmer_temporal_patch_size(
+            patch_embd, patch_size=int(md["clip.vision.patch_size"])
+        ),
         position_embedding_size=position_rows,
         position_embedding_height=grid,
         position_embedding_width=grid,

--- a/src/mobius/integrations/gguf/_mmproj.py
+++ b/src/mobius/integrations/gguf/_mmproj.py
@@ -33,7 +33,10 @@ from __future__ import annotations
 
 __all__ = [
     "build_gemma4_vlm_from_gguf",
+    "build_vlm_from_gguf",
+    "build_muse_glimmer_vlm_from_gguf",
     "read_mmproj_audio_config",
+    "read_mmproj_muse_glimmer_vision_config",
     "read_mmproj_vision_config",
 ]
 
@@ -53,6 +56,89 @@ _GEMMA4_VISION_ROPE_THETA = 100.0
 # Gemma4 vision pooler spatial average pooling kernel (k x k). Not present in
 # mmproj metadata; the SigLIP encoder pools N patches to N/k^2 soft tokens.
 _DEFAULT_POOLING_KERNEL_SIZE = 4
+
+# Muse Glimmer's vision tower uses ordinary 2D RoPE. The mmproj stores no
+# rope.freq_base, so use the published vision config value.
+_MUSE_GLIMMER_VISION_ROPE_THETA = 10_000.0
+# Temporal patch depth (video frames folded into one patch). Not represented in
+# the clip metadata; the published checkpoints use 2.
+_MUSE_GLIMMER_TEMPORAL_PATCH_SIZE = 2
+# Full-attention stride: every 4th block is global, and so is the last block.
+_MUSE_GLIMMER_VISION_FULL_ATTENTION_STRIDE = 4
+
+
+def read_mmproj_muse_glimmer_vision_config(gguf_model: Any):
+    """Extract a Muse Glimmer :class:`VisionConfig` from ``clip.vision.*``.
+
+    Four things the metadata does not carry are recovered from the tensors or
+    from the published vision config:
+
+    ``position_embedding_height`` / ``width``
+        The learned table is ``[grid**2, hidden]``; the grid is square, so the
+        side is ``sqrt(rows)``.
+    ``projector_intermediate_size``
+        The width of the two adapter matrices, read from ``mm.0``.
+    ``fullatt_block_indexes``
+        Muse Glimmer alternates window and full attention on a stride of 4
+        (blocks 3, 7, 11 …) *and* makes the final block full attention.
+    ``temporal_patch_size`` / ``rope_theta``
+        Architectural constants with no clip key; see the module constants.
+
+    Args:
+        gguf_model: A :class:`GGUFModel` for a ``clip`` mmproj file.
+
+    Returns:
+        A populated :class:`VisionConfig`, or ``None`` if the file has no
+        vision encoder.
+    """
+    import math
+
+    from mobius._configs._sub_configs import VisionConfig
+
+    md = gguf_model.metadata
+    if not md.get("clip.has_vision_encoder"):
+        return None
+
+    num_layers = int(md["clip.vision.block_count"])
+    position_rows = int(gguf_model.get_tensor("v.position_embd.weight").shape[0])
+    grid = math.isqrt(position_rows)
+    if grid * grid != position_rows:
+        raise ValueError(
+            f"Muse Glimmer position embedding table has {position_rows} rows, "
+            "which is not a square grid."
+        )
+    patch_embd = gguf_model.get_tensor("v.patch_embd.weight")
+    projector_intermediate_size = int(gguf_model.get_tensor("mm.0.weight").shape[0])
+    hidden_size = int(md["clip.vision.embedding_length"])
+    merge_size = int(md.get("clip.vision.spatial_merge_size", 2))
+
+    stride = _MUSE_GLIMMER_VISION_FULL_ATTENTION_STRIDE
+    full_attention = sorted(
+        {index for index in range(num_layers) if (index + 1) % stride == 0} | {num_layers - 1}
+    )
+
+    return VisionConfig(
+        hidden_size=hidden_size,
+        intermediate_size=int(md["clip.vision.feed_forward_length"]),
+        num_hidden_layers=num_layers,
+        num_attention_heads=int(md["clip.vision.attention.head_count"]),
+        image_size=int(md["clip.vision.image_size"]),
+        patch_size=int(md["clip.vision.patch_size"]),
+        norm_eps=float(md.get("clip.vision.attention.layer_norm_epsilon", 1e-5)),
+        in_channels=int(patch_embd.shape[1]),
+        spatial_merge_size=merge_size,
+        temporal_patch_size=_MUSE_GLIMMER_TEMPORAL_PATCH_SIZE,
+        position_embedding_size=position_rows,
+        position_embedding_height=grid,
+        position_embedding_width=grid,
+        fullatt_block_indexes=full_attention,
+        projector_intermediate_size=projector_intermediate_size,
+        # HF stores the pixel-shuffled width here (hidden * merge**2), not the
+        # text hidden size that clip.vision.projection_dim reports.
+        out_hidden_size=hidden_size * merge_size * merge_size,
+        hidden_act="gelu",
+        rope_theta=_MUSE_GLIMMER_VISION_ROPE_THETA,
+    )
 
 
 def read_mmproj_vision_config(gguf_model: Any):
@@ -500,6 +586,226 @@ def build_gemma4_vlm_from_gguf(
     logger.info("Applied %d mapped weights to the Gemma4 VLM package", len(state_dict))
 
     return pkg
+
+
+def _mmproj_muse_glimmer_vision_to_hf(mmproj_gguf: Any) -> dict:
+    """Load Muse Glimmer mmproj tensors under their HF ``model.vision_*`` names."""
+    import torch
+
+    from mobius.integrations.gguf._mmproj_mapping import (
+        map_mmproj_muse_glimmer_vision_to_hf,
+    )
+
+    state_dict: dict[str, torch.Tensor] = {}
+    for name in mmproj_gguf.tensor_names:
+        hf_name = map_mmproj_muse_glimmer_vision_to_hf(name)
+        if hf_name is None:
+            continue
+        values = np.array(mmproj_gguf.get_tensor(name)).astype(np.float32)
+        if name == "v.patch_embd.weight":
+            # Conv patch embed [out, in_ch, kh, kw] → Linear [out, in_ch*kh*kw].
+            # The encoder consumes pre-patchified pixels in that row-major order.
+            values = values.reshape(values.shape[0], -1)
+        state_dict[hf_name] = torch.from_numpy(values)
+    return state_dict
+
+
+def build_muse_glimmer_vlm_from_gguf(
+    text_gguf_path: str | Path,
+    mmproj_gguf_path: str | Path,
+    *,
+    dtype: str | None = None,
+    execution_provider: str = "default",
+    image_token_id: int | None = None,
+    keep_quantized: bool = True,
+) -> ModelPackage:
+    """Build a Muse Glimmer decoder + vision + embedding package from GGUFs.
+
+    Args:
+        text_gguf_path: Path (or HF ref) to the Muse Glimmer text GGUF.
+        mmproj_gguf_path: Path (or HF ref) to the companion ``clip`` mmproj.
+        dtype: Optional dtype override (e.g. ``"bf16"``).
+        execution_provider: Target EP for EP-aware optimisations.
+        image_token_id: Vocabulary id of the image placeholder token. GGUF
+            carries no such key, so when ``None`` the model's published default
+            is used.
+        keep_quantized: Preserve the text GGUF's quantization for the decoder
+            projections. The token-embedding table and LM head always stay
+            float here: the multimodal split shares one embedding table between
+            the decoder and the separate embedding graph, and that routing keys
+            off the exact float weight name.
+
+    Returns:
+        A :class:`ModelPackage` with ``decoder`` + ``vision_encoder`` +
+        ``embedding`` components.
+
+    The vision tower always stays float — the mmproj ships it as F32/BF16.
+    """
+    import dataclasses
+
+    import torch
+
+    from mobius._builder import build_from_module, resolve_dtype
+    from mobius.integrations.gguf._builder import (
+        _has_quantized_weights,
+        _load_dequantized_state_dict,
+        _load_quantized_state_dict,
+        _normalize_gguf_weights,
+        _replace_native_block_linears,
+        _validate_gguf_model,
+    )
+    from mobius.integrations.gguf._config_mapping import gguf_to_config
+    from mobius.integrations.gguf._reader import GGUFModel
+    from mobius.integrations.gguf._tensor_processors import process_tensors
+    from mobius.models.muse_glimmer import MuseGlimmerForConditionalGeneration
+    from mobius.tasks import MuseGlimmerVLTask
+
+    text_gguf = GGUFModel(_resolve_local_path(text_gguf_path))
+    _validate_gguf_model(text_gguf, source=str(text_gguf_path))
+    text_arch = text_gguf.architecture
+
+    mmproj_gguf = GGUFModel(_resolve_local_path(mmproj_gguf_path))
+    _validate_gguf_model(mmproj_gguf, source=str(mmproj_gguf_path))
+    if mmproj_gguf.architecture != "clip":
+        raise ValueError(
+            f"Expected a 'clip' mmproj GGUF, got architecture "
+            f"{mmproj_gguf.architecture!r} for {mmproj_gguf_path!r}."
+        )
+    logger.info(
+        "Building Muse Glimmer VLM from text=%s mmproj=%s",
+        text_gguf_path,
+        mmproj_gguf_path,
+    )
+
+    # 1. Text config + vision sub-config.
+    config = gguf_to_config(text_gguf)
+    vision_config = read_mmproj_muse_glimmer_vision_config(mmproj_gguf)
+    if vision_config is None:
+        raise ValueError(
+            "mmproj GGUF has no vision encoder (clip.has_vision_encoder is unset)."
+        )
+    config = dataclasses.replace(config, vision=vision_config, audio=None)
+    if image_token_id is not None:
+        config = dataclasses.replace(config, image_token_id=image_token_id)
+    if dtype is not None:
+        resolved = resolve_dtype(dtype)
+        if resolved is not None:
+            config = dataclasses.replace(config, dtype=resolved)
+
+    preserve_quantization = keep_quantized and _has_quantized_weights(text_gguf, text_arch)
+    if keep_quantized and not preserve_quantization:
+        logger.info(
+            "Text GGUF contains no mapped quantized weights; using the float import path"
+        )
+    if preserve_quantization:
+        from mobius._configs import QuantizationConfig
+        from mobius.integrations.gguf._builder import _detect_quant_params
+
+        bits, block_size, is_symmetric = _detect_quant_params(text_gguf, text_arch)
+        config = dataclasses.replace(
+            config,
+            quantization=QuantizationConfig(
+                bits=bits,
+                group_size=block_size,
+                quant_method="gguf",
+                sym=is_symmetric,
+                quantize_embeddings=False,
+                quantize_lm_head=False,
+                tie_word_embeddings=False,
+            ),
+        )
+        logger.info(
+            "Quantized multimodal mode: bits=%d, block_size=%d, symmetric=%s "
+            "(embedding, LM head and vision stay float)",
+            bits,
+            block_size,
+            is_symmetric,
+        )
+
+    # 2. Build the three-component graph.
+    module = MuseGlimmerForConditionalGeneration(config)
+    if preserve_quantization:
+        _replace_native_block_linears(module.decoder, text_gguf, text_arch)
+    pkg = build_from_module(
+        module, config, MuseGlimmerVLTask(), execution_provider=execution_provider
+    )
+    logger.info("Built Muse Glimmer VLM graph (%d components: %s)", len(pkg), list(pkg))
+
+    # 3. Text weights under plain HF names. The quantized loader matches GGUF
+    #    tensors against module paths, so it is given the decoder sub-module
+    #    whose paths are the ``model.*`` HF names it expects.
+    if preserve_quantization:
+        text_state = _load_quantized_state_dict(text_gguf, text_arch, module.decoder, config)
+    else:
+        text_state = _load_dequantized_state_dict(text_gguf, text_arch)
+
+    # 4. Architecture fix-ups (Muse Glimmer's centered block norms) run on the
+    #    plain HF names, exactly as in the text-only path, before the names are
+    #    moved into the multimodal namespace.
+    float_state = {
+        key: value
+        for key, value in text_state.items()
+        if not key.endswith((".scales", ".zero_points", ".qweight"))
+        and value.dtype != torch.uint8
+    }
+    rest = {key: value for key, value in text_state.items() if key not in float_state}
+    float_state = _normalize_gguf_weights(process_tensors(float_state, config))
+    text_state = {**float_state, **rest}
+
+    # 5. Move the text backbone under ``model.language_model.`` and merge in
+    #    the vision tower, then run the model's own HF→ONNX routing.
+    state_dict = {
+        _muse_glimmer_multimodal_name(key): value for key, value in text_state.items()
+    }
+    state_dict.update(_mmproj_muse_glimmer_vision_to_hf(mmproj_gguf))
+    state_dict = module.preprocess_weights(state_dict)
+    pkg.apply_weights(state_dict)
+    logger.info("Applied %d mapped weights to the Muse Glimmer VLM package", len(state_dict))
+
+    return pkg
+
+
+def build_vlm_from_gguf(
+    text_gguf_path: str | Path,
+    mmproj_gguf_path: str | Path,
+    *,
+    dtype: str | None = None,
+    execution_provider: str = "default",
+    keep_quantized: bool = True,
+) -> ModelPackage:
+    """Route a text + mmproj pair to the architecture-specific VLM builder.
+
+    The mmproj itself is always ``general.architecture = clip``, so the text
+    backbone is what decides how the pair is assembled.
+    """
+    from mobius.integrations.gguf._config_mapping import GGUF_ARCH_TO_MODEL_TYPE
+    from mobius.integrations.gguf._reader import GGUFModel
+
+    text_arch = GGUFModel(_resolve_local_path(text_gguf_path)).architecture
+    builder = (
+        build_muse_glimmer_vlm_from_gguf
+        if GGUF_ARCH_TO_MODEL_TYPE.get(text_arch) == "muse_glimmer_text"
+        else build_gemma4_vlm_from_gguf
+    )
+    return builder(
+        text_gguf_path,
+        mmproj_gguf_path,
+        dtype=dtype,
+        execution_provider=execution_provider,
+        keep_quantized=keep_quantized,
+    )
+
+
+def _muse_glimmer_multimodal_name(hf_name: str) -> str:
+    """Nest a text-backbone HF name under the multimodal namespace.
+
+    ``MuseGlimmerForConditionalGeneration.preprocess_weights`` expects the
+    decoder weights as ``model.language_model.*`` and leaves ``lm_head.*``
+    at the top level.
+    """
+    if hf_name.startswith("model."):
+        return "model.language_model." + hf_name[len("model.") :]
+    return hf_name
 
 
 def _mmproj_audio_to_hf(mmproj_gguf: Any) -> dict:

--- a/src/mobius/integrations/gguf/_mmproj.py
+++ b/src/mobius/integrations/gguf/_mmproj.py
@@ -40,6 +40,7 @@ __all__ = [
     "read_mmproj_vision_config",
 ]
 
+import dataclasses
 import logging
 import math
 from pathlib import Path
@@ -63,6 +64,25 @@ _DEFAULT_POOLING_KERNEL_SIZE = 4
 _MUSE_GLIMMER_VISION_ROPE_THETA = 10_000.0
 # Full-attention stride: every 4th block is global, and so is the last block.
 _MUSE_GLIMMER_VISION_FULL_ATTENTION_STRIDE = 4
+
+
+def _with_muse_glimmer_media_token_ids(config: Any) -> Any:
+    """Fill in the media placeholder ids a GGUF cannot carry.
+
+    They belong to the tokenizer, not to the model metadata, so a converted
+    config arrives with both unset. Leaving them that way is not cosmetic: the
+    embedding graph compares ``input_ids`` against them, and the ort-genai
+    exporter omits the field from ``genai_config`` entirely when it is ``None``,
+    producing a package that cannot address video at all.
+    """
+    from mobius.models.muse_glimmer import IMAGE_TOKEN_ID, VIDEO_TOKEN_ID
+
+    updates = {}
+    if config.image_token_id is None:
+        updates["image_token_id"] = IMAGE_TOKEN_ID
+    if config.video_token_id is None:
+        updates["video_token_id"] = VIDEO_TOKEN_ID
+    return dataclasses.replace(config, **updates) if updates else config
 
 
 def _muse_glimmer_temporal_patch_size(patch_embd: Any, *, patch_size: int) -> int:
@@ -714,6 +734,7 @@ def build_muse_glimmer_vlm_from_gguf(
     config = dataclasses.replace(config, vision=vision_config, audio=None)
     if image_token_id is not None:
         config = dataclasses.replace(config, image_token_id=image_token_id)
+    config = _with_muse_glimmer_media_token_ids(config)
     if dtype is not None:
         resolved = resolve_dtype(dtype)
         if resolved is not None:

--- a/src/mobius/integrations/gguf/_mmproj_mapping.py
+++ b/src/mobius/integrations/gguf/_mmproj_mapping.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 __all__ = [
     "is_mmproj_stat_tensor",
     "map_mmproj_audio_to_hf",
+    "map_mmproj_muse_glimmer_vision_to_hf",
     "map_mmproj_vision_to_hf",
 ]
 
@@ -145,6 +146,83 @@ def map_mmproj_vision_to_hf(name: str) -> str | None:
     if name == "mm.input_projection.weight":
         return "embed_vision.embedding_projection.weight"
     return None
+
+
+# ---------------------------------------------------------------------------
+# Muse Glimmer vision tower (v.* / mm.N)
+# ---------------------------------------------------------------------------
+# Muse Glimmer's tower is a dynamic-resolution ViT with a plain pre-norm block
+# (LayerNorm + biased Q/K/V/out + GELU MLP), so unlike Gemma4 there are no
+# post-norms, no SwiGLU gate and no QK norms. The projector is three separate
+# `mm.N` matrices rather than a single input projection: two adapter layers on
+# the pixel-shuffled features and one projection into the text hidden size.
+_MUSE_GLIMMER_VISION_BLOCK_STEMS: dict[str, str] = {
+    "ln1.weight": "norm1.weight",
+    "ln1.bias": "norm1.bias",
+    "ln2.weight": "norm2.weight",
+    "ln2.bias": "norm2.bias",
+    "attn_q.weight": "attn.q_proj.weight",
+    "attn_q.bias": "attn.q_proj.bias",
+    "attn_k.weight": "attn.k_proj.weight",
+    "attn_k.bias": "attn.k_proj.bias",
+    "attn_v.weight": "attn.v_proj.weight",
+    "attn_v.bias": "attn.v_proj.bias",
+    "attn_out.weight": "attn.proj.weight",
+    "attn_out.bias": "attn.proj.bias",
+    "ffn_up.weight": "mlp.fc1.weight",
+    "ffn_up.bias": "mlp.fc1.bias",
+    "ffn_down.weight": "mlp.fc2.weight",
+    "ffn_down.bias": "mlp.fc2.bias",
+}
+
+# The three projector matrices, in file order. mm.0/mm.1 are the adapter that
+# runs on merge_size**2-shuffled patches; mm.2 projects into the text model.
+_MUSE_GLIMMER_PROJECTOR: dict[str, str] = {
+    "mm.0.weight": "model.vision_adapter.fc1.weight",
+    "mm.1.weight": "model.vision_adapter.fc2.weight",
+    "mm.2.weight": "model.vision_projection.weight",
+}
+
+
+def map_mmproj_muse_glimmer_vision_to_hf(name: str) -> str | None:
+    """Map a Muse Glimmer ``clip`` mmproj tensor name to its HF name.
+
+    Returns the name consumed by
+    :meth:`mobius.models.muse_glimmer.MuseGlimmerForConditionalGeneration.preprocess_weights`
+    (``model.vision_tower.*``, ``model.vision_adapter.*``,
+    ``model.vision_projection.*``), or ``None`` for tensors that are skipped.
+
+    The projector matrices are named positionally in the GGUF (``mm.0`` …
+    ``mm.2``); their roles are fixed by the published ``clip.projector_type =
+    muse-glimmer`` layout and confirmed by their shapes — ``mm.0`` consumes
+    ``hidden_size * merge_size**2``, ``mm.2`` produces the text hidden size.
+    """
+    if is_mmproj_stat_tensor(name):
+        return None
+
+    blk = _VISION_BLK.match(name)
+    if blk is not None:
+        idx, stem = blk.group(1), blk.group(2)
+        hf_stem = _MUSE_GLIMMER_VISION_BLOCK_STEMS.get(stem)
+        if hf_stem is None:
+            return None
+        return f"model.vision_tower.layers.{idx}.{hf_stem}"
+
+    top: dict[str, str] = {
+        # Conv patch embedding [out, in_ch, kh, kw]; flattened to the Linear
+        # the encoder uses by the builder.
+        "v.patch_embd.weight": ("model.vision_tower.patch_embedder.patch_embedding.weight"),
+        # [pos_grid**2, hidden] learned table, interpolated per resolution.
+        "v.position_embd.weight": (
+            "model.vision_tower.patch_embedder.position_embedding_table.weight"
+        ),
+        "v.pre_ln.weight": "model.vision_tower.ln_pre.weight",
+        "v.pre_ln.bias": "model.vision_tower.ln_pre.bias",
+        "v.post_ln.weight": "model.vision_tower.ln_post.weight",
+        "v.post_ln.bias": "model.vision_tower.ln_post.bias",
+        **_MUSE_GLIMMER_PROJECTOR,
+    }
+    return top.get(name)
 
 
 def map_mmproj_audio_to_hf(name: str) -> str | None:

--- a/src/mobius/integrations/gguf/_mmproj_mapping_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_mapping_test.py
@@ -159,3 +159,63 @@ class TestAudioMapping:
 
     def test_stat_tensors_skipped(self):
         assert map_mmproj_audio_to_hf("a.blk.0.attn_q.weight.output_min") is None
+
+
+class TestMuseGlimmerVisionMapping:
+    """Muse Glimmer ``clip`` mmproj → HF vision names.
+
+    Verified against ``unsloth/Muse-Glimmer-30B-GGUF``'s
+    ``mmproj-Muse-Glimmer-30B-BF16.gguf``: all 809 tensors map, and the mapped
+    names are exactly the 809 parameters of the published vision encoder graph.
+    """
+
+    def test_block_tensors_land_on_the_vision_tower_layers(self) -> None:
+        from mobius.integrations.gguf._mmproj_mapping import (
+            map_mmproj_muse_glimmer_vision_to_hf as convert,
+        )
+
+        assert (
+            convert("v.blk.7.attn_q.weight")
+            == "model.vision_tower.layers.7.attn.q_proj.weight"
+        )
+        assert convert("v.blk.7.attn_q.bias") == "model.vision_tower.layers.7.attn.q_proj.bias"
+        assert (
+            convert("v.blk.7.attn_out.weight")
+            == "model.vision_tower.layers.7.attn.proj.weight"
+        )
+        assert convert("v.blk.7.ln1.weight") == "model.vision_tower.layers.7.norm1.weight"
+        assert convert("v.blk.7.ln2.bias") == "model.vision_tower.layers.7.norm2.bias"
+        assert convert("v.blk.7.ffn_up.weight") == "model.vision_tower.layers.7.mlp.fc1.weight"
+        assert convert("v.blk.7.ffn_down.bias") == "model.vision_tower.layers.7.mlp.fc2.bias"
+
+    def test_stem_tensors_and_the_three_projector_matrices(self) -> None:
+        from mobius.integrations.gguf._mmproj_mapping import (
+            map_mmproj_muse_glimmer_vision_to_hf as convert,
+        )
+
+        assert (
+            convert("v.patch_embd.weight")
+            == "model.vision_tower.patch_embedder.patch_embedding.weight"
+        )
+        assert (
+            convert("v.position_embd.weight")
+            == "model.vision_tower.patch_embedder.position_embedding_table.weight"
+        )
+        assert convert("v.pre_ln.bias") == "model.vision_tower.ln_pre.bias"
+        assert convert("v.post_ln.weight") == "model.vision_tower.ln_post.weight"
+        # mm.0/mm.1 are the pixel-shuffle adapter, mm.2 the text projection.
+        assert convert("mm.0.weight") == "model.vision_adapter.fc1.weight"
+        assert convert("mm.1.weight") == "model.vision_adapter.fc2.weight"
+        assert convert("mm.2.weight") == "model.vision_projection.weight"
+
+    def test_stats_and_unknown_tensors_are_skipped(self) -> None:
+        from mobius.integrations.gguf._mmproj_mapping import (
+            map_mmproj_muse_glimmer_vision_to_hf as convert,
+        )
+
+        assert convert("v.blk.0.attn_q.input_max") is None
+        # Muse Glimmer's tower has no SwiGLU gate and no QK norms; a file
+        # carrying them is not this architecture.
+        assert convert("v.blk.0.ffn_gate.weight") is None
+        assert convert("v.blk.0.attn_q_norm.weight") is None
+        assert convert("a.blk.0.attn_q.weight") is None

--- a/src/mobius/integrations/gguf/_mmproj_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_test.py
@@ -574,3 +574,200 @@ class TestKeepQuantizedMixedPrecision:
         session = ort.InferenceSession(str(decoder_path), providers=["CPUExecutionProvider"])
         input_names = {graph_input.name for graph_input in session.get_inputs()}
         assert "inputs_embeds" in input_names
+
+
+# Small synthetic Muse Glimmer vision tower dimensions.
+_MG_HIDDEN = 16
+_MG_FFN = 32
+_MG_LAYERS = 6
+_MG_HEADS = 2
+_MG_PATCH = 4
+_MG_GRID = 4
+_MG_MERGE = 2
+_MG_PROJECTOR = 24
+_MG_TEXT_HIDDEN = 32
+
+
+def _write_muse_glimmer_mmproj_gguf(path: Path) -> None:
+    """Write a small synthetic Muse Glimmer ``clip`` mmproj GGUF.
+
+    Mirrors the published ``mmproj-Muse-Glimmer-30B-*.gguf`` layout: biased
+    projections, a plain two-LayerNorm block, no SwiGLU gate, no QK norms, and
+    three positional ``mm.N`` projector matrices.
+    """
+    from gguf import GGUFWriter
+
+    writer = GGUFWriter(str(path), "clip")
+    writer.add_bool("clip.has_vision_encoder", True)
+    writer.add_string("clip.projector_type", "muse-glimmer")
+    writer.add_uint32("clip.vision.embedding_length", _MG_HIDDEN)
+    writer.add_uint32("clip.vision.feed_forward_length", _MG_FFN)
+    writer.add_uint32("clip.vision.block_count", _MG_LAYERS)
+    writer.add_uint32("clip.vision.attention.head_count", _MG_HEADS)
+    writer.add_uint32("clip.vision.image_size", 64)
+    writer.add_uint32("clip.vision.patch_size", _MG_PATCH)
+    writer.add_uint32("clip.vision.projection_dim", _MG_TEXT_HIDDEN)
+    writer.add_uint32("clip.vision.spatial_merge_size", _MG_MERGE)
+    writer.add_float32("clip.vision.attention.layer_norm_epsilon", 1e-5)
+
+    def _f32(name: str, shape: tuple[int, ...]) -> None:
+        writer.add_tensor(name, np.random.randn(*shape).astype(np.float32))
+
+    _f32("v.patch_embd.weight", (_MG_HIDDEN, 3, _MG_PATCH, _MG_PATCH))
+    _f32("v.position_embd.weight", (_MG_GRID * _MG_GRID, _MG_HIDDEN))
+    for stem in ("v.pre_ln", "v.post_ln"):
+        _f32(f"{stem}.weight", (_MG_HIDDEN,))
+        _f32(f"{stem}.bias", (_MG_HIDDEN,))
+    shuffled = _MG_HIDDEN * _MG_MERGE * _MG_MERGE
+    _f32("mm.0.weight", (_MG_PROJECTOR, shuffled))
+    _f32("mm.1.weight", (_MG_PROJECTOR, _MG_PROJECTOR))
+    _f32("mm.2.weight", (_MG_TEXT_HIDDEN, _MG_PROJECTOR))
+
+    for layer in range(_MG_LAYERS):
+        prefix = f"v.blk.{layer}."
+        for norm in ("ln1", "ln2"):
+            _f32(prefix + norm + ".weight", (_MG_HIDDEN,))
+            _f32(prefix + norm + ".bias", (_MG_HIDDEN,))
+        for proj in ("attn_q", "attn_k", "attn_v", "attn_out"):
+            _f32(prefix + proj + ".weight", (_MG_HIDDEN, _MG_HIDDEN))
+            _f32(prefix + proj + ".bias", (_MG_HIDDEN,))
+        _f32(prefix + "ffn_up.weight", (_MG_FFN, _MG_HIDDEN))
+        _f32(prefix + "ffn_up.bias", (_MG_FFN,))
+        _f32(prefix + "ffn_down.weight", (_MG_HIDDEN, _MG_FFN))
+        _f32(prefix + "ffn_down.bias", (_MG_HIDDEN,))
+
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_tensors_to_file()
+    writer.close()
+
+
+class TestReadMuseGlimmerVisionConfig:
+    """Muse Glimmer vision config extraction from a ``clip`` mmproj."""
+
+    @pytest.fixture
+    def mmproj(self, tmp_path: Path) -> Path:
+        path = tmp_path / "mmproj-muse.gguf"
+        _write_muse_glimmer_mmproj_gguf(path)
+        return path
+
+    def test_reads_metadata_fields(self, mmproj: Path):
+        from mobius.integrations.gguf._mmproj import (
+            read_mmproj_muse_glimmer_vision_config,
+        )
+        from mobius.integrations.gguf._reader import GGUFModel
+
+        config = read_mmproj_muse_glimmer_vision_config(GGUFModel(str(mmproj)))
+
+        assert config is not None
+        assert config.hidden_size == _MG_HIDDEN
+        assert config.intermediate_size == _MG_FFN
+        assert config.num_hidden_layers == _MG_LAYERS
+        assert config.num_attention_heads == _MG_HEADS
+        assert config.patch_size == _MG_PATCH
+        assert config.spatial_merge_size == _MG_MERGE
+        assert config.in_channels == 3
+        assert config.norm_eps == pytest.approx(1e-5)
+        assert config.hidden_act == "gelu"
+
+    def test_recovers_the_fields_gguf_does_not_store(self, mmproj: Path):
+        from mobius.integrations.gguf._mmproj import (
+            read_mmproj_muse_glimmer_vision_config,
+        )
+        from mobius.integrations.gguf._reader import GGUFModel
+
+        config = read_mmproj_muse_glimmer_vision_config(GGUFModel(str(mmproj)))
+
+        assert config is not None
+        # Square position grid, read back from the table's row count.
+        assert config.position_embedding_size == _MG_GRID * _MG_GRID
+        assert config.position_embedding_height == _MG_GRID
+        assert config.position_embedding_width == _MG_GRID
+        # Adapter width comes from mm.0.
+        assert config.projector_intermediate_size == _MG_PROJECTOR
+        # HF's out_hidden_size is the pixel-shuffled width, not the text width.
+        assert config.out_hidden_size == _MG_HIDDEN * _MG_MERGE * _MG_MERGE
+        # Every 4th block is global attention, and so is the last one.
+        assert config.fullatt_block_indexes == [3, 5]
+        # Not in GGUF at all; published architectural constants.
+        assert config.temporal_patch_size == 2
+        assert config.rope_theta == pytest.approx(10_000.0)
+
+    def test_returns_none_without_vision_encoder(self, mmproj: Path):
+        from mobius.integrations.gguf._mmproj import (
+            read_mmproj_muse_glimmer_vision_config,
+        )
+        from mobius.integrations.gguf._reader import GGUFModel
+
+        model = GGUFModel(str(mmproj))
+        model.metadata["clip.has_vision_encoder"] = False
+        assert read_mmproj_muse_glimmer_vision_config(model) is None
+
+    def test_non_square_position_table_is_rejected(self, mmproj: Path):
+        from mobius.integrations.gguf._mmproj import (
+            read_mmproj_muse_glimmer_vision_config,
+        )
+        from mobius.integrations.gguf._reader import GGUFModel
+
+        model = GGUFModel(str(mmproj))
+        with (
+            mock.patch.object(
+                model,
+                "get_tensor",
+                side_effect=lambda name: np.zeros((15, _MG_HIDDEN), dtype=np.float32),
+            ),
+            pytest.raises(ValueError, match="not a square grid"),
+        ):
+            read_mmproj_muse_glimmer_vision_config(model)
+
+    def test_vision_tensors_load_under_hf_names(self, mmproj: Path):
+        from mobius.integrations.gguf._mmproj import _mmproj_muse_glimmer_vision_to_hf
+        from mobius.integrations.gguf._reader import GGUFModel
+
+        state = _mmproj_muse_glimmer_vision_to_hf(GGUFModel(str(mmproj)))
+
+        # The conv patch embedding is flattened into the encoder's Linear.
+        patch = state["model.vision_tower.patch_embedder.patch_embedding.weight"]
+        assert tuple(patch.shape) == (_MG_HIDDEN, 3 * _MG_PATCH * _MG_PATCH)
+        assert tuple(state["model.vision_projection.weight"].shape) == (
+            _MG_TEXT_HIDDEN,
+            _MG_PROJECTOR,
+        )
+        assert "model.vision_tower.layers.5.attn.proj.bias" in state
+        # 6 blocks x 16 tensors + 6 stem tensors + 3 projector matrices.
+        assert len(state) == _MG_LAYERS * 16 + 6 + 3
+
+
+class TestVlmRouting:
+    """The text backbone decides which VLM builder assembles the pair."""
+
+    @pytest.mark.parametrize(
+        ("architecture", "expected"),
+        [
+            ("muse-glimmer", "build_muse_glimmer_vlm_from_gguf"),
+            ("muse_glimmer", "build_muse_glimmer_vlm_from_gguf"),
+            ("gemma4", "build_gemma4_vlm_from_gguf"),
+        ],
+    )
+    def test_routes_on_the_text_architecture(
+        self, tmp_path: Path, architecture: str, expected: str
+    ):
+        from mobius.integrations.gguf._mmproj import build_vlm_from_gguf
+
+        text_path = tmp_path / "text.gguf"
+        _write_minimal_gguf(text_path, architecture)
+        package = mock.sentinel.package
+
+        with mock.patch(
+            f"mobius.integrations.gguf._mmproj.{expected}", return_value=package
+        ) as builder:
+            actual = build_vlm_from_gguf(text_path, "mmproj.gguf", keep_quantized=False)
+
+        assert actual is package
+        builder.assert_called_once_with(
+            text_path,
+            "mmproj.gguf",
+            dtype=None,
+            execution_provider="default",
+            keep_quantized=False,
+        )

--- a/src/mobius/integrations/gguf/_mmproj_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_test.py
@@ -795,3 +795,61 @@ class TestMuseGlimmerTemporalPatchSize:
         weight = np.zeros((1536, 3, 13, 14), dtype=np.float32)
         with pytest.raises(ValueError, match="not divisible"):
             _muse_glimmer_temporal_patch_size(weight, patch_size=14)
+
+
+class TestMuseGlimmerMediaTokenIds:
+    """A GGUF carries no tokenizer, so the media placeholder ids arrive unset.
+
+    Leaving them unset is not cosmetic. The embedding graph compares
+    ``input_ids`` against them, and the ort-genai exporter drops the field from
+    ``genai_config`` when it is ``None``, so the exported package loses the
+    ability to address video entirely.
+    """
+
+    @staticmethod
+    def _config(**overrides):
+        from mobius._configs import MuseGlimmerConfig
+
+        values = dict(
+            hidden_size=64,
+            intermediate_size=128,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            num_hidden_layers=2,
+            vocab_size=256,
+        )
+        values.update(overrides)
+        return MuseGlimmerConfig(**values)
+
+    def test_fills_in_the_published_ids(self) -> None:
+        from mobius.integrations.gguf._mmproj import _with_muse_glimmer_media_token_ids
+        from mobius.models.muse_glimmer import IMAGE_TOKEN_ID, VIDEO_TOKEN_ID
+
+        config = self._config()
+        assert config.image_token_id is None
+        assert config.video_token_id is None
+
+        result = _with_muse_glimmer_media_token_ids(config)
+
+        assert result.image_token_id == IMAGE_TOKEN_ID
+        assert result.video_token_id == VIDEO_TOKEN_ID
+
+    def test_does_not_override_ids_the_caller_supplied(self) -> None:
+        from mobius.integrations.gguf._mmproj import _with_muse_glimmer_media_token_ids
+
+        result = _with_muse_glimmer_media_token_ids(
+            self._config(image_token_id=7, video_token_id=9)
+        )
+
+        assert result.image_token_id == 7
+        assert result.video_token_id == 9
+
+    def test_the_embedding_graph_never_compares_against_none(self) -> None:
+        from mobius.models.muse_glimmer import (
+            VIDEO_TOKEN_ID,
+            MuseGlimmerEmbeddingModel,
+        )
+
+        module = MuseGlimmerEmbeddingModel(self._config())
+
+        assert module._video_token_id == VIDEO_TOKEN_ID

--- a/src/mobius/integrations/gguf/_mmproj_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_test.py
@@ -689,8 +689,9 @@ class TestReadMuseGlimmerVisionConfig:
         assert config.out_hidden_size == _MG_HIDDEN * _MG_MERGE * _MG_MERGE
         # Every 4th block is global attention, and so is the last one.
         assert config.fullatt_block_indexes == [3, 5]
-        # Not in GGUF at all; published architectural constants.
-        assert config.temporal_patch_size == 2
+        # Derived from the patch-embedding weight: llama.cpp stores a plain
+        # Conv2d kernel, i.e. a single temporal frame.
+        assert config.temporal_patch_size == 1
         assert config.rope_theta == pytest.approx(10_000.0)
 
     def test_returns_none_without_vision_encoder(self, mmproj: Path):
@@ -771,3 +772,26 @@ class TestVlmRouting:
             execution_provider="default",
             keep_quantized=False,
         )
+
+
+class TestMuseGlimmerTemporalPatchSize:
+    """The temporal depth is read off the weight, not assumed."""
+
+    def test_conv2d_kernel_means_a_single_frame(self) -> None:
+        from mobius.integrations.gguf._mmproj import _muse_glimmer_temporal_patch_size
+
+        weight = np.zeros((1536, 3, 14, 14), dtype=np.float32)
+        assert _muse_glimmer_temporal_patch_size(weight, patch_size=14) == 1
+
+    def test_conv3d_kernel_keeps_its_temporal_depth(self) -> None:
+        from mobius.integrations.gguf._mmproj import _muse_glimmer_temporal_patch_size
+
+        weight = np.zeros((1536, 3, 2, 14, 14), dtype=np.float32)
+        assert _muse_glimmer_temporal_patch_size(weight, patch_size=14) == 2
+
+    def test_indivisible_kernel_is_rejected(self) -> None:
+        from mobius.integrations.gguf._mmproj import _muse_glimmer_temporal_patch_size
+
+        weight = np.zeros((1536, 3, 13, 14), dtype=np.float32)
+        with pytest.raises(ValueError, match="not divisible"):
+            _muse_glimmer_temporal_patch_size(weight, patch_size=14)

--- a/src/mobius/integrations/gguf/_tensor_mapping.py
+++ b/src/mobius/integrations/gguf/_tensor_mapping.py
@@ -292,6 +292,32 @@ _HUNYUAN_EXTRAS: dict[str, str] = {
 
 _HUNYUAN_FAMILY = frozenset({"hunyuan-dense", "hunyuan_v1_dense"})
 
+# Muse Glimmer keeps the Llama projection names but rearranges the norms and
+# adds a sigmoid gate on the attention output.
+#
+# Two GGUF tensors have no HuggingFace counterpart and are deliberately absent
+# from this mapping, which makes `map_gguf_to_hf_names` skip them:
+#
+#   blk.{bid}.attn_q_norm / blk.{bid}.attn_k_norm
+#       Muse Glimmer's QK normalization is scale-free — the HF checkpoint has no
+#       q_norm/k_norm parameters at all. llama.cpp still materializes the tensors
+#       so its generic attention path can multiply by something, so attn_k_norm
+#       is a vector of ones and attn_q_norm is the `qk_scale_factor` scalar
+#       broadcast over head_dim. The scalar is recovered in `_config_mapping`,
+#       which reads it back out of attn_q_norm; dropping the tensors here would
+#       otherwise lose it.
+_MUSE_GLIMMER_EXTRAS: dict[str, str] = {
+    # Muse Glimmer has four norms per block. `ffn_norm` is the *pre*-feedforward
+    # norm, so it overrides the Llama mapping onto post_attention_layernorm.
+    "blk.{bid}.ffn_norm": "model.layers.{bid}.pre_feedforward_layernorm",
+    "blk.{bid}.post_attention_norm": ("model.layers.{bid}.post_attention_layernorm"),
+    "blk.{bid}.post_ffw_norm": ("model.layers.{bid}.post_feedforward_layernorm"),
+    # Sigmoid gate applied to the attention output before o_proj.
+    "blk.{bid}.attn_gate": "model.layers.{bid}.self_attn.gate_proj",
+}
+
+_MUSE_GLIMMER_FAMILY = frozenset({"muse-glimmer", "muse_glimmer"})
+
 _MOE_FAMILY = frozenset(
     {
         "qwen2moe",
@@ -359,6 +385,9 @@ def _build_mapping(
     elif arch in _HUNYUAN_FAMILY:
         result = dict(_LLAMA_MAPPING)
         result.update(_HUNYUAN_EXTRAS)
+    elif arch in _MUSE_GLIMMER_FAMILY:
+        result = dict(_LLAMA_MAPPING)
+        result.update(_MUSE_GLIMMER_EXTRAS)
     elif arch in _MOE_FAMILY:
         result = dict(_LLAMA_MAPPING)
         result.update(_MOE_EXTRAS)
@@ -372,6 +401,7 @@ def _build_mapping(
             | _GEMMA_FAMILY
             | _MOE_FAMILY
             | _HUNYUAN_FAMILY
+            | _MUSE_GLIMMER_FAMILY
             | {"deepseek4", "gemma4", "phi3", "falcon", "gpt2", "mamba"}
         )
         raise ValueError(

--- a/src/mobius/integrations/gguf/_tensor_mapping_test.py
+++ b/src/mobius/integrations/gguf/_tensor_mapping_test.py
@@ -356,3 +356,47 @@ class TestBuildGGUFToHFMap:
 
     def test_empty_input(self) -> None:
         assert build_gguf_to_hf_map([], "llama") == {}
+
+
+class TestMuseGlimmerMapping:
+    """Tests for the Muse Glimmer GGUF tensor names."""
+
+    def test_projections_and_gate(self) -> None:
+        expected = {
+            "token_embd.weight": "model.embed_tokens.weight",
+            "output.weight": "lm_head.weight",
+            "output_norm.weight": "model.norm.weight",
+            "blk.3.attn_q.weight": "model.layers.3.self_attn.q_proj.weight",
+            "blk.3.attn_output.weight": "model.layers.3.self_attn.o_proj.weight",
+            "blk.3.attn_gate.weight": "model.layers.3.self_attn.gate_proj.weight",
+            "blk.3.ffn_down.weight": "model.layers.3.mlp.down_proj.weight",
+        }
+        for source, target in expected.items():
+            assert map_gguf_to_hf_names(source, "muse-glimmer") == target
+
+    def test_four_block_norms(self) -> None:
+        # ffn_norm is the *pre*-feedforward norm here, not the post-attention
+        # norm it maps to in the Llama base mapping.
+        expected = {
+            "blk.7.attn_norm.weight": "model.layers.7.input_layernorm.weight",
+            "blk.7.post_attention_norm.weight": (
+                "model.layers.7.post_attention_layernorm.weight"
+            ),
+            "blk.7.ffn_norm.weight": ("model.layers.7.pre_feedforward_layernorm.weight"),
+            "blk.7.post_ffw_norm.weight": ("model.layers.7.post_feedforward_layernorm.weight"),
+        }
+        for source, target in expected.items():
+            assert map_gguf_to_hf_names(source, "muse-glimmer") == target
+
+    def test_qk_norms_are_dropped(self) -> None:
+        # Muse Glimmer's QK normalization is scale-free: the HF checkpoint has
+        # no q_norm/k_norm parameters, so these llama.cpp-only tensors have no
+        # target. The scale they encode is recovered by the config mapping.
+        assert map_gguf_to_hf_names("blk.0.attn_q_norm.weight", "muse-glimmer") is None
+        assert map_gguf_to_hf_names("blk.0.attn_k_norm.weight", "muse-glimmer") is None
+
+    def test_underscore_spelling_is_accepted(self) -> None:
+        assert (
+            map_gguf_to_hf_names("blk.1.attn_gate.weight", "muse_glimmer")
+            == "model.layers.1.self_attn.gate_proj.weight"
+        )

--- a/src/mobius/integrations/gguf/_tensor_processors.py
+++ b/src/mobius/integrations/gguf/_tensor_processors.py
@@ -188,6 +188,35 @@ def _process_nemotron(
     return state_dict
 
 
+def _process_muse_glimmer(
+    state_dict: dict[str, torch.Tensor],
+    config: Any,
+) -> dict[str, torch.Tensor]:
+    """Restore Muse Glimmer's centered per-block norm weights.
+
+    Muse Glimmer's four per-block norms are *centered*: the HF checkpoint stores
+    ``w`` and the model multiplies by ``w + 1``. llama.cpp folds the ``+ 1`` in
+    at conversion time so its generic RMSNorm can use the tensor directly, so a
+    GGUF file holds ``w_gguf = w_hf + 1`` and importing it needs the offset
+    removed. This is the opposite direction from Gemma/Nemotron, which store
+    ``w_hf - 1``.
+
+    The final ``model.norm`` is a plain RMSNorm in this architecture and is
+    stored uncentered, so it must be left alone -- verified against the
+    published checkpoint, where ``model.norm.weight`` is centered on 0 while the
+    per-block norms are centered on 1.
+    """
+    for name in list(state_dict):
+        if not name.endswith(".weight"):
+            continue
+        if ".layers." not in name:
+            continue
+        if "layernorm" not in name:
+            continue
+        state_dict[name] = state_dict[name] - 1
+    return state_dict
+
+
 def _process_gpt2(
     state_dict: dict[str, torch.Tensor],
     config: Any,
@@ -242,6 +271,7 @@ _PROCESSORS: dict[str, Any] = {
     "gemma2": _process_gemma,
     "gemma3": _process_gemma,
     "nemotron": _process_nemotron,
+    "muse_glimmer_text": _process_muse_glimmer,
     "gpt2": _process_gpt2,
     "mamba": _process_mamba,
 }

--- a/src/mobius/integrations/gguf/_tensor_processors.py
+++ b/src/mobius/integrations/gguf/_tensor_processors.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 # rope and store Q/K in plain HF row order — applying the permute to them
 # scrambles the attention heads and produces garbage output. They must
 # NOT be reverse-permuted.
-LLAMA_QK_PERMUTE_MODEL_TYPES = frozenset({"llama", "mistral"})
+LLAMA_QK_PERMUTE_MODEL_TYPES = frozenset({"llama", "mistral", "muse_glimmer_text"})
 
 
 def needs_llama_qk_permute(model_type: str | None) -> bool:
@@ -205,7 +205,12 @@ def _process_muse_glimmer(
     stored uncentered, so it must be left alone -- verified against the
     published checkpoint, where ``model.norm.weight`` is centered on 0 while the
     per-block norms are centered on 1.
+
+    Muse Glimmer's llama.cpp converter also stores Q/K with the interleaved-rope
+    permutation, on every layer including the NoPE (full-attention) ones, so the
+    llama reverse-permute has to run as well.
     """
+    state_dict = _process_llama(state_dict, config)
     for name in list(state_dict):
         if not name.endswith(".weight"):
             continue

--- a/src/mobius/integrations/gguf/_tensor_processors_test.py
+++ b/src/mobius/integrations/gguf/_tensor_processors_test.py
@@ -296,3 +296,48 @@ class TestProcessTensorsNoop:
         original = {"a.weight": torch.tensor([1.0])}
         result = process_tensors(dict(original), config)
         torch.testing.assert_close(result["a.weight"], original["a.weight"])
+
+
+class TestProcessMuseGlimmer:
+    """Muse Glimmer stores centered block norms as ``w_hf + 1``."""
+
+    def test_block_norms_lose_the_offset(self) -> None:
+        config = SimpleNamespace(model_type="muse_glimmer_text")
+        state_dict = {
+            "model.layers.0.input_layernorm.weight": torch.tensor([1.25, 0.0]),
+            "model.layers.0.post_attention_layernorm.weight": (torch.tensor([2.0, 1.0])),
+            "model.layers.0.pre_feedforward_layernorm.weight": (torch.tensor([1.5])),
+            "model.layers.0.post_feedforward_layernorm.weight": (torch.tensor([0.5])),
+        }
+        result = process_tensors(state_dict, config)
+        torch.testing.assert_close(
+            result["model.layers.0.input_layernorm.weight"],
+            torch.tensor([0.25, -1.0]),
+        )
+        torch.testing.assert_close(
+            result["model.layers.0.post_attention_layernorm.weight"],
+            torch.tensor([1.0, 0.0]),
+        )
+        torch.testing.assert_close(
+            result["model.layers.0.pre_feedforward_layernorm.weight"],
+            torch.tensor([0.5]),
+        )
+        torch.testing.assert_close(
+            result["model.layers.0.post_feedforward_layernorm.weight"],
+            torch.tensor([-0.5]),
+        )
+
+    def test_final_norm_and_projections_are_untouched(self) -> None:
+        # model.norm is a plain RMSNorm in this architecture, and projections
+        # obviously carry no offset.
+        config = SimpleNamespace(model_type="muse_glimmer_text")
+        state_dict = {
+            "model.norm.weight": torch.tensor([0.25, -3.0]),
+            "model.layers.0.self_attn.q_proj.weight": (torch.tensor([[1.0, 2.0]])),
+        }
+        result = process_tensors(state_dict, config)
+        torch.testing.assert_close(result["model.norm.weight"], torch.tensor([0.25, -3.0]))
+        torch.testing.assert_close(
+            result["model.layers.0.self_attn.q_proj.weight"],
+            torch.tensor([[1.0, 2.0]]),
+        )

--- a/src/mobius/integrations/gguf/_tensor_processors_test.py
+++ b/src/mobius/integrations/gguf/_tensor_processors_test.py
@@ -302,7 +302,11 @@ class TestProcessMuseGlimmer:
     """Muse Glimmer stores centered block norms as ``w_hf + 1``."""
 
     def test_block_norms_lose_the_offset(self) -> None:
-        config = SimpleNamespace(model_type="muse_glimmer_text")
+        config = SimpleNamespace(
+            model_type="muse_glimmer_text",
+            num_attention_heads=1,
+            num_key_value_heads=1,
+        )
         state_dict = {
             "model.layers.0.input_layernorm.weight": torch.tensor([1.25, 0.0]),
             "model.layers.0.post_attention_layernorm.weight": (torch.tensor([2.0, 1.0])),
@@ -327,17 +331,39 @@ class TestProcessMuseGlimmer:
             torch.tensor([-0.5]),
         )
 
-    def test_final_norm_and_projections_are_untouched(self) -> None:
-        # model.norm is a plain RMSNorm in this architecture, and projections
-        # obviously carry no offset.
-        config = SimpleNamespace(model_type="muse_glimmer_text")
-        state_dict = {
-            "model.norm.weight": torch.tensor([0.25, -3.0]),
-            "model.layers.0.self_attn.q_proj.weight": (torch.tensor([[1.0, 2.0]])),
-        }
+    def test_final_norm_is_untouched(self) -> None:
+        # model.norm is a plain RMSNorm in this architecture.
+        config = SimpleNamespace(
+            model_type="muse_glimmer_text",
+            num_attention_heads=1,
+            num_key_value_heads=1,
+        )
+        state_dict = {"model.norm.weight": torch.tensor([0.25, -3.0])}
         result = process_tensors(state_dict, config)
         torch.testing.assert_close(result["model.norm.weight"], torch.tensor([0.25, -3.0]))
-        torch.testing.assert_close(
-            result["model.layers.0.self_attn.q_proj.weight"],
-            torch.tensor([[1.0, 2.0]]),
+
+    def test_qk_weights_are_reverse_permuted(self) -> None:
+        # llama.cpp's muse-glimmer converter permutes attn_q/attn_k for
+        # interleaved rope, on every layer including the NoPE ones.
+        config = SimpleNamespace(
+            model_type="muse_glimmer_text",
+            num_attention_heads=1,
+            num_key_value_heads=1,
         )
+        original = torch.arange(8.0).reshape(4, 2)
+        state_dict = {
+            "model.layers.0.self_attn.q_proj.weight": original.clone(),
+            "model.layers.3.self_attn.k_proj.weight": original.clone(),
+            "model.layers.0.self_attn.v_proj.weight": original.clone(),
+        }
+        result = process_tensors(state_dict, config)
+        expected = torch.tensor([[0.0, 1.0], [4.0, 5.0], [2.0, 3.0], [6.0, 7.0]])
+        torch.testing.assert_close(result["model.layers.0.self_attn.q_proj.weight"], expected)
+        torch.testing.assert_close(result["model.layers.3.self_attn.k_proj.weight"], expected)
+        torch.testing.assert_close(result["model.layers.0.self_attn.v_proj.weight"], original)
+
+    def test_quantized_path_permutes_qk(self) -> None:
+        from mobius.integrations.gguf._builder import _needs_qk_permute
+
+        name = "model.layers.0.self_attn.q_proj.weight"
+        assert _needs_qk_permute(name, 32, 2, "muse_glimmer_text") is True

--- a/src/mobius/models/muse_glimmer.py
+++ b/src/mobius/models/muse_glimmer.py
@@ -20,12 +20,81 @@ from mobius.components import (
     Embedding,
     Linear,
     MuseGlimmerVisionModel,
+    QuantizedEmbedding,
     RMSNorm,
     create_attention_bias,
     initialize_rope,
+    make_quantized_linear_factory,
 )
 from mobius.components._attention import StaticCacheState
 from mobius.components._rotary_embedding import apply_rotary_pos_emb
+
+# ---------------------------------------------------------------------------
+# Weight-quantization helpers
+#
+# Muse Glimmer is a VLM whose text decoder and token embeddings may be
+# weight-quantized (MatMulNBits / GatherBlockQuantized) while the vision tower
+# and its projector stay float. The vision modules deliberately never consult
+# ``config.quantization``; these helpers are the single place the text path
+# reads it, which keeps the "text quantized, vision float" contract explicit.
+# ---------------------------------------------------------------------------
+
+
+def _text_quantization_config(config: ArchitectureConfig):
+    """Return the active weight-quantization config, or ``None`` when off."""
+    quantization_config = getattr(config, "quantization", None)
+    if quantization_config is None or quantization_config.quant_method == "none":
+        return None
+    return quantization_config
+
+
+def _text_linear_class(config: ArchitectureConfig) -> type | None:
+    """Return a QuantizedLinear factory for text projections, or ``None``."""
+    quantization_config = _text_quantization_config(config)
+    if quantization_config is None:
+        return None
+    zero_point_dtype = (
+        config.dtype
+        if getattr(quantization_config, "float_zero_point", False)
+        else ir.DataType.UINT8
+    )
+    return make_quantized_linear_factory(
+        bits=quantization_config.bits,
+        block_size=quantization_config.group_size,
+        has_zero_point=not quantization_config.sym,
+        zero_point_dtype=zero_point_dtype,
+    )
+
+
+def _make_text_embedding(config: ArchitectureConfig) -> nn.Module:
+    """Build the token embedding, quantized when the config requests it."""
+    quantization_config = _text_quantization_config(config)
+    if (
+        quantization_config is not None
+        and getattr(quantization_config, "quantize_embeddings", False)
+        and config.hidden_size % quantization_config.group_size == 0
+    ):
+        return QuantizedEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            bits=quantization_config.bits,
+            block_size=quantization_config.group_size,
+            has_zero_point=not quantization_config.sym,
+            padding_idx=config.pad_token_id,
+        )
+    return Embedding(config.vocab_size, config.hidden_size, config.pad_token_id)
+
+
+def _make_lm_head(config: ArchitectureConfig) -> nn.Module:
+    """Build the LM head projection, quantized (MatMulNBits) when requested."""
+    quantization_config = _text_quantization_config(config)
+    if quantization_config is not None and getattr(
+        quantization_config, "quantize_lm_head", False
+    ):
+        linear_cls = _text_linear_class(config)
+        if linear_cls is not None:
+            return linear_cls(config.hidden_size, config.vocab_size, bias=False)
+    return Linear(config.hidden_size, config.vocab_size, bias=False)
 
 
 class MuseGlimmerScaleFreeRMSNorm(nn.Module):
@@ -84,27 +153,28 @@ class MuseGlimmerTextAttention(nn.Module):
         self._num_kv_heads = config.num_key_value_heads
         self._scale = config.head_dim**-0.5
         self._qk_scale_factor = getattr(config, "qk_scale_factor", 1.0)
-        self.q_proj = Linear(
+        linear_class = _text_linear_class(config) or Linear
+        self.q_proj = linear_class(
             config.hidden_size,
             config.num_attention_heads * config.head_dim,
             bias=False,
         )
-        self.k_proj = Linear(
+        self.k_proj = linear_class(
             config.hidden_size,
             config.num_key_value_heads * config.head_dim,
             bias=False,
         )
-        self.v_proj = Linear(
+        self.v_proj = linear_class(
             config.hidden_size,
             config.num_key_value_heads * config.head_dim,
             bias=False,
         )
-        self.o_proj = Linear(
+        self.o_proj = linear_class(
             config.num_attention_heads * config.head_dim,
             config.hidden_size,
             bias=False,
         )
-        self.gate_proj = Linear(
+        self.gate_proj = linear_class(
             config.hidden_size,
             config.num_attention_heads * config.head_dim,
             bias=False,
@@ -199,7 +269,7 @@ class MuseGlimmerTextDecoderLayer(nn.Module):
         super().__init__()
         post_norm_eps = getattr(config, "post_norm_eps", 1e-8)
         self.self_attn = MuseGlimmerTextAttention(config)
-        self.mlp = MLP(config)
+        self.mlp = MLP(config, linear_class=_text_linear_class(config))
         self.input_layernorm = MuseGlimmerCenteredRMSNorm(
             config.hidden_size,
             config.rms_norm_eps,
@@ -259,11 +329,7 @@ class MuseGlimmerTextModel(nn.Module):
             [config.rope_theta] * config.num_hidden_layers,
         )
         self._sliding_window = config.sliding_window
-        self.embed_tokens = Embedding(
-            config.vocab_size,
-            config.hidden_size,
-            config.pad_token_id,
-        )
+        self.embed_tokens = _make_text_embedding(config)
         self.embed_norm = MuseGlimmerScaleFreeRMSNorm(config.hidden_size, config.rms_norm_eps)
         self.layers = nn.ModuleList(
             [MuseGlimmerTextDecoderLayer(config) for _ in range(config.num_hidden_layers)]
@@ -327,7 +393,7 @@ class MuseGlimmerDecoderModel(nn.Module):
     def __init__(self, config: ArchitectureConfig):
         super().__init__()
         self.model = MuseGlimmerTextModel(config)
-        self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.lm_head = _make_lm_head(config)
         self._output_multiplier = getattr(config, "output_multiplier", 1.0)
         self._softcap = getattr(config, "final_logit_softcapping", 0.0)
 
@@ -490,11 +556,7 @@ class MuseGlimmerEmbeddingModel(nn.Module):
 
     def __init__(self, config: ArchitectureConfig):
         super().__init__()
-        self.embed_tokens = Embedding(
-            config.vocab_size,
-            config.hidden_size,
-            config.pad_token_id,
-        )
+        self.embed_tokens = _make_text_embedding(config)
         self.embed_norm = MuseGlimmerScaleFreeRMSNorm(config.hidden_size, config.rms_norm_eps)
         self._hidden_size = config.hidden_size
         self._image_token_id = config.image_token_id or 200092

--- a/src/mobius/models/muse_glimmer.py
+++ b/src/mobius/models/muse_glimmer.py
@@ -29,6 +29,13 @@ from mobius.components import (
 from mobius.components._attention import StaticCacheState
 from mobius.components._rotary_embedding import apply_rotary_pos_emb
 
+# The media placeholder ids belong to the tokenizer, so a config assembled from
+# anything but a full HF checkpoint -- a GGUF import, say -- arrives with them
+# unset. The published Muse Glimmer values stand in, because the embedding
+# graph has to compare ``input_ids`` against a number.
+IMAGE_TOKEN_ID = 200092
+VIDEO_TOKEN_ID = 200091
+
 # ---------------------------------------------------------------------------
 # Weight-quantization helpers
 #
@@ -314,6 +321,25 @@ class MuseGlimmerTextDecoderLayer(nn.Module):
         return op.Add(residual, hidden_states), present_key_value
 
 
+def _resolve_layer_rope_theta(config: ArchitectureConfig) -> list[float | int]:
+    """Return the per-layer RoPE base, with 0 marking a NoPE layer.
+
+    ``layer_rope_theta`` is an optional field, so it is present and ``None``
+    whenever a source config did not carry it -- a shape that ``getattr`` with
+    a default cannot see. ``no_rope_layers`` names the same set of layers, so
+    prefer it before falling back to rotating every layer.
+    """
+    layer_rope_theta = getattr(config, "layer_rope_theta", None)
+    if layer_rope_theta:
+        return list(layer_rope_theta)
+
+    no_rope_layers = set(config.no_rope_layers or ())
+    return [
+        0 if index in no_rope_layers else config.rope_theta
+        for index in range(config.num_hidden_layers)
+    ]
+
+
 class MuseGlimmerTextModel(nn.Module):
     """Muse language backbone with mixed sliding/full attention and NoPE layers."""
 
@@ -323,11 +349,7 @@ class MuseGlimmerTextModel(nn.Module):
         self._layer_types = (
             config.layer_types or ["sliding_attention"] * config.num_hidden_layers
         )
-        self._layer_rope_theta = getattr(
-            config,
-            "layer_rope_theta",
-            [config.rope_theta] * config.num_hidden_layers,
-        )
+        self._layer_rope_theta = _resolve_layer_rope_theta(config)
         self._sliding_window = config.sliding_window
         self.embed_tokens = _make_text_embedding(config)
         self.embed_norm = MuseGlimmerScaleFreeRMSNorm(config.hidden_size, config.rms_norm_eps)
@@ -559,8 +581,8 @@ class MuseGlimmerEmbeddingModel(nn.Module):
         self.embed_tokens = _make_text_embedding(config)
         self.embed_norm = MuseGlimmerScaleFreeRMSNorm(config.hidden_size, config.rms_norm_eps)
         self._hidden_size = config.hidden_size
-        self._image_token_id = config.image_token_id or 200092
-        self._video_token_id = getattr(config, "video_token_id", 200091)
+        self._image_token_id = config.image_token_id or IMAGE_TOKEN_ID
+        self._video_token_id = config.video_token_id or VIDEO_TOKEN_ID
 
     def forward(
         self,

--- a/src/mobius/models/muse_glimmer_test.py
+++ b/src/mobius/models/muse_glimmer_test.py
@@ -19,6 +19,7 @@ from mobius.models.muse_glimmer import (
     MuseGlimmerForConditionalGeneration,
     MuseGlimmerScaleFreeRMSNorm,
     MuseGlimmerTextCausalLMModel,
+    _resolve_layer_rope_theta,
 )
 from mobius.tasks import MuseGlimmerVLTask
 
@@ -68,6 +69,75 @@ def test_muse_glimmer_uses_fused_rms_normalization():
     assert counts["SkipSimplifiedLayerNormalization"] == 1
     assert counts["ReduceMean"] == 0
     assert counts["Pow"] == 0
+
+
+def _text_config(**overrides):
+    """A small text config; ``layer_rope_theta`` is deliberately left unset."""
+    values = dict(
+        hidden_size=64,
+        intermediate_size=128,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        num_hidden_layers=4,
+        vocab_size=256,
+        max_position_embeddings=128,
+        hidden_act="silu",
+        sliding_window=8,
+        pad_token_id=0,
+        rope_type="default",
+        rope_theta=500_000.0,
+        rms_norm_eps=1e-5,
+        dtype=ir.DataType.FLOAT,
+    )
+    values.update(overrides)
+    return MuseGlimmerConfig(**values)
+
+
+def test_nope_layers_survive_a_config_without_layer_rope_theta():
+    """``layer_rope_theta`` is optional and defaults to ``None``.
+
+    ``getattr(config, name, default)`` cannot see that -- the attribute exists,
+    so the default never applies and the model indexes ``None``. Any config
+    that names its NoPE layers has to keep placing them correctly.
+    """
+    config = _text_config(
+        layer_types=[
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+        ],
+        no_rope_layers=[3],
+    )
+    assert config.layer_rope_theta is None
+
+    resolved = _resolve_layer_rope_theta(config)
+
+    assert resolved == [500_000.0, 500_000.0, 500_000.0, 0]
+
+
+def test_every_layer_rotates_when_a_config_names_no_nope_layers():
+    config = _text_config()
+
+    assert _resolve_layer_rope_theta(config) == [500_000.0] * 4
+
+
+def test_an_explicit_layer_rope_theta_wins():
+    config = _text_config(layer_rope_theta=[0, 1.0, 2.0, 3.0])
+
+    assert _resolve_layer_rope_theta(config) == [0, 1.0, 2.0, 3.0]
+
+
+def test_the_text_model_builds_without_layer_rope_theta():
+    config = _text_config(
+        layer_types=["sliding_attention"] * 3 + ["full_attention"],
+        no_rope_layers=[3],
+    )
+
+    module = MuseGlimmerTextCausalLMModel(config)
+
+    assert module.model._layer_rope_theta == [500_000.0, 500_000.0, 500_000.0, 0]
 
 
 def _hf_tiny_muse_glimmer():

--- a/src/mobius/models/muse_glimmer_test.py
+++ b/src/mobius/models/muse_glimmer_test.py
@@ -262,3 +262,71 @@ def test_muse_glimmer_tiny_multimodal_prefill_matches_hf():
         "model.embed_tokens.weight": embed_weight,
         "lm_head.weight": lm_head_weight,
     }
+
+
+def test_muse_glimmer_text_quantization_emits_quantized_ops():
+    from mobius._configs import QuantizationConfig
+
+    config = MuseGlimmerConfig(
+        hidden_size=64,
+        intermediate_size=128,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        num_hidden_layers=2,
+        vocab_size=256,
+        max_position_embeddings=128,
+        hidden_act="silu",
+        layer_types=["sliding_attention", "full_attention"],
+        layer_rope_theta=[500_000.0, 0],
+        sliding_window=8,
+        pad_token_id=0,
+        rope_type="default",
+        rope_theta=500_000.0,
+        rms_norm_eps=1e-5,
+        dtype=ir.DataType.BFLOAT16,
+        quantization=QuantizationConfig(
+            bits=4,
+            group_size=32,
+            quant_method="gguf",
+            sym=False,
+            quantize_embeddings=True,
+            quantize_lm_head=True,
+        ),
+    )
+    module = MuseGlimmerTextCausalLMModel(config)
+    model = build_from_module(module, config)["model"]
+    counts = Counter(node.op_type for node in model.graph)
+
+    # 5 attention projections + 3 MLP projections per layer, plus the LM head.
+    assert counts["MatMulNBits"] == 2 * 8 + 1
+    assert counts["GatherBlockQuantized"] == 1
+    assert counts["MatMul"] == 0
+
+
+def test_muse_glimmer_without_quantization_stays_float():
+    config = MuseGlimmerConfig(
+        hidden_size=64,
+        intermediate_size=128,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        num_hidden_layers=2,
+        vocab_size=256,
+        max_position_embeddings=128,
+        hidden_act="silu",
+        layer_types=["sliding_attention", "full_attention"],
+        layer_rope_theta=[500_000.0, 0],
+        sliding_window=8,
+        pad_token_id=0,
+        rope_type="default",
+        rope_theta=500_000.0,
+        rms_norm_eps=1e-5,
+        dtype=ir.DataType.BFLOAT16,
+    )
+    module = MuseGlimmerTextCausalLMModel(config)
+    model = build_from_module(module, config)["model"]
+    counts = Counter(node.op_type for node in model.graph)
+
+    assert counts["MatMulNBits"] == 0
+    assert counts["GatherBlockQuantized"] == 0

--- a/src/mobius/rewrite_rules/_group_query_attention.py
+++ b/src/mobius/rewrite_rules/_group_query_attention.py
@@ -71,6 +71,126 @@ def _propagate_dtype(source: ir.Value, *targets: ir.Value) -> None:
         target.dtype = dtype
 
 
+def _skip_view_ops(value: ir.Value | None) -> ir.Value | None:
+    """Walk back through shape-only ops that do not change a mask's meaning."""
+    while value is not None:
+        producer = value.producer()
+        if producer is None or producer.op_type not in ("Cast", "Unsqueeze", "Identity"):
+            return value
+        value = producer.inputs[0]
+    return value
+
+
+def _constant_int(value: ir.Value | None) -> int | None:
+    """Return ``value`` as a Python int when it is a graph constant."""
+    if value is None:
+        return None
+    tensor = value.const_value
+    if tensor is None:
+        producer = value.producer()
+        if producer is None or producer.op_type != "Constant":
+            return None
+        attr = producer.attributes.get("value", None)
+        tensor = getattr(attr, "value", None)
+    if tensor is None:
+        return None
+    try:
+        array = tensor.numpy()
+    except Exception:  # pragma: no cover - defensive: exotic tensor backings
+        return None
+    if array.size != 1:
+        return None
+    return int(array.reshape(-1)[0])
+
+
+class _MaskShape:
+    """Outcome of inspecting the mask subgraph behind an attention bias.
+
+    ``recognized`` is False when the mask does something
+    ``GroupQueryAttention`` cannot express, so the ``Attention`` node must be
+    left alone rather than fused.
+    """
+
+    __slots__ = ("recognized", "window")
+
+    def __init__(self, recognized: bool, window: int | None = None) -> None:
+        self.recognized = recognized
+        self.window = window
+
+
+# Cap on how much of the bias subgraph is walked. Mask construction is a few
+# dozen shape/compare ops; anything larger is not a mask we can vouch for.
+_MASK_WALK_LIMIT = 512
+
+
+def _sliding_window_from_less(node: ir.Node) -> int | None:
+    """Return the window of a ``Less(query_index - key_index, window)`` term.
+
+    That comparison is how a sliding window is written into an attention bias:
+    a key is visible while its distance to the query is below ``window``, i.e.
+    ``window`` keys are visible including the query's own position. ORT's
+    ``local_window_size`` is defined the same way ("mask out tokens prior to
+    total_sequence_length - local_window_size"), so the value transfers as is.
+
+    Other ``Less`` comparisons in a mask (a padding test against a dynamic
+    length, say) have no constant bound and return ``None``.
+    """
+    if len(node.inputs) < 2:
+        return None
+    distance = _skip_view_ops(node.inputs[0])
+    distance_producer = distance.producer() if distance is not None else None
+    if distance_producer is None or distance_producer.op_type != "Sub":
+        return None
+    window = _constant_int(node.inputs[1])
+    if window is None or window <= 0:
+        return None
+    return window
+
+
+def local_window_from_attention_bias(attention_bias: ir.Value | None) -> _MaskShape:
+    """Recover the local-attention window baked into an attention bias.
+
+    ``GroupQueryAttention`` takes no attention bias: it rebuilds the mask from
+    ``seqlens_k``/``total_seq_len``. Fusing an ``Attention`` whose bias encodes
+    a sliding window therefore *deletes* that window unless it is re-expressed
+    as the ``local_window_size`` attribute -- and a decoder that silently widens
+    2048-token local attention to global attention produces fluent nonsense once
+    a prompt outgrows the window, with no error raised anywhere.
+
+    Padding and causal terms need no translation (GQA derives both), so the walk
+    only looks for two things: the sliding-window comparison, and any ``Or``,
+    which is how a bidirectional block overlay unmasks positions the plain
+    causal mask forbids. GQA cannot express that, so such a bias is reported as
+    unrecognized and the caller must leave the node unfused.
+    """
+    window: int | None = None
+    seen: set[int] = set()
+    stack = [attention_bias]
+    visited = 0
+    while stack:
+        value = stack.pop()
+        if value is None or id(value) in seen:
+            continue
+        seen.add(id(value))
+        producer = value.producer()
+        if producer is None:
+            continue
+        visited += 1
+        if visited > _MASK_WALK_LIMIT:
+            return _MaskShape(False)
+        if producer.op_type == "Or":
+            return _MaskShape(False)
+        if producer.op_type == "Less":
+            found = _sliding_window_from_less(producer)
+            if found is not None:
+                if window is not None and window != found:
+                    return _MaskShape(False)
+                window = found
+                continue
+        stack.extend(producer.inputs)
+    return _MaskShape(True, window)
+
+
 def _has_unequal_kv_head_dimensions(k, v, past_key, past_value) -> bool:
     """Return whether static K/V shapes prove incompatible GQA head dimensions."""
 
@@ -157,8 +277,16 @@ class RotaryAttentionToGQA(RewriteRuleClassBase):
 
     # ------------------------------------------------------------------ check
 
-    def check(self, context, attn_out, k_pre, v, cos, sin, past_key, past_value, **_):
+    def check(
+        self, context, attn_out, k_pre, v, attention_bias, cos, sin, past_key, past_value, **_
+    ):
         result = MatchResult()
+
+        if not local_window_from_attention_bias(attention_bias).recognized:
+            return result.fail(
+                "Attention bias is not a plain causal/sliding mask; GroupQueryAttention "
+                "would drop it"
+            )
 
         attn = attn_out.producer()
         if attn.attributes.get_float("scale", None) is None:
@@ -261,6 +389,9 @@ class RotaryAttentionToGQA(RewriteRuleClassBase):
         }
         if softcap:
             gqa_attrs["softcap"] = softcap
+        window = local_window_from_attention_bias(attention_bias).window
+        if window is not None:
+            gqa_attrs["local_window_size"] = window
         outputs = op.GroupQueryAttention(
             q_pre,
             k_pre,
@@ -595,8 +726,15 @@ class AttentionToGQA(RewriteRuleClassBase):
 
     # ------------------------------------------------------------------ check
 
-    def check(self, context, attn_out, k, v, past_key, past_value, **_):
+    def check(self, context, attn_out, k, v, attention_bias, past_key, past_value, **_):
         result = MatchResult()
+
+        if not local_window_from_attention_bias(attention_bias).recognized:
+            return result.fail(
+                "Attention bias is not a plain causal/sliding mask; GroupQueryAttention "
+                "would drop it"
+            )
+
         attn = attn_out.producer()
 
         if attn.attributes.get_float("scale", None) is None:
@@ -667,6 +805,9 @@ class AttentionToGQA(RewriteRuleClassBase):
         }
         if softcap:
             gqa_attrs["softcap"] = softcap
+        window = local_window_from_attention_bias(attention_bias).window
+        if window is not None:
+            gqa_attrs["local_window_size"] = window
 
         outputs = op.GroupQueryAttention(
             q,

--- a/src/mobius/rewrite_rules/_group_query_attention_test.py
+++ b/src/mobius/rewrite_rules/_group_query_attention_test.py
@@ -850,3 +850,136 @@ class TestGroupQueryAttentionRules:
         for node in gqa_nodes:
             sc = node.attributes.get("softcap")
             assert sc is None, f"Unexpected softcap attribute on GQA node for Llama: {sc}"
+
+
+class TestSlidingWindowSurvivesFusion:
+    """A window baked into the attention bias must reach ``local_window_size``.
+
+    ``GroupQueryAttention`` ignores the attention bias and rebuilds its mask
+    from ``seqlens_k``/``total_seq_len``, so fusing a windowed ``Attention``
+    without carrying the window over silently turns local attention into global
+    attention. The model still produces fluent text, which is what makes the
+    regression so expensive to find.
+    """
+
+    @staticmethod
+    def _muse_glimmer_config(layer_types: list[str]) -> ArchitectureConfig:
+        from mobius._configs import MuseGlimmerConfig
+
+        return MuseGlimmerConfig(
+            hidden_size=64,
+            intermediate_size=128,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=16,
+            num_hidden_layers=len(layer_types),
+            vocab_size=256,
+            max_position_embeddings=128,
+            hidden_act="silu",
+            layer_types=layer_types,
+            layer_rope_theta=[
+                0.0 if kind == "full_attention" else 500_000.0 for kind in layer_types
+            ],
+            sliding_window=8,
+            pad_token_id=0,
+            rope_type="default",
+            rope_theta=500_000.0,
+            rms_norm_eps=1e-5,
+            dtype=ir.DataType.BFLOAT16,
+        )
+
+    def test_per_layer_window_reaches_the_gqa_nodes(self):
+        from mobius.models.muse_glimmer import MuseGlimmerTextCausalLMModel
+
+        layer_types = ["sliding_attention", "sliding_attention", "full_attention"]
+        config = self._muse_glimmer_config(layer_types)
+        m = build_from_module(MuseGlimmerTextCausalLMModel(config), config)["model"]
+
+        rewrite(m, pattern_rewrite_rules=group_query_attention_rules())
+
+        gqa_nodes = [n for n in m.graph if n.op_type == "GroupQueryAttention"]
+        assert len(gqa_nodes) == len(layer_types)
+        windows = [
+            (
+                n.attributes.get("local_window_size").value
+                if n.attributes.get("local_window_size") is not None
+                else None
+            )
+            for n in gqa_nodes
+        ]
+        # Sliding layers carry the window; the full-attention layer must not.
+        assert windows == [8, 8, None], windows
+
+
+class TestAttentionBiasInspection:
+    """Unit coverage for the bias walk that recovers the window."""
+
+    @staticmethod
+    def _value(name: str) -> ir.Value:
+        return ir.Value(name=name)
+
+    @staticmethod
+    def _const(value: int) -> ir.Value:
+        import numpy as np
+
+        return ir.Value(name=f"const_{value}", const_value=ir.tensor(np.array(value)))
+
+    @classmethod
+    def _op(cls, op_type: str, *inputs: ir.Value) -> ir.Value:
+        node = ir.Node("", op_type, inputs=list(inputs), num_outputs=1)
+        return node.outputs[0]
+
+    def test_sliding_term_is_recovered(self):
+        from mobius.rewrite_rules._group_query_attention import (
+            local_window_from_attention_bias,
+        )
+
+        q_index, kv_index = self._value("q_index"), self._value("kv_index")
+        causal = self._op("GreaterOrEqual", q_index, kv_index)
+        distance = self._op("Sub", q_index, kv_index)
+        within = self._op("Less", distance, self._const(64))
+        bias = self._op("Where", self._op("And", causal, within))
+
+        shape = local_window_from_attention_bias(bias)
+        assert shape.recognized
+        assert shape.window == 64
+
+    def test_padding_comparison_is_not_mistaken_for_a_window(self):
+        from mobius.rewrite_rules._group_query_attention import (
+            local_window_from_attention_bias,
+        )
+
+        # `slot < nonpad_kv_seqlen` is a padding test against a dynamic length,
+        # not a window: no constant bound, and no distance subtraction.
+        slot, seqlen = self._value("slot"), self._value("nonpad_kv_seqlen")
+        bias = self._op("Where", self._op("Less", slot, seqlen))
+
+        shape = local_window_from_attention_bias(bias)
+        assert shape.recognized
+        assert shape.window is None
+
+    def test_plain_causal_bias_has_no_window(self):
+        from mobius.rewrite_rules._group_query_attention import (
+            local_window_from_attention_bias,
+        )
+
+        q_index, kv_index = self._value("q_index"), self._value("kv_index")
+        bias = self._op("Where", self._op("GreaterOrEqual", q_index, kv_index))
+
+        shape = local_window_from_attention_bias(bias)
+        assert shape.recognized
+        assert shape.window is None
+
+    def test_bidirectional_overlay_blocks_fusion(self):
+        from mobius.rewrite_rules._group_query_attention import (
+            local_window_from_attention_bias,
+        )
+
+        q_index, kv_index = self._value("q_index"), self._value("kv_index")
+        causal = self._op("GreaterOrEqual", q_index, kv_index)
+        same_block = self._op("Equal", q_index, kv_index)
+        bias = self._op("Where", self._op("Or", causal, same_block))
+
+        # GQA cannot express an overlay that unmasks non-causal positions, so
+        # the caller must leave the Attention node alone.
+        assert not local_window_from_attention_bias(bias).recognized


### PR DESCRIPTION
Adds GGUF import for the `muse-glimmer` architecture, so `mobius build-gguf` can turn community GGUF checkpoints into the `muse_glimmer_text` / `muse_glimmer` models we already implement.

### Text backbone

Three architecture quirks needed special handling, all verified against a real `unsloth/Muse-Glimmer-30B-GGUF:UD-Q4_K_XL` checkpoint and the matching HF config:

* `blk.N.attn_q_norm` / `attn_k_norm` are not learned weights. Our attention uses a scale-free QK norm, so both tensors are dropped — but `attn_q_norm` is a constant tensor carrying `qk_scale_factor` (3.87), which appears nowhere in the GGUF metadata, so the config postprocessor reads the scalar back out of it before discarding the tensor.
* The four per-block norms are stored as `HF + 1` because our blocks use a centered RMS norm (`weight + 1`). This is the **opposite** direction of Gemma/Nemotron, so the tensor processor subtracts one. The final `output_norm` is a plain RMS norm and is deliberately left untouched.
* `sliding_window_pattern` is a scalar (4), not a per-layer bool array. Layers where `(i + 1) % 4 == 0` use full attention, and those same layers are the NoPE layers, so `layer_types` and `no_rope_layers` both derive from it.

Both spellings of the architecture (`muse-glimmer` and `muse_glimmer`) are accepted consistently — the key map is shared and the metadata prefix comes from the file rather than being hardcoded.

### Vision tower (mmproj)

Muse Glimmer is a VLM; the text GGUF is only the backbone and the vision tower ships in the companion `mmproj-Muse-Glimmer-30B-*.gguf`. `_mmproj.py` was Gemma4-only, so `build_from_gguf(..., mmproj=...)` now routes on the text architecture (the mmproj always calls itself `clip`).

Muse Glimmer's tower is a dynamic-resolution ViT with a plain pre-norm block — biased Q/K/V/out, GELU MLP, two LayerNorms — sharing none of Gemma4's SwiGLU/QK-norm/post-norm stems, so it needs its own name map. Its projector is three positional `mm.N` matrices: two adapter layers over the pixel-shuffled patches and one projection into the text hidden size.

Four values the clip metadata omits are recovered rather than guessed: the square position grid (from the table's row count), the adapter width (from `mm.0`), and the full-attention blocks (every 4th, plus the last). `temporal_patch_size` and the vision rope base have no clip key at all and are named constants.

### Verification

* Config extraction on the real BF16 mmproj matches the published vision config exactly, including `fullatt_block_indexes = [3, 7, ..., 47, 49]`.
* All 809 mmproj tensors map, and the mapped names are exactly the 809 parameters of the published Muse Glimmer vision encoder graph — none missing, none extra.
* `pytest src/mobius/integrations/gguf` — 299 passed.
