### PR TITLE
Fix Qwen3.6 Olive mixed-precision export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Qwen3.5/3.6-MoE mixed float/quantized decoder (Olive checkpoints)
+
+#### Fixed
+
+- **Olive-quantized** Qwen3.5/3.6-**MoE** exports (text and VL) no longer
+  quantize the modules that Olive's quantization walk skips:
+  - `linear_attn` (GatedDeltaNet) projections now use plain `Linear`.
+  - `shared_expert_gate` (the `[1, hidden]` sigmoid gate of `Qwen35MoEBlock`)
+    now uses plain `Linear`.
+
+  Olive's `ModelWrapper` excludes `linear_attn` for the `qwen3_5_moe` /
+  `qwen3_5_moe_text` model types (`MAMBA` table) and every
+  `shared_expert_gate` (`SHARED_EXPERT_GATE` table) from quantization since
+  microsoft/Olive#2630, so those checkpoints never contain the packed
+  `MatMulNBits` initializers the previous graph expected (e.g.
+  `linear_attn.in_proj_qkv.weight` as `[48, 2, 8]` uint8 + scales). Ordinary
+  self-attention, the shared-expert MLP, the dense MLP and the fused
+  `com.microsoft::QMoE` experts remain quantized; router `gate` behavior is
+  unchanged.
+
+  Scope is deliberately narrow:
+  - **Dense** Qwen3.5/3.6 (`Qwen35CausalLMModel` and its VL split) is *not* in
+    Olive's `MAMBA` table, so its `linear_attn` stays quantized.
+  - Other checkpoint formats retain their previous graph construction; this
+    change only aligns Mobius with Olive's module selection.
+
+#### Added
+
+- `Qwen2MoELayer(..., shared_expert_gate_class=...)` to override the linear
+  factory for `shared_expert_gate` only (`None` falls back to `linear_class`,
+  so existing callers are unaffected).
+
+---
+
 ### NVIDIA Cosmos 3 Edge vision-language model (`cosmos3_edge`)
 
 #### Added

--- a/src/mobius/models/moe.py
+++ b/src/mobius/models/moe.py
@@ -276,11 +276,18 @@ class Qwen2MoELayer(MoELayer):
     Forward: ``routing_output + sigmoid(shared_gate(h)) * shared_expert(h)``
 
     ``linear_class``, when provided, is used for the shared expert's MLP and
-    gate, and is threaded through to :class:`MoELayer` so it also drives the
-    dense loop-over-experts fallback (used when the config doesn't match the
-    native QMoE ABI). It has no effect on the fused QMoE path, whose
-    quantized parameters are constructed directly by
-    :meth:`MoELayer._init_qmoe_parameters`.
+    -- by default only -- for ``shared_expert_gate``, and is threaded through
+    to :class:`MoELayer` so it also drives the dense loop-over-experts
+    fallback (used when the config doesn't match the native QMoE ABI). It has
+    no effect on the fused QMoE path, whose quantized parameters are
+    constructed directly by :meth:`MoELayer._init_qmoe_parameters`.
+
+    ``shared_expert_gate_class`` overrides the factory used for the
+    ``shared_expert_gate`` projection only; when it is ``None`` the gate falls
+    back to ``linear_class`` (backward compatible). Callers pass an explicit
+    factory when their checkpoint's quantizer leaves this tiny ``[1, hidden]``
+    gate in floating point — see
+    :class:`~mobius.models.qwen35.Qwen35MoEBlock`.
 
     Replicates HuggingFace ``Qwen2MoeSparseMoeBlock``.
     """
@@ -290,6 +297,7 @@ class Qwen2MoELayer(MoELayer):
         config: ArchitectureConfig,
         gate: nn.Module | None = None,
         linear_class: type | None = None,
+        shared_expert_gate_class: type | None = None,
     ):
         super().__init__(config, gate=gate, linear_class=linear_class)
         assert config.shared_expert_intermediate_size is not None, (
@@ -297,11 +305,13 @@ class Qwen2MoELayer(MoELayer):
         )
         if linear_class is None:
             linear_class = Linear
+        if shared_expert_gate_class is None:
+            shared_expert_gate_class = linear_class
         shared_config = dataclasses.replace(
             config, intermediate_size=config.shared_expert_intermediate_size
         )
         self.shared_expert = MLP(shared_config, linear_class=linear_class)
-        self.shared_expert_gate = linear_class(config.hidden_size, 1, bias=False)
+        self.shared_expert_gate = shared_expert_gate_class(config.hidden_size, 1, bias=False)
 
     def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # Routing expert output: top-k weighted sum  [B, S, H]

--- a/src/mobius/models/moe.py
+++ b/src/mobius/models/moe.py
@@ -276,11 +276,12 @@ class Qwen2MoELayer(MoELayer):
     Forward: ``routing_output + sigmoid(shared_gate(h)) * shared_expert(h)``
 
     ``linear_class``, when provided, is used for the shared expert's MLP and
-    -- by default only -- for ``shared_expert_gate``, and is threaded through
-    to :class:`MoELayer` so it also drives the dense loop-over-experts
-    fallback (used when the config doesn't match the native QMoE ABI). It has
-    no effect on the fused QMoE path, whose quantized parameters are
-    constructed directly by :meth:`MoELayer._init_qmoe_parameters`.
+    for ``shared_expert_gate`` unless ``shared_expert_gate_class`` overrides
+    the gate factory. It is also threaded through to :class:`MoELayer` so it
+    drives the dense loop-over-experts fallback (used when the config doesn't
+    match the native QMoE ABI). It has no effect on the fused QMoE path, whose
+    quantized parameters are constructed directly by
+    :meth:`MoELayer._init_qmoe_parameters`.
 
     ``shared_expert_gate_class`` overrides the factory used for the
     ``shared_expert_gate`` projection only; when it is ``None`` the gate falls

--- a/src/mobius/models/qwen35.py
+++ b/src/mobius/models/qwen35.py
@@ -42,8 +42,11 @@ def _linear_factory(config: ArchitectureConfig) -> type | None:
 
     Returns ``None`` (meaning "use plain ``Linear``") when the model is
     unquantized. Shared by the dense (:class:`Qwen35DecoderLayer`) and MoE
-    (:class:`Qwen35MoEDecoderLayer`) variants so ``self_attn``/``linear_attn``/
-    ``mlp``/``shared_expert`` are all quantized consistently.
+    (:class:`Qwen35MoEDecoderLayer`) variants so ``self_attn``/``mlp``/
+    ``shared_expert`` are all quantized consistently.
+
+    A few modules opt out of this factory for specific quantizers — see
+    :data:`_FLOAT_MODULE_QUANT_METHODS`.
     """
     quantization = config.quantization
     if quantization is None or quantization.quant_method == "none":
@@ -54,6 +57,32 @@ def _linear_factory(config: ArchitectureConfig) -> type | None:
         block_size=quantization.group_size,
         has_zero_point=not quantization.sym,
         zero_point_dtype=zero_point_dtype,
+    )
+
+
+#: Quantizers that produce Qwen3.5/3.6-**MoE** checkpoints in which the
+#: GatedDeltaNet (``linear_attn``) projections and the ``shared_expert_gate``
+#: are left in floating point while the rest of the decoder is quantized.
+#:
+#: Olive's PyTorch-side quantization walk skips both module groups for the
+#: MoE model types: ``ModelWrapper.MAMBA`` maps ``qwen3_5_moe`` and
+#: ``qwen3_5_moe_text`` to ``linear_attn``, and ``SHARED_EXPERT_GATE``
+#: excludes ``shared_expert_gate`` for every model type
+#: (microsoft/Olive#2630). The **dense** Qwen3.5 model types are *not* in
+#: Olive's ``MAMBA`` table, so dense Olive checkpoints still carry a
+#: quantized ``linear_attn`` — the exclusion below is deliberately scoped to
+#: the MoE stack (:class:`Qwen35MoEDecoderLayer` / :class:`Qwen35MoEBlock`).
+#:
+#: Other checkpoint formats retain the graph construction used before this
+#: Olive-specific compatibility fix.
+_FLOAT_MODULE_QUANT_METHODS = frozenset({"olive"})
+
+
+def _keeps_modules_float(config: ArchitectureConfig) -> bool:
+    """True when the checkpoint's quantizer leaves the opt-out modules float."""
+    quantization = config.quantization
+    return (
+        quantization is not None and quantization.quant_method in _FLOAT_MODULE_QUANT_METHODS
     )
 
 
@@ -69,10 +98,19 @@ class Qwen35DecoderLayer(nn.Module):
 
     When ``config.quantization`` is set, ``self_attn``/``linear_attn``/``mlp``
     projections are built with a quantized-linear factory (see
-    :func:`_linear_factory`) so quantized checkpoints (e.g. Olive
-    RTN/GPTQ) load correctly instead of hitting a dense-vs-packed shape
-    mismatch.
+    :func:`_linear_factory`) so quantized checkpoints (e.g. Olive RTN/GPTQ)
+    load correctly instead of hitting a dense-vs-packed shape mismatch.
+
+    ``linear_attn`` (GatedDeltaNet) stays quantized here: Olive's ``MAMBA``
+    exclusion table only covers the MoE model types, so dense Qwen3.5
+    checkpoints do carry packed linear-attention projections. The MoE stack
+    overrides this via :attr:`float_linear_attn_quant_methods` (see
+    :class:`Qwen35MoEDecoderLayer`).
     """
+
+    #: Quantization methods whose checkpoints leave ``linear_attn`` float.
+    #: Empty for the dense stack; see :data:`_FLOAT_MODULE_QUANT_METHODS`.
+    float_linear_attn_quant_methods: frozenset[str] = frozenset()
 
     def __init__(self, config: ArchitectureConfig, layer_idx: int):
         super().__init__()
@@ -83,7 +121,9 @@ class Qwen35DecoderLayer(nn.Module):
         linear_class = _linear_factory(config)
 
         if self.layer_type == "linear_attention":
-            self.linear_attn = GatedDeltaNet(config, linear_class=linear_class)
+            self.linear_attn = GatedDeltaNet(
+                config, linear_class=self._linear_attn_class(config, linear_class)
+            )
         else:
             self.self_attn = Qwen35Attention(config, linear_class=linear_class)
 
@@ -92,6 +132,23 @@ class Qwen35DecoderLayer(nn.Module):
         self.post_attention_layernorm = OffsetRMSNorm(
             config.hidden_size, eps=config.rms_norm_eps
         )
+
+    @classmethod
+    def _linear_attn_class(
+        cls, config: ArchitectureConfig, linear_class: type | None
+    ) -> type | None:
+        """Linear factory for ``linear_attn`` — ``None`` means plain float.
+
+        Returns ``None`` when the checkpoint's quantizer left GatedDeltaNet in
+        floating point (a quantized graph would then expect packed
+        ``MatMulNBits`` initializers the checkpoint never contains); otherwise
+        the same factory used for the rest of the layer.
+        """
+        quantization = config.quantization
+        method = quantization.quant_method if quantization is not None else None
+        if method in cls.float_linear_attn_quant_methods:
+            return None
+        return linear_class
 
     def forward(
         self,
@@ -263,8 +320,30 @@ class Qwen35MoEBlock(Qwen2MoELayer):
         shared_expert.{gate,up,down}_proj.weight
         shared_expert_gate.weight    → sigmoid gate for shared expert
 
-    Retained as a named subclass for readability within the Qwen3.5 hybrid stack.
+    Retained as a named subclass for readability within the Qwen3.5 hybrid stack,
+    and to keep ``shared_expert_gate`` in plain floating :class:`Linear` for the
+    quantizers listed in :data:`_FLOAT_MODULE_QUANT_METHODS`: Olive excludes
+    this ``[1, hidden]`` gate from its quantization walk (microsoft/Olive#2630),
+    so a quantized gate module would expect packed ``MatMulNBits`` initializers
+    that such a checkpoint never contains. Other checkpoint formats retain
+    the previous graph construction. The router ``gate`` (top-k logits) is
+    unaffected — it is created by
+    :class:`~mobius.components._moe.MoELayer` and was never quantized.
     """
+
+    def __init__(
+        self,
+        config: ArchitectureConfig,
+        gate: nn.Module | None = None,
+        linear_class: type | None = None,
+    ):
+        super().__init__(
+            config,
+            gate=gate,
+            linear_class=linear_class,
+            # ``None`` falls back to ``linear_class`` (quantized gate).
+            shared_expert_gate_class=Linear if _keeps_modules_float(config) else None,
+        )
 
 
 class Qwen35MoEDecoderLayer(Qwen35DecoderLayer):
@@ -276,11 +355,25 @@ class Qwen35MoEDecoderLayer(Qwen35DecoderLayer):
 
     The routed experts are quantized via the fused ``com.microsoft::QMoE``
     path (see :class:`~mobius.components._moe.MoELayer`), driven directly
-    by ``config.quantization``. The always-active ``shared_expert``/
-    ``shared_expert_gate`` are not part of that fused op, so they are
-    quantized separately via the same ``linear_class`` factory used for
-    ``self_attn``/``linear_attn``/dense ``mlp`` (see :func:`_linear_factory`).
+    by ``config.quantization``. The always-active ``shared_expert`` is not
+    part of that fused op, so it is quantized separately via the same
+    ``linear_class`` factory used for ``self_attn``/dense ``mlp`` (see
+    :func:`_linear_factory`).
+
+    For Olive-quantized MoE checkpoints only, ``linear_attn`` (via
+    :attr:`float_linear_attn_quant_methods`) and ``shared_expert_gate`` (see
+    :class:`Qwen35MoEBlock`) stay in floating point, matching the modules
+    Olive excludes from its quantization walk for ``qwen3_5_moe`` /
+    ``qwen3_5_moe_text``. Other checkpoint formats retain the previous graph
+    construction.
+
+    Note: ``super().__init__`` builds a dense :class:`MLP` that is immediately
+    replaced by the MoE block here, so the dense module never reaches the
+    exported graph.
     """
+
+    #: Olive leaves the MoE stack's GatedDeltaNet projections float.
+    float_linear_attn_quant_methods: frozenset[str] = _FLOAT_MODULE_QUANT_METHODS
 
     def __init__(self, config: ArchitectureConfig, layer_idx: int):
         super().__init__(config, layer_idx)

--- a/src/mobius/models/qwen35.py
+++ b/src/mobius/models/qwen35.py
@@ -341,7 +341,7 @@ class Qwen35MoEBlock(Qwen2MoELayer):
             config,
             gate=gate,
             linear_class=linear_class,
-            # ``None`` falls back to ``linear_class`` (quantized gate).
+            # ``None`` falls back to ``linear_class``.
             shared_expert_gate_class=Linear if _keeps_modules_float(config) else None,
         )
 

--- a/src/mobius/models/qwen35_test.py
+++ b/src/mobius/models/qwen35_test.py
@@ -13,11 +13,16 @@ random configs -- no checkpoint download.
 
 from __future__ import annotations
 
+import dataclasses
+
+import onnx_ir as ir
+import pytest
 import torch
 
 from mobius._configs import QuantizationConfig, VisionConfig
 from mobius._testing import make_config
 from mobius.models.qwen35 import (
+    Qwen35CausalLMModel,
     Qwen35MoECausalLMModel,
     Qwen35MoEVL3ModelCausalLMModel,
     Qwen35VL3ModelCausalLMModel,
@@ -464,3 +469,224 @@ class TestQwen35VL3ModelQuantization:
         assert result["vision_encoder.visual.blocks.0.mlp.up_proj.weight"] is vision_weight
         assert result["decoder.model.embed_tokens.weight"] is embedding
         assert result["embedding.embed_tokens.weight"] is embedding
+
+
+# ---------------------------------------------------------------------------
+# Mixed float/quantized decoder: Olive-quantized Qwen3.5/3.6-MoE keeps the
+# GatedDeltaNet projections and shared_expert_gate in floating point. Dense
+# Qwen3.5 and GPTQ/AWQ MoE checkpoints stay fully quantized.
+# ---------------------------------------------------------------------------
+
+# GatedDeltaNet dims chosen so in_proj_qkv is [key_dim * 2 + value_dim, _H]
+# = [8 * 2 + 32, 32] = [48, 32] -- the exact shape from the Olive repro.
+_LINEAR_ATTN_DIMS = dict(
+    linear_num_value_heads=2,
+    linear_num_key_heads=1,
+    linear_key_head_dim=8,
+    linear_value_head_dim=16,
+    linear_conv_kernel_dim=4,
+)
+_QKV_OUT = 48
+# Qwen3.5 full attention fuses the output gate into q_proj: 2 * heads * head_dim.
+_Q_OUT = 2 * 4 * 8
+
+
+def _hybrid_moe_config(
+    quantization: QuantizationConfig | None, *, vision: bool = False
+) -> object:
+    """Two-layer Qwen3.5-MoE config: layer 0 linear attention, layer 1 full."""
+    factory = _moe_vl_config if vision else _moe_config
+    config = factory(quantization)
+    config = dataclasses.replace(
+        config,
+        num_hidden_layers=2,
+        layer_types=["linear_attention", "full_attention"],
+        **_LINEAR_ATTN_DIMS,
+    )
+    return config
+
+
+def _hybrid_dense_config(quantization: QuantizationConfig | None) -> object:
+    """Two-layer dense Qwen3.5 config: layer 0 linear attention, layer 1 full."""
+    return make_config(
+        num_hidden_layers=2,
+        hidden_size=_H,
+        intermediate_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        layer_types=["linear_attention", "full_attention"],
+        quantization=quantization,
+        **_LINEAR_ATTN_DIMS,
+    )
+
+
+def _quant(method: str) -> QuantizationConfig:
+    return QuantizationConfig(bits=4, group_size=_BLK, quant_method=method, sym=False)
+
+
+def _olive_quant() -> QuantizationConfig:
+    return _quant("olive")
+
+
+def _packed_shape(out_features: int, in_features: int) -> tuple[int, int, int]:
+    """MatMulNBits initializer shape for an int4 blk-``_BLK`` linear."""
+    return (out_features, in_features // _BLK, _BLK * _BITS // 8)
+
+
+class TestQwen35MixedPrecisionDecoder:
+    """Olive-quantized Qwen3.5/3.6-**MoE** leaves some decoder modules float.
+
+    Olive's quantization walk excludes GatedDeltaNet (``linear_attn``, mapped
+    for ``qwen3_5_moe``/``qwen3_5_moe_text`` only) and ``shared_expert_gate``,
+    while ordinary attention, the shared expert MLP and the routed experts
+    stay quantized. The exported MoE graph must match that mixed layout, and
+    only for Olive: dense Qwen3.5 and GPTQ/AWQ MoE checkpoints keep a fully
+    quantized ``linear_attn``/gate.
+    """
+
+    def test_linear_attention_projections_are_float(self):
+        model = Qwen35MoECausalLMModel(_hybrid_moe_config(_olive_quant()))
+        linear_attn = model.model.layers[0].linear_attn
+
+        assert tuple(linear_attn.in_proj_qkv.weight.shape) == (_QKV_OUT, _H)
+        assert linear_attn.in_proj_qkv.weight.dtype != ir.DataType.UINT8
+        # Float Linear has no packed sidecar parameters.
+        assert not hasattr(linear_attn.in_proj_qkv, "scales")
+        for name in ("in_proj_z", "in_proj_b", "in_proj_a", "out_proj"):
+            projection = getattr(linear_attn, name)
+            assert len(projection.weight.shape) == 2, name
+            assert projection.weight.dtype != ir.DataType.UINT8, name
+            assert not hasattr(projection, "scales"), name
+
+    def test_dense_olive_linear_attention_stays_quantized(self):
+        """Dense Qwen3.5 is absent from Olive's MAMBA table -> still packed."""
+        model = Qwen35CausalLMModel(_hybrid_dense_config(_olive_quant()))
+        linear_attn = model.model.layers[0].linear_attn
+
+        assert tuple(linear_attn.in_proj_qkv.weight.shape) == _packed_shape(_QKV_OUT, _H)
+        assert linear_attn.in_proj_qkv.weight.dtype == ir.DataType.UINT8
+        assert linear_attn.in_proj_qkv.scales is not None
+        for name in ("in_proj_z", "in_proj_b", "in_proj_a", "out_proj"):
+            projection = getattr(linear_attn, name)
+            assert projection.weight.dtype == ir.DataType.UINT8, name
+        # Ordinary attention in the dense stack is quantized as before.
+        assert model.model.layers[1].self_attn.q_proj.weight.dtype == ir.DataType.UINT8
+
+    @pytest.mark.parametrize("method", ["gptq", "awq"])
+    def test_non_olive_quantization_preserves_existing_graph(self, method: str):
+        """The Olive-specific fix does not change other graph formats."""
+        model = Qwen35MoECausalLMModel(_hybrid_moe_config(_quant(method)))
+
+        linear_attn = model.model.layers[0].linear_attn
+        assert tuple(linear_attn.in_proj_qkv.weight.shape) == _packed_shape(_QKV_OUT, _H)
+        assert linear_attn.in_proj_qkv.weight.dtype == ir.DataType.UINT8
+
+        block = model.model.layers[1].mlp
+        assert tuple(block.shared_expert_gate.weight.shape) == _packed_shape(1, _H)
+        assert block.shared_expert_gate.weight.dtype == ir.DataType.UINT8
+        # Routed experts still take the fused QMoE path.
+        assert block.experts is None
+        assert tuple(block.fc1_experts_weights.shape) == (_E, _FC1_OUT, _H * _BITS // 8)
+
+    def test_full_attention_and_shared_expert_stay_quantized(self):
+        model = Qwen35MoECausalLMModel(_hybrid_moe_config(_olive_quant()))
+        layer = model.model.layers[1]
+
+        q_proj = layer.self_attn.q_proj
+        assert tuple(q_proj.weight.shape) == _packed_shape(_Q_OUT, _H)
+        assert q_proj.weight.dtype == ir.DataType.UINT8
+        assert q_proj.scales is not None
+
+        gate_proj = layer.mlp.shared_expert.gate_proj
+        assert tuple(gate_proj.weight.shape) == _packed_shape(_INT, _H)
+        assert gate_proj.weight.dtype == ir.DataType.UINT8
+        assert gate_proj.scales is not None
+
+    def test_shared_expert_gate_is_float_and_router_gate_unchanged(self):
+        model = Qwen35MoECausalLMModel(_hybrid_moe_config(_olive_quant()))
+        block = model.model.layers[1].mlp
+
+        assert tuple(block.shared_expert_gate.weight.shape) == (1, _H)
+        assert block.shared_expert_gate.weight.dtype != ir.DataType.UINT8
+        assert not hasattr(block.shared_expert_gate, "scales")
+
+        # Router gate behavior is untouched: still a plain float [E, H] linear.
+        assert tuple(block.gate.weight.shape) == (_E, _H)
+        assert block.gate.weight.dtype != ir.DataType.UINT8
+
+    def test_routed_experts_remain_fused_qmoe(self):
+        model = Qwen35MoECausalLMModel(_hybrid_moe_config(_olive_quant()))
+        block = model.model.layers[1].mlp
+
+        assert block.experts is None
+        assert tuple(block.fc1_experts_weights.shape) == (_E, _FC1_OUT, _H * _BITS // 8)
+        assert tuple(block.fc2_experts_weights.shape) == (_E, _H, _INT * _BITS // 8)
+
+    def test_unquantized_hybrid_layer_is_unaffected(self):
+        model = Qwen35MoECausalLMModel(_hybrid_moe_config(None))
+        assert tuple(model.model.layers[0].linear_attn.in_proj_qkv.weight.shape) == (
+            _QKV_OUT,
+            _H,
+        )
+        assert tuple(model.model.layers[1].mlp.shared_expert_gate.weight.shape) == (1, _H)
+        assert tuple(model.model.layers[1].self_attn.q_proj.weight.shape) == (_Q_OUT, _H)
+
+    def test_vl_decoder_shares_the_mixed_layout(self):
+        model = Qwen35MoEVL3ModelCausalLMModel(_hybrid_moe_config(_olive_quant(), vision=True))
+        layers = model.decoder.model.layers
+
+        assert tuple(layers[0].linear_attn.in_proj_qkv.weight.shape) == (_QKV_OUT, _H)
+        assert layers[0].linear_attn.in_proj_qkv.weight.dtype != ir.DataType.UINT8
+        assert tuple(layers[1].mlp.shared_expert_gate.weight.shape) == (1, _H)
+        assert layers[1].mlp.shared_expert_gate.weight.dtype != ir.DataType.UINT8
+        assert layers[1].self_attn.q_proj.weight.dtype == ir.DataType.UINT8
+
+    def test_mixed_olive_state_dict_preprocesses_and_binds(self):
+        """Post-#2630 Olive checkpoint (float deltanet + gate) binds cleanly."""
+        config = _hybrid_moe_config(_olive_quant())
+        model = Qwen35MoECausalLMModel(config)
+
+        linear_attn = "model.language_model.layers.0.linear_attn."
+        moe = "model.language_model.layers.1.mlp."
+        attn = "model.language_model.layers.1.self_attn."
+        state_dict: dict[str, torch.Tensor] = {
+            # Float (unquantized by Olive) GatedDeltaNet projections.
+            linear_attn + "in_proj_qkv.weight": torch.rand(_QKV_OUT, _H),
+            linear_attn + "in_proj_z.weight": torch.rand(32, _H),
+            linear_attn + "in_proj_b.weight": torch.rand(2, _H),
+            linear_attn + "in_proj_a.weight": torch.rand(2, _H),
+            linear_attn + "out_proj.weight": torch.rand(_H, 32),
+            # Float shared-expert gate.
+            moe + "shared_expert_gate.weight": torch.rand(1, _H),
+            # Quantized ordinary attention + shared expert.
+            attn + "q_proj.weight_qweight": torch.randint(
+                0, 256, (_Q_OUT, _H * _BITS // 8), dtype=torch.uint8
+            ),
+            attn + "q_proj.weight_scales": torch.rand(_Q_OUT, _H // _BLK),
+            moe + "shared_expert.gate_proj.weight_qweight": torch.randint(
+                0, 256, (_INT, _H * _BITS // 8), dtype=torch.uint8
+            ),
+            moe + "shared_expert.gate_proj.weight_scales": torch.rand(_INT, _H // _BLK),
+        }
+        # Fused QMoE experts for layer 1.
+        for key, value in _olive_expert_state_dict().items():
+            state_dict[key.replace("layers.0.", "layers.1.")] = value
+
+        out = model.preprocess_weights(state_dict)
+        params = dict(model.named_parameters())
+
+        # Every produced initializer binds to a parameter of matching shape.
+        for key, value in out.items():
+            assert key in params, key
+            assert tuple(params[key].shape) == tuple(value.shape), key
+
+        assert tuple(out["model.layers.0.linear_attn.in_proj_qkv.weight"].shape) == (
+            _QKV_OUT,
+            _H,
+        )
+        assert tuple(out["model.layers.1.mlp.shared_expert_gate.weight"].shape) == (1, _H)
+        assert tuple(out["model.layers.1.self_attn.q_proj.weight"].shape) == _packed_shape(
+            _Q_OUT, _H
+        )
+        assert "model.layers.1.mlp.fc1_experts_weights" in out


### PR DESCRIPTION
## Summary

- keep Qwen3.5/3.6-MoE GatedDeltaNet projections in floating point for Olive-format checkpoints
- keep the shared-expert gate floating point while preserving quantized attention, shared-expert MLP, and fused QMoE experts
- preserve existing dense, GPTQ/AWQ, and unquantized graph construction

This aligns Mobius with the module selection introduced by microsoft/Olive#2630 and unblocks the multimodal Qwen3.6-35B-A3B recipe in microsoft/olive-recipes#588.

## Validation

- `python -m pytest -q src/mobius/models/qwen35_test.py src/mobius/components/_gated_deltanet_test.py src/mobius/components/_moe_test.py` (57 passed)
- targeted text/VL tests cover mixed initializer binding, dense Olive behavior, non-Olive graph preservation, and fused QMoE weights