### PR TITLE
fix(onnx-genai): report MoE representation=qmoe for fused int4 graphs

### DIFF
--- a/src/mobius/integrations/onnx_genai/decoder_metadata.py
+++ b/src/mobius/integrations/onnx_genai/decoder_metadata.py
@@ -154,17 +154,55 @@ def build_decoder_metadata(
     return metadata
 
 
+def _moe_representation_from_config(config: Any) -> str:
+    """Return the MoE graph representation implied by *config*'s quantization.
+
+    ``MoELayer`` emits a fused ``com.microsoft::QMoE`` node (one per MoE layer)
+    exactly when :func:`mobius.components._moe._supported_qmoe_quantization`
+    accepts the model's quantization settings (int4, power-of-two
+    ``block_size >= 16``, GPTQ/AWQ/Olive-RTN); otherwise it falls back to the
+    portable loop-over-experts dense representation. The onnx-genai runtime
+    schema (``mixture_of_experts.representation``) distinguishes these as
+    ``qmoe`` vs ``dense_fallback``, and the weight-offload / expert-paging path
+    keys off that distinction -- a fused graph exposes per-expert structure the
+    dense loop hides. Reporting ``dense_fallback`` for a graph that actually
+    fused would make the runtime treat resident experts as an opaque bank.
+
+    This mirrors ``MoELayer``'s construction-time decision from *config* alone.
+    Gates without a ``qmoe_routing`` hook (only ``SparseMixerGate`` today) stay
+    dense even when quantized; those are not reachable through the standard
+    onnx-genai int4 MoE export, so a config-level derivation is faithful for
+    every fused path this emitter produces.
+    """
+    from mobius.components._moe import _supported_qmoe_quantization
+
+    quantization = getattr(config, "quantization", None)
+    if _supported_qmoe_quantization(quantization) is not None:
+        return "qmoe"
+    return "dense_fallback"
+
+
 def moe_metadata_from_config(
-    config: Any, *, representation: str = "dense_fallback"
+    config: Any, *, representation: str | None = None
 ) -> dict[str, Any] | None:
     """Build generic MoE metadata from explicit architecture configuration.
 
     Returns ``None`` for dense models. The emitted contract describes graph
     structure and router semantics only; it never dispatches on a model name.
+
+    When *representation* is ``None`` (the default) it is derived from the
+    config's quantization via :func:`_moe_representation_from_config` so the
+    emitted ``representation`` reflects whether ``MoELayer`` actually fused the
+    experts into ``com.microsoft::QMoE`` (``qmoe``) or emitted the dense
+    loop-over-experts fallback (``dense_fallback``). Callers may pass an
+    explicit value to override the derivation.
     """
     routed_experts = _clean_int(getattr(config, "num_local_experts", None))
     if routed_experts is None or routed_experts <= 1:
         return None
+
+    if representation is None:
+        representation = _moe_representation_from_config(config)
 
     experts_per_token = _clean_int(getattr(config, "num_experts_per_tok", None))
     expert_intermediate_size = _clean_int(

--- a/src/mobius/integrations/onnx_genai/decoder_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/decoder_metadata_test.py
@@ -196,6 +196,44 @@ class TestDecoderMetadata:
         assert meta["model"]["mixture_of_experts"]["routed_expert_count"] == 4
         assert meta["model"]["mixture_of_experts"]["representation"] == "dense_fallback"
 
+    def test_moe_representation_is_qmoe_for_fused_int4_quantization(self):
+        """An int4 blk32 config fuses to QMoE, so metadata must say qmoe.
+
+        The onnx-genai runtime's expert-paging path keys off
+        ``representation``, so a fused graph must not advertise the dense
+        fallback.
+        """
+        cfg = _FakeConfig()
+        cfg.num_local_experts = 8
+        cfg.num_experts_per_tok = 2
+        cfg.moe_intermediate_size = 256
+        cfg.quantization = QuantizationConfig(
+            bits=4, group_size=32, quant_method="olive", sym=False
+        )
+
+        moe = moe_metadata_from_config(cfg)
+
+        assert moe is not None
+        assert moe["representation"] == "qmoe"
+
+    def test_moe_representation_stays_dense_for_unfusable_quantization(self):
+        """A non-power-of-two block size stays dense (unrunnable by CUDA QMoE).
+
+        ``MoELayer`` keeps the dense loop; the metadata must match.
+        """
+        cfg = _FakeConfig()
+        cfg.num_local_experts = 8
+        cfg.num_experts_per_tok = 2
+        cfg.moe_intermediate_size = 256
+        cfg.quantization = QuantizationConfig(
+            bits=4, group_size=48, quant_method="olive", sym=False
+        )
+
+        moe = moe_metadata_from_config(cfg)
+
+        assert moe is not None
+        assert moe["representation"] == "dense_fallback"
+
     def test_moe_metadata_rejects_incomplete_contract(self):
         cfg = _FakeConfig()
         cfg.num_local_experts = 4

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -837,8 +837,55 @@ class TestBuildGraphQuantized:
         expected = 1 * self.NUM_PROJECTIONS_PER_LAYER
         assert len(matmulnbits) == expected
 
+    def _granitemoe_config(self, quantization=None):
+        overrides = dict(
+            num_hidden_layers=2,
+            num_local_experts=8,
+            num_experts_per_tok=2,
+            moe_intermediate_size=32,
+            intermediate_size=32,
+        )
+        if quantization is not None:
+            overrides["quantization"] = quantization
+        return _base_config(**overrides)
 
-class TestBuildGraphVisionLanguage:
+    def test_granitemoe_int4_fuses_to_qmoe(self):
+        """int4 GraniteMoE fuses each MoE layer into one com.microsoft::QMoE node.
+
+        Instead of the dense loop-over-experts (per-expert MatMul + Equal)
+        representation. The CUDA EP executes only the quantized fused MoE ops
+        (QMoE / BlockQuantizedMoE); there is no float MoE kernel, so int4 is the
+        path that yields a fused, runnable graph.
+        """
+        from mobius._configs import QuantizationConfig
+
+        qc = QuantizationConfig(bits=4, group_size=32, quant_method="olive", sym=False)
+        config = self._granitemoe_config(quantization=qc)
+        module = registry.get("granitemoe")(config)
+        pkg = CausalLMTask().build(module, config)
+        model = pkg["model"]
+
+        qmoe = [n for n in model.graph if n.op_type == "QMoE"]
+        equal = [n for n in model.graph if n.op_type == "Equal"]
+        assert len(qmoe) == 2, f"expected one QMoE per MoE layer, got {len(qmoe)}"
+        assert len(equal) == 0, "fused QMoE must not emit per-expert Equal masks"
+
+    def test_granitemoe_dense_has_no_qmoe(self):
+        """Without quantization, GraniteMoE stays on the dense loop path.
+
+        No fused QMoE; per-expert Equal masks present.
+        """
+        config = self._granitemoe_config()
+        module = registry.get("granitemoe")(config)
+        pkg = CausalLMTask().build(module, config)
+        model = pkg["model"]
+
+        qmoe = [n for n in model.graph if n.op_type == "QMoE"]
+        equal = [n for n in model.graph if n.op_type == "Equal"]
+        assert len(qmoe) == 0, "unquantized MoE must not fuse to QMoE"
+        assert len(equal) > 0, "dense fallback selects experts with Equal masks"
+
+
     """Verify multimodal models build correctly."""
 
     def test_phi4mm_multimodal_graph(self):


### PR DESCRIPTION
## What & why

`moe_metadata_from_config` (onnx-genai `inference_metadata.yaml` emitter) hard-coded `mixture_of_experts.representation: dense_fallback` for **every** MoE model — even when Mobius actually fused the experts into a `com.microsoft::QMoE` node. The onnx-genai runtime schema defines `qmoe` as a distinct representation (`["dense_fallback", "moe", "qmoe"]`), and the weight-offload / expert-paging path keys off it. A fused QMoE graph exposes per-expert structure that the dense loop-over-experts fallback hides; reporting `dense_fallback` for a fused model makes the runtime treat the resident expert bank as opaque.

This threads the representation off the same predicate `MoELayer` uses at construction time (`_supported_qmoe_quantization`): `qmoe` for int4, power-of-two `block_size >= 16`, GPTQ/AWQ/Olive-RTN; `dense_fallback` otherwise. Callers can still override with an explicit `representation=`.

## Context (measured)

Investigating why the `granite-3.0-1b-a400m` fixture consumed downstream has **zero** fused MoE nodes (768 per-expert `MatMul` + `Equal`), I confirmed by graph-only builds (no weights):

| granitemoe build | QMoE nodes | Equal nodes |
|---|---|---|
| f16 dense (no quant) | 0 | 16 |
| **int4 olive blk32** | **2 (one/layer)** | **0** |

So Mobius's fused emission already works for GraniteMoE — the fixture is unfused only because it was built **f16-dense**. The downstream CUDA EP executes only *quantized* fused MoE (`com.microsoft::QMoE`, `pkg.nxrt::BlockQuantizedMoE`); it has no float `MoE` kernel, so int4 is the path that yields a fused, runnable graph. The one thing still wrong on the Mobius side was the metadata lying about the representation — fixed here.

## Tests

- `build_graph_test.py`: `test_granitemoe_int4_fuses_to_qmoe` (2 QMoE, 0 Equal) and `test_granitemoe_dense_has_no_qmoe`.
- `decoder_metadata_test.py`: `representation == "qmoe"` for fused int4, `dense_fallback` for a non-pow2 (unfusable) block size. Existing `dense_fallback` assertions unchanged (fake configs carry no quantization).

`ruff check` clean on all three files. Targeted suites pass (27 passed). The 3 `onnxruntime_easy` `ModuleNotFoundError` failures in `TestBuildGraphQuantized` are a pre-existing missing optional dependency in an unrelated gemma4 audio test, not introduced here.
