### PR TITLE
fix(models): fused QMoE export for per-expert GPTQ/AWQ MoE checkpoints (#513)

### DIFF
--- a/src/mobius/_weight_utils.py
+++ b/src/mobius/_weight_utils.py
@@ -621,6 +621,88 @@ def _reshape_packed_qzeros(value: torch.Tensor, bits: int, n_blocks: int) -> tor
     return flat_uint8[..., :zp_cols]
 
 
+def stack_per_expert_moe_weights(
+    state_dict: dict[str, torch.Tensor],
+    *,
+    qmoe_target_path: str,
+) -> dict[str, torch.Tensor]:
+    """Stack per-expert quantized MoE projections into fused expert-major tensors.
+
+    GPTQ/AWQ MoE checkpoints store every routed expert as a separate module
+    (``…{qmoe_target_path}.experts.{i}.{gate,up,down}_proj.*``). The native QMoE
+    packer (:func:`pack_qmoe_expert_weights`) instead expects the fused
+    expert-major tensors that Olive emits
+    (``…{qmoe_target_path}.experts.gate_up_proj.*`` and ``…experts.down_proj.*``
+    with a leading expert dimension). This bridges the two so a per-expert
+    GPTQ/AWQ checkpoint can drive the fused ``com.microsoft::QMoE`` path.
+
+    Runs on the already-reshaped MatMulNBits layout produced by
+    :func:`preprocess_gptq_weights` / :func:`preprocess_awq_weights` (suffixes
+    ``.weight`` ``[N, n_blocks, blob]``, ``.scales`` ``[N, n_blocks]``,
+    ``.zero_points`` ``[N, zp_cols]``). For each expert, gate and up are
+    concatenated along the output-row dimension in HF-concatenated ``[gate; up]``
+    order (the layout ``_interleave_gate_up_rows`` expects), then all experts are
+    stacked into a new leading dimension. Non-expert keys pass through unchanged;
+    per-expert ``bias`` and ``g_idx`` are dropped (the QMoE ABI carries neither).
+
+    A no-op (returns the input unchanged) when the state dict already holds
+    fused expert-major tensors (e.g. Olive checkpoints), so it is safe to call
+    on any quantized MoE state dict.
+    """
+    experts_root = f"{qmoe_target_path}.experts."
+    projections = ("gate_proj", "up_proj", "down_proj")
+    stack_suffixes = ("weight", "scales", "zero_points")
+
+    # groups[expert_prefix][suffix][proj][expert_index] = tensor
+    groups: dict[str, dict[str, dict[str, dict[int, torch.Tensor]]]] = {}
+    passthrough: dict[str, torch.Tensor] = {}
+    for key, value in state_dict.items():
+        marker = experts_root
+        pos = key.find(marker)
+        matched = False
+        if pos != -1:
+            rest = key[pos + len(marker) :]  # e.g. "0.gate_proj.weight"
+            idx_str, _, tail = rest.partition(".")
+            if idx_str.isdigit() and tail:
+                proj, _, suffix = tail.partition(".")
+                if proj in projections:
+                    if suffix in stack_suffixes:
+                        prefix = key[: pos + len(marker) - 1]  # ".../experts"
+                        groups.setdefault(prefix, {}).setdefault(suffix, {}).setdefault(
+                            proj, {}
+                        )[int(idx_str)] = value
+                        matched = True
+                    elif suffix in ("bias", "g_idx"):
+                        # Not carried into the QMoE ABI; drop.
+                        matched = True
+        if not matched:
+            passthrough[key] = value
+
+    if not groups:
+        return state_dict
+
+    def _stack_dense(by_idx: dict[int, torch.Tensor]) -> torch.Tensor:
+        return torch.stack([by_idx[i] for i in range(len(by_idx))], dim=0)
+
+    result = dict(passthrough)
+    for prefix, by_suffix in groups.items():
+        for suffix, by_proj in by_suffix.items():
+            gate = by_proj.get("gate_proj")
+            up = by_proj.get("up_proj")
+            down = by_proj.get("down_proj")
+            if gate is not None and up is not None:
+                if gate.keys() != up.keys():
+                    raise ValueError(f"Mismatched gate/up experts for {prefix} ({suffix})")
+                fused_gate_up = torch.stack(
+                    [torch.cat([gate[i], up[i]], dim=0) for i in range(len(gate))],
+                    dim=0,
+                )
+                result[f"{prefix}.gate_up_proj.{suffix}"] = fused_gate_up
+            if down is not None:
+                result[f"{prefix}.down_proj.{suffix}"] = _stack_dense(down)
+    return result
+
+
 def pack_qmoe_expert_weights(
     state_dict: dict[str, torch.Tensor],
     *,
@@ -1096,6 +1178,9 @@ def preprocess_quantized_weights(
             head_key=head_key,
         )
         if use_qmoe and qmoe_target_path is not None:
+            return_state_dict = stack_per_expert_moe_weights(
+                return_state_dict, qmoe_target_path=qmoe_target_path
+            )
             return_state_dict = pack_qmoe_expert_weights(
                 return_state_dict, target_moe_path=qmoe_target_path
             )
@@ -1109,5 +1194,8 @@ def preprocess_quantized_weights(
     if tie_embeddings and not tied_quantized_table:
         tie_word_embeddings(state_dict, embed_key=embed_key, head_key=head_key)
     if use_qmoe and qmoe_target_path is not None:
+        state_dict = stack_per_expert_moe_weights(
+            state_dict, qmoe_target_path=qmoe_target_path
+        )
         state_dict = pack_qmoe_expert_weights(state_dict, target_moe_path=qmoe_target_path)
     return state_dict

--- a/src/mobius/_weight_utils_test.py
+++ b/src/mobius/_weight_utils_test.py
@@ -20,6 +20,7 @@ from mobius._weight_utils import (
     split_fused_qkv,
     split_gate_up_proj,
     split_interleaved_qkv,
+    stack_per_expert_moe_weights,
     strip_prefix,
     tie_word_embeddings,
     vlm_decoder_weights,
@@ -979,6 +980,48 @@ class TestPreprocessQuantizedWeights:
                 qmoe_quant_methods=("olive",),
             )
 
+    def test_per_expert_gptq_moe_produces_populated_fused_qmoe(self):
+        """Per-expert GPTQ experts stack+pack into non-empty fused QMoE params.
+
+        This is the end-to-end guard for the per-expert -> fused-QMoE path:
+        a symmetric GPTQ MoE checkpoint whose routed experts are stored as
+        separate modules must yield populated ``fc1/fc2_experts_weights`` with a
+        leading expert axis, and leave no per-expert expert tensors behind.
+        """
+        quantization = QuantizationConfig(bits=4, group_size=32, quant_method="gptq", sym=True)
+        num_experts = 3
+        hidden, inter = 256, 128
+        prefix = "model.layers.0.mlp.experts"
+        state_dict: dict[str, torch.Tensor] = {}
+        for e in range(num_experts):
+            # gate/up: in=hidden(256), out=inter(128); down: in=inter(128), out=hidden(256)
+            for proj, k, n in (
+                ("gate_proj", hidden, inter),
+                ("up_proj", hidden, inter),
+                ("down_proj", inter, hidden),
+            ):
+                k_packed = k * 4 // 32
+                n_groups = k // 32
+                state_dict[f"{prefix}.{e}.{proj}.qweight"] = torch.randint(
+                    0, 255, (k_packed, n), dtype=torch.int32
+                )
+                state_dict[f"{prefix}.{e}.{proj}.scales"] = torch.randn(n_groups, n)
+
+        result = preprocess_quantized_weights(
+            state_dict, quantization, qmoe_target_path=".mlp"
+        )
+
+        fc1 = result["model.layers.0.mlp.fc1_experts_weights"]
+        fc2 = result["model.layers.0.mlp.fc2_experts_weights"]
+        assert fc1.shape[0] == num_experts
+        assert fc2.shape[0] == num_experts
+        assert fc1.shape[1] == 2 * inter  # gate rows then up rows
+        assert fc2.shape[1] == hidden
+        assert fc1.numel() > 0 and fc2.numel() > 0
+        # No per-expert expert tensors survive the fusion.
+        assert not any(".experts." in k and ".gate_proj" in k for k in result)
+        assert not any(".experts." in k and ".down_proj" in k for k in result)
+
     @pytest.mark.parametrize("flag", ["quantize_embeddings", "quantize_lm_head"])
     def test_rejects_quantized_embedding_or_lm_head(self, flag):
         quantization = QuantizationConfig(
@@ -1251,3 +1294,102 @@ class TestSplitCodegenQKV:
         """mp_num that doesn't divide hidden raises ValueError."""
         with pytest.raises(ValueError, match="divisible"):
             split_codegen_qkv(torch.zeros(96, 32), num_heads=4, head_dim=8, mp_num=3)
+
+
+class TestStackPerExpertMoEWeights:
+    """Per-expert GPTQ/AWQ MoE tensors -> fused expert-major QMoE layout.
+
+    Runs on the MatMulNBits-reshaped layout produced by preprocess_gptq_weights:
+    ``.weight`` [N, n_blocks, blob], ``.scales`` [N, n_blocks].
+    """
+
+    NUM_EXPERTS = 4
+    HIDDEN = 8
+    INTER = 6
+    N_BLOCKS = 2
+    BLOB = 2  # bits=4 -> block_size/2
+
+    def _per_expert_state_dict(self):
+        prefix = "model.layers.0.mlp.experts"
+        sd = {}
+        # Deterministic distinct values so a permutation/gate-up swap is visible.
+        for e in range(self.NUM_EXPERTS):
+            for proj, out in (
+                ("gate_proj", self.INTER),
+                ("up_proj", self.INTER),
+                ("down_proj", self.HIDDEN),
+            ):
+                base = (e + 1) * 1000 + {"gate_proj": 0, "up_proj": 100, "down_proj": 200}[
+                    proj
+                ]
+                w = (
+                    (base + torch.arange(out * self.N_BLOCKS * self.BLOB))
+                    .reshape(out, self.N_BLOCKS, self.BLOB)
+                    .to(torch.uint8)
+                )
+                s = (
+                    (base + torch.arange(out * self.N_BLOCKS))
+                    .reshape(out, self.N_BLOCKS)
+                    .float()
+                )
+                sd[f"{prefix}.{e}.{proj}.weight"] = w
+                sd[f"{prefix}.{e}.{proj}.scales"] = s
+                sd[f"{prefix}.{e}.{proj}.bias"] = torch.zeros(out)
+        return sd, prefix
+
+    def test_stacks_into_fused_expert_major(self):
+        sd, prefix = self._per_expert_state_dict()
+        result = stack_per_expert_moe_weights(sd, qmoe_target_path=".mlp")
+
+        gu_w = result[f"{prefix}.gate_up_proj.weight"]
+        gu_s = result[f"{prefix}.gate_up_proj.scales"]
+        dn_w = result[f"{prefix}.down_proj.weight"]
+
+        assert gu_w.shape == (self.NUM_EXPERTS, 2 * self.INTER, self.N_BLOCKS, self.BLOB)
+        assert gu_s.shape == (self.NUM_EXPERTS, 2 * self.INTER, self.N_BLOCKS)
+        assert dn_w.shape == (self.NUM_EXPERTS, self.HIDDEN, self.N_BLOCKS, self.BLOB)
+
+        # Per-expert biases/g_idx are dropped; no per-expert keys survive.
+        assert not any(".experts.0." in k for k in result)
+
+    def test_gate_first_then_up_ordering(self):
+        """fc1 rows must be [gate(0:inter); up(inter:2*inter)] per expert."""
+        sd, prefix = self._per_expert_state_dict()
+        result = stack_per_expert_moe_weights(sd, qmoe_target_path=".mlp")
+        gu_w = result[f"{prefix}.gate_up_proj.weight"]
+        for e in range(self.NUM_EXPERTS):
+            torch.testing.assert_close(
+                gu_w[e, : self.INTER], sd[f"{prefix}.{e}.gate_proj.weight"]
+            )
+            torch.testing.assert_close(
+                gu_w[e, self.INTER :], sd[f"{prefix}.{e}.up_proj.weight"]
+            )
+
+    def test_expert_axis_order_preserved(self):
+        """Stacking must preserve expert index order (catches permutation)."""
+        sd, prefix = self._per_expert_state_dict()
+        result = stack_per_expert_moe_weights(sd, qmoe_target_path=".mlp")
+        dn_w = result[f"{prefix}.down_proj.weight"]
+        for e in range(self.NUM_EXPERTS):
+            torch.testing.assert_close(dn_w[e], sd[f"{prefix}.{e}.down_proj.weight"])
+
+    def test_already_fused_is_noop(self):
+        """Olive-style fused expert-major tensors pass through unchanged."""
+        sd = {
+            "model.layers.0.mlp.experts.gate_up_proj.weight": torch.zeros(
+                self.NUM_EXPERTS, 2 * self.INTER, self.N_BLOCKS, self.BLOB
+            ),
+            "model.layers.0.mlp.experts.down_proj.weight": torch.zeros(
+                self.NUM_EXPERTS, self.HIDDEN, self.N_BLOCKS, self.BLOB
+            ),
+        }
+        result = stack_per_expert_moe_weights(sd, qmoe_target_path=".mlp")
+        assert result is sd
+
+    def test_non_expert_keys_pass_through(self):
+        sd, _prefix = self._per_expert_state_dict()
+        sd["model.embed_tokens.weight"] = torch.randn(4, 8)
+        result = stack_per_expert_moe_weights(sd, qmoe_target_path=".mlp")
+        assert torch.equal(
+            result["model.embed_tokens.weight"], sd["model.embed_tokens.weight"]
+        )

--- a/src/mobius/models/moe.py
+++ b/src/mobius/models/moe.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 import dataclasses
 import functools
 import math
-from typing import TYPE_CHECKING
 
+import onnx_ir as ir
 import torch
 from onnxscript import OpBuilder, nn
 
@@ -25,10 +25,31 @@ from mobius.components import (
 )
 from mobius.components._attention import StaticCacheState
 from mobius.components._moe import MLP, SigmoidTopKGate, SoftmaxTopKGate
+from mobius.components._quantized_linear import make_quantized_linear_factory
 from mobius.models.base import CausalLMModel
 
-if TYPE_CHECKING:
-    import onnx_ir as ir
+
+def _quantized_linear_class(config: ArchitectureConfig) -> type | None:
+    """Return a QuantizedLinear factory when the checkpoint is quantized.
+
+    MoE decoder-layer projections (attention Q/K/V/O and the shared-expert MLP
+    ``gate_proj``/``up_proj``/``down_proj``) are quantized in GPTQ/AWQ MoE
+    checkpoints (e.g. Qwen1.5-MoE-A2.7B-GPTQ-Int4 lists ``self_attn.*`` and
+    ``mlp.shared_expert.*`` in ``modules_in_block_to_quantize``), so they must be
+    built through the same quantization-aware factory as the routed experts;
+    otherwise the packed weights fail to load into dense ``Linear`` layers.
+    Returns ``None`` for unquantized configs so callers fall back to dense Linear.
+    """
+    qc = getattr(config, "quantization", None)
+    if qc is None or qc.quant_method == "none":
+        return None
+    zp_dtype = config.dtype if getattr(qc, "float_zero_point", False) else ir.DataType.UINT8
+    return make_quantized_linear_factory(
+        bits=qc.bits,
+        block_size=qc.group_size,
+        has_zero_point=not qc.sym,
+        zero_point_dtype=zp_dtype,
+    )
 
 
 class MoEDecoderLayer(nn.Module):
@@ -56,8 +77,12 @@ class MoEDecoderLayer(nn.Module):
         super().__init__()
         self._post_feedforward_norm = config.post_feedforward_norm
         attention_scale = getattr(config, "attention_multiplier", None)
-        self.self_attn = Attention(config, scale=attention_scale)
-        self.mlp = MoELayer(config, gate=gate)
+        # Quantize attention Q/K/V/O when the checkpoint does (GPTQ/AWQ MoE lists
+        # ``self_attn.*`` in ``modules_in_block_to_quantize``); the MoE decoder path
+        # otherwise builds dense projections that cannot load packed weights.
+        linear_class = _quantized_linear_class(config)
+        self.self_attn = Attention(config, scale=attention_scale, linear_class=linear_class)
+        self.mlp = MoELayer(config, gate=gate, linear_class=linear_class)
         residual_multiplier = getattr(config, "residual_multiplier", None)
         self._residual_multiplier = 1.0 if residual_multiplier is None else residual_multiplier
         if not self._post_feedforward_norm:
@@ -336,7 +361,15 @@ class Qwen2MoEDecoderLayer(MoEDecoderLayer):
         super().__init__(config, gate=gate, norm_class=norm_class)
         # Replace the standard MoELayer with the Qwen2 variant (shared expert).
         # Re-use the gate already created by MoEDecoderLayer.__init__.
-        self.mlp = Qwen2MoELayer(config, gate=self.mlp.gate)
+        # Thread the quantization-aware factory so a GPTQ/AWQ checkpoint's packed
+        # shared-expert weights load (mobius#513). The tiny shared_expert_gate
+        # (hidden -> 1) is left dense: it is excluded from quantization in source.
+        self.mlp = Qwen2MoELayer(
+            config,
+            gate=self.mlp.gate,
+            linear_class=_quantized_linear_class(config),
+            shared_expert_gate_class=Linear,
+        )
 
 
 class Qwen2MoECausalLMModel(CausalLMModel):
@@ -382,7 +415,11 @@ class UngatedSharedMoELayer(MoELayer):
         shared_config = dataclasses.replace(
             config, intermediate_size=config.shared_expert_intermediate_size
         )
-        self.shared_expert = MLP(shared_config)
+        # Quantize the shared expert when the checkpoint does (mobius#513);
+        # GPTQ/AWQ Ernie4.5-MoE / GLM4-MoE pack ``mlp.shared_expert.*``.
+        self.shared_expert = MLP(
+            shared_config, linear_class=_quantized_linear_class(config)
+        )
 
     def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # Routed expert output: top-k weighted sum  [B, S, H]

--- a/src/mobius/models/moe.py
+++ b/src/mobius/models/moe.py
@@ -12,6 +12,7 @@ import torch
 from onnxscript import OpBuilder, nn
 
 from mobius._configs import ArchitectureConfig
+from mobius._weight_utils import preprocess_quantized_weights
 from mobius.components import (
     Attention,
     Embedding,
@@ -49,6 +50,28 @@ def _quantized_linear_class(config: ArchitectureConfig) -> type | None:
         block_size=qc.group_size,
         has_zero_point=not qc.sym,
         zero_point_dtype=zp_dtype,
+    )
+
+
+def _preprocess_moe_weights(model: nn.Module, state_dict) -> dict:
+    """Shared MoE weight preprocessing that routes routed experts through QMoE.
+
+    Applies the standard quantization conversion (GPTQ/AWQ/Olive) and, when the
+    checkpoint's quantization matches the native QMoE ABI, stacks per-expert
+    projections into the fused expert-major tensors and packs them into
+    ``com.microsoft::QMoE`` parameters (``qmoe_target_path=".mlp"`` — the routed
+    ``self.mlp`` block). Float and non-QMoE checkpoints fall through to the dense
+    loop-over-experts representation unchanged.
+
+    Callers pass a state dict whose HF expert layout has already been
+    normalised (see :func:`_rename_moe_expert_weights`).
+    """
+    return preprocess_quantized_weights(
+        state_dict,
+        getattr(model.config, "quantization", None),
+        tie_embeddings=model.config.tie_word_embeddings,
+        qmoe_target_path=".mlp",
+        qmoe_quant_methods=("gptq", "awq", "olive"),
     )
 
 
@@ -287,7 +310,7 @@ class MoECausalLMModel(CausalLMModel):
         self, state_dict: dict[str, torch.Tensor]
     ) -> dict[str, torch.Tensor]:
         state_dict = _rename_moe_expert_weights(state_dict)
-        return super().preprocess_weights(state_dict)
+        return _preprocess_moe_weights(self, state_dict)
 
 
 class Qwen2MoELayer(MoELayer):
@@ -392,7 +415,7 @@ class Qwen2MoECausalLMModel(CausalLMModel):
         self, state_dict: dict[str, torch.Tensor]
     ) -> dict[str, torch.Tensor]:
         state_dict = _rename_moe_expert_weights(state_dict)
-        return super().preprocess_weights(state_dict)
+        return _preprocess_moe_weights(self, state_dict)
 
 
 class UngatedSharedMoELayer(MoELayer):
@@ -417,9 +440,7 @@ class UngatedSharedMoELayer(MoELayer):
         )
         # Quantize the shared expert when the checkpoint does (mobius#513);
         # GPTQ/AWQ Ernie4.5-MoE / GLM4-MoE pack ``mlp.shared_expert.*``.
-        self.shared_expert = MLP(
-            shared_config, linear_class=_quantized_linear_class(config)
-        )
+        self.shared_expert = MLP(shared_config, linear_class=_quantized_linear_class(config))
 
     def forward(self, op: OpBuilder, hidden_states: ir.Value):
         # Routed expert output: top-k weighted sum  [B, S, H]
@@ -487,7 +508,7 @@ class Ernie45MoECausalLMModel(CausalLMModel):
         self, state_dict: dict[str, torch.Tensor]
     ) -> dict[str, torch.Tensor]:
         state_dict = _preprocess_shared_moe_weights(state_dict)
-        return super().preprocess_weights(state_dict)
+        return _preprocess_moe_weights(self, state_dict)
 
 
 class Glm4MoECausalLMModel(CausalLMModel):
@@ -522,7 +543,7 @@ class Glm4MoECausalLMModel(CausalLMModel):
         self, state_dict: dict[str, torch.Tensor]
     ) -> dict[str, torch.Tensor]:
         state_dict = _preprocess_shared_moe_weights(state_dict)
-        return super().preprocess_weights(state_dict)
+        return _preprocess_moe_weights(self, state_dict)
 
 
 class HunYuanMoEV1CausalLMModel(CausalLMModel):

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -846,6 +846,76 @@ class TestBuildGraphQuantized:
         expected = 1 * self.NUM_PROJECTIONS_PER_LAYER
         assert len(matmulnbits) == expected
 
+    def _shared_moe_config(self, model_type, quantization=None):
+        overrides = dict(
+            num_hidden_layers=1,
+            num_local_experts=8,
+            num_experts_per_tok=2,
+            moe_intermediate_size=32,
+            intermediate_size=32,
+            shared_expert_intermediate_size=32,
+            hidden_size=64,
+        )
+        if quantization is not None:
+            overrides["quantization"] = quantization
+        return _base_config(**overrides)
+
+    def test_qwen2_moe_int4_quantizes_shared_expert(self):
+        """int4 Qwen2-MoE builds shared-expert projections as MatMulNBits (mobius#513).
+
+        The GPTQ Qwen1.5-MoE-A2.7B-Int4 checkpoint quantizes
+        ``mlp.shared_expert.{gate,up,down}_proj`` (they appear in
+        ``modules_in_block_to_quantize``). Before the fix ``Qwen2MoEDecoderLayer``
+        built ``Qwen2MoELayer`` without a ``linear_class``, so the shared expert was
+        a dense ``MLP`` whose ``Linear`` layers expected an unpacked ``[hidden,inter]``
+        weight and failed to load the packed GPTQ tensor. The shared-expert MLP must
+        use the quantization-aware factory (three MatMulNBits: gate/up/down), while
+        the tiny ``shared_expert_gate`` (hidden -> 1) stays dense.
+        """
+        from mobius._configs import QuantizationConfig
+
+        qc = QuantizationConfig(bits=4, group_size=32, quant_method="gptq", sym=False)
+        module = registry.get("qwen2_moe")(self._shared_moe_config("qwen2_moe", qc))
+        layer = module.model.layers[0]
+        # Attention projections must also use the quantized factory: the MoE
+        # decoder path previously built dense Attention, so a GPTQ checkpoint's
+        # packed self_attn weights could not load (mobius#513).
+        assert type(layer.self_attn.q_proj).__name__ == "QuantizedLinear"
+        assert type(layer.mlp.shared_expert.gate_proj).__name__ == "QuantizedLinear"
+        assert type(layer.mlp.shared_expert.up_proj).__name__ == "QuantizedLinear"
+        assert type(layer.mlp.shared_expert.down_proj).__name__ == "QuantizedLinear"
+        # Routing projection stays dense (excluded from quantization in the source).
+        assert type(layer.mlp.shared_expert_gate).__name__ == "Linear"
+
+        pkg = CausalLMTask().build(module, module.config)
+        model = pkg["model"]
+        qmoe = [n for n in model.graph if n.op_type == "QMoE"]
+        nbits = [n for n in model.graph if n.op_type == "MatMulNBits"]
+        assert len(qmoe) == 1, f"routed experts must fuse to one QMoE, got {len(qmoe)}"
+        assert len(nbits) >= 3, (
+            f"shared expert must emit >=3 MatMulNBits (gate/up/down), got {len(nbits)}"
+        )
+
+    def test_qwen2_moe_dense_shared_expert_stays_linear(self):
+        """Without quantization the Qwen2-MoE shared expert stays a dense MLP."""
+        module = registry.get("qwen2_moe")(self._shared_moe_config("qwen2_moe"))
+        layer = module.model.layers[0]
+        assert type(layer.mlp.shared_expert.down_proj).__name__ == "Linear"
+        assert type(layer.mlp.shared_expert_gate).__name__ == "Linear"
+
+    def test_glm4_moe_int4_quantizes_shared_expert(self):
+        """int4 GLM4-MoE (ungated shared expert) quantizes its shared expert too.
+
+        Same mobius#513 class of bug in ``UngatedSharedMoELayer`` (Ernie4.5 / GLM4),
+        which built the shared expert with a dense ``MLP`` regardless of quantization.
+        """
+        from mobius._configs import QuantizationConfig
+
+        qc = QuantizationConfig(bits=4, group_size=32, quant_method="gptq", sym=False)
+        module = registry.get("glm4_moe")(self._shared_moe_config("glm4_moe", qc))
+        layer = module.model.layers[0]
+        assert type(layer.mlp.shared_expert.down_proj).__name__ == "QuantizedLinear"
+
 
 class TestBuildGraphVisionLanguage:
     """Verify multimodal models build correctly."""


### PR DESCRIPTION
## Summary

MoE decoder layers built their **attention (Q/K/V/O)** and always-active **shared-expert** projections with dense `Linear`/`MLP` regardless of the checkpoint's quantization. For GPTQ/AWQ MoE checkpoints this makes the model unloadable — the packed weight does not fit a dense `Linear` and export fails with a shape mismatch (mobius#513):

```
Weight shape mismatch for 'model.layers.0.self_attn.k_proj.weight':
model expects [2048, 2048], got [2048, 16, 64]
```

and, once attention loads, the same on `mlp.shared_expert.*`.

The GPTQ checkpoint `Qwen/Qwen1.5-MoE-A2.7B-Chat-GPTQ-Int4` quantizes `self_attn.{q,k,v,o}_proj` and `mlp.shared_expert.{gate,up,down}_proj` (they are listed in `modules_in_block_to_quantize`), so those projections must be built through the same quantization-aware factory as the routed experts.

Affected registry models: `qwen2_moe` (Qwen1.5-MoE), `glm4_moe` and `ernie4_5_moe` (ungated shared expert), plus attention for the whole generic MoE family (Mixtral / GraniteMoE / OLMoE / Qwen3-MoE).

## Root cause

`Qwen2MoELayer` already accepts a `linear_class` (added in #495), but its call site `Qwen2MoEDecoderLayer` never passed one; `UngatedSharedMoELayer` and `MoEDecoderLayer` did not thread quantization at all, so attention was always dense.

## Change

- Add `_quantized_linear_class(config)` deriving `make_quantized_linear_factory(...)` from `config.quantization` (returns `None` when unquantized, so unquantized models are unchanged).
- Thread it into `MoEDecoderLayer` attention and the routed `MoELayer` dense-fallback experts, the `Qwen2MoEDecoderLayer` shared expert, and `UngatedSharedMoELayer`.
- Keep the tiny `shared_expert_gate` (`hidden -> 1`) **dense** (`shared_expert_gate_class=Linear`): it is excluded from quantization in the source checkpoints.

## Tests

Graph-only (no weights / GPU), added to `TestBuildGraphQuantized`:

- `test_qwen2_moe_int4_quantizes_shared_expert` — attention `q_proj` and shared-expert `gate/up/down_proj` become `QuantizedLinear` (>=3 `MatMulNBits`), routed experts still fuse to one `QMoE`, and `shared_expert_gate` stays `Linear`.
- `test_qwen2_moe_dense_shared_expert_stays_linear` — unquantized config keeps the shared expert dense.
- `test_glm4_moe_int4_quantizes_shared_expert` — the ungated-shared variant quantizes its shared expert too.

`pytest tests/build_graph_test.py` MoE-family selection: 192 passed, 14 skipped, no regressions. `ruff check` clean.

## Note (follow-up, out of scope here)

With this fix the Qwen1.5-MoE-GPTQ export progresses past attention and the shared expert, but still fails to populate the **fused QMoE routed-expert weights** (`fc1/fc2_experts_weights`). AutoGPTQ stores the 60 routed experts as *separate per-expert* quantized `nn.Linear` modules, whereas `pack_qmoe_expert_weights` (and the working DeepSeek / Qwen3.5-Olive QMoE paths) expect an *already-fused expert-major* tensor. Wiring per-expert-GPTQ → fused-QMoE stacking for the generic MoE family is a separate change and needs numerical validation, so it is intentionally not included here.

Closes #513


---

## Update — per-expert → fused QMoE stacking now implemented (commit bd666bc)

The "follow-up, out of scope" item above is now **done** in this branch, so the scope of the PR is broadened: Qwen1.5-MoE-A2.7B-GPTQ-Int4 (and the per-expert GPTQ/AWQ MoE family) now export a **fully fused** graph.

### Change
- New `stack_per_expert_moe_weights` in `_weight_utils.py`: after the MatMulNBits reshape, concatenate each expert's `gate_proj`/`up_proj` in HF-concatenated `[gate; up]` order and stack all experts into a leading expert axis, producing the fused `gate_up_proj` / `down_proj` tensors that `pack_qmoe_expert_weights` consumes. No-op on already-fused (Olive) checkpoints.
- Wire the generic MoE models (`MoECausalLMModel`, `Qwen2MoECausalLMModel`, `Ernie45MoECausalLMModel`, `Glm4MoECausalLMModel`) through `preprocess_quantized_weights(qmoe_target_path=".mlp")` via a shared `_preprocess_moe_weights` helper.
- Symmetric GPTQ (`sym=True`) drops zero-points on **both** the dense and QMoE paths (implicit zp=8); no zero-point transport is added. Asymmetric zero-point transport stays out of scope.

### Measured (RTX 4060 8 GB, Qwen1.5-MoE-A2.7B-Chat-GPTQ-Int4)
- **Graph:** before = 0 QMoE / 1440 Equal; after = **24 QMoE / 0 Equal**, `fc1_experts_weights` populated `[60, 2816, 1024]` (was 96 empty initializers).
- **Numerical equivalence** (fp32, same weights, dense per-expert MatMulNBits vs fused QMoE, CUDA): identical greedy output ("Paris"), identical token stream, **identical top-5**, **max abs first-step logit diff 0.072** / mean 0.0058 over 151,936 logits. This magnitude is consistent with fused-SwiGLU FP accumulation order, not a wrong expert mapping (a permutation would diverge massively). Per-tensor validation additionally proved the fused `fc1/fc2` weights+scales are a **byte-exact** rearrangement of the source experts (1080 checks across 3 layers × 60 experts, 0 failures).
- **fp16 note:** the fp16 build produces garbage under `onnxruntime` 1.27.0 because the ORT QMoE CUDA kernel is **fp32-activation-only** (a known runtime kernel constraint, independently recorded on the H200 team's side). The fp32 build runs correctly. This is a runtime kernel property, not an emission bug — the fused graph itself is correct.

### Tests
- `TestStackPerExpertMoEWeights` (5 tests): fused shape, gate-first/up-second row ordering, expert-axis order preservation (catches permutation), Olive already-fused no-op, non-expert passthrough.
- `TestPreprocessQuantizedWeights::test_per_expert_gptq_moe_produces_populated_fused_qmoe`: end-to-end per-expert GPTQ → populated non-empty `fc1/fc2_experts_weights` with a leading expert axis and no surviving per-expert tensors.
- `pytest src/mobius/_weight_utils_test.py src/mobius/components/_moe_test.py src/mobius/rewrite_rules/_qmoe_fusion_test.py` → **162 passed**. `ruff check` + `ruff format --check` clean. (`tests/moe_integration_test.py` needs `onnxruntime_easy`, absent on this box.)
