### PR TITLE
Fix Qwen3.6 VL processor export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Other checkpoint formats retain their previous graph construction; this
     change only aligns Mobius with Olive's module selection.
 
+- Qwen3.6 VL exports now emit the packed Qwen image-processing pipeline when
+  the composite build exposes its unwrapped `qwen3_5_moe_text` config. This
+  adds the required `PatchImage` transform so `pixel_values` matches the
+  vision encoder's rank-2 packed-patch input.
+
 #### Added
 
 - `Qwen2MoELayer(..., shared_expert_gate_class=...)` to override the linear

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -137,6 +137,7 @@ _QWEN_VL_MODEL_TYPES = frozenset(
         "qwen3_5",
         "qwen3_5_vl",
         "qwen3_5_moe",
+        "qwen3_5_moe_text",
         "videochat_flash_qwen",
     }
 )

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -373,6 +373,40 @@ class TestWriteProcessorConfig:
             "merge_size": 2,
         }
 
+    def test_qwen35_moe_text_uses_packed_qwen_image_pipeline(self, tmp_path):
+        """Qwen3.6 VL builds unwrap to the MoE text config before processor export."""
+        vision = mock.MagicMock()
+        vision.image_size = 16_777_216
+        vision.patch_size = 16
+        vision.spatial_merge_size = 2
+        config = mock.MagicMock()
+        config.vision = vision
+        config.model_type = "qwen3_5_moe_text"
+        config.spatial_merge_size = 2
+        config.temporal_patch_size = 2
+
+        path = _write_vision_processor_config(config, str(tmp_path))
+        assert path is not None
+        with open(path) as f:
+            data = json.load(f)
+
+        proc = data["processor"]
+        assert proc["name"] == "qwen2_5_image_processor"
+        transforms = proc["transforms"]
+        assert [t["operation"]["type"] for t in transforms] == [
+            "DecodeImage",
+            "Resize",
+            "Rescale",
+            "Normalize",
+            "PatchImage",
+        ]
+        assert transforms[3]["operation"]["attrs"]["qwen2_5_vl"] == 1
+        assert transforms[4]["operation"]["attrs"] == {
+            "patch_size": 16,
+            "temporal_patch_size": 2,
+            "merge_size": 2,
+        }
+
     def test_gemma3_vision_config(self, tmp_path):
         """Gemma3 gets a fixed-size resize + Permute3D (not the generic branch).
 


### PR DESCRIPTION
## Summary

- recognize the unwrapped `qwen3_5_moe_text` config as a Qwen VL processor target
- emit `PatchImage` and the packed Qwen processor instead of the generic rank-3 image pipeline
- add focused processor-config coverage

## End-to-end evidence

Discovered while validating microsoft/olive-recipes#588 with the real `Qwen/Qwen3.6-35B-A3B` checkpoint:

- before: ORT GenAI processor produced rank-3 `pixel_values`; the exported vision encoder requires rank-2 `[total_patches, 1536]`, so `Generator.set_inputs` failed with `Invalid rank for input: pixel_values Got: 3 Expected: 2`
- after: `processor_config.json` contains `DecodeImage -> Resize -> Rescale -> Normalize -> PatchImage`; ORT GenAI processed a synthetic 256x256 four-color image into 86 input tokens and generated a correct description of a square divided into four quadrants

## Validation

- `python -m pytest -q src/mobius/integrations/ort_genai/auto_export_test.py -k "qwen35_moe_text or muse_glimmer or processor_config_written_with_vision"` (3 passed)
- `python -m pytest -q src/mobius/models/qwen35_test.py` (27 passed)
- real 35B VL KQuant export, `og.Model` load, multimodal processor creation, and image+text generation completed on A100-80GB