### PR TITLE
Correct upstream runtime assets that ship broken

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ docs = ["furo", "myst-parser", "sphinx", "sphinx_copybutton"]
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+"mobius.upstream_patches" = ["data/*/*/*.patch", "data/*/*/*.json", "data/*/*/*.md"]
+
 [tool.setuptools.dynamic]
 version = { attr = "mobius.__version__" }
 

--- a/src/mobius/integrations/onnx_genai/inference_metadata.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata.py
@@ -43,6 +43,7 @@ from typing import Any
 import yaml
 
 from mobius._pipeline_contract import component_presence, optional_input_contract
+from mobius.upstream_patches import apply_asset_patches
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -1635,6 +1636,8 @@ def _copy_runtime_assets(
             _LOGGER.warning(
                 "Could not materialize tokenizer assets from %r: %s", source, error
             )
+
+    apply_asset_patches(output_dir)
 
     return {
         Path(filename).stem: os.path.join(output_dir, filename)

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -54,6 +54,8 @@ import os
 import shutil
 from typing import TYPE_CHECKING, Any
 
+from mobius.upstream_patches import apply_asset_patches
+
 if TYPE_CHECKING:
     import onnx_ir as ir
 
@@ -1496,6 +1498,9 @@ def write_ort_genai_config(
 
     # Ensure chat_template is in tokenizer_config.json
     _fix_chat_template(directory, hf_model_id)
+
+    # Correct assets that ship broken from upstream
+    apply_asset_patches(directory)
 
     logger.info("ORT-GenAI artifacts written: %d files", len(result))
     return result

--- a/src/mobius/upstream_patches/README.md
+++ b/src/mobius/upstream_patches/README.md
@@ -1,0 +1,76 @@
+# upstream_patches
+
+Corrections to runtime assets that ship broken from upstream model repos.
+
+Weights are not the whole package. The chat template, tokenizer config and
+processor config decide whether an agent client can actually drive the model,
+and when one of them is wrong the export is faithful and the deployment is
+still broken. Fixing it by hand does not stick: the defect returns on the next
+re-export, and on every other machine.
+
+## Layout
+
+```
+data/<owner>/<model>/
+    patch.json       what to change, and which upstream revision it was written against
+    README.md        the symptom, the defect, and why this is the right fix
+    <target>.patch   a unified diff
+```
+
+## How a correction finds its target
+
+By the sha256 of the file already in the package, not by a model id. A source
+can be a Hub repo, a snapshot directory or a local checkout, and the hash is
+the same in all three. It also means a correction can only ever rewrite bytes
+it recognises.
+
+When upstream republishes the file, the hash stops matching and the correction
+stops being applied. That is the intended behaviour: a stale correction does
+nothing rather than corrupting a package. `check_upstream` is how you find out.
+
+```
+python -m mobius.upstream_patches.check_upstream
+python -m mobius.upstream_patches.check_upstream meta-models/Muse-Glimmer-30B
+```
+
+It exits non-zero when a recorded file changed upstream. That is not a failure,
+it is a review request: re-verify, then either refresh `revision` and
+`upstream_sha256`, or delete the correction because upstream fixed it.
+
+## Operations
+
+`diff` applies a unified diff to one file.
+
+```json
+{
+  "kind": "diff",
+  "target": "chat_template.jinja",
+  "patch": "chat_template.jinja.patch",
+  "upstream_sha256": "<sha256 of the upstream file this was written against>"
+}
+```
+
+Diffs are applied strictly: the hunk lands at the line it names with the
+context it names, or it does not land. No fuzz, no offset search.
+
+`sync_chat_template` rewrites the `chat_template` key of a JSON config from an
+already-corrected template. Templates get duplicated into
+`tokenizer_config.json`, and a package whose two copies disagree fails in a way
+that depends on which loader you use. It runs only if the template it mirrors
+was actually corrected, so it cannot touch a package the diff skipped.
+
+Prefer a narrow operation over replacing a file wholesale. Checking in a whole
+`tokenizer_config.json` would pin every unrelated key in it to whatever
+upstream happened to have that day.
+
+## Adding a correction
+
+1. Confirm the defect is upstream and not in the exporter. Diff the file in the
+   HF snapshot against what you believe it should be.
+2. Write the diff against the snapshot, and record its revision and sha256.
+3. Explain the defect in `README.md` in terms of the symptom a user sees.
+4. Verify end to end against a real client, and say so.
+
+> [!NOTE]
+> Preference goes to upstream. Open an issue or a PR there first and keep the
+> correction only for as long as it takes to land.

--- a/src/mobius/upstream_patches/__init__.py
+++ b/src/mobius/upstream_patches/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Corrections to runtime assets that ship broken from upstream model repos."""
+
+from __future__ import annotations
+
+__all__ = [
+    "AssetPatch",
+    "PatchError",
+    "apply_asset_patches",
+    "apply_unified_diff",
+    "available_patches",
+]
+
+from mobius.upstream_patches._diff import PatchError, apply_unified_diff
+from mobius.upstream_patches._patches import (
+    AssetPatch,
+    apply_asset_patches,
+    available_patches,
+)

--- a/src/mobius/upstream_patches/_diff.py
+++ b/src/mobius/upstream_patches/_diff.py
@@ -1,0 +1,100 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""A strict unified diff applier.
+
+Strict means no fuzz and no offset search: a hunk applies at the line it names
+with the context it names, or it does not apply at all. That rigidity is the
+point. These diffs are corrections written against a specific upstream file,
+and a hunk that no longer fits is the signal that upstream moved and the
+correction needs a human to look at it again.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+
+_HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+
+
+class PatchError(Exception):
+    """Raised when a diff does not apply cleanly to the given text."""
+
+
+@dataclasses.dataclass(frozen=True)
+class _Hunk:
+    old_start: int
+    lines: tuple[tuple[str, str], ...]
+
+
+def _parse(diff: str) -> list[_Hunk]:
+    hunks: list[_Hunk] = []
+    header: int | None = None
+    body: list[tuple[str, str]] = []
+
+    for line in diff.splitlines():
+        match = _HUNK_HEADER.match(line)
+        if match is not None:
+            if header is not None:
+                hunks.append(_Hunk(header, tuple(body)))
+            header = int(match.group(1))
+            body = []
+            continue
+        if header is None:
+            continue
+        if line.startswith("\\"):
+            # "\ No newline at end of file" annotates the previous line.
+            continue
+        if line[:1] in {" ", "-", "+"}:
+            body.append((line[0], line[1:]))
+        elif not line:
+            body.append((" ", ""))
+
+    if header is not None:
+        hunks.append(_Hunk(header, tuple(body)))
+    if not hunks:
+        raise PatchError("diff contains no hunks")
+    return hunks
+
+
+def apply_unified_diff(original: str, diff: str) -> str:
+    """Apply ``diff`` to ``original`` and return the result.
+
+    Raises:
+        PatchError: if any hunk's context does not match ``original`` exactly.
+    """
+    lines = original.splitlines(keepends=True)
+    result: list[str] = []
+    cursor = 0
+
+    for hunk in _parse(diff):
+        start = hunk.old_start - 1
+        if start < cursor:
+            raise PatchError(f"hunk at line {hunk.old_start} overlaps an earlier hunk")
+        if start > len(lines):
+            raise PatchError(f"hunk starts at line {hunk.old_start}, past end of file")
+        result.extend(lines[cursor:start])
+        cursor = start
+
+        for tag, text in hunk.lines:
+            if tag == "+":
+                result.append(text + "\n")
+                continue
+            if cursor >= len(lines):
+                raise PatchError(f"hunk at line {hunk.old_start} runs past end of file")
+            found = lines[cursor].rstrip("\r\n")
+            if found != text:
+                raise PatchError(
+                    f"context mismatch at line {cursor + 1}: "
+                    f"expected {text!r}, found {found!r}"
+                )
+            if tag == " ":
+                result.append(lines[cursor])
+            cursor += 1
+
+    result.extend(lines[cursor:])
+    patched = "".join(result)
+    if not original.endswith("\n") and patched.endswith("\n"):
+        patched = patched[:-1]
+    return patched

--- a/src/mobius/upstream_patches/_diff_test.py
+++ b/src/mobius/upstream_patches/_diff_test.py
@@ -1,0 +1,72 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for the strict unified diff applier."""
+
+from __future__ import annotations
+
+import difflib
+import unittest
+
+from mobius.upstream_patches import PatchError, apply_unified_diff
+
+_ORIGINAL = "alpha\nbravo\ncharlie\ndelta\n"
+
+_DIFF = """--- a/f
++++ b/f
+@@ -1,4 +1,4 @@
+ alpha
+-bravo
++BRAVO
+ charlie
+ delta
+"""
+
+
+class ApplyUnifiedDiffTest(unittest.TestCase):
+    def test_applies_a_single_hunk(self):
+        self.assertEqual(
+            apply_unified_diff(_ORIGINAL, _DIFF),
+            "alpha\nBRAVO\ncharlie\ndelta\n",
+        )
+
+    def test_applies_two_hunks(self):
+        original = "".join(f"line{index}\n" for index in range(1, 21))
+        modified = original.replace("line2\n", "two\n").replace("line18\n", "eighteen\n")
+        diff = "".join(
+            difflib.unified_diff(
+                original.splitlines(keepends=True),
+                modified.splitlines(keepends=True),
+                "a/f",
+                "b/f",
+            )
+        )
+        self.assertEqual(diff.count("@@ -"), 2)
+        self.assertEqual(apply_unified_diff(original, diff), modified)
+
+    def test_rejects_a_context_mismatch(self):
+        with self.assertRaises(PatchError) as caught:
+            apply_unified_diff("alpha\nBRAVO\ncharlie\ndelta\n", _DIFF)
+        self.assertIn("context mismatch", str(caught.exception))
+
+    def test_rejects_a_hunk_past_the_end_of_the_file(self):
+        with self.assertRaises(PatchError):
+            apply_unified_diff("alpha\n", _DIFF)
+
+    def test_rejects_a_diff_without_hunks(self):
+        with self.assertRaises(PatchError):
+            apply_unified_diff(_ORIGINAL, "--- a/f\n+++ b/f\n")
+
+    def test_preserves_a_missing_trailing_newline(self):
+        original = "alpha\nbravo"
+        diff = "@@ -1,2 +1,2 @@\n-alpha\n+ALPHA\n bravo\n\\ No newline at end of file\n"
+        self.assertEqual(apply_unified_diff(original, diff), "ALPHA\nbravo")
+
+    def test_handles_an_empty_context_line(self):
+        original = "alpha\n\ncharlie\n"
+        diff = "@@ -1,3 +1,3 @@\n alpha\n\n-charlie\n+CHARLIE\n"
+        self.assertEqual(apply_unified_diff(original, diff), "alpha\n\nCHARLIE\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/mobius/upstream_patches/_patches.py
+++ b/src/mobius/upstream_patches/_patches.py
@@ -1,0 +1,163 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Corrections to runtime assets that ship broken from upstream model repos.
+
+A model package is more than weights. It carries a chat template, a tokenizer
+config, a processor config -- files that decide whether an agent client can
+actually drive the model. When one of those is wrong the export is faithful
+and the deployment is still broken, and the defect comes back every time
+somebody re-exports.
+
+The corrections live in ``data/<owner>/<model>/`` as unified diffs written
+against a named upstream revision, next to a ``README.md`` explaining the
+symptom that motivated them. A patch is selected by the sha256 of the file
+already in the package, not by a model id, so it finds its target whether the
+source was a Hub repo, a snapshot directory, or a local checkout -- and it can
+only ever rewrite bytes it recognises.
+
+That hash, plus the strictness of the diff applier, is how upstream is
+tracked: when upstream republishes the file, the patch stops matching and
+stops being applied instead of silently corrupting a package.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import logging
+import pathlib
+from typing import Any
+
+from mobius.upstream_patches._diff import PatchError, apply_unified_diff
+
+_LOGGER = logging.getLogger(__name__)
+
+_DATA_ROOT = pathlib.Path(__file__).parent / "data"
+
+
+@dataclasses.dataclass(frozen=True)
+class AssetPatch:
+    """One upstream correction, loaded from ``data/<owner>/<model>/patch.json``."""
+
+    directory: pathlib.Path
+    upstream_repo: str
+    upstream_revision: str
+    summary: str
+    operations: tuple[dict[str, Any], ...]
+
+    @property
+    def name(self) -> str:
+        return self.upstream_repo
+
+
+def _load(directory: pathlib.Path) -> AssetPatch:
+    with (directory / "patch.json").open(encoding="utf-8") as handle:
+        raw = json.load(handle)
+    upstream = raw["upstream"]
+    return AssetPatch(
+        directory=directory,
+        upstream_repo=upstream["repo"],
+        upstream_revision=upstream["revision"],
+        summary=raw.get("summary", ""),
+        operations=tuple(raw["operations"]),
+    )
+
+
+def available_patches(root: pathlib.Path | None = None) -> list[AssetPatch]:
+    """Return every correction shipped with this package."""
+    base = _DATA_ROOT if root is None else root
+    return [_load(path.parent) for path in sorted(base.glob("*/*/patch.json"))]
+
+
+def _sha256(path: pathlib.Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _apply_diff(package: pathlib.Path, patch: AssetPatch, operation: dict) -> str | None:
+    target = package / operation["target"]
+    if not target.is_file():
+        return None
+    if _sha256(target) != operation["upstream_sha256"]:
+        return None
+
+    diff = (patch.directory / operation["patch"]).read_text(encoding="utf-8")
+    try:
+        patched = apply_unified_diff(target.read_text(encoding="utf-8"), diff)
+    except PatchError:
+        # The hash matched, so the bytes are the ones this diff was written
+        # against; a failure here means the diff itself is wrong.
+        _LOGGER.exception("Patch for %s does not apply to %s", patch.name, target)
+        return None
+
+    target.write_text(patched, encoding="utf-8")
+    return operation["target"]
+
+
+def _sync_chat_template(package: pathlib.Path, operation: dict) -> str | None:
+    """Copy a patched template over the duplicate embedded in a JSON config."""
+    target = package / operation["target"]
+    source = package / operation["source"]
+    if not target.is_file() or not source.is_file():
+        return None
+
+    template = source.read_text(encoding="utf-8")
+    with target.open(encoding="utf-8") as handle:
+        config = json.load(handle)
+    if config.get("chat_template") == template:
+        return None
+
+    config["chat_template"] = template
+    with target.open("w", encoding="utf-8") as handle:
+        json.dump(config, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+    return operation["target"]
+
+
+def apply_asset_patches(
+    package_dir: str | pathlib.Path,
+    *,
+    root: pathlib.Path | None = None,
+) -> list[str]:
+    """Correct any known-broken upstream assets in an exported model package.
+
+    Args:
+        package_dir: directory holding the exported package's runtime assets.
+        root: patch data root; defaults to the corrections shipped here.
+
+    Returns:
+        The names of the files that were rewritten, in application order.
+    """
+    package = pathlib.Path(package_dir)
+    if not package.is_dir():
+        return []
+
+    changed: list[str] = []
+    for patch in available_patches(root):
+        applied: list[str] = []
+        for operation in patch.operations:
+            kind = operation["kind"]
+            if kind == "diff":
+                result = _apply_diff(package, patch, operation)
+            elif kind == "sync_chat_template":
+                # Only meaningful once the template it mirrors was corrected.
+                result = _sync_chat_template(package, operation) if applied else None
+            else:
+                _LOGGER.warning("Unknown patch operation %r in %s", kind, patch.name)
+                continue
+            if result is not None:
+                applied.append(result)
+
+        if applied:
+            _LOGGER.info(
+                "Patched %s in %s (from %s@%s): %s",
+                ", ".join(applied),
+                package,
+                patch.upstream_repo,
+                patch.upstream_revision[:12],
+                patch.summary,
+            )
+            changed.extend(applied)
+
+    return changed

--- a/src/mobius/upstream_patches/_patches.py
+++ b/src/mobius/upstream_patches/_patches.py
@@ -103,8 +103,15 @@ def _sync_chat_template(package: pathlib.Path, operation: dict) -> str | None:
         return None
 
     template = source.read_text(encoding="utf-8")
-    with target.open(encoding="utf-8") as handle:
-        config = json.load(handle)
+    try:
+        with target.open(encoding="utf-8") as handle:
+            config = json.load(handle)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        # Correcting assets is opportunistic: a config we cannot read is a
+        # problem for whoever wrote it, not a reason to fail an export that
+        # would otherwise succeed with the stale embedded copy.
+        _LOGGER.exception("Cannot read %s to sync %s into it", target, source.name)
+        return None
     if config.get("chat_template") == template:
         return None
 

--- a/src/mobius/upstream_patches/_patches_test.py
+++ b/src/mobius/upstream_patches/_patches_test.py
@@ -113,6 +113,22 @@ class ApplyAssetPatchesTest(unittest.TestCase):
     def test_tolerates_a_package_missing_the_target(self):
         self.assertEqual(self._apply(), [])
 
+    def test_tolerates_an_unreadable_tokenizer_config(self):
+        self._write_package()
+        (self.package / "tokenizer_config.json").write_text("{not json", encoding="utf-8")
+        with self.assertLogs("mobius.upstream_patches._patches", level="ERROR"):
+            applied = self._apply()
+        self.assertEqual(
+            applied,
+            ["chat_template.jinja"],
+            "the template is still corrected when its duplicate cannot be read",
+        )
+        self.assertEqual(
+            (self.package / "tokenizer_config.json").read_text(encoding="utf-8"),
+            "{not json",
+            "an unreadable config is left exactly as found, not truncated",
+        )
+
     def test_tolerates_a_missing_package_directory(self):
         self.assertEqual(apply_asset_patches(self.package / "absent", root=self.patches), [])
 

--- a/src/mobius/upstream_patches/_patches_test.py
+++ b/src/mobius/upstream_patches/_patches_test.py
@@ -1,0 +1,140 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for upstream asset correction."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import pathlib
+import tempfile
+import unittest
+
+from mobius.upstream_patches import apply_asset_patches, available_patches
+
+_ORIGINAL = "hello {{ name }}\ngoodbye\n"
+_PATCHED = "hello {{ name }}\nfarewell\n"
+_DIFF = "@@ -1,2 +1,2 @@\n hello {{ name }}\n-goodbye\n+farewell\n"
+
+
+def _write_patch_root(root: pathlib.Path, *, operations: list[dict]) -> pathlib.Path:
+    directory = root / "owner" / "model"
+    directory.mkdir(parents=True)
+    (directory / "chat_template.jinja.patch").write_text(_DIFF, encoding="utf-8")
+    (directory / "patch.json").write_text(
+        json.dumps(
+            {
+                "upstream": {"repo": "owner/model", "revision": "0" * 40},
+                "summary": "say farewell",
+                "operations": operations,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return root
+
+
+def _template_operation() -> dict:
+    return {
+        "kind": "diff",
+        "target": "chat_template.jinja",
+        "patch": "chat_template.jinja.patch",
+        "upstream_sha256": hashlib.sha256(_ORIGINAL.encode()).hexdigest(),
+    }
+
+
+def _sync_operation() -> dict:
+    return {
+        "kind": "sync_chat_template",
+        "target": "tokenizer_config.json",
+        "source": "chat_template.jinja",
+    }
+
+
+class ApplyAssetPatchesTest(unittest.TestCase):
+    def setUp(self):
+        self._temp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self._temp.name)
+        self.package = self.root / "package"
+        self.package.mkdir()
+        self.patches = _write_patch_root(
+            self.root / "patches",
+            operations=[_template_operation(), _sync_operation()],
+        )
+        self.addCleanup(self._temp.cleanup)
+
+    def _write_package(self, template: str = _ORIGINAL, *, tokenizer_config=True):
+        (self.package / "chat_template.jinja").write_text(template, encoding="utf-8")
+        if tokenizer_config:
+            (self.package / "tokenizer_config.json").write_text(
+                json.dumps({"chat_template": template, "model_max_length": 4096}),
+                encoding="utf-8",
+            )
+
+    def _apply(self):
+        return apply_asset_patches(self.package, root=self.patches)
+
+    def test_corrects_a_matching_asset(self):
+        self._write_package()
+        self.assertEqual(self._apply(), ["chat_template.jinja", "tokenizer_config.json"])
+        self.assertEqual(
+            (self.package / "chat_template.jinja").read_text(encoding="utf-8"),
+            _PATCHED,
+        )
+
+    def test_syncs_the_template_duplicated_into_the_tokenizer_config(self):
+        self._write_package()
+        self._apply()
+        with (self.package / "tokenizer_config.json").open(encoding="utf-8") as handle:
+            config = json.load(handle)
+        self.assertEqual(config["chat_template"], _PATCHED)
+        self.assertEqual(config["model_max_length"], 4096, "unrelated keys survive")
+
+    def test_leaves_an_asset_upstream_already_fixed(self):
+        self._write_package(template=_PATCHED)
+        self.assertEqual(self._apply(), [])
+        self.assertEqual(
+            (self.package / "chat_template.jinja").read_text(encoding="utf-8"),
+            _PATCHED,
+        )
+
+    def test_is_idempotent(self):
+        self._write_package()
+        self.assertTrue(self._apply())
+        self.assertEqual(self._apply(), [], "a corrected package is left alone")
+
+    def test_skips_the_sync_when_the_template_was_not_corrected(self):
+        self._write_package(template=_PATCHED)
+        self._apply()
+        with (self.package / "tokenizer_config.json").open(encoding="utf-8") as handle:
+            self.assertEqual(json.load(handle)["chat_template"], _PATCHED)
+
+    def test_tolerates_a_package_missing_the_target(self):
+        self.assertEqual(self._apply(), [])
+
+    def test_tolerates_a_missing_package_directory(self):
+        self.assertEqual(apply_asset_patches(self.package / "absent", root=self.patches), [])
+
+
+class ShippedPatchesTest(unittest.TestCase):
+    def test_every_shipped_patch_is_well_formed(self):
+        patches = available_patches()
+        self.assertTrue(patches, "the package ships at least one correction")
+        for patch in patches:
+            with self.subTest(patch=patch.name):
+                self.assertTrue(patch.summary, "a patch explains itself")
+                self.assertEqual(len(patch.upstream_revision), 40, "pinned by full sha")
+                self.assertTrue(
+                    (patch.directory / "README.md").is_file(),
+                    "a patch records why it exists",
+                )
+                for operation in patch.operations:
+                    self.assertIn(operation["kind"], {"diff", "sync_chat_template"})
+                    if operation["kind"] == "diff":
+                        self.assertTrue((patch.directory / operation["patch"]).is_file())
+                        self.assertEqual(len(operation["upstream_sha256"]), 64)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/mobius/upstream_patches/check_upstream.py
+++ b/src/mobius/upstream_patches/check_upstream.py
@@ -1,0 +1,87 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Report corrections whose upstream file has changed since they were written.
+
+Every ``diff`` operation records the sha256 of the exact bytes it was written
+against. When upstream republishes that file the hash stops matching, the
+correction silently stops being applied, and somebody has to decide whether it
+landed upstream or was restructured around.
+
+Run it against the upstream default branch::
+
+    python -m mobius.upstream_patches.check_upstream
+    python -m mobius.upstream_patches.check_upstream meta-models/Muse-Glimmer-30B
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import pathlib
+import sys
+
+from mobius.upstream_patches._patches import AssetPatch, available_patches
+
+
+def _upstream_sha256(repo: str, filename: str, revision: str) -> str:
+    from huggingface_hub import hf_hub_download
+
+    path = hf_hub_download(repo, filename, revision=revision)
+    return hashlib.sha256(pathlib.Path(path).read_bytes()).hexdigest()
+
+
+def drifted_files(patch: AssetPatch, revision: str) -> list[str]:
+    """Return one report line per file that no longer matches what was recorded."""
+    reports: list[str] = []
+    for operation in patch.operations:
+        recorded = operation.get("upstream_sha256")
+        if not recorded:
+            continue
+        target = operation["target"]
+        try:
+            current = _upstream_sha256(patch.upstream_repo, target, revision)
+        except Exception as error:
+            reports.append(f"{patch.upstream_repo}:{target} could not be fetched: {error}")
+            continue
+        if current != recorded:
+            reports.append(
+                f"{patch.upstream_repo}:{target} changed\n"
+                f"    recorded {recorded} (at {patch.upstream_revision})\n"
+                f"    upstream {current} (at {revision})"
+            )
+    return reports
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "patch",
+        nargs="?",
+        help="owner/model to check; every correction is checked when omitted",
+    )
+    parser.add_argument(
+        "--revision",
+        default="main",
+        help="upstream revision to compare against (default: main)",
+    )
+    args = parser.parse_args(argv)
+
+    patches = available_patches()
+    if args.patch is not None:
+        patches = [patch for patch in patches if patch.upstream_repo == args.patch]
+        if not patches:
+            parser.error(f"no correction for {args.patch!r}")
+
+    reports = [line for patch in patches for line in drifted_files(patch, args.revision)]
+    if reports:
+        print("\n".join(reports))
+        print(f"\n{len(reports)} file(s) drifted; re-verify before trusting the patch")
+        return 1
+
+    print(f"{len(patches)} correction(s) still match their recorded upstream")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/mobius/upstream_patches/data/meta-models/Muse-Glimmer-30B/README.md
+++ b/src/mobius/upstream_patches/data/meta-models/Muse-Glimmer-30B/README.md
@@ -1,0 +1,47 @@
+# meta-models/Muse-Glimmer-30B
+
+## The defect
+
+`chat_template.jinja` derives a namespace from every offered tool name and
+renders it as a wildcard pattern:
+
+```jinja
+{%- set tns = fn.name.split('.')[0] -%}
+...
+{%- set rns.recipients = rns.recipients + ['"' + tns + '.*"'] -%}
+```
+
+`split('.')[0]` on an unqualified name returns the name itself, so a client
+offering plain tool names gets a system preamble that reads:
+
+```
+# Valid recipients: "self", "read.*", "bash.*", "glob.*", "user".
+```
+
+Nothing named `read` is addressable any more -- only things *under* `read`.
+The model does what the preamble asks and supplies a second segment,
+usually by borrowing a parameter name, and emits a call to `read.filePath`.
+The harness rejects it because no such tool was offered.
+
+Observed against every OpenCode session: the first tool call of each task
+failed, the agent recovered on retry, and every task paid for the round trip.
+
+## The fix
+
+Treat the dot as the signal it is. A name that contains one is namespaced and
+keeps the `"ns.*"` pattern; a name without one is already the whole address
+and is rendered verbatim.
+
+The same guard is applied to the tool metadata block, which otherwise emits a
+namespace entry for a tool that has no namespace.
+
+## Scope
+
+Clients that offer namespaced tool names are unaffected -- they render exactly
+as before. The change only reaches names that upstream was mangling.
+
+## Verification
+
+Rendered both shapes with jinja2 and diffed the preamble; ran a read task and
+a multi-tool debug task (read, edit, bash, todowrite) end to end through
+OpenCode against the INT4 CUDA export with no invalid tool errors.

--- a/src/mobius/upstream_patches/data/meta-models/Muse-Glimmer-30B/chat_template.jinja.patch
+++ b/src/mobius/upstream_patches/data/meta-models/Muse-Glimmer-30B/chat_template.jinja.patch
@@ -1,0 +1,37 @@
+--- a/chat_template.jinja
++++ b/chat_template.jinja
+@@ -58,9 +58,11 @@
+     {%- set nsns = namespace(seen=[]) -%}
+     {%- for tool in tools -%}
+         {%- set fn = tool.function if tool.function is defined else tool -%}
+-        {%- set tns = fn.name.split('.')[0] -%}
+-        {%- if tns not in nsns.seen -%}
+-            {%- set nsns.seen = nsns.seen + [tns] -%}
++        {%- if '.' in fn.name -%}
++            {%- set tns = fn.name.split('.')[0] -%}
++            {%- if tns not in nsns.seen -%}
++                {%- set nsns.seen = nsns.seen + [tns] -%}
++            {%- endif -%}
+         {%- endif -%}
+     {%- endfor -%}
+     {%- set nd = tool_namespace_descriptions if tool_namespace_descriptions is defined else {} -%}
+@@ -89,13 +91,17 @@
+     {%- if tools -%}
+         {%- for tool in tools -%}
+             {%- set fn = tool.function if tool.function is defined else tool -%}
+-            {%- set tns = fn.name.split('.')[0] -%}
++            {%- if '.' in fn.name -%}
++                {%- set tns = '"' + fn.name.split('.')[0] + '.*"' -%}
++            {%- else -%}
++                {%- set tns = '"' + fn.name + '"' -%}
++            {%- endif -%}
+             {%- if tns not in rns.nslist -%}
+                 {%- set rns.nslist = rns.nslist + [tns] -%}
+             {%- endif -%}
+         {%- endfor -%}
+         {%- for tns in rns.nslist -%}
+-            {%- set rns.recipients = rns.recipients + ['"' + tns + '.*"'] -%}
++            {%- set rns.recipients = rns.recipients + [tns] -%}
+         {%- endfor -%}
+     {%- endif -%}
+     {%- set rns.recipients = rns.recipients + ['"user"'] -%}

--- a/src/mobius/upstream_patches/data/meta-models/Muse-Glimmer-30B/patch.json
+++ b/src/mobius/upstream_patches/data/meta-models/Muse-Glimmer-30B/patch.json
@@ -1,0 +1,20 @@
+{
+  "upstream": {
+    "repo": "meta-models/Muse-Glimmer-30B",
+    "revision": "a4e59da52a7bc87ae7251dd5545c0dd437c44b68"
+  },
+  "summary": "Render a bare tool name as an exact recipient instead of a namespace pattern.",
+  "operations": [
+    {
+      "kind": "diff",
+      "target": "chat_template.jinja",
+      "patch": "chat_template.jinja.patch",
+      "upstream_sha256": "cfc67e5f349f37690dfd31ed1f18bc4442a9dd32fe39a648f993cb4eb3cae678"
+    },
+    {
+      "kind": "sync_chat_template",
+      "target": "tokenizer_config.json",
+      "source": "chat_template.jinja"
+    }
+  ]
+}


### PR DESCRIPTION
## The problem

Weights are not the whole package. The chat template, tokenizer config and processor config decide whether an agent client can actually drive the model. When one of them is wrong the export is faithful and the deployment is still broken.

`meta-models/Muse-Glimmer-30B` has such a defect. Its chat template derives a namespace from every offered tool name and renders it as a wildcard:

```jinja
{%- set tns = fn.name.split('.')[0] -%}
{%- set rns.recipients = rns.recipients + ['"' + tns + '.*"'] -%}
```

`split('.')[0]` on an unqualified name returns the name itself, so a client offering plain tool names gets a preamble reading:

```
# Valid recipients: "self", "read.*", "bash.*", "glob.*", "user".
```

Nothing named `read` is addressable any more, only things *under* `read`. The model does what the preamble asks and supplies a second segment, usually by borrowing a parameter name, and emits `read.filePath`. Observed against every OpenCode session: the first tool call of each task failed and the agent recovered on retry, so every task paid for a wasted round trip.

Fixing the file in an exported package by hand does not stick. The defect returns on the next re-export and on every other machine.

## The change

A `mobius.upstream_patches` subpackage owns this class of correction.

```
data/<owner>/<model>/
    patch.json       what to change, and which upstream revision it was written against
    README.md        the symptom, the defect, and why this is the right fix
    <target>.patch   a unified diff
```

Two decisions carry the design.

**A correction is a diff, not a copy.** Checking in a whole corrected file would pin every unrelated byte in it to whatever upstream happened to have that day. A diff states only the change, and it is applied strictly -- the hunk lands at the line it names with the context it names, no fuzz and no offset search.

**A correction is selected by content hash, not by model id.** A source may be a Hub repo, a snapshot directory or a local checkout; the sha256 of the file is the same in all three, and there is no id to thread through the export. It also means a correction can only ever rewrite bytes it recognises.

Together these make going stale safe. When upstream republishes the file the hash stops matching, the correction stops being applied, and nothing is corrupted. `python -m mobius.upstream_patches.check_upstream` reports that drift so it can be re-reviewed -- upstream may have fixed it, or restructured around it.

A second operation kind, `sync_chat_template`, rewrites the `chat_template` key duplicated into `tokenizer_config.json`. Packages whose two copies disagree fail in a way that depends on which loader you use. It runs only when the template it mirrors was actually corrected.

Both export paths -- `onnx_genai.inference_metadata._copy_runtime_assets` and `ort_genai.auto_export` -- apply corrections after materializing runtime assets.

## Verification

- 15 new unit tests covering the diff applier (context mismatch, multi-hunk, missing trailing newline, empty context line) and the applier (idempotence, unrelated keys surviving the JSON rewrite, a package upstream already fixed being left alone).
- Applied to a real `meta-models/Muse-Glimmer-30B` snapshot through `_copy_runtime_assets`: output is byte-identical to the template that was verified end to end through OpenCode against the INT4 CUDA export, with a read task and a multi-tool debug task (read, edit, bash, todowrite) completing with no invalid tool errors.
- `check_upstream` confirms the recorded hash still matches upstream `main`, i.e. the defect is live.
- `ruff check` and `ruff format` clean.
- 9 failures in `ort_genai/auto_export_test.py::TestWriteProcessorConfig` are pre-existing (`AutoProcessor` import), reproduced identically on a clean tree.

## Follow-up

The defect has been reported upstream. This correction should be deleted once it lands there.