### PR TITLE
Honor generation config token IDs in ORT GenAI export

### DIFF
--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -188,6 +188,19 @@ def _select_ort_model_type(
     return _resolve_ort_genai_model_type(hf_model_type or "unknown")
 
 
+def _load_generation_config(model_id: str):
+    """Load optional Hugging Face generation settings without requiring the file."""
+    import transformers
+
+    try:
+        return transformers.GenerationConfig.from_pretrained(model_id)
+    except OSError:
+        logger.debug(
+            "No generation_config.json found for %s; using model config token IDs", model_id
+        )
+        return None
+
+
 def _graph_input_names(model: ir.Model) -> list[str]:
     """Return non-KV-cache input names from an ONNX model graph.
 
@@ -1270,6 +1283,8 @@ def write_ort_genai_config(
         directory: Output directory (created if needed).
         hf_model_id: HuggingFace model ID or local model directory. When provided,
             used to fetch token IDs (``bos``/``eos``/``pad``) and copy tokenizer files.
+            Token IDs from ``generation_config.json`` take precedence over model config
+            values because generation configs may define additional stop tokens.
             When ``None``, token IDs are read from ``pkg.config`` fields
             (``bos_token_id``, ``eos_token_id``, ``pad_token_id``) populated
             by :meth:`~mobius._configs.ArchitectureConfig.from_transformers`,
@@ -1400,6 +1415,20 @@ def write_ort_genai_config(
         # "not set" sentinel (negative IDs are never valid token positions).
         _pad = getattr(config, "pad_token_id", None)
         pad_token_id = None if (_pad is None or _pad < 0) else _pad
+
+    generation_config_source = hf_model_id or local_config_dir
+    if generation_config_source and (
+        generation_config := _load_generation_config(generation_config_source)
+    ):
+        generation_bos_token_id = getattr(generation_config, "bos_token_id", None)
+        generation_eos_token_id = getattr(generation_config, "eos_token_id", None)
+        generation_pad_token_id = getattr(generation_config, "pad_token_id", None)
+        if generation_bos_token_id is not None:
+            bos_token_id = generation_bos_token_id
+        if generation_eos_token_id is not None:
+            eos_token_id = generation_eos_token_id
+        if generation_pad_token_id is not None:
+            pad_token_id = generation_pad_token_id
 
     # Phi4MM quirk: HF reports model_type='phi' but the model package
     # includes an 'audio_encoder' component that distinguishes it from plain Phi.

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -1014,6 +1014,10 @@ class TestWriteOrtGenaiConfigLocalDir:
                     pad_token_id=0,
                 ),
             ),
+            mock.patch(
+                "mobius.integrations.ort_genai.auto_export._load_generation_config",
+                return_value=None,
+            ),
         ):
             (out / "tokenizer.json").write_text("{}")  # pretend HF copy happened
             write_ort_genai_config(
@@ -1468,6 +1472,10 @@ class TestExportForOrtGenai:
                 return_value=["tokenizer.json"],
             ) as mock_copy,
             mock.patch("transformers.AutoConfig.from_pretrained") as mock_hf,
+            mock.patch(
+                "mobius.integrations.ort_genai.auto_export._load_generation_config",
+                return_value=None,
+            ),
         ):
             mock_hf.return_value = mock.MagicMock(
                 model_type="qwen2", bos_token_id=1, eos_token_id=2, pad_token_id=0
@@ -1488,6 +1496,10 @@ class TestExportForOrtGenai:
                 return_value=[],
             ),
             mock.patch("transformers.AutoConfig.from_pretrained") as mock_hf,
+            mock.patch(
+                "mobius.integrations.ort_genai.auto_export._load_generation_config",
+                return_value=None,
+            ),
         ):
             mock_hf.return_value = mock.MagicMock(
                 model_type="mage_vl", bos_token_id=1, eos_token_id=2, pad_token_id=0
@@ -1500,6 +1512,44 @@ class TestExportForOrtGenai:
             )
 
         mock_hf.assert_called_once_with("microsoft/Mage-VL", trust_remote_code=True)
+
+    def test_generation_config_multi_eos_overrides_model_config(self, tmp_path):
+        """generation_config.json stop tokens take precedence over the model config."""
+        from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
+
+        pkg = self._make_pkg()
+        hf_config = mock.MagicMock(
+            model_type="qwen3_5_moe",
+            bos_token_id=248044,
+            eos_token_id=248044,
+            pad_token_id=None,
+        )
+        generation_config = mock.MagicMock(
+            bos_token_id=248044,
+            eos_token_id=[248046, 248044],
+            pad_token_id=248044,
+        )
+        with (
+            mock.patch("transformers.AutoConfig.from_pretrained", return_value=hf_config),
+            mock.patch(
+                "mobius.integrations.ort_genai.auto_export._load_generation_config",
+                return_value=generation_config,
+            ),
+            mock.patch(
+                "mobius.integrations.ort_genai.auto_export._copy_tokenizer_files",
+                return_value=[],
+            ),
+        ):
+            result = write_ort_genai_config(
+                pkg,
+                str(tmp_path),
+                hf_model_id="Qwen/Qwen3.6-35B-A3B",
+            )
+
+        with open(result["genai_config"]) as f:
+            data = json.load(f)
+        assert data["model"]["eos_token_id"] == [248046, 248044]
+        assert data["model"]["pad_token_id"] == 248044
 
     def test_ep_default_normalizes_to_cpu(self, tmp_path):
         """ep='default' is normalized to cpu (provider_options=[])."""
@@ -2649,6 +2699,10 @@ class TestGemma4RealModel:
         )
         with (
             mock.patch("transformers.AutoConfig.from_pretrained", return_value=fake_hf),
+            mock.patch(
+                "mobius.integrations.ort_genai.auto_export._load_generation_config",
+                return_value=None,
+            ),
             mock.patch(
                 "mobius.integrations.ort_genai.auto_export._copy_tokenizer_files",
                 return_value=[],


### PR DESCRIPTION
## Summary

- load optional Hugging Face `generation_config.json` when writing ORT GenAI artifacts
- prefer generation-config BOS/EOS/PAD IDs over model-config values
- preserve multi-EOS stop tokens such as Qwen3.6's `[<|im_end|>, <|endoftext|>]`

Qwen3.6 defines scalar EOS `248044` in its text model config but `[248046, 248044]` in its generation config. Ignoring the latter causes generated ORT GenAI packages to miss `<|im_end|>` as a stopping token.

## Testing

- `python -m pytest -q src/mobius/integrations/ort_genai/auto_export_test.py` (112 passed)
- `ruff check src/mobius/integrations/ort_genai/auto_export.py src/mobius/integrations/ort_genai/auto_export_test.py`
- `ruff format --check src/mobius/integrations/ort_genai/auto_export.py src/mobius/integrations/ort_genai/auto_export_test.py`
