### PR TITLE
Restore formatting and Windows asset-patch tests

### DIFF
--- a/src/mobius/_inspect_test.py
+++ b/src/mobius/_inspect_test.py
@@ -239,7 +239,8 @@ def test_explicit_task_without_config_returns_roles_without_source_paths(monkeyp
         staticmethod(lambda *a, **k: (_ for _ in ()).throw(OSError("no config"))),
     )
     monkeypatch.setattr(
-        "mobius.integrations.transformers._config_resolver._try_load_config_json", lambda *_a, **_k: None
+        "mobius.integrations.transformers._config_resolver._try_load_config_json",
+        lambda *_a, **_k: None,
     )
 
     components = inspect_components("anything", task="vision-language")
@@ -280,7 +281,8 @@ def test_unresolvable_config_raises(monkeypatch):
         staticmethod(lambda *a, **k: (_ for _ in ()).throw(OSError("no config"))),
     )
     monkeypatch.setattr(
-        "mobius.integrations.transformers._config_resolver._try_load_config_json", lambda *_a, **_k: None
+        "mobius.integrations.transformers._config_resolver._try_load_config_json",
+        lambda *_a, **_k: None,
     )
     with pytest.raises(ValueError, match="Could not load a HuggingFace config"):
         inspect_components("fake/diffusers-pipeline")

--- a/src/mobius/upstream_patches/_patches_test.py
+++ b/src/mobius/upstream_patches/_patches_test.py
@@ -65,7 +65,7 @@ class ApplyAssetPatchesTest(unittest.TestCase):
         self.addCleanup(self._temp.cleanup)
 
     def _write_package(self, template: str = _ORIGINAL, *, tokenizer_config=True):
-        (self.package / "chat_template.jinja").write_text(template, encoding="utf-8")
+        (self.package / "chat_template.jinja").write_bytes(template.encode("utf-8"))
         if tokenizer_config:
             (self.package / "tokenizer_config.json").write_text(
                 json.dumps({"chat_template": template, "model_max_length": 4096}),


### PR DESCRIPTION
## Summary

- apply the repository Ruff formatter to two long calls added by #378
- write the asset-patch SHA fixture as exact UTF-8 bytes so Windows newline translation cannot change LF to CRLF before hashing
- restore the all-files lint job and the four asset-patch tests failing across all Windows Python versions on `main` and dependent pull requests

## Validation

- `9 passed, 1 subtests passed` — `src/mobius/upstream_patches/_patches_test.py`
- Ruff check and format passed for both changed test files
- `git diff --check`

Only test formatting/fixture construction changes; runtime behavior is unchanged.