### PR TITLE
Map Qwen3.5 VLM exports to native ORT GenAI type

### DIFF
--- a/src/mobius/_execution_providers.py
+++ b/src/mobius/_execution_providers.py
@@ -362,6 +362,7 @@ def _register_builtins() -> None:
                 {ir.DataType.FLOAT, ir.DataType.FLOAT16, ir.DataType.BFLOAT16}
             ),
             supports_skip_layer_norm=False,
+            supports_matmul_nbits=False,
             enable_graph_capture=True,
             supports_past_present_share_buffer=True,
         ),

--- a/src/mobius/functions/matmul_nbits_test.py
+++ b/src/mobius/functions/matmul_nbits_test.py
@@ -131,7 +131,7 @@ class TestMatMulNBitsInlineParity:
 
 
 class TestMatMulNBitsEpGating:
-    """A qnn build lowers MatMulNBits to QDQ; a cpu build keeps the contrib op."""
+    """EPs without native MatMulNBits support lower blockwise INT4 to QDQ."""
 
     def _build(self, ep: str):
         import dataclasses
@@ -179,5 +179,10 @@ class TestMatMulNBitsEpGating:
 
     def test_qnn_lowers_to_qdq(self):
         ops = self._build("qnn")
+        assert ops.get("MatMulNBits", 0) == 0
+        assert ops.get("DequantizeLinear", 0) > 0
+
+    def test_trt_rtx_lowers_to_qdq(self):
+        ops = self._build("trt-rtx")
         assert ops.get("MatMulNBits", 0) == 0
         assert ops.get("DequantizeLinear", 0) > 0

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -95,8 +95,16 @@ _ORT_GENAI_MODEL_TYPE: dict[str, str] = {
     "qwen2_vl": "qwen2_5_vl",
     "qwen3_vl": "qwen3_vl",
     "qwen3_vl_text": "qwen3_vl",
-    "qwen3_5": "qwen2_5_vl",
-    "qwen3_5_vl": "qwen2_5_vl",
+    # Qwen3.5 / Qwen3.6 use the Qwen-VL auxiliary vision+embedding pipeline
+    # but a hybrid DeltaNet/full-attention decoder, so they must select the
+    # native ORT GenAI qwen3_5 model type rather than the Qwen2.5-VL decoder.
+    "qwen3_5": "qwen3_5",
+    "qwen3_5_text": "qwen3_5",
+    "qwen3_5_vl": "qwen3_5",
+    "qwen3_5_vl_text": "qwen3_5",
+    "qwen3_5_moe": "qwen3_5",
+    "qwen3_5_moe_text": "qwen3_5",
+    "qwen3_5_moe_vl": "qwen3_5",
     # MiniCPM uses standard 1D decoder position IDs (unlike Qwen-VL MRoPE).
     # The phi3v multimodal runtime provides that contract; callers supply
     # HF-preprocessed packed pixels through Generator.set_inputs().
@@ -1219,7 +1227,17 @@ def _write_genai_config(
                     if model_type == "mage_vl"
                     else "processor_config.json"
                 )
-                if model_type in {"mage_vl", "qwen3_vl", "qwen3_vl_text"}:
+                if model_type in {
+                    "mage_vl",
+                    "qwen3_vl",
+                    "qwen3_vl_text",
+                    "qwen3_5",
+                    "qwen3_5_vl",
+                    "qwen3_5_vl_text",
+                    "qwen3_5_moe",
+                    "qwen3_5_moe_text",
+                    "qwen3_5_moe_vl",
+                }:
                     patch_size = getattr(vision_cfg, "patch_size", None)
                     window_size = getattr(vision_cfg, "window_size", None)
                     if patch_size is not None:

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -149,11 +149,33 @@ _QWEN_VL_MODEL_TYPES = frozenset(
         "qwen3_vl_text",
         "qwen3_5",
         "qwen3_5_vl",
+        "qwen3_5_vl_text",
         "qwen3_5_moe",
+        "qwen3_5_moe_vl",
         "qwen3_5_moe_text",
         "videochat_flash_qwen",
     }
 )
+_QWEN35_VL_MODEL_TYPES = frozenset(
+    {
+        "qwen3_5",
+        "qwen3_5_vl",
+        "qwen3_5_vl_text",
+        "qwen3_5_moe",
+        "qwen3_5_moe_text",
+        "qwen3_5_moe_vl",
+    }
+)
+_QWEN35_TRT_RTX_EMBEDDING_PROVIDER_OPTIONS = {
+    "nv_profile_min_shapes": "input_ids:1x1,image_features:0x1024",
+    "nv_profile_opt_shapes": "input_ids:1x226,image_features:192x1024",
+    "nv_profile_max_shapes": "input_ids:1x1024,image_features:2520x1024",
+}
+_QWEN35_TRT_RTX_VISION_PROVIDER_OPTIONS = {
+    "nv_profile_min_shapes": "pixel_values:600x1536",
+    "nv_profile_opt_shapes": "pixel_values:600x1536",
+    "nv_profile_max_shapes": "pixel_values:600x1536",
+}
 
 _TOKENIZER_FILES = [
     "tokenizer.json",
@@ -1227,17 +1249,10 @@ def _write_genai_config(
                     if model_type == "mage_vl"
                     else "processor_config.json"
                 )
-                if model_type in {
-                    "mage_vl",
-                    "qwen3_vl",
-                    "qwen3_vl_text",
-                    "qwen3_5",
-                    "qwen3_5_vl",
-                    "qwen3_5_vl_text",
-                    "qwen3_5_moe",
-                    "qwen3_5_moe_text",
-                    "qwen3_5_moe_vl",
-                }:
+                if (
+                    model_type in {"mage_vl", "qwen3_vl", "qwen3_vl_text"}
+                    or model_type in _QWEN35_VL_MODEL_TYPES
+                ):
                     patch_size = getattr(vision_cfg, "patch_size", None)
                     window_size = getattr(vision_cfg, "window_size", None)
                     if patch_size is not None:
@@ -1246,6 +1261,13 @@ def _write_genai_config(
                         vision_kwargs["window_size"] = window_size
                     vision_kwargs["tokens_per_second"] = float(
                         getattr(config, "tokens_per_second", 2.0)
+                    )
+                if ep == "trt-rtx" and model_type in _QWEN35_VL_MODEL_TYPES:
+                    vision_kwargs["embedding_provider_options"] = (
+                        _QWEN35_TRT_RTX_EMBEDDING_PROVIDER_OPTIONS
+                    )
+                    vision_kwargs["vision_provider_options"] = (
+                        _QWEN35_TRT_RTX_VISION_PROVIDER_OPTIONS
                     )
 
             if vision_input_mapping is not None:

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -1276,33 +1276,60 @@ class TestExportForOrtGenai:
         assert model["vision"]["patch_size"] == 16
         assert model["vision"]["window_size"] == 112
         assert model["vision"]["tokens_per_second"] == pytest.approx(2.0)
-        assert model["decoder"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
-            "enable_cuda_graph"
-        ] == "1"
-        assert model["vision"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
-            "enable_cuda_graph"
-        ] == "0"
-        assert model["embedding"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
-            "enable_cuda_graph"
-        ] == "0"
-        assert model["embedding"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
-            "nv_profile_min_shapes"
-        ] == "input_ids:1x1,image_features:0x1024"
-        assert model["embedding"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
-            "nv_profile_opt_shapes"
-        ] == "input_ids:1x226,image_features:192x1024"
-        assert model["embedding"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
-            "nv_profile_max_shapes"
-        ] == "input_ids:1x1024,image_features:2520x1024"
-        assert model["vision"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
-            "nv_profile_min_shapes"
-        ] == "pixel_values:600x1536"
-        assert model["vision"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
-            "nv_profile_opt_shapes"
-        ] == "pixel_values:600x1536"
-        assert model["vision"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
-            "nv_profile_max_shapes"
-        ] == "pixel_values:600x1536"
+        assert (
+            model["decoder"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
+                "enable_cuda_graph"
+            ]
+            == "1"
+        )
+        assert (
+            model["vision"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
+                "enable_cuda_graph"
+            ]
+            == "0"
+        )
+        assert (
+            model["embedding"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
+                "enable_cuda_graph"
+            ]
+            == "0"
+        )
+        assert (
+            model["embedding"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
+                "nv_profile_min_shapes"
+            ]
+            == "input_ids:1x1,image_features:0x1024"
+        )
+        assert (
+            model["embedding"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
+                "nv_profile_opt_shapes"
+            ]
+            == "input_ids:1x226,image_features:192x1024"
+        )
+        assert (
+            model["embedding"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
+                "nv_profile_max_shapes"
+            ]
+            == "input_ids:1x1024,image_features:2520x1024"
+        )
+        assert (
+            model["vision"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
+                "nv_profile_min_shapes"
+            ]
+            == "pixel_values:600x1536"
+        )
+        assert (
+            model["vision"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
+                "nv_profile_opt_shapes"
+            ]
+            == "pixel_values:600x1536"
+        )
+        assert (
+            model["vision"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
+                "nv_profile_max_shapes"
+            ]
+            == "pixel_values:600x1536"
+        )
 
     def test_qwen36_vl_hf_parent_type_maps_to_qwen35_runtime(self, tmp_path):
         import dataclasses
@@ -1360,6 +1387,7 @@ class TestExportForOrtGenai:
                 "mobius.integrations.ort_genai.auto_export._copy_tokenizer_files",
                 return_value=[],
             ),
+            mock.patch("transformers.AutoProcessor.from_pretrained", side_effect=OSError),
         ):
             result = write_ort_genai_config(
                 pkg,

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -1226,6 +1226,134 @@ class TestExportForOrtGenai:
         assert model["vision"]["patch_size"] == 16
         assert model["vision"]["window_size"] == 64
 
+    def test_qwen35_vl_uses_native_qwen35_runtime_type(self, tmp_path):
+        import dataclasses
+
+        from mobius._model_package import ModelPackage
+        from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
+
+        @dataclasses.dataclass
+        class FakeVision:
+            image_size: int = 448
+            patch_size: int = 16
+            spatial_merge_size: int = 2
+            window_size: int = 112
+
+        @dataclasses.dataclass
+        class FakeConfig:
+            model_type: str = "qwen3_5_vl"
+            vocab_size: int = 248064
+            hidden_size: int = 2048
+            num_hidden_layers: int = 2
+            num_attention_heads: int = 16
+            num_key_value_heads: int = 8
+            head_dim: int = 128
+            image_token_id: int = 248056
+            vision_start_token_id: int = 248053
+            video_token_id: int = 248057
+            tokens_per_second: float = 2.0
+            temporal_patch_size: int = 2
+            vision: FakeVision = dataclasses.field(default_factory=FakeVision)
+
+        pkg = ModelPackage(
+            {
+                "decoder": _mock_model(),
+                "vision_encoder": _mock_model(),
+                "embedding": _mock_model(),
+            },
+            config=FakeConfig(),
+        )
+
+        result = write_ort_genai_config(pkg, str(tmp_path), ep="trt-rtx")
+
+        with open(result["genai_config"]) as f:
+            data = json.load(f)
+        model = data["model"]
+        assert model["type"] == "qwen3_5"
+        assert model["image_token_id"] == 248056
+        assert model["vision_start_token_id"] == 248053
+        assert model["video_token_id"] == 248057
+        assert model["vision"]["patch_size"] == 16
+        assert model["vision"]["window_size"] == 112
+        assert model["vision"]["tokens_per_second"] == pytest.approx(2.0)
+        assert model["decoder"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
+            "enable_cuda_graph"
+        ] == "1"
+        assert model["vision"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
+            "enable_cuda_graph"
+        ] == "0"
+        assert model["embedding"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
+            "enable_cuda_graph"
+        ] == "0"
+
+    def test_qwen36_vl_hf_parent_type_maps_to_qwen35_runtime(self, tmp_path):
+        import dataclasses
+
+        from mobius._model_package import ModelPackage
+        from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
+
+        @dataclasses.dataclass
+        class FakeVision:
+            image_size: int = 448
+            patch_size: int = 16
+            spatial_merge_size: int = 2
+
+        @dataclasses.dataclass
+        class FakeConfig:
+            # build_transformers_model unwraps Qwen3.6 VL to the text sub-config,
+            # but write_ort_genai_config must preserve the multimodal HF parent
+            # type and map it to ORT GenAI's native qwen3_5 runtime.
+            model_type: str = "qwen3_5_moe_text"
+            vocab_size: int = 248064
+            hidden_size: int = 2048
+            num_hidden_layers: int = 2
+            num_attention_heads: int = 16
+            num_key_value_heads: int = 8
+            head_dim: int = 128
+            image_token_id: int = 248056
+            vision_start_token_id: int = 248053
+            video_token_id: int = 248057
+            tokens_per_second: float = 2.0
+            temporal_patch_size: int = 2
+            vision: FakeVision = dataclasses.field(default_factory=FakeVision)
+
+        pkg = ModelPackage(
+            {
+                "decoder": _mock_model(),
+                "vision_encoder": _mock_model(),
+                "embedding": _mock_model(),
+            },
+            config=FakeConfig(),
+        )
+
+        hf_config = mock.MagicMock(
+            model_type="qwen3_5_moe",
+            bos_token_id=248044,
+            eos_token_id=248044,
+            pad_token_id=248044,
+        )
+        with (
+            mock.patch("transformers.AutoConfig.from_pretrained", return_value=hf_config),
+            mock.patch(
+                "mobius.integrations.ort_genai.auto_export._load_generation_config",
+                return_value=None,
+            ),
+            mock.patch(
+                "mobius.integrations.ort_genai.auto_export._copy_tokenizer_files",
+                return_value=[],
+            ),
+        ):
+            result = write_ort_genai_config(
+                pkg,
+                str(tmp_path),
+                hf_model_id="Qwen/Qwen3.6-35B-A3B",
+            )
+
+        with open(result["genai_config"]) as f:
+            data = json.load(f)
+        assert data["model"]["type"] == "qwen3_5"
+        assert data["model"]["vision"]["patch_size"] == 16
+
     def test_mage_vl_is_rejected_before_writing_runtime_artifacts(self, tmp_path):
         import dataclasses
 

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -1285,6 +1285,24 @@ class TestExportForOrtGenai:
         assert model["embedding"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
             "enable_cuda_graph"
         ] == "0"
+        assert model["embedding"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
+            "nv_profile_min_shapes"
+        ] == "input_ids:1x1,image_features:0x1024"
+        assert model["embedding"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
+            "nv_profile_opt_shapes"
+        ] == "input_ids:1x226,image_features:192x1024"
+        assert model["embedding"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
+            "nv_profile_max_shapes"
+        ] == "input_ids:1x1024,image_features:2520x1024"
+        assert model["vision"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
+            "nv_profile_min_shapes"
+        ] == "pixel_values:600x1536"
+        assert model["vision"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
+            "nv_profile_opt_shapes"
+        ] == "pixel_values:600x1536"
+        assert model["vision"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
+            "nv_profile_max_shapes"
+        ] == "pixel_values:600x1536"
 
     def test_qwen36_vl_hf_parent_type_maps_to_qwen35_runtime(self, tmp_path):
         import dataclasses

--- a/src/mobius/integrations/ort_genai/genai_config.py
+++ b/src/mobius/integrations/ort_genai/genai_config.py
@@ -108,6 +108,7 @@ def _make_session_options(
     ep: str,
     *,
     enable_graph_capture: bool | None = None,
+    provider_options: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Return session options with EP-specific provider_options.
 
@@ -117,12 +118,16 @@ def _make_session_options(
     """
     from mobius.integrations.ort_genai.ep_config import make_provider_options
 
+    options = make_provider_options(
+        ep,
+        enable_graph_capture=enable_graph_capture,
+    )
+    if provider_options and options:
+        next(iter(options[0].values())).update(provider_options)
+
     return {
         "log_id": "onnxruntime-genai",
-        "provider_options": make_provider_options(
-            ep,
-            enable_graph_capture=enable_graph_capture,
-        ),
+        "provider_options": options,
     }
 
 
@@ -305,6 +310,8 @@ class GenaiConfigGenerator:
         tokens_per_second: float | None = None,
         patch_size: int | None = None,
         window_size: int | None = None,
+        vision_provider_options: dict[str, str] | None = None,
+        embedding_provider_options: dict[str, str] | None = None,
     ) -> GenaiConfigGenerator:
         """Add VLM vision + embedding sections.
 
@@ -358,6 +365,7 @@ class GenaiConfigGenerator:
             "session_options": _make_session_options(
                 self.ep,
                 enable_graph_capture=False,
+                provider_options=vision_provider_options,
             ),
         }
         if spatial_merge_size is not None:
@@ -380,6 +388,7 @@ class GenaiConfigGenerator:
             "session_options": _make_session_options(
                 self.ep,
                 enable_graph_capture=False,
+                provider_options=embedding_provider_options,
             ),
         }
         self._vlm_token_ids["image_token_id"] = image_token_id

--- a/src/mobius/integrations/ort_genai/genai_config.py
+++ b/src/mobius/integrations/ort_genai/genai_config.py
@@ -404,6 +404,7 @@ class GenaiConfigGenerator:
         filename: str = "embedding/model.onnx",
         input_names: dict[str, str] | None = None,
         output_names: dict[str, str] | None = None,
+        provider_options: dict[str, str] | None = None,
     ) -> GenaiConfigGenerator:
         """Add a standalone multimodal embedding stage."""
         self._embedding = {
@@ -420,6 +421,7 @@ class GenaiConfigGenerator:
             "session_options": _make_session_options(
                 self.ep,
                 enable_graph_capture=False,
+                provider_options=provider_options,
             ),
         }
         return self

--- a/src/mobius/integrations/ort_genai/genai_config.py
+++ b/src/mobius/integrations/ort_genai/genai_config.py
@@ -339,6 +339,10 @@ class GenaiConfigGenerator:
             tokens_per_second: Video/image timestamp rate for Qwen3-VL.
             patch_size: Vision patch size.
             window_size: Vision window size.
+            vision_provider_options: Provider option overrides merged into
+                the EP defaults for the vision encoder session.
+            embedding_provider_options: Provider option overrides merged into
+                the EP defaults for the embedding session.
 
         Returns self for chaining.
         """
@@ -406,7 +410,19 @@ class GenaiConfigGenerator:
         output_names: dict[str, str] | None = None,
         provider_options: dict[str, str] | None = None,
     ) -> GenaiConfigGenerator:
-        """Add a standalone multimodal embedding stage."""
+        """Add a standalone multimodal embedding stage.
+
+        Args:
+            filename: Embedding ONNX model filename.
+            input_names: Override embedding model input name mapping.
+                Defaults to input_ids + audio_features.
+            output_names: Override embedding model output name mapping.
+                Defaults to inputs_embeds.
+            provider_options: Provider option overrides merged into the EP
+                defaults for the embedding session.
+
+        Returns self for chaining.
+        """
         self._embedding = {
             "filename": filename,
             "inputs": input_names

--- a/src/mobius/integrations/ort_genai/genai_config_test.py
+++ b/src/mobius/integrations/ort_genai/genai_config_test.py
@@ -670,6 +670,35 @@ def test_cuda_decoder_graph_capture_can_be_disabled():
     assert decoder_options[0]["cuda"]["enable_cuda_graph"] == "0"
 
 
+def test_embedding_session_options_can_be_updated():
+    gen = GenaiConfigGenerator(
+        "gemma4",
+        vocab_size=262144,
+        hidden_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        ep="trt-rtx",
+    ).with_embedding(
+        provider_options={
+            "nv_profile_min_shapes": "input_ids:1x1,image_features:0x1024",
+            "nv_profile_opt_shapes": "input_ids:1x226,image_features:192x1024",
+        },
+    )
+
+    embedding_options = gen.generate()["model"]["embedding"]["session_options"][
+        "provider_options"
+    ][0]["NvTensorRtRtx"]
+    assert embedding_options["enable_cuda_graph"] == "0"
+    assert embedding_options["nv_profile_min_shapes"] == (
+        "input_ids:1x1,image_features:0x1024"
+    )
+    assert embedding_options["nv_profile_opt_shapes"] == (
+        "input_ids:1x226,image_features:192x1024"
+    )
+
+
 class TestGenaiConfigWrite:
     """Test writing genai_config.json to disk."""
 

--- a/src/mobius/integrations/ort_genai/genai_config_test.py
+++ b/src/mobius/integrations/ort_genai/genai_config_test.py
@@ -681,15 +681,21 @@ def test_embedding_session_options_can_be_updated():
         head_dim=16,
         ep="trt-rtx",
     ).with_embedding(
+        input_names={"input_ids": "input_ids", "image_features": "image_features"},
         provider_options={
             "nv_profile_min_shapes": "input_ids:1x1,image_features:0x1024",
             "nv_profile_opt_shapes": "input_ids:1x226,image_features:192x1024",
         },
     )
 
-    embedding_options = gen.generate()["model"]["embedding"]["session_options"][
-        "provider_options"
-    ][0]["NvTensorRtRtx"]
+    embedding_config = gen.generate()["model"]["embedding"]
+    embedding_options = embedding_config["session_options"]["provider_options"][0][
+        "NvTensorRtRtx"
+    ]
+    assert embedding_config["inputs"] == {
+        "input_ids": "input_ids",
+        "image_features": "image_features",
+    }
     assert embedding_options["enable_cuda_graph"] == "0"
     assert embedding_options["nv_profile_min_shapes"] == (
         "input_ids:1x1,image_features:0x1024"


### PR DESCRIPTION
## Summary
- Map Qwen3.5/Qwen3.6 VLM ORT GenAI exports to the native `qwen3_5` runtime type instead of the Qwen2.5-VL alias
- Include Qwen-specific vision metadata (`patch_size`, `window_size`, `tokens_per_second`) for Qwen3.5/Qwen3.6 VLM configs
- Add Qwen3.5/Qwen3.6 VLM TRT-RTX auxiliary component provider profiles for `embedding` and `vision`, with graph capture disabled on those component sessions
- Allow standalone embedding session provider options to be updated independently through `with_embedding()`
- Keep TRT-RTX INT4 exports on QDQ format by lowering `MatMulNBits` for the TRT-RTX EP
- Add regression coverage for dense Qwen3.5 VLM TRT-RTX component settings, Qwen3.6 MoE-VL parent-type mapping, standalone embedding provider overrides, and TRT-RTX MatMulNBits lowering

## Test
- `python -m pytest src\mobius\integrations\ort_genai\auto_export_test.py -q -k "qwen35_vl or qwen36_vl or qwen3_vl_writes" --tb=short`
- `python -m pytest src\mobius\functions\matmul_nbits_test.py -q -k "EpGating" --tb=short`
- `python -m pytest src\mobius\integrations\ort_genai\genai_config_test.py -q -k "embedding_session_options_can_be_updated or cuda_enables_decoder_graph_capture_only" --tb=short`
- `python -m pytest src\mobius\integrations\ort_genai\auto_export_test.py src\mobius\functions\matmul_nbits_test.py -q -k "qwen35_vl or qwen36_vl or qwen3_vl_writes or EpGating" --tb=short`