### PR TITLE
Support legacy PyTorch-only Hugging Face checkpoints

### DIFF
--- a/src/mobius/integrations/_weight_loading.py
+++ b/src/mobius/integrations/_weight_loading.py
@@ -250,9 +250,7 @@ def _local_weight_paths(model_dir: pathlib.Path) -> tuple[list[str], str] | None
         try:
             path.relative_to(root)
         except ValueError as exc:
-            raise ValueError(
-                f"Unsafe weight filename in weight index: {filename!r}"
-            ) from exc
+            raise ValueError(f"Unsafe weight filename in weight index: {filename!r}") from exc
         if not path.is_file():
             raise FileNotFoundError(f"Weight file referenced by index not found: {path}")
         paths.append(str(path))

--- a/src/mobius/integrations/_weight_loading.py
+++ b/src/mobius/integrations/_weight_loading.py
@@ -1,16 +1,15 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# SECURITY: Do NOT use torch.load() or pickle deserialization anywhere in this
-# module.  Only safetensors is permitted for weight loading to prevent arbitrary
-# code execution from untrusted weight files.
+# SECURITY: Prefer safetensors. Legacy PyTorch checkpoints are loaded only with
+# ``weights_only=True``, which rejects arbitrary Python objects.
 
 """Weight loading and application for ONNX models.
 
 This module handles downloading model weights from HuggingFace Hub and
-applying them to ONNX IR models. All weight loading uses the safetensors
-format exclusively — no ``torch.load`` or pickle deserialization is used,
-eliminating arbitrary code execution risks from untrusted weight files.
+applying them to ONNX IR models. Safetensors is preferred. Legacy HuggingFace
+checkpoints that only publish ``pytorch_model.bin`` are loaded with
+``torch.load(weights_only=True)`` so arbitrary Python objects are rejected.
 """
 
 from __future__ import annotations
@@ -38,6 +37,8 @@ logger = logging.getLogger(__name__)
 
 _WEIGHT_INDEX_NAME = "model.safetensors.index.json"
 _SINGLE_WEIGHT_NAME = "model.safetensors"
+_PYTORCH_WEIGHT_INDEX_NAME = "pytorch_model.bin.index.json"
+_SINGLE_PYTORCH_WEIGHT_NAME = "pytorch_model.bin"
 
 
 def _assign_weight(
@@ -197,7 +198,7 @@ def _parallel_download(
 
 
 def _validate_weight_filenames(filenames: list[str]) -> list[str]:
-    """Validate safetensors filenames from a weight index.
+    """Validate filenames from a weight index.
 
     The HuggingFace index is model data, so reject absolute paths and path traversal
     before using entries as local filesystem paths or Hub filenames.
@@ -207,7 +208,7 @@ def _validate_weight_filenames(filenames: list[str]) -> list[str]:
         normalized = filename.replace("\\", "/")
         path = pathlib.PurePosixPath(normalized)
         if path.is_absolute() or ".." in path.parts:
-            raise ValueError(f"Unsafe weight filename in safetensors index: {filename!r}")
+            raise ValueError(f"Unsafe weight filename in weight index: {filename!r}")
         validated.append(normalized)
     return validated
 
@@ -218,20 +219,28 @@ def _weight_filenames_from_index(index_path: pathlib.Path) -> list[str]:
     return _validate_weight_filenames(sorted(set(index["weight_map"].values())))
 
 
-def _local_weight_paths(model_dir: pathlib.Path) -> list[str] | None:
-    """Return local safetensors paths for a HuggingFace checkpoint directory."""
+def _local_weight_paths(model_dir: pathlib.Path) -> tuple[list[str], str] | None:
+    """Return local weight paths and format for a HuggingFace checkpoint directory."""
     if not model_dir.is_dir():
         return None
 
     index_path = model_dir / _WEIGHT_INDEX_NAME
     if index_path.is_file():
         filenames = _weight_filenames_from_index(index_path)
+        weight_format = "safetensors"
     elif (model_dir / _SINGLE_WEIGHT_NAME).is_file():
         filenames = [_SINGLE_WEIGHT_NAME]
+        weight_format = "safetensors"
+    elif (model_dir / _PYTORCH_WEIGHT_INDEX_NAME).is_file():
+        filenames = _weight_filenames_from_index(model_dir / _PYTORCH_WEIGHT_INDEX_NAME)
+        weight_format = "pytorch"
+    elif (model_dir / _SINGLE_PYTORCH_WEIGHT_NAME).is_file():
+        filenames = [_SINGLE_PYTORCH_WEIGHT_NAME]
+        weight_format = "pytorch"
     else:
         raise FileNotFoundError(
             f"Local checkpoint directory has no '{_WEIGHT_INDEX_NAME}' or "
-            f"'{_SINGLE_WEIGHT_NAME}': {model_dir}"
+            f"'{_SINGLE_WEIGHT_NAME}', nor legacy PyTorch weights: {model_dir}"
         )
 
     root = model_dir.resolve()
@@ -242,14 +251,12 @@ def _local_weight_paths(model_dir: pathlib.Path) -> list[str] | None:
             path.relative_to(root)
         except ValueError as exc:
             raise ValueError(
-                f"Unsafe weight filename in safetensors index: {filename!r}"
+                f"Unsafe weight filename in weight index: {filename!r}"
             ) from exc
         if not path.is_file():
-            raise FileNotFoundError(
-                f"Weight file referenced by safetensors index not found: {path}"
-            )
+            raise FileNotFoundError(f"Weight file referenced by index not found: {path}")
         paths.append(str(path))
-    return paths
+    return paths, weight_format
 
 
 def _dequantize_fp8_weights(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
@@ -307,31 +314,64 @@ def _dequantize_fp8_weights(state_dict: dict[str, torch.Tensor]) -> dict[str, to
 def _download_weights(model_id: str, revision: str | None = None) -> dict[str, torch.Tensor]:
     """Download weights from HuggingFace and return as a state dict.
 
-    Uses local safetensors files when *model_id* is a directory, otherwise
-    downloads from HuggingFace Hub. Uses parallel downloads when multiple
-    safetensors shards exist.
+    Prefers safetensors and falls back to legacy PyTorch state dictionaries
+    loaded with ``weights_only=True``. Uses parallel downloads for shards.
     """
-    paths = _local_weight_paths(pathlib.Path(model_id))
-    if paths is None:
+    local_weights = _local_weight_paths(pathlib.Path(model_id))
+    if local_weights is None:
         try:
             kwargs = {"repo_id": model_id, "filename": _WEIGHT_INDEX_NAME}
             if revision is not None:
                 kwargs["revision"] = revision
             index_path = pathlib.Path(hf_hub_download(**kwargs))
             all_files = _weight_filenames_from_index(index_path)
+            weight_format = "safetensors"
         except EntryNotFoundError:
-            all_files = [_SINGLE_WEIGHT_NAME]
-
-        paths = _parallel_download(
-            model_id,
-            all_files,
-            revision=revision,
-            desc="safetensors",
-        )
+            try:
+                kwargs = {"repo_id": model_id, "filename": _SINGLE_WEIGHT_NAME}
+                if revision is not None:
+                    kwargs["revision"] = revision
+                paths = [hf_hub_download(**kwargs)]
+                weight_format = "safetensors"
+            except EntryNotFoundError:
+                try:
+                    kwargs = {"repo_id": model_id, "filename": _PYTORCH_WEIGHT_INDEX_NAME}
+                    if revision is not None:
+                        kwargs["revision"] = revision
+                    index_path = pathlib.Path(hf_hub_download(**kwargs))
+                    all_files = _weight_filenames_from_index(index_path)
+                    weight_format = "pytorch"
+                except EntryNotFoundError:
+                    all_files = [_SINGLE_PYTORCH_WEIGHT_NAME]
+                    weight_format = "pytorch"
+                paths = _parallel_download(
+                    model_id,
+                    all_files,
+                    revision=revision,
+                    desc=weight_format,
+                )
+        else:
+            paths = _parallel_download(
+                model_id,
+                all_files,
+                revision=revision,
+                desc=weight_format,
+            )
+    else:
+        paths, weight_format = local_weights
 
     state_dict: dict[str, torch.Tensor] = {}
     for path in tqdm.tqdm(paths, desc="Loading weights"):
-        state_dict.update(safetensors.torch.load_file(path))
+        if weight_format == "safetensors":
+            state_dict.update(safetensors.torch.load_file(path))
+        else:
+            shard = torch.load(path, map_location="cpu", weights_only=True)
+            if not isinstance(shard, dict) or not all(
+                isinstance(name, str) and isinstance(value, torch.Tensor)
+                for name, value in shard.items()
+            ):
+                raise TypeError(f"Legacy weight file is not a tensor state dict: {path}")
+            state_dict.update(shard)
 
     state_dict = _dequantize_fp8_weights(state_dict)
     return state_dict

--- a/src/mobius/integrations/_weight_loading_test.py
+++ b/src/mobius/integrations/_weight_loading_test.py
@@ -5,8 +5,8 @@
 
 These tests guard against regressions in the security posture of weight
 loading code. They verify:
-1. Safetensors is preferred over pickle-based formats.
-2. No unguarded ``torch.load`` calls exist in the source.
+1. Safetensors is preferred over legacy PyTorch formats.
+2. Legacy ``torch.load`` calls always use ``weights_only=True``.
 3. Path traversal attacks are blocked in weight file paths.
 4. Temporary files are cleaned up after weight operations.
 5. Corrupted / truncated weight files are handled gracefully.
@@ -28,6 +28,7 @@ import onnx_ir as ir
 import pytest
 import safetensors.torch
 import torch
+from huggingface_hub.utils import EntryNotFoundError
 
 from mobius._builder import build_from_module
 from mobius._model_package import ModelPackage
@@ -77,7 +78,7 @@ def _build_model_with_weights() -> tuple[ir.Model, list[str]]:
 
 
 class TestSafetensorsPreference:
-    """Verify that the codebase only uses safetensors — never pickle."""
+    """Verify that safetensors is preferred and legacy loading is guarded."""
 
     @pytest.mark.parametrize("weight_file", _WEIGHT_FILES, ids=lambda p: p.name)
     def test_no_pickle_import(self, weight_file):
@@ -98,8 +99,8 @@ class TestSafetensorsPreference:
         assert not violations, f"Forbidden pickle imports in {weight_file.name}: {violations}"
 
     @pytest.mark.parametrize("weight_file", _WEIGHT_FILES, ids=lambda p: p.name)
-    def test_no_torch_load(self, weight_file):
-        """Weight loading files must not call torch.load (pickle-based)."""
+    def test_no_unguarded_torch_load(self, weight_file):
+        """Weight loading files must guard torch.load with weights_only=True."""
         if not weight_file.exists():
             pytest.skip(f"{weight_file.name} does not exist yet")
         source = weight_file.read_text(encoding="utf-8")
@@ -113,23 +114,27 @@ class TestSafetensorsPreference:
                     and isinstance(func.value, ast.Name)
                     and func.value.id == "torch"
                 ):
-                    pytest.fail(f"torch.load found in {weight_file.name}:{node.lineno}")
+                    assert any(
+                        kw.arg == "weights_only"
+                        and isinstance(kw.value, ast.Constant)
+                        and kw.value.value is True
+                        for kw in node.keywords
+                    ), f"unguarded torch.load found in {weight_file.name}:{node.lineno}"
 
-    def test_safetensors_is_the_only_format_used(self):
-        """Weight files referenced in weight loading code are .safetensors only."""
+    def test_safetensors_remains_preferred(self):
+        """Safetensors lookup must occur before legacy PyTorch lookup."""
         for weight_file in _WEIGHT_FILES:
             if not weight_file.exists():
                 continue
             source = weight_file.read_text(encoding="utf-8")
             assert "safetensors" in source, f"No safetensors usage in {weight_file.name}"
-            for dangerous_ext in [".bin", ".pkl", ".pickle", ".pt", ".pth"]:
-                assert dangerous_ext not in source, (
-                    f"Found reference to unsafe format '{dangerous_ext}' in {weight_file.name}"
-                )
+            assert source.index("_SINGLE_WEIGHT_NAME") < source.index(
+                "_SINGLE_PYTORCH_WEIGHT_NAME"
+            )
 
-    def test_safetensors_load_file_is_only_weight_loader(self):
-        """safetensors.torch.load_file must be the only weight deserialization call."""
-        forbidden_loaders = {"load", "load_state_dict", "unpickle"}
+    def test_no_other_weight_deserializers(self):
+        """Only safetensors.load_file and guarded torch.load may deserialize weights."""
+        forbidden_loaders = {"load_state_dict", "unpickle"}
         for weight_file in _WEIGHT_FILES:
             if not weight_file.exists():
                 continue
@@ -193,6 +198,21 @@ class TestLocalSafetensorsLoading:
         assert torch.equal(state_dict["a.weight"], shard_a["a.weight"])
         assert torch.equal(state_dict["b.weight"], shard_b["b.weight"])
 
+    def test_local_legacy_pytorch_state_dict_loaded_without_hub(self, tmp_path, monkeypatch):
+        data = {"weight": torch.ones(2, 3)}
+        torch.save(data, tmp_path / "pytorch_model.bin")
+
+        def _unexpected_hub_call(*_args, **_kwargs):
+            raise AssertionError("local checkpoint should not call hf_hub_download")
+
+        monkeypatch.setattr(
+            "mobius.integrations._weight_loading.hf_hub_download", _unexpected_hub_call
+        )
+
+        state_dict = _download_weights(str(tmp_path))
+
+        assert torch.equal(state_dict["weight"], data["weight"])
+
     def test_local_directory_without_safetensors_raises_without_hub(
         self, tmp_path, monkeypatch
     ):
@@ -217,6 +237,32 @@ class TestLocalSafetensorsLoading:
 
         with pytest.raises(ValueError, match="Unsafe weight filename"):
             _download_weights(str(tmp_path))
+
+
+def test_hub_legacy_pytorch_fallback_preserves_revision(tmp_path, monkeypatch):
+    """A Hub repo with no safetensors falls back to pinned PyTorch weights."""
+    weight_path = tmp_path / "pytorch_model.bin"
+    expected = {"weight": torch.arange(6).reshape(2, 3)}
+    torch.save(expected, weight_path)
+    calls = []
+
+    def _download(*, repo_id, filename, revision=None):
+        calls.append((repo_id, filename, revision))
+        if filename == "pytorch_model.bin":
+            return str(weight_path)
+        raise EntryNotFoundError(filename)
+
+    monkeypatch.setattr("mobius.integrations._weight_loading.hf_hub_download", _download)
+
+    state_dict = _download_weights("legacy/model", revision="immutable-sha")
+
+    assert torch.equal(state_dict["weight"], expected["weight"])
+    assert calls == [
+        ("legacy/model", "model.safetensors.index.json", "immutable-sha"),
+        ("legacy/model", "model.safetensors", "immutable-sha"),
+        ("legacy/model", "pytorch_model.bin.index.json", "immutable-sha"),
+        ("legacy/model", "pytorch_model.bin", "immutable-sha"),
+    ]
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- keep safetensors as the preferred Hugging Face weight format
- fall back to `pytorch_model.bin` / sharded PyTorch indexes when a pinned repository publishes no safetensors
- call `torch.load(..., weights_only=True)` and reject any non-tensor state-dict values
- preserve immutable `revision` on every fallback lookup and keep path-traversal validation for indexed shards
- support local legacy checkpoint directories with the same safety checks

## Motivation

`Rostlab/prot_bert` at immutable revision `7a894481acdc12202f0a415dd567f6cfdb698908` is a supported BERT architecture but only publishes `pytorch_model.bin`. Mobius previously attempted `model.safetensors` and failed with a 404, preventing a real-weight ONNX export.

## Validation

- targeted tests: **57 passed**
- exported real pinned ProtBert weights to external-data ONNX
- graph contains 30 ONNX `Attention` nodes and 1,675,558,912 bytes of external weights
- ONNX Runtime 1.29.0 CPU load succeeded
- real protein probe: shape `[1, 39, 1024]`, CLS norm `6.334549427032471`, all finite
- security tests require literal `weights_only=True`
- fallback test verifies immutable revision propagation for every Hub lookup

The private distribution package also contains canonical hashless inference metadata, tokenizer assets, request/output evidence, graph report, timings, and per-file provenance hashes.
