### PR TITLE
Support compact SD and complete video diffusion workflows

### DIFF
--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -205,6 +205,9 @@ def _cmd_build(args: argparse.Namespace) -> None:
         raise SystemExit("Error: --max-length can only be used with --runtime onnx-genai.")
     if max_length is not None and max_length <= 0:
         raise SystemExit("Error: --max-length must be a positive integer.")
+    guidance_scale = getattr(args, "guidance_scale", None)
+    if guidance_scale is not None and args.runtime != "onnx-genai":
+        raise SystemExit("Error: --guidance-scale can only be used with --runtime onnx-genai.")
 
     # Validate static-cache + --task compatibility.
     if args.static_cache and args.task is not None:
@@ -469,6 +472,7 @@ def _save_package(
                 config=config,
                 source=source,
                 revision=getattr(args, "revision", None),
+                guidance_scale=getattr(args, "guidance_scale", None),
             )
         except ValueError as error:
             raise SystemExit(f"Error: {error}") from error
@@ -822,6 +826,18 @@ def main(argv: list[str] | None = None) -> None:
             "document for LLMs, or an iterative pipeline document for diffusion). "
             "When used with --model, tokenizer files are downloaded from HuggingFace; "
             "with --config (local directory), they are copied from that directory."
+        ),
+    )
+    build_parser.add_argument(
+        "--guidance-scale",
+        type=float,
+        default=None,
+        metavar="SCALE",
+        help=(
+            "Classifier-free guidance scale for --runtime onnx-genai diffusion "
+            "metadata. Required for conditioned diffusion pipelines so export does "
+            "not guess a source pipeline's generation default; pass 1.0 explicitly "
+            "for unguided generation."
         ),
     )
     build_parser.add_argument(

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -604,6 +604,7 @@ def _cmd_convert_comfyui(args: argparse.Namespace) -> None:
         args.checkpoint,
         args.output,
         sdxl=getattr(args, "sdxl", False),
+        revision=args.revision,
     )
     wf = result.workflow
     print(f"Converted ComfyUI workflow -> {result.output_dir}")
@@ -998,6 +999,11 @@ def main(argv: list[str] | None = None) -> None:
         help="Optional diffusers directory or Hugging Face model id whose "
         "scheduler config supplies the noise-schedule betas (Stable Diffusion "
         "defaults are used when omitted).",
+    )
+    comfy_parser.add_argument(
+        "--revision",
+        default=None,
+        help="Pinned Hugging Face revision used to resolve the checkpoint scheduler config.",
     )
     comfy_parser.add_argument(
         "--output", "-o", required=True, help="Output directory for the pipeline metadata."

--- a/src/mobius/generation/_policy_components.py
+++ b/src/mobius/generation/_policy_components.py
@@ -1642,21 +1642,37 @@ def build_tensor_scale(dtype: ir.DataType = ir.DataType.FLOAT) -> PolicyComponen
     return _component("mobius.policy.auxiliary@1", graph, {})
 
 
+def build_tensor_cast(
+    input_dtype: ir.DataType,
+    output_dtype: ir.DataType,
+    dims: Sequence[str],
+) -> PolicyComponent:
+    """Cast an arbitrary-rank tensor without changing its logical layout."""
+    graph, builder = _make_graph("tensor_cast")
+    tensor = builder.input("tensor", input_dtype, list(dims))
+    cast = builder.op.Cast(tensor, to=output_dtype)
+    cast.shape = tensor.shape
+    builder.add_output(cast, "cast")
+    return _component("mobius.policy.auxiliary@1", graph, {})
+
+
 def build_tensor_clamp(
     dtype: ir.DataType = ir.DataType.FLOAT,
+    dims: Sequence[str] = ("batch", "channels", "height", "width"),
     *,
     minimum: float,
     maximum: float,
 ) -> PolicyComponent:
-    """Clamp a rank-4 tensor to an explicitly declared numeric range."""
+    """Clamp an arbitrary-rank tensor to a declared runtime output range."""
     graph, builder = _make_graph("tensor_clamp")
-    op = builder.op
-    tensor = builder.input("tensor", dtype, ["batch", "channels", "height", "width"])
-    clamped = op.Clip(
-        tensor,
-        op.Cast(op.Constant(value_float=minimum), to=dtype),
-        op.Cast(op.Constant(value_float=maximum), to=dtype),
+    tensor = builder.input("tensor", dtype, list(dims))
+    minimum_value = builder.op.CastLike(
+        builder.op.Constant(value_float=float(minimum)), tensor
     )
+    maximum_value = builder.op.CastLike(
+        builder.op.Constant(value_float=float(maximum)), tensor
+    )
+    clamped = builder.op.Clip(tensor, minimum_value, maximum_value)
     clamped.shape = tensor.shape
     builder.add_output(clamped, "clamped")
     return _component("mobius.policy.auxiliary@1", graph, {})
@@ -1673,7 +1689,10 @@ def build_zeros_like(dtype: ir.DataType = ir.DataType.FLOAT) -> PolicyComponent:
     return _component("mobius.policy.auxiliary@1", graph, {})
 
 
-def build_guidance_combine(dtype: ir.DataType = ir.DataType.FLOAT) -> PolicyComponent:
+def build_guidance_combine(
+    dtype: ir.DataType = ir.DataType.FLOAT,
+    latent_dims: Sequence[str] = ("batch", "channels", "height", "width"),
+) -> PolicyComponent:
     """Combine two conditioned estimates by a per-row guidance scale.
 
     ``estimate = unconditional + scale * (conditional - unconditional)`` is the
@@ -1682,13 +1701,14 @@ def build_guidance_combine(dtype: ir.DataType = ir.DataType.FLOAT) -> PolicyComp
     """
     graph, builder = _make_graph("guidance_combine")
     op = builder.op
-    unconditional = builder.input(
-        "unconditional", dtype, ["batch", "channels", "height", "width"]
-    )
-    conditional = builder.input("conditional", dtype, ["batch", "channels", "height", "width"])
+    unconditional = builder.input("unconditional", dtype, list(latent_dims))
+    conditional = builder.input("conditional", dtype, list(latent_dims))
     scale = builder.input("scale", ir.DataType.FLOAT, ["batch"])
-    # (batch,) -> (batch, 1, 1, 1) so the row scale broadcasts over the latent.
-    factor = op.Unsqueeze(op.Cast(scale, to=dtype), op.Constant(value_ints=[1, 2, 3]))
+    # (batch,) -> (batch, 1, ..., 1) so the row scale broadcasts over the latent.
+    factor = op.Unsqueeze(
+        op.Cast(scale, to=dtype),
+        op.Constant(value_ints=list(range(1, len(latent_dims)))),
+    )
     estimate = op.Add(unconditional, op.Mul(factor, op.Sub(conditional, unconditional)))
     estimate.shape = unconditional.shape
     builder.add_output(estimate, "estimate")
@@ -2168,8 +2188,9 @@ def build_ddim_solver_step(
     latent_dims: Sequence[str] = _IMAGE_LATENT_DIMS,
     *,
     clip_sample_range: float | None = None,
+    prediction_type: str = "epsilon",
 ) -> PolicyComponent:
-    """Build the deterministic DDIM update (``eta = 0``, epsilon prediction).
+    """Build the deterministic DDIM update (``eta = 0``).
 
     ``schedule`` holds the cumulative alpha of every denoising step followed by
     the alpha of the final step's predecessor, so entry ``i + 1`` is the
@@ -2181,8 +2202,12 @@ def build_ddim_solver_step(
     ``clip_sample_range`` reproduces schedulers configured with
     ``clip_sample=True``, which clamp the predicted clean sample before the
     reverse step. ``latent_dims`` names the latent axes, so the same update
-    serves image and video latents.
+    serves image and video latents. ``prediction_type`` selects the scheduler's
+    architecture-neutral output interpretation: ``epsilon``, ``sample``, or
+    ``v_prediction``.
     """
+    if prediction_type not in {"epsilon", "sample", "v_prediction"}:
+        raise ValueError(f"unsupported DDIM prediction_type {prediction_type!r}")
     graph, builder = _make_graph("ddim_solver_step")
     op = builder.op
     sample = builder.input("sample", dtype, list(latent_dims))
@@ -2197,16 +2222,31 @@ def build_ddim_solver_step(
         op.Cast(op.Gather(schedule, next_step, axis=0), to=dtype), broadcast_axes
     )
     one = op.CastLike(op.Constant(value_float=1.0), sample)
-    # Recover the predicted clean latent, then re-noise it to alpha_prev.
-    pred_original = op.Div(
-        op.Sub(sample, op.Mul(op.Sqrt(op.Sub(one, alpha)), derivative)), op.Sqrt(alpha)
-    )
+    alpha_sqrt = op.Sqrt(alpha)
+    beta_sqrt = op.Sqrt(op.Sub(one, alpha))
+    if prediction_type == "epsilon":
+        pred_original = op.Div(
+            op.Sub(sample, op.Mul(beta_sqrt, derivative)), alpha_sqrt
+        )
+        pred_epsilon = derivative
+    elif prediction_type == "sample":
+        pred_original = derivative
+        pred_epsilon = op.Div(
+            op.Sub(sample, op.Mul(alpha_sqrt, pred_original)), beta_sqrt
+        )
+    else:
+        pred_original = op.Sub(
+            op.Mul(alpha_sqrt, sample), op.Mul(beta_sqrt, derivative)
+        )
+        pred_epsilon = op.Add(
+            op.Mul(alpha_sqrt, derivative), op.Mul(beta_sqrt, sample)
+        )
     if clip_sample_range is not None:
         limit = op.CastLike(op.Constant(value_float=float(clip_sample_range)), sample)
         pred_original = op.Clip(pred_original, op.Neg(limit), limit)
     next_sample = op.Add(
         op.Mul(op.Sqrt(alpha_prev), pred_original),
-        op.Mul(op.Sqrt(op.Sub(one, alpha_prev)), derivative),
+        op.Mul(op.Sqrt(op.Sub(one, alpha_prev)), pred_epsilon),
     )
     _set_public_shape(next_sample, list(latent_dims))
     builder.add_output(next_sample, "next_state")
@@ -2349,6 +2389,7 @@ def build_true_cfg(
 
 
 SOLVER_BUILDERS = {
+    "ddim": build_ddim_solver_step,
     "euler": build_euler_solver_step,
     "multistep": build_multistep_solver_step,
 }
@@ -2737,7 +2778,9 @@ def build_schedule_history_append(dtype: ir.DataType) -> PolicyComponent:
     history = builder.input("history", dtype, ["batch", "history"])
     timestep = builder.input("timestep", dtype, ["batch"])
     updated = op.Concat(history, op.Unsqueeze(timestep, op.Constant(value_ints=[1])), axis=1)
-    _set_public_shape(updated, ["batch", "history"])
+    # Appending changes the temporal extent, so the output must not reuse the
+    # input symbol: runtimes may otherwise preallocate the old zero-length shape.
+    _set_public_shape(updated, ["batch", "next_history"])
     builder.add_output(updated, "next")
     return _component("mobius.policy.auxiliary@1", graph, {})
 

--- a/src/mobius/generation/_policy_components.py
+++ b/src/mobius/generation/_policy_components.py
@@ -2220,8 +2220,11 @@ def build_ddim_solver_step(
         pred_epsilon = derivative
     elif prediction_type == "sample":
         pred_original = derivative
-        pred_epsilon = op.Div(
-            op.Sub(sample, op.Mul(alpha_sqrt, pred_original)), beta_sqrt
+        epsilon_numerator = op.Sub(sample, op.Mul(alpha_sqrt, pred_original))
+        pred_epsilon = op.Where(
+            op.Greater(beta_sqrt, op.CastLike(op.Constant(value_float=0.0), sample)),
+            op.Div(epsilon_numerator, beta_sqrt),
+            op.CastLike(op.Constant(value_float=0.0), sample),
         )
     else:
         pred_original = op.Sub(
@@ -2774,7 +2777,10 @@ def build_schedule_history_append(dtype: ir.DataType) -> PolicyComponent:
     return _component("mobius.policy.auxiliary@1", graph, {})
 
 
-def build_video_decode_chunk_count(latent_frame_axis: int = 2) -> PolicyComponent:
+def build_video_decode_chunk_count(
+    latent_frame_axis: int = 2,
+    dtype: ir.DataType = ir.DataType.FLOAT,
+) -> PolicyComponent:
     """Number of causal decode chunks a latent clip is split into.
 
     Mirrors ``AutoencoderKLCogVideoX._decode``: ``max(latent_frames // 2, 1)``.
@@ -2783,7 +2789,7 @@ def build_video_decode_chunk_count(latent_frame_axis: int = 2) -> PolicyComponen
     op = builder.op
     latent = builder.input(
         "latent",
-        ir.DataType.FLOAT,
+        dtype,
         ["batch", "channels", "latent_frames", "height", "width"],
     )
     frames = op.Shape(latent, start=latent_frame_axis, end=latent_frame_axis + 1)
@@ -2796,7 +2802,10 @@ def build_video_decode_chunk_count(latent_frame_axis: int = 2) -> PolicyComponen
     return _component("mobius.policy.auxiliary@1", graph, {})
 
 
-def build_video_decode_chunk(latent_frame_axis: int = 2) -> PolicyComponent:
+def build_video_decode_chunk(
+    latent_frame_axis: int = 2,
+    dtype: ir.DataType = ir.DataType.FLOAT,
+) -> PolicyComponent:
     """Slice the latent frames belonging to one causal decode chunk.
 
     Reproduces the reference chunk walk, where the odd frame left over by the
@@ -2810,7 +2819,7 @@ def build_video_decode_chunk(latent_frame_axis: int = 2) -> PolicyComponent:
     op = builder.op
     latent = builder.input(
         "latent",
-        ir.DataType.FLOAT,
+        dtype,
         ["batch", "channels", "latent_frames", "height", "width"],
     )
     step = builder.input("step", ir.DataType.INT64, ["batch"])
@@ -2878,7 +2887,10 @@ def build_video_conv_cache_initializer(
     return _component("mobius.policy.auxiliary@1", graph, {})
 
 
-def build_video_latent_permute(perm: list[int]) -> PolicyComponent:
+def build_video_latent_permute(
+    perm: list[int],
+    dtype: ir.DataType = ir.DataType.FLOAT,
+) -> PolicyComponent:
     """Reorder a video latent between the denoiser and VAE layouts.
 
     CogVideoX denoises ``[batch, frames, channels, height, width]`` but decodes
@@ -2887,22 +2899,21 @@ def build_video_latent_permute(perm: list[int]) -> PolicyComponent:
     """
     graph, builder = _make_graph("video_latent_permute")
     op = builder.op
-    source = builder.input(
-        "latent", ir.DataType.FLOAT, ["batch", "frames", "channels", "height", "width"]
-    )
+    source = builder.input("latent", dtype, ["batch", "frames", "channels", "height", "width"])
     permuted = op.Transpose(source, perm=perm)
     _set_public_shape(permuted, ["batch", "channels", "frames", "height", "width"])
     builder.add_output(permuted, "permuted")
     return _component("mobius.policy.auxiliary@1", graph, {})
 
 
-def build_video_latent_unscale(scaling_factor: float) -> PolicyComponent:
+def build_video_latent_unscale(
+    scaling_factor: float,
+    dtype: ir.DataType = ir.DataType.FLOAT,
+) -> PolicyComponent:
     """Undo the autoencoder's latent scaling before decoding."""
     graph, builder = _make_graph("video_latent_unscale")
     op = builder.op
-    latent = builder.input(
-        "latent", ir.DataType.FLOAT, ["batch", "channels", "frames", "height", "width"]
-    )
+    latent = builder.input("latent", dtype, ["batch", "channels", "frames", "height", "width"])
     unscaled = op.Div(latent, op.CastLike(op.Constant(value_float=scaling_factor), latent))
     _set_public_shape(unscaled, ["batch", "channels", "frames", "height", "width"])
     builder.add_output(unscaled, "unscaled")

--- a/src/mobius/generation/_policy_components.py
+++ b/src/mobius/generation/_policy_components.py
@@ -1642,20 +1642,6 @@ def build_tensor_scale(dtype: ir.DataType = ir.DataType.FLOAT) -> PolicyComponen
     return _component("mobius.policy.auxiliary@1", graph, {})
 
 
-def build_tensor_cast(
-    input_dtype: ir.DataType,
-    output_dtype: ir.DataType,
-    dims: Sequence[str],
-) -> PolicyComponent:
-    """Cast an arbitrary-rank tensor without changing its logical layout."""
-    graph, builder = _make_graph("tensor_cast")
-    tensor = builder.input("tensor", input_dtype, list(dims))
-    cast = builder.op.Cast(tensor, to=output_dtype)
-    cast.shape = tensor.shape
-    builder.add_output(cast, "cast")
-    return _component("mobius.policy.auxiliary@1", graph, {})
-
-
 def build_tensor_clamp(
     dtype: ir.DataType = ir.DataType.FLOAT,
     dims: Sequence[str] = ("batch", "channels", "height", "width"),
@@ -1733,7 +1719,7 @@ def build_tensor_cast(
     target_dtype: ir.DataType,
     dims: Sequence[str] = ("batch", "heads", "sequence", "head_dim"),
 ) -> PolicyComponent:
-    """Cast a typed tensor at an explicit component precision boundary."""
+    """Cast an arbitrary-rank tensor at an explicit component precision boundary."""
     graph, builder = _make_graph("tensor_cast")
     value = builder.input("value", source_dtype, list(dims))
     cast = builder.op.Cast(value, to=target_dtype)

--- a/src/mobius/generation/_policy_components.py
+++ b/src/mobius/generation/_policy_components.py
@@ -228,6 +228,7 @@ def build_boolean_not() -> PolicyComponent:
         keepdims=1,
     )
     continued = builder.op.Equal(any_done, builder.op.Constant(value_int=0))
+    continued.dtype = ir.DataType.BOOL
     continued.shape = ir.Shape([1])
     builder.add_output(continued, "continue")
     return _component("mobius.policy.auxiliary@1", graph, {})
@@ -1255,6 +1256,7 @@ def build_adaptive_k_policy(*, max_k: int = 16, min_k: int = 1) -> PolicyCompone
     )
     next_k = op.Where(valid, computed_k, current_k)
     next_estimates = op.Where(valid_col, computed_estimates, estimates)
+    next_k.dtype = ir.DataType.INT64
     next_k.shape = ir.Shape(["batch"])
     next_estimates.shape = ir.Shape(["batch", estimate_slots])
     builder.add_output(next_k, "next_k")
@@ -1471,6 +1473,8 @@ def build_seeded_categorical_sampler() -> PolicyComponent:
         op.Add(counter, op.Constant(value_int=1)),
         counter,
     )
+    token_ids.dtype = ir.DataType.INT64
+    next_counter.dtype = ir.DataType.INT64
     _set_public_shape(logits, ["batch", "vocabulary"])
     for value in (temperature, top_k, top_p, min_p, seed, counter, active, done):
         _set_public_shape(value, ["batch"])
@@ -1573,6 +1577,9 @@ def build_eos_termination(*, row_selective: bool = False) -> PolicyComponent:
         _set_public_shape(active, ["batch"])
         _set_public_shape(done, ["batch"])
         _set_public_shape(next_active, ["batch"])
+        next_active.dtype = ir.DataType.BOOL
+    done.dtype = ir.DataType.BOOL
+    continued.dtype = ir.DataType.BOOL
     _set_public_shape(continued, [1])
     builder.add_output(done, "done")
     if row_selective:
@@ -2214,9 +2221,7 @@ def build_ddim_solver_step(
     alpha_sqrt = op.Sqrt(alpha)
     beta_sqrt = op.Sqrt(op.Sub(one, alpha))
     if prediction_type == "epsilon":
-        pred_original = op.Div(
-            op.Sub(sample, op.Mul(beta_sqrt, derivative)), alpha_sqrt
-        )
+        pred_original = op.Div(op.Sub(sample, op.Mul(beta_sqrt, derivative)), alpha_sqrt)
         pred_epsilon = derivative
     elif prediction_type == "sample":
         pred_original = derivative
@@ -2227,12 +2232,8 @@ def build_ddim_solver_step(
             op.CastLike(op.Constant(value_float=0.0), sample),
         )
     else:
-        pred_original = op.Sub(
-            op.Mul(alpha_sqrt, sample), op.Mul(beta_sqrt, derivative)
-        )
-        pred_epsilon = op.Add(
-            op.Mul(alpha_sqrt, derivative), op.Mul(beta_sqrt, sample)
-        )
+        pred_original = op.Sub(op.Mul(alpha_sqrt, sample), op.Mul(beta_sqrt, derivative))
+        pred_epsilon = op.Add(op.Mul(alpha_sqrt, derivative), op.Mul(beta_sqrt, sample))
     if clip_sample_range is not None:
         limit = op.CastLike(op.Constant(value_float=float(clip_sample_range)), sample)
         pred_original = op.Clip(pred_original, op.Neg(limit), limit)

--- a/src/mobius/generation/_policy_components.py
+++ b/src/mobius/generation/_policy_components.py
@@ -1662,17 +1662,20 @@ def build_tensor_clamp(
     *,
     minimum: float,
     maximum: float,
+    output_dtype: ir.DataType | None = None,
 ) -> PolicyComponent:
     """Clamp an arbitrary-rank tensor to a declared runtime output range."""
     graph, builder = _make_graph("tensor_clamp")
     tensor = builder.input("tensor", dtype, list(dims))
+    output_dtype = output_dtype or dtype
+    clamp_input = tensor if output_dtype == dtype else builder.op.Cast(tensor, to=output_dtype)
     minimum_value = builder.op.CastLike(
-        builder.op.Constant(value_float=float(minimum)), tensor
+        builder.op.Constant(value_float=float(minimum)), clamp_input
     )
     maximum_value = builder.op.CastLike(
-        builder.op.Constant(value_float=float(maximum)), tensor
+        builder.op.Constant(value_float=float(maximum)), clamp_input
     )
-    clamped = builder.op.Clip(tensor, minimum_value, maximum_value)
+    clamped = builder.op.Clip(clamp_input, minimum_value, maximum_value)
     clamped.shape = tensor.shape
     builder.add_output(clamped, "clamped")
     return _component("mobius.policy.auxiliary@1", graph, {})

--- a/src/mobius/generation/_policy_components_test.py
+++ b/src/mobius/generation/_policy_components_test.py
@@ -594,6 +594,18 @@ def test_batched_policy_v2_ports_use_exact_public_shapes():
         assert {port.name: [str(dim) for dim in port.shape] for port in ports} == expected[
             name
         ]
+    assert {
+        port.name: port.dtype
+        for component in components.values()
+        for port in component.model.graph.outputs
+    } == {
+        "token": ir.DataType.INT64,
+        "next_counter": ir.DataType.INT64,
+        "done": ir.DataType.BOOL,
+        "next_active": ir.DataType.BOOL,
+        "continue": ir.DataType.BOOL,
+        "next": ir.DataType.INT64,
+    }
 
 
 def test_seeded_sampler_applies_request_top_k(tmp_path):

--- a/src/mobius/generation/_policy_components_test.py
+++ b/src/mobius/generation/_policy_components_test.py
@@ -794,6 +794,29 @@ def test_ddim_solver_runtime_parity_on_a_video_latent(tmp_path):
     np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
 
 
+def test_ddim_solver_v_prediction_runtime_parity(tmp_path):
+    dims = ["batch", "frames", "channels", "height", "width"]
+    sample = np.linspace(-1.5, 1.5, 24, dtype=np.float32).reshape(1, 3, 2, 2, 2)
+    velocity = np.full_like(sample, 0.25)
+    schedule = np.array([0.4, 0.9, 1.0], np.float32)
+    (actual,) = _run(
+        build_ddim_solver_step(latent_dims=dims, prediction_type="v_prediction"),
+        tmp_path,
+        {
+            "sample": sample,
+            "derivative": velocity,
+            "step": np.array([0], np.int64),
+            "schedule": schedule,
+        },
+    )
+    alpha, alpha_prev = schedule[:2]
+    beta = 1 - alpha
+    pred_original = np.sqrt(alpha) * sample - np.sqrt(beta) * velocity
+    pred_epsilon = np.sqrt(alpha) * velocity + np.sqrt(beta) * sample
+    expected = np.sqrt(alpha_prev) * pred_original + np.sqrt(1 - alpha_prev) * pred_epsilon
+    np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+
+
 def test_ddim_solver_clips_the_predicted_clean_latent(tmp_path):
     dims = ["batch", "frames", "channels", "height", "width"]
     sample = np.full((1, 1, 1, 1, 1), 8.0, np.float32)

--- a/src/mobius/generation/_policy_components_test.py
+++ b/src/mobius/generation/_policy_components_test.py
@@ -76,6 +76,20 @@ def _run_model(model, tmp_path, feeds):
     return session.run(None, feeds)
 
 
+def test_tensor_clamp_can_cast_bfloat16_output_to_float32(tmp_path):
+    component = build_tensor_clamp(
+        ir.DataType.BFLOAT16,
+        ["batch", "channels"],
+        minimum=-1.0,
+        maximum=1.0,
+        output_dtype=ir.DataType.FLOAT,
+    )
+    assert component.model.graph.outputs[0].dtype == ir.DataType.FLOAT
+    path = tmp_path / "bfloat16_tensor_clamp.onnx"
+    ir.save(component.model, path)
+    ort.InferenceSession(str(path), providers=["CPUExecutionProvider"])
+
+
 def test_grammar_logits_processor_applies_mask_and_forced_tokens(tmp_path):
     logits = np.array([[1.0, 4.0, 3.0], [5.0, 2.0, 1.0]], np.float32)
     (tokens,) = _run(

--- a/src/mobius/generation/_policy_components_test.py
+++ b/src/mobius/generation/_policy_components_test.py
@@ -831,6 +831,45 @@ def test_ddim_solver_v_prediction_runtime_parity(tmp_path):
     np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
 
 
+def test_ddim_solver_sample_prediction_runtime_parity(tmp_path):
+    dims = ["batch", "frames", "channels", "height", "width"]
+    sample = np.linspace(-1.0, 1.0, 24, dtype=np.float32).reshape(1, 3, 2, 2, 2)
+    pred_original = np.full_like(sample, 0.25)
+    schedule = np.array([0.4, 0.9, 1.0], np.float32)
+    (actual,) = _run(
+        build_ddim_solver_step(latent_dims=dims, prediction_type="sample"),
+        tmp_path,
+        {
+            "sample": sample,
+            "derivative": pred_original,
+            "step": np.array([0], np.int64),
+            "schedule": schedule,
+        },
+    )
+    alpha, alpha_prev = schedule[:2]
+    pred_epsilon = (sample - np.sqrt(alpha) * pred_original) / np.sqrt(1 - alpha)
+    expected = np.sqrt(alpha_prev) * pred_original + np.sqrt(1 - alpha_prev) * pred_epsilon
+    np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+
+
+def test_ddim_solver_sample_prediction_handles_unit_alpha(tmp_path):
+    sample = np.full((1, 1, 1, 1, 1), 0.25, np.float32)
+    (actual,) = _run(
+        build_ddim_solver_step(
+            latent_dims=["batch", "frames", "channels", "height", "width"],
+            prediction_type="sample",
+        ),
+        tmp_path,
+        {
+            "sample": sample,
+            "derivative": sample,
+            "step": np.array([0], np.int64),
+            "schedule": np.array([1.0, 1.0], np.float32),
+        },
+    )
+    np.testing.assert_allclose(actual, sample)
+
+
 def test_ddim_solver_clips_the_predicted_clean_latent(tmp_path):
     dims = ["batch", "frames", "channels", "height", "width"]
     sample = np.full((1, 1, 1, 1, 1), 8.0, np.float32)
@@ -1078,6 +1117,25 @@ def test_guidance_combine_extrapolates_per_row(tmp_path):
         + np.array([7.5, 0.0], np.float32).reshape(2, 1, 1, 1) * (conditional - unconditional),
         rtol=1e-6,
     )
+
+
+def test_guidance_combine_broadcasts_over_video_latents(tmp_path):
+    dims = ["batch", "frames", "channels", "height", "width"]
+    unconditional = np.ones((2, 3, 2, 2, 2), dtype=np.float32)
+    conditional = np.full_like(unconditional, 3.0)
+    (guided,) = _run(
+        build_guidance_combine(latent_dims=dims),
+        tmp_path,
+        {
+            "unconditional": unconditional,
+            "conditional": conditional,
+            "scale": np.array([2.0, 0.5], np.float32),
+        },
+    )
+    expected = unconditional + np.array([2.0, 0.5], np.float32).reshape(2, 1, 1, 1, 1) * (
+        conditional - unconditional
+    )
+    np.testing.assert_allclose(guided, expected, rtol=1e-6)
 
 
 def test_multistep_solver_matches_dpmsolverpp_second_order(tmp_path):

--- a/src/mobius/integrations/diffusers/_builder.py
+++ b/src/mobius/integrations/diffusers/_builder.py
@@ -67,6 +67,7 @@ def _init_diffusers_class_map() -> None:
         QwenImageConfig,
         QwenImageTextEncoderConfig,
         QwenImageVAEConfig,
+        T5TextEncoderConfig,
         UNet2DConfig,
         VAEConfig,
     )
@@ -96,6 +97,7 @@ def _init_diffusers_class_map() -> None:
     from mobius.models.qwen_image import QwenImageTransformer2DModel
     from mobius.models.qwen_image_vae import AutoencoderKLQwenImageModel
     from mobius.models.qwen_vl import Qwen25VLCausalLMModel
+    from mobius.models.t5 import T5EncoderModel
     from mobius.models.unet import UNet2DConditionModel
     from mobius.models.vae import AutoencoderKLModel
 
@@ -114,6 +116,11 @@ def _init_diffusers_class_map() -> None:
                 "denoising",
             ),
             "CLIPTextModel": (CLIPTextModel, CLIPTextConfig, "feature-extraction"),
+            "T5EncoderModel": (
+                T5EncoderModel,
+                T5TextEncoderConfig,
+                "t5-text-encoding",
+            ),
             "QwenImageTransformer2DModel": (
                 QwenImageTransformer2DModel,
                 QwenImageConfig,

--- a/src/mobius/integrations/diffusers/_builder_test.py
+++ b/src/mobius/integrations/diffusers/_builder_test.py
@@ -61,6 +61,7 @@ class TestInitDiffusersClassMap:
             "Qwen2_5_VLForConditionalGeneration",
             "UNet2DConditionModel",
             "CLIPTextModel",
+            "T5EncoderModel",
             "AutoencoderKL",
             "AutoencoderKLQwenImage",
             "AutoencoderKLCogVideoX",
@@ -97,6 +98,7 @@ class TestInitDiffusersClassMap:
             "video-denoising",
             "video-vae",
             "feature-extraction",
+            "t5-text-encoding",
             "minimax-music3-condition",
             "minimax-music3-denoising",
             "minimax-music3-language",
@@ -451,7 +453,7 @@ class TestBuildDiffusersPipelineFiltering:
         mock_load_index.return_value = {
             "_class_name": "FluxPipeline",
             "scheduler": ["diffusers", "EulerDiscreteScheduler"],
-            "text_encoder": ["transformers", "T5EncoderModel"],
+            "text_encoder": ["transformers", "UnsupportedTextEncoderModel"],
         }
         with pytest.raises(ValueError, match="No supported neural network"):
             build_diffusers_pipeline("fake/model", load_weights=False)

--- a/src/mobius/integrations/diffusers/_configs.py
+++ b/src/mobius/integrations/diffusers/_configs.py
@@ -63,6 +63,25 @@ class CLIPTextConfig:
         )
 
 
+class T5TextEncoderConfig:
+    """Adapter for a T5 encoder embedded in a diffusers pipeline."""
+
+    @classmethod
+    def from_diffusers(cls, config: dict) -> ArchitectureConfig:
+        """Create the native Mobius T5 configuration."""
+        import transformers
+
+        from mobius._configs import ArchitectureConfig
+
+        fields = dict(config)
+        fields.pop("architectures", None)
+        fields.pop("transformers_version", None)
+        fields.pop("torch_dtype", None)
+        model_type = fields.pop("model_type", "t5")
+        hf_config = transformers.AutoConfig.for_model(model_type, **fields)
+        return ArchitectureConfig.from_transformers(hf_config)
+
+
 class QwenImageTextEncoderConfig:
     """Adapter for the Qwen2.5-VL prompt encoder bundled with Qwen Image Edit."""
 
@@ -265,6 +284,7 @@ class UNet2DConfig:
     # block). ``None`` = every block has cross-attention (legacy behavior).
     down_block_types: tuple[str, ...] | None = None
     up_block_types: tuple[str, ...] | None = None
+    mid_block_type: str | None = "UNetMidBlock2DCrossAttn"
     addition_embed_type: str | None = None
     addition_time_embed_dim: int | None = None
     projection_class_embeddings_input_dim: int | None = None
@@ -302,6 +322,7 @@ class UNet2DConfig:
                 if config.get("up_block_types") is not None
                 else None
             ),
+            mid_block_type=config.get("mid_block_type", "UNetMidBlock2DCrossAttn"),
             addition_embed_type=config.get("addition_embed_type"),
             addition_time_embed_dim=config.get("addition_time_embed_dim"),
             projection_class_embeddings_input_dim=config.get(

--- a/src/mobius/integrations/diffusers/_configs_test.py
+++ b/src/mobius/integrations/diffusers/_configs_test.py
@@ -16,6 +16,7 @@ from mobius.integrations.diffusers._configs import (
     CLIPTextConfig,
     QwenImageConfig,
     QwenImageVAEConfig,
+    T5TextEncoderConfig,
     UNet2DConfig,
 )
 
@@ -89,6 +90,32 @@ class TestUNet2DConfigFromDiffusers:
         assert tuple(unet.block_out_channels) == (320, 640, 1280, 1280)
         assert unet.cross_attention_dim == 768
         assert unet.layers_per_block == 2
+
+    def test_preserves_explicitly_absent_mid_block(self):
+        unet = UNet2DConfig.from_diffusers({"mid_block_type": None})
+        assert unet.mid_block_type is None
+
+
+def test_t5_text_encoder_config_maps_diffusers_fields():
+    config = T5TextEncoderConfig.from_diffusers(
+        {
+            "model_type": "t5",
+            "vocab_size": 32128,
+            "d_model": 4096,
+            "d_ff": 10240,
+            "d_kv": 64,
+            "num_layers": 24,
+            "num_heads": 64,
+            "feed_forward_proj": "gated-gelu",
+            "relative_attention_num_buckets": 32,
+            "relative_attention_max_distance": 128,
+        }
+    )
+    assert config.hidden_size == 4096
+    assert config.intermediate_size == 10240
+    assert config.num_hidden_layers == 24
+    assert config.num_attention_heads == 64
+    assert config.is_gated_act
 
 
 class TestQwenImageEditOfficialConfigs:

--- a/src/mobius/integrations/gguf/_repacker_test.py
+++ b/src/mobius/integrations/gguf/_repacker_test.py
@@ -731,9 +731,11 @@ class TestRepackQ6K:
             np.float16([1.5] * n_super).tobytes(), dtype=np.uint8
         ).reshape(n_super, 2)
 
-        expected = gguf_quants.dequantize(
-            blocks.reshape(-1).copy(), GGMLQuantizationType.Q6_K
-        ).astype(np.float32).ravel()
+        expected = (
+            gguf_quants.dequantize(blocks.reshape(-1).copy(), GGMLQuantizationType.Q6_K)
+            .astype(np.float32)
+            .ravel()
+        )
         got = _dequantize_q6_k(blocks)
 
         np.testing.assert_array_equal(got, expected)

--- a/src/mobius/integrations/gguf/_tokenizer.py
+++ b/src/mobius/integrations/gguf/_tokenizer.py
@@ -230,9 +230,7 @@ def _reconstruct_tokenizer_from_ggml(gguf_path: Path, output_dir: str | Path) ->
             if split_patterns:
                 tokenizer.pre_tokenizer = pre_tokenizers.Sequence(
                     [
-                        pre_tokenizers.Split(
-                            pattern=Regex(pattern), behavior="isolated"
-                        )
+                        pre_tokenizers.Split(pattern=Regex(pattern), behavior="isolated")
                         for pattern in split_patterns
                     ]
                     + [byte_level_pre]

--- a/src/mobius/integrations/onnx_genai/auto_export.py
+++ b/src/mobius/integrations/onnx_genai/auto_export.py
@@ -42,6 +42,7 @@ from mobius.integrations.onnx_genai.workflow_metadata import (
     write_speculative_workflow_metadata,
     write_speech_to_text_workflow_metadata,
     write_tts_workflow_metadata,
+    write_video_diffusion_workflow_metadata,
     write_vlm_workflow_metadata,
 )
 
@@ -132,6 +133,61 @@ def _diffusion_schedule(
         training_sigmas,
     )
     return timesteps.tolist(), [*sigmas.tolist(), 0.0]
+
+
+def _ddim_alpha_schedule(
+    scheduler: SchedulerConfig, num_inference_steps: int
+) -> tuple[list[float], list[float]]:
+    """Materialize DDIM timesteps and cumulative alphas from diffusers config."""
+    if scheduler.kind != "ddim":
+        raise ValueError(f"video workflow requires a DDIM scheduler, got {scheduler.kind!r}")
+    if num_inference_steps > scheduler.num_train_timesteps:
+        raise ValueError("num_inference_steps exceeds the DDIM training schedule")
+    if scheduler.beta_schedule == "scaled_linear":
+        betas = (
+            np.linspace(
+                np.sqrt(scheduler.beta_start),
+                np.sqrt(scheduler.beta_end),
+                scheduler.num_train_timesteps,
+                dtype=np.float64,
+            )
+            ** 2
+        )
+    elif scheduler.beta_schedule == "linear":
+        betas = np.linspace(
+            scheduler.beta_start,
+            scheduler.beta_end,
+            scheduler.num_train_timesteps,
+            dtype=np.float64,
+        )
+    else:
+        raise ValueError(f"unsupported DDIM beta schedule {scheduler.beta_schedule!r}")
+    alphas_cumprod = np.cumprod(1.0 - betas)
+    alphas_cumprod = alphas_cumprod / (
+        scheduler.snr_shift_scale + (1.0 - scheduler.snr_shift_scale) * alphas_cumprod
+    )
+    if scheduler.rescale_betas_zero_snr:
+        alpha_sqrt = np.sqrt(alphas_cumprod)
+        first, last = alpha_sqrt[0], alpha_sqrt[-1]
+        alpha_sqrt = (alpha_sqrt - last) * first / (first - last)
+        alphas_cumprod = alpha_sqrt**2
+    if scheduler.timestep_spacing == "linspace":
+        timesteps = np.linspace(
+            0, scheduler.num_train_timesteps - 1, num_inference_steps
+        ).round()[::-1]
+    elif scheduler.timestep_spacing == "leading":
+        step_ratio = scheduler.num_train_timesteps // num_inference_steps
+        timesteps = (np.arange(num_inference_steps) * step_ratio).round()[::-1]
+        timesteps += scheduler.steps_offset
+    elif scheduler.timestep_spacing == "trailing":
+        step_ratio = scheduler.num_train_timesteps / num_inference_steps
+        timesteps = np.round(np.arange(scheduler.num_train_timesteps, 0, -step_ratio)) - 1
+    else:
+        raise ValueError(f"unsupported DDIM timestep spacing {scheduler.timestep_spacing!r}")
+    timesteps = timesteps.astype(np.int64)
+    final_alpha = 1.0 if scheduler.set_alpha_to_one else float(alphas_cumprod[0])
+    schedule = [*(float(alphas_cumprod[index]) for index in timesteps), final_alpha]
+    return timesteps.astype(np.float64).tolist(), schedule
 
 
 _DENOISER_KEYS = ("denoiser", "transformer", "unet")
@@ -473,6 +529,19 @@ def _looks_like_diffusion(pkg: Any) -> bool:
     return any(k in names for k in _DENOISER_KEYS) or any(
         k in names for k in ("vae", "vae_decoder", "vae_encoder")
     )
+
+
+def _looks_like_video_diffusion(pkg: Any) -> bool:
+    try:
+        denoiser = next(pkg[name] for name in _DENOISER_KEYS if name in pkg)
+        sample = next(
+            value
+            for value in denoiser.graph.inputs
+            if value.name in {"sample", "latent", "hidden_states"}
+        )
+    except (AttributeError, KeyError, StopIteration, TypeError):
+        return False
+    return sample.shape is not None and len(sample.shape) == 5
 
 
 def _looks_like_language_diffusion(pkg: Any) -> bool:
@@ -834,6 +903,40 @@ def write_onnx_genai_config(
                 schedule=sigma_schedule,
                 timesteps=timesteps,
                 guidance_scale=1.0 if guidance_scale is None else guidance_scale,
+                artifact_paths=kwargs.pop("artifact_paths", None),
+            )
+            artifacts = {"inference_metadata": path}
+            tokenizer_path = _write_hf_tokenizer(output_dir, source, revision=revision)
+            if tokenizer_path is not None:
+                artifacts["tokenizer"] = tokenizer_path
+            return artifacts
+        if _looks_like_video_diffusion(pkg):
+            if scheduler is None:
+                scheduler = load_diffusers_scheduler_config(source, revision=revision)
+            resolved_scheduler = scheduler or SchedulerConfig(kind="ddim")
+            timesteps, alpha_schedule = _ddim_alpha_schedule(
+                resolved_scheduler, num_inference_steps
+            )
+            scaling_factor = load_diffusers_vae_scaling_factor(source) or 1.0
+            path = write_video_diffusion_workflow_metadata(
+                pkg,
+                output_dir,
+                num_inference_steps=num_inference_steps,
+                schedule=alpha_schedule,
+                timesteps=timesteps,
+                solver="ddim",
+                prediction_type=resolved_scheduler.prediction_type,
+                clip_sample_range=(
+                    resolved_scheduler.clip_sample_range
+                    if resolved_scheduler.clip_sample
+                    else None
+                ),
+                scaling_factor=scaling_factor,
+                guidance_scale=(
+                    None
+                    if guidance_scale is None or np.isclose(guidance_scale, 1.0)
+                    else float(guidance_scale)
+                ),
             )
             artifacts = {"inference_metadata": path}
             tokenizer_path = _write_hf_tokenizer(output_dir, source, revision=revision)

--- a/src/mobius/integrations/onnx_genai/auto_export.py
+++ b/src/mobius/integrations/onnx_genai/auto_export.py
@@ -886,7 +886,7 @@ def write_onnx_genai_config(
                     "pass guidance_scale explicitly using the source pipeline's default"
                 )
             if scheduler is None:
-                scheduler = load_diffusers_scheduler_config(source)
+                scheduler = load_diffusers_scheduler_config(source, revision=revision)
             if scheduler is None:
                 raise ValueError(
                     "image-edit workflow requires the diffusers scheduler config; "
@@ -928,7 +928,9 @@ def write_onnx_genai_config(
                     "pass guidance_scale=1.0 for unguided generation, or the source "
                     "pipeline's classifier-free guidance default"
                 )
-            scaling_factor = load_diffusers_vae_scaling_factor(source) or 1.0
+            scaling_factor = (
+                load_diffusers_vae_scaling_factor(source, revision=revision) or 1.0
+            )
             path = write_video_diffusion_workflow_metadata(
                 pkg,
                 output_dir,
@@ -986,7 +988,7 @@ def write_onnx_genai_config(
             else float(guidance_scale)
         )
         decoder_input_scale = 1.0
-        scaling_factor = load_diffusers_vae_scaling_factor(source)
+        scaling_factor = load_diffusers_vae_scaling_factor(source, revision=revision)
         if scaling_factor:
             decoder_input_scale = 1.0 / scaling_factor
         path = write_diffusion_workflow_metadata(

--- a/src/mobius/integrations/onnx_genai/auto_export.py
+++ b/src/mobius/integrations/onnx_genai/auto_export.py
@@ -880,6 +880,11 @@ def write_onnx_genai_config(
     if _looks_like_diffusion(pkg):
         is_image_edit = _looks_like_image_edit(pkg)
         if is_image_edit:
+            if guidance_scale is None:
+                raise ValueError(
+                    "image-edit workflow must declare its true-CFG guidance: "
+                    "pass guidance_scale explicitly using the source pipeline's default"
+                )
             if scheduler is None:
                 scheduler = load_diffusers_scheduler_config(source)
             if scheduler is None:
@@ -902,7 +907,7 @@ def write_onnx_genai_config(
                 num_inference_steps=num_inference_steps,
                 schedule=sigma_schedule,
                 timesteps=timesteps,
-                guidance_scale=1.0 if guidance_scale is None else guidance_scale,
+                guidance_scale=guidance_scale,
                 artifact_paths=kwargs.pop("artifact_paths", None),
             )
             artifacts = {"inference_metadata": path}
@@ -917,6 +922,12 @@ def write_onnx_genai_config(
             timesteps, alpha_schedule = _ddim_alpha_schedule(
                 resolved_scheduler, num_inference_steps
             )
+            if guidance_scale is None:
+                raise ValueError(
+                    "video diffusion workflow must declare its guidance: "
+                    "pass guidance_scale=1.0 for unguided generation, or the source "
+                    "pipeline's classifier-free guidance default"
+                )
             scaling_factor = load_diffusers_vae_scaling_factor(source) or 1.0
             path = write_video_diffusion_workflow_metadata(
                 pkg,

--- a/src/mobius/integrations/onnx_genai/auto_export_test.py
+++ b/src/mobius/integrations/onnx_genai/auto_export_test.py
@@ -17,8 +17,10 @@ from mobius._configs import QuantizationConfig
 from mobius._model_package import ModelPackage
 from mobius.integrations.onnx_genai import write_onnx_genai_config
 from mobius.integrations.onnx_genai.auto_export import (
+    _ddim_alpha_schedule,
     _flow_match_euler_schedule,
     _looks_like_image_edit,
+    _looks_like_video_diffusion,
 )
 from mobius.integrations.onnx_genai.inference_metadata import SchedulerConfig
 from mobius.integrations.onnx_genai.inference_metadata_test import (
@@ -92,6 +94,65 @@ def _diffusion_package(*, text: bool = False):
     )
     components.update({"denoiser": denoiser, "vae_decoder": vae})
     return ModelPackage(components)
+
+
+def _video_diffusion_package() -> ModelPackage:
+    latent = ["batch", "frames", 4, "height", "width"]
+    transformer = _model(
+        "transformer",
+        [
+            _value("sample", ir.DataType.FLOAT, latent),
+            _value("timestep", ir.DataType.FLOAT, ["batch"]),
+            _value(
+                "encoder_hidden_states",
+                ir.DataType.FLOAT,
+                ["batch", "prompt_sequence", 32],
+            ),
+        ],
+        [("noise_pred", ir.DataType.FLOAT, latent)],
+    )
+    text_encoder = _model(
+        "text_encoder",
+        [_value("input_ids", ir.DataType.INT64, ["batch", "prompt_sequence"])],
+        [
+            (
+                "encoder_hidden_states",
+                ir.DataType.FLOAT,
+                ["batch", "prompt_sequence", 32],
+            )
+        ],
+    )
+    vae = _model(
+        "vae_decoder",
+        [
+            _value(
+                "latent_sample",
+                ir.DataType.FLOAT,
+                ["batch", 4, "latent_frames", "height", "width"],
+            ),
+            _value(
+                "conv_cache.conv_in",
+                ir.DataType.FLOAT,
+                ["batch", 4, "cache_frames", "height", "width"],
+            ),
+        ],
+        [
+            ("sample", ir.DataType.FLOAT, ["batch", 3, "video_frames", "height", "width"]),
+            (
+                "conv_cache_out.conv_in",
+                ir.DataType.FLOAT,
+                ["batch", 4, "cache_frames", "height", "width"],
+            ),
+        ],
+    )
+    vae.metadata_props["mobius.conv_cache.spatial_scale.conv_cache.conv_in"] = "1"
+    return ModelPackage(
+        {
+            "transformer": transformer,
+            "text_encoder": text_encoder,
+            "vae_decoder": vae,
+        }
+    )
 
 
 class _MultimodalPkg(dict):
@@ -379,6 +440,37 @@ def test_dispatch_diffusion(tmp_path):
     assert (tmp_path / "policies" / "schedule_lookup.onnx").is_file()
 
 
+def test_dispatch_video_diffusion_uses_typed_ddim(tmp_path, monkeypatch):
+    package = _video_diffusion_package()
+    assert _looks_like_video_diffusion(package)
+    scheduler = SchedulerConfig(
+        kind="ddim",
+        prediction_type="v_prediction",
+        timestep_spacing="trailing",
+        rescale_betas_zero_snr=True,
+        snr_shift_scale=3.0,
+    )
+    monkeypatch.setattr(
+        "mobius.integrations.onnx_genai.auto_export._write_hf_tokenizer",
+        lambda *args, **kwargs: None,
+    )
+    artifacts = write_onnx_genai_config(
+        package,
+        str(tmp_path),
+        scheduler=scheduler,
+        num_inference_steps=2,
+        guidance_scale=6.0,
+    )
+    with open(artifacts["inference_metadata"]) as handle:
+        metadata = yaml.safe_load(handle)
+    workflow = metadata["pipeline"]["workflow"]
+    assert workflow["outputs"]["video"]["contract"]["rank"] == 5
+    loop = next(step for step in workflow["steps"] if step["kind"] == "loop")
+    assert [node["component"] for node in loop["steps"]].count("transformer") == 2
+    _, schedule = _ddim_alpha_schedule(scheduler, 2)
+    assert schedule[0] < schedule[1] <= schedule[2]
+
+
 def test_single_diffusion_component_requires_explicit_vae(tmp_path):
     pkg = _DiffusionPkg({"transformer": object()})
     with pytest.raises(
@@ -521,10 +613,15 @@ def test_dispatch_image_edit_emits_workflow(tmp_path):
         num_inference_steps=8,
         image_seq_len=4104,
         guidance_scale=4.0,
+        artifact_paths={"transformer": "models/transformer.onnx"},
     )
     with open(arts["inference_metadata"]) as handle:
         meta = yaml.safe_load(handle)
     workflow = meta["pipeline"]["workflow"]
+    assert (
+        workflow["components"]["transformer"]["implementation"]["artifact"]
+        == "models/transformer.onnx"
+    )
 
     loop = next(step for step in workflow["steps"] if step["kind"] == "loop")
 

--- a/src/mobius/integrations/onnx_genai/auto_export_test.py
+++ b/src/mobius/integrations/onnx_genai/auto_export_test.py
@@ -481,6 +481,45 @@ def test_video_diffusion_requires_explicit_guidance(tmp_path):
         )
 
 
+def test_video_diffusion_forwards_revision_to_semantic_config_loaders(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_scheduler(source, *, revision=None):
+        calls.append(("scheduler", source, revision))
+        return SchedulerConfig(kind="ddim")
+
+    def fake_vae_scaling(source, *, revision=None):
+        calls.append(("vae", source, revision))
+        return 0.13025
+
+    monkeypatch.setattr(
+        "mobius.integrations.onnx_genai.auto_export.load_diffusers_scheduler_config",
+        fake_scheduler,
+    )
+    monkeypatch.setattr(
+        "mobius.integrations.onnx_genai.auto_export.load_diffusers_vae_scaling_factor",
+        fake_vae_scaling,
+    )
+    monkeypatch.setattr(
+        "mobius.integrations.onnx_genai.auto_export._write_hf_tokenizer",
+        lambda *args, **kwargs: None,
+    )
+
+    write_onnx_genai_config(
+        _video_diffusion_package(),
+        str(tmp_path),
+        source="zai-org/CogVideoX-2b",
+        revision="pinned-revision",
+        num_inference_steps=2,
+        guidance_scale=6.0,
+    )
+
+    assert calls == [
+        ("scheduler", "zai-org/CogVideoX-2b", "pinned-revision"),
+        ("vae", "zai-org/CogVideoX-2b", "pinned-revision"),
+    ]
+
+
 def test_single_diffusion_component_requires_explicit_vae(tmp_path):
     pkg = _DiffusionPkg({"transformer": object()})
     with pytest.raises(
@@ -688,6 +727,35 @@ def test_image_edit_requires_explicit_guidance(tmp_path):
         )
 
 
+def test_image_edit_forwards_revision_to_scheduler_loader(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_scheduler(source, *, revision=None):
+        calls.append((source, revision))
+        return SchedulerConfig.from_diffusers(_FLOW_MATCH_SCHEDULER)
+
+    monkeypatch.setattr(
+        "mobius.integrations.onnx_genai.auto_export.load_diffusers_scheduler_config",
+        fake_scheduler,
+    )
+    monkeypatch.setattr(
+        "mobius.integrations.onnx_genai.auto_export._write_hf_tokenizer",
+        lambda *args, **kwargs: None,
+    )
+
+    write_onnx_genai_config(
+        _image_edit_package(),
+        str(tmp_path),
+        source="Qwen/Qwen-Image-Edit-2509",
+        revision="pinned-revision",
+        num_inference_steps=2,
+        image_seq_len=4104,
+        guidance_scale=4.0,
+    )
+
+    assert calls == [("Qwen/Qwen-Image-Edit-2509", "pinned-revision")]
+
+
 @pytest.mark.parametrize("dtype", [ir.DataType.FLOAT16, ir.DataType.BFLOAT16])
 def test_image_edit_contract_uses_float_clamp_output(tmp_path, dtype):
     source = tmp_path / "source"
@@ -821,6 +889,40 @@ def test_dispatch_diffusion_auto_reads_scheduler_from_source(tmp_path):
     }
     schedule = ir.load(out / "policies" / "diffusion_schedule.onnx")
     assert list(schedule.graph.outputs[0].shape) == [16]
+
+
+def test_diffusion_forwards_revision_to_semantic_config_loaders(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_scheduler(source, *, revision=None):
+        calls.append(("scheduler", source, revision))
+        return SchedulerConfig(kind="euler")
+
+    def fake_vae_scaling(source, *, revision=None):
+        calls.append(("vae", source, revision))
+        return 0.18215
+
+    monkeypatch.setattr(
+        "mobius.integrations.onnx_genai.auto_export.load_diffusers_scheduler_config",
+        fake_scheduler,
+    )
+    monkeypatch.setattr(
+        "mobius.integrations.onnx_genai.auto_export.load_diffusers_vae_scaling_factor",
+        fake_vae_scaling,
+    )
+
+    write_onnx_genai_config(
+        _diffusion_package(),
+        str(tmp_path),
+        source="nota-ai/bk-sdm-small",
+        revision="pinned-revision",
+        num_inference_steps=2,
+    )
+
+    assert calls == [
+        ("scheduler", "nota-ai/bk-sdm-small", "pinned-revision"),
+        ("vae", "nota-ai/bk-sdm-small", "pinned-revision"),
+    ]
 
 
 def test_dispatch_vision_multimodal_pipeline(tmp_path):

--- a/src/mobius/integrations/onnx_genai/auto_export_test.py
+++ b/src/mobius/integrations/onnx_genai/auto_export_test.py
@@ -471,6 +471,16 @@ def test_dispatch_video_diffusion_uses_typed_ddim(tmp_path, monkeypatch):
     assert schedule[0] < schedule[1] <= schedule[2]
 
 
+def test_video_diffusion_requires_explicit_guidance(tmp_path):
+    with pytest.raises(ValueError, match="video diffusion workflow must declare"):
+        write_onnx_genai_config(
+            _video_diffusion_package(),
+            str(tmp_path),
+            scheduler=SchedulerConfig(kind="ddim"),
+            num_inference_steps=2,
+        )
+
+
 def test_single_diffusion_component_requires_explicit_vae(tmp_path):
     pkg = _DiffusionPkg({"transformer": object()})
     with pytest.raises(
@@ -480,7 +490,7 @@ def test_single_diffusion_component_requires_explicit_vae(tmp_path):
         write_onnx_genai_config(pkg, str(tmp_path), num_inference_steps=2)
 
 
-def _image_edit_package():
+def _image_edit_package(dtype: ir.DataType = ir.DataType.FLOAT):
     """Build a Qwen-Image-Edit-shaped package with the real port contract.
 
     Mirrors ``QwenImageTask``: rank-3 packed latents, a ``target_sequence_length``
@@ -490,11 +500,11 @@ def _image_edit_package():
     transformer = _model(
         "transformer",
         [
-            _value("sample", ir.DataType.FLOAT, tokens),
+            _value("sample", dtype, tokens),
             _value("timestep", ir.DataType.FLOAT, ["batch"]),
             _value(
                 "encoder_hidden_states",
-                ir.DataType.FLOAT,
+                dtype,
                 ["batch", "text_sequence_length", 32],
             ),
             _value(
@@ -502,23 +512,23 @@ def _image_edit_package():
                 ir.DataType.BOOL,
                 ["batch", "text_sequence_length"],
             ),
-            _value("image_rotary_cos", ir.DataType.FLOAT, ["image_sequence_length", 8]),
-            _value("image_rotary_sin", ir.DataType.FLOAT, ["image_sequence_length", 8]),
-            _value("text_rotary_cos", ir.DataType.FLOAT, ["text_sequence_length", 8]),
-            _value("text_rotary_sin", ir.DataType.FLOAT, ["text_sequence_length", 8]),
+            _value("image_rotary_cos", dtype, ["image_sequence_length", 8]),
+            _value("image_rotary_sin", dtype, ["image_sequence_length", 8]),
+            _value("text_rotary_cos", dtype, ["text_sequence_length", 8]),
+            _value("text_rotary_sin", dtype, ["text_sequence_length", 8]),
             _value("target_sequence_length", ir.DataType.INT64, [1]),
         ],
-        [("noise_pred", ir.DataType.FLOAT, tokens)],
+        [("noise_pred", dtype, tokens)],
     )
     vae_encoder = _model(
         "vae_encoder",
-        [_value("pixel_values", ir.DataType.FLOAT, ["batch", 3, 1, "height", "width"])],
-        [("latent_sample", ir.DataType.FLOAT, ["batch", 16, 1, "lheight", "lwidth"])],
+        [_value("pixel_values", dtype, ["batch", 3, 1, "height", "width"])],
+        [("latent_sample", dtype, ["batch", 16, 1, "lheight", "lwidth"])],
     )
     vae_decoder = _model(
         "vae_decoder",
-        [_value("latent_sample", ir.DataType.FLOAT, ["batch", 16, 1, "lheight", "lwidth"])],
-        [("image", ir.DataType.FLOAT, ["batch", 3, 1, "height", "width"])],
+        [_value("latent_sample", dtype, ["batch", 16, 1, "lheight", "lwidth"])],
+        [("image", dtype, ["batch", 3, 1, "height", "width"])],
     )
     return ModelPackage(
         {
@@ -665,6 +675,44 @@ def test_dispatch_image_edit_emits_workflow(tmp_path):
         assert (output / "policies" / f"{policy}.onnx").is_file()
 
 
+def test_image_edit_requires_explicit_guidance(tmp_path):
+    source = tmp_path / "source"
+    _write_scheduler(source)
+    with pytest.raises(ValueError, match="image-edit workflow must declare"):
+        write_onnx_genai_config(
+            _image_edit_package(),
+            str(tmp_path / "output"),
+            source=str(source),
+            num_inference_steps=8,
+            image_seq_len=4104,
+        )
+
+
+@pytest.mark.parametrize("dtype", [ir.DataType.FLOAT16, ir.DataType.BFLOAT16])
+def test_image_edit_contract_uses_float_clamp_output(tmp_path, dtype):
+    source = tmp_path / "source"
+    output = tmp_path / "output"
+    package = _image_edit_package(dtype)
+    _write_scheduler(source)
+    artifacts = write_onnx_genai_config(
+        package,
+        str(output),
+        source=str(source),
+        num_inference_steps=2,
+        image_seq_len=4104,
+        guidance_scale=4.0,
+    )
+    with open(artifacts["inference_metadata"]) as handle:
+        workflow = yaml.safe_load(handle)["pipeline"]["workflow"]
+
+    assert package["vae_decoder"].graph.outputs[0].dtype == dtype
+    assert (
+        package.policy_components["image_output_clamp"].model.graph.outputs[0].dtype
+        == ir.DataType.FLOAT
+    )
+    assert workflow["outputs"]["image"]["contract"]["dtype"] == "float32"
+
+
 def test_image_edit_requires_image_seq_len(tmp_path):
     """The schedule is resolution dependent, so it cannot be guessed."""
     source = tmp_path / "source"
@@ -675,6 +723,7 @@ def test_image_edit_requires_image_seq_len(tmp_path):
             str(tmp_path / "output"),
             source=str(source),
             num_inference_steps=8,
+            guidance_scale=4.0,
         )
 
 
@@ -685,6 +734,7 @@ def test_image_edit_requires_scheduler_config(tmp_path):
             str(tmp_path / "output"),
             num_inference_steps=8,
             image_seq_len=4104,
+            guidance_scale=4.0,
         )
 
 

--- a/src/mobius/integrations/onnx_genai/auto_export_test.py
+++ b/src/mobius/integrations/onnx_genai/auto_export_test.py
@@ -551,7 +551,7 @@ def test_dispatch_image_edit_emits_workflow(tmp_path):
     ]
 
     tail = [step["component"] for step in workflow["steps"] if step["kind"] == "invoke"]
-    assert tail == ["unpack_latents", "vae_decoder"]
+    assert tail == ["unpack_latents", "vae_decoder", "image_output_clamp"]
 
     # Positive and negative conditioning cannot share a sequence contract.
     inputs = workflow["inputs"]

--- a/src/mobius/integrations/onnx_genai/comfyui_test.py
+++ b/src/mobius/integrations/onnx_genai/comfyui_test.py
@@ -15,6 +15,8 @@ from mobius.integrations.onnx_genai.comfyui import (
     translate_comfyui_workflow,
     translate_comfyui_workflow_file,
 )
+from mobius.integrations.onnx_genai.convert import convert_comfyui_workflow
+from mobius.integrations.onnx_genai.inference_metadata import SchedulerConfig
 
 # ComfyUI's canonical "default" text-to-image API-format workflow (trimmed).
 _DEFAULT_TXT2IMG = {
@@ -73,6 +75,29 @@ def test_parse_recovers_full_run_params():
     assert wf.sampler_name == "euler"
     assert wf.scheduler_kind == "euler"
     assert wf.checkpoint == "v1-5.safetensors"
+
+
+def test_conversion_forwards_revision_to_scheduler_loader(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_scheduler(source, *, revision=None):
+        calls.append((source, revision))
+        return SchedulerConfig(kind="euler")
+
+    monkeypatch.setattr(
+        "mobius.integrations.onnx_genai.convert.load_diffusers_scheduler_config",
+        fake_scheduler,
+    )
+
+    convert_comfyui_workflow(
+        _DEFAULT_TXT2IMG,
+        "nota-ai/bk-sdm-small",
+        str(tmp_path),
+        revision="pinned-revision",
+        compute_timesteps=False,
+    )
+
+    assert calls == [("nota-ai/bk-sdm-small", "pinned-revision")]
 
 
 def test_parse_traces_checkpoint_through_lora():

--- a/src/mobius/integrations/onnx_genai/convert.py
+++ b/src/mobius/integrations/onnx_genai/convert.py
@@ -52,14 +52,21 @@ class ConversionResult:
 
 
 def _scheduler_for_workflow(
-    workflow: ComfyUIWorkflow, checkpoint_source: str | None
+    workflow: ComfyUIWorkflow,
+    checkpoint_source: str | None,
+    *,
+    revision: str | None = None,
 ) -> SchedulerConfig:
     """Build the scheduler config from the workflow + diffusers checkpoint config.
 
     Sampler *kind*/*spacing* come from the ComfyUI graph; the noise *schedule*
     (betas) from the diffusers checkpoint config (SD defaults if unavailable).
     """
-    base = load_diffusers_scheduler_config(checkpoint_source) if checkpoint_source else None
+    base = (
+        load_diffusers_scheduler_config(checkpoint_source, revision=revision)
+        if checkpoint_source
+        else None
+    )
     return SchedulerConfig(
         kind=workflow.scheduler_kind,
         num_train_timesteps=base.num_train_timesteps if base else 1000,
@@ -174,6 +181,7 @@ def convert_comfyui_workflow(
     *,
     sdxl: bool = False,
     compute_timesteps: bool = True,
+    revision: str | None = None,
 ) -> ConversionResult:
     """Translate a ComfyUI workflow into an onnx-genai pipeline metadata directory.
 
@@ -193,6 +201,8 @@ def convert_comfyui_workflow(
             conditioning edges).
         compute_timesteps: Whether to precompute the diffusers inference timesteps
             (requires ``diffusers``); when False they are omitted.
+        revision: Optional pinned Hugging Face revision for the checkpoint's
+            scheduler config.
 
     Returns:
         A :class:`ConversionResult` with the written paths and parsed workflow.
@@ -201,7 +211,11 @@ def convert_comfyui_workflow(
     os.makedirs(output_dir, exist_ok=True)
     use_karras = parsed_workflow.scheduler_spacing == "karras"
     use_exponential = parsed_workflow.scheduler_spacing == "exponential"
-    scheduler = _scheduler_for_workflow(parsed_workflow, checkpoint_source)
+    scheduler = _scheduler_for_workflow(
+        parsed_workflow,
+        checkpoint_source,
+        revision=revision,
+    )
 
     timesteps = None
     if compute_timesteps:

--- a/src/mobius/integrations/onnx_genai/inference_metadata.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata.py
@@ -2271,7 +2271,11 @@ def load_diffusers_scheduler_config(
         return None
 
 
-def load_diffusers_vae_scaling_factor(source: str | None) -> float | None:
+def load_diffusers_vae_scaling_factor(
+    source: str | None,
+    *,
+    revision: str | None = None,
+) -> float | None:
     """Best-effort load of a diffusers ``vae/config.json`` ``scaling_factor``.
 
     The latent a diffusion sampler carries is scaled by this factor before the
@@ -2293,7 +2297,7 @@ def load_diffusers_vae_scaling_factor(source: str | None) -> float | None:
         try:
             from huggingface_hub import hf_hub_download
 
-            path = hf_hub_download(source, "vae/config.json")
+            path = hf_hub_download(source, "vae/config.json", revision=revision)
             with open(path, encoding="utf-8") as handle:
                 raw = json.load(handle)
         except Exception as err:

--- a/src/mobius/integrations/onnx_genai/inference_metadata.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata.py
@@ -2057,6 +2057,13 @@ class SchedulerConfig:
     beta_end: float = 0.012
     beta_schedule: str = "scaled_linear"
     prediction_type: str = "epsilon"
+    clip_sample: bool = False
+    clip_sample_range: float = 1.0
+    set_alpha_to_one: bool = True
+    steps_offset: int = 0
+    timestep_spacing: str = "leading"
+    rescale_betas_zero_snr: bool = False
+    snr_shift_scale: float = 1.0
     use_karras_sigmas: bool = False
     use_exponential_sigmas: bool = False
     shift: float | None = None
@@ -2086,6 +2093,13 @@ class SchedulerConfig:
                 beta_start=self.beta_start,
                 beta_end=self.beta_end,
                 beta_schedule=self.beta_schedule,
+                clip_sample=self.clip_sample,
+                clip_sample_range=self.clip_sample_range,
+                set_alpha_to_one=self.set_alpha_to_one,
+                steps_offset=self.steps_offset,
+                timestep_spacing=self.timestep_spacing,
+                rescale_betas_zero_snr=self.rescale_betas_zero_snr,
+                snr_shift_scale=self.snr_shift_scale,
             )
         if self.use_karras_sigmas:
             meta["use_karras_sigmas"] = True
@@ -2162,6 +2176,13 @@ class SchedulerConfig:
                     "flow_prediction" if kind == "flow_match_euler" else "epsilon",
                 )
             ),
+            clip_sample=bool(config.get("clip_sample")),
+            clip_sample_range=float(config.get("clip_sample_range", 1.0)),
+            set_alpha_to_one=bool(config.get("set_alpha_to_one", True)),
+            steps_offset=int(config.get("steps_offset", 0)),
+            timestep_spacing=str(config.get("timestep_spacing", "leading")),
+            rescale_betas_zero_snr=bool(config.get("rescale_betas_zero_snr")),
+            snr_shift_scale=float(config.get("snr_shift_scale", 1.0)),
             use_karras_sigmas=bool(config.get("use_karras_sigmas")),
             use_exponential_sigmas=bool(config.get("use_exponential_sigmas")),
             shift=float(config["shift"]) if config.get("shift") is not None else None,

--- a/src/mobius/integrations/onnx_genai/inference_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata_test.py
@@ -35,6 +35,7 @@ from mobius.integrations.onnx_genai.inference_metadata import (
     build_native_vlm_package_metadata,
     is_native_vlm_package,
     load_diffusers_scheduler_config,
+    load_diffusers_vae_scaling_factor,
     validate_executable_closure,
     write_diffusion_pipeline_metadata,
     write_native_vlm_package_metadata,
@@ -1690,6 +1691,25 @@ class TestBuildDiffusionPipelineMetadata:
         # Unsupported scheduler must not raise from the loader; returns None so
         # the caller falls back to the DDIM default.
         assert load_diffusers_scheduler_config(str(tmp_path)) is None
+
+    def test_load_vae_scaling_factor_forwards_revision(self, tmp_path, monkeypatch):
+        config = tmp_path / "vae_config.json"
+        config.write_text(json.dumps({"scaling_factor": 0.13025}), encoding="utf-8")
+        calls = []
+
+        def fake_download(source, filename, *, revision=None):
+            calls.append((source, filename, revision))
+            return str(config)
+
+        monkeypatch.setattr("huggingface_hub.hf_hub_download", fake_download)
+
+        factor = load_diffusers_vae_scaling_factor(
+            "zai-org/CogVideoX-2b",
+            revision="pinned-revision",
+        )
+
+        assert factor == pytest.approx(0.13025)
+        assert calls == [("zai-org/CogVideoX-2b", "vae/config.json", "pinned-revision")]
 
     def test_rejects_zero_steps(self):
         with pytest.raises(ValueError):

--- a/src/mobius/integrations/onnx_genai/inference_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata_test.py
@@ -1592,6 +1592,24 @@ class TestBuildDiffusionPipelineMetadata:
         assert sched.kind == "ddim"
         assert sched.beta_end == pytest.approx(0.02)
 
+    def test_scheduler_preserves_cogvideox_ddim_equation_fields(self):
+        sched = SchedulerConfig.from_diffusers(
+            {
+                "_class_name": "CogVideoXDDIMScheduler",
+                "prediction_type": "v_prediction",
+                "clip_sample": False,
+                "set_alpha_to_one": True,
+                "timestep_spacing": "trailing",
+                "rescale_betas_zero_snr": True,
+                "snr_shift_scale": 3.0,
+            }
+        )
+        assert sched.kind == "ddim"
+        assert sched.prediction_type == "v_prediction"
+        assert sched.timestep_spacing == "trailing"
+        assert sched.rescale_betas_zero_snr
+        assert sched.snr_shift_scale == pytest.approx(3.0)
+
     def test_scheduler_maps_euler_class(self):
         sched = SchedulerConfig.from_diffusers(
             {"_class_name": "EulerDiscreteScheduler", "beta_schedule": "scaled_linear"}

--- a/src/mobius/integrations/onnx_genai/workflow_metadata.py
+++ b/src/mobius/integrations/onnx_genai/workflow_metadata.py
@@ -3900,7 +3900,12 @@ def build_video_diffusion_workflow_metadata(
 
     if solver not in ("euler", "ddim"):
         raise ValueError("video solver must be 'euler' or 'ddim'")
+    if solver == "euler" and prediction_type != "epsilon":
+        raise ValueError("video Euler solver only supports epsilon prediction")
+    if solver == "ddim" and schedule is None:
+        raise ValueError("video DDIM requires an explicit cumulative-alpha schedule")
     latent_dims = ["batch", "frames", "channels", "height", "width"]
+    vae_dims = ["batch", "channels", "frames", "height", "width"]
     attach_policy_components(pkg, PolicyCapabilities())
     if solver == "ddim":
         # DDIM defines scale_model_input as the identity and consumes cumulative
@@ -3929,24 +3934,57 @@ def build_video_diffusion_workflow_metadata(
         pkg.add_policy_component(
             "guidance_combine", build_guidance_combine(estimate_output.dtype, latent_dims)
         )
+    conditioning_cast = (
+        conditioning_output is not None
+        and conditioning_input is not None
+        and conditioning_output.dtype != conditioning_input.dtype
+    )
+    if conditioning_cast:
+        pkg.add_policy_component(
+            "conditioning_cast",
+            build_tensor_cast(
+                conditioning_output.dtype,
+                conditioning_input.dtype,
+                _contract(conditioning_input)["shape"],
+            ),
+        )
     pkg.add_policy_component(
         "video_latent_init",
-        build_video_latent_initializer(sample_input.dtype, init_noise_sigma),
+        build_video_latent_initializer(
+            sample_input.dtype,
+            init_noise_sigma,
+            history_dtype=timestep_input.dtype,
+        ),
     )
     pkg.add_policy_component(
         "schedule_history_append", build_schedule_history_append(timestep_input.dtype)
     )
     pkg.add_policy_component(
         "video_latent_permute",
-        build_video_latent_permute(latent_permutation or [0, 2, 1, 3, 4]),
+        build_video_latent_permute(
+            latent_permutation or [0, 2, 1, 3, 4],
+            sample_input.dtype,
+        ),
+    )
+    vae_cast = sample_input.dtype != vae_input.dtype
+    if vae_cast:
+        pkg.add_policy_component(
+            "video_vae_cast",
+            build_tensor_cast(sample_input.dtype, vae_input.dtype, vae_dims),
+        )
+    pkg.add_policy_component(
+        "video_latent_unscale",
+        build_video_latent_unscale(scaling_factor, vae_input.dtype),
     )
     pkg.add_policy_component(
-        "video_latent_unscale", build_video_latent_unscale(scaling_factor)
+        "video_decode_chunks", build_video_decode_chunk_count(dtype=vae_input.dtype)
     )
-    pkg.add_policy_component("video_decode_chunks", build_video_decode_chunk_count())
-    pkg.add_policy_component("video_decode_chunk", build_video_decode_chunk())
     pkg.add_policy_component(
-        "video_conv_cache_init", build_video_conv_cache_initializer(cache_entries)
+        "video_decode_chunk", build_video_decode_chunk(dtype=vae_input.dtype)
+    )
+    pkg.add_policy_component(
+        "video_conv_cache_init",
+        build_video_conv_cache_initializer(cache_entries, vae_input.dtype),
     )
 
     schedule_values = schedule or [
@@ -4069,18 +4107,43 @@ def build_video_diffusion_workflow_metadata(
                     "externally_suppliable": True,
                 }
                 negative_text_inputs[value.name] = negative_name
-        conditioning_value = "conditioning.hidden_states"
-        setup_nodes.append(
-            _invoke(text_name, text_inputs, {conditioning_output.name: conditioning_value})
+        raw_conditioning_value = "conditioning.raw_hidden_states"
+        conditioning_value = (
+            "conditioning.hidden_states" if conditioning_cast else raw_conditioning_value
         )
+        setup_nodes.append(
+            _invoke(text_name, text_inputs, {conditioning_output.name: raw_conditioning_value})
+        )
+        if conditioning_cast:
+            setup_nodes.append(
+                _invoke(
+                    "conditioning_cast",
+                    {"value": raw_conditioning_value},
+                    {"cast": conditioning_value},
+                )
+            )
         if guidance_scale is not None:
+            raw_negative_value = "conditioning.raw_negative_hidden_states"
+            negative_value = (
+                "conditioning.negative_hidden_states"
+                if conditioning_cast
+                else raw_negative_value
+            )
             setup_nodes.append(
                 _invoke(
                     text_name,
                     negative_text_inputs,
-                    {conditioning_output.name: "conditioning.negative_hidden_states"},
+                    {conditioning_output.name: raw_negative_value},
                 )
             )
+            if conditioning_cast:
+                setup_nodes.append(
+                    _invoke(
+                        "conditioning_cast",
+                        {"value": raw_negative_value},
+                        {"cast": negative_value},
+                    )
+                )
             inputs["request.guidance_scale"] = {
                 "contract": row_float,
                 "role": {
@@ -4147,9 +4210,7 @@ def build_video_diffusion_workflow_metadata(
     else:
         negative_denoiser_inputs = dict(denoiser_inputs)
         assert conditioning_input is not None
-        negative_denoiser_inputs[conditioning_input.name] = (
-            "conditioning.negative_hidden_states"
-        )
+        negative_denoiser_inputs[conditioning_input.name] = negative_value
         body_nodes.extend(
             [
                 _invoke(
@@ -4357,9 +4418,24 @@ def build_video_diffusion_workflow_metadata(
                     {"latent": "latent.final"},
                     {"permuted": "decode.latent_permuted"},
                 ),
+                *(
+                    [
+                        _invoke(
+                            "video_vae_cast",
+                            {"value": "decode.latent_permuted"},
+                            {"cast": "decode.latent_cast"},
+                        )
+                    ]
+                    if vae_cast
+                    else []
+                ),
                 _invoke(
                     "video_latent_unscale",
-                    {"latent": "decode.latent_permuted"},
+                    {
+                        "latent": (
+                            "decode.latent_cast" if vae_cast else "decode.latent_permuted"
+                        )
+                    },
                     {"unscaled": "decode.latent"},
                 ),
                 _invoke(

--- a/src/mobius/integrations/onnx_genai/workflow_metadata.py
+++ b/src/mobius/integrations/onnx_genai/workflow_metadata.py
@@ -3514,6 +3514,7 @@ def build_image_edit_workflow_metadata(
             ],
             minimum=-1.0,
             maximum=1.0,
+            output_dtype=ir.DataType.FLOAT,
         ),
     )
 

--- a/src/mobius/integrations/onnx_genai/workflow_metadata.py
+++ b/src/mobius/integrations/onnx_genai/workflow_metadata.py
@@ -3086,7 +3086,7 @@ def build_diffusion_workflow_metadata(
             setup_nodes.append(
                 _invoke(
                     "conditioning_cast",
-                    {"tensor": conditional_encoder_value},
+                    {"value": conditional_encoder_value},
                     {"cast": conditioning_value},
                 )
             )
@@ -3142,7 +3142,7 @@ def build_diffusion_workflow_metadata(
                 setup_nodes.append(
                     _invoke(
                         "conditioning_cast",
-                        {"tensor": unconditional_encoder_value},
+                        {"value": unconditional_encoder_value},
                         {"cast": unconditional_value},
                     )
                 )

--- a/src/mobius/integrations/onnx_genai/workflow_metadata.py
+++ b/src/mobius/integrations/onnx_genai/workflow_metadata.py
@@ -66,9 +66,9 @@ from mobius.generation import (
     build_sequence_concat,
     build_sequence_length,
     build_shape_constant,
-    build_tensor_scale,
     build_tensor_cast,
     build_tensor_clamp,
+    build_tensor_scale,
     build_termination_batch_initializer,
     build_token_state_update,
     build_token_to_slot,
@@ -3093,9 +3093,7 @@ def build_diffusion_workflow_metadata(
         if guidance_scale is not None:
             unconditional_value = "conditioning.unconditional"
             unconditional_encoder_value = (
-                "conditioning.unconditional_raw"
-                if casts_conditioning
-                else unconditional_value
+                "conditioning.unconditional_raw" if casts_conditioning else unconditional_value
             )
             negative_inputs = {}
             for index, value in enumerate(text_encoder.graph.inputs):
@@ -3522,7 +3520,6 @@ def build_image_edit_workflow_metadata(
     batch = latent_contract["shape"][0]
     batch_int = {"dtype": "int64", "rank": 1, "shape": [batch]}
     batch_bool = {"dtype": "bool", "rank": 1, "shape": [batch]}
-    row_float = {"dtype": "float32", "rank": 1, "shape": [batch]}
     control_int = {"dtype": "int64", "rank": 1, "shape": [1]}
 
     conditioning_ports = ("encoder_hidden_states", "encoder_hidden_states_mask")
@@ -4237,30 +4234,30 @@ def build_video_diffusion_workflow_metadata(
         )
     body_nodes.extend(
         [
-        _invoke(
-            "solver_step",
-            {
-                "sample": "state.latent.body",
-                "derivative": "denoiser.estimate",
-                "step": "loop.iteration",
-                "schedule": "diffusion.schedule",
-            },
-            {"next_state": "latent.body"},
-            {"solver": _effect("solver.0", "solver.1")},
-        ),
-        _invoke(
-            "schedule_history_append",
-            {
-                "history": "state.scheduler_history.body",
-                "timestep": "diffusion.timestep",
-            },
-            {"next": "scheduler_history.body"},
-        ),
-        _invoke(
-            "continue_predicate",
-            {"done": "package.false"},
-            {"continue": "loop.continue"},
-        ),
+            _invoke(
+                "solver_step",
+                {
+                    "sample": "state.latent.body",
+                    "derivative": "denoiser.estimate",
+                    "step": "loop.iteration",
+                    "schedule": "diffusion.schedule",
+                },
+                {"next_state": "latent.body"},
+                {"solver": _effect("solver.0", "solver.1")},
+            ),
+            _invoke(
+                "schedule_history_append",
+                {
+                    "history": "state.scheduler_history.body",
+                    "timestep": "diffusion.timestep",
+                },
+                {"next": "scheduler_history.body"},
+            ),
+            _invoke(
+                "continue_predicate",
+                {"done": "package.false"},
+                {"continue": "loop.continue"},
+            ),
         ]
     )
 

--- a/src/mobius/integrations/onnx_genai/workflow_metadata.py
+++ b/src/mobius/integrations/onnx_genai/workflow_metadata.py
@@ -3436,6 +3436,8 @@ def build_image_edit_workflow_metadata(
     schedule: list[float],
     timesteps: list[float],
     guidance_scale: float,
+    output_value_range: str = "negative_one_to_one",
+    artifact_paths: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Build a flow-matching image-edit workflow with true classifier-free guidance.
 
@@ -3500,6 +3502,20 @@ def build_image_edit_workflow_metadata(
     pkg.add_policy_component("unpack_latents", build_unpack_latents_2x2(dtype))
     pkg.add_policy_component("sequence_concat", build_sequence_concat(dtype))
     pkg.add_policy_component("true_cfg", build_true_cfg(dtype, guidance_scale=guidance_scale))
+    if output_value_range != "negative_one_to_one":
+        raise ValueError("image-edit workflow currently emits negative_one_to_one images")
+    pkg.add_policy_component(
+        "image_output_clamp",
+        build_tensor_clamp(
+            decoder_output.dtype,
+            [
+                "batch" if index == 0 else f"axis_{index}"
+                for index in range(len(decoder_output.shape or []))
+            ],
+            minimum=-1.0,
+            maximum=1.0,
+        ),
+    )
 
     batch = latent_contract["shape"][0]
     batch_int = {"dtype": "int64", "rank": 1, "shape": [batch]}
@@ -3652,17 +3668,18 @@ def build_image_edit_workflow_metadata(
         "inputs": inputs,
         "outputs": {
             "image": {
-                "contract": _contract(decoder_output),
+                "contract": _request_aligned(_contract(decoder_output)),
                 "role": "image",
-                # Same VAE-decode contract as build_diffusion_workflow_metadata:
-                # Qwen Image Edit (and any package with this component shape)
-                # decodes to pixels normalized to [-1, 1], not [0, 1].
-                "value_range": "negative_one_to_one",
+                "value_range": output_value_range,
                 "stage": "pre_adapter",
             }
         },
         "components": {
-            name: _component(model, _artifact(name, len(pkg))) for name, model in pkg.items()
+            name: _component(
+                model,
+                (artifact_paths or {}).get(name, _artifact(name, len(pkg))),
+            )
+            for name, model in pkg.items()
         },
         "state": {
             "latent": {
@@ -3715,7 +3732,12 @@ def build_image_edit_workflow_metadata(
                 _invoke(
                     "vae_decoder",
                     {decoder_input.name: "vae.latent"},
-                    {decoder_output.name: "vae.image"},
+                    {decoder_output.name: "vae.raw_image"},
+                ),
+                _invoke(
+                    "image_output_clamp",
+                    {"tensor": "vae.raw_image"},
+                    {"clamped": "vae.image"},
                 ),
                 {
                     "kind": "emit",
@@ -3744,6 +3766,7 @@ def write_image_edit_workflow_metadata(
     schedule: list[float],
     timesteps: list[float],
     guidance_scale: float,
+    artifact_paths: dict[str, str] | None = None,
 ) -> str:
     os.makedirs(output_dir, exist_ok=True)
     metadata = build_image_edit_workflow_metadata(
@@ -3752,6 +3775,7 @@ def write_image_edit_workflow_metadata(
         schedule=schedule,
         timesteps=timesteps,
         guidance_scale=guidance_scale,
+        artifact_paths=artifact_paths,
     )
     pkg.save_policy_components(output_dir)
     add_adapter_service_to_metadata(metadata, pkg, output_dir)

--- a/src/mobius/integrations/onnx_genai/workflow_metadata.py
+++ b/src/mobius/integrations/onnx_genai/workflow_metadata.py
@@ -67,6 +67,8 @@ from mobius.generation import (
     build_sequence_length,
     build_shape_constant,
     build_tensor_scale,
+    build_tensor_cast,
+    build_tensor_clamp,
     build_termination_batch_initializer,
     build_token_state_update,
     build_token_to_slot,
@@ -2761,6 +2763,7 @@ def build_diffusion_workflow_metadata(
     guidance_scale: float | None = None,
     latent_source: str = "application",
     latent_row_shape: list[int] | None = None,
+    output_value_range: str = "negative_one_to_one",
 ) -> dict[str, Any]:
     """Build a fixed-schedule diffusion workflow with explicit latent state.
 
@@ -2805,11 +2808,11 @@ def build_diffusion_workflow_metadata(
     assert estimate_output is not None
     assert vae_input is not None
     assert vae_output is not None
-    if len(sample_input.shape or []) != 4 or _contract(sample_input) != _contract(
-        estimate_output
+    if len(sample_input.shape or []) != 4 or not _contracts_compatible(
+        sample_input, estimate_output
     ):
         raise ValueError("diffusion workflow requires matching rank-4 latent/estimate")
-    if _contract(vae_input) != _contract(sample_input):
+    if not _contracts_compatible(vae_input, sample_input):
         raise ValueError("VAE latent input must match the solver latent contract")
 
     text_name = next(
@@ -2833,11 +2836,17 @@ def build_diffusion_workflow_metadata(
             (
                 value
                 for value in text_encoder.graph.outputs
-                if _contract(value) == _contract(conditioning_input)
+                if _contracts_compatible(value, conditioning_input)
             ),
             next(iter(text_encoder.graph.outputs), None),
         )
     conditioned = text_encoder is not None and conditioning_output is not None
+    casts_conditioning = (
+        conditioned
+        and conditioning_input is not None
+        and conditioning_output is not None
+        and conditioning_output.dtype != conditioning_input.dtype
+    )
     if guidance_scale is not None and not conditioned:
         raise ValueError("classifier-free guidance requires a conditioned denoiser")
     if latent_source == "seed" and not latent_row_shape:
@@ -2888,6 +2897,34 @@ def build_diffusion_workflow_metadata(
         pkg.add_policy_component(
             "guidance_combine", build_guidance_combine(sample_input.dtype)
         )
+    if output_value_range != "negative_one_to_one":
+        raise ValueError("diffusion workflow currently emits negative_one_to_one images")
+    pkg.add_policy_component(
+        "image_output_clamp",
+        build_tensor_clamp(
+            vae_output.dtype,
+            [
+                "batch" if index == 0 else f"axis_{index}"
+                for index in range(len(vae_output.shape or []))
+            ],
+            minimum=-1.0,
+            maximum=1.0,
+        ),
+    )
+    if casts_conditioning:
+        assert conditioning_input is not None
+        assert conditioning_output is not None
+        pkg.add_policy_component(
+            "conditioning_cast",
+            build_tensor_cast(
+                conditioning_output.dtype,
+                conditioning_input.dtype,
+                [
+                    "batch" if index == 0 else f"axis_{index}"
+                    for index in range(len(conditioning_output.shape or []))
+                ],
+            ),
+        )
     if latent_source == "seed":
         pkg.add_policy_component(
             "latent_row_shape", build_shape_constant(list(latent_row_shape or ()))
@@ -2895,7 +2932,7 @@ def build_diffusion_workflow_metadata(
         pkg.add_policy_component("latent_noise", build_counter_rng_normal(sample_input.dtype))
 
     batch = _contract(sample_input)["shape"][0]
-    latent_contract = _contract(sample_input)
+    latent_contract = _request_aligned(_contract(sample_input))
     row_int = _request_aligned({"dtype": "int64", "rank": 1, "shape": [batch]})
     row_float = _request_aligned({"dtype": "float32", "rank": 1, "shape": [batch]})
     batch_int = _request_aligned({"dtype": "int64", "rank": 1, "shape": [batch]})
@@ -2931,17 +2968,9 @@ def build_diffusion_workflow_metadata(
         )
     outputs: dict[str, Any] = {
         "image": {
-            "contract": _contract(vae_output),
+            "contract": _request_aligned(_contract(vae_output)),
             "role": "image",
-            # The port plays the semantic role of a diffusers-style VAE
-            # decode: by convention those pixels are normalized to [-1, 1],
-            # with the [0, 1]/uint8 rescale happening downstream in an image
-            # processor, never inside the decoder graph. Real VAE decoders
-            # may bound this range with a final Tanh (as the synthetic
-            # conformance fixture now does) or may rely on training to keep
-            # outputs within range without an explicit bounding op; either
-            # way the declared value_range must hold.
-            "value_range": "negative_one_to_one",
+            "value_range": output_value_range,
             "stage": "pre_adapter",
         },
         "latent": {
@@ -3024,6 +3053,9 @@ def build_diffusion_workflow_metadata(
         assert text_encoder is not None
         assert conditioning_output is not None
         conditioning_value = "conditioning.hidden_states"
+        conditional_encoder_value = (
+            "conditioning.hidden_states_raw" if casts_conditioning else conditioning_value
+        )
         text_inputs = {}
         for index, value in enumerate(text_encoder.graph.inputs):
             name = f"request.{value.name}"
@@ -3047,26 +3079,55 @@ def build_diffusion_workflow_metadata(
             _invoke(
                 text_name,
                 text_inputs,
-                {conditioning_output.name: conditioning_value},
+                {conditioning_output.name: conditional_encoder_value},
             )
         )
+        if casts_conditioning:
+            setup_nodes.append(
+                _invoke(
+                    "conditioning_cast",
+                    {"tensor": conditional_encoder_value},
+                    {"cast": conditioning_value},
+                )
+            )
         if guidance_scale is not None:
             unconditional_value = "conditioning.unconditional"
+            unconditional_encoder_value = (
+                "conditioning.unconditional_raw"
+                if casts_conditioning
+                else unconditional_value
+            )
             negative_inputs = {}
-            for value in text_encoder.graph.inputs:
+            for index, value in enumerate(text_encoder.graph.inputs):
                 name = f"request.negative_{value.name}"
                 inputs[name] = {
                     "contract": _contract(value),
-                    "role": {"kind": "opaque"},
-                    "source": {"kind": "application", "name": f"negative_{value.name}"},
+                    "role": (
+                        {
+                            "kind": "runtime",
+                            "version": "1.0",
+                            "role": "negative_prompt_tokens",
+                        }
+                        if index == 0
+                        else {"kind": "opaque"}
+                    ),
+                    "source": (
+                        {"kind": "request", "field": "negative_prompt_tokens"}
+                        if index == 0
+                        else {"kind": "application", "name": f"negative_{value.name}"}
+                    ),
                     "required": True,
                     "externally_suppliable": True,
                 }
                 negative_inputs[value.name] = name
             inputs["request.guidance_scale"] = {
                 "contract": row_float,
-                "role": {"kind": "opaque"},
-                "source": {"kind": "application", "name": "guidance_scale"},
+                "role": {
+                    "kind": "runtime",
+                    "version": "1.0",
+                    "role": "guidance_scale",
+                },
+                "source": {"kind": "request", "field": "guidance_scale"},
                 "required": False,
                 "default": float(guidance_scale),
             }
@@ -3074,9 +3135,17 @@ def build_diffusion_workflow_metadata(
                 _invoke(
                     text_name,
                     negative_inputs,
-                    {conditioning_output.name: unconditional_value},
+                    {conditioning_output.name: unconditional_encoder_value},
                 )
             )
+            if casts_conditioning:
+                setup_nodes.append(
+                    _invoke(
+                        "conditioning_cast",
+                        {"tensor": unconditional_encoder_value},
+                        {"cast": unconditional_value},
+                    )
+                )
 
     state: dict[str, Any] = {
         "latent": {
@@ -3232,7 +3301,12 @@ def build_diffusion_workflow_metadata(
             _invoke(
                 vae_name,
                 {vae_input.name: decoder_input_value},
-                {vae_output.name: "vae.image"},
+                {vae_output.name: "vae.raw_image"},
+            ),
+            _invoke(
+                "image_output_clamp",
+                {"tensor": "vae.raw_image"},
+                {"clamped": "vae.image"},
             ),
             {
                 "kind": "emit",
@@ -3430,6 +3504,7 @@ def build_image_edit_workflow_metadata(
     batch = latent_contract["shape"][0]
     batch_int = {"dtype": "int64", "rank": 1, "shape": [batch]}
     batch_bool = {"dtype": "bool", "rank": 1, "shape": [batch]}
+    row_float = {"dtype": "float32", "rank": 1, "shape": [batch]}
     control_int = {"dtype": "int64", "rank": 1, "shape": [1]}
 
     conditioning_ports = ("encoder_hidden_states", "encoder_hidden_states_mask")
@@ -3697,6 +3772,8 @@ def build_video_diffusion_workflow_metadata(
     latent_permutation: list[int] | None = None,
     solver: str = "euler",
     clip_sample_range: float | None = None,
+    prediction_type: str = "epsilon",
+    guidance_scale: float | None = None,
 ) -> dict[str, Any]:
     """Build a text-to-video diffusion workflow over rank-5 temporal latents.
 
@@ -3793,6 +3870,8 @@ def build_video_diffusion_workflow_metadata(
             ),
             next(iter(text_encoder.graph.outputs), None),
         )
+    if guidance_scale is not None and (text_encoder is None or conditioning_output is None):
+        raise ValueError("video classifier-free guidance requires a text encoder")
 
     if solver not in ("euler", "ddim"):
         raise ValueError("video solver must be 'euler' or 'ddim'")
@@ -3807,7 +3886,10 @@ def build_video_diffusion_workflow_metadata(
         pkg.add_policy_component(
             "solver_step",
             build_ddim_solver_step(
-                sample_input.dtype, latent_dims, clip_sample_range=clip_sample_range
+                sample_input.dtype,
+                latent_dims,
+                clip_sample_range=clip_sample_range,
+                prediction_type=prediction_type,
             ),
         )
     else:
@@ -3818,6 +3900,10 @@ def build_video_diffusion_workflow_metadata(
             "solver_step", build_euler_solver_step(sample_input.dtype, latent_dims)
         )
     pkg.add_policy_component("continue_predicate", build_boolean_not())
+    if guidance_scale is not None:
+        pkg.add_policy_component(
+            "guidance_combine", build_guidance_combine(estimate_output.dtype, latent_dims)
+        )
     pkg.add_policy_component(
         "video_latent_init",
         build_video_latent_initializer(sample_input.dtype, init_noise_sigma),
@@ -3854,6 +3940,7 @@ def build_video_diffusion_workflow_metadata(
     batch = latent_contract["shape"][0]
     batch_int = {"dtype": "int64", "rank": 1, "shape": [batch]}
     batch_bool = {"dtype": "bool", "rank": 1, "shape": [batch]}
+    row_float = {"dtype": "float32", "rank": 1, "shape": [batch]}
     control_int = {"dtype": "int64", "rank": 1, "shape": [1]}
     history_contract = _request_aligned(
         {
@@ -3914,6 +4001,7 @@ def build_video_diffusion_workflow_metadata(
     conditioning_value = None
     if text_encoder is not None and conditioning_output is not None:
         text_inputs = {}
+        negative_text_inputs = {}
         for index, value in enumerate(text_encoder.graph.inputs):
             name = f"request.{value.name}"
             inputs[name] = {
@@ -3931,10 +4019,55 @@ def build_video_diffusion_workflow_metadata(
                 "required": True,
             }
             text_inputs[value.name] = name
+            if guidance_scale is not None:
+                negative_name = f"request.negative_{value.name}"
+                inputs[negative_name] = {
+                    "contract": _request_aligned(_contract(value)),
+                    "role": (
+                        {
+                            "kind": "runtime",
+                            "version": "1.0",
+                            "role": "negative_prompt_tokens",
+                        }
+                        if index == 0
+                        else {"kind": "opaque"}
+                    ),
+                    "source": (
+                        {"kind": "request", "field": "negative_prompt_tokens"}
+                        if index == 0
+                        else {
+                            "kind": "application",
+                            "name": f"negative_{value.name}",
+                        }
+                    ),
+                    "required": True,
+                    "externally_suppliable": True,
+                }
+                negative_text_inputs[value.name] = negative_name
         conditioning_value = "conditioning.hidden_states"
         setup_nodes.append(
             _invoke(text_name, text_inputs, {conditioning_output.name: conditioning_value})
         )
+        if guidance_scale is not None:
+            setup_nodes.append(
+                _invoke(
+                    text_name,
+                    negative_text_inputs,
+                    {conditioning_output.name: "conditioning.negative_hidden_states"},
+                )
+            )
+            inputs["request.guidance_scale"] = {
+                "contract": row_float,
+                "role": {
+                    "kind": "runtime",
+                    "version": "1.0",
+                    "role": "guidance_scale",
+                },
+                "source": {"kind": "request", "field": "guidance_scale"},
+                "required": False,
+                "default": guidance_scale,
+                "externally_suppliable": True,
+            }
     if conditioning_input is not None and conditioning_value is None:
         # No text encoder ships with the package, so the prompt embedding is
         # supplied by the application. Conditioning stays a declared input
@@ -3977,7 +4110,46 @@ def build_video_diffusion_workflow_metadata(
             },
             {"model_input": "diffusion.model_input"},
         ),
-        _invoke(denoiser_name, denoiser_inputs, {estimate_output.name: "denoiser.estimate"}),
+    ]
+    if guidance_scale is None:
+        body_nodes.append(
+            _invoke(
+                denoiser_name,
+                denoiser_inputs,
+                {estimate_output.name: "denoiser.estimate"},
+            )
+        )
+    else:
+        negative_denoiser_inputs = dict(denoiser_inputs)
+        assert conditioning_input is not None
+        negative_denoiser_inputs[conditioning_input.name] = (
+            "conditioning.negative_hidden_states"
+        )
+        body_nodes.extend(
+            [
+                _invoke(
+                    denoiser_name,
+                    negative_denoiser_inputs,
+                    {estimate_output.name: "denoiser.unconditional"},
+                ),
+                _invoke(
+                    denoiser_name,
+                    denoiser_inputs,
+                    {estimate_output.name: "denoiser.conditional"},
+                ),
+                _invoke(
+                    "guidance_combine",
+                    {
+                        "unconditional": "denoiser.unconditional",
+                        "conditional": "denoiser.conditional",
+                        "scale": "request.guidance_scale",
+                    },
+                    {"estimate": "denoiser.estimate"},
+                ),
+            ]
+        )
+    body_nodes.extend(
+        [
         _invoke(
             "solver_step",
             {
@@ -4002,7 +4174,8 @@ def build_video_diffusion_workflow_metadata(
             {"done": "package.false"},
             {"continue": "loop.continue"},
         ),
-    ]
+        ]
+    )
 
     decode_body: list[dict[str, Any]] = [
         _invoke(

--- a/src/mobius/integrations/onnx_genai/workflow_metadata.py
+++ b/src/mobius/integrations/onnx_genai/workflow_metadata.py
@@ -3517,6 +3517,7 @@ def build_image_edit_workflow_metadata(
             output_dtype=ir.DataType.FLOAT,
         ),
     )
+    clamp_output = pkg.policy_components["image_output_clamp"].model.graph.outputs[0]
 
     batch = latent_contract["shape"][0]
     batch_int = {"dtype": "int64", "rank": 1, "shape": [batch]}
@@ -3669,7 +3670,7 @@ def build_image_edit_workflow_metadata(
         "inputs": inputs,
         "outputs": {
             "image": {
-                "contract": _request_aligned(_contract(decoder_output)),
+                "contract": _request_aligned(_contract(clamp_output)),
                 "role": "image",
                 "value_range": output_value_range,
                 "stage": "pre_adapter",

--- a/src/mobius/integrations/onnx_genai/workflow_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/workflow_metadata_test.py
@@ -475,16 +475,21 @@ def test_language_diffusion_uses_exclusive_ssa_workflow():
     assert graph["steps"][1]["mode"] == "replace"
 
 
-def _video_package(*, cache_ports: bool = True, latent_rank: int = 5) -> ModelPackage:
+def _video_package(
+    *,
+    cache_ports: bool = True,
+    latent_rank: int = 5,
+    dtype: ir.DataType = ir.DataType.FLOAT,
+    timestep_dtype: ir.DataType = ir.DataType.INT64,
+    text_encoder_dtype: ir.DataType | None = None,
+) -> ModelPackage:
     latent_shape: list[int | str] = ["batch", "num_frames", 4, "height", "width"]
     if latent_rank == 4:
         latent_shape = ["batch", 4, "height", "width"]
-    sample = _value("sample", ir.DataType.FLOAT, latent_shape)
-    timestep = _value("timestep", ir.DataType.INT64, ["batch"])
-    conditioning = _value(
-        "encoder_hidden_states", ir.DataType.FLOAT, ["batch", "prompt_sequence", 32]
-    )
-    noise_pred = _value("noise_pred", ir.DataType.FLOAT, latent_shape)
+    sample = _value("sample", dtype, latent_shape)
+    timestep = _value("timestep", timestep_dtype, ["batch"])
+    conditioning = _value("encoder_hidden_states", dtype, ["batch", "prompt_sequence", 32])
+    noise_pred = _value("noise_pred", dtype, latent_shape)
     denoiser = ir.Graph(
         inputs=[sample, timestep, conditioning],
         outputs=[noise_pred],
@@ -495,12 +500,12 @@ def _video_package(*, cache_ports: bool = True, latent_rank: int = 5) -> ModelPa
 
     latent_sample = _value(
         "latent_sample",
-        ir.DataType.FLOAT,
+        dtype,
         ["batch", 4, "latent_frames", "latent_height", "latent_width"],
     )
     frames = _value(
         "sample",
-        ir.DataType.FLOAT,
+        dtype,
         ["batch", 3, "frames", "2*latent_height", "2*latent_width"],
     )
     vae_inputs = [latent_sample]
@@ -509,14 +514,14 @@ def _video_package(*, cache_ports: bool = True, latent_rank: int = 5) -> ModelPa
         vae_inputs.append(
             _value(
                 "conv_cache.conv_in",
-                ir.DataType.FLOAT,
+                dtype,
                 ["batch", 4, "cache_frames", "latent_height", "latent_width"],
             )
         )
         vae_outputs.append(
             _value(
                 "conv_cache_out.conv_in",
-                ir.DataType.FLOAT,
+                dtype,
                 ["batch", 4, "cache_frames", "latent_height", "latent_width"],
             )
         )
@@ -529,17 +534,35 @@ def _video_package(*, cache_ports: bool = True, latent_rank: int = 5) -> ModelPa
     )
     vae_model = ir.Model(vae, ir_version=11)
     vae_model.metadata_props["mobius.conv_cache.spatial_scale.conv_cache.conv_in"] = "1"
-    return ModelPackage(
-        {
-            "transformer": ir.Model(denoiser, ir_version=11),
-            "vae_decoder": vae_model,
-        }
-    )
+    components = {
+        "transformer": ir.Model(denoiser, ir_version=11),
+        "vae_decoder": vae_model,
+    }
+    if text_encoder_dtype is not None:
+        text_graph = ir.Graph(
+            inputs=[_value("input_ids", ir.DataType.INT64, ["batch", "prompt_sequence"])],
+            outputs=[
+                _value(
+                    "encoder_hidden_states",
+                    text_encoder_dtype,
+                    ["batch", "prompt_sequence", 32],
+                )
+            ],
+            nodes=[],
+            name="text_encoder",
+            opset_imports={"": 24},
+        )
+        components["text_encoder"] = ir.Model(text_graph, ir_version=11)
+    return ModelPackage(components)
 
 
 def test_video_diffusion_keeps_the_temporal_axis_through_every_stage():
     metadata = build_video_diffusion_workflow_metadata(
-        _video_package(), num_inference_steps=2, solver="ddim"
+        _video_package(),
+        num_inference_steps=2,
+        solver="ddim",
+        schedule=[0.4, 0.9, 1.0],
+        timesteps=[1, 0],
     )
     workflow = metadata["pipeline"]["workflow"]
 
@@ -691,6 +714,46 @@ def test_image_edit_workflow_declares_image_value_range():
     published = metadata["pipeline"]["workflow"]["outputs"]["image"]
     assert published["role"] == "image"
     assert published["value_range"] == "negative_one_to_one"
+
+
+def test_video_diffusion_cfg_and_reduced_precision_contracts():
+    package = _video_package(
+        dtype=ir.DataType.FLOAT16,
+        timestep_dtype=ir.DataType.FLOAT,
+        text_encoder_dtype=ir.DataType.FLOAT,
+    )
+    metadata = build_video_diffusion_workflow_metadata(
+        package,
+        num_inference_steps=2,
+        solver="ddim",
+        schedule=[0.4, 0.9, 1.0],
+        timesteps=[1, 0],
+        guidance_scale=6.0,
+    )
+    workflow = metadata["pipeline"]["workflow"]
+    loop = next(step for step in workflow["steps"] if step["kind"] == "loop")
+    components = [node["component"] for node in loop["steps"] if node["kind"] == "invoke"]
+    assert components.count("transformer") == 2
+    assert "guidance_combine" in components
+    assert [node["component"] for node in loop["setup"]].count("conditioning_cast") == 2
+    assert (
+        workflow["inputs"]["request.negative_input_ids"]["role"]["role"]
+        == "negative_prompt_tokens"
+    )
+    assert (
+        package.policy_components["video_latent_init"].model.graph.outputs[1].dtype
+        == ir.DataType.FLOAT
+    )
+    for name in (
+        "video_latent_permute",
+        "video_latent_unscale",
+        "video_decode_chunks",
+        "video_decode_chunk",
+        "video_conv_cache_init",
+    ):
+        assert (
+            package.policy_components[name].model.graph.inputs[0].dtype == ir.DataType.FLOAT16
+        )
 
 
 def test_language_diffusion_rejects_zero_steps():

--- a/src/mobius/models/__init__.py
+++ b/src/mobius/models/__init__.py
@@ -162,6 +162,7 @@ __all__ = [
     "StarCoder2CausalLMModel",
     "T2IAdapterModel",
     "T5ForConditionalGeneration",
+    "T5EncoderModel",
     "UNet2DConditionModel",
     "load_unet_lora_safetensors",
     "remap_diffusers_unet_lora",
@@ -352,7 +353,7 @@ from mobius.models.sensevoice_small import SenseVoiceSmallModel
 from mobius.models.smollm import SmolLM3CausalLMModel
 from mobius.models.sortformer import SortformerConfig, SortformerDiarizationModel
 from mobius.models.starcoder2 import StarCoder2CausalLMModel
-from mobius.models.t5 import T5ForConditionalGeneration
+from mobius.models.t5 import T5EncoderModel, T5ForConditionalGeneration
 from mobius.models.unet import (
     UNet2DConditionModel,
     load_unet_lora_safetensors,

--- a/src/mobius/models/t5.py
+++ b/src/mobius/models/t5.py
@@ -332,6 +332,19 @@ class T5Encoder(nn.Module):
             max_distance=self._max_distance,
             num_heads=self._num_heads,
         )
+        if attention_mask is not None:
+            # HF T5 adds a broadcastable padding bias to the learned relative
+            # bias: [B, S] -> [B, 1, 1, S]. Masked keys receive a large
+            # negative value so every query ignores padding tokens.
+            valid = op.CastLike(attention_mask, position_bias)
+            padding = op.Mul(
+                op.Sub(op.CastLike(op.Constant(value_float=1.0), position_bias), valid),
+                op.CastLike(op.Constant(value_float=-10000.0), position_bias),
+            )
+            position_bias = op.Add(
+                position_bias,
+                op.Unsqueeze(padding, op.Constant(value_ints=[1, 2])),
+            )
         for block in self.block:
             hidden_states = block(op, hidden_states, attention_bias=position_bias)
         hidden_states = self.final_layer_norm(op, hidden_states)

--- a/src/mobius/models/t5.py
+++ b/src/mobius/models/t5.py
@@ -475,6 +475,40 @@ class T5ForConditionalGeneration(nn.Module):
         return new_state_dict
 
 
+class T5EncoderModel(nn.Module):
+    """Encoder-only T5 model used as a diffusion prompt encoder."""
+
+    default_task = "t5-text-encoding"
+    category = "encoder"
+
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+        self.config = config
+        self.encoder = T5Encoder(config)
+
+    def forward(
+        self,
+        op: OpBuilder,
+        input_ids: ir.Value,
+        attention_mask: ir.Value | None = None,
+    ):
+        return self.encoder(op, input_ids=input_ids, attention_mask=attention_mask)
+
+    def preprocess_weights(
+        self, state_dict: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        new_state_dict = {}
+        for name, tensor in state_dict.items():
+            new_name = _rename_t5_weight(name)
+            if new_name is not None and new_name.startswith("encoder."):
+                new_state_dict[new_name] = tensor
+        if "encoder.embed_tokens.weight" not in new_state_dict:
+            shared = state_dict.get("shared.weight")
+            if shared is not None:
+                new_state_dict["encoder.embed_tokens.weight"] = shared
+        return new_state_dict
+
+
 # ---------------------------------------------------------------------------
 # Weight name mapping
 # ---------------------------------------------------------------------------

--- a/src/mobius/models/t5_test.py
+++ b/src/mobius/models/t5_test.py
@@ -13,6 +13,29 @@ import pytest
 from mobius.models.t5 import _rename_t5_weight
 
 
+def test_t5_encoder_is_public_and_consumes_attention_mask():
+    from mobius._configs import ArchitectureConfig
+    from mobius.models import T5EncoderModel
+    from mobius.tasks import T5TextEncoderTask
+
+    config = ArchitectureConfig(
+        vocab_size=32,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        head_dim=8,
+        hidden_act="relu",
+        relative_attention_num_buckets=8,
+        relative_attention_max_distance=16,
+    )
+    graph = T5TextEncoderTask().build(T5EncoderModel(config), config)["model"].graph
+    attention_mask = next(value for value in graph.inputs if value.name == "attention_mask")
+    assert list(attention_mask.uses())
+    assert any(node.op_type == "Unsqueeze" for node in graph)
+
+
 class TestRelativePositionBucket:
     """Test T5 log-linear bucket computation against reference NumPy impl."""
 

--- a/src/mobius/models/unet.py
+++ b/src/mobius/models/unet.py
@@ -591,14 +591,18 @@ class UNet2DConditionModel(nn.Module):
             )
 
         # Mid block
-        self.mid_block = _UNetMidBlock2DCrossAttn(
-            channels=block_out_channels[-1],
-            time_embed_dim=time_embed_dim,
-            cross_attention_dim=config.cross_attention_dim,
-            attention_head_dim=config.attention_head_dim,
-            norm_num_groups=config.norm_num_groups,
-            linear_class=linear_class,
-            use_linear_projection=config.use_linear_projection,
+        self.mid_block = (
+            _UNetMidBlock2DCrossAttn(
+                channels=block_out_channels[-1],
+                time_embed_dim=time_embed_dim,
+                cross_attention_dim=config.cross_attention_dim,
+                attention_head_dim=config.attention_head_dim,
+                norm_num_groups=config.norm_num_groups,
+                linear_class=linear_class,
+                use_linear_projection=config.use_linear_projection,
+            )
+            if config.mid_block_type is not None
+            else None
         )
 
         # Up blocks (reversed)
@@ -681,7 +685,8 @@ class UNet2DConditionModel(nn.Module):
             down_block_res_samples.extend(res_samples)
 
         # Mid
-        sample = self.mid_block(op, sample, emb, encoder_hidden_states)
+        if self.mid_block is not None:
+            sample = self.mid_block(op, sample, emb, encoder_hidden_states)
 
         # Up
         for up_block in self.up_blocks:

--- a/src/mobius/models/unet_parity_test.py
+++ b/src/mobius/models/unet_parity_test.py
@@ -44,6 +44,28 @@ def _remap_transformer(state_dict: dict) -> dict:
     return out
 
 
+def test_unet_without_mid_block_builds_complete_graph():
+    from mobius.integrations.diffusers._configs import UNet2DConfig
+    from mobius.models.unet import UNet2DConditionModel
+    from mobius.tasks._denoising import DenoisingTask
+
+    config = UNet2DConfig(
+        in_channels=4,
+        out_channels=4,
+        block_out_channels=(32, 64),
+        layers_per_block=1,
+        norm_num_groups=32,
+        cross_attention_dim=16,
+        attention_head_dim=8,
+        down_block_types=("CrossAttnDownBlock2D", "DownBlock2D"),
+        up_block_types=("UpBlock2D", "CrossAttnUpBlock2D"),
+        mid_block_type=None,
+    )
+    model = DenoisingTask().build(UNet2DConditionModel(config), config)["model"]
+    assert [value.name for value in model.graph.outputs] == ["noise_pred"]
+    assert not any(name.startswith("mid_block.") for name in model.graph.initializers)
+
+
 def test_cross_attention_block_matches_diffusers():
     pytest.importorskip("diffusers")
     import onnx_ir

--- a/src/mobius/tasks/__init__.py
+++ b/src/mobius/tasks/__init__.py
@@ -146,8 +146,8 @@ from mobius.tasks._seq2seq import Seq2SeqTask
 from mobius.tasks._speech_language import SpeechLanguageTask
 from mobius.tasks._speech_to_text import SpeechToTextTask
 from mobius.tasks._ssm_causal_lm import SSM2CausalLMTask, SSMCausalLMTask
-from mobius.tasks._tts import TTSTask
 from mobius.tasks._t5_text_encoder import T5TextEncoderTask
+from mobius.tasks._tts import TTSTask
 from mobius.tasks._vae import VAETask
 from mobius.tasks._video_denoising import VideoDenoisingTask
 from mobius.tasks._video_vae import VideoVAETask

--- a/src/mobius/tasks/__init__.py
+++ b/src/mobius/tasks/__init__.py
@@ -78,6 +78,7 @@ __all__ = [
     "SpeechToTextTask",
     "TASK_REGISTRY",
     "TTSTask",
+    "T5TextEncoderTask",
     "VAETask",
     "VideoDenoisingTask",
     "VideoVAETask",
@@ -146,6 +147,7 @@ from mobius.tasks._speech_language import SpeechLanguageTask
 from mobius.tasks._speech_to_text import SpeechToTextTask
 from mobius.tasks._ssm_causal_lm import SSM2CausalLMTask, SSMCausalLMTask
 from mobius.tasks._tts import TTSTask
+from mobius.tasks._t5_text_encoder import T5TextEncoderTask
 from mobius.tasks._vae import VAETask
 from mobius.tasks._video_denoising import VideoDenoisingTask
 from mobius.tasks._video_vae import VideoVAETask
@@ -192,6 +194,7 @@ TASK_REGISTRY: dict[str, type[ModelTask]] = {
     "moshi-depformer": MoshiDepformerTask,
     "moshi-temporal": MoshiTemporalTask,
     "text-generation": CausalLMTask,
+    "t5-text-encoding": T5TextEncoderTask,
     "deepseek-v4": DeepSeekV4Task,
     "hybrid-text-generation": HybridCausalLMTask,
     "dflash-draft": DFlashDraftTask,

--- a/src/mobius/tasks/_t5_text_encoder.py
+++ b/src/mobius/tasks/_t5_text_encoder.py
@@ -1,0 +1,41 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""T5 prompt encoder task for diffusion pipelines."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import onnx_ir as ir
+from onnxscript import nn
+
+from mobius._configs import ArchitectureConfig
+from mobius._model_package import ModelPackage
+from mobius.tasks._base import ModelTask, _make_graph, _make_model
+
+
+class T5TextEncoderTask(ModelTask):
+    """Build the two-input T5 encoder contract used by diffusers."""
+
+    model_roles: ClassVar[dict[str, str]] = {"model": "encoder"}
+
+    def build(self, module: nn.Module, config: ArchitectureConfig) -> ModelPackage:
+        graph, builder = _make_graph(name="t5_text_encoder")
+        input_ids = builder.input(
+            "input_ids",
+            dtype=ir.DataType.INT64,
+            shape=["batch", "sequence_length"],
+        )
+        attention_mask = builder.input(
+            "attention_mask",
+            dtype=ir.DataType.INT64,
+            shape=["batch", "sequence_length"],
+        )
+        hidden_states = module(
+            builder.op,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+        )
+        builder.add_output(hidden_states, "last_hidden_state")
+        return ModelPackage({"model": _make_model(graph)}, config=config)

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -619,6 +619,53 @@ class TestCLIInfo:
         assert "Supported" in out
 
 
+class TestCLIConvertComfyUI:
+    def test_revision_is_forwarded_to_conversion(self, tmp_path):
+        workflow_path = tmp_path / "workflow.json"
+        workflow_path.write_text("{}", encoding="utf-8")
+        result = SimpleNamespace(
+            output_dir=str(tmp_path / "output"),
+            metadata_path=str(tmp_path / "output" / "inference_metadata.yaml"),
+            run_params_path=str(tmp_path / "output" / "run.json"),
+            workflow=SimpleNamespace(
+                steps=20,
+                cfg=7.5,
+                sampler_name="euler",
+                scheduler_kind="euler",
+                width=512,
+                height=512,
+                loras=[],
+                prompt="a cat",
+                negative_prompt="",
+                seed=42,
+            ),
+        )
+        with mock.patch(
+            "mobius.integrations.onnx_genai.convert_comfyui_workflow",
+            return_value=result,
+        ) as convert:
+            main(
+                [
+                    "convert-comfyui",
+                    str(workflow_path),
+                    "--checkpoint",
+                    "nota-ai/bk-sdm-small",
+                    "--revision",
+                    "pinned-revision",
+                    "--output",
+                    str(tmp_path / "output"),
+                ]
+            )
+
+        convert.assert_called_once_with(
+            {},
+            "nota-ai/bk-sdm-small",
+            str(tmp_path / "output"),
+            sdxl=False,
+            revision="pinned-revision",
+        )
+
+
 class TestCLIBuildRuntime:
     """Test the ``--runtime`` flag on the ``build`` subcommand."""
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -757,7 +757,35 @@ class TestCLIBuildRuntime:
             config=pkg.config,
             source="/models/vlm",
             revision=None,
+            guidance_scale=None,
         )
+
+    def test_runtime_onnx_genai_forwards_guidance_scale(self):
+        pkg = mock.MagicMock()
+        pkg.items.return_value = []
+        pkg.__iter__.return_value = iter(("transformer", "text_encoder", "vae_decoder"))
+        pkg.config = object()
+        args = SimpleNamespace(
+            max_shard_size=None,
+            max_workers=8,
+            external_data="onnx",
+            execution_provider="cpu",
+            no_weights=True,
+            runtime="onnx-genai",
+            config="/models/video",
+            model=None,
+            guidance_scale=6.0,
+        )
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            mock.patch(
+                "mobius.integrations.onnx_genai.write_onnx_genai_config",
+                return_value={},
+            ) as writer,
+        ):
+            _save_package(pkg, tmpdir, args, None, None)
+
+        assert writer.call_args.kwargs["guidance_scale"] == pytest.approx(6.0)
 
     def test_runtime_onnx_genai_does_not_fallback_for_unsupported_vlm(self):
         pkg = mock.MagicMock()

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -775,6 +775,7 @@ class TestCLIBuildRuntime:
             config="/models/video",
             model=None,
             guidance_scale=6.0,
+            revision="pinned-revision",
         )
         with (
             tempfile.TemporaryDirectory() as tmpdir,
@@ -786,6 +787,7 @@ class TestCLIBuildRuntime:
             _save_package(pkg, tmpdir, args, None, None)
 
         assert writer.call_args.kwargs["guidance_scale"] == pytest.approx(6.0)
+        assert writer.call_args.kwargs["revision"] == "pinned-revision"
 
     def test_runtime_onnx_genai_does_not_fallback_for_unsupported_vlm(self):
         pkg = mock.MagicMock()

--- a/tests/fixtures/onnx_genai_workflows/diffusion/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/diffusion/inference_metadata.yaml
@@ -387,6 +387,35 @@ pipeline:
               rank: 1
               shape:
               - 1
+      image_output_clamp:
+        implementation:
+          kind: onnx
+          artifact: policies/image_output_clamp.onnx
+        ports:
+          inputs:
+            tensor:
+              dtype: float32
+              rank: 4
+              shape:
+              - batch
+              - axis_1
+              - axis_2
+              - axis_3
+              batch_layout:
+                kind: request_aligned
+                axis: 0
+          outputs:
+            clamped:
+              dtype: float32
+              rank: 4
+              shape:
+              - batch
+              - axis_1
+              - axis_2
+              - axis_3
+              batch_layout:
+                kind: request_aligned
+                axis: 0
     state:
       latent_state:
         contract:
@@ -520,7 +549,13 @@ pipeline:
       inputs:
         latent: latent_state
       outputs:
-        image: vae.image
+        image: vae.raw_image
+    - kind: invoke
+      component: image_output_clamp
+      inputs:
+        tensor: vae.raw_image
+      outputs:
+        clamped: vae.image
     - kind: emit
       value: latent_state
       output: latent

--- a/tests/fixtures/onnx_genai_workflows/diffusion_guided/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/diffusion_guided/inference_metadata.yaml
@@ -100,10 +100,11 @@ pipeline:
             kind: request_aligned
             axis: 0
         role:
-          kind: opaque
+          kind: runtime
+          version: '1.0'
+          role: negative_prompt_tokens
         source:
-          kind: application
-          name: negative_input_ids
+          kind: request
         required: true
         externally_suppliable: true
       request.guidance_scale:
@@ -116,10 +117,11 @@ pipeline:
             kind: request_aligned
             axis: 0
         role:
-          kind: opaque
+          kind: runtime
+          version: '1.0'
+          role: guidance_scale
         source:
-          kind: application
-          name: guidance_scale
+          kind: request
         required: false
         default: 7.5
       package.loop_0_active:
@@ -512,6 +514,35 @@ pipeline:
             conditional: conditional
             scale: scale
             estimate: estimate
+      image_output_clamp:
+        implementation:
+          kind: onnx
+          artifact: policies/image_output_clamp.onnx
+        ports:
+          inputs:
+            tensor:
+              dtype: float32
+              rank: 4
+              shape:
+              - batch
+              - axis_1
+              - axis_2
+              - axis_3
+              batch_layout:
+                kind: request_aligned
+                axis: 0
+          outputs:
+            clamped:
+              dtype: float32
+              rank: 4
+              shape:
+              - batch
+              - axis_1
+              - axis_2
+              - axis_3
+              batch_layout:
+                kind: request_aligned
+                axis: 0
       latent_row_shape:
         implementation:
           kind: onnx
@@ -767,7 +798,13 @@ pipeline:
       inputs:
         latent: diffusion.decoder_input
       outputs:
-        image: vae.image
+        image: vae.raw_image
+    - kind: invoke
+      component: image_output_clamp
+      inputs:
+        tensor: vae.raw_image
+      outputs:
+        clamped: vae.image
     - kind: emit
       value: latent_state
       output: latent

--- a/tests/fixtures/onnx_genai_workflows/video/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/video/inference_metadata.yaml
@@ -361,7 +361,7 @@ pipeline:
               rank: 2
               shape:
               - batch
-              - history
+              - next_history
               batch_layout:
                 kind: request_aligned
                 axis: 0


### PR DESCRIPTION
## Summary
- export BK-SDM checkpoints without a UNet mid-block
- add encoder-only T5 export for CogVideoX
- add typed DDIM epsilon/sample/v-prediction contracts
- add model-agnostic video CFG, layout, unscale, causal-cache, and recurrence workflows
- add typed cast/clamp adapters and nested artifact paths for image APIs/image edit

## Validation
- 76 policy/workflow tests passed
- earlier targeted model tests: 27 passed
- real Stable Diffusion and CogVideoX packages validated and executed through ONNX GenAI