### PR TITLE
Fix inference metadata producer invariants

### DIFF
--- a/src/mobius/_model_package.py
+++ b/src/mobius/_model_package.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 __all__ = ["ModelPackage"]
 
-import hashlib
 import inspect
 import logging
 import os
@@ -392,7 +391,6 @@ class ModelPackage(UserDict[str, ir.Model]):
                     {
                         "location": relative_location,
                         "loader_capability": "onnx-genai.adapters.json@1",
-                        "sha256": hashlib.sha256(payload).hexdigest(),
                         "scale_encoding": "alpha_over_rank",
                         "format": "json",
                     }
@@ -406,13 +404,10 @@ class ModelPackage(UserDict[str, ir.Model]):
                     relative_location = f"adapters/{alias}/adapter.onnx_adapter"
                     destination = os.path.join(directory, relative_location)
                     shutil.copyfile(source_path, destination)
-                    with open(destination, "rb") as handle:
-                        payload = handle.read()
                     weight_artifacts.append(
                         {
                             "location": relative_location,
                             "loader_capability": "onnxruntime.lora-adapter@1",
-                            "sha256": hashlib.sha256(payload).hexdigest(),
                             "scale_encoding": "baked",
                             "format": "ort_genai",
                         }
@@ -429,17 +424,11 @@ class ModelPackage(UserDict[str, ir.Model]):
                     config_destination = os.path.join(directory, relative_config)
                     shutil.copyfile(source_weights, destination)
                     shutil.copyfile(source_config, config_destination)
-                    with open(destination, "rb") as handle:
-                        payload = handle.read()
-                    with open(config_destination, "rb") as handle:
-                        config_payload = handle.read()
                     weight_artifacts.append(
                         {
                             "location": relative_location,
                             "loader_capability": "onnx-genai.adapters.hf-peft@1",
-                            "sha256": hashlib.sha256(payload).hexdigest(),
                             "config_location": relative_config,
-                            "config_sha256": hashlib.sha256(config_payload).hexdigest(),
                             "scale_encoding": "alpha_over_rank",
                             "format": "hf_peft",
                         }
@@ -462,7 +451,6 @@ class ModelPackage(UserDict[str, ir.Model]):
                 "index": artifact_index,
                 "identity": artifact.stable_identity,
                 "version": artifact.version,
-                "base_model_fingerprint": artifact.base_fingerprint,
                 "rank": rank,
                 "alpha": alpha,
                 "dtype": dtype,

--- a/src/mobius/adapters_test.py
+++ b/src/mobius/adapters_test.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import shutil
 import uuid
@@ -37,6 +36,14 @@ from mobius import (
 from mobius.integrations.onnx_genai.inference_metadata import (
     add_adapter_service_to_metadata,
 )
+
+
+def _mapping_keys(value: object) -> set[str]:
+    if isinstance(value, dict):
+        return set(value) | {key for nested in value.values() for key in _mapping_keys(nested)}
+    if isinstance(value, list):
+        return {key for nested in value for key in _mapping_keys(nested)}
+    return set()
 
 
 def _model(weight: np.ndarray | None = None) -> ir.Model:
@@ -601,7 +608,7 @@ def test_onnx_adapter_source_can_be_declared_for_native_capability() -> None:
         ]
         copied = output_directory / declared["location"]
         assert copied.read_bytes() == source_path.read_bytes()
-        assert declared["sha256"] == hashlib.sha256(copied.read_bytes()).hexdigest()
+        assert "sha256" not in declared
     finally:
         shutil.rmtree(directory)
 
@@ -674,9 +681,11 @@ def test_exact_onnx_genai_catalog_and_portable_bundle_serialization() -> None:
         add_adapter_service_to_metadata(metadata, package, str(directory))
         service = metadata["adapters"]
         assert "adapters" not in metadata["pipeline"]["workflow"]
-        assert service["base_model_fingerprint"].startswith(
-            "onnx-genai-targeted-base-v1:sha256:"
-        )
+        assert {
+            "sha256",
+            "config_sha256",
+            "base_model_fingerprint",
+        }.isdisjoint(_mapping_keys(metadata))
         assert service["selection"] == {
             "segments": "request.adapter_segments",
             "adapter_counts": "request.adapter_counts",
@@ -739,8 +748,6 @@ def test_exact_onnx_genai_catalog_and_portable_bundle_serialization() -> None:
         assert weight["loader_capability"] == "onnx-genai.adapters.json@1"
         assert weight["scale_encoding"] == "alpha_over_rank"
         assert weight["location"] == "adapters/red/adapter.json"
-        assert len(weight["sha256"]) == 64
-        assert weight["sha256"] == hashlib.sha256(payload).hexdigest()
         bundle = json.loads(payload)
         assert set(bundle["targets"]) == {"layers.0.self_attn.q_proj"}
         assert len(bundle["targets"]["layers.0.self_attn.q_proj"]["a"]) == 8

--- a/src/mobius/integrations/onnx_genai/inference_metadata.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata.py
@@ -1651,7 +1651,6 @@ def add_adapter_service_to_metadata(
     if workflow is not None:
         workflow.pop("adapters", None)
     metadata["adapters"] = {
-        "base_model_fingerprint": manifest.base_fingerprint,
         "target_manifest": pkg.adapter_target_manifest_metadata(),
         "discovery_fallback": options.discovery_fallback,
         "selection": {

--- a/src/mobius/integrations/onnx_genai/workflow_metadata.py
+++ b/src/mobius/integrations/onnx_genai/workflow_metadata.py
@@ -812,6 +812,11 @@ def _state_group(
     into the ``past`` binding, while a growable cache returns a fresh, longer
     tensor each step and must never be aliased onto its own input.
     """
+    annotated_ports = {
+        component: {cell: _annotated_alias(alias) for cell, alias in aliases.items()}
+        for component, aliases in ports.items()
+    }
+    _validate_attention_alias_layer_sets({kind: annotated_ports})
     group: dict[str, Any] = {
         "kind": kind,
         "sequence_axis": sequence_axis,
@@ -819,10 +824,7 @@ def _state_group(
         "aliasing": (aliasing if aliasing is not None else _aliasing_for_storage(storage)),
         "reuse": {"prefix_reusable": True, "evictable_prefix": False},
         "capabilities": {"snapshot": True, "fork": True},
-        "ports": {
-            component: {cell: _annotated_alias(alias) for cell, alias in aliases.items()}
-            for component, aliases in ports.items()
-        },
+        "ports": annotated_ports,
     }
     if logical_lengths is not None:
         group["logical_lengths"] = logical_lengths
@@ -894,6 +896,47 @@ def _state_group_kinds(config: Any, cache_pairs: list[tuple[ir.Value, ir.Value]]
     return kinds
 
 
+def _validate_attention_alias_layer_sets(
+    grouped_ports: dict[str, dict[str, dict[str, dict[str, Any]]]],
+) -> None:
+    """Require split key/value aliases to cover the same numeric layers."""
+    for group_name, components in grouped_ports.items():
+        for component, aliases in components.items():
+            layers_by_role: dict[str, dict[int, str]] = {"key": {}, "value": {}}
+            for alias_name, alias in aliases.items():
+                role = alias.get("role")
+                if role not in layers_by_role:
+                    continue
+                layer = alias.get("layer")
+                if not isinstance(layer, int):
+                    raise TypeError(
+                        f"state group {group_name!r} component {component!r} alias "
+                        f"{alias_name!r} declares role {role!r} without a numeric layer"
+                    )
+                previous = layers_by_role[role].get(layer)
+                if previous is not None:
+                    raise ValueError(
+                        f"state group {group_name!r} component {component!r} declares "
+                        f"duplicate {role} aliases for layer {layer}: "
+                        f"{previous!r} and {alias_name!r}"
+                    )
+                layers_by_role[role][layer] = alias_name
+
+            key_layers = set(layers_by_role["key"])
+            value_layers = set(layers_by_role["value"])
+            if not key_layers and not value_layers:
+                continue
+            if key_layers != value_layers:
+                raise ValueError(
+                    f"state group {group_name!r} component {component!r} must declare "
+                    "one key and one value alias for the same attention layers; "
+                    f"key layers are {sorted(key_layers)}, "
+                    f"value layers are {sorted(value_layers)}, "
+                    f"missing value layers are {sorted(key_layers - value_layers)}, "
+                    f"missing key layers are {sorted(value_layers - key_layers)}"
+                )
+
+
 def _state_service_groups(
     *,
     config: Any,
@@ -954,6 +997,7 @@ def _state_service_groups(
             grouped_ports[cell_group[cell]].setdefault(component, {})[cell] = _annotated_alias(
                 alias
             )
+    _validate_attention_alias_layer_sets(grouped_ports)
     groups = {}
     for kind, update in distinct:
         is_scattered = update == "indexed_scatter"

--- a/src/mobius/integrations/onnx_genai/workflow_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/workflow_metadata_test.py
@@ -19,6 +19,7 @@ from mobius.integrations.onnx_genai.inference_metadata_test import (
 from mobius.integrations.onnx_genai.workflow_metadata import (
     _kv_storage_contract,
     _static_cache_ports,
+    _validate_attention_alias_layer_sets,
     build_language_diffusion_pipeline_metadata,
     build_speculative_workflow_metadata,
     build_video_diffusion_workflow_metadata,
@@ -396,6 +397,11 @@ def test_vlm_writer_derives_real_decoder_contract_from_artifact(tmp_path):
     assert all("past_present_share_buffer" not in node.attributes for node in decoder.graph)
     kv_ports = decoder_cache["ports"]["decoder"]
     assert len(kv_ports) == 104
+    layers_by_role = {
+        role: {alias["layer"] for alias in kv_ports.values() if alias["role"] == role}
+        for role in ("key", "value")
+    }
+    assert layers_by_role["key"] == layers_by_role["value"] == set(range(52))
     assert kv_ports["cache_103"] == {
         "input": "past_key_values.51.value",
         "output": "present.51.value",
@@ -636,6 +642,11 @@ def _speculative_package(
                 ir.DataType.FLOAT,
                 ["batch", 2, "past_sequence", 8],
             ),
+            _value(
+                "past_key_values.0.value",
+                ir.DataType.FLOAT,
+                ["batch", 4, "past_sequence", 4],
+            ),
         ],
         [
             _value("target_scores", ir.DataType.FLOAT, ["batch", 4, 32]),
@@ -643,6 +654,11 @@ def _speculative_package(
                 "present.0.key",
                 ir.DataType.FLOAT,
                 ["batch", 2, "past_sequence + 4", 8],
+            ),
+            _value(
+                "present.0.value",
+                ir.DataType.FLOAT,
+                ["batch", 4, "past_sequence + 4", 4],
             ),
         ],
     )
@@ -724,15 +740,70 @@ def test_speculative_workflow_uses_per_row_ragged_state_and_rng():
         "full_attention"
     )
     assert "slot_ids" not in workflow["serving"]
-    assert workflow["serving"]["state_service"]["groups"]["verifier_cache"]["ports"][
+    verifier_ports = workflow["serving"]["state_service"]["groups"]["verifier_cache"]["ports"][
         "verifier"
-    ]["cache_0"] == {
+    ]
+    assert verifier_ports["cache_0"] == {
         "input": "past_key_values.0.key",
         "output": "present.0.key",
         "role": "key",
         "layer": 0,
     }
+    assert verifier_ports["cache_1"] == {
+        "input": "past_key_values.0.value",
+        "output": "present.0.value",
+        "role": "value",
+        "layer": 0,
+    }
     assert any(item["cell"].startswith("cache_") for item in workflow["steps"][0]["carried"])
+
+
+def test_attention_state_group_rejects_mismatched_key_value_layers():
+    verifier = _graph_model(
+        "verifier",
+        [
+            _value("proposed_tokens", ir.DataType.INT64, ["batch", 4]),
+            _value(
+                "past_key_values.0.key",
+                ir.DataType.FLOAT,
+                ["batch", 2, "past_sequence", 8],
+            ),
+        ],
+        [
+            _value("target_scores", ir.DataType.FLOAT, ["batch", 4, 32]),
+            _value(
+                "present.0.key",
+                ir.DataType.FLOAT,
+                ["batch", 2, "past_sequence + 4", 8],
+            ),
+        ],
+    )
+    package = _speculative_package()
+    package["verifier"] = verifier
+    with pytest.raises(
+        ValueError,
+        match=r"key layers are \[0\].*value layers are \[\]",
+    ):
+        build_speculative_workflow_metadata(package)
+
+
+def test_attention_state_group_rejects_equal_count_mismatched_layer_sets():
+    with pytest.raises(
+        ValueError,
+        match=r"key layers are \[0, 1\].*value layers are \[0, 2\]",
+    ):
+        _validate_attention_alias_layer_sets(
+            {
+                "full_attention": {
+                    "decoder": {
+                        "key_0": {"role": "key", "layer": 0},
+                        "key_1": {"role": "key", "layer": 1},
+                        "value_0": {"role": "value", "layer": 0},
+                        "value_2": {"role": "value", "layer": 2},
+                    }
+                }
+            }
+        )
 
 
 def _decoder_with_cache(domain: str, op_type: str) -> ir.Model:

--- a/tests/compare_onnx_genai_validation_packages.py
+++ b/tests/compare_onnx_genai_validation_packages.py
@@ -58,6 +58,11 @@ def _model(path: Path) -> dict[str, Any]:
 # it in a form no reviewer can read; ``_artifacts_exist`` below checks that
 # every one the metadata names was actually produced.
 _GENERATED_SUFFIXES = {".onnx", ".data", ".safetensors"}
+_RETIRED_INFERENCE_METADATA_FIELDS = {
+    "sha256",
+    "config_sha256",
+    "base_model_fingerprint",
+}
 
 
 def _reviewable_files(directory: Path) -> set[Path]:
@@ -91,6 +96,60 @@ def _artifacts_exist(committed: Path, generated: Path) -> list[str]:
     return missing
 
 
+def _metadata_invariant_errors(root: Path) -> list[str]:
+    """Check authored metadata invariants on serialized package output."""
+    errors: list[str] = []
+
+    def retired_fields(value: Any, path: str) -> None:
+        if isinstance(value, dict):
+            for key, nested in value.items():
+                field_path = f"{path}.{key}" if path else str(key)
+                if key in _RETIRED_INFERENCE_METADATA_FIELDS:
+                    errors.append(f"{field_path}: retired inference-metadata field")
+                retired_fields(nested, field_path)
+        elif isinstance(value, list):
+            for index, nested in enumerate(value):
+                retired_fields(nested, f"{path}[{index}]")
+
+    for metadata_path in sorted(root.rglob("inference_metadata.yaml")):
+        package = metadata_path.parent.relative_to(root)
+        metadata = yaml.safe_load(metadata_path.read_text(encoding="utf-8"))
+        retired_fields(metadata, str(package))
+        workflow = ((metadata.get("pipeline") or {}).get("workflow")) or {}
+        state_service = (workflow.get("serving") or {}).get("state_service") or {}
+        groups = state_service.get("groups") or {}
+        for group_name, group in groups.items():
+            if not str(group.get("kind", "")).endswith("attention"):
+                continue
+            for component, aliases in (group.get("ports") or {}).items():
+                layers_by_role: dict[str, list[int]] = {"key": [], "value": []}
+                for alias_name, alias in aliases.items():
+                    role = alias.get("role")
+                    if role not in layers_by_role:
+                        continue
+                    layer = alias.get("layer")
+                    if not isinstance(layer, int):
+                        errors.append(
+                            f"{package}: group {group_name!r} component {component!r} "
+                            f"alias {alias_name!r} has role {role!r} without numeric layer"
+                        )
+                        continue
+                    layers_by_role[role].append(layer)
+                key_layers = layers_by_role["key"]
+                value_layers = layers_by_role["value"]
+                if (
+                    len(key_layers) != len(set(key_layers))
+                    or len(value_layers) != len(set(value_layers))
+                    or set(key_layers) != set(value_layers)
+                ):
+                    errors.append(
+                        f"{package}: group {group_name!r} component {component!r} "
+                        f"has key layers {sorted(key_layers)} and "
+                        f"value layers {sorted(value_layers)}"
+                    )
+    return errors
+
+
 def _content(path: Path) -> Any:
     if path.suffix == ".onnx":
         return _model(path)
@@ -116,6 +175,10 @@ def main() -> None:
 
     if absent := _artifacts_exist(args.expected, args.actual):
         raise SystemExit(f"declared artifact was not generated: {absent}")
+
+    for label, root in (("committed", args.expected), ("generated", args.actual)):
+        if errors := _metadata_invariant_errors(root):
+            raise SystemExit(f"{label} inference metadata violates invariants: {errors}")
 
     changed = [
         str(relative)

--- a/tests/fixtures/onnx_genai_workflows/adapter/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/adapter/inference_metadata.yaml
@@ -154,7 +154,6 @@ pipeline:
       output: result
       mode: replace
 adapters:
-  base_model_fingerprint: onnx-genai-targeted-base-v1:sha256:702704827be590661fd77676445ddaf1557e4f4d446eaa7bcfb78754466cccdb
   target_manifest:
     targets:
     - id: projection
@@ -193,7 +192,6 @@ adapters:
       index: 0
       identity: blue
       version: '1'
-      base_model_fingerprint: onnx-genai-targeted-base-v1:sha256:702704827be590661fd77676445ddaf1557e4f4d446eaa7bcfb78754466cccdb
       rank: 1
       alpha: 1.0
       dtype: float32
@@ -202,7 +200,6 @@ adapters:
       weights:
       - location: adapters/blue/adapter.json
         loader_capability: onnx-genai.adapters.json@1
-        sha256: d9e67499ad74d4c2d62c45a79ceeea8dfa94893afde9615ea6030b79d052ddbe
         scale_encoding: alpha_over_rank
         format: json
       bindings:
@@ -212,7 +209,6 @@ adapters:
       index: 1
       identity: green
       version: '1'
-      base_model_fingerprint: onnx-genai-targeted-base-v1:sha256:702704827be590661fd77676445ddaf1557e4f4d446eaa7bcfb78754466cccdb
       rank: 1
       alpha: 1.0
       dtype: float32
@@ -221,7 +217,6 @@ adapters:
       weights:
       - location: adapters/green/adapter.json
         loader_capability: onnx-genai.adapters.json@1
-        sha256: d49ae9a3336884fa1ed8503caca1380699788add893870a670f6290c473bc935
         scale_encoding: alpha_over_rank
         format: json
       bindings:
@@ -231,7 +226,6 @@ adapters:
       index: 2
       identity: peft
       version: '1'
-      base_model_fingerprint: onnx-genai-targeted-base-v1:sha256:702704827be590661fd77676445ddaf1557e4f4d446eaa7bcfb78754466cccdb
       rank: 1
       alpha: 1.0
       dtype: float32
@@ -242,14 +236,11 @@ adapters:
       weights:
       - location: adapters/peft/adapter.json
         loader_capability: onnx-genai.adapters.json@1
-        sha256: 4351d2c682e0d1666ca3fdd6e967baaab6ab93c33cf5ace7bf3d6269713e85ce
         scale_encoding: alpha_over_rank
         format: json
       - location: adapters/peft/adapter_model.safetensors
         loader_capability: onnx-genai.adapters.hf-peft@1
-        sha256: c927c136719514dc03fd9f2e11b49ecbca0b4f28a87925a801fb069e29e078d8
         config_location: adapters/peft/adapter_config.json
-        config_sha256: b8419ce55415ad1be8844bd6eaef9a873881f172f427694b1d8e46049a8784df
         scale_encoding: alpha_over_rank
         format: hf_peft
       bindings:
@@ -259,7 +250,6 @@ adapters:
       index: 3
       identity: red
       version: '1'
-      base_model_fingerprint: onnx-genai-targeted-base-v1:sha256:702704827be590661fd77676445ddaf1557e4f4d446eaa7bcfb78754466cccdb
       rank: 1
       alpha: 1.0
       dtype: float32
@@ -268,7 +258,6 @@ adapters:
       weights:
       - location: adapters/red/adapter.json
         loader_capability: onnx-genai.adapters.json@1
-        sha256: b4bd656305aa2fea1d518df351af5fd3bf99b3d0a6c8bd8501dfc5107ac278a1
         scale_encoding: alpha_over_rank
         format: json
       bindings:

--- a/tests/fixtures/onnx_genai_workflows/decoder/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/decoder/inference_metadata.yaml
@@ -725,6 +725,17 @@ pipeline:
               batch_layout:
                 kind: request_aligned
                 axis: 0
+            past_key_values.0.value:
+              dtype: float32
+              rank: 4
+              shape:
+              - batch
+              - 4
+              - past_sequence
+              - 4
+              batch_layout:
+                kind: request_aligned
+                axis: 0
       decoder_step_update:
         implementation:
           kind: onnx
@@ -1121,6 +1132,27 @@ pipeline:
         management: runtime
         release_boundary: invocation
         service_group: decoder_cache
+      cache_1:
+        contract:
+          dtype: float32
+          rank: 4
+          shape:
+          - batch
+          - 4
+          - past_sequence
+          - 4
+          batch_layout:
+            kind: request_aligned
+            axis: 0
+        scope: invocation
+        initializer: decoder.setup.present.0.value
+        recurrence:
+          kind: bounded
+          axis: 2
+          max: package.max_context
+        management: runtime
+        release_boundary: invocation
+        service_group: decoder_cache
     serving:
       active: active
       done: done
@@ -1142,6 +1174,11 @@ pipeline:
                   output: present.0.key
                   role: key
                   layer: 0
+                cache_1:
+                  input: past_key_values.0.value
+                  output: present.0.value
+                  role: value
+                  layer: 0
     steps:
     - kind: loop
       setup:
@@ -1158,16 +1195,19 @@ pipeline:
           position_ids: initializer.position_ids
           body_position_ids: initializer.body_position_ids
           past_key_values.0.key: initializer.past_key_values.0.key
+          past_key_values.0.value: initializer.past_key_values.0.value
       - kind: invoke
         component: model
         inputs:
           input_ids: request.input_ids
           past_key_values.0.key: initializer.past_key_values.0.key
+          past_key_values.0.value: initializer.past_key_values.0.value
           attention_mask: initializer.attention_mask
           position_ids: initializer.position_ids
         outputs:
           logits: decoder.setup.logits
           present.0.key: decoder.setup.present.0.key
+          present.0.value: decoder.setup.present.0.value
       - kind: invoke
         component: termination_batch_initializer
         inputs:
@@ -1277,11 +1317,13 @@ pipeline:
         inputs:
           input_ids: token.body
           past_key_values.0.key: cache_0
+          past_key_values.0.value: cache_1
           attention_mask: attention_mask
           position_ids: position_ids
         outputs:
           logits: decoder.body.logits
           present.0.key: decoder.body.present.0.key
+          present.0.value: decoder.body.present.0.value
       - kind: invoke
         component: last_token_logits
         inputs:
@@ -1321,6 +1363,8 @@ pipeline:
         next: decoder_step.body_position_ids
       - cell: cache_0
         next: decoder.body.present.0.key
+      - cell: cache_1
+        next: decoder.body.present.0.value
       termination: generation_eos
       iteration:
         value: loop.iteration

--- a/tests/fixtures/onnx_genai_workflows/speculative/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/speculative/inference_metadata.yaml
@@ -261,6 +261,24 @@ pipeline:
           kind: application
           name: verifier.past_key_values.0.key
         required: true
+      request.verifier.past_key_values.0.value:
+        contract:
+          dtype: float32
+          rank: 4
+          shape:
+          - batch
+          - 4
+          - past_sequence
+          - 4
+          batch_layout:
+            kind: request_aligned
+            axis: 0
+        role:
+          kind: opaque
+        source:
+          kind: application
+          name: verifier.past_key_values.0.value
+        required: true
     outputs:
       tokens:
         contract:
@@ -1123,6 +1141,28 @@ pipeline:
         service_group: verifier_cache
         management: runtime
         release_boundary: invocation
+      cache_1:
+        contract:
+          dtype: float32
+          rank: 4
+          shape:
+          - batch
+          - 4
+          - past_sequence
+          - 4
+          batch_layout:
+            kind: request_aligned
+            axis: 0
+        class: semantic
+        scope: invocation
+        initializer: request.verifier.past_key_values.0.value
+        recurrence:
+          kind: bounded
+          axis: 2
+          max: package.max_context
+        service_group: verifier_cache
+        management: runtime
+        release_boundary: invocation
     serving:
       active: active
       done: done
@@ -1146,6 +1186,11 @@ pipeline:
                   input: past_key_values.0.key
                   output: present.0.key
                   role: key
+                  layer: 0
+                cache_1:
+                  input: past_key_values.0.value
+                  output: present.0.value
+                  role: value
                   layer: 0
             logical_lengths: cache_lengths
     effects:
@@ -1204,9 +1249,11 @@ pipeline:
         inputs:
           proposed_tokens: proposal.tokens
           past_key_values.0.key: cache_0
+          past_key_values.0.value: cache_1
         outputs:
           target_scores: target.scores
           present.0.key: verifier.present.0.key
+          present.0.value: verifier.present.0.value
       - kind: invoke
         component: speculative_acceptance
         inputs:
@@ -1310,6 +1357,8 @@ pipeline:
         next: adaptive.next_estimates
       - cell: cache_0
         next: verifier.present.0.key
+      - cell: cache_1
+        next: verifier.present.0.value
       iteration:
         value: speculative.iteration
         contract:

--- a/tests/generate_onnx_genai_validation_packages.py
+++ b/tests/generate_onnx_genai_validation_packages.py
@@ -99,10 +99,15 @@ def _executable_decoder_package() -> ModelPackage:
     input_ids = builder.input("input_ids", ir.DataType.INT64, ["batch", "sequence"])
     builder.input("attention_mask", ir.DataType.INT64, ["batch", "total_sequence"])
     builder.input("position_ids", ir.DataType.INT64, ["batch", "sequence"])
-    past = builder.input(
+    past_key = builder.input(
         "past_key_values.0.key",
         ir.DataType.FLOAT,
         ["batch", 2, "past_sequence", 8],
+    )
+    past_value = builder.input(
+        "past_key_values.0.value",
+        ir.DataType.FLOAT,
+        ["batch", 4, "past_sequence", 4],
     )
     shape = builder.op.Shape(input_ids)
     logits = builder.op.ConstantOfShape(
@@ -111,22 +116,35 @@ def _executable_decoder_package() -> ModelPackage:
     )
     batch = builder.op.Shape(input_ids, start=0, end=1)
     sequence = builder.op.Shape(input_ids, start=1, end=2)
-    cache_shape = builder.op.Concat(
+    key_update_shape = builder.op.Concat(
         batch,
         builder.op.Constant(value_ints=[2]),
         sequence,
         builder.op.Constant(value_ints=[8]),
         axis=0,
     )
-    update = builder.op.ConstantOfShape(cache_shape, value=ir.tensor([0.0]))
-    present = builder.op.Concat(past, update, axis=2)
+    value_update_shape = builder.op.Concat(
+        batch,
+        builder.op.Constant(value_ints=[4]),
+        sequence,
+        builder.op.Constant(value_ints=[4]),
+        axis=0,
+    )
+    key_update = builder.op.ConstantOfShape(key_update_shape, value=ir.tensor([0.0]))
+    value_update = builder.op.ConstantOfShape(value_update_shape, value=ir.tensor([0.0]))
+    present_key = builder.op.Concat(past_key, key_update, axis=2)
+    present_value = builder.op.Concat(past_value, value_update, axis=2)
     builder.add_output(
         _typed(logits, ir.DataType.FLOAT, ["batch", "sequence", 128]),
         "logits",
     )
     builder.add_output(
-        _typed(present, ir.DataType.FLOAT, ["batch", 2, "present_sequence", 8]),
+        _typed(present_key, ir.DataType.FLOAT, ["batch", 2, "present_sequence", 8]),
         "present.0.key",
+    )
+    builder.add_output(
+        _typed(present_value, ir.DataType.FLOAT, ["batch", 4, "present_sequence", 4]),
+        "present.0.value",
     )
     config = _Cfg()
     config.eos_token_id = 127
@@ -599,10 +617,15 @@ def _executable_speculative_package() -> ModelPackage:
 
     verifier_graph, verifier_builder = _graph("verifier")
     proposed = verifier_builder.input("proposed_tokens", ir.DataType.INT64, ["batch", 4])
-    past = verifier_builder.input(
+    past_key = verifier_builder.input(
         "past_key_values.0.key",
         ir.DataType.FLOAT,
         ["batch", 2, "past_sequence", 8],
+    )
+    past_value = verifier_builder.input(
+        "past_key_values.0.value",
+        ir.DataType.FLOAT,
+        ["batch", 4, "past_sequence", 4],
     )
     batch = verifier_builder.op.Shape(proposed, start=0, end=1)
     row = verifier_builder.op.Range(
@@ -631,7 +654,7 @@ def _executable_speculative_package() -> ModelPackage:
         verifier_builder.op.Constant(value_floats=[0.0, 1.0]),
         axis=-1,
     )
-    cache_update = verifier_builder.op.ConstantOfShape(
+    key_update = verifier_builder.op.ConstantOfShape(
         verifier_builder.op.Concat(
             batch,
             verifier_builder.op.Constant(value_ints=[2, 4, 8]),
@@ -639,18 +662,35 @@ def _executable_speculative_package() -> ModelPackage:
         ),
         value=ir.tensor([0.0]),
     )
-    present = verifier_builder.op.Concat(past, cache_update, axis=2)
+    value_update = verifier_builder.op.ConstantOfShape(
+        verifier_builder.op.Concat(
+            batch,
+            verifier_builder.op.Constant(value_ints=[4, 4, 4]),
+            axis=0,
+        ),
+        value=ir.tensor([0.0]),
+    )
+    present_key = verifier_builder.op.Concat(past_key, key_update, axis=2)
+    present_value = verifier_builder.op.Concat(past_value, value_update, axis=2)
     verifier_builder.add_output(
         _typed(target_scores, ir.DataType.FLOAT, ["batch", 4, 32]),
         "target_scores",
     )
     verifier_builder.add_output(
         _typed(
-            present,
+            present_key,
             ir.DataType.FLOAT,
             ["batch", 2, "past_sequence + 4", 8],
         ),
         "present.0.key",
+    )
+    verifier_builder.add_output(
+        _typed(
+            present_value,
+            ir.DataType.FLOAT,
+            ["batch", 4, "past_sequence + 4", 4],
+        ),
+        "present.0.value",
     )
     return ModelPackage(
         {


### PR DESCRIPTION
## Summary

- stop serializing retired `sha256`, `config_sha256`, and `base_model_fingerprint` fields in authored inference metadata
- require split attention state groups to emit exactly one key and one value alias for identical numeric layer sets
- preserve heterogeneous key/value head counts and geometry while pairing by layer
- regenerate adapter, decoder, and speculative workflow fixtures
- scan both committed and newly generated metadata for retired fields and malformed K/V layer sets

## Cross-repository context

This is the paired Mobius producer update for onnx-genai PR #1688. All 13 generated Mobius packages validate with that PR's validator, and all 12 workflow conformance tests pass against its runtime.

PR #536's PEFT implementation was not modified. After this lands, #536 should merge `main` and retain its PEFT implementation while taking the hashless serialization changes in `save_adapter_artifacts`, the adapter-service fingerprint removal, and updated adapter fixtures/expectations.

## Validation

- `python3 -m pytest src/mobius/adapters_test.py src/mobius/integrations/onnx_genai -q --tb=short` — 247 passed, 5 skipped
- Ruff check and format check for all changed Python files
- generated/committed ONNX GenAI package comparison — passed
- onnx-genai #1688 metadata validator — 13 packages passed
- onnx-genai #1688 workflow conformance — 12 passed
