### PR TITLE
Declare linear effects in shared-state workflows

### DIFF
--- a/src/mobius/integrations/onnx_genai/shared_state_flow_metadata.py
+++ b/src/mobius/integrations/onnx_genai/shared_state_flow_metadata.py
@@ -662,6 +662,7 @@ def build_shared_state_pixel_flow_workflow_metadata(
             "adapter_abis": {"onnx-genai.image-preprocess": "1"},
             "capabilities": [
                 "workflow_ssa",
+                "linear_effects",
                 "typed_emit",
                 "nested_control_flow",
                 "loop_induction_values",

--- a/src/mobius/models/sensenova_u1_test.py
+++ b/src/mobius/models/sensenova_u1_test.py
@@ -513,6 +513,7 @@ class TestInferenceMetadataStatus:
             package, config, num_inference_steps=2
         )
         workflow = metadata["pipeline"]["workflow"]
+        assert "linear_effects" in workflow["manifest"]["capabilities"]
         assert set(workflow["components"]) >= {
             "embedding",
             "vision_encoder",

--- a/tests/fixtures/onnx_genai_workflows/shared_state_pixel_flow/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/shared_state_pixel_flow/inference_metadata.yaml
@@ -54,6 +54,7 @@ pipeline:
         onnx-genai.image-preprocess: '1'
       capabilities:
       - workflow_ssa
+      - linear_effects
       - typed_emit
       - nested_control_flow
       - loop_induction_values


### PR DESCRIPTION
## Summary

- declare `linear_effects` for shared-state pixel-flow workflows that thread effect tokens
- update the checked-in generated fixture
- add a model-level regression assertion

## Why

`justinchuby/onnx-genai` main now validates that workflows using effect tokens declare the canonical `linear_effects` capability. The Mobius producer omitted it, making the `Mobius producer conformance` workflow fail on `validation/generated/shared_state_pixel_flow`.

Failing run: https://github.com/justinchuby/onnx-genai/actions/runs/32580469289

## Validation

- targeted SenseNova shared-state metadata test
- generated shared-state package accepted by current `onnx-genai-metadata` validator
- Ruff 0.16.2 check and format check
- fixture comparison confirms `shared_state_pixel_flow` matches (unrelated pre-existing fixture drift remains in decoder/speculative/static_cache/vlm)
