### PR TITLE
Fix missing YaRN mscale softmax-scale correction in DeepSeek MLA

### DIFF
--- a/src/mobius/components/_deepseek_mla.py
+++ b/src/mobius/components/_deepseek_mla.py
@@ -20,6 +20,7 @@ from mobius.components._common import Linear
 from mobius.components._rms_norm import RMSNorm
 from mobius.components._rotary_embedding import (
     apply_rotary_pos_emb,
+    yarn_apply_mscale,
 )
 
 if TYPE_CHECKING:
@@ -94,12 +95,18 @@ class DeepSeekMLA(nn.Module):
             bias=False,
         )
 
-        # Attention scale: 1/sqrt(qk_head_dim).
-        # YaRN mscale is handled by the cos/sin cache (attention_factor
-        # is applied to cos/sin in YarnRope), so no additional scaling
-        # is needed here. The cos/sin scaling produces attention_factor^2
-        # effect on the attention logits automatically.
-        self.scaling = scale if scale is not None else self.qk_head_dim**-0.5
+        # Attention scale: 1/sqrt(qk_head_dim), with an additional YaRN
+        # mscale^2 softmax-scale correction when YaRN is active (see
+        # ``yarn_apply_mscale``). This is separate from the RoPE cos/sin
+        # ``attention_factor`` applied inside YarnRope, which only rescales
+        # the rope portion of Q/K, not the full attention logit.
+        self.scaling = (
+            scale
+            if scale is not None
+            else yarn_apply_mscale(
+                config.rope_type, config.rope_scaling, self.qk_head_dim**-0.5
+            )
+        )
 
         # Whether RoPE uses interleaved layout (DeepSeek-V3 uses this)
         self._rope_interleave = config.rope_interleave

--- a/src/mobius/components/_deepseek_mla_test.py
+++ b/src/mobius/components/_deepseek_mla_test.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import math
+
 import pytest
 
 from mobius._testing import (
@@ -103,6 +105,66 @@ class TestDeepSeekMLAInit:
 
     def test_custom_scale(self):
         config = _mla_config()
+        mla = DeepSeekMLA(config, scale=0.25)
+        assert mla.scaling == pytest.approx(0.25)
+
+    def test_yarn_mscale_softmax_scale_correction(self):
+        """YaRN-active configs apply an extra mscale^2 softmax-scale factor.
+
+        Regression test for the missing DeepSeek-V2/V3 YaRN attention
+        softmax-scale correction (HF's ``yarn_apply_mscale``): the RoPE
+        cos/sin ``attention_factor`` only rescales the rope portion of Q/K,
+        not the full attention logit, so a separate ``mscale_all_dim``-based
+        correction must also be applied to ``self.scaling``. Values mirror
+        the real ``deepseek-ai/DeepSeek-V2-Lite`` config.
+        """
+        config = _mla_config(
+            rope_type="yarn",
+            rope_scaling={
+                "factor": 40,
+                "mscale": 0.707,
+                "mscale_all_dim": 0.707,
+                "original_max_position_embeddings": 4096,
+            },
+        )
+        mla = DeepSeekMLA(config)
+        qk_head_dim = 12 + 4  # 16
+        mscale = 0.1 * 0.707 * math.log(40) + 1.0
+        expected = qk_head_dim**-0.5 * mscale * mscale
+        assert mla.scaling == pytest.approx(expected)
+        # Sanity: the correction is non-trivial (not silently a no-op).
+        assert mla.scaling != pytest.approx(qk_head_dim**-0.5)
+
+    def test_yarn_mscale_correction_skipped_when_rope_type_default(self):
+        """No mscale correction is applied outside of YaRN.
+
+        Matches HF's ``rope_parameters.get("rope_type", "default") !=
+        "default"`` guard.
+        """
+        config = _mla_config(
+            rope_type="default",
+            rope_scaling={"factor": 40, "mscale_all_dim": 0.707},
+        )
+        mla = DeepSeekMLA(config)
+        qk_head_dim = 12 + 4  # 16
+        assert mla.scaling == pytest.approx(qk_head_dim**-0.5)
+
+    def test_yarn_mscale_correction_skipped_when_mscale_all_dim_zero(self):
+        """No correction when ``mscale_all_dim`` is unset/zero, matching HF."""
+        config = _mla_config(
+            rope_type="yarn",
+            rope_scaling={"factor": 40, "mscale_all_dim": 0.0},
+        )
+        mla = DeepSeekMLA(config)
+        qk_head_dim = 12 + 4  # 16
+        assert mla.scaling == pytest.approx(qk_head_dim**-0.5)
+
+    def test_custom_scale_overrides_yarn_correction(self):
+        """An explicit ``scale=`` always wins over the YaRN correction."""
+        config = _mla_config(
+            rope_type="yarn",
+            rope_scaling={"factor": 40, "mscale_all_dim": 0.707},
+        )
         mla = DeepSeekMLA(config, scale=0.25)
         assert mla.scaling == pytest.approx(0.25)
 

--- a/src/mobius/components/_rotary_embedding.py
+++ b/src/mobius/components/_rotary_embedding.py
@@ -313,7 +313,7 @@ class LongRope(BaseRope):
         return self._cast_embeddings(op, cos, sin)
 
 
-def yarn_apply_mscale(rope_type: str, rope_scaling: dict | None, scaling: float) -> float:
+def yarn_apply_mscale(rope_type: str | None, rope_scaling: dict | None, scaling: float) -> float:
     """Apply the DeepSeek-V2/V3 YaRN attention-softmax scale correction.
 
     This mirrors HuggingFace's ``yarn_apply_mscale`` in

--- a/src/mobius/components/_rotary_embedding.py
+++ b/src/mobius/components/_rotary_embedding.py
@@ -313,6 +313,33 @@ class LongRope(BaseRope):
         return self._cast_embeddings(op, cos, sin)
 
 
+def yarn_apply_mscale(rope_type: str, rope_scaling: dict | None, scaling: float) -> float:
+    """Apply the DeepSeek-V2/V3 YaRN attention-softmax scale correction.
+
+    This mirrors HuggingFace's ``yarn_apply_mscale`` in
+    ``modeling_deepseek_v2.py``: DeepSeek's MLA attention modules multiply
+    the softmax scale (``qk_head_dim**-0.5``) by ``mscale(factor,
+    mscale_all_dim) ** 2`` whenever YaRN is active. This is *independent*
+    of — and in addition to — the ``attention_factor`` that :class:`YarnRope`
+    applies to the RoPE cos/sin cache: that factor only rescales the
+    rotated (rope) portion of Q/K, while this correction rescales the whole
+    attention logit (rope + nope portions alike). Omitting it reproduces
+    exactly at position 0 (single-key softmax is scale-invariant) but
+    diverges sharply at position >= 1 for any real YaRN-scaled checkpoint
+    where ``mscale_all_dim`` is non-zero (e.g. DeepSeek-V2-Lite, DeepSeek-V3).
+    """
+    if rope_type == "default" or not rope_scaling:
+        return scaling
+    mscale_all_dim = rope_scaling.get("mscale_all_dim") or 0.0
+    if not mscale_all_dim:
+        return scaling
+    factor = rope_scaling.get("factor") or 1.0
+    if factor <= 1:
+        return scaling
+    mscale = 0.1 * mscale_all_dim * math.log(factor) + 1.0
+    return scaling * mscale * mscale
+
+
 class YarnRope(BaseRope):
     """YaRN (Yet another RoPE extensioN) rotary embeddings.
 

--- a/tests/synthetic_parity_test.py
+++ b/tests/synthetic_parity_test.py
@@ -160,10 +160,19 @@ _ATOL_OVERRIDES: dict[str, float] = {
     # Gemma3 VL: same QK-norm FP accumulation as gemma3_text (~0.045 max diff).
     # argmax_match=True (near-tie), cosine=0.996 — functionally correct.
     "gemma3": 0.05,
-    # DeepSeek-V3: sigmoid-gated MoE with fused expert weights. Sequential vs batched
-    # expert dispatch produces FP accumulation differences → ~0.034 max diff.
-    # Near-tie argmax, cosine=0.996 — functionally correct.
-    "deepseek_v3": 0.04,
+    # DeepSeek-V3: previously carried a 0.04 override attributed to "MoE
+    # dispatch FP accumulation", but that was masking a real bug: the
+    # DeepSeek-V2/V3 MLA softmax scale was missing the YaRN
+    # mscale_all_dim^2 correction HF applies (see
+    # ``mobius.components._rotary_embedding.yarn_apply_mscale``). Fixed in
+    # ``_deepseek_mla.py``. Post-fix, remaining diff is genuine FP-order
+    # noise from parallel MoE dispatch: ~3.5e-5 measured via a standalone
+    # interpreter, ~1.2e-3 measured under this pytest process (both
+    # reproducible in their own harness — the residual gap is ORT
+    # intra-op thread-schedule dependent, not seed-dependent). 0.0025
+    # keeps ~2x headroom over the higher measurement while staying 16x
+    # tighter than the old 0.04.
+    "deepseek_v3": 0.0025,
     # dots1: same DeepSeek V3 architecture (sigmoid routing + shared experts).
     # MoE dispatch accumulation differences → similar tolerance needed.
     "dots1": 0.04,


### PR DESCRIPTION
## Root cause

DeepSeek-V2/V3's MLA attention applies **two independent** YaRN corrections in HuggingFace's reference implementation (`modeling_deepseek_v2.py`):

1. `attention_scaling` on the RoPE cos/sin cache — rescales only the *rope* portion of Q/K. Mobius's `YarnRope` already implements this correctly.
2. A separate softmax-scale multiplier applied inside `DeepseekV2Attention.__init__` (HF's `yarn_apply_mscale`): `scaling = qk_head_dim**-0.5 * mscale**2`, where `mscale = 0.1 * mscale_all_dim * log(factor) + 1.0`. This rescales the **entire** attention logit (rope + nope portions alike).

`src/mobius/components/_deepseek_mla.py` implemented (1) but not (2), on the mistaken assumption (captured in the removed code comment) that (1) alone reproduces the needed effect. That's false whenever `mscale == mscale_all_dim` (as in `deepseek-ai/DeepSeek-V2-Lite`, both 0.707): (1)'s ratio-based `attention_factor` collapses to exactly `1.0` (a no-op), while (2) is still a real ~1.59x correction that HF applies. `deepseek-ai/DeepSeek-V3`'s official config (`mscale=mscale_all_dim=1.0`) has the same gap (missing ~1.87x correction).

### Symptom

`DeepSeekMLA` reproduced HF logits almost exactly at **position 0** (a single-key softmax is scale-invariant to any positive multiplier) but diverged by up to **~0.9 absolute / 93% of elements at position ≥ 1**, for both `DeepSeek-V2-Lite` and a real `DeepSeek-V3` config — reproducible even in a single **dense** (non-MoE) layer, which isolated the bug to attention/RoPE scaling rather than MoE routing.

## Fix

Added `yarn_apply_mscale()` in `src/mobius/components/_rotary_embedding.py`, mirroring HF's helper of the same name exactly (same guards: no-op when `rope_type == "default"`, no-op when `mscale_all_dim` is falsy). `DeepSeekMLA.__init__` now calls it to compute `self.scaling` whenever no explicit `scale=` override is passed.

## Before / after evidence

Using real HF configs (random weights, single dense MLA layer / full 4-layer model):

| Config | Before (max abs diff, position ≥ 1) | After |
|---|---|---|
| `deepseek-ai/DeepSeek-V2-Lite` (factor=40, mscale=mscale_all_dim=0.707) | up to ~0.9 | ~5e-6 (FP noise) |
| `deepseek-ai/DeepSeek-V3` config (factor=40, mscale=mscale_all_dim=1.0) | missing ~1.87x scale (confirmed via config inspection) | corrected |

## Tests

- `tests/integration_test.py::test_deepseek_v2_lite_prefill_logits_match` and `::test_deepseek_non_mla_decoder_prefill_logits_match` — **both previously FAILED** with large divergence at prefill positions ≥ 1; **now PASS** at `rtol=atol=1e-3`.
- `src/mobius/components/_deepseek_mla_test.py` — 4 new unit tests: exact `mscale^2` correction value (mirroring `DeepSeek-V2-Lite`'s real rope_scaling), the `rope_type == "default"` no-op guard, the `mscale_all_dim == 0` no-op guard, and that an explicit `scale=` override still wins.
- `tests/synthetic_parity_test.py`: removed the `deepseek_v3` atol override of `0.04` (previously attributed to "MoE dispatch FP accumulation" — actually this same bug being masked) and replaced it with an empirically measured `0.0025`. Residual FP-order noise from parallel MoE dispatch measured at ~3.5e-5 in a bare interpreter and a reproducible ~1.2e-3 under this repo's pytest process (ORT intra-op thread-schedule dependent, not seed-dependent); `0.0025` keeps ~2x headroom over the higher measurement while being 16x tighter than the old `0.04`.

### Commands run

```
python3 -m pytest src/mobius/components/_deepseek_mla_test.py src/mobius/components/_rotary_embedding_test.py -q
python3 -m pytest tests/integration_test.py -k "deepseek_v2_lite_prefill_logits_match or deepseek_non_mla_decoder_prefill_logits_match" -q
python3 -m pytest "tests/synthetic_parity_test.py::test_synthetic_parity" -k "deepseek or dots1 or glm4" -q
python3 -m pytest tests/synthetic_parity_test.py -q   # full suite: only pre-existing, unrelated `modernbert-decoder` failure (confirmed present on origin/main too)
ruff check src/mobius/components/_deepseek_mla.py src/mobius/components/_deepseek_mla_test.py src/mobius/components/_rotary_embedding.py tests/synthetic_parity_test.py
ruff format --check <same files>
```

All pass (25/25 MLA unit tests incl. 4 new, 63/63 combined MLA+rotary unit tests, 2/2 target integration tests, full synthetic-parity suite green aside from the pre-existing unrelated `modernbert-decoder` failure).

## Out of scope (not included in this PR)

- GLM-5.2 (`glm_moe_dsa`) registration/export — separate, unrelated follow-up (tracked via PR #404).
- The `deepseek_v4` synthetic-parity config-override bug in `tests/_test_configs.py` (`Weight shape mismatch for model.layers.0.self_attn.q_b_proj.weight`) — separate, unrelated fast-follow.

---
Working as Sapper (Systems Dev for Models & Preprocess).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
