### PR TITLE
test(onnx-genai): enforce IR>=11 and default opset>=24 on generated graphs

### DIFF
--- a/tests/onnx_genai_version_floor_test.py
+++ b/tests/onnx_genai_version_floor_test.py
@@ -1,0 +1,73 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Every ONNX graph this producer emits carries a modern IR and opset floor.
+
+Mobius constructs graphs declaratively with ``onnx_ir`` and targets a single
+opset (``mobius._constants.OPSET_VERSION``) and IR version. That is only worth
+anything if it cannot quietly lapse: a component built through a path that
+never set ``opset_imports`` would inherit an *empty* default domain, and a
+model built without an explicit ``ir_version`` would fall back to whatever the
+serializer picks — either would still serialize, still load, and still pass
+every feature test while silently shipping a stale contract to the runtime.
+
+So this test regenerates every conformance package — decoder, static-cache,
+VLM, shared-state pixel flow, diffusion (both variants), TTS, speculative,
+masked, video, codec, the two protein encoders, the adapter package, and every
+attached policy artifact — and asserts, for each ``.onnx`` file, that it
+declares IR version >= 11 and a default-domain opset >= 24. It loads through
+``onnx_ir`` only; it uses no protobuf APIs and carries no allowlist. A single
+graph built through a path that inherits empty defaults fails here rather than
+reaching a runtime.
+"""
+
+from __future__ import annotations
+
+import os
+
+import onnx_ir as ir
+
+from mobius._constants import OPSET_VERSION
+
+# The IR version every Mobius model declares. Set once at construction in
+# ``mobius.tasks._base._make_model`` and ``mobius.generation._policy_components``
+# (both ``ir.Model(graph, ir_version=11)``); restated here as the enforced floor
+# so a regression to an older, serializer-chosen default is a failure.
+MINIMUM_IR_VERSION = 11
+
+# The default ("") domain floor. ``OPSET_VERSION`` is the single opset the whole
+# package targets; a graph below it — or one that never imported the default
+# domain at all, and so reports ``None`` — is a stale or empty contract.
+MINIMUM_DEFAULT_OPSET = OPSET_VERSION
+
+
+def _onnx_models(root: str) -> list[str]:
+    """Every serialized ONNX graph in the materialized package tree."""
+    return sorted(
+        os.path.join(directory, name)
+        for directory, _subdirs, files in os.walk(root)
+        for name in files
+        if name.endswith(".onnx")
+    )
+
+
+def test_every_generated_onnx_declares_modern_ir_and_opset(materialized_workflow_packages):
+    paths = _onnx_models(materialized_workflow_packages)
+    # A tree with no graphs would pass every per-file assertion vacuously; the
+    # generator emits well over a hundred, so a near-empty tree is itself a bug.
+    assert len(paths) > 100, f"expected the generator to emit many graphs, found {len(paths)}"
+
+    violations: list[str] = []
+    for path in paths:
+        model = ir.load(path)
+        relative = os.path.relpath(path, materialized_workflow_packages)
+        ir_version = model.ir_version
+        default_opset = model.opset_imports.get("")
+        if ir_version is None or ir_version < MINIMUM_IR_VERSION:
+            violations.append(f"{relative}: ir_version={ir_version} < {MINIMUM_IR_VERSION}")
+        if default_opset is None or default_opset < MINIMUM_DEFAULT_OPSET:
+            violations.append(
+                f"{relative}: default opset={default_opset} < {MINIMUM_DEFAULT_OPSET}"
+            )
+
+    assert not violations, "ONNX graphs below the IR/opset floor:\n" + "\n".join(violations)


### PR DESCRIPTION
## What

Adds a lightweight regression test, `tests/onnx_genai_version_floor_test.py`, that materializes **every** ONNX GenAI conformance package via the existing session-scoped `materialized_workflow_packages` fixture and asserts, for each generated `.onnx` file, that it declares:

- **IR version ≥ 11**
- **default-domain (`""`) opset ≥ 24** (`mobius._constants.OPSET_VERSION`)

It loads through `onnx_ir` only — **no protobuf APIs, no allowlist**.

## Why

Mobius builds every ONNX graph declaratively with `onnx_ir` and targets a single opset and IR version, set once at construction (`tasks._base._make_model` and `generation._policy_components`, both `ir.Model(graph, ir_version=11)`; `_make_graph`/`_graph` set `opset_imports={"": OPSET_VERSION}`). Nothing guarded that floor end-to-end. A component built through a path that never set `opset_imports` would inherit an **empty default domain**, and a model built without an explicit `ir_version` would fall back to a serializer-chosen default — either would still serialize, still load, and still pass every feature test while silently shipping a stale contract to the runtime.

## Audit evidence

Regenerated the full tree and inspected all **143** generated `.onnx` models with `onnx_ir`:

- IR versions: `{11: 143}`
- default (`""`) opsets: `{24: 143}`
- opset domains seen: `{('', 24): 143, ('com.microsoft', 1): 11}`
- function-level opset issues: none

Coverage spans real producer graphs (TTS, ESM-2, ProtBert — built by the tasks, not the local synthetic helper) **and** every synthesized policy artifact (`*/policies/*.onnx`). **All already satisfy the floor**, so no fixture `onnx_ir` construction needed fixing — this PR is the guard, not a fix.

There are **no checked-in `.onnx` files** in the repo (only metadata YAML under `tests/fixtures/onnx_genai_workflows`); the graphs are a deterministic function of the generator, so the test enforces the floor on the regenerated tree.

## Validation

- `tests/generate_onnx_genai_validation_packages.py` → generates 143 graphs
- `tests/compare_onnx_genai_validation_packages.py tests/fixtures/onnx_genai_workflows <generated>` → exit 0 (committed metadata matches)
- `pytest tests/onnx_genai_version_floor_test.py` → passes (asserts against all 143 graphs)
- `pytest tests/onnx_genai_version_floor_test.py tests/diffusion_vae_value_range_test.py tests/canonical_workflow_contract_test.py` → 163 passed
- ruff check + ruff format → clean
- Non-vacuity verified: the assertion flags both a low `ir_version` and an empty default-domain opset when injected.