### PR TITLE
Add GLM-5.2 (glm_moe_dsa) model support with DSA/IndexShare + full-attention fallback

### DIFF
--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -41,6 +41,7 @@ _BUILD_FEATURES: dict[str, str] = {
     "fp8-kv-cache": "fp8_kv_cache",
     "prune-prefill-prefix": "prune_prefill_prefix",
     "text-only": "text_only",
+    "glm-full-attention": "glm_full_attention",
 }
 
 
@@ -342,6 +343,13 @@ def _cmd_build(args: argparse.Namespace) -> None:
         config = _config_from_hf(hf_config, parent_config=parent_config)
         if dtype_override is not None:
             config = dataclasses.replace(config, dtype=dtype_override)
+        if args.glm_full_attention:
+            if model_type != "glm_moe_dsa":
+                raise SystemExit(
+                    "Error: --features glm-full-attention is only supported for "
+                    f"model_type 'glm_moe_dsa' (got '{model_type}')."
+                )
+            config = dataclasses.replace(config, use_dsa=False)
         if static_cache_params is not None:
             task = _resolve_static_cache_task(model_type)
         elif task is None:
@@ -389,6 +397,7 @@ def _cmd_build(args: argparse.Namespace) -> None:
             fp8_kv_cache=fp8_kv_cache,
             kv_cache_scales=kv_cache_scales,
             prune_prefill_prefix=prune_prefill_prefix,
+            glm_full_attention=args.glm_full_attention,
         )
 
     _save_package(pkg, output_dir, args, optimize, component_filter)

--- a/src/mobius/_configs/_base.py
+++ b/src/mobius/_configs/_base.py
@@ -495,6 +495,30 @@ class ArchitectureConfig(BaseModelConfig):
     swiglu_limit: float = 0.0
     num_nextn_predict_layers: int = 0
 
+    # GLM-5.2 (``glm_moe_dsa``) DeepSeek Sparse Attention (DSA).
+    #
+    # ``use_dsa`` is not an upstream HF field -- it is a Mobius export-time
+    # toggle (default True) flipped to False by ``--glm-full-attention`` /
+    # ``config_overrides={"use_dsa": False}`` to fall back to plain dense MLA
+    # (reusing ``DeepSeekV3TextModel`` unchanged) on runtimes that cannot yet
+    # execute ``pkg.nxrt::IndexShare``.
+    use_dsa: bool = True
+    # Per-layer indexer schedule ("full" runs the indexer; "shared" reuses the
+    # top-k selection from the closest preceding "full" layer). When the
+    # checkpoint config omits this list, it is derived from
+    # ``index_topk_freq`` / ``index_skip_topk_offset`` -- see
+    # ``mobius.models.glm_moe_dsa._indexer_types``, which mirrors HF
+    # ``GlmMoeDsaConfig.__post_init__`` exactly.
+    indexer_types: list[str] | None = None
+    index_topk_freq: int | None = None
+    index_skip_topk_offset: int | None = None
+    indexer_rope_interleave: bool = False
+    # Whether the (currently unexported, see ``glm_moe_dsa.py``) MTP layer is
+    # meant to reuse the target's shared top-k indices rather than running its
+    # own indexer pass. Recorded for round-tripping/documentation; not yet
+    # acted on since MTP export itself is out of scope this cycle.
+    index_share_for_mtp_iteration: bool = False
+
     # Vision shared fields (accessed as top-level config.X by tasks)
     mm_tokens_per_image: int | None = None
     image_token_id: int | None = None
@@ -897,8 +921,20 @@ class ArchitectureConfig(BaseModelConfig):
             n_group=getattr(config, "n_group", 1),
             topk_group=getattr(config, "topk_group", 1),
             routed_scaling_factor=getattr(config, "routed_scaling_factor", 1.0),
-            scoring_func=getattr(config, "scoring_func", "softmax"),
-            topk_method=getattr(config, "topk_method", "greedy"),
+            # ``scoring_func``/``topk_method`` are not real HF dataclass
+            # fields on ``GlmMoeDsaConfig`` -- transformers hardcodes
+            # sigmoid + e_score_correction_bias + (degenerate, n_group=1)
+            # top-k routing for GLM-5.2 rather than exposing it as a config
+            # knob. A checkpoint that omits these keys entirely (unlike the
+            # real zai-org/GLM-5.2 config.json, which sets them explicitly)
+            # would otherwise silently default to the wrong (softmax/greedy)
+            # DeepSeek-V2 routing.
+            scoring_func=getattr(
+                config, "scoring_func", "sigmoid" if model_type == "glm_moe_dsa" else "softmax"
+            ),
+            topk_method=getattr(
+                config, "topk_method", "noaux_tc" if model_type == "glm_moe_dsa" else "greedy"
+            ),
             first_k_dense_replace=getattr(config, "first_k_dense_replace", 0),
             n_shared_experts=getattr(config, "n_shared_experts", None),
             # Multi-head Latent Attention (MLA)
@@ -927,6 +963,21 @@ class ArchitectureConfig(BaseModelConfig):
             ),
             swiglu_limit=getattr(config, "swiglu_limit", 0.0),
             num_nextn_predict_layers=getattr(config, "num_nextn_predict_layers", 0),
+            # GLM-5.2 DSA. ``use_dsa`` has no HF equivalent -- every checkpoint
+            # defaults to the sparse path; ``--glm-full-attention`` overrides
+            # it afterwards via ``dataclasses.replace``/``config_overrides``.
+            use_dsa=getattr(config, "use_dsa", True),
+            indexer_types=(
+                list(config.indexer_types)
+                if getattr(config, "indexer_types", None) is not None
+                else None
+            ),
+            index_topk_freq=getattr(config, "index_topk_freq", None),
+            index_skip_topk_offset=getattr(config, "index_skip_topk_offset", None),
+            indexer_rope_interleave=getattr(config, "indexer_rope_interleave", False),
+            index_share_for_mtp_iteration=getattr(
+                config, "index_share_for_mtp_iteration", False
+            ),
             # Encoder-specific
             type_vocab_size=getattr(config, "type_vocab_size", 0),
             # Encoder-decoder

--- a/src/mobius/_registry.py
+++ b/src/mobius/_registry.py
@@ -68,6 +68,7 @@ from mobius.models import (
     Glm4CausalLMModel,
     Glm4MoECausalLMModel,
     GlmCausalLMModel,
+    GlmMoeDsaCausalLMModel,
     GPTOSSCausalLMModel,
     GraniteCausalLMModel,
     GraniteMoECausalLMModel,
@@ -582,6 +583,8 @@ _REGISTRATIONS: dict[str, ModelRegistration] = {
     "deepseek_v3": ModelRegistration(DeepSeekV3CausalLMModel),
     "deepseek_v4": ModelRegistration(DeepSeekV4CausalLMModel, task="deepseek-v4"),
     "deepseek_vl_v2": ModelRegistration(DeepSeekOCR2CausalLMModel),
+    # --- GLM-5.2 (MLA + DeepSeek Sparse Attention (DSA) + MoE) ---
+    "glm_moe_dsa": ModelRegistration(GlmMoeDsaCausalLMModel),
     # --- SSM (Mamba / Mamba2) ---
     "falcon_mamba": ModelRegistration(MambaCausalLMModel),
     "mamba": ModelRegistration(MambaCausalLMModel),
@@ -1027,6 +1030,8 @@ _TEST_MODEL_IDS: dict[str, str] = {
     "deepseek_v2_moe": "deepseek-ai/DeepSeek-V2-Lite",
     "deepseek_v3": "deepseek-ai/DeepSeek-V3",
     "deepseek_v4": "deepseek-ai/DeepSeek-V4-Flash",
+    # --- GLM-5.2 (MLA + DSA + MoE) ---
+    "glm_moe_dsa": "zai-org/GLM-5.2",
 
     # --- SSM (Mamba) ---
     "mamba": "state-spaces/mamba-130m-hf",
@@ -1288,6 +1293,7 @@ _FAMILY_OVERRIDES: dict[str, str] = {
     "deepseek_v3": "deepseek",
     "deepseek_v4": "deepseek",
     "deepseek_vl_v2": "deepseek",
+    "glm_moe_dsa": "glm",
     "olmo": "olmo",
     "olmo2": "olmo",
     "olmo3": "olmo",
@@ -1361,6 +1367,7 @@ _VARIANT_LABELS: dict[str, str] = {
     "deepseek_v2_moe": "mla+moe",
     "deepseek_v3": "mla+moe",
     "deepseek_v4": "dense-csa-fallback+mtp+moe+hc",
+    "glm_moe_dsa": "mla+dsa-indexshare+full-attention-fallback+moe",
     "phi3small": "blocksparse",
     "falcon_h1": "hybrid-ssm",
     "mamba": "ssm",

--- a/src/mobius/integrations/transformers/_builder.py
+++ b/src/mobius/integrations/transformers/_builder.py
@@ -158,11 +158,18 @@ def build_transformers_model(
     fp8_kv_cache: bool = False,
     kv_cache_scales: dict[int, tuple[float, float]] | None = None,
     prune_prefill_prefix: bool = False,
+    glm_full_attention: bool = False,
 ) -> ModelPackage:
     """Build a model package from a Transformers checkpoint.
 
     If the repository is not a supported Transformers checkpoint, dispatch to
     the Diffusers integration so :func:`mobius.build` remains ecosystem-agnostic.
+
+    ``glm_full_attention`` is the ``--glm-full-attention`` CLI feature: it
+    forces ``config.use_dsa=False`` so GLM-5.2 (``glm_moe_dsa``) exports plain
+    dense causal attention (executable on stock ORT) instead of the DSA
+    ``IndexShare`` path, which requires the native custom-op runtime kernel.
+    It is only valid for ``model_type == "glm_moe_dsa"``.
     """
     from mobius.integrations.diffusers import build_diffusers_pipeline
     from mobius.integrations.transformers._config_resolver import (
@@ -181,6 +188,12 @@ def build_transformers_model(
                 f"text_only=True is not supported for '{model_id}': it does not "
                 "resolve to a registered text-capable model_type (it looks like "
                 "a diffusers pipeline or an unsupported config)."
+            )
+        if glm_full_attention:
+            raise ValueError(
+                f"glm_full_attention=True is not supported for '{model_id}': it "
+                "does not resolve to a registered 'glm_moe_dsa' model_type (it "
+                "looks like a diffusers pipeline or an unsupported config)."
             )
         return build_diffusers_pipeline(
             model_id,
@@ -225,6 +238,14 @@ def build_transformers_model(
             config,
             output_layer_indices=list(output_layer_indices),
         )
+    if glm_full_attention:
+        if model_type != "glm_moe_dsa":
+            raise ValueError(
+                f"glm_full_attention=True is not supported for model_type "
+                f"'{model_type}'. It is only available for GLM-5.2 "
+                "('glm_moe_dsa') checkpoints."
+            )
+        config = dataclasses.replace(config, use_dsa=False)
     if task is None:
         task = _default_task_for_model(model_type)
 

--- a/src/mobius/integrations/transformers/_builder_test.py
+++ b/src/mobius/integrations/transformers/_builder_test.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from unittest import mock
 
 import onnx_ir as ir
+import pytest
 from onnxscript import nn
 
 from mobius._model_package import ModelPackage
@@ -57,6 +58,72 @@ def test_transformers_build_uses_canonical_weight_loader(monkeypatch) -> None:
     download.assert_called_once_with("fake/model", revision=None)
 
 
+def test_glm_full_attention_overrides_use_dsa_for_glm_moe_dsa(monkeypatch) -> None:
+    """``--glm-full-attention`` forces ``config.use_dsa=False`` for GLM-5.2."""
+    hf_config = type("HFConfig", (), {"model_type": "glm_moe_dsa"})()
+    config = make_config(model_type="glm_moe_dsa", use_dsa=True)
+    model = ir.Model(ir.Graph([], [], nodes=[], name="model"), ir_version=11)
+    package = ModelPackage({"model": model}, config=config)
+    captured_configs: list = []
+
+    monkeypatch.setattr(
+        transformers_builder,
+        "_load_transformers_config",
+        lambda *args, **kwargs: (hf_config, False),
+    )
+    monkeypatch.setattr(
+        transformers_builder,
+        "_select_primary_config",
+        lambda value: (value, value, "glm_moe_dsa"),
+    )
+    monkeypatch.setattr(
+        transformers_builder,
+        "_resolve_module_class",
+        lambda *args, **kwargs: (_DummyModule, "text-generation", "glm_moe_dsa"),
+    )
+    monkeypatch.setattr(_config_resolver, "_config_from_hf", lambda *args, **kwargs: config)
+
+    def fake_build_from_module(_module, built_config, *args, **kwargs):
+        captured_configs.append(built_config)
+        return package
+
+    monkeypatch.setattr(transformers_builder, "build_from_module", fake_build_from_module)
+    monkeypatch.setattr(transformers_builder, "_download_weights", mock.Mock(return_value={}))
+
+    result = transformers_builder.build_transformers_model(
+        "zai-org/GLM-5.2", glm_full_attention=True
+    )
+
+    assert result is package
+    assert captured_configs[0].use_dsa is False
+
+
+def test_glm_full_attention_rejects_non_glm_model_type(monkeypatch) -> None:
+    """``--glm-full-attention`` is only meaningful for ``glm_moe_dsa``."""
+    hf_config = type("HFConfig", (), {"model_type": "qwen2"})()
+    config = make_config(model_type="qwen2")
+
+    monkeypatch.setattr(
+        transformers_builder,
+        "_load_transformers_config",
+        lambda *args, **kwargs: (hf_config, False),
+    )
+    monkeypatch.setattr(
+        transformers_builder,
+        "_select_primary_config",
+        lambda value: (value, value, "qwen2"),
+    )
+    monkeypatch.setattr(
+        transformers_builder,
+        "_resolve_module_class",
+        lambda *args, **kwargs: (_DummyModule, "text-generation", "qwen2"),
+    )
+    monkeypatch.setattr(_config_resolver, "_config_from_hf", lambda *args, **kwargs: config)
+
+    with pytest.raises(ValueError, match="glm_full_attention=True is not supported"):
+        transformers_builder.build_transformers_model("fake/model", glm_full_attention=True)
+
+
 def test_build_threads_revision_to_diffusers_fallback(monkeypatch) -> None:
     import transformers
 
@@ -99,3 +166,35 @@ def test_build_threads_revision_to_diffusers_fallback(monkeypatch) -> None:
             },
         )
     ]
+
+
+def test_glm_full_attention_rejects_diffusers_dispatch(monkeypatch) -> None:
+    """``--glm-full-attention`` must raise on the diffusers-dispatch branch.
+
+    Mirrors the existing ``text_only`` guard on the same early-return path:
+    a repo that doesn't resolve to a registered ``model_type`` (and so falls
+    through to the Diffusers integration) can never be GLM-5.2, so silently
+    ignoring the flag there would swallow a real user error.
+    """
+    import transformers
+
+    monkeypatch.setattr(
+        transformers.AutoConfig,
+        "from_pretrained",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("not transformers")),
+    )
+    monkeypatch.setattr(
+        _config_resolver, "_try_load_config_json", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        diffusers_builder,
+        "build_diffusers_pipeline",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("should not reach build_diffusers_pipeline")
+        ),
+    )
+
+    with pytest.raises(ValueError, match="glm_full_attention=True is not supported"):
+        transformers_builder.build_transformers_model(
+            "fake/diffusers", glm_full_attention=True
+        )

--- a/src/mobius/models/__init__.py
+++ b/src/mobius/models/__init__.py
@@ -65,6 +65,7 @@ __all__ = [
     "GlmAsrForConditionalGeneration",
     "Glm4MoECausalLMModel",
     "GlmCausalLMModel",
+    "GlmMoeDsaCausalLMModel",
     "GraniteCausalLMModel",
     "GraniteMoECausalLMModel",
     "GraniteMoeHybridCausalLMModel",
@@ -234,6 +235,7 @@ from mobius.models.gemma4 import (
 from mobius.models.gemma4_assistant import Gemma4AssistantCausalLMModel
 from mobius.models.glm import Glm4CausalLMModel, GlmCausalLMModel
 from mobius.models.glm_asr import GlmAsrForConditionalGeneration
+from mobius.models.glm_moe_dsa import GlmMoeDsaCausalLMModel
 from mobius.models.gpt2 import GPT2CausalLMModel
 from mobius.models.gpt_neox import GPTNeoXCausalLMModel, GPTNeoXJapaneseCausalLMModel
 from mobius.models.gptj_codegen import CodeGenCausalLMModel, GPTJCausalLMModel

--- a/src/mobius/models/glm_moe_dsa.py
+++ b/src/mobius/models/glm_moe_dsa.py
@@ -1,0 +1,686 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""GLM-5.2 (``glm_moe_dsa``) MLA + DeepSeek Sparse Attention (DSA) + MoE.
+
+Reference: ``transformers.models.glm_moe_dsa`` (``GlmMoeDsaForCausalLM``),
+the authoritative ground truth for this architecture's config derivation
+and forward semantics. GLM-5.2 reuses DeepSeek-V3's MLA/MoE building blocks
+almost unchanged (identical fused-expert HF weight layout, identical
+sigmoid + correction-bias + degenerate-group-of-one top-k routing) and adds
+one new mechanism: DeepSeek Sparse Attention (DSA), where a lightweight
+per-layer "indexer" selects the ``index_topk`` most relevant key positions
+per query token, and only "full" layers run the indexer -- "shared" layers
+reuse the nearest preceding "full" layer's selection unchanged.
+
+Two export paths are supported:
+
+- ``config.use_dsa=True`` (default): DSA is exported using the frozen
+  ``pkg.nxrt::IndexShare`` custom op (see
+  ``docs/architecture/INDEXSHARE_DESIGN.md`` in onnx-genai), which gathers
+  only the indexer-selected key/value positions at runtime.
+- ``config.use_dsa=False`` (the ``--glm-full-attention`` CLI feature):
+  falls back to plain dense MLA -- literally ``DeepSeekV3TextModel``,
+  unchanged -- which any ``Attention``-op-supporting runtime (including
+  stock ORT) can already execute today.
+
+Multi-token-prediction (MTP) is intentionally **not** exported this cycle:
+the reference ``GlmMoeDsaForCausalLM`` implementation has no MTP module at
+all and explicitly ignores ``model.layers.<num_hidden_layers>.*`` (MTP)
+weights on load via ``_keys_to_ignore_on_load_unexpected``. This exporter
+follows the same precedent: MTP weights are dropped with a clear, logged
+capability message rather than shipping a from-scratch, unvalidated MTP
+graph. See ``mobius.models.qwen35_mtp`` for the generic standalone-MTP-head
+pattern a future slice should reuse to add GLM-5.2 MTP support.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import re
+
+import onnx_ir as ir
+import torch
+from onnxscript import OpBuilder, nn
+
+from mobius._configs import ArchitectureConfig
+from mobius.components import (
+    MLP,
+    DeepSeekMLA,
+    Embedding,
+    LayerNorm,
+    Linear,
+    RMSNorm,
+    create_attention_bias,
+    initialize_rope,
+)
+from mobius.components._rotary_embedding import apply_rotary_pos_emb
+from mobius.models.deepseek import (
+    DeepSeekMoEGate,
+    DeepSeekV3CausalLMModel,
+    DeepSeekV3TextModel,
+    _DeepSeekMoEFFN,
+    _linear_factory,
+)
+
+logger = logging.getLogger(__name__)
+
+# Matches "model.layers.<idx>.<rest>" HF state_dict keys so MTP-layer
+# weights (idx >= num_hidden_layers) can be identified for dropping.
+_LAYER_RE = re.compile(r"^model\.layers\.(\d+)\.(.+)$")
+
+
+def _indexer_types(config: ArchitectureConfig) -> list[str]:
+    """Per-layer full/shared DSA indexer schedule.
+
+    Mirrors HF ``GlmMoeDsaConfig.__post_init__`` exactly: an explicit
+    ``indexer_types`` list always wins (and must have one entry per hidden
+    layer); otherwise every layer is "full" except that layers are "shared"
+    unless ``(i - offset + 1)`` clamped to >= 0 is a multiple of ``freq``.
+    Defaults (``freq=1``, ``offset=2``) match upstream and make every layer
+    "full" when the checkpoint config omits both fields.
+    """
+    if config.indexer_types is not None:
+        indexer_types = list(config.indexer_types)
+        if len(indexer_types) != config.num_hidden_layers:
+            raise ValueError(
+                "indexer_types must contain exactly one entry per hidden layer "
+                f"(expected {config.num_hidden_layers}, got {len(indexer_types)})"
+            )
+        return indexer_types
+    freq = max(config.index_topk_freq or 1, 1)
+    offset = config.index_skip_topk_offset if config.index_skip_topk_offset is not None else 2
+    return [
+        "full" if (max(i - offset + 1, 0) % freq) == 0 else "shared"
+        for i in range(config.num_hidden_layers)
+    ]
+
+
+class GlmMoeDsaIndexer(nn.Module):
+    """DeepSeek Sparse Attention (DSA) token indexer for "full" layers.
+
+    Projects a lightweight, single-head key (``wk``) and a per-index-head
+    query (``wq_b``, fed from the main attention's ``q_a_layernorm`` output)
+    and scores every key position with a ReLU'd, head-weighted dot product.
+    Only ``qk_rope_head_dim`` of ``index_head_dim`` is RoPE-rotated -- the
+    remainder passes through unrotated -- matching
+    ``transformers.models.glm_moe_dsa.modeling_glm_moe_dsa.GlmMoeDsaIndexer``
+    exactly. The top ``index_topk`` scored positions (ascending, per
+    ``pkg.nxrt::IndexShare``'s strictly-increasing-index requirement) are
+    returned for the caller to either consume directly or thread to
+    subsequent "shared" layers.
+    """
+
+    def __init__(self, config: ArchitectureConfig, linear_class: type | None = None):
+        super().__init__()
+        assert config.q_lora_rank is not None
+        assert config.index_head_dim is not None
+        assert config.index_n_heads is not None
+        assert config.qk_rope_head_dim is not None
+        if linear_class is None:
+            linear_class = Linear
+        self.head_dim = config.index_head_dim
+        self.n_heads = config.index_n_heads
+        self.qk_rope_head_dim = config.qk_rope_head_dim
+        self.index_topk = int(config.index_topk or 2048)
+        self.rope_interleave = config.indexer_rope_interleave
+        # Matches HF's ``softmax_scale = self.head_dim**-0.5`` -- note this
+        # uses the *indexer's* head_dim (index_head_dim), not the main
+        # attention's qk_head_dim.
+        self.softmax_scale = self.head_dim**-0.5
+        self.wq_b = linear_class(config.q_lora_rank, self.n_heads * self.head_dim, bias=False)
+        self.wk = linear_class(config.hidden_size, self.head_dim, bias=False)
+        self.k_norm = LayerNorm(self.head_dim, eps=1e-6)
+        self.weights_proj = linear_class(config.hidden_size, self.n_heads, bias=False)
+
+    def _rope_split(
+        self,
+        op: OpBuilder,
+        x: ir.Value,
+        num_heads: int,
+        position_embeddings: tuple,
+    ) -> ir.Value:
+        """RoPE-rotate only the leading ``qk_rope_head_dim`` slice of ``x``.
+
+        ``x`` is ``(B, S, num_heads, head_dim)``. Unlike the main MLA
+        attention (where the entire rope slice *is* the rotated portion),
+        the indexer's ``index_head_dim`` is wider than
+        ``qk_rope_head_dim``: only the first ``qk_rope_head_dim`` columns
+        rotate and the remaining ``head_dim - qk_rope_head_dim`` columns
+        pass through unchanged, then the two are re-concatenated.
+        """
+        pass_dim = self.head_dim - self.qk_rope_head_dim
+        rot, pas = op.Split(x, [self.qk_rope_head_dim, pass_dim], axis=-1, _outputs=2)
+        rot = op.Reshape(rot, [0, 0, -1])
+        rot = apply_rotary_pos_emb(
+            op,
+            rot,
+            position_embeddings,
+            num_heads=num_heads,
+            rotary_embedding_dim=0,
+            interleaved=self.rope_interleave,
+        )
+        rot = op.Reshape(rot, [0, 0, num_heads, self.qk_rope_head_dim])
+        return op.Concat(rot, pas, axis=-1)
+
+    def project_key(
+        self,
+        op: OpBuilder,
+        hidden_states: ir.Value,
+        position_embeddings: tuple,
+    ) -> ir.Value:
+        """Compute this token's (rope-split) indexer key: ``(B, S, head_dim)``."""
+        key = self.k_norm(op, self.wk(op, hidden_states))
+        key = op.Reshape(key, [0, 0, 1, self.head_dim])
+        key = self._rope_split(op, key, num_heads=1, position_embeddings=position_embeddings)
+        return op.Reshape(key, [0, 0, self.head_dim])
+
+    def select(
+        self,
+        op: OpBuilder,
+        hidden_states: ir.Value,
+        q_resid: ir.Value,
+        position_embeddings: tuple,
+        all_index_keys: ir.Value,
+        attention_bias: ir.Value,
+    ) -> ir.Value:
+        query = self.wq_b(op, q_resid)
+        query = op.Reshape(query, [0, 0, self.n_heads, self.head_dim])
+        query = self._rope_split(op, query, self.n_heads, position_embeddings)
+        query = op.Cast(query, to=ir.DataType.FLOAT)  # (B, S, H, D)
+
+        keys = op.Cast(all_index_keys, to=ir.DataType.FLOAT)  # (B, T, D)
+        keys_t = op.Transpose(keys, perm=[0, 2, 1])  # (B, D, T)
+        # A plain 4D-query x 3D-key MatMul broadcasts the batch dims
+        # right-aligned, so a (B, S) vs (B,) batch shape silently pairs the
+        # query's S axis with the key's B axis whenever batch_size != seq_len.
+        # Insert the query's singleton head axis explicitly (matching HF's
+        # ``k.transpose(-1, -2).unsqueeze(1)``) so the (B, S, H, D) x
+        # (B, 1, D, T) broadcast is unambiguous regardless of B vs S.
+        keys_t = op.Unsqueeze(keys_t, [1])  # (B, 1, D, T)
+        scores = op.MatMul(query, keys_t)  # (B, S, H, T)
+        scores = op.Mul(scores, self.softmax_scale)
+        scores = op.Relu(scores)
+
+        weights = self.weights_proj(op, hidden_states)  # (B, S, H)
+        weights = op.Cast(weights, to=ir.DataType.FLOAT)
+        weights = op.Mul(weights, self.n_heads**-0.5)
+        # Head-weighted sum: (B, S, H, T) -> (B, S, T).
+        scores = op.ReduceSum(op.Mul(scores, op.Unsqueeze(weights, [3])), [2], keepdims=False)
+
+        # The additive causal mask is sized to the attention key axis, which
+        # the native decoder exposes at fixed KV capacity while the indexer
+        # key cache grows with the logical prefix. Slice the mask down to
+        # the score key length so the add stays broadcast-compatible under
+        # both the logical (ORT) and fixed-capacity (native decode) shapes.
+        key_length = op.Shape(scores, start=2, end=3)
+        causal = op.Squeeze(attention_bias, [1])
+        causal = op.Slice(
+            causal, op.Constant(value_ints=[0]), key_length, op.Constant(value_ints=[2])
+        )
+        scores = op.Add(scores, op.Cast(causal, to=ir.DataType.FLOAT))
+
+        k = op.Min(key_length, op.Constant(value_ints=[self.index_topk]))
+        _, indices = op.TopK(scores, k, axis=-1, largest=1, sorted=0, _outputs=2)
+        # ``pkg.nxrt::IndexShare`` requires the selected key positions to be
+        # strictly increasing per row. TopK returns them in score order, so
+        # sort the chosen positions ascending. The runtime TopK kernel is
+        # f32-only, so round-trip through float before restoring Int64.
+        indices = op.Cast(indices, to=ir.DataType.FLOAT)
+        indices, _ = op.TopK(indices, k, axis=-1, largest=0, sorted=1, _outputs=2)
+        return op.Cast(indices, to=ir.DataType.INT64)
+
+    def forward(
+        self,
+        op: OpBuilder,
+        hidden_states: ir.Value,
+        q_resid: ir.Value,
+        position_embeddings: tuple,
+        past_index_key: ir.Value | None,
+        attention_bias: ir.Value,
+    ) -> tuple[ir.Value, ir.Value]:
+        current_index_key = self.project_key(op, hidden_states, position_embeddings)
+        all_index_keys = (
+            current_index_key
+            if past_index_key is None
+            else op.Concat(past_index_key, current_index_key, axis=1)
+        )
+        indices = self.select(
+            op, hidden_states, q_resid, position_embeddings, all_index_keys, attention_bias
+        )
+        return all_index_keys, indices
+
+
+class GlmMoeDsaAttention(DeepSeekMLA):
+    """MLA attention with a packed indexer-key cache and IndexShare output.
+
+    Reuses ``DeepSeekMLA``'s exact Q/KV projection and RoPE math (duplicated
+    here rather than factored out, since ``DeepSeekMLA.forward`` does not
+    expose an overridable "run attention" seam); the only behavioral
+    difference is the final attention call, which selects the
+    indexer-chosen key/value positions via ``pkg.nxrt::IndexShare`` instead
+    of a dense ``Attention`` op over the whole KV cache.
+
+    The indexer's own key cache is packed into the *same* present-KV tuple
+    as the main attention (index-key columns appended after the main key
+    columns) so the exported graph keeps the usual 2-tensor present-KV
+    convention per layer instead of doubling KV cache tensors.
+    """
+
+    def __init__(
+        self,
+        config: ArchitectureConfig,
+        indexer_type: str,
+        linear_class: type | None = None,
+    ):
+        super().__init__(config, linear_class=linear_class)
+        self.indexer_type = indexer_type
+        self.dtype = config.dtype
+        self.main_key_dim = self.num_heads * self.qk_head_dim
+        self.main_value_dim = self.num_heads * self.v_head_dim
+        self.index_head_dim = int(config.index_head_dim or 0)
+        if indexer_type == "full":
+            self.indexer = GlmMoeDsaIndexer(config, linear_class)
+
+    def _unpack_past(self, op: OpBuilder, past_key_value: tuple):
+        packed_key, packed_value = past_key_value
+        key_tokens = op.Squeeze(packed_key, [1])
+        main_key = op.Slice(key_tokens, [0], [self.main_key_dim], [2])
+        main_key = op.Transpose(
+            op.Reshape(main_key, [0, 0, self.num_heads, self.qk_head_dim]),
+            perm=[0, 2, 1, 3],
+        )
+        value_tokens = op.Squeeze(packed_value, [1])
+        main_value = op.Transpose(
+            op.Reshape(value_tokens, [0, 0, self.num_heads, self.v_head_dim]),
+            perm=[0, 2, 1, 3],
+        )
+        index_key = None
+        if self.indexer_type == "full":
+            index_key = op.Slice(
+                key_tokens,
+                [self.main_key_dim],
+                [self.main_key_dim + self.index_head_dim],
+                [2],
+            )
+        return (main_key, main_value), index_key
+
+    def _pack_present(
+        self,
+        op: OpBuilder,
+        present: tuple,
+        index_keys: ir.Value | None,
+    ) -> tuple:
+        key = op.Reshape(
+            op.Transpose(present[0], perm=[0, 2, 1, 3]), [0, 0, self.main_key_dim]
+        )
+        if index_keys is not None:
+            key = op.Concat(key, index_keys, axis=-1)
+        value = op.Reshape(
+            op.Transpose(present[1], perm=[0, 2, 1, 3]),
+            [0, 0, self.main_value_dim],
+        )
+        return op.Unsqueeze(key, [1]), op.Unsqueeze(value, [1])
+
+    def _index_share_attention(
+        self,
+        op: OpBuilder,
+        q: ir.Value,
+        key: ir.Value,
+        value: ir.Value,
+        main_past: tuple | None,
+        topk_indices: ir.Value,
+    ) -> tuple[ir.Value, ir.Value, ir.Value]:
+        """Device-resident selected-token attention via ``pkg.nxrt::IndexShare``.
+
+        Replaces the dense additive-sparse-mask + ``Attention`` lowering
+        with the frozen ``IndexShare`` op, which gathers only the indexer's
+        selected key positions. Causality is carried entirely by the
+        (already causal) ``topk_indices``, so no dense additive mask island
+        is emitted here.
+
+        ``IndexShare`` requires a homogeneous head size across query/key/
+        value. MLA's value head (``v_head_dim``) is narrower than the
+        query/key head (``qk_head_dim``), so the value is zero-padded up to
+        ``qk_head_dim`` for the kernel and the padding columns are sliced
+        back off the output. The returned present key/value stay in their
+        native (unpadded) BNSH layout so the packed KV cache is unchanged.
+
+        The frozen ``IndexShare`` schema pins ``query``/``key``/``value`` (and
+        its ``output``) to f32 regardless of the model's compute dtype (see
+        ``docs/architecture/INDEXSHARE_DESIGN.md``), so the query/key/padded
+        value are cast to float right before the call and the result is cast
+        back to ``self.dtype`` before returning -- the returned present
+        key/value stay in their native dtype for the packed KV cache.
+        """
+        q_bnsh = op.Transpose(
+            op.Reshape(q, [0, 0, self.num_heads, self.qk_head_dim]), perm=[0, 2, 1, 3]
+        )
+        cur_key = op.Transpose(
+            op.Reshape(key, [0, 0, self.num_heads, self.qk_head_dim]), perm=[0, 2, 1, 3]
+        )
+        cur_value = op.Transpose(
+            op.Reshape(value, [0, 0, self.num_heads, self.v_head_dim]), perm=[0, 2, 1, 3]
+        )
+        present_key = cur_key
+        present_value = cur_value
+        if main_past is not None:
+            present_key = op.Concat(main_past[0], cur_key, axis=2)
+            present_value = op.Concat(main_past[1], cur_value, axis=2)
+
+        value_pad = self.qk_head_dim - self.v_head_dim
+        padded_value = present_value
+        if value_pad > 0:
+            # Zero-pad the value head up to ``qk_head_dim`` without ``Pad``
+            # (which the CUDA EP has no handler for). Build a device-resident
+            # zero block of the value's own dtype and concatenate it onto
+            # the head axis.
+            pad_shape = op.Concat(
+                op.Shape(present_value, start=0, end=3),
+                op.Constant(value_ints=[value_pad]),
+                axis=0,
+            )
+            zeros = op.Expand(op.Cast(op.Constant(value_float=0.0), to=self.dtype), pad_shape)
+            padded_value = op.Concat(present_value, zeros, axis=3)
+
+        # The frozen IndexShare schema pins query/key/value (and its output)
+        # to f32 regardless of the model's compute dtype -- cast the inputs
+        # here and cast the output back below, leaving the returned
+        # present_key/present_value (packed KV cache) in their native dtype.
+        needs_cast = self.dtype != ir.DataType.FLOAT
+        q_f32 = op.Cast(q_bnsh, to=ir.DataType.FLOAT) if needs_cast else q_bnsh
+        key_f32 = op.Cast(present_key, to=ir.DataType.FLOAT) if needs_cast else present_key
+        value_f32 = op.Cast(padded_value, to=ir.DataType.FLOAT) if needs_cast else padded_value
+
+        selected_indices = op.Unsqueeze(topk_indices, [1])
+        attn_output = op.IndexShare(
+            q_f32,
+            key_f32,
+            value_f32,
+            None,
+            None,
+            selected_indices,
+            num_heads=self.num_heads,
+            kv_num_heads=self.num_heads,
+            scale=self.scaling,
+            _domain="pkg.nxrt",
+            _outputs=1,
+        )
+        if needs_cast:
+            attn_output = op.Cast(attn_output, to=self.dtype)
+        if value_pad > 0:
+            attn_output = op.Slice(attn_output, [0], [self.v_head_dim], [3])
+        attn_output = op.Reshape(
+            op.Transpose(attn_output, perm=[0, 2, 1, 3]),
+            [0, 0, self.num_heads * self.v_head_dim],
+        )
+        return attn_output, present_key, present_value
+
+    def forward(
+        self,
+        op: OpBuilder,
+        hidden_states: ir.Value,
+        attention_bias: ir.Value,
+        position_embeddings: tuple,
+        past_key_value: tuple | None = None,
+        shared_topk_indices: ir.Value | None = None,
+    ):
+        q_resid = self.q_a_layernorm(op, self.q_a_proj(op, hidden_states))
+        q = self.q_b_proj(op, q_resid)
+        q = op.Reshape(q, [0, 0, self.num_heads, self.qk_head_dim])
+        q_nope, q_rope = op.Split(
+            q, [self.qk_nope_head_dim, self.qk_rope_head_dim], axis=-1, _outputs=2
+        )
+        q_rope = op.Reshape(q_rope, [0, 0, -1])
+        q_rope = apply_rotary_pos_emb(
+            op,
+            q_rope,
+            position_embeddings,
+            num_heads=self.num_heads,
+            interleaved=self._rope_interleave,
+        )
+        q = op.Concat(
+            op.Reshape(q_nope, [0, 0, self.num_heads, self.qk_nope_head_dim]),
+            op.Reshape(q_rope, [0, 0, self.num_heads, self.qk_rope_head_dim]),
+            axis=-1,
+        )
+        q = op.Reshape(q, [0, 0, self.num_heads * self.qk_head_dim])
+
+        compressed_kv = self.kv_a_proj_with_mqa(op, hidden_states)
+        kv_latent, k_rope = op.Split(
+            compressed_kv, [self.kv_lora_rank, self.qk_rope_head_dim], axis=-1, _outputs=2
+        )
+        kv_latent = self.kv_a_layernorm(op, kv_latent)
+        kv = self.kv_b_proj(op, kv_latent)
+        kv = op.Reshape(kv, [0, 0, self.num_heads, self.qk_nope_head_dim + self.v_head_dim])
+        k_nope, value = op.Split(
+            kv, [self.qk_nope_head_dim, self.v_head_dim], axis=-1, _outputs=2
+        )
+        value = op.Reshape(value, [0, 0, -1])
+        k_rope = apply_rotary_pos_emb(
+            op, k_rope, position_embeddings, num_heads=1, interleaved=self._rope_interleave
+        )
+        k_rope = op.Tile(k_rope, [1, 1, self.num_heads])
+        key = op.Concat(
+            op.Reshape(k_nope, [0, 0, self.num_heads, self.qk_nope_head_dim]),
+            op.Reshape(k_rope, [0, 0, self.num_heads, self.qk_rope_head_dim]),
+            axis=-1,
+        )
+        key = op.Reshape(key, [0, 0, self.num_heads * self.qk_head_dim])
+
+        main_past = None
+        past_index_key = None
+        if past_key_value is not None:
+            main_past, past_index_key = self._unpack_past(op, past_key_value)
+
+        all_index_keys = None
+        topk_indices = shared_topk_indices
+        if self.indexer_type == "full":
+            all_index_keys, topk_indices = self.indexer(
+                op, hidden_states, q_resid, position_embeddings, past_index_key, attention_bias
+            )
+        if topk_indices is None:
+            raise ValueError(
+                "GLM-5.2 'shared' DSA layers require top-k indices threaded "
+                "from a preceding 'full' indexer layer"
+            )
+
+        attn_output, present_key, present_value = self._index_share_attention(
+            op, q, key, value, main_past, topk_indices
+        )
+        attn_output = self.o_proj(op, attn_output)
+        present = self._pack_present(op, (present_key, present_value), all_index_keys)
+        return attn_output, present, topk_indices
+
+
+class GlmMoeDsaDecoderLayer(nn.Module):
+    """DSA decoder layer: MLA+IndexShare attention plus MoE/dense FFN."""
+
+    def __init__(
+        self,
+        config: ArchitectureConfig,
+        indexer_type: str,
+        is_moe: bool,
+        linear_class: type | None = None,
+    ):
+        super().__init__()
+        self.self_attn = GlmMoeDsaAttention(config, indexer_type, linear_class)
+        if is_moe:
+            self.mlp = _DeepSeekMoEFFN(
+                config, DeepSeekMoEGate(config), linear_class=linear_class
+            )
+        else:
+            self.mlp = MLP(config, linear_class=linear_class)
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        op: OpBuilder,
+        hidden_states: ir.Value,
+        attention_bias: ir.Value,
+        position_embeddings: tuple,
+        past_key_value: tuple | None,
+        shared_topk_indices: ir.Value | None,
+    ):
+        residual = hidden_states
+        hidden_states = self.input_layernorm(op, hidden_states)
+        hidden_states, present, topk_indices = self.self_attn(
+            op,
+            hidden_states,
+            attention_bias,
+            position_embeddings,
+            past_key_value,
+            shared_topk_indices,
+        )
+        hidden_states = op.Add(residual, hidden_states)
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(op, hidden_states)
+        hidden_states = self.mlp(op, hidden_states)
+        hidden_states = op.Add(residual, hidden_states)
+        return hidden_states, present, topk_indices
+
+
+class GlmMoeDsaTextModel(nn.Module):
+    """GLM-5.2 text backbone: embed -> N x (MLA+DSA/MoE) layers -> norm."""
+
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+        self.config = config
+        self.embed_tokens = Embedding(config.vocab_size, config.hidden_size)
+        linear_class = _linear_factory(config)
+        indexer_types = _indexer_types(config)
+        self.layers = nn.ModuleList(
+            [
+                GlmMoeDsaDecoderLayer(
+                    config,
+                    indexer_types[i],
+                    is_moe=i >= config.first_k_dense_replace,
+                    linear_class=linear_class,
+                )
+                for i in range(config.num_hidden_layers)
+            ]
+        )
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+        # RoPE applies only to the qk_rope_head_dim portion of Q/K (and, via
+        # GlmMoeDsaIndexer._rope_split, the same-sized leading slice of the
+        # indexer's wider index_head_dim) -- never the full head_dim. Build
+        # the shared cos/sin cache from qk_rope_head_dim explicitly rather
+        # than relying on the upstream HF config's own self-correcting
+        # ``head_dim = qk_rope_head_dim`` (``GlmMoeDsaConfig.__post_init__``):
+        # a raw config.json loaded without that Python class in the loop
+        # would otherwise leave the un-fixed (larger) raw ``head_dim``, as
+        # was the case for DeepSeek-V2/V3 (see ``DeepSeekV3TextModel``).
+        if config.qk_rope_head_dim is not None and config.qk_rope_head_dim > 0:
+            rope_config = dataclasses.replace(config, head_dim=config.qk_rope_head_dim)
+        else:
+            rope_config = config
+        self.rotary_emb = initialize_rope(rope_config)
+
+    def forward(
+        self,
+        op: OpBuilder,
+        input_ids: ir.Value,
+        attention_mask: ir.Value,
+        position_ids: ir.Value,
+        past_key_values: list | None = None,
+        inputs_embeds: ir.Value | None = None,
+    ):
+        if inputs_embeds is not None:
+            hidden_states = inputs_embeds
+        else:
+            hidden_states = self.embed_tokens(op, input_ids)
+        position_embeddings = self.rotary_emb(op, position_ids)
+        attention_bias = create_attention_bias(
+            op,
+            input_ids=hidden_states if input_ids is None else input_ids,
+            attention_mask=attention_mask,
+            dtype=self.config.dtype,
+        )
+
+        presents = []
+        past_kvs = past_key_values or [None] * len(self.layers)
+        shared_topk_indices = None
+        for layer, past_kv in zip(self.layers, past_kvs):
+            hidden_states, present, shared_topk_indices = layer(
+                op,
+                hidden_states,
+                attention_bias,
+                position_embeddings,
+                past_kv,
+                shared_topk_indices,
+            )
+            presents.append(present)
+
+        hidden_states = self.norm(op, hidden_states)
+        return hidden_states, presents
+
+
+class GlmMoeDsaCausalLMModel(DeepSeekV3CausalLMModel):
+    """GLM-5.2 (``zai-org/GLM-5.2``) causal LM: MLA + DSA + MoE.
+
+    model_type: glm_moe_dsa
+
+    DSA (top-k sparse attention via the frozen ``pkg.nxrt::IndexShare`` op)
+    is the default export path (``config.use_dsa=True``, the default).
+    Setting ``config.use_dsa=False`` (the ``--glm-full-attention`` CLI
+    feature) instead builds the plain dense-MLA ``DeepSeekV3TextModel``
+    unchanged, which any ``Attention``-op-supporting runtime -- including
+    stock ORT -- can already execute. ``preprocess_weights`` drops every DSA
+    indexer weight in that case since nothing in the dense graph consumes it.
+
+    Multi-token-prediction (MTP) is out of scope this cycle: see the module
+    docstring. ``preprocess_weights`` drops ``model.layers.N.*`` weights for
+    ``N >= num_hidden_layers`` (MTP) with a logged capability message rather
+    than silently or accidentally feeding them into the base decoder.
+    """
+
+    default_task: str = "text-generation"
+    category: str = "Mixture of Experts"
+
+    def __init__(self, config: ArchitectureConfig):
+        if config.indexer_types is None:
+            config = dataclasses.replace(config, indexer_types=_indexer_types(config))
+        nn.Module.__init__(self)
+        self.config = config
+        self.model = (
+            GlmMoeDsaTextModel(config) if config.use_dsa else DeepSeekV3TextModel(config)
+        )
+        self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def preprocess_weights(
+        self, state_dict: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        mtp_keys = []
+        for key in state_dict:
+            match = _LAYER_RE.match(key)
+            if match is not None and int(match.group(1)) >= self.config.num_hidden_layers:
+                mtp_keys.append(key)
+        if mtp_keys:
+            logger.warning(
+                "Dropping %d GLM-5.2 multi-token-prediction (MTP) weight(s) "
+                "under model.layers.%d.* and above: MTP export is out of "
+                "scope this cycle. The reference transformers "
+                "GlmMoeDsaForCausalLM implementation has no MTP module "
+                "either and ignores these same keys on load "
+                "(_keys_to_ignore_on_load_unexpected).",
+                len(mtp_keys),
+                self.config.num_hidden_layers,
+            )
+        filtered = {k: v for k, v in state_dict.items() if k not in mtp_keys}
+
+        if not self.config.use_dsa:
+            indexer_keys = [k for k in filtered if ".self_attn.indexer." in k]
+            if indexer_keys:
+                logger.info(
+                    "Dropping %d GLM-5.2 DSA indexer weight(s): "
+                    "config.use_dsa=False (--glm-full-attention) exports "
+                    "plain dense MLA, which does not consume the indexer.",
+                    len(indexer_keys),
+                )
+            filtered = {k: v for k, v in filtered.items() if k not in indexer_keys}
+
+        return DeepSeekV3CausalLMModel.preprocess_weights(self, filtered)

--- a/src/mobius/models/glm_moe_dsa_test.py
+++ b/src/mobius/models/glm_moe_dsa_test.py
@@ -1,0 +1,720 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for GLM-5.2 (``glm_moe_dsa``) enablement.
+
+Covers: registry wiring, the ``indexer_types`` full/shared schedule formula
+(matching HF ``GlmMoeDsaConfig.__post_init__`` exactly, including the real
+``zai-org/GLM-5.2`` ``offset=3, freq=4`` schedule), HF config extraction
+(including the ``scoring_func``/``topk_method`` model-type-defaulting fix
+for fields that are not real ``GlmMoeDsaConfig`` dataclass fields), the DSA
+(``IndexShare``) vs ``--glm-full-attention`` dense-fallback graph-build
+structural contract, MTP/indexer weight dropping, and a numeric parity
+check of the indexer against the real installed
+``transformers.models.glm_moe_dsa`` reference implementation.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import onnx_ir as ir
+import onnxruntime as ort
+import pytest
+import torch
+
+from mobius._builder import build_from_module
+from mobius._configs import ArchitectureConfig, QuantizationConfig
+from mobius._registry import registry
+from mobius._testing import count_op_type, create_test_builder, create_test_input, make_config
+from mobius.components._rotary_embedding import initialize_rope
+from mobius.models.glm_moe_dsa import (
+    GlmMoeDsaCausalLMModel,
+    GlmMoeDsaIndexer,
+    _indexer_types,
+)
+
+transformers = pytest.importorskip("transformers")
+from transformers.models.glm_moe_dsa.configuration_glm_moe_dsa import (  # noqa: E402
+    GlmMoeDsaConfig,
+)
+from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import (  # noqa: E402
+    GlmMoeDsaIndexer as HFGlmMoeDsaIndexer,
+)
+from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import (  # noqa: E402
+    GlmMoeDsaRotaryEmbedding,
+    apply_rotary_pos_emb_interleave,
+)
+
+
+def _glm_config(**overrides) -> ArchitectureConfig:
+    """Tiny real-config-derived GLM-5.2 fixture (4 layers, full/shared mix).
+
+    Dimensions are shape-faithful to the pinned ``zai-org/GLM-5.2`` identity
+    (MLA + DSA, sigmoid/noaux_tc grouped-topk routing, one shared expert)
+    but shrunk to a handful of experts/heads so tests build/run in
+    milliseconds. ``indexer_types`` is explicit (``["full", "shared",
+    "full", "shared"]``) so structural assertions don't depend on the
+    default-schedule formula (covered separately by
+    ``test_indexer_types_*``).
+    """
+    defaults = dict(
+        vocab_size=48,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        head_dim=16,
+        max_position_embeddings=32,
+        q_lora_rank=24,
+        kv_lora_rank=16,
+        qk_nope_head_dim=8,
+        qk_rope_head_dim=8,
+        v_head_dim=16,
+        first_k_dense_replace=0,
+        num_local_experts=4,
+        num_experts_per_tok=2,
+        n_group=2,
+        topk_group=1,
+        n_shared_experts=1,
+        moe_intermediate_size=16,
+        scoring_func="sigmoid",
+        topk_method="noaux_tc",
+        norm_topk_prob=True,
+        routed_scaling_factor=2.5,
+        index_n_heads=2,
+        index_head_dim=16,
+        index_topk=3,
+        indexer_rope_interleave=True,
+        indexer_types=["full", "shared", "full", "shared"],
+        use_dsa=True,
+    )
+    defaults.update(overrides)
+    return make_config(**defaults)
+
+
+# --------------------------------------------------------------------------
+# Registry
+# --------------------------------------------------------------------------
+
+
+def test_registry_maps_glm_moe_dsa_to_causal_lm_model():
+    assert registry.get("glm_moe_dsa") is GlmMoeDsaCausalLMModel
+
+
+# --------------------------------------------------------------------------
+# _indexer_types() -- full/shared DSA schedule
+# --------------------------------------------------------------------------
+
+
+class TestIndexerTypes:
+    def test_explicit_list_is_used_verbatim(self):
+        config = _glm_config(num_hidden_layers=3, indexer_types=["full", "full", "shared"])
+        assert _indexer_types(config) == ["full", "full", "shared"]
+
+    def test_explicit_list_length_mismatch_raises(self):
+        config = _glm_config(num_hidden_layers=4, indexer_types=["full", "shared"])
+        with pytest.raises(ValueError, match="one entry per hidden layer"):
+            _indexer_types(config)
+
+    def test_default_with_no_freq_offset_is_all_full(self):
+        """freq=1 (default) makes every layer 'full', matching HF's default."""
+        config = _glm_config(
+            num_hidden_layers=4,
+            indexer_types=None,
+            index_topk_freq=None,
+            index_skip_topk_offset=None,
+        )
+        assert _indexer_types(config) == ["full"] * 4
+
+    def test_default_matches_real_glm_5_2_offset_and_freq(self):
+        """Cross-check the schedule formula against a hand-derived expectation.
+
+        offset=3, freq=4 (the real zai-org/GLM-5.2 config) -> full at
+        layers 0, 1, 2, 6 for an 8-layer slice, matching
+        ``GlmMoeDsaConfig.__post_init__``'s own formula exactly.
+        """
+        config = _glm_config(
+            num_hidden_layers=8,
+            indexer_types=None,
+            index_topk_freq=4,
+            index_skip_topk_offset=3,
+        )
+        assert _indexer_types(config) == [
+            "full",
+            "full",
+            "full",
+            "shared",
+            "shared",
+            "shared",
+            "full",
+            "shared",
+        ]
+
+    def test_default_matches_hf_post_init_formula_directly(self):
+        """Cross-check against the real HF config's own derivation.
+
+        Not just a hand-verified expectation.
+        """
+        hf_config = GlmMoeDsaConfig(
+            num_hidden_layers=8, index_topk_freq=4, index_skip_topk_offset=3
+        )
+        config = _glm_config(
+            num_hidden_layers=8,
+            indexer_types=None,
+            index_topk_freq=4,
+            index_skip_topk_offset=3,
+        )
+        assert _indexer_types(config) == hf_config.indexer_types
+
+
+# --------------------------------------------------------------------------
+# HF config extraction: scoring_func/topk_method model-type defaulting fix
+# --------------------------------------------------------------------------
+
+
+class TestHFConfigExtraction:
+    def test_glm_moe_dsa_defaults_to_sigmoid_noaux_tc_when_omitted(self):
+        """Regression test for scoring_func/topk_method model-type defaulting.
+
+        GlmMoeDsaConfig doesn't declare scoring_func/topk_method as real
+        dataclass fields, so a config that omits them (unlike the real
+        zai-org/GLM-5.2 config.json, which sets them explicitly) must still
+        extract GLM's architecturally-fixed sigmoid + noaux_tc routing --
+        not silently fall back to DeepSeek's softmax/greedy defaults.
+        """
+        hf_config = GlmMoeDsaConfig(hidden_size=32, num_hidden_layers=2)
+        assert not hasattr(hf_config, "scoring_func")
+        assert not hasattr(hf_config, "topk_method")
+
+        config = ArchitectureConfig.from_transformers(hf_config)
+        assert config.scoring_func == "sigmoid"
+        assert config.topk_method == "noaux_tc"
+
+    def test_explicit_scoring_func_in_config_is_respected(self):
+        hf_config = GlmMoeDsaConfig(
+            hidden_size=32, num_hidden_layers=2, scoring_func="softmax", topk_method="greedy"
+        )
+        config = ArchitectureConfig.from_transformers(hf_config)
+        assert config.scoring_func == "softmax"
+        assert config.topk_method == "greedy"
+
+    def test_non_glm_model_type_keeps_deepseek_defaults(self):
+        """The model-type-conditional default must not leak into DeepSeek."""
+        from transformers.models.deepseek_v3.configuration_deepseek_v3 import (
+            DeepseekV3Config,
+        )
+
+        hf_config = DeepseekV3Config(hidden_size=32, num_hidden_layers=2)
+        assert not hasattr(hf_config, "scoring_func")
+        config = ArchitectureConfig.from_transformers(hf_config)
+        assert config.scoring_func == "softmax"
+        assert config.topk_method == "greedy"
+
+    def test_extracts_dsa_indexer_fields_and_num_local_experts_alias(self):
+        hf_config = GlmMoeDsaConfig(
+            hidden_size=32,
+            num_hidden_layers=4,
+            n_routed_experts=4,
+            index_n_heads=2,
+            index_head_dim=16,
+            index_topk=3,
+            index_topk_freq=4,
+            index_skip_topk_offset=3,
+        )
+        config = ArchitectureConfig.from_transformers(hf_config)
+        assert config.num_local_experts == 4
+        assert config.index_n_heads == 2
+        assert config.index_head_dim == 16
+        assert config.index_topk == 3
+        assert config.index_topk_freq == 4
+        assert config.index_skip_topk_offset == 3
+        assert config.use_dsa is True  # no HF equivalent -- always defaults True.
+
+
+# --------------------------------------------------------------------------
+# Graph build: DSA (IndexShare) path vs --glm-full-attention dense fallback
+# --------------------------------------------------------------------------
+
+
+class TestGlmMoeDsaGraphBuild:
+    def _build(self, **overrides):
+        config = _glm_config(**overrides)
+        model = GlmMoeDsaCausalLMModel(config)
+        package = build_from_module(model, config, task="text-generation")
+        return config, package["model"]
+
+    def test_dsa_path_emits_one_index_share_per_hidden_layer_and_no_attention(self):
+        config, onnx_model = self._build()
+        graph = onnx_model.graph
+        assert count_op_type(graph, "IndexShare") == config.num_hidden_layers
+        assert count_op_type(graph, "Attention") == 0
+        assert count_op_type(graph, "GroupQueryAttention") == 0
+        assert count_op_type(graph, "MultiHeadAttention") == 0
+
+    def test_index_share_inputs_are_float32_under_a_non_float_dtype(self):
+        """Regression test for the frozen ``IndexShare`` f32-only schema.
+
+        The op's query/key/value/output are pinned to f32 by
+        ``docs/architecture/INDEXSHARE_DESIGN.md`` regardless of the model's
+        compute dtype, and the real ``zai-org/GLM-5.2`` checkpoint is
+        bfloat16. Build under a non-float dtype and assert every IndexShare
+        node's first three inputs resolve to FLOAT so a missing cast (which
+        would otherwise only surface as a runtime dtype mismatch under a
+        non-default dtype) is caught at graph-build time.
+        """
+        config, onnx_model = self._build(dtype=ir.DataType.FLOAT16)
+        graph = onnx_model.graph
+        index_share_nodes = [n for n in graph if n.op_type == "IndexShare"]
+        assert len(index_share_nodes) == config.num_hidden_layers
+        for node in index_share_nodes:
+            query, key, value = node.inputs[0], node.inputs[1], node.inputs[2]
+            assert query.dtype == ir.DataType.FLOAT
+            assert key.dtype == ir.DataType.FLOAT
+            assert value.dtype == ir.DataType.FLOAT
+
+    def test_dsa_path_full_layers_get_indexer_weights_shared_layers_dont(self):
+        _config, onnx_model = self._build()
+        initializer_names = {i.name for i in onnx_model.graph.initializers.values()}
+        for i, indexer_type in enumerate(["full", "shared", "full", "shared"]):
+            has_indexer_weight = any(
+                f"layers.{i}.self_attn.indexer." in name for name in initializer_names
+            )
+            assert has_indexer_weight == (indexer_type == "full"), (
+                i,
+                indexer_type,
+                has_indexer_weight,
+            )
+
+    def test_full_attention_fallback_emits_dense_attention_and_no_index_share(self):
+        config, onnx_model = self._build(use_dsa=False)
+        graph = onnx_model.graph
+        assert count_op_type(graph, "IndexShare") == 0
+        dense_attn_ops = (
+            count_op_type(graph, "Attention")
+            + count_op_type(graph, "GroupQueryAttention")
+            + count_op_type(graph, "MultiHeadAttention")
+        )
+        assert dense_attn_ops > 0
+        initializer_names = {i.name for i in onnx_model.graph.initializers.values()}
+        assert not any(".self_attn.indexer." in name for name in initializer_names)
+        del config
+
+    def test_moe_layers_use_dense_expert_loop_without_quantization(self):
+        """Verify dense per-expert MoE path is used without quantization.
+
+        No quantization configured -> the (already-tested, unchanged)
+        DeepSeek dense per-expert MoE path, not QMoE.
+        """
+        _config, onnx_model = self._build()
+        assert count_op_type(onnx_model.graph, "QMoE") == 0
+
+    def test_moe_layers_fuse_to_qmoe_when_quantized(self):
+        """Verify quantized MoE layers fuse to a single QMoE node.
+
+        Same QMoE fusion path proven for DeepSeek-V4 (#550) wires
+        through unchanged for GLM-5.2's config shape -- one QMoE node per
+        MoE layer, no per-expert MatMulNBits loop left over for the routed
+        experts (other quantized linears -- attention projections, shared
+        expert -- legitimately still lower to MatMulNBits; only the
+        *routed-expert* dense loop must disappear).
+        """
+        config, onnx_model = self._build(
+            first_k_dense_replace=0,
+            quantization=QuantizationConfig(
+                bits=4, group_size=16, quant_method="gptq", sym=True
+            ),
+        )
+        graph = onnx_model.graph
+        assert count_op_type(graph, "QMoE") == config.num_hidden_layers
+        expert_matmulnbits = [
+            node
+            for node in graph
+            if node.op_type == "MatMulNBits"
+            and any(
+                ".mlp.moe.experts." in (v.name or "") for v in node.inputs if v is not None
+            )
+        ]
+        assert expert_matmulnbits == []
+
+
+# --------------------------------------------------------------------------
+# preprocess_weights: MTP drop + indexer drop for the dense fallback
+# --------------------------------------------------------------------------
+
+
+class TestPreprocessWeights:
+    def _state_dict(self, config: ArchitectureConfig) -> dict[str, torch.Tensor]:
+        model = GlmMoeDsaCausalLMModel(config)
+        state = {
+            name: torch.zeros(tuple(int(d) for d in p.shape))
+            for name, p in model.named_parameters()
+        }
+        # Convert Mobius's own attribute-path names into the HF-style
+        # ``model.layers.N.*`` names preprocess_weights expects on input.
+        renamed = {
+            f"model.{name}" if not name.startswith("lm_head") else name: v
+            for name, v in state.items()
+        }
+        return renamed
+
+    def test_drops_mtp_layer_weights_with_warning(self, caplog):
+        config = _glm_config(num_hidden_layers=4)
+        model = GlmMoeDsaCausalLMModel(config)
+        state = self._state_dict(config)
+        # Inject a fake MTP layer (index == num_hidden_layers) as the real
+        # transformers checkpoint would ship one.
+        state["model.layers.4.input_layernorm.weight"] = torch.zeros(config.hidden_size)
+        state["model.layers.4.mlp.gate_proj.weight"] = torch.zeros(
+            config.intermediate_size, config.hidden_size
+        )
+
+        with caplog.at_level(logging.WARNING):
+            out = model.preprocess_weights(state)
+
+        assert not any(k.startswith("layers.4.") for k in out)
+        assert any("multi-token-prediction" in r.message for r in caplog.records)
+
+    def test_dense_fallback_drops_indexer_weights(self):
+        config = _glm_config(use_dsa=False)
+        model = GlmMoeDsaCausalLMModel(config)
+        state = self._state_dict(config)
+        state["model.layers.0.self_attn.indexer.wk.weight"] = torch.zeros(
+            config.index_head_dim, config.hidden_size
+        )
+        out = model.preprocess_weights(state)
+        assert not any(".self_attn.indexer." in k for k in out)
+
+    def test_dsa_path_keeps_indexer_weights(self):
+        config = _glm_config(use_dsa=True)
+        model = GlmMoeDsaCausalLMModel(config)
+        state = self._state_dict(config)
+        out = model.preprocess_weights(state)
+        assert any(".self_attn.indexer." in k for k in out)
+
+
+# --------------------------------------------------------------------------
+# Numeric parity: GlmMoeDsaIndexer vs the real transformers reference
+# --------------------------------------------------------------------------
+
+
+class TestIndexerNumericParity:
+    """Validates the two bugs fixed vs the stale sibling branch.
+
+    The indexer's RoPE split (rope only ``qk_rope_head_dim`` of the wider
+    ``index_head_dim``) and the 4D-query x 3D-key MatMul broadcast (which
+    silently pairs the wrong axes whenever batch_size != seq_len).
+
+    Raw (post-mask, pre-top-k) index scores are compared exactly against a
+    manual PyTorch recompute using the *real* installed
+    ``transformers.models.glm_moe_dsa`` RoPE/rotation helpers -- this is
+    the strongest available ground truth and is immune to the top-k
+    tie-breaking differences between ``torch.topk`` and ONNX ``TopK`` that
+    make direct selected-index comparison unreliable on tied/degenerate
+    scores (verified empirically: raw scores match to float32 precision
+    while ties at the exact top-k boundary can pick different -- but
+    equally valid -- indices).
+    """
+
+    def _build_indexer_pair(
+        self,
+        rng,
+        batch,
+        seq_len,
+        hidden_size,
+        q_lora_rank,
+        index_head_dim,
+        index_n_heads,
+        qk_rope_head_dim,
+        index_topk,
+    ):
+        hf_config = GlmMoeDsaConfig(
+            hidden_size=hidden_size,
+            q_lora_rank=q_lora_rank,
+            index_head_dim=index_head_dim,
+            index_n_heads=index_n_heads,
+            qk_rope_head_dim=qk_rope_head_dim,
+            index_topk=index_topk,
+            num_hidden_layers=1,
+            max_position_embeddings=32,
+        )
+        hf_indexer = HFGlmMoeDsaIndexer(hf_config, layer_idx=0)
+        hf_indexer.eval()
+        with torch.no_grad():
+            for p in hf_indexer.parameters():
+                p.copy_(
+                    torch.from_numpy(rng.standard_normal(p.shape).astype(np.float32)) * 2.0
+                )
+
+        config = make_config(
+            hidden_size=hidden_size,
+            q_lora_rank=q_lora_rank,
+            index_head_dim=index_head_dim,
+            index_n_heads=index_n_heads,
+            qk_rope_head_dim=qk_rope_head_dim,
+            index_topk=index_topk,
+            indexer_rope_interleave=True,
+            rope_type="default",
+            head_dim=qk_rope_head_dim,
+            max_position_embeddings=32,
+        )
+        mobius_indexer = GlmMoeDsaIndexer(config)
+        state = dict(hf_indexer.state_dict())
+        for name, param in mobius_indexer.named_parameters():
+            param.const_value = ir.tensor(state[name].detach().numpy().astype(np.float32))
+        return hf_config, hf_indexer, config, mobius_indexer
+
+    def _run_mobius_indexer(
+        self, config, mobius_indexer, hidden_np, q_resid_np, position_ids_np, bias_np
+    ):
+        builder, op, graph = create_test_builder()
+        batch, seq_len, hidden_size = hidden_np.shape
+        q_lora_rank = q_resid_np.shape[-1]
+        hidden_states = create_test_input(
+            builder, "hidden_states", [batch, seq_len, hidden_size]
+        )
+        q_resid = create_test_input(builder, "q_resid", [batch, seq_len, q_lora_rank])
+        position_ids = ir.Value(
+            name="position_ids",
+            shape=ir.Shape([batch, seq_len]),
+            type=ir.TensorType(ir.DataType.INT64),
+        )
+        graph.inputs.append(position_ids)
+        attention_bias = create_test_input(
+            builder, "attention_bias", [batch, 1, seq_len, seq_len]
+        )
+
+        rotary_emb = initialize_rope(config)
+        position_embeddings = rotary_emb(op, position_ids)
+        _all_keys, indices = mobius_indexer(
+            op, hidden_states, q_resid, position_embeddings, None, attention_bias
+        )
+        indices.name = "indices"
+        graph.outputs.append(indices)
+
+        model = ir.Model(graph, ir_version=11)
+        session = ort.InferenceSession(
+            ir.to_proto(model).SerializeToString(), providers=["CPUExecutionProvider"]
+        )
+        (indices_out,) = session.run(
+            None,
+            {
+                "hidden_states": hidden_np,
+                "q_resid": q_resid_np,
+                "position_ids": position_ids_np,
+                "attention_bias": bias_np,
+            },
+        )
+        return indices_out
+
+    def _hf_raw_scores(
+        self,
+        hf_config,
+        hf_indexer,
+        hidden_np,
+        q_resid_np,
+        position_ids_np,
+        bias_np,
+        qk_rope_head_dim,
+        index_head_dim,
+        index_n_heads,
+    ):
+        rope = GlmMoeDsaRotaryEmbedding(hf_config)
+        with torch.no_grad():
+            cos, sin = rope(torch.zeros(1), torch.tensor(position_ids_np))
+            hs_t = torch.tensor(hidden_np)
+            qr_t = torch.tensor(q_resid_np)
+            batch, seq_len, _ = hidden_np.shape
+            q = hf_indexer.wq_b(qr_t).view(batch, seq_len, index_n_heads, index_head_dim)
+            q_rot, q_pass = torch.split(
+                q, [qk_rope_head_dim, index_head_dim - qk_rope_head_dim], dim=-1
+            )
+            k = hf_indexer.k_norm(hf_indexer.wk(hs_t)).unsqueeze(2)
+            k_rot, k_pass = torch.split(
+                k, [qk_rope_head_dim, index_head_dim - qk_rope_head_dim], dim=-1
+            )
+            q_rot, k_rot = apply_rotary_pos_emb_interleave(
+                q_rot, k_rot, cos, sin, unsqueeze_dim=2
+            )
+            q_full = torch.cat([q_rot, q_pass], dim=-1)
+            k_full = torch.cat([k_rot, k_pass], dim=-1).squeeze(2)
+            scores = (
+                torch.matmul(q_full.float(), k_full.transpose(-1, -2).float().unsqueeze(1))
+                * hf_indexer.softmax_scale
+            )
+            scores = torch.relu(scores)
+            weights = hf_indexer.weights_proj(hs_t).float() * (index_n_heads**-0.5)
+            index_scores = torch.matmul(weights.unsqueeze(-2), scores).squeeze(-2)
+            index_scores = index_scores + torch.tensor(bias_np).squeeze(1)
+        return index_scores.numpy()
+
+    def test_raw_scores_match_real_hf_reference_batch_ne_seq_len(self):
+        """Verify raw indexer scores match HF when batch_size != seq_len.
+
+        batch_size != seq_len on purpose: this is exactly the shape the
+        stale sibling branch's un-``unsqueeze``d MatMul broadcast bug
+        silently mishandled.
+        """
+        rng = np.random.default_rng(42)
+        batch, seq_len = 3, 6
+        hidden_size, q_lora_rank = 8, 6
+        index_head_dim, index_n_heads, qk_rope_head_dim, index_topk = 8, 2, 4, 3
+
+        hf_config, hf_indexer, config, mobius_indexer = self._build_indexer_pair(
+            rng,
+            batch,
+            seq_len,
+            hidden_size,
+            q_lora_rank,
+            index_head_dim,
+            index_n_heads,
+            qk_rope_head_dim,
+            index_topk,
+        )
+
+        hidden_np = (rng.standard_normal((batch, seq_len, hidden_size)) * 3).astype(np.float32)
+        q_resid_np = (rng.standard_normal((batch, seq_len, q_lora_rank)) * 3).astype(
+            np.float32
+        )
+        position_ids_np = np.tile(np.arange(seq_len), (batch, 1)).astype(np.int64)
+        bias_np = np.zeros((batch, 1, seq_len, seq_len), dtype=np.float32)
+        causal = np.triu(np.ones((seq_len, seq_len), dtype=bool), k=1)
+        bias_np[:, :, causal] = -3.4e38
+
+        expected_scores = self._hf_raw_scores(
+            hf_config,
+            hf_indexer,
+            hidden_np,
+            q_resid_np,
+            position_ids_np,
+            bias_np,
+            qk_rope_head_dim,
+            index_head_dim,
+            index_n_heads,
+        )
+
+        # Recompute Mobius's own raw scores (pre-topk) the same way the
+        # module does internally, via a patched select() that also emits
+        # the score tensor -- mirrors GlmMoeDsaIndexer.select() exactly.
+        builder, op, graph = create_test_builder()
+        hidden_states = create_test_input(
+            builder, "hidden_states", [batch, seq_len, hidden_size]
+        )
+        q_resid = create_test_input(builder, "q_resid", [batch, seq_len, q_lora_rank])
+        position_ids = ir.Value(
+            name="position_ids",
+            shape=ir.Shape([batch, seq_len]),
+            type=ir.TensorType(ir.DataType.INT64),
+        )
+        graph.inputs.append(position_ids)
+        attention_bias = create_test_input(
+            builder, "attention_bias", [batch, 1, seq_len, seq_len]
+        )
+        rotary_emb = initialize_rope(config)
+        position_embeddings = rotary_emb(op, position_ids)
+
+        query = mobius_indexer.wq_b(op, q_resid)
+        query = op.Reshape(query, [0, 0, mobius_indexer.n_heads, mobius_indexer.head_dim])
+        query = mobius_indexer._rope_split(
+            op, query, mobius_indexer.n_heads, position_embeddings
+        )
+        query = op.Cast(query, to=ir.DataType.FLOAT)
+        key = mobius_indexer.project_key(op, hidden_states, position_embeddings)
+        keys_t = op.Unsqueeze(
+            op.Transpose(op.Cast(key, to=ir.DataType.FLOAT), perm=[0, 2, 1]), [1]
+        )
+        raw = op.Mul(op.MatMul(query, keys_t), mobius_indexer.softmax_scale)
+        raw = op.Relu(raw)
+        weights = op.Mul(
+            op.Cast(mobius_indexer.weights_proj(op, hidden_states), to=ir.DataType.FLOAT),
+            mobius_indexer.n_heads**-0.5,
+        )
+        scores = op.ReduceSum(op.Mul(raw, op.Unsqueeze(weights, [3])), [2], keepdims=False)
+        scores = op.Add(scores, op.Cast(op.Squeeze(attention_bias, [1]), to=ir.DataType.FLOAT))
+        scores.name = "scores"
+        graph.outputs.append(scores)
+        model = ir.Model(graph, ir_version=11)
+        session = ort.InferenceSession(
+            ir.to_proto(model).SerializeToString(), providers=["CPUExecutionProvider"]
+        )
+        (actual_scores,) = session.run(
+            None,
+            {
+                "hidden_states": hidden_np,
+                "q_resid": q_resid_np,
+                "position_ids": position_ids_np,
+                "attention_bias": bias_np,
+            },
+        )
+
+        np.testing.assert_allclose(actual_scores, expected_scores, rtol=1e-3, atol=1e-2)
+
+    def test_select_returns_true_top_k_strictly_increasing_indices(self):
+        """Verify selected indices form a true top-k, tie-breaking aside.
+
+        Independent of any cross-framework tie-breaking: the selected
+        indices must (a) be a valid top-k of Mobius's own scores (every
+        selected score >= every non-selected causally-valid score) and
+        (b) be strictly increasing, satisfying ``pkg.nxrt::IndexShare``'s
+        ascending-index requirement.
+        """
+        rng = np.random.default_rng(7)
+        batch, seq_len = 2, 7
+        hidden_size, q_lora_rank = 8, 6
+        index_head_dim, index_n_heads, qk_rope_head_dim, index_topk = 8, 2, 4, 3
+
+        _hf_config, _hf_indexer, config, mobius_indexer = self._build_indexer_pair(
+            rng,
+            batch,
+            seq_len,
+            hidden_size,
+            q_lora_rank,
+            index_head_dim,
+            index_n_heads,
+            qk_rope_head_dim,
+            index_topk,
+        )
+        hidden_np = (rng.standard_normal((batch, seq_len, hidden_size)) * 3).astype(np.float32)
+        q_resid_np = (rng.standard_normal((batch, seq_len, q_lora_rank)) * 3).astype(
+            np.float32
+        )
+        position_ids_np = np.tile(np.arange(seq_len), (batch, 1)).astype(np.int64)
+        bias_np = np.zeros((batch, 1, seq_len, seq_len), dtype=np.float32)
+        causal = np.triu(np.ones((seq_len, seq_len), dtype=bool), k=1)
+        bias_np[:, :, causal] = -3.4e38
+
+        indices_out = self._run_mobius_indexer(
+            config, mobius_indexer, hidden_np, q_resid_np, position_ids_np, bias_np
+        )
+
+        # Strictly increasing (IndexShare ABI contract).
+        assert np.all(np.diff(indices_out, axis=-1) > 0)
+
+        expected_scores = self._hf_raw_scores(
+            _hf_config,
+            _hf_indexer,
+            hidden_np,
+            q_resid_np,
+            position_ids_np,
+            bias_np,
+            qk_rope_head_dim,
+            index_head_dim,
+            index_n_heads,
+        )
+        for b in range(batch):
+            for s in range(seq_len):
+                valid = expected_scores[b, s, : s + 1]
+                selected = indices_out[b, s]
+                selected_scores = expected_scores[b, s, selected]
+                non_selected = np.setdiff1d(np.arange(s + 1), selected)
+                if non_selected.size == 0:
+                    continue
+                # Every selected (causally valid) score must be >= every
+                # non-selected causally valid score -- true top-k property,
+                # tolerant of ties at the boundary.
+                assert (
+                    selected_scores.min() >= expected_scores[b, s, non_selected].max() - 1e-4
+                )
+                del valid


### PR DESCRIPTION
## Summary

Registers the `glm_moe_dsa` model_type — **`zai-org/GLM-5.2`**, architecture `GlmMoeDsaForCausalLM` (78 layers, hidden 6144, MLA+DSA, 256 routed + 1 shared expert, top-8, sigmoid/noaux_tc routing, `routed_scaling_factor=2.5`, 1 MTP layer, default RoPE) — by **reusing existing DeepSeek MLA/MoE/QMoE-fusion machinery** rather than merging draft PR #404 or sibling branch `feat/glm-dsa-indexshare` wholesale.

Both stale branches were diffed and classified hunk-by-hunk against current `main`. Several correctness bugs present in the sibling branch were identified and **not** carried over — fixed from scratch instead:
1. Indexer RoPE split only rotating `qk_rope_head_dim` of the wider `index_head_dim` (sibling rotated the whole head).
2. A 4D-query × 3D-key `MatMul` broadcast that silently mispairs axes whenever `batch_size != seq_len` (sibling omitted an `unsqueeze`).
3. (Found during independent review of *this* PR, fixed here) `IndexShare`'s query/key/value inputs must be cast to f32 per the frozen op schema (`docs/architecture/INDEXSHARE_DESIGN.md` in onnx-genai) regardless of the model's compute dtype — the real `zai-org/GLM-5.2` checkpoint is bfloat16.

## What's included

- **`src/mobius/models/glm_moe_dsa.py`** (new): `GlmMoeDsaIndexer` (DSA top-k scoring/selection), `GlmMoeDsaAttention` (subclasses `DeepSeekMLA`, exports the frozen `pkg.nxrt::IndexShare` op per the "full"/"shared" indexer schedule), `GlmMoeDsaDecoderLayer`, `GlmMoeDsaTextModel`, `GlmMoeDsaCausalLMModel` (subclasses `DeepSeekV3CausalLMModel`). Existing DeepSeek MLA math, MoE gate/FFN, and QMoE fusion (#550) are reused unchanged.
- **`config.use_dsa=False`** (new **`--glm-full-attention`** CLI feature) switches to plain dense MLA attention, executable on stock ONNX Runtime today, as an explicit fallback until the native `IndexShare` runtime kernel lands in onnx-genai. Wired through both the `--config` (local dir) and `--model` (HF id, including the diffusers-dispatch fallback branch) build paths, validated to only apply to `glm_moe_dsa`.
- **`src/mobius/_configs/_base.py`**: 6 new `ArchitectureConfig` fields for DSA (`index_topk`, `index_head_dim`, `index_n_heads`, `index_topk_freq`, `index_skip_topk_offset`, `use_dsa`) and HF-config extraction, including a `model_type == "glm_moe_dsa"`-conditional default so `scoring_func`/`topk_method` correctly resolve to GLM's sigmoid/noaux_tc routing. (The real `GlmMoeDsaConfig` does not declare these as dataclass fields at all when omitted from `config.json` — they're silently absent, not defaulted — so without this fix GLM-5.2 would silently inherit DeepSeek's softmax/greedy routing defaults.)
- **`src/mobius/_registry.py`**, **`src/mobius/models/__init__.py`**: registration wiring.
- **`src/mobius/models/glm_moe_dsa_test.py`** (new, 21 tests): registry mapping; indexer schedule formula (cross-checked against the real installed `transformers.models.glm_moe_dsa` config's own `.indexer_types` derivation, not just a hand-written expectation); `scoring_func`/`topk_method` regression test; graph-build structural tests for both the DSA and full-attention-fallback paths (`IndexShare`/`Attention` op counts, indexer-weight presence, QMoE-fusion node count, **and a regression test asserting `IndexShare`'s query/key/value inputs are float32 under a non-float compute dtype** — verified to fail without the fix above and pass with it); `preprocess_weights` tests (MTP-layer and indexer-weight dropping); two numeric-parity tests against the real HF reference implementation (raw index-score parity to ~1e-6, and a tie-tolerant "true top-k + strictly increasing indices" property test — selected-index-*set* equality is deliberately not asserted because `torch.topk` and ONNX `TopK` have different, individually valid tie-breaking conventions at degenerate/tied score boundaries; this was verified empirically, not assumed).
- **`src/mobius/integrations/transformers/_builder_test.py`**: tests for the new `glm_full_attention` override/validation on both the main and diffusers-dispatch code paths.

## Explicitly out of scope (no open tracking issue found — searched `onnxruntime/mobius` issues for GLM/MTP/DSA/IndexShare/GGUF, none exist)

- **MTP (multi-token-prediction) layer.** The real `transformers.models.glm_moe_dsa` reference implementation itself has no MTP module — `preprocess_weights` drops MTP-layer weights with a warning, matching upstream's own `_keys_to_ignore_on_load_unexpected` pattern. Base-model logits never accidentally include an unsupported MTP path. Exporting MTP is a follow-up.
- GGUF import support.
- CUDA residency policy / q* / scheduler work.

## Local evidence

- `ruff check` / `ruff format --check`: clean (pinned lintrunner version `0.16.2`).
- `pytest src/mobius/models/ -q` (full directory, excluding `arch_validation`/`golden`/`generation`/`benchmark` markers): **523 passed, 4 skipped**.
- `pytest src/mobius/models/glm_moe_dsa_test.py src/mobius/models/deepseek_test.py src/mobius/models/deepseek_v4_test.py src/mobius/_registry_test.py src/mobius/integrations/transformers/ src/mobius/_configs/ -q`: **146 passed**.
- Independent review (via a separate agent pass over the staged diff) found and this PR fixes: the `IndexShare` f32-input-cast bug above (blocker) and a missing `glm_full_attention` validation gap on the diffusers-dispatch branch (should-fix, also fixed + tested here).

## Remaining runtime/MTP/full-model blockers & next onnx-genai gate

- **Native `IndexShare` runtime kernel**: this PR only emits the frozen `pkg.nxrt::IndexShare` op into the graph; actually generating tokens end-to-end for the DSA path requires the corresponding onnx-genai/ORT custom-op kernel to exist and execute it. That is the concrete next onnx-genai-side gate — without it, only the `--glm-full-attention` dense fallback (stock-ORT-executable) can currently run tokens today.
- **MTP layer**: tracked as a documented follow-up above, no export path yet.
- **GGUF import**: not attempted in this slice.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
