### PR TITLE
Fix GLM-5.2 (glm_moe_dsa) opset import + KV-cache shape bugs found via real export

### DIFF
--- a/src/mobius/_registry.py
+++ b/src/mobius/_registry.py
@@ -584,7 +584,7 @@ _REGISTRATIONS: dict[str, ModelRegistration] = {
     "deepseek_v4": ModelRegistration(DeepSeekV4CausalLMModel, task="deepseek-v4"),
     "deepseek_vl_v2": ModelRegistration(DeepSeekOCR2CausalLMModel),
     # --- GLM-5.2 (MLA + DeepSeek Sparse Attention (DSA) + MoE) ---
-    "glm_moe_dsa": ModelRegistration(GlmMoeDsaCausalLMModel),
+    "glm_moe_dsa": ModelRegistration(GlmMoeDsaCausalLMModel, task="glm-moe-dsa"),
     # --- SSM (Mamba / Mamba2) ---
     "falcon_mamba": ModelRegistration(MambaCausalLMModel),
     "mamba": ModelRegistration(MambaCausalLMModel),

--- a/src/mobius/models/glm_moe_dsa.py
+++ b/src/mobius/models/glm_moe_dsa.py
@@ -394,6 +394,11 @@ class GlmMoeDsaAttention(DeepSeekMLA):
         value_f32 = op.Cast(padded_value, to=ir.DataType.FLOAT) if needs_cast else padded_value
 
         selected_indices = op.Unsqueeze(topk_indices, [1])
+        # pkg.nxrt is a custom onnx-genai runtime domain; the ONNX checker
+        # requires every domain used by a node to have a matching
+        # opset_imports entry (not automatically added by the op call),
+        # same as BlockQuantizedMatMul in _quantized_linear.py.
+        op.builder.graph.opset_imports["pkg.nxrt"] = 1
         attn_output = op.IndexShare(
             q_f32,
             key_f32,
@@ -684,3 +689,31 @@ class GlmMoeDsaCausalLMModel(DeepSeekV3CausalLMModel):
             filtered = {k: v for k, v in filtered.items() if k not in indexer_keys}
 
         return DeepSeekV3CausalLMModel.preprocess_weights(self, filtered)
+
+    def dsa_kv_cache_specs(self) -> list[tuple[int, int]]:
+        """Per-layer ``(key_head_dim, value_head_dim)`` for the packed DSA cache.
+
+        Only meaningful when ``config.use_dsa`` (``self.model`` is a
+        :class:`GlmMoeDsaTextModel`): ``GlmMoeDsaAttention._pack_present``
+        packs the indexer's own key cache into the *same* present-KV tensor
+        as the main attention (indexer columns appended after the main key
+        columns), so the key head_dim varies per layer -- "full" indexer
+        layers add ``index_head_dim`` extra columns, "shared" layers don't
+        -- unlike the uniform per-layer shape every other registered task
+        assumes. Reads the exact dims off the already-constructed attention
+        modules (rather than recomputing from config) so this can never
+        drift from what ``_pack_present``/``_unpack_past`` actually produce.
+        Consumed by :class:`mobius.tasks._glm_moe_dsa.GlmMoeDsaTask`.
+        """
+        return [
+            (
+                layer.self_attn.main_key_dim
+                + (
+                    layer.self_attn.index_head_dim
+                    if layer.self_attn.indexer_type == "full"
+                    else 0
+                ),
+                layer.self_attn.main_value_dim,
+            )
+            for layer in self.model.layers
+        ]

--- a/src/mobius/tasks/__init__.py
+++ b/src/mobius/tasks/__init__.py
@@ -42,6 +42,7 @@ __all__ = [
     "Gemma4Task",
     "Gemma4UnifiedTask",
     "Gemma4TextCausalLMTask",
+    "GlmMoeDsaTask",
     "HybridCausalLMTask",
     "Cosmos3EdgeVLTask",
     "HybridQwenVLTask",
@@ -121,6 +122,7 @@ from mobius.tasks._gemma4 import (
     Gemma4UnifiedTask,
 )
 from mobius.tasks._gemma4_assistant import Gemma4AssistantTask
+from mobius.tasks._glm_moe_dsa import GlmMoeDsaTask
 from mobius.tasks._glmasr_speech_language import GlmAsrSpeechLanguageTask
 from mobius.tasks._hunyuan_vl_mot import HunYuanVLMoTTask
 from mobius.tasks._image_classification import ImageClassificationTask
@@ -222,6 +224,7 @@ TASK_REGISTRY: dict[str, type[ModelTask]] = {
     "gemma4-text-generation": Gemma4TextCausalLMTask,
     "gemma4-unified": Gemma4UnifiedTask,
     "gemma4-assistant": Gemma4AssistantTask,
+    "glm-moe-dsa": GlmMoeDsaTask,
     "hunyuan-vl-mot": HunYuanVLMoTTask,
     "sensenova-u1": SenseNovaU1Task,
     "multimodal": MultiModalTask,

--- a/src/mobius/tasks/_glm_moe_dsa.py
+++ b/src/mobius/tasks/_glm_moe_dsa.py
@@ -1,0 +1,107 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Graph task for GLM-5.2 (``glm_moe_dsa``): DSA's packed IndexShare KV cache."""
+
+from __future__ import annotations
+
+import onnx_ir as ir
+
+from mobius._configs import ArchitectureConfig
+from mobius._model_package import ModelPackage
+from mobius.tasks._base import ModelTask, _make_graph, _make_model
+from mobius.tasks._causal_lm import CausalLMTask
+
+
+class GlmMoeDsaTask(ModelTask):
+    """Causal LM build for GLM-5.2, aware of DSA's packed per-layer KV cache.
+
+    ``GlmMoeDsaAttention`` (the DSA/IndexShare attention path, default when
+    ``config.use_dsa=True``) packs the indexer's own key cache into the
+    *same* present-KV tensor as the main attention -- one packed "head" of
+    width ``main_key_dim`` (plus ``index_head_dim`` extra columns on layers
+    whose indexer is "full" rather than "shared") -- instead of the generic
+    per-head ``[batch, num_heads, seq, head_dim]`` convention every other
+    registered causal-LM task assumes. That per-layer-varying width can't be
+    expressed by the generic :class:`~mobius.tasks._causal_lm.CausalLMTask`
+    (uniform shape across layers), so DSA mode needs its own cache
+    declaration, read directly off the built module via
+    ``GlmMoeDsaCausalLMModel.dsa_kv_cache_specs()`` to guarantee it never
+    drifts from what ``_pack_present``/``_unpack_past`` actually produce.
+
+    ``config.use_dsa=False`` (the ``--glm-full-attention`` fallback) builds
+    a plain dense ``DeepSeekV3TextModel`` with the standard MLA present-KV
+    convention, which ``CausalLMTask`` already declares correctly -- so
+    that mode delegates to it unchanged rather than duplicating its
+    input/output wiring.
+    """
+
+    def build(self, module, config: ArchitectureConfig) -> ModelPackage:
+        if not config.use_dsa:
+            return CausalLMTask().build(module, config)
+        return self._build_dsa(module, config)
+
+    def _build_dsa(self, module, config: ArchitectureConfig) -> ModelPackage:
+        specs_fn = getattr(module, "dsa_kv_cache_specs", None)
+        if not callable(specs_fn):
+            raise TypeError(
+                f"{type(module).__name__} must implement dsa_kv_cache_specs() "
+                "to build with GlmMoeDsaTask in DSA mode."
+            )
+        cache_specs = specs_fn()
+
+        graph, builder = _make_graph("glm_moe_dsa")
+        op = builder.op
+
+        batch = ir.SymbolicDim("batch")
+        seq_len = ir.SymbolicDim("sequence_len")
+        past_seq_len = ir.SymbolicDim("past_sequence_len")
+
+        input_ids = builder.input("input_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len])
+        attention_mask = builder.input(
+            "attention_mask",
+            dtype=ir.DataType.INT64,
+            shape=[batch, "past_sequence_len + sequence_len"],
+        )
+        position_ids = builder.input(
+            "position_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len]
+        )
+
+        past_key_values = []
+        for i, (key_head_dim, value_head_dim) in enumerate(cache_specs):
+            past_key = builder.input(
+                f"past_key_values.{i}.key",
+                dtype=config.dtype,
+                shape=[batch, 1, past_seq_len, key_head_dim],
+            )
+            past_value = builder.input(
+                f"past_key_values.{i}.value",
+                dtype=config.dtype,
+                shape=[batch, 1, past_seq_len, value_head_dim],
+            )
+            past_key_values.append((past_key, past_value))
+
+        logits, present_key_values = module(
+            op,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+        )
+        builder.add_output(logits, "logits")
+
+        # Stamp explicit present shapes/dtypes: ``pkg.nxrt::IndexShare`` has
+        # no registered symbolic-shape-inference function (unlike the plain
+        # ONNX ``Attention``/``com.microsoft::GroupQueryAttention`` ops), so
+        # the present.* outputs would otherwise be left untyped.
+        total_seq_len = "past_sequence_len + sequence_len"
+        for i, (present_key, present_value) in enumerate(present_key_values):
+            key_head_dim, value_head_dim = cache_specs[i]
+            present_key.shape = ir.Shape([batch, 1, total_seq_len, key_head_dim])
+            present_key.type = ir.TensorType(config.dtype)
+            present_value.shape = ir.Shape([batch, 1, total_seq_len, value_head_dim])
+            present_value.type = ir.TensorType(config.dtype)
+            builder.add_output(present_key, f"present.{i}.key")
+            builder.add_output(present_value, f"present.{i}.value")
+
+        return ModelPackage({"model": _make_model(graph)}, config=config)

--- a/tests/_test_configs.py
+++ b/tests/_test_configs.py
@@ -650,6 +650,47 @@ CAUSAL_LM_CONFIGS: list[tuple[str, dict, bool]] = [
         },
         True,
     ),
+    # glm_moe_dsa (zai-org/GLM-5.2): DeepSeekV3CausalLMModel subclass adding
+    # DeepSeek Sparse Attention (DSA) indexers on top of MLA. Field values
+    # below are shape-shrunk from the real zai-org/GLM-5.2 config.json
+    # (n_group=1, topk_group=1, routed_scaling_factor=2.5, sigmoid/noaux_tc,
+    # index_n_heads=32->2, index_head_dim=128->8, index_topk=2048->4). The
+    # real checkpoint config also sets num_nextn_predict_layers=1 (it ships
+    # model.layers.<num_hidden_layers>.* MTP weights), but the reference
+    # transformers.models.glm_moe_dsa modeling code only builds
+    # range(num_hidden_layers) decoder layers and has no MTP module, so those
+    # weights are unused/unexpected keys under from_pretrained -- see
+    # glm_moe_dsa.py for the matching drop-with-capability-message behavior.
+    (
+        "glm_moe_dsa",
+        {
+            # MLA: kv heads must equal attn heads (see MLA note near top of file).
+            "num_key_value_heads": TINY_HEADS,
+            "q_lora_rank": 32,
+            "kv_lora_rank": 16,
+            "qk_nope_head_dim": 16,
+            "qk_rope_head_dim": 8,
+            "v_head_dim": 16,
+            "num_local_experts": 4,
+            "num_experts_per_tok": 2,
+            "moe_intermediate_size": 32,
+            "n_group": 1,
+            "topk_group": 1,
+            "routed_scaling_factor": 2.5,
+            "scoring_func": "sigmoid",
+            "topk_method": "noaux_tc",
+            "first_k_dense_replace": 1,
+            "n_shared_experts": 1,
+            "rope_interleave": True,
+            "index_n_heads": 2,
+            "index_head_dim": 8,
+            "index_topk": 4,
+            "index_topk_freq": None,
+            "indexer_types": ["full", "shared"],
+            "num_nextn_predict_layers": 1,
+        },
+        True,
+    ),
     (
         "deepseek_v4",
         {

--- a/tests/model_coverage_test.py
+++ b/tests/model_coverage_test.py
@@ -221,6 +221,7 @@ _COVERAGE_SKIP: dict[str, str] = {
     "dbrx": "Large MoE (132B) — no small public checkpoint",
     "deepseek_v3": "Very large MoE (671B) — no small public checkpoint",
     "deepseek_v4": "Very large MoE (284B) — no small public checkpoint",
+    "glm_moe_dsa": "Very large MoE (~1.5T, zai-org/GLM-5.2) — no small public checkpoint",
     "llama4_text": "Very large MoE (109B) — no small public checkpoint",
     "qwen3_5_moe": "Large MoE (22B) — no small public checkpoint",
     # --- Models without test_model_id ---

--- a/tests/synthetic_parity_test.py
+++ b/tests/synthetic_parity_test.py
@@ -84,6 +84,17 @@ _SKIP_REASONS: dict[str, str] = {
     # Zamba weight-tying references layers.2.shared_transf (the third layer) but
     # the tiny config only has 2 layers — HF tie_weights validation crashes.
     "zamba": "Zamba weight-tying requires num_layers > 2; tiny 2-layer config causes HF tie_weights error",
+    # GLM-5.2's default (config.use_dsa=True) DSA/IndexShare path emits
+    # pkg.nxrt::IndexShare -- a custom onnx-genai-runtime domain with no
+    # stock-ORT registration, so this generic OnnxModelSession-based harness
+    # can never execute it (unlike com.microsoft::QMoE, a real ORT contrib
+    # op). DSA numeric correctness is covered instead by the dedicated
+    # GlmMoeDsaIndexer-vs-transformers parity test in glm_moe_dsa_test.py and
+    # by onnx-genai's native-CPU/CUDA e2e regression
+    # (glm_tiny_qmoe_native_cuda_e2e.rs); the config.use_dsa=False
+    # (--glm-full-attention) dense-MLA fallback has no custom ops and would
+    # be exercised by this harness if the tiny config defaulted to it.
+    "glm_moe_dsa": "DSA/IndexShare emits pkg.nxrt::IndexShare, unsupported by stock ORT",
 }
 
 # Per-model atol overrides for L3 synthetic parity.


### PR DESCRIPTION
## Summary

While exporting a tiny GLM-5.2 (`glm_moe_dsa`) fixture through the production `build_from_module()` pipeline (for an onnx-genai end-to-end native-runtime test), two real, previously-undetected bugs surfaced in `#555`'s GLM-5.2 support. `#555` had only ever been exercised through a manual `registry.get()+task.build()` sequence that skips shape inference and the ONNX checker — this is the first time the model has gone through the full production pipeline.

## Bug 1: missing `pkg.nxrt` opset import

`GlmMoeDsaAttention`'s `op.IndexShare(...)` call (custom `pkg.nxrt`-domain op) never registered `opset_imports["pkg.nxrt"] = 1`. The ONNX checker rejects this with "No opset import for domain 'pkg.nxrt'". This was previously masked because quantized fixtures also emit `BlockQuantizedMatMul` on the same domain, incidentally registering the import as a side effect — but a float/non-quantized DSA export produces an invalid graph. Fixed by adding the same explicit registration `_quantized_linear.py`'s `BlockQuantizedMatMul` already does, right before the `IndexShare` call.

## Bug 2: KV-cache shape mismatch (needs a dedicated task)

`glm_moe_dsa` was registered with the generic `CausalLMTask`, which declares uniform per-head `[batch, num_heads, seq, head_dim]` past/present KV shapes. GLM's DSA attention (`_pack_present`/`_unpack_past`) instead packs the indexer's key cache into the *same* present-KV tensor as the main attention, at a **per-layer-varying** width — "full" indexer layers add `index_head_dim` extra key columns, "shared" layers don't. This produced a graph-build-time `Squeeze` shape mismatch, previously invisible because a broad `except Exception` in the shape-inference pass silently swallowed it as an "upstream bug" warning.

Fixed with a new `GlmMoeDsaTask` (mirrors the `DeepSeekV4Task` precedent for models needing a dedicated cache convention):
- `config.use_dsa=False` (`--glm-full-attention` fallback): delegates unchanged to `CausalLMTask`, which already builds the plain dense MLA model correctly.
- `config.use_dsa=True`: builds explicit per-layer past/present KV I/O by reading exact dims off the constructed module via a new `GlmMoeDsaCausalLMModel.dsa_kv_cache_specs()` method, so the task can never drift from what `_pack_present`/`_unpack_past` actually produce.

## Also in this PR

- `tests/_test_configs.py`: new `glm_moe_dsa` entry in `ALL_CAUSAL_LM_CONFIGS`, shape-shrunk from the real `zai-org/GLM-5.2` config.json. This addition is what exposed both bugs above via existing coverage tests. Includes a documented note on why MTP weights (`num_nextn_predict_layers=1` in the real checkpoint) are legitimately unused: `transformers==5.15.0`'s `glm_moe_dsa` modeling code has no MTP module and hardcodes `_keys_to_ignore_on_load_unexpected` for the trailing MTP layer.
- `tests/model_coverage_test.py`: `glm_moe_dsa` added to `_COVERAGE_SKIP` (no small public checkpoint), matching `deepseek_v3`/`deepseek_v4` precedent.
- `tests/synthetic_parity_test.py`: `glm_moe_dsa` added to `_SKIP_REASONS` — the default DSA/IndexShare path emits a custom `pkg.nxrt` op with no stock-ORT registration, so this generic harness can never execute it; DSA numerics are covered separately by `glm_moe_dsa_test.py`'s dedicated indexer parity test and onnx-genai's native e2e regression test.

## Tests

- `glm_moe_dsa_test.py`: 21/21 passed
- `_registry_test.py` + `_builder_test.py`: 43/43 passed
- `model_coverage_test.py` + `build_graph_test.py` (glm_moe_dsa/deepseek filter): 57 passed, 8 skipped
- `synthetic_parity_test.py` + `weight_alignment_test.py` (glm_moe_dsa filter): 1 passed, 1 skipped (documented skip, not silent)
- Full `model_coverage_test.py` + `build_graph_test.py` + `synthetic_parity_test.py` + `weight_alignment_test.py`: 2434 passed, 341 skipped, 62 xfailed, 3 pre-existing failures unrelated to this diff (gemma4/gemma3n multimodal `audio_features` None, modernbert-decoder L3 tolerance) — confirmed unrelated by inspecting touched files
- `ruff check` + `ruff format --check`: clean
- Independent review completed (verified fixes by reproducing pre-fix failures on the parent commit, tracing exact shape math through `_pack_present`/`_unpack_past`, and re-running the full test suite) — no findings

## Context

This is a follow-up to #555 (GLM-5.2 model support), discovered while building the onnx-genai end-to-end test fixture. Scope is intentionally limited to these two bugs plus the test-config gap that exposed them — no GLM-5.2 registration semantics, MoE routing, YaRN, or attention changes beyond the two fixes above.

Working as Sapper (Systems Dev for Models & Preprocess).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>