### PR TITLE
Disable ONNX Runtime telemetry repo-wide

### DIFF
--- a/.github/workflows/arch_diff.yml
+++ b/.github/workflows/arch_diff.yml
@@ -23,6 +23,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  ORT_DISABLE_TELEMETRY: "1"
   BASE_REF: ${{ github.event.pull_request.base.sha || github.event.inputs.base_ref || 'origin/main' }}
   HEAD_REF: ${{ github.event.pull_request.head.sha || github.event.inputs.head_ref || 'HEAD' }}
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,6 +24,7 @@ concurrency:
 # For PRs: uses the PR base and head SHAs for exact reproducibility.
 # For workflow_dispatch: uses the input values or falls back to main.
 env:
+  ORT_DISABLE_TELEMETRY: "1"
   BASE_REF: ${{ github.event.pull_request.base.sha || github.event.inputs.base_ref || 'main' }}
   HEAD_REF: ${{ github.event.pull_request.head.sha || github.event.inputs.head_ref || 'main' }}
 

--- a/.github/workflows/golden_regen.yml
+++ b/.github/workflows/golden_regen.yml
@@ -29,6 +29,12 @@ concurrency:
   group: golden-regen
   cancel-in-progress: true
 
+# Repo rule: ONNX Runtime telemetry stays off. Workflow-level so every job and step inherits
+# it, including those that reach ORT without going through pytest and so never load the
+# rootdir conftest that sets it locally.
+env:
+  ORT_DISABLE_TELEMETRY: "1"
+
 jobs:
   regenerate:
     name: Regenerate Golden Files

--- a/.github/workflows/gpu_l4_golden_parity.yml
+++ b/.github/workflows/gpu_l4_golden_parity.yml
@@ -34,6 +34,12 @@ concurrency:
   group: gpu-l4-tests-${{ github.ref }}
   cancel-in-progress: true
 
+# Repo rule: ONNX Runtime telemetry stays off. Workflow-level so every job and step inherits
+# it, including those that reach ORT without going through pytest and so never load the
+# rootdir conftest that sets it locally.
+env:
+  ORT_DISABLE_TELEMETRY: "1"
+
 jobs:
   golden-tests:
     name: L4 - Verify ONNX output matches HuggingFace golden checkpoints

--- a/.github/workflows/gpu_l5_generation_e2e.yml
+++ b/.github/workflows/gpu_l5_generation_e2e.yml
@@ -34,6 +34,12 @@ concurrency:
   group: gpu-l5-tests-${{ github.ref }}
   cancel-in-progress: true
 
+# Repo rule: ONNX Runtime telemetry stays off. Workflow-level so every job and step inherits
+# it, including those that reach ORT without going through pytest and so never load the
+# rootdir conftest that sets it locally.
+env:
+  ORT_DISABLE_TELEMETRY: "1"
+
 jobs:
   generation-tests:
     name: L5 - Full token generation and decoding correctness

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Repo rule: ONNX Runtime telemetry stays off. Workflow-level so every job and step inherits
+# it, including those that reach ORT without going through pytest and so never load the
+# rootdir conftest that sets it locally.
+env:
+  ORT_DISABLE_TELEMETRY: "1"
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/nightly_l2.yml
+++ b/.github/workflows/nightly_l2.yml
@@ -16,6 +16,12 @@ concurrency:
   group: nightly-l2
   cancel-in-progress: true
 
+# Repo rule: ONNX Runtime telemetry stays off. Workflow-level so every job and step inherits
+# it, including those that reach ORT without going through pytest and so never load the
+# rootdir conftest that sets it locally.
+env:
+  ORT_DISABLE_TELEMETRY: "1"
+
 jobs:
   arch-validation:
     name: L2 Architecture Validation

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,12 @@ concurrency:
   group: pages
   cancel-in-progress: true
 
+# Repo rule: ONNX Runtime telemetry stays off. Workflow-level so every job and step inherits
+# it, including those that reach ORT without going through pytest and so never load the
+# rootdir conftest that sets it locally.
+env:
+  ORT_DISABLE_TELEMETRY: "1"
+
 jobs:
   build:
     name: Build Documentation

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,12 @@ on:
 permissions:
   contents: read
 
+# Repo rule: ONNX Runtime telemetry stays off. Workflow-level so every job and step inherits
+# it, including those that reach ORT without going through pytest and so never load the
+# rootdir conftest that sets it locally.
+env:
+  ORT_DISABLE_TELEMETRY: "1"
+
 jobs:
   build:
     name: Build distribution

--- a/.github/workflows/validation_examples_gpu.yml
+++ b/.github/workflows/validation_examples_gpu.yml
@@ -12,6 +12,12 @@ concurrency:
   group: examples-gpu-${{ github.ref }}
   cancel-in-progress: true
 
+# Repo rule: ONNX Runtime telemetry stays off. Workflow-level so every job and step inherits
+# it, including those that reach ORT without going through pytest and so never load the
+# rootdir conftest that sets it locally.
+env:
+  ORT_DISABLE_TELEMETRY: "1"
+
 jobs:
   run-example:
     name: "Validation Example / ${{ matrix.name }}"

--- a/conftest.py
+++ b/conftest.py
@@ -9,6 +9,14 @@ import importlib
 import os
 import sys
 
+# Repo rule: ONNX Runtime telemetry stays off. ORT reads this when its native library loads, so it
+# has to be set before anything imports `onnxruntime` — a fixture, even session-scoped and autouse,
+# runs too late because test modules import ORT at module scope. The rootdir conftest is imported
+# before those, which makes this the earliest reliable point.
+#
+# Assigned only if unset, so an explicit ORT_DISABLE_TELEMETRY=0 still wins for debugging.
+os.environ.setdefault("ORT_DISABLE_TELEMETRY", "1")
+
 # Insert the worktree src/ at the front of sys.path so it takes priority
 # over any installed (editable or otherwise) copy of the package.
 _src = os.path.join(os.path.dirname(__file__), "src")

--- a/tests/telemetry_policy_test.py
+++ b/tests/telemetry_policy_test.py
@@ -1,0 +1,53 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Guards the repo rule that ONNX Runtime telemetry is disabled.
+
+The rule is enforced in two places that share no code — the rootdir ``conftest.py`` and every CI
+workflow — because a workflow step that reaches ORT without going through pytest never loads the
+conftest. Config duplicated across files with nothing tying it together is what drifts, so it is
+checked here.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_WORKFLOW_DIR = _REPO_ROOT / ".github" / "workflows"
+_WORKFLOWS = sorted(p.name for p in _WORKFLOW_DIR.glob("*.yml"))
+
+
+def test_telemetry_is_disabled_in_this_process() -> None:
+    """The rootdir conftest must set this before anything imports ``onnxruntime``.
+
+    ORT reads the variable when its native library loads, so a fixture — even session-scoped and
+    autouse — is too late: test modules import ORT at module scope. Asserted on the environment
+    because ORT exposes no way to read the setting back.
+    """
+    assert os.environ.get("ORT_DISABLE_TELEMETRY") == "1", (
+        "ORT_DISABLE_TELEMETRY is not set for the test process; it belongs in the rootdir "
+        "conftest.py, before any onnxruntime import"
+    )
+
+
+def test_every_workflow_exists() -> None:
+    """Guard the guard: if the glob stopped matching, the parametrized test would silently pass."""
+    assert _WORKFLOWS, f"no workflows found under {_WORKFLOW_DIR}"
+
+
+@pytest.mark.parametrize("workflow", _WORKFLOWS)
+def test_workflow_disables_telemetry(workflow: str) -> None:
+    """Set at workflow level, so all jobs and steps inherit it.
+
+    Job-level would leave any ORT-invoking step in an unpatched job uncovered, and there is no
+    reason for the setting to vary by job.
+    """
+    yaml = pytest.importorskip("yaml")
+    config = yaml.safe_load((_WORKFLOW_DIR / workflow).read_text())
+    assert config.get("env", {}).get("ORT_DISABLE_TELEMETRY") == "1", (
+        f"{workflow} does not set ORT_DISABLE_TELEMETRY at workflow level"
+    )


### PR DESCRIPTION
Repo rule: ONNX Runtime does not phone home from this repository's test runs or CI.

## Why the rootdir conftest

ORT reads `ORT_DISABLE_TELEMETRY` when its native library loads, so it must be in the environment **before** anything imports `onnxruntime`. A fixture — even session-scoped and autouse — is too late, because test modules import ORT at module scope. The rootdir `conftest.py` is imported before those. 39 files here import `onnxruntime`, so no narrower hook would cover them.

## Where it's set

| Where | Covers |
| --- | --- |
| `conftest.py` (rootdir) | every pytest run |
| `.github/workflows/*.yml` | all 10 workflows, at workflow level so every job and step inherits it — including steps that reach ORT without going through pytest |

`arch_diff.yml` and `benchmark.yml` already had a top-level `env:`, so the key was merged into those rather than adding a second block. Both mechanisms assign only if unset, so an explicit `ORT_DISABLE_TELEMETRY=0` still wins for deliberate debugging.

## Deliberately not set inside the package

mobius is a library. Mutating a process-wide environment variable at import would silently change ORT's behaviour for anything that depends on us. The rule covers this repo's own entry points; it isn't ours to impose on downstream callers.

## Verified rather than assumed

`ORT_DISABLE_TELEMETRY` is present in the 1.29.0 `libonnxruntime` and pybind binaries. Worth checking first — a variable ORT ignored would look like a fix while changing nothing, which is worse than no fix at all.

## Guard

`tests/telemetry_policy_test.py` covers both mechanisms, because config duplicated across eleven files with no shared code is exactly what rots. It also asserts the workflow glob is non-empty, so the parametrized case can't silently pass by matching nothing.

I confirmed the guards aren't vacuous by reverting each mechanism in turn — 2 of the 12 cases fail, one per mechanism.

## Context

This came out of an unrelated debugging session on the MLX EP, where ORT's 1DS telemetry HTTP worker was seen locking an already-destroyed mutex during interpreter teardown and aborting the process (`Abort trap: 6`) *after* all tests had passed — a background-thread throw that is never caught, so it takes the run down and reds CI on an unrelated change. That was on macOS/arm64 and isn't necessarily reachable here, so this PR is scoped to the privacy rule rather than claiming a stability fix.

## Testing

`733 passed / 218 skipped` for `tests/telemetry_policy_test.py` + `tests/model_coverage_test.py`. `lintrunner` clean.
