### PR TITLE
Fix DeepSeek MoE routed experts losing linear_class quantization

### DIFF
--- a/src/mobius/models/deepseek.py
+++ b/src/mobius/models/deepseek.py
@@ -315,7 +315,14 @@ class _DeepSeekMoEFFN(nn.Module):
         super().__init__()
         assert config.num_local_experts is not None
         assert config.moe_intermediate_size is not None
-        self.moe = MoELayer(config, gate=gate)
+        # ``linear_class`` must reach the routed-expert dense-loop fallback
+        # too (not just the shared expert below): otherwise a quantized
+        # config quantizes every other linear in the model (attention,
+        # dense FFN, shared expert) but silently leaves the routed MoE
+        # experts as plain float `MatMul`, which both loses quantization
+        # and breaks the `fuse_dense_moe_to_qmoe` post-hoc rewrite (it
+        # only matches a quantized `MatMulNBits` dense-fallback pattern).
+        self.moe = MoELayer(config, gate=gate, linear_class=linear_class)
         # Shared expert uses moe_intermediate_size * n_shared_experts
         n_shared = config.n_shared_experts or 1
         shared_intermediate = config.moe_intermediate_size * n_shared

--- a/src/mobius/models/deepseek_test.py
+++ b/src/mobius/models/deepseek_test.py
@@ -97,6 +97,57 @@ def test_deepseek_dense_moe_fallback_matches_numpy_reference():
     assert all(node.domain != "com.microsoft" for node in graph)
 
 
+def test_deepseek_moe_ffn_linear_class_reaches_routed_experts():
+    """``linear_class`` must reach the routed dense-loop experts, not just the shared expert.
+
+    Regression test for a bug where ``_DeepSeekMoEFFN`` constructed its
+    ``MoELayer`` without forwarding ``linear_class``, so a quantized config
+    quantized attention/dense-FFN/shared-expert linears but silently left the
+    routed MoE experts as plain float ``MatMul`` -- losing quantization and
+    breaking the ``fuse_dense_moe_to_qmoe`` post-hoc rewrite, which only
+    matches a quantized ``MatMulNBits`` dense-fallback pattern.
+    """
+    from mobius.components._common import Linear
+
+    created: list[Linear] = []
+
+    class TrackingLinear(Linear):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            created.append(self)
+
+    config = make_config(
+        hidden_size=4,
+        intermediate_size=8,
+        moe_intermediate_size=3,
+        num_local_experts=4,
+        num_experts_per_tok=2,
+        n_group=2,
+        topk_group=1,
+        n_shared_experts=1,
+        scoring_func="sigmoid",
+        topk_method="noaux_tc",
+    )
+    module = _DeepSeekMoEFFN(config, DeepSeekMoEGate(config), linear_class=TrackingLinear)
+
+    # The dense loop-over-experts fallback must have been built with
+    # TrackingLinear for every routed expert's projections. Check
+    # `module.moe.experts` directly (not the global `created` list) so this
+    # assertion can't pass merely because the shared expert below picked up
+    # the class -- that path already worked before this fix.
+    assert module.moe.experts is not None
+    routed_linears = [m for m in module.moe.experts.modules() if isinstance(m, Linear)]
+    assert len(routed_linears) > 0
+    assert all(isinstance(m, TrackingLinear) for m in routed_linears)
+    # The shared expert must still be quantized too (it already worked
+    # before this fix; guard against a future regression there as well).
+    shared_linears = [m for m in module.shared_experts.modules() if isinstance(m, Linear)]
+    assert len(shared_linears) > 0
+    assert all(isinstance(m, TrackingLinear) for m in shared_linears)
+    # Sanity: the tracking list saw both groups (routed + shared).
+    assert len(created) == len(routed_linears) + len(shared_linears)
+
+
 def test_noaux_tc_supports_single_expert_groups():
     config = make_config(
         hidden_size=4,


### PR DESCRIPTION
## Root cause

`_DeepSeekMoEFFN.__init__` (src/mobius/models/deepseek.py) accepted `linear_class`
but only forwarded it to `_SharedExpertMLP`, not to the `MoELayer` that builds
the routed-expert dense loop-over-experts fallback:

```python
self.moe = MoELayer(config, gate=gate)  # linear_class silently dropped
```

Consequence: a quantized config correctly quantized attention, dense FFN, and
the shared expert, but every routed MoE expert's gate/up/down projections
stayed plain float `MatMul`. This both loses quantization for the routed
experts and breaks the `fuse_dense_moe_to_qmoe` post-hoc rewrite, which only
pattern-matches a quantized `MatMulNBits` dense-fallback shape — so a
quantized DeepSeek-V2/V3 config would silently fail to fuse into QMoE for its
routed experts.

DeepSeek-V4 is unaffected: its `DeepSeekV4MoE` uses `expert_factory` to build
`_DeepSeekV4Expert`, which independently recomputes its quantized class from
`config.quantization` per-expert rather than relying on `MoELayer`'s
`linear_class` forwarding — verified via review, no matching fix needed there.

## Fix

One line: thread `linear_class` through to the routed-expert `MoELayer`:

```python
self.moe = MoELayer(config, gate=gate, linear_class=linear_class)
```

## Tests

Added `test_deepseek_moe_ffn_linear_class_reaches_routed_experts` in
`deepseek_test.py`, which isolates the assertion on `module.moe.experts`
(routed) separately from `module.shared_experts` (already worked before this
fix), rather than relying on an aggregate creation count — so it can't pass
for the wrong reason.

- Verified the new test **fails** on pre-fix code (`assert False` at the
  routed-experts isinstance check) and **passes** post-fix.
- Full suite: `PYTHONPATH=src python3 -m pytest src/` → **3249 passed, 9
  skipped**, no failures.
- `ruff check` / `ruff format --check` on changed files: clean.
- Independently reviewed (separate reviewer pass over the diff); verdict:
  **Approve**, no findings.

## Scope

Deliberately minimal and focused: does not touch GLM-5.2 registration,
DeepSeek-V4 QMoE export, YaRN, or any other follow-up — those are tracked/
landed separately (#548, #550, #555, #559, #560).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>