### PR TITLE
Unify the build CLI surface: positional output_dir, shared shard sizing, drop --keep-quantized

### DIFF
--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -301,7 +301,7 @@ dequantize/requantize for multimodal and mixed source qtypes.
 ### Synopsis
 
 ```bash
-mobius build-gguf GGUF_PATH [options]
+mobius build-gguf GGUF_PATH OUTPUT_DIR [options]
 ```
 
 ### Arguments
@@ -309,14 +309,14 @@ mobius build-gguf GGUF_PATH [options]
 | Argument | Description |
 |----------|-------------|
 | `GGUF_PATH` | Path to a `.gguf` model file. |
+| `OUTPUT_DIR` | Output directory for the ONNX model. |
 
 ### Options
 
 | Option | Description |
 |--------|-------------|
-| `--output DIR`, `-o DIR` | Output directory. Default: `<gguf_stem>_onnx/`. |
+| `--max-shard-size SIZE` | Maximum external-data shard size (e.g. `5GB`). |
 | `--dequantize` | Explicitly dequantize all GGUF weights to float. |
-| `--keep-quantized` | Deprecated compatibility alias for the default quantization-preserving behavior. Cannot be combined with `--dequantize`. |
 | `--dtype DTYPE` | Target dtype for model weights: `f16`, `bf16`, `f32`. |
 | `--external-data FORMAT` | External data format: `onnx` (default) or `safetensors`. |
 | `--ep EP` | Target execution provider for EP-aware optimization. |
@@ -328,13 +328,13 @@ mobius build-gguf GGUF_PATH [options]
 
 ```bash
 # Basic GGUF conversion (preserves supported quantization)
-mobius build-gguf model.gguf --output output/
+mobius build-gguf model.gguf output/
 
 # Explicitly dequantize all weights
-mobius build-gguf model.gguf --output output-float/ --dequantize
+mobius build-gguf model.gguf output-float/ --dequantize
 
 # Convert with specific dtype
-mobius build-gguf model.gguf --output output/ --dtype f16
+mobius build-gguf model.gguf output/ --dtype f16
 ```
 
 F32-, F16-, and BF16-only files build normally as float models because they

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -109,7 +109,7 @@ pkg.save("output/model/")
 Or via CLI:
 
 ```bash
-mobius build-gguf path/to/model.gguf --output output/model/
+mobius build-gguf path/to/model.gguf output/model/
 ```
 
 Pass `--dequantize` on the CLI, or `keep_quantized=False` to

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -559,7 +559,7 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
         print("Dequantized mode: converting GGUF weights to float...")
 
     gguf_path = args.gguf_path
-    output_dir = args.output or os.path.splitext(gguf_path)[0] + "_onnx"
+    output_dir = args.output_dir
     os.makedirs(output_dir, exist_ok=True)
 
     if args.max_seq_len is not None and not args.static_cache:
@@ -588,6 +588,7 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
     pkg.save(
         output_dir,
         external_data=args.external_data,
+        max_shard_size_bytes=_parse_size(args.max_shard_size) if args.max_shard_size else None,
         max_workers=args.max_workers,
     )
     for name in pkg:
@@ -772,6 +773,12 @@ def _add_shared_build_arguments(parser: argparse.ArgumentParser) -> None:
         help="External data format (default: onnx).",
     )
     parser.add_argument(
+        "--max-shard-size",
+        metavar="SIZE",
+        default=None,
+        help="Maximum external-data shard size (e.g. '5GB'). Used by both ONNX and safetensors.",
+    )
+    parser.add_argument(
         "--max-workers",
         type=int,
         default=8,
@@ -832,12 +839,6 @@ def build_parser() -> argparse.ArgumentParser:
         "--task",
         default=None,
         help="Model task (auto-detected if not specified). Use 'mobius list tasks' to see available tasks.",
-    )
-    build_parser.add_argument(
-        "--max-shard-size",
-        metavar="SIZE",
-        default=None,
-        help="Maximum external-data shard size (e.g. '5GB'). Used by both ONNX and safetensors.",
     )
     build_parser.add_argument(
         "--no-weights",
@@ -948,11 +949,8 @@ def build_parser() -> argparse.ArgumentParser:
         help="Path to a .gguf model file.",
     )
     gguf_parser.add_argument(
-        "--output",
-        "-o",
-        default=None,
-        metavar="DIR",
-        help="Output directory (default: <gguf_stem>_onnx/).",
+        "output_dir",
+        help="Output directory for the ONNX model.",
     )
     gguf_parser.add_argument(
         "--mmproj",
@@ -966,19 +964,10 @@ def build_parser() -> argparse.ArgumentParser:
             "experimental."
         ),
     )
-    quantization_group = gguf_parser.add_mutually_exclusive_group()
-    quantization_group.add_argument(
+    gguf_parser.add_argument(
         "--dequantize",
         action="store_true",
         help="Dequantize all GGUF weights to float instead of preserving quantization.",
-    )
-    quantization_group.add_argument(
-        "--keep-quantized",
-        action="store_true",
-        help=(
-            "Deprecated compatibility alias; supported GGUF quantization is "
-            "preserved by default."
-        ),
     )
     gguf_parser.add_argument(
         "--runtime",

--- a/src/mobius/_cli_option_parity_test.py
+++ b/src/mobius/_cli_option_parity_test.py
@@ -1,0 +1,123 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for the unified ``build`` / ``build-gguf`` argument surface.
+
+``build`` and ``build-gguf`` describe the same operation from two sources, so an
+option that exists on both should be spelled and behave the same way. These tests
+pin the parts of that which were previously inconsistent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mobius.__main__ import build_parser
+
+_MINIMAL = {
+    "build": ["--model", "some/model", "out_dir"],
+    "build-gguf": ["some.gguf", "out_dir"],
+}
+
+
+class TestOutputDirIsPositionalEverywhere:
+    """Both commands take the output directory the same way.
+
+    ``build-gguf`` used to take ``--output/-o`` with a default derived from the
+    GGUF filename, so the same concept was positional-and-required on one command
+    and optional-with-a-default on the other.
+    """
+
+    @pytest.mark.parametrize("command", ["build", "build-gguf"])
+    def test_output_dir_is_a_required_positional(self, command):
+        args = build_parser().parse_args([command, *_MINIMAL[command]])
+        assert args.output_dir == "out_dir"
+
+        with pytest.raises(SystemExit):
+            # Dropping the trailing output_dir must be an error, not a default.
+            build_parser().parse_args([command, *_MINIMAL[command][:-1]])
+
+    def test_gguf_no_longer_accepts_the_output_flag(self):
+        """The old spelling is gone rather than silently kept as an alias.
+
+        Left in place it would be a second way to say the same thing, and the two
+        would drift.
+        """
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(["build-gguf", "some.gguf", "-o", "out_dir"])
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(["build-gguf", "some.gguf", "--output", "out_dir"])
+
+
+class TestKeepQuantizedRemoved:
+    def test_flag_is_gone(self):
+        """It was documented as deprecated and never read.
+
+        ``_cmd_build_gguf`` computed ``keep_quantized = not args.dequantize`` and
+        never looked at ``args.keep_quantized``, so passing it did nothing beyond
+        occupying the mutually exclusive group.
+        """
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(["build-gguf", "some.gguf", "out", "--keep-quantized"])
+
+    def test_dequantize_still_works(self):
+        """Removing the dead alias must not disturb the flag that does the work."""
+        args = build_parser().parse_args(["build-gguf", "some.gguf", "out", "--dequantize"])
+        assert args.dequantize is True
+
+        default = build_parser().parse_args(["build-gguf", "some.gguf", "out"])
+        assert default.dequantize is False
+
+
+class TestSharedSaveOptions:
+    """Options that control how the package is written exist on both commands."""
+
+    @pytest.mark.parametrize("command", ["build", "build-gguf"])
+    @pytest.mark.parametrize(
+        "flag,value,dest",
+        [
+            ("--max-shard-size", "5GB", "max_shard_size"),
+            ("--max-workers", "2", "max_workers"),
+            ("--external-data", "safetensors", "external_data"),
+            ("--dtype", "f16", "dtype"),
+        ],
+    )
+    def test_option_is_accepted_by_both(self, command, flag, value, dest):
+        args = build_parser().parse_args([command, *_MINIMAL[command], flag, value])
+        parsed = getattr(args, dest)
+        assert str(parsed) == value or parsed == int(value)
+
+    @pytest.mark.parametrize(
+        "flag", ["--max-shard-size", "--max-workers", "--external-data", "--dtype", "--ep"]
+    )
+    def test_help_text_matches_across_commands(self, flag):
+        """Same flag, same wording — these had already drifted once."""
+        parser = build_parser()
+        subparsers = next(
+            action
+            for action in parser._actions
+            if isinstance(action, __import__("argparse")._SubParsersAction)
+        )
+        helps = {}
+        for command in ("build", "build-gguf"):
+            sub = subparsers.choices[command]
+            action = next(a for a in sub._actions if flag in a.option_strings)
+            helps[command] = action.help
+        assert helps["build"] == helps["build-gguf"], (
+            f"{flag} is documented differently on build vs build-gguf: {helps}"
+        )
+
+    def test_max_shard_size_reaches_the_gguf_save(self):
+        """Parsing it is not enough — it has to be threaded into ``pkg.save``.
+
+        An option that parses but is never forwarded is worse than a missing one:
+        the user gets no error and no sharding.
+        """
+        import inspect
+
+        from mobius import __main__ as cli
+
+        source = inspect.getsource(cli._cmd_build_gguf)
+        assert "max_shard_size_bytes" in source, (
+            "build-gguf accepts --max-shard-size but never passes it to save()"
+        )

--- a/src/mobius/_strip_debug_metadata_test.py
+++ b/src/mobius/_strip_debug_metadata_test.py
@@ -185,7 +185,7 @@ class TestReleaseFlag:
     #: real parser rather than a stand-in.
     _MINIMAL_ARGS: ClassVar[dict[str, list[str]]] = {
         "build": ["--model", "some/model", "out_dir"],
-        "build-gguf": ["some.gguf"],
+        "build-gguf": ["some.gguf", "out_dir"],
     }
 
     def test_build_and_gguf_describe_release_identically(self):

--- a/tests/gguf_test.py
+++ b/tests/gguf_test.py
@@ -476,7 +476,9 @@ class TestCLIBuildGGUF:
             main(["build-gguf", "--help"])
         out = capsys.readouterr().out
         assert "--dequantize" in out
-        assert "preserved by default" in out
+        assert "output_dir" in out, "output directory is a positional, like build"
+        assert "--keep-quantized" not in out, "the unread deprecated alias was removed"
+        assert "--max-shard-size" in out, "shard sizing applies to GGUF builds too"
 
     def test_missing_gguf_path_errors(self):
         """build-gguf requires a gguf_path argument."""
@@ -493,7 +495,7 @@ class TestCLIBuildGGUF:
 
         path = _create_tiny_gguf(tmp_path / f"test-{float_type}.gguf", float_type=float_type)
         output_dir = tmp_path / f"output-{float_type}"
-        main(["build-gguf", path, "--output", str(output_dir)])
+        main(["build-gguf", path, str(output_dir)])
 
         package = ModelPackage.load(str(output_dir))
         op_types = {node.op_type for node in package["model"].graph}
@@ -504,16 +506,21 @@ class TestCLIBuildGGUF:
         ("extra_args", "expected"),
         [
             ([], True),
-            (["--keep-quantized"], True),
             (["--dequantize"], False),
         ],
     )
     def test_quantization_flag_parsing(self, tmp_path, extra_args, expected):
-        """Default, compatibility alias, and explicit opt-out map to the API."""
+        """Quantization is preserved by default; ``--dequantize`` opts out.
+
+        The ``--keep-quantized`` alias that used to be covered here was removed:
+        it was never read (``keep_quantized = not args.dequantize``), so the case
+        asserting it produced ``True`` was really just re-testing the default.
+        """
         from mobius.__main__ import main
 
         package = mock.MagicMock()
         package.__iter__.return_value = iter(())
+        package.values.return_value = iter(())
         with mock.patch(
             "mobius.integrations.gguf.build_from_gguf",
             return_value=package,
@@ -522,27 +529,12 @@ class TestCLIBuildGGUF:
                 [
                     "build-gguf",
                     str(tmp_path / "model.gguf"),
-                    "--output",
                     str(tmp_path / "output"),
                     *extra_args,
                 ]
             )
 
         assert build.call_args.kwargs["keep_quantized"] is expected
-
-    def test_contradictory_quantization_flags_error(self, tmp_path):
-        from mobius.__main__ import main
-
-        with pytest.raises(SystemExit) as exc_info:
-            main(
-                [
-                    "build-gguf",
-                    str(tmp_path / "model.gguf"),
-                    "--keep-quantized",
-                    "--dequantize",
-                ]
-            )
-        assert exc_info.value.code == 2
 
     def test_ort_genai_runtime_is_forwarded_to_package_writer(self, tmp_path):
         """build-gguf forwards the selected runtime after saving the graph."""
@@ -565,10 +557,9 @@ class TestCLIBuildGGUF:
                 [
                     "build-gguf",
                     str(tmp_path / "model.gguf"),
+                    str(output_dir),
                     "--runtime",
                     "ort-genai",
-                    "--output",
-                    str(output_dir),
                 ]
             )
 


### PR DESCRIPTION
Follow-up to the option audit in #566, which found these but deliberately left them because each **breaks existing invocations**. Grouped into one PR so there is a single breaking change to communicate rather than three.

> **Stacked on #566** (`justinchuby-release-strip-metadata`), because that PR moved the shared build options into `_add_shared_build_arguments` and this one adds to it. Merge #566 first.

## Breaking changes

### 1. `--keep-quantized` removed

Documented as a deprecated alias, and **never read**: `_cmd_build_gguf` computes `keep_quantized = not args.dequantize` and never looks at `args.keep_quantized`. Passing it did nothing beyond occupying the mutually exclusive group, which goes with it since `--dequantize` is now its only member.

*Migration:* delete it. Quantization is preserved by default; `--dequantize` opts out.

### 2. `build-gguf` takes `output_dir` positionally

It was `--output/-o` with a default of `<gguf_stem>_onnx/`, so the same concept was required-and-positional on `build` and optional-with-a-default on `build-gguf`.

```diff
- mobius build-gguf model.gguf --output out/
+ mobius build-gguf model.gguf out/
```

The derived default is gone — an output path is now always explicit, as it already was for `build`. The old spelling is removed outright rather than kept as an alias: two ways to say the same thing is exactly what lets them drift, which is the problem #566 was fixing.

### 3. `--max-shard-size` now works on `build-gguf`

It only existed on `build`, though nothing about it is specific to a HuggingFace source. Moved into `_add_shared_build_arguments` next to the other save-side options, and **threaded into the GGUF `pkg.save` call**.

That second part matters on its own: an option that parses but is never forwarded is worse than a missing one, because the user gets no error and no sharding. `test_max_shard_size_reaches_the_gguf_save` covers it separately from the parsing tests.

## Testing

Every change is covered by the new `_cli_option_parity_test.py`, and each test was **confirmed to fail when its change is reverted**:

| Reverted | Result |
|---|---|
| Restore `--output/-o` | 7 tests fail |
| Re-add `--keep-quantized` | removal test fails |
| Drop the `max_shard_size_bytes` forwarding | plumbing test fails, parsing tests still pass |

That last row is the interesting one — it is the case a parsing-only test would have missed.

Also added `test_help_text_matches_across_commands`, which asserts the shared options are documented identically on both subcommands. They had already drifted once (#566), so this pins it rather than relying on the shared helper being used correctly forever.

## Also updated

- `tests/gguf_test.py` — the `--keep-quantized` parametrization asserted `True`, which was just re-testing the default.
- `docs/cli_reference.md`, `docs/getting-started.md`.
- Left `docs/design/gguf-support-proposal.md` alone: historical design document, not usage docs.

Suite: **1 failed / 6441 passed** — the failure is the pre-existing `synthetic_parity[granitemoehybrid]`. `lintrunner` clean.
