### PR TITLE
Restore canonical CLI output option and document release exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,16 +104,16 @@ See the [EP quickstart](docs/ep_quickstart.md) and
 ### CLI
 
 ```sh
-mobius build --model Qwen/Qwen2.5-0.5B output_dir/
+mobius build --model Qwen/Qwen2.5-0.5B --output output_dir/
 
 # Build for CUDA with f16
-mobius build --model meta-llama/Llama-3.2-1B output_dir/ --ep cuda --dtype f16
+mobius build --model meta-llama/Llama-3.2-1B --output output_dir/ --ep cuda --dtype f16
 
 # Build a diffusers pipeline (all components)
-mobius build --model Qwen/Qwen-Image-2512 output_dir/
+mobius build --model Qwen/Qwen-Image-2512 --output output_dir/
 
 # Build encoder-decoder model (produces encoder/model.onnx + decoder/model.onnx)
-mobius build --model openai/whisper-tiny output_dir/
+mobius build --model openai/whisper-tiny --output output_dir/
 ```
 
 Build-mode toggles use the cargo-style `--features` option. Available features
@@ -121,7 +121,7 @@ are `static-cache`, `fp8-kv-cache`, `prune-prefill-prefix`, and `text-only`. Pas
 as a comma-separated list or repeat the option:
 
 ```sh
-mobius build --model meta-llama/Llama-3.2-1B output_dir/ \
+mobius build --model meta-llama/Llama-3.2-1B --output output_dir/ \
       --features static-cache,prune-prefill-prefix --max-seq-len 2048
 ```
 
@@ -130,7 +130,7 @@ by stripping build-time debug and provenance metadata. Functional `mobius.*`
 metadata is preserved:
 
 ```sh
-mobius build --model meta-llama/Llama-3.2-1B output_dir/ --release
+mobius build --model meta-llama/Llama-3.2-1B --output output_dir/ --release
 mobius build-gguf model.gguf --output output_dir/ --release
 ```
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,15 @@ mobius build --model meta-llama/Llama-3.2-1B output_dir/ \
       --features static-cache,prune-prefill-prefix --max-seq-len 2048
 ```
 
+Use `--release` with either `build` or `build-gguf` to reduce saved model size
+by stripping build-time debug and provenance metadata. Functional `mobius.*`
+metadata is preserved:
+
+```sh
+mobius build --model meta-llama/Llama-3.2-1B output_dir/ --release
+mobius build-gguf model.gguf --output output_dir/ --release
+```
+
 See the [CLI Reference](https://onnxruntime.github.io/mobius/cli_reference.html) for all subcommands and flags.
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ mobius build --model meta-llama/Llama-3.2-1B --output output_dir/ \
       --features static-cache,prune-prefill-prefix --max-seq-len 2048
 ```
 
-Use `--release` with either `build` or `build-gguf` to reduce saved model size
-by stripping build-time debug and provenance metadata. Functional `mobius.*`
-metadata is preserved:
+Use `--release` with either `build` or `build-gguf` to potentially reduce saved model size
+by stripping build-time debug and provenance metadata. Functional metadata with keys prefixed by
+`mobius.` is preserved:
 
 ```sh
 mobius build --model meta-llama/Llama-3.2-1B --output output_dir/ --release

--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -177,7 +177,7 @@ python -m mobius build `
   --config .\nemotron-bf16 `
   --dtype bf16 --ep cuda `
   --external-data safetensors --max-shard-size 5GB `
-  .\nemotron-bf16-onnx
+  --output .\nemotron-bf16-onnx
 ```
 
 After the BF16 package passes full-logit and generation parity, quantize its

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -15,8 +15,8 @@ Build an ONNX model from a HuggingFace model ID or local config directory.
 ### Synopsis
 
 ```bash
-mobius build --model MODEL_ID OUTPUT_DIR [options]
-mobius build --config CONFIG_PATH OUTPUT_DIR [options]
+mobius build --model MODEL_ID --output OUTPUT_DIR [options]
+mobius build --config CONFIG_PATH --output OUTPUT_DIR [options]
 ```
 
 The model task is auto-detected from the model type. For example, Whisper
@@ -24,11 +24,11 @@ models automatically use `speech-to-text`, standard LLMs use
 `text-generation`, and diffusers pipelines are detected and built as
 multi-component packages.
 
-### Arguments
+### Output Option
 
-| Argument | Description |
-|----------|-------------|
-| `OUTPUT_DIR` | Output directory for the ONNX model files. Created if it doesn't exist. |
+| Option | Description |
+|--------|-------------|
+| `--output OUTPUT_DIR`, `-o OUTPUT_DIR` | Required output directory for the ONNX model files. Created if it doesn't exist. |
 
 ### Source Options (mutually exclusive)
 
@@ -70,25 +70,25 @@ capabilities.
 
 ```bash
 # Default (portable ONNX with standard fusions as model local functions)
-mobius build --model meta-llama/Llama-3.2-1B output/
+mobius build --model meta-llama/Llama-3.2-1B --output output/
 
 # CPU (GQA fusion for f32)
-mobius build --model meta-llama/Llama-3.2-1B output/ --ep cpu
+mobius build --model meta-llama/Llama-3.2-1B --output output/ --ep cpu
 
 # CUDA GPU (GQA, SkipNorm, PackQKV fusions for f16/bf16)
-mobius build --model meta-llama/Llama-3.2-1B output/ --ep cuda --dtype f16
+mobius build --model meta-llama/Llama-3.2-1B --output output/ --ep cuda --dtype f16
 
 # DirectML (GQA without fused RoPE)
-mobius build --model meta-llama/Llama-3.2-1B output/ --ep dml --dtype f16
+mobius build --model meta-llama/Llama-3.2-1B --output output/ --ep dml --dtype f16
 
 # TensorRT-RTX (GQA, no SkipLayerNorm)
-mobius build --model meta-llama/Llama-3.2-1B output/ --ep trt-rtx --dtype f16
+mobius build --model meta-llama/Llama-3.2-1B --output output/ --ep trt-rtx --dtype f16
 
 # WebGPU
-mobius build --model meta-llama/Llama-3.2-1B output/ --ep webgpu --dtype f16
+mobius build --model meta-llama/Llama-3.2-1B --output output/ --ep webgpu --dtype f16
 
 # Strict ONNX standard (zero custom ops)
-mobius build --model meta-llama/Llama-3.2-1B output/ --ep onnx-standard
+mobius build --model meta-llama/Llama-3.2-1B --output output/ --ep onnx-standard
 ```
 
 ### Optimization Rules (`--optimize`)
@@ -119,14 +119,14 @@ optimization.
 
 ```bash
 # Apply specific rules
-mobius build --model meta-llama/Llama-3.2-1B output/ \
+mobius build --model meta-llama/Llama-3.2-1B --output output/ \
     --optimize=group_query_attention,skip_norm
 
 # Apply all available rules
-mobius build --model meta-llama/Llama-3.2-1B output/ --optimize
+mobius build --model meta-llama/Llama-3.2-1B --output output/ --optimize
 
 # Combine EP-aware building with additional post-hoc rules
-mobius build --model meta-llama/Llama-3.2-1B output/ \
+mobius build --model meta-llama/Llama-3.2-1B --output output/ \
     --ep cuda --dtype f16 --optimize=bias_gelu
 ```
 
@@ -141,7 +141,7 @@ They can be combined when you need both EP-aware construction and additional
 post-hoc rules:
 
 ```bash
-mobius build --model meta-llama/Llama-3.2-1B output/ \
+mobius build --model meta-llama/Llama-3.2-1B --output output/ \
     --ep cuda --dtype f16 --optimize=bias_gelu
 ```
 
@@ -164,7 +164,7 @@ tokenizer files to the output directory:
 #### Example
 
 ```bash
-mobius build --model Qwen/Qwen2.5-0.5B output/ \
+mobius build --model Qwen/Qwen2.5-0.5B --output output/ \
     --ep cuda --dtype f16 --runtime ort-genai
 ```
 
@@ -192,13 +192,13 @@ The legacy boolean flags `--static-cache`, `--fp8-kv-cache`, and
 `--text-only` have been removed in favor of `--features`.
 
 ```bash
-mobius build --model meta-llama/Llama-3.2-1B output/ \
+mobius build --model meta-llama/Llama-3.2-1B --output output/ \
     --features static-cache --max-seq-len 2048
 
-mobius build --model Qwen/Qwen2.5-0.5B output/ \
+mobius build --model Qwen/Qwen2.5-0.5B --output output/ \
     --ep cuda --dtype f16 --features fp8-kv-cache
 
-mobius build --model meta-llama/Llama-3.2-1B output/ \
+mobius build --model meta-llama/Llama-3.2-1B --output output/ \
     --features prune-prefill-prefix
 ```
 
@@ -223,10 +223,11 @@ Cannot be combined with `--task`.
 #### Example
 
 ```bash
-mobius build --model meta-llama/Llama-3.2-1B output/ --features static-cache
+mobius build --model meta-llama/Llama-3.2-1B --output output/ \
+    --features static-cache
 
 # With explicit max sequence length
-mobius build --model meta-llama/Llama-3.2-1B output/ \
+mobius build --model meta-llama/Llama-3.2-1B --output output/ \
     --features static-cache --max-seq-len 2048
 ```
 
@@ -248,7 +249,7 @@ it off when the build-time provenance would help inspect or debug the graph.
 
 ```bash
 # Release export from a HuggingFace model
-mobius build --model meta-llama/Llama-3.2-1B output/ --release
+mobius build --model meta-llama/Llama-3.2-1B --output output/ --release
 
 # Release export from GGUF
 mobius build-gguf model.gguf --output output/ --release
@@ -273,7 +274,8 @@ mobius build-gguf model.gguf --output output/ --release
 
 ```bash
 # Export gemma-4-12B's text backbone as a GQA decoder-only LLM
-mobius build --model google/gemma-4-12B output/ --features text-only --ep cuda --dtype f16
+mobius build --model google/gemma-4-12B --output output/ \
+    --features text-only --ep cuda --dtype f16
 ```
 
 For a full ORT-GenAI text-only package (with `genai_config.json`), use
@@ -284,31 +286,34 @@ For a full ORT-GenAI text-only package (with `genai_config.json`), use
 
 ```bash
 # Build from a HuggingFace model ID
-mobius build --model Qwen/Qwen2.5-0.5B output_dir/
+mobius build --model Qwen/Qwen2.5-0.5B --output output_dir/
 
 # Build without weights (graph skeleton only)
-mobius build --model meta-llama/Llama-3.2-1B output_dir/ --no-weights
+mobius build --model meta-llama/Llama-3.2-1B --output output_dir/ --no-weights
 
 # Build from a local config directory
-mobius build --config /path/to/model/ output_dir/
+mobius build --config /path/to/model/ --output output_dir/
 
 # Export with safetensors external data
-mobius build --model Qwen/Qwen2.5-0.5B output_dir/ --external-data safetensors
+mobius build --model Qwen/Qwen2.5-0.5B --output output_dir/ \
+    --external-data safetensors
 
 # Build encoder-decoder model (produces encoder.onnx + decoder.onnx)
-mobius build --model openai/whisper-tiny output_dir/
+mobius build --model openai/whisper-tiny --output output_dir/
 
 # Build a diffusers pipeline (auto-detected)
-mobius build --model Qwen/Qwen-Image-2512 output_dir/
+mobius build --model Qwen/Qwen-Image-2512 --output output_dir/
 
 # Build only the VAE decoder from a diffusers pipeline
-mobius build --model Qwen/Qwen-Image-2512 output_dir/ --component vae_decoder
+mobius build --model Qwen/Qwen-Image-2512 --output output_dir/ \
+    --component vae_decoder
 
 # Override task explicitly
-mobius build --model google/gemma-3-4b-pt output_dir/ --task vision-language
+mobius build --model google/gemma-3-4b-pt --output output_dir/ \
+    --task vision-language
 
 # Build for ORT GenAI runtime
-mobius build --model Qwen/Qwen2.5-0.5B output_dir/ \
+mobius build --model Qwen/Qwen2.5-0.5B --output output_dir/ \
     --ep cuda --dtype f16 --runtime ort-genai
 ```
 
@@ -326,7 +331,7 @@ dequantize/requantize for multimodal and mixed source qtypes.
 ### Synopsis
 
 ```bash
-mobius build-gguf GGUF_PATH OUTPUT_DIR [options]
+mobius build-gguf GGUF_PATH --output OUTPUT_DIR [options]
 ```
 
 ### Arguments
@@ -334,12 +339,12 @@ mobius build-gguf GGUF_PATH OUTPUT_DIR [options]
 | Argument | Description |
 |----------|-------------|
 | `GGUF_PATH` | Path to a `.gguf` model file. |
-| `OUTPUT_DIR` | Output directory for the ONNX model. |
 
 ### Options
 
 | Option | Description |
 |--------|-------------|
+| `--output OUTPUT_DIR`, `-o OUTPUT_DIR` | Required output directory for the ONNX model. |
 | `--max-shard-size SIZE` | Maximum external-data shard size (e.g. `5GB`). |
 | `--dequantize` | Explicitly dequantize all GGUF weights to float. |
 | `--dtype DTYPE` | Target dtype for model weights: `f16`, `bf16`, `f32`. |
@@ -354,13 +359,13 @@ mobius build-gguf GGUF_PATH OUTPUT_DIR [options]
 
 ```bash
 # Basic GGUF conversion (preserves supported quantization)
-mobius build-gguf model.gguf output/
+mobius build-gguf model.gguf --output output/
 
 # Explicitly dequantize all weights
-mobius build-gguf model.gguf output-float/ --dequantize
+mobius build-gguf model.gguf --output output-float/ --dequantize
 
 # Convert with specific dtype
-mobius build-gguf model.gguf output/ --dtype f16
+mobius build-gguf model.gguf --output output/ --dtype f16
 ```
 
 F32-, F16-, and BF16-only files build normally as float models because they

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -237,11 +237,11 @@ mobius build --model meta-llama/Llama-3.2-1B --output output/ \
 --release
 ```
 
-Create a smaller saved model by removing build-time debug and provenance
+Reduce saved model size by removing build-time debug and provenance
 metadata immediately before serialization. This includes source module paths,
 class hierarchies, name scopes, originating rewrite rules, and
 symbolic-shape-inference internals. Functional metadata whose keys begin with
-`mobius.*` is preserved.
+`mobius.` is preserved.
 
 `--release` applies to both `mobius build` and `mobius build-gguf`. It changes
 metadata only, not the graph structure, weights, or inference behavior. Leave

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -230,6 +230,30 @@ mobius build --model meta-llama/Llama-3.2-1B output/ \
     --features static-cache --max-seq-len 2048
 ```
 
+### Release Builds (`--release`)
+
+```
+--release
+```
+
+Create a smaller saved model by removing build-time debug and provenance
+metadata immediately before serialization. This includes source module paths,
+class hierarchies, name scopes, originating rewrite rules, and
+symbolic-shape-inference internals. Functional metadata whose keys begin with
+`mobius.*` is preserved.
+
+`--release` applies to both `mobius build` and `mobius build-gguf`. It changes
+metadata only, not the graph structure, weights, or inference behavior. Leave
+it off when the build-time provenance would help inspect or debug the graph.
+
+```bash
+# Release export from a HuggingFace model
+mobius build --model meta-llama/Llama-3.2-1B output/ --release
+
+# Release export from GGUF
+mobius build-gguf model.gguf --output output/ --release
+```
+
 ### Other Flags
 
 | Option | Description |
@@ -240,6 +264,7 @@ mobius build --model meta-llama/Llama-3.2-1B output/ \
 | `--no-weights` | Export graph structure only, without weight data. Useful for inspection or testing. |
 | `--external-data FORMAT` | External data format: `onnx` (default) or `safetensors`. |
 | `--max-shard-size SIZE` | Maximum shard size for safetensors external data (e.g. `5GB`). Only used with `--external-data safetensors`. |
+| `--release` | Strip build-time debug and provenance metadata before saving while preserving functional `mobius.*` metadata. |
 | `--trust-remote-code` | Trust remote code when loading the HuggingFace model config. |
 | `--component NAME` | Build only one component from a diffusers pipeline (e.g. `--component vae_decoder`). |
 | `--kv-cache-scale-file PATH` | Optional JSON file of calibrated per-layer FP8 KV-cache scales (onnxruntime-genai format). Only used with the `fp8-kv-cache` feature; without it all layers use a unit scale of 1.0. |
@@ -321,6 +346,7 @@ mobius build-gguf GGUF_PATH OUTPUT_DIR [options]
 | `--external-data FORMAT` | External data format: `onnx` (default) or `safetensors`. |
 | `--ep EP` | Target execution provider for EP-aware optimization. |
 | `--runtime RUNTIME` | `onnx-genai` emits supported runtime metadata. `ort-genai` is rejected until GGUF cache/tokenizer generation coverage exists. |
+| `--release` | Strip build-time debug and provenance metadata before saving while preserving functional `mobius.*` metadata. |
 | `--static-cache` | Build a fixed-width cache where supported. |
 | `--max-seq-len N` | Set the fixed cache length; requires `--static-cache`. |
 

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -265,7 +265,7 @@ mobius build-gguf model.gguf --output output/ --release
 | `--no-weights` | Export graph structure only, without weight data. Useful for inspection or testing. |
 | `--external-data FORMAT` | External data format: `onnx` (default) or `safetensors`. |
 | `--max-shard-size SIZE` | Maximum shard size for safetensors external data (e.g. `5GB`). Only used with `--external-data safetensors`. |
-| `--release` | Strip build-time debug and provenance metadata before saving while preserving functional `mobius.*` metadata. |
+| `--release` | Strip build-time debug and provenance metadata before saving while preserving functional `mobius.` metadata. |
 | `--trust-remote-code` | Trust remote code when loading the HuggingFace model config. |
 | `--component NAME` | Build only one component from a diffusers pipeline (e.g. `--component vae_decoder`). |
 | `--kv-cache-scale-file PATH` | Optional JSON file of calibrated per-layer FP8 KV-cache scales (onnxruntime-genai format). Only used with the `fp8-kv-cache` feature; without it all layers use a unit scale of 1.0. |

--- a/docs/ep_quickstart.md
+++ b/docs/ep_quickstart.md
@@ -41,7 +41,7 @@ pkg.save("output/llama/")
 CLI equivalent (see [CLI Reference](cli_reference.md) for all `--ep` options):
 
 ```bash
-mobius build --model meta-llama/Llama-3.2-1B output/ \
+mobius build --model meta-llama/Llama-3.2-1B --output output/ \
   --ep cuda --dtype f16
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -109,7 +109,7 @@ pkg.save("output/model/")
 Or via CLI:
 
 ```bash
-mobius build-gguf path/to/model.gguf output/model/
+mobius build-gguf path/to/model.gguf --output output/model/
 ```
 
 Pass `--dequantize` on the CLI, or `keep_quantized=False` to
@@ -182,20 +182,20 @@ rewrite(model, pattern_rewrite_rules=skip_norm_rules())
 Or via CLI:
 
 ```bash
-mobius build --model Qwen/Qwen2.5-0.5B output/ --ep cuda --dtype f16
+mobius build --model Qwen/Qwen2.5-0.5B --output output/ --ep cuda --dtype f16
 ```
 
 ## CLI Quick Start
 
 ```bash
 # Basic build
-mobius build --model meta-llama/Llama-3.2-1B output/
+mobius build --model meta-llama/Llama-3.2-1B --output output/
 
 # Build for CUDA with f16
-mobius build --model meta-llama/Llama-3.2-1B output/ --ep cuda --dtype f16
+mobius build --model meta-llama/Llama-3.2-1B --output output/ --ep cuda --dtype f16
 
 # Build for ORT GenAI runtime
-mobius build --model meta-llama/Llama-3.2-1B output/ --ep cuda --dtype f16 --runtime ort-genai
+mobius build --model meta-llama/Llama-3.2-1B --output output/ --ep cuda --dtype f16 --runtime ort-genai
 ```
 
 The `mobius` CLI has these subcommands:

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -10,6 +10,7 @@ import glob
 import json
 import logging
 import os
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import tqdm
@@ -750,6 +751,45 @@ def _add_release_argument(parser: argparse.ArgumentParser) -> None:
     )
 
 
+class _UniqueOutputAction(argparse.Action):
+    """Reject repeated ``--output`` spellings instead of silently taking the last."""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: str,
+        option_string: str | None = None,
+    ) -> None:
+        if getattr(namespace, self.dest, None) is not None:
+            parser.error("--output/-o may be specified only once.")
+        setattr(namespace, self.dest, values)
+
+
+class _MobiusArgumentParser(argparse.ArgumentParser):
+    """Normalize the canonical output option and hidden positional compatibility."""
+
+    def parse_args(
+        self,
+        args: Sequence[str] | None = None,
+        namespace: argparse.Namespace | None = None,
+    ) -> argparse.Namespace:
+        parsed = super().parse_args(args, namespace)
+        if getattr(parsed, "command", None) not in {"build", "build-gguf"}:
+            return parsed
+
+        output_dir = parsed.output_dir
+        legacy_output_dir = parsed._legacy_output_dir
+        if output_dir is None and legacy_output_dir is None:
+            self.error("--output/-o is required.")
+        if output_dir is not None and legacy_output_dir is not None:
+            self.error("use --output/-o or the legacy positional output_dir, not both.")
+
+        parsed.output_dir = output_dir if output_dir is not None else legacy_output_dir
+        del parsed._legacy_output_dir
+        return parsed
+
+
 def _add_shared_build_arguments(parser: argparse.ArgumentParser) -> None:
     """Add the options that mean exactly the same thing on every build command.
 
@@ -760,6 +800,20 @@ def _add_shared_build_arguments(parser: argparse.ArgumentParser) -> None:
     restricts) stay declared locally, so a divergence has to be written down on
     purpose.
     """
+    parser.add_argument(
+        "--output",
+        "-o",
+        dest="output_dir",
+        action=_UniqueOutputAction,
+        default=None,
+        metavar="OUTPUT_DIR",
+        help="Output directory for the ONNX model.",
+    )
+    parser.add_argument(
+        "_legacy_output_dir",
+        nargs="?",
+        help=argparse.SUPPRESS,
+    )
     parser.add_argument(
         "--dtype",
         choices=sorted(DTYPE_MAP),
@@ -812,14 +866,21 @@ def build_parser() -> argparse.ArgumentParser:
     could only reach it by invoking ``--help`` and catching ``SystemExit`` — an
     assertion that holds regardless of what the arguments actually do.
     """
-    parser = argparse.ArgumentParser(
+    parser = _MobiusArgumentParser(
         prog="mobius",
         description="Build ONNX models for GenAI from HuggingFace model architectures.",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     # --- build ---
-    build_parser = subparsers.add_parser("build", help="Build an ONNX model.")
+    build_parser = subparsers.add_parser(
+        "build",
+        help="Build an ONNX model.",
+        usage=(
+            "mobius build (--model MODEL_ID | --config CONFIG_PATH) "
+            "--output OUTPUT_DIR [options]"
+        ),
+    )
     source_group = build_parser.add_mutually_exclusive_group(required=True)
     source_group.add_argument(
         "--model",
@@ -830,10 +891,6 @@ def build_parser() -> argparse.ArgumentParser:
         "--config",
         metavar="CONFIG_PATH",
         help="Path to a local model directory containing config.json (and optionally safetensors weights).",
-    )
-    build_parser.add_argument(
-        "output_dir",
-        help="Output directory for the ONNX model.",
     )
     build_parser.add_argument(
         "--task",
@@ -942,15 +999,13 @@ def build_parser() -> argparse.ArgumentParser:
 
     # --- build-gguf ---
     gguf_parser = subparsers.add_parser(
-        "build-gguf", help="Build ONNX model from a GGUF file."
+        "build-gguf",
+        help="Build ONNX model from a GGUF file.",
+        usage="mobius build-gguf GGUF_PATH --output OUTPUT_DIR [options]",
     )
     gguf_parser.add_argument(
         "gguf_path",
         help="Path to a .gguf model file.",
-    )
-    gguf_parser.add_argument(
-        "output_dir",
-        help="Output directory for the ONNX model.",
     )
     gguf_parser.add_argument(
         "--mmproj",

--- a/src/mobius/_cli_option_parity_test.py
+++ b/src/mobius/_cli_option_parity_test.py
@@ -14,39 +14,86 @@ import pytest
 
 from mobius.__main__ import build_parser
 
-_MINIMAL = {
-    "build": ["--model", "some/model", "out_dir"],
-    "build-gguf": ["some.gguf", "out_dir"],
+_SOURCE_ARGS = {
+    "build": ["--model", "some/model"],
+    "build-gguf": ["some.gguf"],
 }
 
 
-class TestOutputDirIsPositionalEverywhere:
-    """Both commands take the output directory the same way.
-
-    ``build-gguf`` used to take ``--output/-o`` with a default derived from the
-    GGUF filename, so the same concept was positional-and-required on one command
-    and optional-with-a-default on the other.
-    """
+class TestOutputDirForms:
+    """Both build commands expose one canonical output option."""
 
     @pytest.mark.parametrize("command", ["build", "build-gguf"])
-    def test_output_dir_is_a_required_positional(self, command):
-        args = build_parser().parse_args([command, *_MINIMAL[command]])
+    @pytest.mark.parametrize("flag", ["--output", "-o"])
+    def test_output_option_is_accepted(self, command, flag):
+        args = build_parser().parse_args([command, *_SOURCE_ARGS[command], flag, "out_dir"])
         assert args.output_dir == "out_dir"
 
-        with pytest.raises(SystemExit):
-            # Dropping the trailing output_dir must be an error, not a default.
-            build_parser().parse_args([command, *_MINIMAL[command][:-1]])
+    @pytest.mark.parametrize("command", ["build", "build-gguf"])
+    def test_legacy_positional_is_still_accepted(self, command):
+        args = build_parser().parse_args([command, *_SOURCE_ARGS[command], "out_dir"])
+        assert args.output_dir == "out_dir"
 
-    def test_gguf_no_longer_accepts_the_output_flag(self):
-        """The old spelling is gone rather than silently kept as an alias.
+    @pytest.mark.parametrize("command", ["build", "build-gguf"])
+    def test_missing_output_is_rejected(self, command):
+        with pytest.raises(SystemExit):
+            build_parser().parse_args([command, *_SOURCE_ARGS[command]])
 
-        Left in place it would be a second way to say the same thing, and the two
-        would drift.
-        """
+    @pytest.mark.parametrize("command", ["build", "build-gguf"])
+    @pytest.mark.parametrize("positional", ["out_dir", "different_out_dir"])
+    def test_option_and_positional_together_are_rejected(self, command, positional):
         with pytest.raises(SystemExit):
-            build_parser().parse_args(["build-gguf", "some.gguf", "-o", "out_dir"])
+            build_parser().parse_args(
+                [
+                    command,
+                    *_SOURCE_ARGS[command],
+                    positional,
+                    "--output",
+                    "out_dir",
+                ]
+            )
+
+    @pytest.mark.parametrize("command", ["build", "build-gguf"])
+    @pytest.mark.parametrize("second_flag", ["--output", "-o"])
+    def test_repeated_output_option_is_rejected(self, command, second_flag):
         with pytest.raises(SystemExit):
-            build_parser().parse_args(["build-gguf", "some.gguf", "--output", "out_dir"])
+            build_parser().parse_args(
+                [
+                    command,
+                    *_SOURCE_ARGS[command],
+                    "--output",
+                    "out_dir",
+                    second_flag,
+                    "other_dir",
+                ]
+            )
+
+    @pytest.mark.parametrize(
+        ("command", "handler_name"),
+        [("build", "_cmd_build"), ("build-gguf", "_cmd_build_gguf")],
+    )
+    def test_cli_dispatch_receives_normalized_output(self, monkeypatch, command, handler_name):
+        from mobius import __main__ as cli
+
+        received = []
+        monkeypatch.setattr(
+            cli,
+            handler_name,
+            lambda args: received.append(args.output_dir),
+        )
+
+        cli.main([command, *_SOURCE_ARGS[command], "--output", "out_dir"])
+
+        assert received == ["out_dir"]
+
+    @pytest.mark.parametrize("command", ["build", "build-gguf"])
+    def test_help_advertises_only_output_option(self, command, capsys):
+        with pytest.raises(SystemExit):
+            build_parser().parse_args([command, "--help"])
+        help_text = capsys.readouterr().out
+        assert "--output OUTPUT_DIR" in help_text
+        assert "legacy positional" not in help_text
+        assert "[_legacy_output_dir]" not in help_text
 
 
 class TestKeepQuantizedRemoved:
@@ -58,14 +105,18 @@ class TestKeepQuantizedRemoved:
         occupying the mutually exclusive group.
         """
         with pytest.raises(SystemExit):
-            build_parser().parse_args(["build-gguf", "some.gguf", "out", "--keep-quantized"])
+            build_parser().parse_args(
+                ["build-gguf", "some.gguf", "--output", "out", "--keep-quantized"]
+            )
 
     def test_dequantize_still_works(self):
         """Removing the dead alias must not disturb the flag that does the work."""
-        args = build_parser().parse_args(["build-gguf", "some.gguf", "out", "--dequantize"])
+        args = build_parser().parse_args(
+            ["build-gguf", "some.gguf", "--output", "out", "--dequantize"]
+        )
         assert args.dequantize is True
 
-        default = build_parser().parse_args(["build-gguf", "some.gguf", "out"])
+        default = build_parser().parse_args(["build-gguf", "some.gguf", "--output", "out"])
         assert default.dequantize is False
 
 
@@ -83,7 +134,16 @@ class TestSharedSaveOptions:
         ],
     )
     def test_option_is_accepted_by_both(self, command, flag, value, dest):
-        args = build_parser().parse_args([command, *_MINIMAL[command], flag, value])
+        args = build_parser().parse_args(
+            [
+                command,
+                *_SOURCE_ARGS[command],
+                "--output",
+                "out_dir",
+                flag,
+                value,
+            ]
+        )
         parsed = getattr(args, dest)
         assert str(parsed) == value or parsed == int(value)
 

--- a/src/mobius/_strip_debug_metadata_test.py
+++ b/src/mobius/_strip_debug_metadata_test.py
@@ -184,8 +184,8 @@ class TestReleaseFlag:
     #: Smallest argument set each build command accepts, so the test exercises the
     #: real parser rather than a stand-in.
     _MINIMAL_ARGS: ClassVar[dict[str, list[str]]] = {
-        "build": ["--model", "some/model", "out_dir"],
-        "build-gguf": ["some.gguf", "out_dir"],
+        "build": ["--model", "some/model", "--output", "out_dir"],
+        "build-gguf": ["some.gguf", "--output", "out_dir"],
     }
 
     def test_build_and_gguf_describe_release_identically(self):

--- a/tests/gguf_test.py
+++ b/tests/gguf_test.py
@@ -476,7 +476,7 @@ class TestCLIBuildGGUF:
             main(["build-gguf", "--help"])
         out = capsys.readouterr().out
         assert "--dequantize" in out
-        assert "output_dir" in out, "output directory is a positional, like build"
+        assert "--output OUTPUT_DIR" in out
         assert "--keep-quantized" not in out, "the unread deprecated alias was removed"
         assert "--max-shard-size" in out, "shard sizing applies to GGUF builds too"
 
@@ -495,7 +495,7 @@ class TestCLIBuildGGUF:
 
         path = _create_tiny_gguf(tmp_path / f"test-{float_type}.gguf", float_type=float_type)
         output_dir = tmp_path / f"output-{float_type}"
-        main(["build-gguf", path, str(output_dir)])
+        main(["build-gguf", path, "--output", str(output_dir)])
 
         package = ModelPackage.load(str(output_dir))
         op_types = {node.op_type for node in package["model"].graph}
@@ -529,6 +529,7 @@ class TestCLIBuildGGUF:
                 [
                     "build-gguf",
                     str(tmp_path / "model.gguf"),
+                    "--output",
                     str(tmp_path / "output"),
                     *extra_args,
                 ]
@@ -557,6 +558,7 @@ class TestCLIBuildGGUF:
                 [
                     "build-gguf",
                     str(tmp_path / "model.gguf"),
+                    "--output",
                     str(output_dir),
                     "--runtime",
                     "ort-genai",


### PR DESCRIPTION
## Summary

- make `--output OUTPUT_DIR` / `-o OUTPUT_DIR` the canonical output interface for both `mobius build` and `mobius build-gguf`
- retain positional `output_dir` as hidden backward compatibility
- require exactly one output specification and reject mixed or repeated forms
- document `--release` for both build commands, including preservation of functional `mobius.*` metadata
- update all README and docs CLI examples to use `--output`

## Compatibility and help

Argparse help and usage advertise only `--output/-o`. Existing positional invocations continue to parse, but combining positional and flag forms is rejected even when values match.

## CLI library audit

No CLI dependency was added. Typer or Click would not materially simplify this change: the existing argparse parser already centralizes shared build options, while hidden positional compatibility and exact-one-source validation would still require custom callbacks or preprocessing. A migration would also change established help/error behavior and require broad command/test churn for limited benefit.

## Testing

- `python -m pytest src/mobius/_cli_option_parity_test.py src/mobius/_strip_debug_metadata_test.py -q --tb=short`
- `python -m pytest tests/gguf_test.py -q -k 'TestCLIBuildGGUF' --tb=short`
- `python -m pytest tests/cli_test.py -q --tb=short`
- `lintrunner f --output oneline --all-files`