### PR TITLE
Reuse compatible GGUF weights as ONNX external data

### DIFF
--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -90,19 +90,24 @@ Repacked, requantized, dequantized, or synthesized tensors are true storage
 changes and therefore go to the sidecar.
 
 Float transpose, norm-offset arithmetic, Llama Q/K row permutation, and Mamba
-`A_log` arithmetic are not inherent storage incompatibilities: ONNX can express
-them as graph operations over the original external tensor. They are deferred
-from this first PR because each transform needs consumer-aware graph rewiring
-and runtime validation across constant-folding implementations. Until that work
-lands, those transformed tensors also go to the sidecar rather than being
-misrepresented as byte-compatible.
+`A_log`/shape transforms are not inherent storage incompatibilities. Reuse mode
+keeps their original F32/F16 bytes in the GGUF and inserts the corresponding
+ONNX `Transpose`, `Sub`, `Neg`/`Log`, or `Reshape` operations before their graph
+consumers. Opaque packed UINT8 blocks are never passed through a generic ONNX
+`Transpose`; only a consumer with a proven native block layout can reuse them.
 
-When a package later contains graph-level external-weight transforms, create ORT
-sessions with graph optimization disabled
+Create ORT sessions with graph optimization disabled
 (`SessionOptions.graph_optimization_level = ORT_DISABLE_ALL`) so ORT does not
 constant-fold them into another materialized weight copy. This first version
-already recommends that setting for stable package-size behavior, although its
-direct tensors require no transform.
+therefore rejects `--runtime ort-genai`: the current `genai_config.json` schema
+has no supported session option that can require disabled constant folding.
+Use direct ONNX Runtime for reuse packages.
+
+Disabling folding preserves storage reuse but does not make transforms free at
+runtime. A transpose/permutation or arithmetic node may allocate a transformed
+weight buffer and consume startup or execution time. The package avoids a second
+on-disk copy; peak runtime memory and performance remain transform- and
+execution-provider-dependent.
 
 ## Behavior
 

--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -22,6 +22,7 @@ def build_from_gguf(
     mmproj: str | Path | None = None,
     static_cache: bool = False,
     max_seq_len: int | None = None,
+    reuse_gguf_weights: bool = False,
 ) -> ModelPackage:
 ```
 
@@ -37,6 +38,7 @@ def build_from_gguf(
 | `mmproj` | `str \| Path \| None` | `None` | Optional companion multimodal-projector GGUF. |
 | `static_cache` | `bool` | `False` | Build a fixed-width KV cache when the architecture supports it. |
 | `max_seq_len` | `int \| None` | `None` | Static-cache sequence limit. |
+| `reuse_gguf_weights` | `bool` | `False` | Reuse byte-compatible F32/F16 and native IQ/MXFP4 tensor ranges from the original GGUF instead of copying them into ONNX external data. |
 
 ## Returns
 
@@ -62,6 +64,45 @@ pkg.save("output/llama-float/")
 # Via CLI
 mobius build-gguf llama-3.2-1b-q4_0.gguf --output output/llama/
 ```
+
+### Reuse the original GGUF as external data
+
+Place the GGUF directly in the output directory, then opt in:
+
+```bash
+mobius build-gguf output/llama/model.gguf \
+  --output output/llama/ \
+  --reuse-gguf-weights
+```
+
+The package contains `model.onnx`, the original GGUF, `model.onnx.data` with
+only converted/materialized tensors, and `gguf-reuse.json`. The manifest pins
+the GGUF location, size, SHA-256, qtypes, and exact reused ranges. ONNX runtimes
+do not enforce that digest; applications can call
+`mobius.integrations.gguf.verify_gguf_reuse_manifest()` before session creation.
+
+Initial support is deliberately limited to one flat text model. Multimodal,
+MTP, nested, sharded, symlinked, absolute, and parent-relative GGUF layouts are
+rejected rather than copied or linked. F32/F16 tensors and compatible
+IQ4_NL/IQ4_XS/IQ3_S/IQ3_XXS/IQ2_XXS/IQ2_XS/IQ2_S/IQ1_S/IQ1_M/MXFP4
+projection/output tensors can be reused when no logical transform is required.
+Repacked, requantized, dequantized, or synthesized tensors are true storage
+changes and therefore go to the sidecar.
+
+Float transpose, norm-offset arithmetic, Llama Q/K row permutation, and Mamba
+`A_log` arithmetic are not inherent storage incompatibilities: ONNX can express
+them as graph operations over the original external tensor. They are deferred
+from this first PR because each transform needs consumer-aware graph rewiring
+and runtime validation across constant-folding implementations. Until that work
+lands, those transformed tensors also go to the sidecar rather than being
+misrepresented as byte-compatible.
+
+When a package later contains graph-level external-weight transforms, create ORT
+sessions with graph optimization disabled
+(`SessionOptions.graph_optimization_level = ORT_DISABLE_ALL`) so ORT does not
+constant-fold them into another materialized weight copy. This first version
+already recommends that setting for stable package-size behavior, although its
+direct tensors require no transform.
 
 ## Behavior
 

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -606,6 +606,12 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
     mmproj_path = getattr(args, "mmproj", None)
     keep_quantized = not args.dequantize
     reuse_gguf_weights = args.reuse_gguf_weights
+    if reuse_gguf_weights and args.runtime == "ort-genai":
+        raise SystemExit(
+            "Error: --reuse-gguf-weights cannot be combined with --runtime ort-genai "
+            "because genai_config.json cannot require disabled ORT constant folding. "
+            "Use direct ONNX Runtime with ORT_DISABLE_ALL."
+        )
 
     if keep_quantized:
         print("Preserving supported GGUF quantization (float-only inputs stay float)...")

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -605,6 +605,7 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
 
     mmproj_path = getattr(args, "mmproj", None)
     keep_quantized = not args.dequantize
+    reuse_gguf_weights = args.reuse_gguf_weights
 
     if keep_quantized:
         print("Preserving supported GGUF quantization (float-only inputs stay float)...")
@@ -632,6 +633,7 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
         execution_provider=args.execution_provider,
         static_cache=args.static_cache,
         max_seq_len=args.max_seq_len,
+        reuse_gguf_weights=reuse_gguf_weights,
     )
 
     if args.release:
@@ -1182,6 +1184,15 @@ def build_parser() -> argparse.ArgumentParser:
         "--dequantize",
         action="store_true",
         help="Dequantize all GGUF weights to float instead of preserving quantization.",
+    )
+    gguf_parser.add_argument(
+        "--reuse-gguf-weights",
+        action="store_true",
+        help=(
+            "Reuse compatible tensor byte ranges directly from the original GGUF. "
+            "The GGUF must be a real file in the flat output directory; converted "
+            "weights are written to model.onnx.data."
+        ),
     )
     gguf_parser.add_argument(
         "--runtime",

--- a/src/mobius/_model_package.py
+++ b/src/mobius/_model_package.py
@@ -93,6 +93,8 @@ class ModelPackage(UserDict[str, ir.Model]):
     ) -> None:
         super().__init__(models or {})
         self.config = config
+        # Optional persistence policy attached by the GGUF importer.
+        self.gguf_reuse_plan: Any = None
         self.policy_components = dict(policy_components or {})
         self.adapter_target_manifest = adapter_target_manifest
         self.adapter_service_options = adapter_service_options or AdapterServiceOptions()
@@ -202,6 +204,18 @@ class ModelPackage(UserDict[str, ir.Model]):
             )
         if max_workers <= 0:
             raise ValueError(f"max_workers must be positive, got {max_workers}.")
+        reuse_plan = getattr(self, "gguf_reuse_plan", None)
+        if reuse_plan is not None:
+            if external_data != "onnx":
+                raise ValueError(
+                    "GGUF weight reuse requires external_data='onnx'; safetensors "
+                    "cannot preserve arbitrary GGUF byte ranges."
+                )
+            if max_shard_size_bytes is not None:
+                raise ValueError(
+                    "GGUF weight reuse writes one converted-weight sidecar and does "
+                    "not support max_shard_size_bytes."
+                )
         os.makedirs(directory, exist_ok=True)
         selected = {
             name: model
@@ -209,7 +223,10 @@ class ModelPackage(UserDict[str, ir.Model]):
             if components is None or components(name)
         }
         use_subfolders = len(selected) > 1
+        if reuse_plan is not None and (len(selected) != 1 or use_subfolders):
+            raise ValueError("GGUF weight reuse currently supports one flat ONNX model only.")
 
+        converted_tensors: tuple[str, ...] = ()
         for name, model in selected.items():
             callback = _make_progress_callback() if progress_bar else None
             if check_weights:
@@ -221,7 +238,16 @@ class ModelPackage(UserDict[str, ir.Model]):
                 model_dir = directory
             path = os.path.join(model_dir, "model.onnx")
             with _namespaced_symbolic_dimensions(model, f"component.{name}") as saved_model:
-                if external_data == "safetensors":
+                if reuse_plan is not None:
+                    from mobius.integrations.gguf._reuse import save_reuse_model
+
+                    converted_tensors = save_reuse_model(
+                        saved_model,
+                        path,
+                        reuse_plan,
+                        callback=callback,
+                    )
+                elif external_data == "safetensors":
                     ir.save_safetensors(
                         saved_model,
                         path,
@@ -238,6 +264,17 @@ class ModelPackage(UserDict[str, ir.Model]):
                         save_kwargs["max_workers"] = max_workers
                     ir.save(saved_model, path, **save_kwargs)
 
+        if reuse_plan is not None:
+            from mobius.integrations.gguf._reuse import write_reuse_manifest
+
+            write_reuse_manifest(directory, reuse_plan, converted_tensors)
+        else:
+            # Re-saving a loaded reuse package through the ordinary saver copies
+            # all weights into ONNX external data, so any old reuse manifest in
+            # the destination would become a false provenance claim.
+            stale_reuse_manifest = os.path.join(directory, "gguf-reuse.json")
+            if os.path.isfile(stale_reuse_manifest):
+                os.remove(stale_reuse_manifest)
         if include_policy_components:
             self.save_policy_components(directory, check_weights=check_weights)
         if include_adapter_artifacts:
@@ -594,6 +631,8 @@ class ModelPackage(UserDict[str, ir.Model]):
         self,
         state_dict: dict[str, torch.Tensor],
         prefix_map: dict[str, str] | None = None,
+        *,
+        fold_constants: bool = True,
     ) -> None:
         """Apply weights from a state dict across component models.
 
@@ -654,6 +693,9 @@ class ModelPackage(UserDict[str, ir.Model]):
                     applied |= _apply_weights_to_model(model, unmatched)
 
         _log_weight_mapping(state_dict, applied)
+
+        if not fold_constants:
+            return
 
         # Fold constants now that weights have been loaded.
         # PackQKV emits Concat(w_q, w_k, w_v) in the graph; those nodes can only

--- a/src/mobius/_model_package.py
+++ b/src/mobius/_model_package.py
@@ -226,7 +226,6 @@ class ModelPackage(UserDict[str, ir.Model]):
         if reuse_plan is not None and (len(selected) != 1 or use_subfolders):
             raise ValueError("GGUF weight reuse currently supports one flat ONNX model only.")
 
-        converted_tensors: tuple[str, ...] = ()
         for name, model in selected.items():
             callback = _make_progress_callback() if progress_bar else None
             if check_weights:
@@ -239,9 +238,9 @@ class ModelPackage(UserDict[str, ir.Model]):
             path = os.path.join(model_dir, "model.onnx")
             with _namespaced_symbolic_dimensions(model, f"component.{name}") as saved_model:
                 if reuse_plan is not None:
-                    from mobius.integrations.gguf._reuse import save_reuse_model
+                    from mobius.integrations.gguf._reuse import save_reuse_package
 
-                    converted_tensors = save_reuse_model(
+                    save_reuse_package(
                         saved_model,
                         path,
                         reuse_plan,
@@ -264,11 +263,7 @@ class ModelPackage(UserDict[str, ir.Model]):
                         save_kwargs["max_workers"] = max_workers
                     ir.save(saved_model, path, **save_kwargs)
 
-        if reuse_plan is not None:
-            from mobius.integrations.gguf._reuse import write_reuse_manifest
-
-            write_reuse_manifest(directory, reuse_plan, converted_tensors)
-        else:
+        if reuse_plan is None:
             # Re-saving a loaded reuse package through the ordinary saver copies
             # all weights into ONNX external data, so any old reuse manifest in
             # the destination would become a false provenance claim.

--- a/src/mobius/integrations/gguf/__init__.py
+++ b/src/mobius/integrations/gguf/__init__.py
@@ -45,6 +45,7 @@ from mobius.integrations.gguf._preflight import (
     preflight_hf_gguf,
     preflight_local_gguf,
 )
+from mobius.integrations.gguf._reuse import verify_gguf_reuse_manifest
 from mobius.integrations.gguf._runtime_package import write_gguf_runtime_package
 from mobius.integrations.gguf._shard_set import (
     GgufShardError,
@@ -60,6 +61,7 @@ __all__ = [
     "build_gemma4_vlm_from_gguf",
     "write_gguf_runtime_package",
     "write_gguf_tokenizer_json",
+    "verify_gguf_reuse_manifest",
     # Multi-shard GGUF import
     "GgufShardSet",
     "GgufShardManifest",

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -767,10 +767,26 @@ def build_from_gguf(
         }
         float_dict = {k: state_dict[k] for k in float_keys}
         quant_dict = {k: state_dict[k] for k in state_dict if k not in float_keys}
+        before_processing = dict(float_dict)
         float_dict = process_tensors(float_dict, config)
+        if reuse_candidates_by_id is not None:
+            _record_reuse_process_transforms(
+                before_processing,
+                float_dict,
+                reuse_candidates_by_id,
+                config,
+            )
         state_dict = {**float_dict, **quant_dict}
     else:
+        before_processing = dict(state_dict)
         state_dict = process_tensors(state_dict, config)
+        if reuse_candidates_by_id is not None:
+            _record_reuse_process_transforms(
+                before_processing,
+                state_dict,
+                reuse_candidates_by_id,
+                config,
+            )
 
     # 7b. Normalize GGUF-specific weight shapes to match HF conventions.
     # This converts GGUF tensor quirks (stacked experts, 1D gates, 2D
@@ -834,6 +850,53 @@ def build_from_gguf(
             pkg.mtp_head = mtp_pkg
 
     return pkg
+
+
+def _record_reuse_process_transforms(
+    before: dict,
+    after: dict,
+    candidates: dict,
+    config,
+) -> None:
+    """Carry exact-byte candidates through known graph-expressible transforms."""
+    import dataclasses
+
+    from mobius.integrations.gguf._tensor_processors import needs_llama_qk_permute
+
+    for name, transformed in after.items():
+        original = before.get(name)
+        if original is None or id(original) == id(transformed):
+            continue
+        candidate = candidates.get(id(original))
+        if candidate is None:
+            continue
+
+        transform: str | None = None
+        parameter: int | None = None
+        if needs_llama_qk_permute(getattr(config, "model_type", None)) and (
+            ".q_proj." in name or ".k_proj." in name
+        ):
+            transform = "llama_qk_permute"
+            parameter = (
+                config.num_attention_heads
+                if ".q_proj." in name
+                else config.num_key_value_heads
+            )
+        elif "A_log" in name:
+            transform = "log_neg"
+        elif "norm" in name and original.shape == transformed.shape:
+            transform = "subtract_one"
+        elif tuple(reversed(original.shape)) == tuple(transformed.shape):
+            transform = "transpose"
+        elif original.numel() == transformed.numel():
+            transform = "reshape"
+
+        if transform is not None:
+            candidates[id(transformed)] = dataclasses.replace(
+                candidate,
+                transform=transform,
+                transform_parameter=parameter,
+            )
 
 
 def _is_quantized_weight(key: str, state_dict: dict) -> bool:
@@ -1551,7 +1614,11 @@ def _load_dequantized_state_dict(
 
                     offset, length, qtype_name = gguf_model.tensor_storage_range(gguf_name)
                     reuse_candidates[id(tensor)] = GGUFReuseCandidate(
-                        gguf_name, offset, length, qtype_name
+                        gguf_name,
+                        offset,
+                        length,
+                        qtype_name,
+                        tuple(int(dim) for dim in np_array.shape),
                     )
         else:
             if warn_unmapped:
@@ -1713,7 +1780,11 @@ def _load_quantized_state_dict(
 
                     offset, length, qtype_name = gguf_model.tensor_storage_range(gguf_name)
                     reuse_candidates[id(w)] = GGUFReuseCandidate(
-                        gguf_name, offset, length, qtype_name
+                        gguf_name,
+                        offset,
+                        length,
+                        qtype_name,
+                        tuple(int(dim) for dim in w.shape),
                     )
             n_repacked += len(native_targets)
         elif should_repack:
@@ -1807,7 +1878,11 @@ def _load_quantized_state_dict(
 
                 offset, length, qtype_name = gguf_model.tensor_storage_range(gguf_name)
                 reuse_candidates[id(tensor)] = GGUFReuseCandidate(
-                    gguf_name, offset, length, qtype_name
+                    gguf_name,
+                    offset,
+                    length,
+                    qtype_name,
+                    tuple(int(dim) for dim in arr.shape),
                 )
 
     logger.info(

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -431,6 +431,7 @@ def build_from_gguf(
     static_cache: bool = False,
     max_seq_len: int | None = None,
     allow_dense_moe: bool | None = None,
+    reuse_gguf_weights: bool = False,
 ) -> ModelPackage:
     """Build an ONNX :class:`ModelPackage` from a GGUF file.
 
@@ -497,6 +498,10 @@ def build_from_gguf(
             ``False`` — the build fails closed with a typed capability error
             rather than silently shipping a dense graph. This is a research /
             correctness knob and makes no throughput claim.
+        reuse_gguf_weights: Reuse compatible tensor payloads directly from the
+            original GGUF via ONNX external-data ranges. The GGUF must be a real
+            file in the final flat output directory. Converted tensors are
+            written once to ``model.onnx.data``.
 
     Returns:
         A :class:`ModelPackage` containing the built model(s).
@@ -514,6 +519,10 @@ def build_from_gguf(
     # vision/audio encoders are assembled by the dedicated VLM builder. Keep
     # build_from_gguf as the single public entry point (text-only or multimodal).
     if mmproj is not None:
+        if reuse_gguf_weights:
+            raise ValueError(
+                "reuse_gguf_weights=True does not yet support multimodal/mmproj packages."
+            )
         if static_cache:
             raise ValueError("static_cache=True is not supported with a companion mmproj.")
         from mobius.integrations.gguf._mmproj import build_vlm_from_gguf
@@ -560,6 +569,12 @@ def build_from_gguf(
     gguf_path = _resolve_gguf_path(gguf_path)
     gguf_model = open_gguf_model(gguf_path)
     _validate_gguf_model(gguf_model, source=str(gguf_path))
+    if reuse_gguf_weights and not gguf_model.is_little_endian:
+        raise ValueError(
+            "reuse_gguf_weights=True requires a little-endian GGUF because ONNX "
+            "external tensors interpret the referenced bytes as little-endian. "
+            "Build without reuse to convert this file."
+        )
     gguf_arch = gguf_model.architecture
     logger.info("Loaded GGUF model: %s (arch=%s)", gguf_path, gguf_arch)
     preserve_quantization = keep_quantized and _has_quantized_weights(gguf_model, gguf_arch)
@@ -715,10 +730,21 @@ def build_from_gguf(
     )
 
     # 6. Load tensors from GGUF → state_dict
+    reuse_candidates_by_id = {} if reuse_gguf_weights else None
     if preserve_quantization:
-        state_dict = _load_quantized_state_dict(gguf_model, gguf_arch, module, config)
+        state_dict = _load_quantized_state_dict(
+            gguf_model,
+            gguf_arch,
+            module,
+            config,
+            reuse_candidates=reuse_candidates_by_id,
+        )
     else:
-        state_dict = _load_dequantized_state_dict(gguf_model, gguf_arch)
+        state_dict = _load_dequantized_state_dict(
+            gguf_model,
+            gguf_arch,
+            reuse_candidates=reuse_candidates_by_id,
+        )
 
     logger.info(
         "Mapped %d state_dict entries from GGUF tensors",
@@ -758,7 +784,24 @@ def build_from_gguf(
 
     # 9. Apply weights to ONNX model
     prefix_map = getattr(module, "weight_prefix_map", None)
-    pkg.apply_weights(state_dict, prefix_map=prefix_map)
+    pkg.apply_weights(
+        state_dict,
+        prefix_map=prefix_map,
+        fold_constants=not reuse_gguf_weights,
+    )
+    if reuse_gguf_weights:
+        from mobius.integrations.gguf._reuse import attach_reused_initializers
+
+        if emit_mtp_head:
+            raise ValueError(
+                "reuse_gguf_weights=True does not yet support packages with an MTP sidecar."
+            )
+        final_candidates = {
+            name: reuse_candidates_by_id[id(tensor)]
+            for name, tensor in state_dict.items()
+            if id(tensor) in reuse_candidates_by_id
+        }
+        attach_reused_initializers(pkg, gguf_path, final_candidates)
 
     # 9b. Sparse-MoE fusion + honesty gate (final graph state).
     # Now that every native block carries its real packed bytes, collapse the
@@ -1468,6 +1511,7 @@ def _load_dequantized_state_dict(
     gguf_arch: str,
     name_mapper: Callable[[str, str], str | None] | None = None,
     warn_unmapped: bool = True,
+    reuse_candidates: dict | None = None,
 ) -> dict:
     """Load all tensors dequantized to float (Phase 1 path).
 
@@ -1498,7 +1542,17 @@ def _load_dequantized_state_dict(
             # writable so PyTorch can mutate if needed.
             if not np_array.flags.writeable:
                 np_array = np.array(np_array)
-            state_dict[hf_name] = torch.from_numpy(np_array)
+            tensor = torch.from_numpy(np_array)
+            state_dict[hf_name] = tensor
+            if reuse_candidates is not None:
+                qtype = gguf_model.get_tensor_type(gguf_name)
+                if getattr(qtype, "name", None) in {"F32", "F16"}:
+                    from mobius.integrations.gguf._reuse import GGUFReuseCandidate
+
+                    offset, length, qtype_name = gguf_model.tensor_storage_range(gguf_name)
+                    reuse_candidates[id(tensor)] = GGUFReuseCandidate(
+                        gguf_name, offset, length, qtype_name
+                    )
         else:
             if warn_unmapped:
                 logger.warning("Unmapped GGUF tensor: %s (skipped)", gguf_name)
@@ -1512,6 +1566,7 @@ def _load_quantized_state_dict(
     config,
     name_mapper: Callable[[str, str], str | None] | None = None,
     warn_unmapped: bool = True,
+    reuse_candidates: dict | None = None,
 ) -> dict:
     """Load tensors, preserving native blocks or normalizing to MatMulNBits.
 
@@ -1635,12 +1690,13 @@ def _load_quantized_state_dict(
             for index, native_stem in enumerate(native_targets):
                 w = torch.from_numpy(np.array(packed[index], copy=True))
                 target_name = f"{native_stem}.weight"
-                if _needs_qk_permute(
+                needs_permute = _needs_qk_permute(
                     target_name,
                     num_heads,
                     num_kv_heads,
                     model_type,
-                ):
+                )
+                if needs_permute:
                     n_head = (
                         num_heads
                         if ".q_proj." in target_name or ".qkv_proj." in target_name
@@ -1648,6 +1704,17 @@ def _load_quantized_state_dict(
                     )
                     w = _reverse_permute(w, n_head)
                 state_dict[target_name] = w
+                if (
+                    reuse_candidates is not None
+                    and len(native_targets) == 1
+                    and not needs_permute
+                ):
+                    from mobius.integrations.gguf._reuse import GGUFReuseCandidate
+
+                    offset, length, qtype_name = gguf_model.tensor_storage_range(gguf_name)
+                    reuse_candidates[id(w)] = GGUFReuseCandidate(
+                        gguf_name, offset, length, qtype_name
+                    )
             n_repacked += len(native_targets)
         elif should_repack:
             if is_tencent_q1_0_tensor:
@@ -1730,7 +1797,18 @@ def _load_quantized_state_dict(
                     arr = np.array(arr)
             else:
                 arr = dequantize(raw, qtype).reshape(np_shape)
-            state_dict[hf_name] = torch.from_numpy(arr)
+            tensor = torch.from_numpy(arr)
+            state_dict[hf_name] = tensor
+            if reuse_candidates is not None and qtype in (
+                GGMLQuantizationType.F32,
+                GGMLQuantizationType.F16,
+            ):
+                from mobius.integrations.gguf._reuse import GGUFReuseCandidate
+
+                offset, length, qtype_name = gguf_model.tensor_storage_range(gguf_name)
+                reuse_candidates[id(tensor)] = GGUFReuseCandidate(
+                    gguf_name, offset, length, qtype_name
+                )
 
     logger.info(
         "Loaded %d state_dict entries (%d GGUF tensors repacked for quantized ops, "

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -544,7 +544,7 @@ def build_from_gguf(
         GGUF_ARCH_TO_MODEL_TYPE,
         gguf_to_config,
     )
-    from mobius.integrations.gguf._shard_set import open_gguf_model
+    from mobius.integrations.gguf._shard_set import GgufShardSet, open_gguf_model
     from mobius.integrations.gguf._tensor_processors import (
         process_tensors,
     )
@@ -569,6 +569,11 @@ def build_from_gguf(
     gguf_path = _resolve_gguf_path(gguf_path)
     gguf_model = open_gguf_model(gguf_path)
     _validate_gguf_model(gguf_model, source=str(gguf_path))
+    if reuse_gguf_weights and isinstance(gguf_model, GgufShardSet):
+        raise ValueError(
+            "reuse_gguf_weights=True does not yet support multi-shard GGUF sets. "
+            "Build without reuse to preserve current multi-shard import behavior."
+        )
     if reuse_gguf_weights and not gguf_model.is_little_endian:
         raise ValueError(
             "reuse_gguf_weights=True requires a little-endian GGUF because ONNX "

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -564,6 +564,23 @@ class TestReuseGgufWeights:
             package.save(str(tmp_path), progress_bar=False)
         assert gguf_path.stat().st_size == package.gguf_reuse_plan.size
 
+    def test_generated_looking_files_without_journal_are_preserved(self, tmp_path: Path):
+        from mobius.integrations.gguf import build_from_gguf
+
+        token = "0" * 32
+        gguf_path = tmp_path / f".model.onnx.{token}.tmp"
+        unrelated = tmp_path / f".gguf-reuse.json.{token}.tmp"
+        _write_quantized_gguf(gguf_path, projection_quantization="f32")
+        source_bytes = gguf_path.read_bytes()
+        unrelated.write_bytes(b"user-owned temporary data")
+
+        build_from_gguf(gguf_path, reuse_gguf_weights=True).save(
+            str(tmp_path), progress_bar=False
+        )
+
+        assert gguf_path.read_bytes() == source_bytes
+        assert unrelated.read_bytes() == b"user-owned temporary data"
+
     def test_ordinary_resave_removes_stale_reuse_manifest(self, tmp_path: Path):
         from mobius._model_package import ModelPackage
         from mobius.integrations.gguf import build_from_gguf

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -411,8 +411,14 @@ class TestReuseGgufWeights:
         manifest = json.loads((tmp_path / "gguf-reuse.json").read_text())
         converted = manifest["converted_tensors"]
         assert len(converted) == len(set(converted))
-        assert converted.count("model.layers.0.self_attn.q_proj.weight") == 1
+        assert "model.layers.0.self_attn.q_proj.weight" not in converted
         assert "model.embed_tokens.weight" not in converted
+        q_route = next(
+            route
+            for route in manifest["reused_tensors"]
+            if route["initializer"] == "model.layers.0.self_attn.q_proj.weight"
+        )
+        assert q_route["transform"] == "llama_qk_permute"
         reloaded = ModelPackage.load(str(tmp_path))
         initializers = reloaded["model"].graph.initializers
         embedding = initializers["model.embed_tokens.weight"].const_value
@@ -421,9 +427,13 @@ class TestReuseGgufWeights:
         assert embedding.location == "model.gguf"
         assert embedding.offset is not None
         assert embedding.length == 256 * 64 * 4
-        # Llama Q weights require a logical row permutation, so they are converted.
+        # Llama Q weights keep their GGUF bytes; ONNX performs the row permutation.
         assert isinstance(q_proj, ir.ExternalTensor)
-        assert q_proj.location == "model.onnx.data"
+        assert q_proj.location == "model.gguf"
+        assert any(
+            node.name == "model.layers.0.self_attn.q_proj.weight.gguf_reuse.Transpose"
+            for node in reloaded["model"].graph
+        )
 
         options = ort.SessionOptions()
         options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
@@ -442,6 +452,16 @@ class TestReuseGgufWeights:
         outputs = session.run(None, feeds)
         assert outputs[0].shape == (1, 2, 256)
         assert np.isfinite(outputs[0]).all()
+
+        reference_dir = tmp_path / "reference"
+        build_from_gguf(gguf_path).save(str(reference_dir), progress_bar=False)
+        reference_session = ort.InferenceSession(
+            str(reference_dir / "model.onnx"),
+            sess_options=options,
+            providers=["CPUExecutionProvider"],
+        )
+        reference_outputs = reference_session.run(None, feeds)
+        np.testing.assert_allclose(outputs[0], reference_outputs[0], rtol=1e-5, atol=1e-5)
 
     def test_native_projection_bytes_are_not_copied_to_sidecar(self, tmp_path: Path):
         from mobius.integrations.gguf import build_from_gguf
@@ -553,6 +573,297 @@ class TestReuseGgufWeights:
         loaded = ModelPackage.load(str(tmp_path))
         loaded.save(str(tmp_path), progress_bar=False)
         assert not (tmp_path / "gguf-reuse.json").exists()
+
+    def test_verifier_rejects_unmanifested_external_initializer(self, tmp_path: Path):
+        from mobius.integrations.gguf import (
+            build_from_gguf,
+            verify_gguf_reuse_manifest,
+        )
+
+        gguf_path = tmp_path / "source.gguf"
+        _write_quantized_gguf(gguf_path, projection_quantization="f32")
+        build_from_gguf(gguf_path, reuse_gguf_weights=True).save(
+            str(tmp_path), progress_bar=False
+        )
+        model_path = tmp_path / "model.onnx"
+        model = ir.load(model_path)
+        initializer = next(
+            value
+            for value in model.graph.initializers.values()
+            if not isinstance(value.const_value, ir.ExternalTensor)
+        )
+        tensor = initializer.const_value
+        assert tensor is not None
+        initializer.const_value = ir.ExternalTensor(
+            "model.onnx.data",
+            0,
+            tensor.nbytes,
+            tensor.dtype,
+            shape=tensor.shape,
+            name=tensor.name or initializer.name,
+            base_dir=tmp_path,
+        )
+        ir.save(model, model_path)
+
+        with pytest.raises(ValueError, match="Unmanifested sidecar initializer"):
+            verify_gguf_reuse_manifest(tmp_path)
+
+    def test_verifier_rejects_wrong_external_dtype(self, tmp_path: Path):
+        from mobius.integrations.gguf import (
+            build_from_gguf,
+            verify_gguf_reuse_manifest,
+        )
+
+        gguf_path = tmp_path / "source.gguf"
+        _write_quantized_gguf(gguf_path, projection_quantization="f32")
+        build_from_gguf(gguf_path, reuse_gguf_weights=True).save(
+            str(tmp_path), progress_bar=False
+        )
+        model_path = tmp_path / "model.onnx"
+        model = ir.load(model_path)
+        initializer = model.graph.initializers["model.embed_tokens.weight"]
+        external = initializer.const_value
+        assert isinstance(external, ir.ExternalTensor)
+        initializer.const_value = ir.ExternalTensor(
+            external.location,
+            external.offset,
+            external.length,
+            ir.DataType.UINT8,
+            shape=ir.Shape([external.length]),
+            name=external.name,
+            base_dir=tmp_path,
+        )
+        initializer.dtype = ir.DataType.UINT8
+        initializer.shape = ir.Shape([external.length])
+        ir.save(model, model_path)
+
+        with pytest.raises(ValueError, match="incompatible dtype"):
+            verify_gguf_reuse_manifest(tmp_path)
+
+    def test_verifier_rejects_wrong_manifest_qtype(self, tmp_path: Path):
+        from mobius.integrations.gguf import (
+            build_from_gguf,
+            verify_gguf_reuse_manifest,
+        )
+
+        gguf_path = tmp_path / "source.gguf"
+        _write_quantized_gguf(gguf_path, projection_quantization="f32")
+        build_from_gguf(gguf_path, reuse_gguf_weights=True).save(
+            str(tmp_path), progress_bar=False
+        )
+        manifest_path = tmp_path / "gguf-reuse.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["reused_tensors"][0]["qtype"] = "F16"
+        manifest_path.write_text(json.dumps(manifest))
+
+        with pytest.raises(ValueError, match="does not match source tensor"):
+            verify_gguf_reuse_manifest(tmp_path)
+
+    def test_failed_rerun_restores_existing_package(self, tmp_path: Path, monkeypatch):
+        from mobius.integrations.gguf import _reuse, build_from_gguf
+
+        gguf_path = tmp_path / "source.gguf"
+        _write_quantized_gguf(gguf_path, projection_quantization="f32")
+        build_from_gguf(gguf_path, reuse_gguf_weights=True).save(
+            str(tmp_path), progress_bar=False
+        )
+        artifact_names = ("model.onnx", "model.onnx.data", "gguf-reuse.json")
+        original = {name: (tmp_path / name).read_bytes() for name in artifact_names}
+
+        real_replace = _reuse.os.replace
+        injected = False
+
+        def fail_manifest_install(source, destination):
+            nonlocal injected
+            source_path = Path(source)
+            destination_path = Path(destination)
+            if (
+                not injected
+                and source_path.name.startswith(".gguf-reuse.json.")
+                and destination_path.name == "gguf-reuse.json"
+            ):
+                injected = True
+                raise OSError("injected manifest install failure")
+            return real_replace(source, destination)
+
+        monkeypatch.setattr(_reuse.os, "replace", fail_manifest_install)
+        rerun = build_from_gguf(gguf_path, reuse_gguf_weights=True)
+        with pytest.raises(OSError, match="injected"):
+            rerun.save(str(tmp_path), progress_bar=False)
+
+        assert injected
+        assert {name: (tmp_path / name).read_bytes() for name in artifact_names} == original
+        assert not list(tmp_path.glob(".*.tmp"))
+        assert not list(tmp_path.glob(".*.backup"))
+
+    def test_interrupted_rerun_recovers_from_transaction_journal(
+        self, tmp_path: Path, monkeypatch
+    ):
+        from mobius.integrations.gguf import (
+            _reuse,
+            build_from_gguf,
+            verify_gguf_reuse_manifest,
+        )
+
+        gguf_path = tmp_path / "source.gguf"
+        _write_quantized_gguf(gguf_path, projection_quantization="f32")
+        build_from_gguf(gguf_path, reuse_gguf_weights=True).save(
+            str(tmp_path), progress_bar=False
+        )
+        artifact_names = ("model.onnx", "model.onnx.data", "gguf-reuse.json")
+        original = {name: (tmp_path / name).read_bytes() for name in artifact_names}
+
+        real_replace = _reuse.os.replace
+        interrupted = False
+
+        def interrupt_manifest_install(source, destination):
+            nonlocal interrupted
+            source_path = Path(source)
+            destination_path = Path(destination)
+            if (
+                not interrupted
+                and source_path.name.startswith(".gguf-reuse.json.")
+                and destination_path.name == "gguf-reuse.json"
+            ):
+                interrupted = True
+                raise KeyboardInterrupt
+            return real_replace(source, destination)
+
+        monkeypatch.setattr(_reuse.os, "replace", interrupt_manifest_install)
+        rerun = build_from_gguf(gguf_path, reuse_gguf_weights=True)
+        with pytest.raises(KeyboardInterrupt):
+            rerun.save(str(tmp_path), progress_bar=False)
+        monkeypatch.setattr(_reuse.os, "replace", real_replace)
+
+        verify_gguf_reuse_manifest(tmp_path)
+        assert {name: (tmp_path / name).read_bytes() for name in artifact_names} == original
+        assert not (tmp_path / ".gguf-reuse.transaction.json").exists()
+        assert not list(tmp_path.glob(".*.backup"))
+
+    def test_verifier_rejects_wrong_transform_parameter(self, tmp_path: Path):
+        from mobius.integrations.gguf import (
+            build_from_gguf,
+            verify_gguf_reuse_manifest,
+        )
+
+        gguf_path = tmp_path / "source.gguf"
+        _write_quantized_gguf(gguf_path, projection_quantization="f32")
+        build_from_gguf(gguf_path, reuse_gguf_weights=True).save(
+            str(tmp_path), progress_bar=False
+        )
+        manifest_path = tmp_path / "gguf-reuse.json"
+        manifest = json.loads(manifest_path.read_text())
+        q_route = next(
+            route
+            for route in manifest["reused_tensors"]
+            if route["transform"] == "llama_qk_permute"
+        )
+        q_route["transform_parameter"] = 3
+        manifest_path.write_text(json.dumps(manifest))
+
+        with pytest.raises(ValueError, match="Invalid Q/K head count"):
+            verify_gguf_reuse_manifest(tmp_path)
+
+    def test_verifier_rejects_wrong_transform_permutation(self, tmp_path: Path):
+        from mobius.integrations.gguf import (
+            build_from_gguf,
+            verify_gguf_reuse_manifest,
+        )
+
+        gguf_path = tmp_path / "source.gguf"
+        _write_quantized_gguf(gguf_path, projection_quantization="f32")
+        build_from_gguf(gguf_path, reuse_gguf_weights=True).save(
+            str(tmp_path), progress_bar=False
+        )
+        model_path = tmp_path / "model.onnx"
+        model = ir.load(model_path)
+        transpose = next(
+            node
+            for node in model.graph
+            if node.name == "model.layers.0.self_attn.q_proj.weight.gguf_reuse.Transpose"
+        )
+        transpose.attributes["perm"] = ir.AttrInt64s("perm", [0, 1, 2, 3])
+        ir.save(model, model_path)
+
+        with pytest.raises(ValueError, match="Q/K permutation shapes are wrong"):
+            verify_gguf_reuse_manifest(tmp_path)
+
+    def test_overwrite_rejects_filesystem_without_hardlinks(self, tmp_path: Path, monkeypatch):
+        from mobius.integrations.gguf import _reuse, build_from_gguf
+
+        gguf_path = tmp_path / "source.gguf"
+        _write_quantized_gguf(gguf_path, projection_quantization="f32")
+        package = build_from_gguf(gguf_path, reuse_gguf_weights=True)
+        package.save(str(tmp_path), progress_bar=False)
+        original = (tmp_path / "model.onnx").read_bytes()
+
+        def reject_link(source, destination):
+            raise OSError("hard links unavailable")
+
+        monkeypatch.setattr(_reuse.os, "link", reject_link)
+        with pytest.raises(ValueError, match="requires same-directory hard-link"):
+            package.save(str(tmp_path), progress_bar=False)
+        assert (tmp_path / "model.onnx").read_bytes() == original
+        assert not (tmp_path / ".gguf-reuse.transaction.json").exists()
+
+    def test_recovery_rejects_unsafe_journal_paths(self, tmp_path: Path):
+        from mobius.integrations.gguf import _reuse
+
+        victim = tmp_path.parent / "victim"
+        victim.write_bytes(b"keep")
+        journal = {
+            "managed": [
+                {
+                    "final": "../victim",
+                    "backup": ".victim.00000000000000000000000000000000.backup",
+                    "had_existing": True,
+                },
+                {
+                    "final": "model.onnx.data",
+                    "backup": ".model.onnx.data.00000000000000000000000000000000.backup",
+                    "had_existing": False,
+                },
+                {
+                    "final": "gguf-reuse.json",
+                    "backup": ".gguf-reuse.json.00000000000000000000000000000000.backup",
+                    "had_existing": False,
+                },
+            ],
+            "staged": [
+                ".model.onnx.00000000000000000000000000000000.tmp",
+                ".gguf-reuse.json.00000000000000000000000000000000.tmp",
+            ],
+        }
+        (tmp_path / ".gguf-reuse.transaction.json").write_text(json.dumps(journal))
+
+        with pytest.raises(ValueError, match="Unsafe GGUF transaction"):
+            _reuse._recover_transaction(tmp_path)
+        assert victim.read_bytes() == b"keep"
+
+    def test_transaction_removes_obsolete_sidecar(self, tmp_path: Path):
+        from mobius.integrations.gguf import _reuse
+
+        final_model = tmp_path / "model.onnx"
+        final_sidecar = tmp_path / "model.onnx.data"
+        final_manifest = tmp_path / "gguf-reuse.json"
+        for path in (final_model, final_sidecar, final_manifest):
+            path.write_bytes(b"old")
+        staged_model = tmp_path / f".model.onnx.{'0' * 32}.tmp"
+        staged_manifest = tmp_path / f".gguf-reuse.json.{'1' * 32}.tmp"
+        staged_model.write_bytes(b"new model")
+        staged_manifest.write_bytes(b"new manifest")
+
+        _reuse._replace_artifacts(
+            {
+                final_model: staged_model,
+                final_manifest: staged_manifest,
+            },
+            (final_model, final_sidecar, final_manifest),
+        )
+
+        assert final_model.read_bytes() == b"new model"
+        assert final_manifest.read_bytes() == b"new manifest"
+        assert not final_sidecar.exists()
 
 
 class TestBuildQuantizedGguf:

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
@@ -388,6 +390,169 @@ def mixed_native_q5_q8_gguf(tmp_path: Path) -> Path:
         value_projection_quantization="q5_1",
     )
     return path
+
+
+class TestReuseGgufWeights:
+    """Tests for mixed GGUF references plus converted ONNX sidecar weights."""
+
+    def test_mixed_save_preserves_ranges_and_runs(self, tmp_path: Path):
+        from mobius._model_package import ModelPackage
+        from mobius.integrations.gguf import (
+            build_from_gguf,
+            verify_gguf_reuse_manifest,
+        )
+
+        gguf_path = tmp_path / "model.gguf"
+        _write_quantized_gguf(gguf_path, projection_quantization="f32")
+        package = build_from_gguf(gguf_path, reuse_gguf_weights=True)
+        package.save(str(tmp_path), progress_bar=False)
+
+        verify_gguf_reuse_manifest(tmp_path)
+        manifest = json.loads((tmp_path / "gguf-reuse.json").read_text())
+        converted = manifest["converted_tensors"]
+        assert len(converted) == len(set(converted))
+        assert converted.count("model.layers.0.self_attn.q_proj.weight") == 1
+        assert "model.embed_tokens.weight" not in converted
+        reloaded = ModelPackage.load(str(tmp_path))
+        initializers = reloaded["model"].graph.initializers
+        embedding = initializers["model.embed_tokens.weight"].const_value
+        q_proj = initializers["model.layers.0.self_attn.q_proj.weight"].const_value
+        assert isinstance(embedding, ir.ExternalTensor)
+        assert embedding.location == "model.gguf"
+        assert embedding.offset is not None
+        assert embedding.length == 256 * 64 * 4
+        # Llama Q weights require a logical row permutation, so they are converted.
+        assert isinstance(q_proj, ir.ExternalTensor)
+        assert q_proj.location == "model.onnx.data"
+
+        options = ort.SessionOptions()
+        options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+        session = ort.InferenceSession(
+            str(tmp_path / "model.onnx"),
+            sess_options=options,
+            providers=["CPUExecutionProvider"],
+        )
+        feeds = {
+            "input_ids": np.zeros((1, 2), dtype=np.int64),
+            "attention_mask": np.zeros((1, 2), dtype=np.int64),
+            "position_ids": np.zeros((1, 2), dtype=np.int64),
+            "past_key_values.0.key": np.zeros((1, 2, 0, 16), dtype=np.float32),
+            "past_key_values.0.value": np.zeros((1, 2, 0, 16), dtype=np.float32),
+        }
+        outputs = session.run(None, feeds)
+        assert outputs[0].shape == (1, 2, 256)
+        assert np.isfinite(outputs[0]).all()
+
+    def test_native_projection_bytes_are_not_copied_to_sidecar(self, tmp_path: Path):
+        from mobius.integrations.gguf import build_from_gguf
+        from mobius.integrations.gguf._reader import GGUFModel
+
+        gguf_path = tmp_path / "model.gguf"
+        _write_quantized_gguf(
+            gguf_path,
+            architecture="qwen2",
+            hidden_size=256,
+            num_heads=4,
+            num_kv_heads=4,
+            intermediate_size=256,
+            projection_quantization="iq4_nl",
+        )
+        package = build_from_gguf(gguf_path, reuse_gguf_weights=True)
+        package.save(str(tmp_path), progress_bar=False)
+
+        source = GGUFModel(gguf_path)
+        offset, length, _ = source.tensor_storage_range("blk.0.attn_q.weight")
+        direct_payload = gguf_path.read_bytes()[offset : offset + length]
+        sidecar = (tmp_path / "model.onnx.data").read_bytes()
+        assert direct_payload not in sidecar
+
+        reloaded = ir.load(tmp_path / "model.onnx")
+        q_proj = reloaded.graph.initializers[
+            "model.layers.0.self_attn.q_proj.weight"
+        ].const_value
+        assert isinstance(q_proj, ir.ExternalTensor)
+        assert (q_proj.location, q_proj.offset, q_proj.length) == (
+            "model.gguf",
+            offset,
+            length,
+        )
+
+    def test_rejects_non_flat_source_and_detects_identity_change(self, tmp_path: Path):
+        from mobius.integrations.gguf import (
+            build_from_gguf,
+            verify_gguf_reuse_manifest,
+        )
+
+        source_dir = tmp_path / "source"
+        source_dir.mkdir()
+        gguf_path = source_dir / "model.gguf"
+        _write_quantized_gguf(gguf_path, projection_quantization="f32")
+        package = build_from_gguf(gguf_path, reuse_gguf_weights=True)
+
+        with pytest.raises(ValueError, match="flat same-directory packaging"):
+            package.save(str(tmp_path / "output"), progress_bar=False)
+
+        package.save(str(source_dir), progress_bar=False)
+        with gguf_path.open("r+b") as stream:
+            stream.seek(-1, 2)
+            byte = stream.read(1)
+            stream.seek(-1, 2)
+            stream.write(bytes([byte[0] ^ 0xFF]))
+        with pytest.raises(ValueError, match="identity mismatch"):
+            verify_gguf_reuse_manifest(source_dir)
+
+    def test_does_not_reuse_same_size_dtype_cast(self, tmp_path: Path):
+        from mobius.integrations.gguf import build_from_gguf
+
+        gguf_path = tmp_path / "model.gguf"
+        _write_quantized_gguf(
+            gguf_path,
+            projection_quantization="f16",
+            float_type="f16",
+        )
+        with pytest.raises(ValueError, match="no byte-compatible tensors"):
+            build_from_gguf(
+                gguf_path,
+                dtype="bf16",
+                reuse_gguf_weights=True,
+            )
+
+    def test_rejects_generated_artifact_name_collision(self, tmp_path: Path):
+        from mobius.integrations.gguf import build_from_gguf
+
+        gguf_path = tmp_path / "model.onnx.data"
+        _write_quantized_gguf(gguf_path, projection_quantization="f32")
+        package = build_from_gguf(gguf_path, reuse_gguf_weights=True)
+        with pytest.raises(ValueError, match="collides"):
+            package.save(str(tmp_path), progress_bar=False)
+        # Validation happens before any generated artifact can truncate the source.
+        assert gguf_path.stat().st_size == package.gguf_reuse_plan.size
+
+    def test_rejects_hardlink_to_generated_artifact(self, tmp_path: Path):
+        from mobius.integrations.gguf import build_from_gguf
+
+        gguf_path = tmp_path / "source.gguf"
+        _write_quantized_gguf(gguf_path, projection_quantization="f32")
+        package = build_from_gguf(gguf_path, reuse_gguf_weights=True)
+        os.link(gguf_path, tmp_path / "model.onnx.data")
+
+        with pytest.raises(ValueError, match="hard-linked"):
+            package.save(str(tmp_path), progress_bar=False)
+        assert gguf_path.stat().st_size == package.gguf_reuse_plan.size
+
+    def test_ordinary_resave_removes_stale_reuse_manifest(self, tmp_path: Path):
+        from mobius._model_package import ModelPackage
+        from mobius.integrations.gguf import build_from_gguf
+
+        gguf_path = tmp_path / "source.gguf"
+        _write_quantized_gguf(gguf_path, projection_quantization="f32")
+        build_from_gguf(gguf_path, reuse_gguf_weights=True).save(
+            str(tmp_path), progress_bar=False
+        )
+
+        loaded = ModelPackage.load(str(tmp_path))
+        loaded.save(str(tmp_path), progress_bar=False)
+        assert not (tmp_path / "gguf-reuse.json").exists()
 
 
 class TestBuildQuantizedGguf:

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -537,10 +537,13 @@ class TestReuseGgufWeights:
                 reuse_gguf_weights=True,
             )
 
-    def test_rejects_generated_artifact_name_collision(self, tmp_path: Path):
+    @pytest.mark.parametrize("artifact_name", ["model.onnx.data", ".gguf-reuse.lock"])
+    def test_rejects_generated_artifact_name_collision(
+        self, tmp_path: Path, artifact_name: str
+    ):
         from mobius.integrations.gguf import build_from_gguf
 
-        gguf_path = tmp_path / "model.onnx.data"
+        gguf_path = tmp_path / artifact_name
         _write_quantized_gguf(gguf_path, projection_quantization="f32")
         package = build_from_gguf(gguf_path, reuse_gguf_weights=True)
         with pytest.raises(ValueError, match="collides"):
@@ -548,13 +551,14 @@ class TestReuseGgufWeights:
         # Validation happens before any generated artifact can truncate the source.
         assert gguf_path.stat().st_size == package.gguf_reuse_plan.size
 
-    def test_rejects_hardlink_to_generated_artifact(self, tmp_path: Path):
+    @pytest.mark.parametrize("artifact_name", ["model.onnx.data", ".gguf-reuse.lock"])
+    def test_rejects_hardlink_to_generated_artifact(self, tmp_path: Path, artifact_name: str):
         from mobius.integrations.gguf import build_from_gguf
 
         gguf_path = tmp_path / "source.gguf"
         _write_quantized_gguf(gguf_path, projection_quantization="f32")
         package = build_from_gguf(gguf_path, reuse_gguf_weights=True)
-        os.link(gguf_path, tmp_path / "model.onnx.data")
+        os.link(gguf_path, tmp_path / artifact_name)
 
         with pytest.raises(ValueError, match="hard-linked"):
             package.save(str(tmp_path), progress_bar=False)
@@ -659,6 +663,121 @@ class TestReuseGgufWeights:
         with pytest.raises(ValueError, match="does not match source tensor"):
             verify_gguf_reuse_manifest(tmp_path)
 
+    @pytest.mark.parametrize("length_delta", [-1, 1])
+    def test_verifier_rejects_wrong_sidecar_byte_length(
+        self, tmp_path: Path, length_delta: int
+    ):
+        from mobius.integrations.gguf import (
+            build_from_gguf,
+            verify_gguf_reuse_manifest,
+        )
+
+        gguf_path = tmp_path / "source.gguf"
+        _write_quantized_gguf(gguf_path, projection_quantization="f32")
+        build_from_gguf(gguf_path, reuse_gguf_weights=True).save(
+            str(tmp_path), progress_bar=False
+        )
+        model_path = tmp_path / "model.onnx"
+        model = ir.load(model_path)
+        initializer = next(
+            value
+            for value in model.graph.initializers.values()
+            if isinstance(value.const_value, ir.ExternalTensor)
+            and value.const_value.location == "model.onnx.data"
+        )
+        external = initializer.const_value
+        assert isinstance(external, ir.ExternalTensor)
+        assert external.length is not None
+        initializer.const_value = ir.ExternalTensor(
+            external.location,
+            external.offset,
+            external.length + length_delta,
+            external.dtype,
+            shape=external.shape,
+            name=external.name,
+            base_dir=tmp_path,
+        )
+        ir.save(model, model_path)
+
+        with pytest.raises(ValueError, match="byte length"):
+            verify_gguf_reuse_manifest(tmp_path)
+
+    def test_save_and_verifier_do_not_run_behind_active_writer(self, tmp_path: Path):
+        from mobius.integrations.gguf import (
+            _reuse,
+            build_from_gguf,
+            verify_gguf_reuse_manifest,
+        )
+
+        gguf_path = tmp_path / "source.gguf"
+        _write_quantized_gguf(gguf_path, projection_quantization="f32")
+        package = build_from_gguf(gguf_path, reuse_gguf_weights=True)
+        package.save(str(tmp_path), progress_bar=False)
+
+        with _reuse._package_lock(tmp_path):
+            operations = (
+                lambda: verify_gguf_reuse_manifest(tmp_path),
+                lambda: package.save(str(tmp_path), progress_bar=False),
+            )
+            for operation in operations:
+                with pytest.raises(ValueError, match="locked by active writer"):
+                    operation()
+
+    @pytest.mark.parametrize(
+        "artifact_name", [".gguf-reuse.lock", ".gguf-reuse.transaction.json"]
+    )
+    def test_rejects_dangling_control_artifact_symlink(
+        self, tmp_path: Path, artifact_name: str
+    ):
+        from mobius.integrations.gguf import (
+            _reuse,
+            build_from_gguf,
+            verify_gguf_reuse_manifest,
+        )
+
+        gguf_path = tmp_path / "source.gguf"
+        _write_quantized_gguf(gguf_path, projection_quantization="f32")
+        build_from_gguf(gguf_path, reuse_gguf_weights=True).save(
+            str(tmp_path), progress_bar=False
+        )
+        artifact = tmp_path / artifact_name
+        if artifact_name == _reuse._LOCK_NAME:
+            artifact.unlink()
+        artifact.symlink_to(tmp_path / "missing-target")
+
+        with pytest.raises(ValueError, match="Unsafe GGUF"):
+            if artifact_name == _reuse._LOCK_NAME:
+                verify_gguf_reuse_manifest(tmp_path)
+            else:
+                build_from_gguf(gguf_path, reuse_gguf_weights=True).save(
+                    str(tmp_path), progress_bar=False
+                )
+        assert artifact.is_symlink()
+
+    @pytest.mark.parametrize(
+        "artifact_name", ["model.onnx", "model.onnx.data", "gguf-reuse.json"]
+    )
+    def test_verifier_rejects_symlinked_package_artifact(
+        self, tmp_path: Path, artifact_name: str
+    ):
+        from mobius.integrations.gguf import (
+            build_from_gguf,
+            verify_gguf_reuse_manifest,
+        )
+
+        gguf_path = tmp_path / "source.gguf"
+        _write_quantized_gguf(gguf_path, projection_quantization="f32")
+        build_from_gguf(gguf_path, reuse_gguf_weights=True).save(
+            str(tmp_path), progress_bar=False
+        )
+        artifact = tmp_path / artifact_name
+        moved = tmp_path / f"{artifact_name}.moved"
+        artifact.replace(moved)
+        artifact.symlink_to(moved)
+
+        with pytest.raises(ValueError, match="Unsafe GGUF"):
+            verify_gguf_reuse_manifest(tmp_path)
+
     def test_failed_rerun_restores_existing_package(self, tmp_path: Path, monkeypatch):
         from mobius.integrations.gguf import _reuse, build_from_gguf
 
@@ -739,6 +858,34 @@ class TestReuseGgufWeights:
         assert {name: (tmp_path / name).read_bytes() for name in artifact_names} == original
         assert not (tmp_path / ".gguf-reuse.transaction.json").exists()
         assert not list(tmp_path.glob(".*.backup"))
+
+    def test_committed_transaction_recovery_keeps_new_artifacts(self, tmp_path: Path):
+        from mobius.integrations.gguf import _reuse
+
+        token = "0" * 32
+        managed = []
+        for name in ("model.onnx", "model.onnx.data", "gguf-reuse.json"):
+            final = tmp_path / name
+            final.write_bytes(f"new {name}".encode())
+            backup_name = f".{name}.{token}.backup"
+            (tmp_path / backup_name).write_bytes(f"old {name}".encode())
+            managed.append({"final": name, "backup": backup_name, "had_existing": True})
+        journal = {
+            "phase": "committed",
+            "managed": managed,
+            "staged": [
+                f".model.onnx.{token}.tmp",
+                f".gguf-reuse.json.{token}.tmp",
+            ],
+        }
+        (tmp_path / ".gguf-reuse.transaction.json").write_text(json.dumps(journal))
+
+        _reuse._recover_transaction(tmp_path)
+
+        for name in ("model.onnx", "model.onnx.data", "gguf-reuse.json"):
+            assert (tmp_path / name).read_bytes() == f"new {name}".encode()
+        assert not list(tmp_path.glob(".*.backup"))
+        assert not (tmp_path / ".gguf-reuse.transaction.json").exists()
 
     def test_verifier_rejects_wrong_transform_parameter(self, tmp_path: Path):
         from mobius.integrations.gguf import (

--- a/src/mobius/integrations/gguf/_reader.py
+++ b/src/mobius/integrations/gguf/_reader.py
@@ -230,6 +230,11 @@ class GGUFModel:
         """
         return list(self._reader.tensors)
 
+    @property
+    def is_little_endian(self) -> bool:
+        """Whether raw tensor payloads use ONNX-compatible little-endian bytes."""
+        return getattr(self._reader.endianess, "name", None) == "LITTLE"
+
     def _dequantize_tensor(self, tensor) -> np.ndarray:
         """Dequantize a single :class:`ReaderTensor` to a numpy array.
 
@@ -342,6 +347,17 @@ class GGUFModel:
         if name not in self._tensor_index:
             raise KeyError(f"Tensor '{name}' not found in GGUF file.")
         return self._reader.get_tensor(self._tensor_index[name]).tensor_type
+
+    def tensor_storage_range(self, name: str) -> tuple[int, int, str]:
+        """Return the exact file offset, byte length, and qtype for a tensor."""
+        if name not in self._tensor_index:
+            raise KeyError(f"Tensor '{name}' not found in GGUF file.")
+        tensor = self._reader.get_tensor(self._tensor_index[name])
+        return (
+            int(tensor.data_offset),
+            int(tensor.n_bytes),
+            str(getattr(tensor.tensor_type, "name", tensor.tensor_type)),
+        )
 
     def __repr__(self) -> str:
         arch = self.architecture if self._reader else "?"

--- a/src/mobius/integrations/gguf/_reuse.py
+++ b/src/mobius/integrations/gguf/_reuse.py
@@ -1,0 +1,287 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Preserve compatible GGUF tensor payloads as ONNX external data."""
+
+from __future__ import annotations
+
+__all__ = ["GGUFReuseCandidate", "GGUFReusePlan", "verify_gguf_reuse_manifest"]
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import TYPE_CHECKING
+
+import onnx_ir as ir
+
+if TYPE_CHECKING:
+    from mobius._model_package import ModelPackage
+
+_MANIFEST_NAME = "gguf-reuse.json"
+_SIDECAR_NAME = "model.onnx.data"
+_EXTERNAL_WEIGHT_THRESHOLD = 256
+_GENERATED_NAMES = frozenset({"model.onnx", _SIDECAR_NAME, _MANIFEST_NAME})
+_FLOAT_QTYPE_DTYPES = {
+    "F32": ir.DataType.FLOAT,
+    "F16": ir.DataType.FLOAT16,
+}
+
+
+@dataclass(frozen=True)
+class GGUFReuseCandidate:
+    """A final state-dict tensor that can read its exact bytes from the GGUF."""
+
+    source_name: str
+    offset: int
+    length: int
+    qtype: str
+
+
+@dataclass(frozen=True)
+class GGUFReuseTensor:
+    """A source range bound to an ONNX initializer."""
+
+    initializer: str
+    source_name: str
+    offset: int
+    length: int
+    qtype: str
+
+
+@dataclass(frozen=True)
+class GGUFReusePlan:
+    """Source identity and exact tensor ranges used by a mixed ONNX package."""
+
+    source_path: Path
+    size: int
+    sha256: str
+    tensors: tuple[GGUFReuseTensor, ...]
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def attach_reused_initializers(
+    package: ModelPackage,
+    source_path: str | Path,
+    candidates: dict[str, GGUFReuseCandidate],
+) -> None:
+    """Replace eligible in-memory initializers with GGUF ExternalTensors."""
+    if len(package) != 1:
+        raise ValueError(
+            "reuse_gguf_weights=True currently supports only single-model, flat packages."
+        )
+
+    source = Path(source_path).absolute()
+    if source.is_symlink():
+        raise ValueError(
+            "reuse_gguf_weights=True does not accept a symlinked GGUF. "
+            "Use the real GGUF file in the ONNX output directory."
+        )
+
+    model = next(iter(package.values()))
+    reused: list[GGUFReuseTensor] = []
+    for name, candidate in candidates.items():
+        initializer = model.graph.initializers.get(name)
+        if initializer is None or initializer.const_value is None:
+            continue
+        tensor = initializer.const_value
+        expected_dtype = _FLOAT_QTYPE_DTYPES.get(candidate.qtype, ir.DataType.UINT8)
+        if tensor.dtype != expected_dtype:
+            continue
+        if tensor.nbytes != candidate.length:
+            continue
+        initializer.const_value = ir.ExternalTensor(
+            source.name,
+            candidate.offset,
+            candidate.length,
+            tensor.dtype,
+            shape=tensor.shape,
+            name=tensor.name or name,
+            base_dir=source.parent,
+        )
+        reused.append(
+            GGUFReuseTensor(
+                initializer=name,
+                source_name=candidate.source_name,
+                offset=candidate.offset,
+                length=candidate.length,
+                qtype=candidate.qtype,
+            )
+        )
+
+    if not reused:
+        raise ValueError(
+            "reuse_gguf_weights=True found no byte-compatible tensors. "
+            "This initial implementation reuses unchanged F32/F16 tensors and "
+            "runtime-native IQ/MXFP4 projection blocks; transformed or repacked "
+            "weights use the ONNX sidecar. Some float transforms are graph-expressible "
+            "but are deferred from this first implementation."
+        )
+
+    package.gguf_reuse_plan = GGUFReusePlan(
+        source_path=source,
+        size=source.stat().st_size,
+        sha256=_sha256(source),
+        tensors=tuple(sorted(reused, key=lambda tensor: tensor.initializer)),
+    )
+
+
+def _validate_source(plan: GGUFReusePlan, output_directory: Path) -> None:
+    source = plan.source_path
+    if source.is_symlink():
+        raise ValueError("The GGUF source became a symlink; refusing an unsafe external path.")
+    if source.parent.resolve() != output_directory.resolve():
+        raise ValueError(
+            "reuse_gguf_weights=True requires flat same-directory packaging: move the "
+            f"GGUF to {output_directory} before building. Mobius will not copy, hardlink, "
+            "or symlink a multi-GB source file."
+        )
+    if source.name in _GENERATED_NAMES:
+        raise ValueError(
+            f"The GGUF source name {source.name!r} collides with a generated package "
+            "artifact. Rename the GGUF before building."
+        )
+    for generated_name in _GENERATED_NAMES:
+        generated_path = output_directory / generated_name
+        if generated_path.exists() and os.path.samefile(source, generated_path):
+            raise ValueError(
+                f"The GGUF source is hard-linked to generated artifact "
+                f"{generated_name!r}. Use an independent real file."
+            )
+    if source.stat().st_size != plan.size or _sha256(source) != plan.sha256:
+        raise ValueError(
+            "The GGUF source no longer matches the file used to build this package "
+            "(size or SHA-256 changed). Rebuild from the intended GGUF."
+        )
+
+
+def save_reuse_model(
+    model: ir.Model,
+    path: str | Path,
+    plan: GGUFReusePlan,
+    *,
+    callback=None,
+) -> tuple[str, ...]:
+    """Save mixed GGUF references plus one converted-weight sidecar."""
+    path = Path(path)
+    _validate_source(plan, path.parent)
+
+    memory_initializers = [
+        value
+        for graph in model.graphs()
+        for value in graph.initializers.values()
+        if value.const_value is not None
+        and not isinstance(value.const_value, ir.ExternalTensor)
+        and value.const_value.nbytes > _EXTERNAL_WEIGHT_THRESHOLD
+    ]
+    original_tensors = [value.const_value for value in memory_initializers]
+    converted_names = tuple(sorted(value.name for value in memory_initializers))
+
+    try:
+        if memory_initializers:
+            external_tensors = ir.external_data.convert_tensors_to_external(
+                original_tensors,
+                base_dir=path.parent,
+                relative_path=_SIDECAR_NAME,
+                callback=callback,
+            )
+            for value, external_tensor in zip(
+                memory_initializers, external_tensors, strict=True
+            ):
+                value.const_value = external_tensor
+        ir.save(model, path)
+    finally:
+        for value, tensor in zip(memory_initializers, original_tensors, strict=True):
+            value.const_value = tensor
+
+    return converted_names
+
+
+def write_reuse_manifest(
+    directory: str | Path,
+    plan: GGUFReusePlan,
+    converted_tensors: tuple[str, ...],
+) -> None:
+    """Write source identity and per-tensor routing without runtime claims."""
+    payload = {
+        "format": "mobius.gguf-external-data.v1",
+        "source": {
+            "location": plan.source_path.name,
+            "size": plan.size,
+            "sha256": plan.sha256,
+        },
+        "reused_tensors": [
+            {
+                "initializer": tensor.initializer,
+                "source_tensor": tensor.source_name,
+                "offset": tensor.offset,
+                "length": tensor.length,
+                "qtype": tensor.qtype,
+            }
+            for tensor in plan.tensors
+        ],
+        "converted_tensors": list(converted_tensors),
+        "runtime_verification": (
+            "ONNX runtimes resolve location/offset/length but do not enforce this SHA-256."
+        ),
+    }
+    manifest_path = Path(directory) / _MANIFEST_NAME
+    manifest_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def verify_gguf_reuse_manifest(directory: str | Path) -> None:
+    """Verify the packaged GGUF's size, digest, and pinned tensor ranges."""
+    root = Path(directory)
+    manifest = json.loads((root / _MANIFEST_NAME).read_text())
+    source_info = manifest["source"]
+    location = source_info["location"]
+    posix = PurePosixPath(location)
+    windows = PureWindowsPath(location)
+    if (
+        posix.is_absolute()
+        or windows.is_absolute()
+        or windows.drive
+        or posix.parts != (location,)
+        or windows.parts != (location,)
+        or location in {".", ".."}
+    ):
+        raise ValueError(f"Unsafe GGUF manifest location: {location!r}")
+    source = root / location
+    if source.is_symlink() or not source.is_file():
+        raise ValueError(f"GGUF manifest source is missing or unsafe: {source}")
+    if (
+        source.stat().st_size != source_info["size"]
+        or _sha256(source) != source_info["sha256"]
+    ):
+        raise ValueError("GGUF source identity mismatch (size or SHA-256).")
+    for tensor in manifest["reused_tensors"]:
+        if tensor["offset"] < 0 or tensor["length"] <= 0:
+            raise ValueError(f"Invalid GGUF range for {tensor['initializer']!r}.")
+        if tensor["offset"] + tensor["length"] > source_info["size"]:
+            raise ValueError(f"GGUF range exceeds the source for {tensor['initializer']!r}.")
+
+    model = ir.load(root / "model.onnx")
+    for tensor in manifest["reused_tensors"]:
+        initializer = model.graph.initializers.get(tensor["initializer"])
+        external = None if initializer is None else initializer.const_value
+        if not isinstance(external, ir.ExternalTensor):
+            raise ValueError(
+                f"Manifest initializer {tensor['initializer']!r} is not external."
+            )
+        if (
+            external.location != location
+            or external.offset != tensor["offset"]
+            or external.length != tensor["length"]
+        ):
+            raise ValueError(
+                f"Manifest range does not match ONNX initializer "
+                f"{tensor['initializer']!r}."
+            )

--- a/src/mobius/integrations/gguf/_reuse.py
+++ b/src/mobius/integrations/gguf/_reuse.py
@@ -10,10 +10,14 @@ __all__ = ["GGUFReuseCandidate", "GGUFReusePlan", "verify_gguf_reuse_manifest"]
 import hashlib
 import json
 import os
+import re
+import uuid
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 
+import numpy as np
 import onnx_ir as ir
 
 if TYPE_CHECKING:
@@ -21,12 +25,24 @@ if TYPE_CHECKING:
 
 _MANIFEST_NAME = "gguf-reuse.json"
 _SIDECAR_NAME = "model.onnx.data"
+_TRANSACTION_NAME = ".gguf-reuse.transaction.json"
 _EXTERNAL_WEIGHT_THRESHOLD = 256
-_GENERATED_NAMES = frozenset({"model.onnx", _SIDECAR_NAME, _MANIFEST_NAME})
+_GENERATED_NAMES = frozenset({"model.onnx", _SIDECAR_NAME, _MANIFEST_NAME, _TRANSACTION_NAME})
 _FLOAT_QTYPE_DTYPES = {
     "F32": ir.DataType.FLOAT,
     "F16": ir.DataType.FLOAT16,
 }
+
+
+class _TransactionEntry(TypedDict):
+    final: str
+    backup: str
+    had_existing: bool
+
+
+class _TransactionJournal(TypedDict):
+    managed: list[_TransactionEntry]
+    staged: list[str]
 
 
 @dataclass(frozen=True)
@@ -37,6 +53,9 @@ class GGUFReuseCandidate:
     offset: int
     length: int
     qtype: str
+    source_shape: tuple[int, ...]
+    transform: str | None = None
+    transform_parameter: int | None = None
 
 
 @dataclass(frozen=True)
@@ -48,6 +67,10 @@ class GGUFReuseTensor:
     offset: int
     length: int
     qtype: str
+    transform: str | None
+    source_shape: tuple[int, ...]
+    final_shape: tuple[int, ...]
+    transform_parameter: int | None
 
 
 @dataclass(frozen=True)
@@ -93,17 +116,19 @@ def attach_reused_initializers(
         if initializer is None or initializer.const_value is None:
             continue
         tensor = initializer.const_value
+        final_shape = tuple(int(dim) for dim in tensor.shape)
         expected_dtype = _FLOAT_QTYPE_DTYPES.get(candidate.qtype, ir.DataType.UINT8)
         if tensor.dtype != expected_dtype:
             continue
         if tensor.nbytes != candidate.length:
             continue
+        _insert_external_transform(model.graph, initializer, candidate)
         initializer.const_value = ir.ExternalTensor(
             source.name,
             candidate.offset,
             candidate.length,
             tensor.dtype,
-            shape=tensor.shape,
+            shape=ir.Shape(candidate.source_shape),
             name=tensor.name or name,
             base_dir=source.parent,
         )
@@ -114,6 +139,10 @@ def attach_reused_initializers(
                 offset=candidate.offset,
                 length=candidate.length,
                 qtype=candidate.qtype,
+                transform=candidate.transform,
+                source_shape=candidate.source_shape,
+                final_shape=final_shape,
+                transform_parameter=candidate.transform_parameter,
             )
         )
 
@@ -121,9 +150,9 @@ def attach_reused_initializers(
         raise ValueError(
             "reuse_gguf_weights=True found no byte-compatible tensors. "
             "This initial implementation reuses unchanged F32/F16 tensors and "
-            "runtime-native IQ/MXFP4 projection blocks; transformed or repacked "
-            "weights use the ONNX sidecar. Some float transforms are graph-expressible "
-            "but are deferred from this first implementation."
+            "runtime-native IQ/MXFP4 projection blocks, including supported "
+            "graph-expressible float transforms. Repacked or otherwise unsupported "
+            "weights use the ONNX sidecar."
         )
 
     package.gguf_reuse_plan = GGUFReusePlan(
@@ -132,6 +161,169 @@ def attach_reused_initializers(
         sha256=_sha256(source),
         tensors=tuple(sorted(reused, key=lambda tensor: tensor.initializer)),
     )
+
+
+def _shape_initializer(graph: ir.Graph, name: str, shape: tuple[int, ...]) -> ir.Value:
+    value = ir.Value(name=name)
+    value.const_value = ir.tensor(np.asarray(shape, dtype=np.int64), name=name)
+    value.shape = ir.Shape([len(shape)])
+    value.dtype = ir.DataType.INT64
+    graph.initializers[name] = value
+    return value
+
+
+def _insert_external_transform(
+    graph: ir.Graph,
+    initializer: ir.Value,
+    candidate: GGUFReuseCandidate,
+) -> None:
+    """Reproduce a byte-preserving GGUF-to-graph float transform at runtime."""
+    if candidate.transform is None:
+        return
+    uses = list(initializer.uses())
+    if not uses:
+        return
+    dtype = initializer.dtype
+    final_shape = initializer.shape
+    assert dtype is not None and final_shape is not None
+    prefix = f"{initializer.name}.gguf_reuse"
+    output = ir.Value(
+        name=f"{prefix}.output",
+        shape=final_shape,
+        type=ir.TensorType(dtype),
+    )
+    initializer.replace_all_uses_with(output)
+    initializer.shape = ir.Shape(candidate.source_shape)
+
+    nodes: list[ir.Node]
+    if candidate.transform == "transpose":
+        nodes = [
+            ir.Node(
+                "",
+                "Transpose",
+                inputs=[initializer],
+                outputs=[output],
+                attributes=ir.convenience.convert_attributes(
+                    {"perm": list(reversed(range(len(candidate.source_shape))))}
+                ),
+                name=f"{prefix}.Transpose",
+            )
+        ]
+    elif candidate.transform == "subtract_one":
+        np_dtype = np.float16 if dtype == ir.DataType.FLOAT16 else np.float32
+        one = ir.Value(name=f"{prefix}.one")
+        one.const_value = ir.tensor(np.asarray(1, dtype=np_dtype), name=one.name)
+        one.shape = ir.Shape([])
+        one.dtype = dtype
+        graph.initializers[one.name] = one
+        nodes = [
+            ir.Node(
+                "",
+                "Sub",
+                inputs=[initializer, one],
+                outputs=[output],
+                name=f"{prefix}.Sub",
+            )
+        ]
+    elif candidate.transform == "log_neg":
+        negated = ir.Value(
+            name=f"{prefix}.negated",
+            shape=ir.Shape(candidate.source_shape),
+            type=ir.TensorType(dtype),
+        )
+        nodes = [
+            ir.Node(
+                "",
+                "Neg",
+                inputs=[initializer],
+                outputs=[negated],
+                name=f"{prefix}.Neg",
+            ),
+            ir.Node(
+                "",
+                "Log",
+                inputs=[negated],
+                outputs=[output],
+                name=f"{prefix}.Log",
+            ),
+        ]
+    elif candidate.transform in {"reshape", "llama_qk_permute"}:
+        if candidate.transform == "reshape":
+            shape = _shape_initializer(
+                graph,
+                f"{prefix}.shape",
+                tuple(int(dim) for dim in final_shape),
+            )
+            nodes = [
+                ir.Node(
+                    "",
+                    "Reshape",
+                    inputs=[initializer, shape],
+                    outputs=[output],
+                    name=f"{prefix}.Reshape",
+                )
+            ]
+        else:
+            n_head = candidate.transform_parameter
+            assert n_head is not None
+            dim = candidate.source_shape[0] // n_head // 2
+            expanded_shape = (
+                n_head,
+                dim,
+                2,
+                *candidate.source_shape[1:],
+            )
+            shape1 = _shape_initializer(graph, f"{prefix}.shape1", expanded_shape)
+            shape2 = _shape_initializer(
+                graph,
+                f"{prefix}.shape2",
+                candidate.source_shape,
+            )
+            expanded = ir.Value(
+                name=f"{prefix}.expanded",
+                shape=ir.Shape(expanded_shape),
+                type=ir.TensorType(dtype),
+            )
+            permuted_shape = (
+                n_head,
+                2,
+                dim,
+                *candidate.source_shape[1:],
+            )
+            permuted = ir.Value(
+                name=f"{prefix}.permuted",
+                shape=ir.Shape(permuted_shape),
+                type=ir.TensorType(dtype),
+            )
+            perm = [0, 2, 1, *range(3, len(expanded_shape))]
+            nodes = [
+                ir.Node(
+                    "",
+                    "Reshape",
+                    inputs=[initializer, shape1],
+                    outputs=[expanded],
+                    name=f"{prefix}.Reshape1",
+                ),
+                ir.Node(
+                    "",
+                    "Transpose",
+                    inputs=[expanded],
+                    outputs=[permuted],
+                    attributes=ir.convenience.convert_attributes({"perm": perm}),
+                    name=f"{prefix}.Transpose",
+                ),
+                ir.Node(
+                    "",
+                    "Reshape",
+                    inputs=[permuted, shape2],
+                    outputs=[output],
+                    name=f"{prefix}.Reshape2",
+                ),
+            ]
+    else:
+        raise ValueError(f"Unknown GGUF external transform {candidate.transform!r}.")
+
+    graph.insert_before(uses[0][0], nodes)
 
 
 def _validate_source(plan: GGUFReusePlan, output_directory: Path) -> None:
@@ -163,16 +355,241 @@ def _validate_source(plan: GGUFReusePlan, output_directory: Path) -> None:
         )
 
 
-def save_reuse_model(
+def _manifest_payload(
+    plan: GGUFReusePlan,
+    converted_tensors: tuple[str, ...],
+) -> dict[str, object]:
+    return {
+        "format": "mobius.gguf-external-data.v1",
+        "source": {
+            "location": plan.source_path.name,
+            "size": plan.size,
+            "sha256": plan.sha256,
+        },
+        "reused_tensors": [
+            {
+                "initializer": tensor.initializer,
+                "source_tensor": tensor.source_name,
+                "offset": tensor.offset,
+                "length": tensor.length,
+                "qtype": tensor.qtype,
+                "transform": tensor.transform,
+                "source_shape": list(tensor.source_shape),
+                "final_shape": list(tensor.final_shape),
+                "transform_parameter": tensor.transform_parameter,
+            }
+            for tensor in plan.tensors
+        ],
+        "converted_tensors": list(converted_tensors),
+        "runtime_verification": (
+            "ONNX runtimes resolve location/offset/length but do not enforce this SHA-256."
+        ),
+    }
+
+
+def _write_json(path: Path, payload: Mapping[str, object]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    with path.open("rb") as stream:
+        os.fsync(stream.fileno())
+
+
+def _fsync_file(path: Path) -> None:
+    with path.open("rb") as stream:
+        os.fsync(stream.fileno())
+
+
+def _fsync_directory(path: Path) -> None:
+    if os.name == "nt":
+        return
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _replace_artifacts(
+    replacements: dict[Path, Path],
+    managed_paths: tuple[Path, ...],
+) -> None:
+    """Install staged files with a durable rollback journal."""
+    root = managed_paths[0].parent
+    _recover_transaction(root)
+    _require_hard_link_backups(root, managed_paths)
+    token = uuid.uuid4().hex
+    backups: dict[Path, Path] = {}
+    installed: list[Path] = []
+    transaction_path = root / _TRANSACTION_NAME
+    journal: _TransactionJournal = {
+        "managed": [
+            {
+                "final": path.name,
+                "backup": f".{path.name}.{token}.backup",
+                "had_existing": path.exists(),
+            }
+            for path in managed_paths
+        ],
+        "staged": [path.name for path in replacements.values()],
+    }
+    _write_json(transaction_path, journal)
+    _fsync_directory(root)
+    try:
+        for entry, final_path in zip(journal["managed"], managed_paths, strict=True):
+            if final_path.exists():
+                backup = root / entry["backup"]
+                os.link(final_path, backup)
+                backups[final_path] = backup
+        _fsync_directory(root)
+        for final_path in managed_paths:
+            if final_path not in replacements:
+                final_path.unlink(missing_ok=True)
+                installed.append(final_path)
+        for final_path, staged_path in replacements.items():
+            os.replace(staged_path, final_path)
+            installed.append(final_path)
+        _fsync_directory(root)
+    except Exception:
+        for final_path in reversed(installed):
+            final_path.unlink(missing_ok=True)
+        for final_path, backup in reversed(tuple(backups.items())):
+            os.replace(backup, final_path)
+            backup.unlink(missing_ok=True)
+        transaction_path.unlink(missing_ok=True)
+        _fsync_directory(root)
+        raise
+    else:
+        transaction_path.unlink()
+        _fsync_directory(root)
+        for backup in backups.values():
+            backup.unlink(missing_ok=True)
+
+
+def _require_hard_link_backups(root: Path, managed_paths: tuple[Path, ...]) -> None:
+    """Fail before a transaction when durable same-directory backups are unavailable."""
+    if not any(path.exists() for path in managed_paths):
+        return
+    token = uuid.uuid4().hex
+    probe = root / f".gguf-reuse.{token}.link-probe"
+    linked = root / f".gguf-reuse.{token}.link-probe-copy"
+    try:
+        probe.write_bytes(b"probe")
+        _fsync_file(probe)
+        os.link(probe, linked)
+        _fsync_directory(root)
+    except OSError as error:
+        raise ValueError(
+            "Atomic GGUF package overwrite requires same-directory hard-link "
+            "support for rollback backups. Save to a filesystem that supports "
+            "hard links or choose a new empty output directory."
+        ) from error
+    finally:
+        linked.unlink(missing_ok=True)
+        probe.unlink(missing_ok=True)
+
+
+def _recover_transaction(root: Path) -> None:
+    """Roll back an interrupted artifact replacement before using the package."""
+    transaction_path = root / _TRANSACTION_NAME
+    if not transaction_path.is_file():
+        return
+    journal = _validated_transaction_journal(transaction_path)
+    for entry in journal["managed"]:
+        final_path = root / entry["final"]
+        backup = root / entry["backup"]
+        if backup.exists():
+            os.replace(backup, final_path)
+            backup.unlink(missing_ok=True)
+        elif not entry["had_existing"]:
+            final_path.unlink(missing_ok=True)
+    for staged_name in journal["staged"]:
+        (root / staged_name).unlink(missing_ok=True)
+    transaction_path.unlink(missing_ok=True)
+    _fsync_directory(root)
+
+
+def _validated_transaction_journal(path: Path) -> _TransactionJournal:
+    """Parse a journal without allowing paths outside the package directory."""
+    journal = json.loads(path.read_text())
+    if not isinstance(journal, dict):
+        raise TypeError("Invalid GGUF transaction journal.")
+    managed = journal.get("managed")
+    staged = journal.get("staged")
+    expected_finals = {"model.onnx", _SIDECAR_NAME, _MANIFEST_NAME}
+    if not isinstance(managed, list) or not isinstance(staged, list):
+        raise TypeError("Invalid GGUF transaction journal.")
+    if len(managed) != len(expected_finals):
+        raise ValueError("Invalid GGUF transaction journal managed artifact set.")
+
+    validated_managed: list[_TransactionEntry] = []
+    seen_finals: set[str] = set()
+    for entry in managed:
+        if not isinstance(entry, dict):
+            raise TypeError("Invalid GGUF transaction journal entry.")
+        final = entry.get("final")
+        backup = entry.get("backup")
+        had_existing = entry.get("had_existing")
+        if (
+            not isinstance(final, str)
+            or final not in expected_finals
+            or final in seen_finals
+            or not isinstance(backup, str)
+            or re.fullmatch(
+                rf"\.{re.escape(final)}\.[0-9a-f]{{32}}\.backup",
+                backup,
+            )
+            is None
+            or not isinstance(had_existing, bool)
+        ):
+            raise ValueError("Unsafe GGUF transaction journal entry.")
+        seen_finals.add(final)
+        validated_managed.append(
+            {"final": final, "backup": backup, "had_existing": had_existing}
+        )
+    if seen_finals != expected_finals:
+        raise ValueError("Invalid GGUF transaction journal managed artifact set.")
+
+    validated_staged: list[str] = []
+    staged_finals: set[str] = set()
+    for staged_name in staged:
+        if not isinstance(staged_name, str) or staged_name in validated_staged:
+            raise ValueError("Unsafe GGUF transaction staged artifact.")
+        matched_final = next(
+            (
+                final
+                for final in expected_finals
+                if re.fullmatch(
+                    rf"\.{re.escape(final)}\.[0-9a-f]{{32}}\.tmp",
+                    staged_name,
+                )
+            ),
+            None,
+        )
+        if matched_final is None or matched_final in staged_finals:
+            raise ValueError("Unsafe GGUF transaction staged artifact.")
+        staged_finals.add(matched_final)
+        validated_staged.append(staged_name)
+    if not {"model.onnx", _MANIFEST_NAME}.issubset(staged_finals):
+        raise ValueError("GGUF transaction journal omits required staged artifacts.")
+    return {"managed": validated_managed, "staged": validated_staged}
+
+
+def save_reuse_package(
     model: ir.Model,
     path: str | Path,
     plan: GGUFReusePlan,
     *,
     callback=None,
 ) -> tuple[str, ...]:
-    """Save mixed GGUF references plus one converted-weight sidecar."""
+    """Transactionally save mixed GGUF references plus a converted sidecar."""
     path = Path(path)
+    _recover_transaction(path.parent)
     _validate_source(plan, path.parent)
+    token = uuid.uuid4().hex
+    staged_model = path.with_name(f".{path.name}.{token}.tmp")
+    staged_sidecar = path.with_name(f".{_SIDECAR_NAME}.{token}.tmp")
+    staged_manifest = path.with_name(f".{_MANIFEST_NAME}.{token}.tmp")
+    final_sidecar = path.parent / _SIDECAR_NAME
+    final_manifest = path.parent / _MANIFEST_NAME
 
     memory_initializers = [
         value
@@ -190,69 +607,80 @@ def save_reuse_model(
             external_tensors = ir.external_data.convert_tensors_to_external(
                 original_tensors,
                 base_dir=path.parent,
-                relative_path=_SIDECAR_NAME,
+                relative_path=staged_sidecar.name,
                 callback=callback,
             )
             for value, external_tensor in zip(
                 memory_initializers, external_tensors, strict=True
             ):
-                value.const_value = external_tensor
-        ir.save(model, path)
+                value.const_value = ir.ExternalTensor(
+                    _SIDECAR_NAME,
+                    external_tensor.offset,
+                    external_tensor.length,
+                    external_tensor.dtype,
+                    shape=external_tensor.shape,
+                    name=external_tensor.name,
+                    base_dir=path.parent,
+                )
+            _fsync_file(staged_sidecar)
+        ir.save(model, staged_model)
+        _fsync_file(staged_model)
+        _write_json(staged_manifest, _manifest_payload(plan, converted_names))
+        verify_gguf_reuse_manifest(
+            path.parent,
+            model_path=staged_model,
+            manifest_path=staged_manifest,
+            sidecar_path=staged_sidecar if memory_initializers else None,
+        )
+        replacements = {
+            path: staged_model,
+            final_manifest: staged_manifest,
+        }
+        if memory_initializers:
+            replacements[final_sidecar] = staged_sidecar
+        _replace_artifacts(
+            replacements,
+            (path, final_sidecar, final_manifest),
+        )
     finally:
         for value, tensor in zip(memory_initializers, original_tensors, strict=True):
             value.const_value = tensor
+        staged_model.unlink(missing_ok=True)
+        staged_sidecar.unlink(missing_ok=True)
+        staged_manifest.unlink(missing_ok=True)
 
     return converted_names
 
 
-def write_reuse_manifest(
-    directory: str | Path,
-    plan: GGUFReusePlan,
-    converted_tensors: tuple[str, ...],
-) -> None:
-    """Write source identity and per-tensor routing without runtime claims."""
-    payload = {
-        "format": "mobius.gguf-external-data.v1",
-        "source": {
-            "location": plan.source_path.name,
-            "size": plan.size,
-            "sha256": plan.sha256,
-        },
-        "reused_tensors": [
-            {
-                "initializer": tensor.initializer,
-                "source_tensor": tensor.source_name,
-                "offset": tensor.offset,
-                "length": tensor.length,
-                "qtype": tensor.qtype,
-            }
-            for tensor in plan.tensors
-        ],
-        "converted_tensors": list(converted_tensors),
-        "runtime_verification": (
-            "ONNX runtimes resolve location/offset/length but do not enforce this SHA-256."
-        ),
-    }
-    manifest_path = Path(directory) / _MANIFEST_NAME
-    manifest_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
-
-
-def verify_gguf_reuse_manifest(directory: str | Path) -> None:
-    """Verify the packaged GGUF's size, digest, and pinned tensor ranges."""
-    root = Path(directory)
-    manifest = json.loads((root / _MANIFEST_NAME).read_text())
-    source_info = manifest["source"]
-    location = source_info["location"]
+def _safe_flat_location(location: str) -> bool:
     posix = PurePosixPath(location)
     windows = PureWindowsPath(location)
-    if (
+    return not (
         posix.is_absolute()
         or windows.is_absolute()
         or windows.drive
         or posix.parts != (location,)
         or windows.parts != (location,)
         or location in {".", ".."}
-    ):
+    )
+
+
+def verify_gguf_reuse_manifest(
+    directory: str | Path,
+    *,
+    model_path: str | Path | None = None,
+    manifest_path: str | Path | None = None,
+    sidecar_path: str | Path | None = None,
+) -> None:
+    """Verify the packaged GGUF's size, digest, and pinned tensor ranges."""
+    root = Path(directory)
+    if model_path is None and manifest_path is None and sidecar_path is None:
+        _recover_transaction(root)
+    manifest_file = Path(manifest_path) if manifest_path is not None else root / _MANIFEST_NAME
+    manifest = json.loads(manifest_file.read_text())
+    source_info = manifest["source"]
+    location = source_info["location"]
+    if not _safe_flat_location(location):
         raise ValueError(f"Unsafe GGUF manifest location: {location!r}")
     source = root / location
     if source.is_symlink() or not source.is_file():
@@ -262,26 +690,233 @@ def verify_gguf_reuse_manifest(directory: str | Path) -> None:
         or _sha256(source) != source_info["sha256"]
     ):
         raise ValueError("GGUF source identity mismatch (size or SHA-256).")
-    for tensor in manifest["reused_tensors"]:
+    reused_entries = manifest["reused_tensors"]
+    converted_names = manifest["converted_tensors"]
+    if len({entry["initializer"] for entry in reused_entries}) != len(reused_entries):
+        raise ValueError("GGUF reuse manifest contains duplicate initializer routes.")
+    if len(set(converted_names)) != len(converted_names):
+        raise ValueError("GGUF reuse manifest contains duplicate converted tensors.")
+    reused_names = {entry["initializer"] for entry in reused_entries}
+    if reused_names.intersection(converted_names):
+        raise ValueError("GGUF reused and converted initializer routes must be disjoint.")
+
+    from mobius.integrations.gguf._reader import GGUFModel
+
+    gguf_model = GGUFModel(source)
+    reused_by_name = {entry["initializer"]: entry for entry in reused_entries}
+    for tensor in reused_entries:
         if tensor["offset"] < 0 or tensor["length"] <= 0:
             raise ValueError(f"Invalid GGUF range for {tensor['initializer']!r}.")
         if tensor["offset"] + tensor["length"] > source_info["size"]:
             raise ValueError(f"GGUF range exceeds the source for {tensor['initializer']!r}.")
-
-    model = ir.load(root / "model.onnx")
-    for tensor in manifest["reused_tensors"]:
-        initializer = model.graph.initializers.get(tensor["initializer"])
-        external = None if initializer is None else initializer.const_value
-        if not isinstance(external, ir.ExternalTensor):
-            raise ValueError(
-                f"Manifest initializer {tensor['initializer']!r} is not external."
-            )
-        if (
-            external.location != location
-            or external.offset != tensor["offset"]
-            or external.length != tensor["length"]
+        actual_offset, actual_length, actual_qtype = gguf_model.tensor_storage_range(
+            tensor["source_tensor"]
+        )
+        if (actual_offset, actual_length, actual_qtype) != (
+            tensor["offset"],
+            tensor["length"],
+            tensor["qtype"],
         ):
             raise ValueError(
-                f"Manifest range does not match ONNX initializer "
-                f"{tensor['initializer']!r}."
+                f"Manifest GGUF route does not match source tensor "
+                f"{tensor['source_tensor']!r}."
             )
+
+    model_file = Path(model_path) if model_path is not None else root / "model.onnx"
+    model = ir.load(model_file)
+    external_by_name: dict[str, ir.ExternalTensor] = {}
+    external_values_by_name: dict[str, ir.Value] = {}
+    nodes_by_name: dict[str, ir.Node] = {}
+    for graph in model.graphs():
+        for node in graph:
+            if node.name:
+                nodes_by_name[node.name] = node
+        for initializer in graph.initializers.values():
+            external = initializer.const_value
+            if not isinstance(external, ir.ExternalTensor):
+                continue
+            if initializer.name in external_by_name:
+                raise ValueError(
+                    f"External initializer name {initializer.name!r} is ambiguous."
+                )
+            external_by_name[initializer.name] = external
+            external_values_by_name[initializer.name] = initializer
+            if not _safe_flat_location(str(external.location)):
+                raise ValueError(
+                    f"Unsafe external initializer location: {external.location!r}."
+                )
+
+    sidecar_file = Path(sidecar_path) if sidecar_path is not None else root / _SIDECAR_NAME
+    sidecar_size = sidecar_file.stat().st_size if sidecar_file.is_file() else None
+    sidecar_ranges: list[tuple[int, int, str]] = []
+    for name, external in external_by_name.items():
+        if external.location == location:
+            tensor = reused_by_name.get(name)
+            if tensor is None:
+                raise ValueError(f"Unmanifested GGUF external initializer {name!r}.")
+            expected_dtype = _FLOAT_QTYPE_DTYPES.get(tensor["qtype"], ir.DataType.UINT8)
+            source_shape = tuple(tensor["source_shape"])
+            if (
+                external.dtype != expected_dtype
+                or external.nbytes != tensor["length"]
+                or tuple(int(dim) for dim in external.shape) != source_shape
+            ):
+                raise ValueError(
+                    f"GGUF initializer {name!r} has incompatible dtype, shape, or byte length."
+                )
+            if external.offset != tensor["offset"] or external.length != tensor["length"]:
+                raise ValueError(f"Manifest range does not match ONNX initializer {name!r}.")
+            _verify_transform_graph(
+                name,
+                external_values_by_name[name],
+                tensor,
+                nodes_by_name,
+            )
+        elif external.location == _SIDECAR_NAME:
+            if name not in converted_names:
+                raise ValueError(f"Unmanifested sidecar initializer {name!r}.")
+            if (
+                sidecar_size is None
+                or external.offset is None
+                or external.length is None
+                or external.offset < 0
+                or external.length <= 0
+                or external.offset + external.length > sidecar_size
+            ):
+                raise ValueError(f"Invalid sidecar range for initializer {name!r}.")
+            sidecar_ranges.append((external.offset, external.offset + external.length, name))
+        else:
+            raise ValueError(
+                f"External initializer {name!r} uses unapproved location "
+                f"{external.location!r}."
+            )
+
+    for tensor in reused_entries:
+        external = external_by_name.get(tensor["initializer"])
+        if external is None or external.location != location:
+            raise ValueError(
+                f"Manifest initializer {tensor['initializer']!r} is not GGUF-backed."
+            )
+    for name in converted_names:
+        external = external_by_name.get(name)
+        if external is None or external.location != _SIDECAR_NAME:
+            raise ValueError(
+                f"Converted initializer {name!r} is not stored in {_SIDECAR_NAME!r}."
+            )
+    previous_end = 0
+    for start, end, name in sorted(sidecar_ranges):
+        if start < previous_end:
+            raise ValueError(f"Overlapping sidecar range for initializer {name!r}.")
+        previous_end = end
+
+
+def _verify_transform_graph(
+    initializer_name: str,
+    initializer: ir.Value,
+    route: dict,
+    nodes_by_name: dict[str, ir.Node],
+) -> None:
+    transform = route["transform"]
+    source_shape = tuple(route["source_shape"])
+    final_shape = tuple(route["final_shape"])
+    parameter = route["transform_parameter"]
+    if transform is None:
+        if source_shape != final_shape:
+            raise ValueError(
+                f"Untransformed GGUF initializer {initializer_name!r} changes shape."
+            )
+        return
+
+    suffixes = {
+        "transpose": (("Transpose", "Transpose"),),
+        "subtract_one": (("Sub", "Sub"),),
+        "log_neg": (("Neg", "Neg"), ("Log", "Log")),
+        "reshape": (("Reshape", "Reshape"),),
+        "llama_qk_permute": (
+            ("Reshape1", "Reshape"),
+            ("Transpose", "Transpose"),
+            ("Reshape2", "Reshape"),
+        ),
+    }
+    try:
+        expected_nodes = suffixes[transform]
+    except KeyError as error:
+        raise ValueError(f"Unknown manifest transform {transform!r}.") from error
+
+    prefix = f"{initializer_name}.gguf_reuse"
+    nodes: list[ir.Node] = []
+    for suffix, op_type in expected_nodes:
+        node = nodes_by_name.get(f"{prefix}.{suffix}")
+        if node is None or node.op_type != op_type:
+            raise ValueError(f"Missing or invalid {transform} graph for {initializer_name!r}.")
+        nodes.append(node)
+    if not nodes[0].inputs or nodes[0].inputs[0] is None:
+        raise ValueError(f"Transform graph for {initializer_name!r} has no source input.")
+    if nodes[0].inputs[0].name != initializer_name:
+        raise ValueError(f"Transform graph for {initializer_name!r} uses the wrong source.")
+    uses = initializer.uses()
+    if len(uses) != 1 or uses[0][0].name != nodes[0].name:
+        raise ValueError(
+            f"GGUF initializer {initializer_name!r} bypasses its transform graph."
+        )
+    output = nodes[-1].outputs[0]
+    if output.shape is None or tuple(int(dim) for dim in output.shape) != final_shape:
+        raise ValueError(f"Transform output shape is wrong for {initializer_name!r}.")
+
+    if transform == "transpose":
+        expected_perm = tuple(reversed(range(len(source_shape))))
+        if (
+            tuple(reversed(source_shape)) != final_shape
+            or tuple(nodes[0].attributes["perm"].as_ints()) != expected_perm
+        ):
+            raise ValueError(f"Transpose semantics are wrong for {initializer_name!r}.")
+    if transform in {"subtract_one", "log_neg", "llama_qk_permute"}:
+        if source_shape != final_shape:
+            raise ValueError(f"Transform shapes are inconsistent for {initializer_name!r}.")
+    if transform == "subtract_one":
+        constant = nodes[0].inputs[1]
+        if (
+            constant is None
+            or constant.const_value is None
+            or constant.const_value.numpy().shape != ()
+            or not np.isclose(float(constant.const_value.numpy()), 1.0)
+        ):
+            raise ValueError(f"Norm offset constant is wrong for {initializer_name!r}.")
+    if transform == "log_neg" and nodes[1].inputs[0] is not nodes[0].outputs[0]:
+        raise ValueError(f"Log/Neg wiring is wrong for {initializer_name!r}.")
+    if transform == "reshape":
+        shape_input = nodes[0].inputs[1]
+        if (
+            np.prod(source_shape) != np.prod(final_shape)
+            or shape_input is None
+            or shape_input.const_value is None
+            or tuple(int(value) for value in shape_input.const_value.numpy()) != final_shape
+        ):
+            raise ValueError(f"Reshape semantics are wrong for {initializer_name!r}.")
+    if transform == "llama_qk_permute":
+        if not isinstance(parameter, int) or source_shape[0] % (parameter * 2):
+            raise ValueError(f"Invalid Q/K head count for {initializer_name!r}.")
+        dim = source_shape[0] // parameter // 2
+        expanded_shape = (parameter, dim, 2, *source_shape[1:])
+        permuted_shape = (parameter, 2, dim, *source_shape[1:])
+        expanded = nodes[0].outputs[0]
+        permuted = nodes[1].outputs[0]
+        shape1 = nodes[0].inputs[1]
+        shape2 = nodes[2].inputs[1]
+        expected_perm = (0, 2, 1, *range(3, len(expanded_shape)))
+        if (
+            expanded.shape is None
+            or tuple(int(value) for value in expanded.shape) != expanded_shape
+            or permuted.shape is None
+            or tuple(int(value) for value in permuted.shape) != permuted_shape
+            or nodes[1].inputs[0] is not expanded
+            or nodes[2].inputs[0] is not permuted
+            or tuple(nodes[1].attributes["perm"].as_ints()) != expected_perm
+            or shape1 is None
+            or shape1.const_value is None
+            or tuple(int(value) for value in shape1.const_value.numpy()) != expanded_shape
+            or shape2 is None
+            or shape2.const_value is None
+            or tuple(int(value) for value in shape2.const_value.numpy()) != source_shape
+        ):
+            raise ValueError(f"Q/K permutation shapes are wrong for {initializer_name!r}.")

--- a/src/mobius/integrations/gguf/_reuse.py
+++ b/src/mobius/integrations/gguf/_reuse.py
@@ -11,8 +11,10 @@ import hashlib
 import json
 import os
 import re
+import stat
 import uuid
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, TypedDict
@@ -23,11 +25,19 @@ import onnx_ir as ir
 if TYPE_CHECKING:
     from mobius._model_package import ModelPackage
 
+if os.name == "nt":
+    import msvcrt
+else:
+    import fcntl
+
 _MANIFEST_NAME = "gguf-reuse.json"
 _SIDECAR_NAME = "model.onnx.data"
 _TRANSACTION_NAME = ".gguf-reuse.transaction.json"
+_LOCK_NAME = ".gguf-reuse.lock"
 _EXTERNAL_WEIGHT_THRESHOLD = 256
-_GENERATED_NAMES = frozenset({"model.onnx", _SIDECAR_NAME, _MANIFEST_NAME, _TRANSACTION_NAME})
+_GENERATED_NAMES = frozenset(
+    {"model.onnx", _SIDECAR_NAME, _MANIFEST_NAME, _TRANSACTION_NAME, _LOCK_NAME}
+)
 _FLOAT_QTYPE_DTYPES = {
     "F32": ir.DataType.FLOAT,
     "F16": ir.DataType.FLOAT16,
@@ -41,6 +51,7 @@ class _TransactionEntry(TypedDict):
 
 
 class _TransactionJournal(TypedDict):
+    phase: str
     managed: list[_TransactionEntry]
     staged: list[str]
 
@@ -387,10 +398,141 @@ def _manifest_payload(
     }
 
 
-def _write_json(path: Path, payload: Mapping[str, object]) -> None:
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
-    with path.open("rb") as stream:
-        os.fsync(stream.fileno())
+def _open_exclusive(path: Path) -> int:
+    """Create a regular file without following a pre-existing link."""
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    return os.open(path, flags, 0o600)
+
+
+def _open_lock_path(path: Path) -> int:
+    """Open or create the persistent lock without accepting an entry swap."""
+    flags = os.O_RDWR | os.O_CREAT | os.O_EXCL
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        return os.open(path, flags, 0o600)
+    except FileExistsError:
+        entry_identity = path.lstat()
+        if not stat.S_ISREG(entry_identity.st_mode):
+            raise ValueError(f"Unsafe GGUF lock artifact: {path}")
+        flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(path, flags)
+        opened_identity = os.fstat(descriptor)
+        current_identity = path.lstat()
+        identities = (
+            (entry_identity.st_dev, entry_identity.st_ino),
+            (opened_identity.st_dev, opened_identity.st_ino),
+            (current_identity.st_dev, current_identity.st_ino),
+        )
+        if len(set(identities)) != 1 or not stat.S_ISREG(opened_identity.st_mode):
+            os.close(descriptor)
+            raise ValueError(f"Unsafe GGUF lock artifact: {path}")
+        return descriptor
+
+
+def _write_json_exclusive(path: Path, payload: Mapping[str, object]) -> None:
+    encoded = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode()
+    descriptor = _open_exclusive(path)
+    try:
+        with os.fdopen(descriptor, "wb", closefd=False) as stream:
+            stream.write(encoded)
+            stream.flush()
+            os.fsync(stream.fileno())
+    finally:
+        os.close(descriptor)
+
+
+def _require_regular_or_missing(path: Path, *, artifact: str) -> None:
+    """Reject links, directories, devices, and sockets at generated paths."""
+    try:
+        mode = path.lstat().st_mode
+    except FileNotFoundError:
+        return
+    if not stat.S_ISREG(mode):
+        raise ValueError(f"Unsafe GGUF {artifact} artifact: {path}")
+
+
+def _acquire_file_lock(descriptor: int, *, shared: bool = False) -> None:
+    try:
+        if os.name == "nt":
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            mode = msvcrt.LK_NBRLCK if shared else msvcrt.LK_NBLCK
+            msvcrt.locking(descriptor, mode, 1)
+        else:
+            mode = fcntl.LOCK_SH if shared else fcntl.LOCK_EX
+            fcntl.flock(descriptor, mode | fcntl.LOCK_NB)
+    except OSError as error:
+        raise ValueError("GGUF package is locked by active writer.") from error
+
+
+def _release_file_lock(descriptor: int) -> None:
+    if os.name == "nt":
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+    else:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+
+
+@contextmanager
+def _package_lock(root: Path) -> Iterator[None]:
+    """Serialize package verification, recovery, and replacement."""
+    lock_path = root / _LOCK_NAME
+    _require_regular_or_missing(lock_path, artifact="lock")
+    descriptor = _open_lock_path(lock_path)
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise ValueError(f"Unsafe GGUF lock artifact: {lock_path}")
+        # Windows byte-range locks require the byte to exist.
+        if os.fstat(descriptor).st_size == 0:
+            os.write(descriptor, b"\n")
+            os.fsync(descriptor)
+        _acquire_file_lock(descriptor)
+        _fsync_directory(root)
+        try:
+            yield
+        finally:
+            _release_file_lock(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+@contextmanager
+def _verification_lock(root: Path) -> Iterator[None]:
+    """Hold a non-mutating shared lock while reading an installed package."""
+    lock_path = root / _LOCK_NAME
+    _require_regular_or_missing(lock_path, artifact="lock")
+    if not lock_path.exists():
+        try:
+            descriptor = _open_lock_path(lock_path)
+            if os.fstat(descriptor).st_size == 0:
+                os.write(descriptor, b"\n")
+                os.fsync(descriptor)
+        except PermissionError:
+            # A read-only legacy package cannot admit a writer either.
+            yield
+            return
+    else:
+        entry_identity = lock_path.lstat()
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(lock_path, flags)
+        opened_identity = os.fstat(descriptor)
+        current_identity = lock_path.lstat()
+        identities = (
+            (entry_identity.st_dev, entry_identity.st_ino),
+            (opened_identity.st_dev, opened_identity.st_ino),
+            (current_identity.st_dev, current_identity.st_ino),
+        )
+        if len(set(identities)) != 1 or not stat.S_ISREG(opened_identity.st_mode):
+            os.close(descriptor)
+            raise ValueError(f"Unsafe GGUF lock artifact: {lock_path}")
+    try:
+        _acquire_file_lock(descriptor, shared=True)
+        try:
+            yield
+        finally:
+            _release_file_lock(descriptor)
+    finally:
+        os.close(descriptor)
 
 
 def _fsync_file(path: Path) -> None:
@@ -414,13 +556,34 @@ def _replace_artifacts(
 ) -> None:
     """Install staged files with a durable rollback journal."""
     root = managed_paths[0].parent
-    _recover_transaction(root)
+    with _package_lock(root):
+        _recover_transaction_locked(root, preserve=frozenset(replacements.values()))
+        _replace_artifacts_locked(replacements, managed_paths)
+
+
+def _replace_artifacts_locked(
+    replacements: dict[Path, Path],
+    managed_paths: tuple[Path, ...],
+) -> None:
+    """Install staged files while the caller owns the package lock."""
+    root = managed_paths[0].parent
     _require_hard_link_backups(root, managed_paths)
     token = uuid.uuid4().hex
     backups: dict[Path, Path] = {}
     installed: list[Path] = []
     transaction_path = root / _TRANSACTION_NAME
+    committed_path = root / f".{_TRANSACTION_NAME}.{token}.tmp"
+    _require_regular_or_missing(transaction_path, artifact="transaction journal")
+    if transaction_path.exists():
+        raise ValueError(f"Unexpected GGUF transaction journal: {transaction_path}")
+    for final_path in managed_paths:
+        _require_regular_or_missing(final_path, artifact="managed")
+    for staged_path in replacements.values():
+        _require_regular_or_missing(staged_path, artifact="staged")
+        if not staged_path.is_file():
+            raise ValueError(f"Missing GGUF staged artifact: {staged_path}")
     journal: _TransactionJournal = {
+        "phase": "replacing",
         "managed": [
             {
                 "final": path.name,
@@ -431,12 +594,12 @@ def _replace_artifacts(
         ],
         "staged": [path.name for path in replacements.values()],
     }
-    _write_json(transaction_path, journal)
-    _fsync_directory(root)
+    _publish_json(transaction_path, journal, token)
     try:
         for entry, final_path in zip(journal["managed"], managed_paths, strict=True):
             if final_path.exists():
                 backup = root / entry["backup"]
+                _require_regular_or_missing(backup, artifact="backup")
                 os.link(final_path, backup)
                 backups[final_path] = backup
         _fsync_directory(root)
@@ -448,6 +611,11 @@ def _replace_artifacts(
             os.replace(staged_path, final_path)
             installed.append(final_path)
         _fsync_directory(root)
+        committed_journal = dict(journal)
+        committed_journal["phase"] = "committed"
+        _write_json_exclusive(committed_path, committed_journal)
+        os.replace(committed_path, transaction_path)
+        _fsync_directory(root)
     except Exception:
         for final_path in reversed(installed):
             final_path.unlink(missing_ok=True)
@@ -455,13 +623,15 @@ def _replace_artifacts(
             os.replace(backup, final_path)
             backup.unlink(missing_ok=True)
         transaction_path.unlink(missing_ok=True)
+        committed_path.unlink(missing_ok=True)
         _fsync_directory(root)
         raise
     else:
-        transaction_path.unlink()
-        _fsync_directory(root)
         for backup in backups.values():
             backup.unlink(missing_ok=True)
+        _fsync_directory(root)
+        transaction_path.unlink()
+        _fsync_directory(root)
 
 
 def _require_hard_link_backups(root: Path, managed_paths: tuple[Path, ...]) -> None:
@@ -472,7 +642,11 @@ def _require_hard_link_backups(root: Path, managed_paths: tuple[Path, ...]) -> N
     probe = root / f".gguf-reuse.{token}.link-probe"
     linked = root / f".gguf-reuse.{token}.link-probe-copy"
     try:
-        probe.write_bytes(b"probe")
+        descriptor = _open_exclusive(probe)
+        os.write(descriptor, b"probe")
+        os.fsync(descriptor)
+        os.close(descriptor)
+        _require_regular_or_missing(linked, artifact="link probe")
         _fsync_file(probe)
         os.link(probe, linked)
         _fsync_directory(root)
@@ -489,21 +663,79 @@ def _require_hard_link_backups(root: Path, managed_paths: tuple[Path, ...]) -> N
 
 def _recover_transaction(root: Path) -> None:
     """Roll back an interrupted artifact replacement before using the package."""
+    with _package_lock(root):
+        _recover_transaction_locked(root)
+
+
+def _recover_transaction_locked(
+    root: Path, *, preserve: frozenset[Path] = frozenset()
+) -> None:
+    """Roll back an interrupted replacement while owning the package lock."""
     transaction_path = root / _TRANSACTION_NAME
-    if not transaction_path.is_file():
+    _require_regular_or_missing(transaction_path, artifact="transaction journal")
+    if not transaction_path.exists():
+        _cleanup_stale_temporary_artifacts_locked(root, preserve=preserve)
         return
     journal = _validated_transaction_journal(transaction_path)
+    if journal["phase"] == "committed":
+        for entry in journal["managed"]:
+            backup = root / entry["backup"]
+            _require_regular_or_missing(backup, artifact="backup")
+            backup.unlink(missing_ok=True)
+        for staged_name in journal["staged"]:
+            staged_path = root / staged_name
+            _require_regular_or_missing(staged_path, artifact="staged")
+            staged_path.unlink(missing_ok=True)
+        transaction_path.unlink()
+        _fsync_directory(root)
+        _cleanup_stale_temporary_artifacts_locked(root)
+        return
     for entry in journal["managed"]:
         final_path = root / entry["final"]
         backup = root / entry["backup"]
+        _require_regular_or_missing(final_path, artifact="managed")
+        _require_regular_or_missing(backup, artifact="backup")
         if backup.exists():
             os.replace(backup, final_path)
             backup.unlink(missing_ok=True)
         elif not entry["had_existing"]:
             final_path.unlink(missing_ok=True)
     for staged_name in journal["staged"]:
-        (root / staged_name).unlink(missing_ok=True)
+        staged_path = root / staged_name
+        _require_regular_or_missing(staged_path, artifact="staged")
+        staged_path.unlink(missing_ok=True)
     transaction_path.unlink(missing_ok=True)
+    _fsync_directory(root)
+    _cleanup_stale_temporary_artifacts_locked(root)
+
+
+def _publish_json(path: Path, payload: Mapping[str, object], token: str) -> None:
+    """Durably publish JSON without exposing an empty or partial final file."""
+    temporary = path.with_name(f".{path.name}.{token}.tmp")
+    _require_regular_or_missing(temporary, artifact="transaction journal temporary")
+    try:
+        _write_json_exclusive(temporary, payload)
+        os.replace(temporary, path)
+        _fsync_directory(path.parent)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _cleanup_stale_temporary_artifacts_locked(
+    root: Path, *, preserve: frozenset[Path] = frozenset()
+) -> None:
+    """Remove only generated temporary files while no writer can be active."""
+    final_names = {"model.onnx", _SIDECAR_NAME, _MANIFEST_NAME, _TRANSACTION_NAME}
+    for path in root.iterdir():
+        if path in preserve:
+            continue
+        if not any(
+            re.fullmatch(rf"\.{re.escape(name)}\.[0-9a-f]{{32}}\.tmp", path.name)
+            for name in final_names
+        ):
+            continue
+        _require_regular_or_missing(path, artifact="stale temporary")
+        path.unlink()
     _fsync_directory(root)
 
 
@@ -514,8 +746,13 @@ def _validated_transaction_journal(path: Path) -> _TransactionJournal:
         raise TypeError("Invalid GGUF transaction journal.")
     managed = journal.get("managed")
     staged = journal.get("staged")
+    phase = journal.get("phase", "replacing")
     expected_finals = {"model.onnx", _SIDECAR_NAME, _MANIFEST_NAME}
-    if not isinstance(managed, list) or not isinstance(staged, list):
+    if (
+        phase not in {"replacing", "committed"}
+        or not isinstance(managed, list)
+        or not isinstance(staged, list)
+    ):
         raise TypeError("Invalid GGUF transaction journal.")
     if len(managed) != len(expected_finals):
         raise ValueError("Invalid GGUF transaction journal managed artifact set.")
@@ -570,7 +807,7 @@ def _validated_transaction_journal(path: Path) -> _TransactionJournal:
         validated_staged.append(staged_name)
     if not {"model.onnx", _MANIFEST_NAME}.issubset(staged_finals):
         raise ValueError("GGUF transaction journal omits required staged artifacts.")
-    return {"managed": validated_managed, "staged": validated_staged}
+    return {"phase": phase, "managed": validated_managed, "staged": validated_staged}
 
 
 def save_reuse_package(
@@ -582,72 +819,78 @@ def save_reuse_package(
 ) -> tuple[str, ...]:
     """Transactionally save mixed GGUF references plus a converted sidecar."""
     path = Path(path)
-    _recover_transaction(path.parent)
-    _validate_source(plan, path.parent)
-    token = uuid.uuid4().hex
-    staged_model = path.with_name(f".{path.name}.{token}.tmp")
-    staged_sidecar = path.with_name(f".{_SIDECAR_NAME}.{token}.tmp")
-    staged_manifest = path.with_name(f".{_MANIFEST_NAME}.{token}.tmp")
-    final_sidecar = path.parent / _SIDECAR_NAME
-    final_manifest = path.parent / _MANIFEST_NAME
+    with _package_lock(path.parent):
+        _recover_transaction_locked(path.parent)
+        _validate_source(plan, path.parent)
+        token = uuid.uuid4().hex
+        staged_model = path.with_name(f".{path.name}.{token}.tmp")
+        staged_sidecar = path.with_name(f".{_SIDECAR_NAME}.{token}.tmp")
+        staged_manifest = path.with_name(f".{_MANIFEST_NAME}.{token}.tmp")
+        final_sidecar = path.parent / _SIDECAR_NAME
+        final_manifest = path.parent / _MANIFEST_NAME
+        for staged_path in (staged_model, staged_sidecar, staged_manifest):
+            _require_regular_or_missing(staged_path, artifact="staged")
+            if staged_path.exists():
+                raise ValueError(f"Unexpected GGUF staged artifact: {staged_path}")
 
-    memory_initializers = [
-        value
-        for graph in model.graphs()
-        for value in graph.initializers.values()
-        if value.const_value is not None
-        and not isinstance(value.const_value, ir.ExternalTensor)
-        and value.const_value.nbytes > _EXTERNAL_WEIGHT_THRESHOLD
-    ]
-    original_tensors = [value.const_value for value in memory_initializers]
-    converted_names = tuple(sorted(value.name for value in memory_initializers))
+        memory_initializers = [
+            value
+            for graph in model.graphs()
+            for value in graph.initializers.values()
+            if value.const_value is not None
+            and not isinstance(value.const_value, ir.ExternalTensor)
+            and value.const_value.nbytes > _EXTERNAL_WEIGHT_THRESHOLD
+        ]
+        original_tensors = [value.const_value for value in memory_initializers]
+        converted_names = tuple(sorted(value.name for value in memory_initializers))
 
-    try:
-        if memory_initializers:
-            external_tensors = ir.external_data.convert_tensors_to_external(
-                original_tensors,
-                base_dir=path.parent,
-                relative_path=staged_sidecar.name,
-                callback=callback,
-            )
-            for value, external_tensor in zip(
-                memory_initializers, external_tensors, strict=True
-            ):
-                value.const_value = ir.ExternalTensor(
-                    _SIDECAR_NAME,
-                    external_tensor.offset,
-                    external_tensor.length,
-                    external_tensor.dtype,
-                    shape=external_tensor.shape,
-                    name=external_tensor.name,
+        try:
+            if memory_initializers:
+                external_tensors = ir.external_data.convert_tensors_to_external(
+                    original_tensors,
                     base_dir=path.parent,
+                    relative_path=staged_sidecar.name,
+                    callback=callback,
                 )
-            _fsync_file(staged_sidecar)
-        ir.save(model, staged_model)
-        _fsync_file(staged_model)
-        _write_json(staged_manifest, _manifest_payload(plan, converted_names))
-        verify_gguf_reuse_manifest(
-            path.parent,
-            model_path=staged_model,
-            manifest_path=staged_manifest,
-            sidecar_path=staged_sidecar if memory_initializers else None,
-        )
-        replacements = {
-            path: staged_model,
-            final_manifest: staged_manifest,
-        }
-        if memory_initializers:
-            replacements[final_sidecar] = staged_sidecar
-        _replace_artifacts(
-            replacements,
-            (path, final_sidecar, final_manifest),
-        )
-    finally:
-        for value, tensor in zip(memory_initializers, original_tensors, strict=True):
-            value.const_value = tensor
-        staged_model.unlink(missing_ok=True)
-        staged_sidecar.unlink(missing_ok=True)
-        staged_manifest.unlink(missing_ok=True)
+                for value, external_tensor in zip(
+                    memory_initializers, external_tensors, strict=True
+                ):
+                    value.const_value = ir.ExternalTensor(
+                        _SIDECAR_NAME,
+                        external_tensor.offset,
+                        external_tensor.length,
+                        external_tensor.dtype,
+                        shape=external_tensor.shape,
+                        name=external_tensor.name,
+                        base_dir=path.parent,
+                    )
+                _fsync_file(staged_sidecar)
+            ir.save(model, staged_model)
+            _fsync_file(staged_model)
+            _write_json_exclusive(staged_manifest, _manifest_payload(plan, converted_names))
+            verify_gguf_reuse_manifest(
+                path.parent,
+                model_path=staged_model,
+                manifest_path=staged_manifest,
+                sidecar_path=staged_sidecar if memory_initializers else None,
+                _lock_held=True,
+            )
+            replacements = {
+                path: staged_model,
+                final_manifest: staged_manifest,
+            }
+            if memory_initializers:
+                replacements[final_sidecar] = staged_sidecar
+            _replace_artifacts_locked(
+                replacements,
+                (path, final_sidecar, final_manifest),
+            )
+        finally:
+            for value, tensor in zip(memory_initializers, original_tensors, strict=True):
+                value.const_value = tensor
+            for staged_path in (staged_model, staged_sidecar, staged_manifest):
+                _require_regular_or_missing(staged_path, artifact="staged")
+                staged_path.unlink(missing_ok=True)
 
     return converted_names
 
@@ -671,12 +914,40 @@ def verify_gguf_reuse_manifest(
     model_path: str | Path | None = None,
     manifest_path: str | Path | None = None,
     sidecar_path: str | Path | None = None,
+    _lock_held: bool = False,
 ) -> None:
     """Verify the packaged GGUF's size, digest, and pinned tensor ranges."""
     root = Path(directory)
-    if model_path is None and manifest_path is None and sidecar_path is None:
+    if not _lock_held:
+        recover = False
+        with _verification_lock(root):
+            transaction_path = root / _TRANSACTION_NAME
+            _require_regular_or_missing(transaction_path, artifact="transaction journal")
+            recover = (
+                model_path is None
+                and manifest_path is None
+                and sidecar_path is None
+                and transaction_path.exists()
+            )
+            if not recover:
+                return verify_gguf_reuse_manifest(
+                    root,
+                    model_path=model_path,
+                    manifest_path=manifest_path,
+                    sidecar_path=sidecar_path,
+                    _lock_held=True,
+                )
         _recover_transaction(root)
+        return verify_gguf_reuse_manifest(
+            root,
+            model_path=model_path,
+            manifest_path=manifest_path,
+            sidecar_path=sidecar_path,
+        )
     manifest_file = Path(manifest_path) if manifest_path is not None else root / _MANIFEST_NAME
+    _require_regular_or_missing(manifest_file, artifact="manifest")
+    if not manifest_file.is_file():
+        raise ValueError(f"GGUF reuse manifest is missing: {manifest_file}")
     manifest = json.loads(manifest_file.read_text())
     source_info = manifest["source"]
     location = source_info["location"]
@@ -723,6 +994,9 @@ def verify_gguf_reuse_manifest(
             )
 
     model_file = Path(model_path) if model_path is not None else root / "model.onnx"
+    _require_regular_or_missing(model_file, artifact="model")
+    if not model_file.is_file():
+        raise ValueError(f"GGUF reuse model is missing: {model_file}")
     model = ir.load(model_file)
     external_by_name: dict[str, ir.ExternalTensor] = {}
     external_values_by_name: dict[str, ir.Value] = {}
@@ -747,6 +1021,7 @@ def verify_gguf_reuse_manifest(
                 )
 
     sidecar_file = Path(sidecar_path) if sidecar_path is not None else root / _SIDECAR_NAME
+    _require_regular_or_missing(sidecar_file, artifact="sidecar")
     sidecar_size = sidecar_file.stat().st_size if sidecar_file.is_file() else None
     sidecar_ranges: list[tuple[int, int, str]] = []
     for name, external in external_by_name.items():
@@ -775,15 +1050,29 @@ def verify_gguf_reuse_manifest(
         elif external.location == _SIDECAR_NAME:
             if name not in converted_names:
                 raise ValueError(f"Unmanifested sidecar initializer {name!r}.")
+            shape = tuple(external.shape)
+            if any(not isinstance(dim, int) or dim < 0 for dim in shape):
+                raise ValueError(
+                    f"Unsupported sidecar dtype or shape for initializer {name!r}."
+                )
+            try:
+                expected_nbytes = external.nbytes
+            except (TypeError, ValueError) as error:
+                raise ValueError(
+                    f"Unsupported sidecar dtype or shape for initializer {name!r}."
+                ) from error
             if (
                 sidecar_size is None
                 or external.offset is None
                 or external.length is None
                 or external.offset < 0
                 or external.length <= 0
+                or external.length != expected_nbytes
                 or external.offset + external.length > sidecar_size
             ):
-                raise ValueError(f"Invalid sidecar range for initializer {name!r}.")
+                raise ValueError(
+                    f"Invalid sidecar range or byte length for initializer {name!r}."
+                )
             sidecar_ranges.append((external.offset, external.offset + external.length, name))
         else:
             raise ValueError(

--- a/src/mobius/integrations/gguf/_reuse.py
+++ b/src/mobius/integrations/gguf/_reuse.py
@@ -557,7 +557,7 @@ def _replace_artifacts(
     """Install staged files with a durable rollback journal."""
     root = managed_paths[0].parent
     with _package_lock(root):
-        _recover_transaction_locked(root, preserve=frozenset(replacements.values()))
+        _recover_transaction_locked(root)
         _replace_artifacts_locked(replacements, managed_paths)
 
 
@@ -667,14 +667,11 @@ def _recover_transaction(root: Path) -> None:
         _recover_transaction_locked(root)
 
 
-def _recover_transaction_locked(
-    root: Path, *, preserve: frozenset[Path] = frozenset()
-) -> None:
+def _recover_transaction_locked(root: Path) -> None:
     """Roll back an interrupted replacement while owning the package lock."""
     transaction_path = root / _TRANSACTION_NAME
     _require_regular_or_missing(transaction_path, artifact="transaction journal")
     if not transaction_path.exists():
-        _cleanup_stale_temporary_artifacts_locked(root, preserve=preserve)
         return
     journal = _validated_transaction_journal(transaction_path)
     if journal["phase"] == "committed":
@@ -688,7 +685,6 @@ def _recover_transaction_locked(
             staged_path.unlink(missing_ok=True)
         transaction_path.unlink()
         _fsync_directory(root)
-        _cleanup_stale_temporary_artifacts_locked(root)
         return
     for entry in journal["managed"]:
         final_path = root / entry["final"]
@@ -706,7 +702,6 @@ def _recover_transaction_locked(
         staged_path.unlink(missing_ok=True)
     transaction_path.unlink(missing_ok=True)
     _fsync_directory(root)
-    _cleanup_stale_temporary_artifacts_locked(root)
 
 
 def _publish_json(path: Path, payload: Mapping[str, object], token: str) -> None:
@@ -719,24 +714,6 @@ def _publish_json(path: Path, payload: Mapping[str, object], token: str) -> None
         _fsync_directory(path.parent)
     finally:
         temporary.unlink(missing_ok=True)
-
-
-def _cleanup_stale_temporary_artifacts_locked(
-    root: Path, *, preserve: frozenset[Path] = frozenset()
-) -> None:
-    """Remove only generated temporary files while no writer can be active."""
-    final_names = {"model.onnx", _SIDECAR_NAME, _MANIFEST_NAME, _TRANSACTION_NAME}
-    for path in root.iterdir():
-        if path in preserve:
-            continue
-        if not any(
-            re.fullmatch(rf"\.{re.escape(name)}\.[0-9a-f]{{32}}\.tmp", path.name)
-            for name in final_names
-        ):
-            continue
-        _require_regular_or_missing(path, artifact="stale temporary")
-        path.unlink()
-    _fsync_directory(root)
 
 
 def _validated_transaction_journal(path: Path) -> _TransactionJournal:

--- a/src/mobius/integrations/gguf/_runtime_package.py
+++ b/src/mobius/integrations/gguf/_runtime_package.py
@@ -64,6 +64,13 @@ def write_gguf_runtime_package(
     """
     if runtime not in ("onnx-genai", "ort-genai"):
         raise ValueError(f"Unknown runtime {runtime!r}; expected 'onnx-genai' or 'ort-genai'.")
+    if runtime == "ort-genai" and getattr(pkg, "gguf_reuse_plan", None) is not None:
+        raise ValueError(
+            "ORT GenAI packaging is not supported with reused GGUF weights because "
+            "genai_config.json has no supported setting that disables ORT constant "
+            "folding. Use direct ONNX Runtime with ORT_DISABLE_ALL, or build without "
+            "reuse_gguf_weights."
+        )
 
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/src/mobius/integrations/gguf/_runtime_package_test.py
+++ b/src/mobius/integrations/gguf/_runtime_package_test.py
@@ -94,6 +94,18 @@ class TestWriteGgufRuntimePackage:
                 runtime="tflite",
             )
 
+    def test_ort_genai_rejects_reused_gguf_weights(self, tmp_path):
+        pkg = _FakePackage()
+        pkg.gguf_reuse_plan = object()
+        with pytest.raises(ValueError, match="no supported setting"):
+            write_gguf_runtime_package(
+                pkg,
+                tmp_path / "m.gguf",
+                tmp_path / "out",
+                runtime="ort-genai",
+            )
+        assert not (tmp_path / "out").exists()
+
     def test_save_model_false_leaves_an_already_saved_graph_alone(self, tmp_path):
         """The CLI saves the graph itself, then asks only for runtime artifacts."""
         pkg = _FakePackage()

--- a/tests/gguf_test.py
+++ b/tests/gguf_test.py
@@ -561,6 +561,22 @@ class TestCLIBuildGGUF:
 
         assert build.call_args.kwargs["reuse_gguf_weights"] is True
 
+    def test_reuse_rejects_ort_genai_runtime(self, tmp_path):
+        from mobius.__main__ import main
+
+        with pytest.raises(SystemExit, match="cannot be combined"):
+            main(
+                [
+                    "build-gguf",
+                    str(tmp_path / "model.gguf"),
+                    "--output",
+                    str(tmp_path / "output"),
+                    "--reuse-gguf-weights",
+                    "--runtime",
+                    "ort-genai",
+                ]
+            )
+
     def test_ort_genai_runtime_is_forwarded_to_package_writer(self, tmp_path):
         """build-gguf forwards the selected runtime after saving the graph."""
         from mobius.__main__ import main

--- a/tests/gguf_test.py
+++ b/tests/gguf_test.py
@@ -476,6 +476,7 @@ class TestCLIBuildGGUF:
             main(["build-gguf", "--help"])
         out = capsys.readouterr().out
         assert "--dequantize" in out
+        assert "--reuse-gguf-weights" in out
         assert "--output OUTPUT_DIR" in out
         assert "--keep-quantized" not in out, "the unread deprecated alias was removed"
         assert "--max-shard-size" in out, "shard sizing applies to GGUF builds too"
@@ -536,6 +537,29 @@ class TestCLIBuildGGUF:
             )
 
         assert build.call_args.kwargs["keep_quantized"] is expected
+
+    def test_reuse_flag_is_forwarded(self, tmp_path):
+        """The explicit CLI opt-in reaches the GGUF API unchanged."""
+        from mobius.__main__ import main
+
+        package = mock.MagicMock()
+        package.__iter__.return_value = iter(())
+        package.values.return_value = iter(())
+        with mock.patch(
+            "mobius.integrations.gguf.build_from_gguf",
+            return_value=package,
+        ) as build:
+            main(
+                [
+                    "build-gguf",
+                    str(tmp_path / "model.gguf"),
+                    "--output",
+                    str(tmp_path / "output"),
+                    "--reuse-gguf-weights",
+                ]
+            )
+
+        assert build.call_args.kwargs["reuse_gguf_weights"] is True
 
     def test_ort_genai_runtime_is_forwarded_to_package_writer(self, tmp_path):
         """build-gguf forwards the selected runtime after saving the graph."""


### PR DESCRIPTION
## Summary

Stacked on #571 (`justinchuby-gguf-registry-foundation`). Adds an explicit opt-in path that publishes ONNX beside the original GGUF without writing a second full copy of byte-compatible weights.

```bash
mobius build-gguf output/model.gguf --output output/ --reuse-gguf-weights
```

```python
package = build_from_gguf("output/model.gguf", reuse_gguf_weights=True)
package.save("output/")
```

## Storage and transform behavior

- Unchanged F32/F16 tensors and consumer-compatible native IQ4_NL, IQ4_XS, IQ3_S, IQ3_XXS, IQ2_XXS, IQ2_XS, IQ2_S, IQ1_S, IQ1_M, and MXFP4 tensors point at exact GGUF `location + offset + length` ranges.
- Float transpose, norm offset, Llama Q/K row permutation, and Mamba `A_log`/shape transforms keep the source bytes and run as ONNX graph operations. Opaque packed UINT8 is never generically transposed.
- Repacked, requantized, dequantized, synthesized, or otherwise materialized large tensors are written exactly once to `model.onnx.data`.
- Disabling constant folding preserves the on-disk reuse but transformed weights may still allocate runtime buffers and add startup/execution cost.

## Persistence and verification

A persistent same-directory advisory lock serializes writers, recovery, and shared verification. Mixed saving stages and fsyncs the sidecar, model, and manifest, validates the complete staged package, then installs it through an atomically published durable transaction journal with hard-linked rollback backups. The journal records replacing/committed state so crashes cannot produce mixed rollback or leak full backup copies. Interrupted reruns recover before save/verification; failed reruns restore prior artifacts; obsolete sidecars are removed transactionally.

Recovery deletes only staged and backup paths owned by a structurally and path-validated journal; generated-looking filenames are never treated as proof of ownership. Lock, journal, staged, backup, model, manifest, and sidecar paths reject symlinks and non-regular artifacts. Lock acquisition validates directory-entry/opened inode identity; journal files are created through exclusive no-follow temporary files and atomic replacement.

`gguf-reuse.json` pins source location, size, SHA-256, source tensor/qtype/range, initializer dtype/length, source/final shapes, transform name, and transform parameters. Verification enumerates every ONNX external initializer: each must be either an exact manifest-pinned GGUF range or a non-overlapping range in the one permitted sidecar. Sidecar ranges must exactly equal the byte count implied by concrete non-negative shape and supported dtype. Verification rejects unmanifested/unsafe locations, wrong dtype/qtype/shape/ranges, mixed reused/converted claims, and mutated transform wiring/constants/permutations.

## Scope and runtime requirements

This PR supports one flat text-model package. The real little-endian GGUF must already be in the output directory. It rejects nested/non-flat packaging, mmproj/MTP packages, symlinks, unsafe hardlinks, generated-name collisions, changed source identity, safetensors output, and sidecar sharding rather than copying or linking the GGUF.

Use direct ONNX Runtime with graph optimization disabled:

```python
options = ort.SessionOptions()
options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
```

`--reuse-gguf-weights --runtime ort-genai` is rejected because the current `genai_config.json` schema has no supported setting that requires disabled constant folding.

## Validation

- 214 affected GGUF builder, ModelPackage, runtime-package, CLI, API, and option-parity tests pass.
- Synthetic mixed GGUF/sidecar execution matches the ordinary converted package numerically on ORT CPU with optimizations disabled.
- Tests cover writer/verifier ownership, committed and interrupted crash recovery, atomic journal publication, unsafe links/artifacts, source collisions, preservation of generated-looking source/user files, complete external enumeration, exact sidecar nbytes, qtype/dtype/range and transform mutations, source identity, hardlink capability, stale-sidecar removal, and exception rollback.
- `lintrunner f --output oneline --all-files` and `lintrunner -a` pass locally.

## Waiver

No multi-GB public GGUF was downloaded. Real-weight validation is deferred to avoid a large network/storage dependency; synthetic files use the real GGUF writer/reader, exact offsets, native block routes, mixed persistence, reload, and ORT execution.