### PR TITLE
Validate every stored GGUF quantization type

### DIFF
--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -123,10 +123,10 @@ execution-provider-dependent.
 
 F32-, F16-, and BF16-only GGUFs use the normal float import path even though
 `keep_quantized=True` is the default: there is no quantization to preserve.
-Quantized GGUFs containing only qtypes with no supported preservation target
-(for example, pure Q6_K or Q5_K weights) fail with an actionable error rather
-than silently becoming float. Pass `keep_quantized=False` to request that float
-conversion explicitly.
+Quantized GGUFs whose qtypes have no trustworthy decoder or compatible runtime
+kernel (currently `Q2_0`) fail with an actionable error. Decoder-backed formats
+such as `Q5_K` use the explicit dequantize/requantize route; they are not
+silently treated as preserved source quantization.
 
 ## Supported GGUF Architectures
 
@@ -226,19 +226,90 @@ implemented and validated. These include fused/interleaved or dual-form QKV
 ## Supported stored quantization types
 
 `mobius/integrations/gguf/_quant_registry.py` covers all 43 `ggml_type` slots
-at the same pinned commit and answers four separate questions per slot:
-whether the GGUF parse layer can read it, whether it can be dequantized to
-float, whether its blocks are handed to the runtime unchanged, and whether it
-can be repacked into a `MatMulNBits` affine layout.
+and all 25 active storage-quantized types at the same pinned commit. Every
+stored qtype has one explicit projection/output route. The table is generated
+from that registry and checked byte-for-byte by `_quant_registry_test.py`.
 
-- **Repacked to `MatMulNBits`**: `Q4_0`, `Q4_1`, `Q8_0`, `Q4_K`, `Q6_K`, `Q1_0`.
-- **Preserved byte-for-byte**: `MXFP4`, `IQ4_NL`, `IQ4_XS`, `IQ3_S`, `IQ3_XXS`,
-  `IQ2_XXS`, `IQ2_XS`, `IQ2_S`, `IQ1_S`, `IQ1_M`.
-- **Rejected**: the eight retired slots (`Q4_2`, `Q4_3`, `Q4_0_4_4`,
-  `Q4_0_4_8`, `Q4_0_8_8`, `IQ4_NL_4_4`, `IQ4_NL_4_8`, `IQ4_NL_8_8`), which have
-  a block size of 0 and are unreadable at the GGUF parse layer, and `Q8_1` /
-  `Q8_K`, which are compute-only intermediates that are never valid weight
-  storage.
+<!-- BEGIN GGUF QUANTIZATION MATRIX (generated; see _quant_registry.py) -->
+
+| Stored qtype | ID | Projection/output route | Direct exactness | Embedding route | Expert-major route | Non-MatMul route | Runtime |
+|---|---:|---|---|---|---|---|---|
+| `Q4_0` | 2 | affine repack | exact | affine repack | rejected | dequantize to float | deferred |
+| `Q4_1` | 3 | affine repack | lossy | affine repack | rejected | dequantize to float | deferred |
+| `Q5_0` | 6 | dequantize/requantize | — | dequantize/requantize | rejected | dequantize to float | deferred |
+| `Q5_1` | 7 | dequantize/requantize | — | dequantize/requantize | rejected | dequantize to float | deferred |
+| `Q8_0` | 8 | affine repack | exact | affine repack | rejected | dequantize to float | deferred |
+| `Q2_K` | 10 | dequantize/requantize | — | dequantize/requantize | rejected | dequantize to float | deferred |
+| `Q3_K` | 11 | dequantize/requantize | — | dequantize/requantize | rejected | dequantize to float | deferred |
+| `Q4_K` | 12 | affine repack | lossy | affine repack | rejected | dequantize to float | deferred |
+| `Q5_K` | 13 | dequantize/requantize | — | dequantize/requantize | rejected | dequantize to float | deferred |
+| `Q6_K` | 14 | affine repack | lossy | affine repack | rejected | dequantize to float | deferred |
+| `IQ2_XXS` | 16 | native byte-preserved | — | dequantize/requantize | native byte-preserved | dequantize to float | deferred |
+| `IQ2_XS` | 17 | native byte-preserved | — | dequantize/requantize | native byte-preserved | dequantize to float | deferred |
+| `IQ3_XXS` | 18 | native byte-preserved | — | dequantize/requantize | native byte-preserved | dequantize to float | deferred |
+| `IQ1_S` | 19 | native byte-preserved | — | dequantize/requantize | native byte-preserved | dequantize to float | deferred |
+| `IQ4_NL` | 20 | native byte-preserved | — | dequantize/requantize | native byte-preserved | dequantize to float | deferred |
+| `IQ3_S` | 21 | native byte-preserved | — | dequantize/requantize | native byte-preserved | dequantize to float | deferred |
+| `IQ2_S` | 22 | native byte-preserved | — | dequantize/requantize | native byte-preserved | dequantize to float | deferred |
+| `IQ4_XS` | 23 | native byte-preserved | — | dequantize/requantize | native byte-preserved | dequantize to float | deferred |
+| `IQ1_M` | 29 | native byte-preserved | — | dequantize/requantize | native byte-preserved | dequantize to float | deferred |
+| `TQ1_0` | 34 | dequantize/requantize | — | dequantize/requantize | rejected | dequantize to float | deferred |
+| `TQ2_0` | 35 | dequantize/requantize | — | dequantize/requantize | rejected | dequantize to float | deferred |
+| `MXFP4` | 39 | native byte-preserved | — | dequantize/requantize | native byte-preserved | dequantize to float | deferred |
+| `NVFP4` | 40 | dequantize/requantize | — | dequantize/requantize | rejected | dequantize to float | deferred |
+| `Q1_0` | 41 | affine repack | exact | affine repack | rejected | rejected | deferred |
+| `Q2_0` | 42 | rejected | — | rejected | rejected | rejected | deferred |
+
+<!-- END GGUF QUANTIZATION MATRIX -->
+
+`Q4_0`, `Q8_0`, and mainline `Q1_0` have exact formulas when the graph uses
+their direct affine target. Exactness is target-dependent: normalizing `Q8_0`
+to a mixed graph's 4-bit/block-32 target is lossy, while `Q1_0` is rejected
+when its exact 2-bit/block-128 target cannot be used because it has no decoder.
+`Q4_1` rounds its floating source offset to an integer zero point; `Q4_K` and
+`Q6_K` are decoded and requantized to 4-bit/block-32, so those direct affine
+routes are lossy. The remaining dequantize/requantize routes use the pinned
+`gguf-py` decoder and a 4-bit/block-32 target. `Q2_0` is rejected because the
+pinned package has neither a decoder nor a compatible runtime kernel.
+
+Native bytes are only valid for compatible `BlockQuantizedMatMul`
+projection/output weights. They are not a `GatherBlockQuantized` embedding
+ABI. Tied input/output weights may share one affine table, but native projection
+support does not make the embedding native. Native expert-major tensors are
+accepted only when the source is contiguous and maps to complete per-expert
+projection rows. Non-native expert-major tensors are rejected in quantized mode
+until a complete split-and-repack path exists; `keep_quantized=False` retains
+the existing float normalization path. Norms, biases, and other non-MatMul
+tensors are dequantized to float or rejected. Runtime remains **deferred** until
+real-weight ONNX Runtime execution is recorded; graph construction and operator
+ABI matching are not runtime evidence.
+
+### Representative mixed-qtype evidence
+
+The following file was downloaded and inspected; its preset name was not used
+to infer tensor formats:
+
+- Repository: `lmstudio-community/Qwen2.5-0.5B-Instruct-GGUF`
+- Revision: `3b32d0bf1ac136098d417677c7d757360f1ceb6b`
+- Filename: `Qwen2.5-0.5B-Instruct-Q4_K_M.gguf`
+- Size: `397807936` bytes
+- LFS SHA-256: `fa4d41b65761ed565cac6b5f62e35135d050408b033114a128ab308c02b2e83a`
+- Tensor inventory: 290 tensors: 121 `F32`, 132 `Q5_0`, 12 `Q4_K`,
+  12 `Q6_K`, and 13 `Q8_0`
+- Element inventory: 71,552 `F32`; 251,854,848 `Q5_0`; 52,297,728
+  `Q4_K`; 52,297,728 `Q6_K`; 137,510,912 `Q8_0`
+- Build evidence: direct import produced one model with 169 `MatMulNBits`
+  nodes, one `GatherBlockQuantized` node, and no `BlockQuantizedMatMul` nodes
+
+This file therefore takes mixed routes: `Q4_K`/`Q6_K` use their declared lossy
+affine conversion, `Q5_0` dequantizes/requantizes, and `Q8_0` is converted to
+the graph's common 4-bit/block-32 target rather than retaining its standalone
+8-bit affine layout. This is build evidence, not runtime execution evidence.
+
+The eight retired slots (`Q4_2`, `Q4_3`, `Q4_0_4_4`, `Q4_0_4_8`,
+`Q4_0_8_8`, `IQ4_NL_4_4`, `IQ4_NL_4_8`, `IQ4_NL_8_8`) have block size zero
+and are unreadable. `Q8_1` and `Q8_K` are compute-only intermediates, never
+valid GGUF weight storage.
 
 
 ## NVIDIA Nemotron 3.5 Lightning waiver

--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -131,10 +131,10 @@ silently treated as preserved source quantization.
 ## Supported GGUF Architectures
 
 Support is declared once, in
-`mobius/integrations/gguf/_arch_registry.py`, as four independent verdicts per
-architecture — config extraction, tensor mapping, graph construction, and
-runtime packaging. Anything short of "supported" carries a reason, and the
-table below is checked against the registry by
+`mobius/integrations/gguf/_arch_registry.py`, as five independent verdicts per
+architecture — config extraction, tensor mapping, graph construction, runtime
+packaging, and quantized import. Anything short of "supported" carries a reason,
+and the table below is checked against the registry by
 `_arch_registry_test.py::TestDocumentedSupportMatrix`, so it cannot drift.
 
 Being listed is not a support claim. `build_from_gguf` refuses every
@@ -143,42 +143,42 @@ reason.
 
 <!-- BEGIN GGUF SUPPORT MATRIX (generated; see _arch_registry.py) -->
 
-| GGUF architecture | Accepted aliases | mobius `model_type` | Status |
-|---|---|---|---|
-| `arcee` | — | `arcee` | runtime deferred |
-| `bloom` | — | `bloom` | tensor_map deferred |
-| `clip` | — | — | config rejected; tensor_map rejected; graph rejected; runtime rejected |
-| `cohere2` | — | `cohere2` | runtime deferred |
-| `deci` | — | `llama` | supported |
-| `deepseek4` | — | `deepseek_v4` | supported |
-| `exaone` | — | `exaone` | runtime deferred |
-| `falcon` | — | `falcon` | supported |
-| `gemma` | — | `gemma` | supported |
-| `gemma2` | — | `gemma2` | supported |
-| `gemma3` | — | `gemma3_text` | supported |
-| `gemma4` | — | `gemma4_text` | supported |
-| `glm-dsa` | `glm_dsa` | `glm_moe_dsa` | tensor_map deferred |
-| `gpt2` | — | `gpt2` | supported |
-| `hunyuan-dense` | `hunyuan_v1_dense` | `hunyuan_v1_dense` | supported |
-| `internlm2` | — | `internlm2` | supported |
-| `llama` | `mistral` | `llama` | supported |
-| `mamba` | — | `mamba` | supported |
-| `muse-glimmer` | `muse_glimmer` | `muse_glimmer_text` | supported |
-| `nemotron` | — | `nemotron` | supported |
-| `nemotron_h_moe` | — | — | config rejected; tensor_map rejected; graph rejected; runtime rejected |
-| `olmo` | — | `olmo` | supported |
-| `olmo2` | — | `olmo2` | supported |
-| `phi3` | — | `phi3` | supported |
-| `qwen2` | — | `qwen2` | supported |
-| `qwen2moe` | `qwen2_moe` | `qwen2_moe` | supported |
-| `qwen3` | — | `qwen3` | supported |
-| `qwen35` | — | `qwen3_5_text` | supported |
-| `qwen35moe` | — | `qwen3_5_moe` | supported |
-| `qwen3moe` | `qwen3_moe` | `qwen3_moe` | supported |
-| `smollm3` | — | `smollm3` | supported |
-| `stablelm` | — | `stablelm` | supported |
-| `starcoder2` | — | `starcoder2` | supported |
-| `t5` | — | `t5` | tensor_map deferred |
+| GGUF architecture | Accepted aliases | mobius `model_type` | Float import | Quantized import |
+|---|---|---|---|---|
+| `arcee` | — | `arcee` | runtime deferred | unreachable |
+| `bloom` | — | `bloom` | tensor_map deferred | unreachable |
+| `clip` | — | — | config rejected; tensor_map rejected; graph rejected; runtime rejected | unreachable |
+| `cohere2` | — | `cohere2` | runtime deferred | unreachable |
+| `deci` | — | `llama` | supported | supported |
+| `deepseek4` | — | `deepseek_v4` | supported | supported |
+| `exaone` | — | `exaone` | runtime deferred | unreachable |
+| `falcon` | — | `falcon` | supported | supported |
+| `gemma` | — | `gemma` | supported | supported |
+| `gemma2` | — | `gemma2` | supported | supported |
+| `gemma3` | — | `gemma3_text` | supported | supported |
+| `gemma4` | — | `gemma4_text` | supported | supported |
+| `glm-dsa` | `glm_dsa` | `glm_moe_dsa` | tensor_map deferred | unreachable |
+| `gpt2` | — | `gpt2` | supported | supported |
+| `hunyuan-dense` | `hunyuan_v1_dense` | `hunyuan_v1_dense` | supported | supported |
+| `internlm2` | — | `internlm2` | supported | rejected |
+| `llama` | `mistral` | `llama` | supported | supported |
+| `mamba` | — | `mamba` | supported | supported |
+| `muse-glimmer` | `muse_glimmer` | `muse_glimmer_text` | supported | supported |
+| `nemotron` | — | `nemotron` | supported | supported |
+| `nemotron_h_moe` | — | — | config rejected; tensor_map rejected; graph rejected; runtime rejected | unreachable |
+| `olmo` | — | `olmo` | supported | supported |
+| `olmo2` | — | `olmo2` | supported | supported |
+| `phi3` | — | `phi3` | supported | supported |
+| `qwen2` | — | `qwen2` | supported | supported |
+| `qwen2moe` | `qwen2_moe` | `qwen2_moe` | supported | supported |
+| `qwen3` | — | `qwen3` | supported | supported |
+| `qwen35` | — | `qwen3_5_text` | supported | supported |
+| `qwen35moe` | — | `qwen3_5_moe` | supported | supported |
+| `qwen3moe` | `qwen3_moe` | `qwen3_moe` | supported | supported |
+| `smollm3` | — | `smollm3` | supported | supported |
+| `stablelm` | — | `stablelm` | supported | supported |
+| `starcoder2` | — | `starcoder2` | supported | supported |
+| `t5` | — | `t5` | tensor_map deferred | unreachable |
 
 <!-- END GGUF SUPPORT MATRIX -->
 
@@ -229,6 +229,9 @@ implemented and validated. These include fused/interleaved or dual-form QKV
 and all 25 active storage-quantized types at the same pinned commit. Every
 stored qtype has one explicit projection/output route. The table is generated
 from that registry and checked byte-for-byte by `_quant_registry_test.py`.
+Those routes apply only when the architecture table above marks quantized
+import supported; otherwise `keep_quantized=True` is rejected before graph
+construction.
 
 <!-- BEGIN GGUF QUANTIZATION MATRIX (generated; see _quant_registry.py) -->
 

--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -145,13 +145,13 @@ reason.
 
 | GGUF architecture | Accepted aliases | mobius `model_type` | Float import | Quantized import |
 |---|---|---|---|---|
-| `arcee` | — | `arcee` | runtime deferred | unreachable |
+| `arcee` | — | `arcee` | runtime deferred | supported |
 | `bloom` | — | `bloom` | tensor_map deferred | unreachable |
 | `clip` | — | — | config rejected; tensor_map rejected; graph rejected; runtime rejected | unreachable |
-| `cohere2` | — | `cohere2` | runtime deferred | unreachable |
+| `cohere2` | — | `cohere2` | runtime deferred | supported |
 | `deci` | — | `llama` | supported | supported |
 | `deepseek4` | — | `deepseek_v4` | supported | supported |
-| `exaone` | — | `exaone` | runtime deferred | unreachable |
+| `exaone` | — | `exaone` | runtime deferred | supported |
 | `falcon` | — | `falcon` | supported | supported |
 | `gemma` | — | `gemma` | supported | supported |
 | `gemma2` | — | `gemma2` | supported | supported |

--- a/src/mobius/integrations/gguf/_arch_registry.py
+++ b/src/mobius/integrations/gguf/_arch_registry.py
@@ -98,6 +98,12 @@ _RUNTIME_VALIDATION_PENDING = (
     "generation validation. Runtime packaging remains deferred until that evidence exists."
 )
 
+_NO_QUANTIZED_PROJECTION_REASON = (
+    "The mobius graph uses floating Linear modules for this architecture, so no "
+    "MatMulNBits or BlockQuantizedMatMul target can consume preserved GGUF projection "
+    "weights. Use keep_quantized=False for explicit float import."
+)
+
 
 _SPECS: tuple[GGUFArchitectureSpec, ...] = (
     # ---------------------------------------------------------------- Llama
@@ -232,6 +238,8 @@ _SPECS: tuple[GGUFArchitectureSpec, ...] = (
         tensor_map_recipe=("llama",),
         tensor_processor="llama",
         llama_qk_permute=True,
+        quantized_import=Support.REJECTED,
+        reason=_NO_QUANTIZED_PROJECTION_REASON,
     ),
     GGUFArchitectureSpec(
         gguf_arch="olmo",
@@ -343,12 +351,14 @@ _SPECS: tuple[GGUFArchitectureSpec, ...] = (
         gguf_arch="bloom",
         model_type="bloom",
         tensor_map=Support.DEFERRED,
+        quantized_import=Support.REJECTED,
         reason=_NO_TENSOR_MAP,
     ),
     GGUFArchitectureSpec(
         gguf_arch="t5",
         model_type="t5",
         tensor_map=Support.DEFERRED,
+        quantized_import=Support.REJECTED,
         reason=(
             "T5 is an encoder-decoder with separate enc.*/dec.* tensor namespaces, "
             "relative attention bias, and cross-attention, none of which the "
@@ -361,6 +371,7 @@ _SPECS: tuple[GGUFArchitectureSpec, ...] = (
         tensor_map=Support.REJECTED,
         graph=Support.REJECTED,
         runtime=Support.REJECTED,
+        quantized_import=Support.REJECTED,
         reason=_NEMOTRON_H_MOE_REASON,
     ),
     GGUFArchitectureSpec(
@@ -369,6 +380,7 @@ _SPECS: tuple[GGUFArchitectureSpec, ...] = (
         tensor_map=Support.REJECTED,
         graph=Support.REJECTED,
         runtime=Support.REJECTED,
+        quantized_import=Support.REJECTED,
         reason=_MMPROJ_REASON,
     ),
 )

--- a/src/mobius/integrations/gguf/_arch_registry_test.py
+++ b/src/mobius/integrations/gguf/_arch_registry_test.py
@@ -63,8 +63,11 @@ _EXPECTED_SUPPORTED_COUNT = 29
 # modules before joining this set.
 _EXPECTED_QUANTIZED_IMPORT_ARCHITECTURES = frozenset(
     {
+        "arcee",
+        "cohere2",
         "deci",
         "deepseek4",
+        "exaone",
         "falcon",
         "gemma",
         "gemma2",
@@ -76,6 +79,8 @@ _EXPECTED_QUANTIZED_IMPORT_ARCHITECTURES = frozenset(
         "mamba",
         "muse-glimmer",
         "nemotron",
+        "olmo",
+        "olmo2",
         "phi3",
         "qwen2",
         "qwen2moe",
@@ -83,6 +88,7 @@ _EXPECTED_QUANTIZED_IMPORT_ARCHITECTURES = frozenset(
         "qwen35",
         "qwen35moe",
         "qwen3moe",
+        "smollm3",
         "stablelm",
         "starcoder2",
     }

--- a/src/mobius/integrations/gguf/_arch_registry_test.py
+++ b/src/mobius/integrations/gguf/_arch_registry_test.py
@@ -58,6 +58,36 @@ from mobius.integrations.gguf._upstream import upstream_architectures
 #: accidentally losing an architecture is a failure rather than a silence.
 _EXPECTED_SUPPORTED_COUNT = 29
 
+# Quantized reachability is separately pinned from float importability. A new
+# architecture must explicitly prove that its graph exposes packed projection
+# modules before joining this set.
+_EXPECTED_QUANTIZED_IMPORT_ARCHITECTURES = frozenset(
+    {
+        "deci",
+        "deepseek4",
+        "falcon",
+        "gemma",
+        "gemma2",
+        "gemma3",
+        "gemma4",
+        "gpt2",
+        "hunyuan-dense",
+        "llama",
+        "mamba",
+        "muse-glimmer",
+        "nemotron",
+        "phi3",
+        "qwen2",
+        "qwen2moe",
+        "qwen3",
+        "qwen35",
+        "qwen35moe",
+        "qwen3moe",
+        "stablelm",
+        "starcoder2",
+    }
+)
+
 
 class TestCapabilityClosure:
     """The four capability verdicts must not contradict each other."""
@@ -85,7 +115,9 @@ class TestCapabilityClosure:
     def test_every_unsupported_capability_carries_a_reason(self, spec) -> None:
         """Support must never be denied silently."""
         unsupported = [
-            name for name, verdict in spec.verdicts.items() if verdict is not Support.SUPPORTED
+            name
+            for name, verdict in spec.capabilities.items()
+            if verdict is not Support.SUPPORTED
         ]
         if unsupported:
             assert spec.reason, f"{spec.gguf_arch}: {unsupported} lack a reason"
@@ -103,6 +135,30 @@ class TestCapabilityClosure:
     def test_the_supported_set_is_pinned(self) -> None:
         """Gaining or losing support is a deliberate, reviewable change."""
         assert len(supported_architectures()) == _EXPECTED_SUPPORTED_COUNT
+
+    def test_quantized_import_set_is_pinned(self) -> None:
+        """Builder acceptance and rejection must come from an explicit policy set."""
+        actual = frozenset(
+            spec.gguf_arch
+            for spec in iter_arch_specs()
+            if spec.is_importable and spec.quantized_import is Support.SUPPORTED
+        )
+        assert actual == _EXPECTED_QUANTIZED_IMPORT_ARCHITECTURES
+
+    def test_every_float_importable_architecture_has_a_quantized_verdict(self) -> None:
+        """Float graph support must not be mistaken for quantized graph reachability."""
+        actual = {
+            spec.gguf_arch: spec.quantized_import
+            for spec in iter_arch_specs()
+            if spec.is_importable
+        }
+        assert set(actual) == set(supported_architectures())
+        assert actual["internlm2"] is Support.REJECTED
+        assert all(
+            verdict is Support.SUPPORTED
+            for arch, verdict in actual.items()
+            if arch != "internlm2"
+        )
 
 
 class TestNameResolutionClosure:
@@ -291,16 +347,24 @@ class TestDocumentedSupportMatrix:
         for spec in sorted(iter_arch_specs(), key=lambda s: s.gguf_arch):
             aliases = ", ".join(f"`{a}`" for a in sorted(spec.aliases)) or "—"
             model_type = f"`{spec.model_type}`" if spec.model_type else "—"
+            core_verdicts = {
+                name: verdict
+                for name, verdict in spec.verdicts.items()
+                if name != "quantized_import"
+            }
             status = (
                 "supported"
                 if all(verdict is Support.SUPPORTED for verdict in spec.verdicts.values())
                 else "; ".join(
                     f"{name} {verdict.value}"
-                    for name, verdict in spec.verdicts.items()
+                    for name, verdict in core_verdicts.items()
                     if verdict is not Support.SUPPORTED
                 )
             )
-            rows.append(f"| `{spec.gguf_arch}` | {aliases} | {model_type} | {status} |")
+            quantized = spec.quantized_import.value if spec.is_importable else "unreachable"
+            rows.append(
+                f"| `{spec.gguf_arch}` | {aliases} | {model_type} | {status} | {quantized} |"
+            )
         return rows
 
     def test_the_doc_table_matches_the_registry(self) -> None:

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -6,7 +6,7 @@
 Converts ``.gguf`` model files to ONNX using the standard build
 pipeline. Quantized preservation is the default: affine linear-layer weights
 are repacked into MatMulNBits format and compatible token embeddings into
-GatherBlockQuantized format. For text-only builds, runtime-supported native
+GatherBlockQuantized format. For text-only builds, operator-native
 IQ/MXFP4 projection blocks are preserved for BlockQuantizedMatMul. Multimodal
 text backbones and mixed presets such as Q4_K_M are normalized to one affine
 layout, so not every source tensor is byte-preserved. Other tensors are
@@ -445,7 +445,7 @@ def build_from_gguf(
     8. Apply weights to the ONNX model
 
     By default, supported affine tensors are repacked into MatMulNBits format.
-    For text-only builds, runtime-supported native IQ/MXFP4 projection blocks
+    For text-only builds, operator-native IQ/MXFP4 projection blocks
     are retained byte-for-byte for BlockQuantizedMatMul. Multimodal text
     backbones normalize quantized projections to a common affine layout. GGUFs
     containing only F32, F16, or BF16 weights use the float path because there
@@ -467,7 +467,7 @@ def build_from_gguf(
             defaults to float32.
         keep_quantized: Preserve quantization when quantized tensors are
             present. This is the default. Supported affine blocks are repacked,
-            text-only runtime-supported native IQ/MXFP4 projection blocks
+            text-only operator-native IQ/MXFP4 projection blocks
             retain their bytes, and mixed or multimodal source types can be
             normalized to a common affine layout. Set to ``False`` to
             dequantize all weights.
@@ -838,19 +838,12 @@ def build_from_gguf(
     # attach it to the package so the CLI can save it into a ``mtp/`` subdir.
     # Auto-detected from source-tensor presence (see step 4b).
     if emit_mtp_head:
-        try:
-            mtp_pkg = build_mtp_head_from_gguf(
-                gguf_model,
-                config,
-                preserve_quantization=preserve_quantization,
-                execution_provider=execution_provider,
-            )
-        except Exception:  # pragma: no cover - defensive: never fail the backbone
-            logger.exception(
-                "Failed to build the Qwen3.5/3.8 MTP head sidecar; the backbone "
-                "model was exported without a self-speculative drafter."
-            )
-            mtp_pkg = None
+        mtp_pkg = build_mtp_head_from_gguf(
+            gguf_model,
+            config,
+            preserve_quantization=preserve_quantization,
+            execution_provider=execution_provider,
+        )
         if mtp_pkg is not None:
             pkg.mtp_head = mtp_pkg
 
@@ -980,10 +973,19 @@ def _replace_child_module(root, path: str, replacement) -> None:
     setattr(parent, child_name, replacement)
 
 
-def _replace_native_block_linears(module, gguf_model, gguf_arch: str) -> None:
+def _replace_native_block_linears(
+    module,
+    gguf_model,
+    gguf_arch: str,
+    *,
+    name_mapper: Callable[[str, str], str | None] | None = None,
+) -> None:
     """Swap MatMulNBits scaffolding for runtime-supported native linears."""
     from mobius.components import BlockQuantizedLinear, QuantizedLinear
     from mobius.integrations.gguf._tensor_mapping import map_gguf_to_hf_names
+
+    if name_mapper is None:
+        name_mapper = map_gguf_to_hf_names
 
     module_map = dict(module.named_modules())
     quantized_stems = {
@@ -994,7 +996,7 @@ def _replace_native_block_linears(module, gguf_model, gguf_arch: str) -> None:
         format_name = _native_block_format(qtype)
         if format_name is None:
             continue
-        hf_name = map_gguf_to_hf_names(gguf_name, gguf_arch)
+        hf_name = name_mapper(gguf_name, gguf_arch)
         if hf_name is None:
             continue
         for stem in _native_block_target_stems(hf_name, np_shape, quantized_stems):
@@ -1348,25 +1350,52 @@ def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, int, bool]:
 
     from mobius.integrations.gguf._quant_registry import (
         explicit_zero_point_type_names,
+        float_storage_type_ids,
         get_quant_spec,
     )
     from mobius.integrations.gguf._repacker import can_repack, repack_quant_params
+    from mobius.integrations.gguf._spec import QuantImportRoute
     from mobius.integrations.gguf._tencent_q1_0 import is_tencent_q1_0_layout
     from mobius.integrations.gguf._tensor_mapping import (
         map_gguf_to_hf_names,
     )
 
     counts: Counter = Counter()
+    float_type_ids = float_storage_type_ids()
     for name, _raw, qtype, _shape in gguf_model.tensor_items_raw():
         hf_name = map_gguf_to_hf_names(name, gguf_arch)
         if hf_name is None or not hf_name.endswith(".weight"):
             continue
-        counts[qtype] += 1
+        type_id = getattr(qtype, "value", qtype)
+        if type_id not in float_type_ids:
+            counts[qtype] += 1
 
     if not counts:
         raise ValueError(
             "No mapped weight tensors found in GGUF file. "
             "Use keep_quantized=False for dequantized import."
+        )
+
+    quant_specs = {qtype: get_quant_spec(qtype) for qtype in counts}
+    unknown = [qtype for qtype, spec in quant_specs.items() if spec is None]
+    if unknown:
+        names = ", ".join(sorted(getattr(qtype, "name", str(qtype)) for qtype in unknown))
+        raise ValueError(
+            f"GGUF contains qtypes outside the pinned llama.cpp census: {names}. "
+            "Update the importer policy before loading this file."
+        )
+    rejected = [
+        spec
+        for spec in quant_specs.values()
+        if spec is not None and spec.import_route is QuantImportRoute.REJECTED
+    ]
+    if rejected:
+        details = "; ".join(
+            f"{spec.name}: {spec.reason or 'no supported importer route'}" for spec in rejected
+        )
+        raise ValueError(
+            "GGUF contains stored qtypes that cannot be imported safely: "
+            f"{details} Re-quantize those tensors to a supported qtype."
         )
 
     native_counts = Counter(
@@ -1384,6 +1413,16 @@ def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, int, bool]:
             "scaffolding for non-native quantized tensors",
         )
         return 4, 32, can_omit_zero_points
+
+    if any(
+        spec is not None and spec.import_route is QuantImportRoute.DEQUANTIZE_REQUANTIZE
+        for spec in quant_specs.values()
+    ):
+        logger.info(
+            "GGUF contains qtypes requiring dequantize/requantize; using the "
+            "supported 4-bit/block-32 affine target"
+        )
+        return 4, 32, False
 
     # Q4_K_M is deliberately a mixed preset. Depending on tensor dimensions
     # and importance it may contain mostly Q5_0 plus Q4_K, Q6_K, and Q8_0.
@@ -1463,7 +1502,9 @@ def _can_quantize_embedding(
     modules. Preserve the GGUF embedding only when its repacked representation
     uses the same bit width and block size as the projection weights.
     """
+    from mobius.integrations.gguf._quant_registry import quant_import_decision
     from mobius.integrations.gguf._repacker import repack_quant_params
+    from mobius.integrations.gguf._spec import QuantImportRoute, TensorRole
     from mobius.integrations.gguf._tencent_q1_0 import is_tencent_q1_0_layout
     from mobius.integrations.gguf._tensor_mapping import map_gguf_to_hf_names
 
@@ -1480,7 +1521,15 @@ def _can_quantize_embedding(
             return False
         qtype = tensor.tensor_type
         qtype_val = qtype.value if hasattr(qtype, "value") else qtype
-        return repack_quant_params(qtype_val) == (bits, block_size)
+        if repack_quant_params(qtype_val) == (bits, block_size):
+            return True
+        route, _, _ = quant_import_decision(
+            qtype,
+            TensorRole.EMBEDDING,
+            target_bits=bits,
+            target_block_size=block_size,
+        )
+        return route is QuantImportRoute.DEQUANTIZE_REQUANTIZE
     return False
 
 
@@ -1522,6 +1571,7 @@ def repack_gguf_weight_to_target(
     target_block_size: int,
     target_symmetric: bool,
     tensor_name: str,
+    tensor_role=None,
 ):
     """Repack one 2-D GGUF weight to the graph's common MatMulNBits target.
 
@@ -1547,14 +1597,31 @@ def repack_gguf_weight_to_target(
     """
     import numpy as np
 
+    from mobius.integrations.gguf._quant_registry import quant_import_decision
     from mobius.integrations.gguf._repacker import (
         can_repack,
         repack_dequantized_tensor,
         repack_gguf_tensor,
     )
+    from mobius.integrations.gguf._spec import QuantImportRoute, TensorRole
+
+    if tensor_role is None:
+        tensor_role = TensorRole.PROJECTION
+    route, _exactness, reason = quant_import_decision(
+        qtype,
+        tensor_role,
+        target_bits=target_bits,
+        target_block_size=target_block_size,
+    )
+    if route is QuantImportRoute.REJECTED:
+        qtype_name = getattr(qtype, "name", str(qtype))
+        raise ValueError(
+            f"Cannot import GGUF tensor {tensor_name} ({qtype_name}, "
+            f"role={tensor_role.value}): {reason}"
+        )
 
     qtype_val = qtype.value if hasattr(qtype, "value") else qtype
-    if can_repack(qtype_val):
+    if route is QuantImportRoute.AFFINE_REPACK and can_repack(qtype_val):
         shape_2d = (int(np_shape[0]), int(np_shape[1]))
         repacked = repack_gguf_tensor(raw.ravel().view(np.uint8), qtype_val, shape_2d)
         if repacked.bits == target_bits and repacked.block_size == target_block_size:
@@ -1657,13 +1724,24 @@ def _load_quantized_state_dict(
     import torch
     from gguf import GGMLQuantizationType, dequantize
 
-    from mobius.components import BlockQuantizedLinear, QuantizedEmbedding, QuantizedLinear
+    from mobius.components import (
+        BlockQuantizedLinear,
+        Embedding,
+        Linear,
+        QuantizedEmbedding,
+        QuantizedLinear,
+    )
+    from mobius.integrations.gguf._quant_registry import (
+        get_quant_spec,
+        quant_import_decision,
+    )
     from mobius.integrations.gguf._repacker import (
         can_repack,
         preserve_native_blocks,
         repack_dequantized_tensor,
         repack_gguf_tensor,
     )
+    from mobius.integrations.gguf._spec import QuantImportRoute, TensorRole
     from mobius.integrations.gguf._tencent_q1_0 import (
         is_tencent_q1_0_layout,
         parse_tencent_q1_0_tensor,
@@ -1683,6 +1761,8 @@ def _load_quantized_state_dict(
     quantized_stems = set()
     native_block_stems: dict[str, str] = {}
     quantized_embedding_stems = set()
+    float_linear_stems = set()
+    embedding_stems = set()
     for mod_name, mod in module.named_modules():
         if isinstance(mod, QuantizedLinear) or getattr(mod, "_gguf_quantized_linear", False):
             quantized_stems.add(mod_name)
@@ -1690,6 +1770,11 @@ def _load_quantized_state_dict(
             native_block_stems[mod_name] = mod._format
         elif isinstance(mod, QuantizedEmbedding):
             quantized_embedding_stems.add(mod_name)
+            embedding_stems.add(mod_name)
+        elif isinstance(mod, Linear):
+            float_linear_stems.add(mod_name)
+        elif isinstance(mod, Embedding):
+            embedding_stems.add(mod_name)
 
     num_heads = getattr(config, "num_attention_heads", None)
     num_kv_heads = getattr(config, "num_key_value_heads", None)
@@ -1745,6 +1830,67 @@ def _load_quantized_state_dict(
             set(native_block_stems),
         )
         native_spec = _native_block_spec(qtype)
+        quant_spec = get_quant_spec(qtype)
+        is_embedding_tensor = stem is not None and stem in embedding_stems
+        tensor_role = (
+            TensorRole.EMBEDDING
+            if is_embedding_tensor
+            else TensorRole.EXPERT
+            if len(np_shape) == 3 and ".experts." in hf_name
+            else TensorRole.OUTPUT
+            if hf_name == "lm_head.weight"
+            else TensorRole.PROJECTION
+            if stem is not None
+            and (
+                stem in quantized_stems
+                or stem in native_block_stems
+                or stem in float_linear_stems
+            )
+            else TensorRole.NON_MATMUL
+        )
+        route = QuantImportRoute.DEQUANTIZE_REQUANTIZE
+        if quant_spec is not None and quant_spec.is_quantized_storage:
+            route, _exactness, reason = quant_import_decision(
+                qtype,
+                tensor_role,
+                target_bits=target_bits,
+                target_block_size=target_block_size,
+            )
+            if route is QuantImportRoute.REJECTED:
+                raise ValueError(
+                    f"Cannot import GGUF tensor {gguf_name} mapped to {hf_name} "
+                    f"({quant_spec.name}, role={tensor_role.value}): {reason}"
+                )
+            if route is QuantImportRoute.NATIVE_BYTES and not native_targets:
+                raise ValueError(
+                    f"Cannot preserve native {quant_spec.name} bytes for {hf_name}: "
+                    "the mapped module does not expose a compatible "
+                    "BlockQuantizedMatMul target."
+                )
+            if (
+                tensor_role is TensorRole.EMBEDDING
+                and route is not QuantImportRoute.DEQUANTIZE_FLOAT
+                and not is_quantized_embedding
+            ):
+                raise ValueError(
+                    f"Cannot keep {quant_spec.name} embedding {hf_name} quantized: "
+                    "the model graph does not expose GatherBlockQuantized. Use "
+                    "keep_quantized=False for explicit float import."
+                )
+            if (
+                tensor_role in {TensorRole.PROJECTION, TensorRole.OUTPUT}
+                and route
+                in {
+                    QuantImportRoute.AFFINE_REPACK,
+                    QuantImportRoute.DEQUANTIZE_REQUANTIZE,
+                }
+                and not should_repack
+            ):
+                raise ValueError(
+                    f"Cannot keep {quant_spec.name} {tensor_role.value} {hf_name} "
+                    "quantized: the model graph does not expose MatMulNBits. Use "
+                    "keep_quantized=False for explicit float import."
+                )
         if native_targets and native_spec is not None:
             n_out = int(np_shape[-2])
             k_in = int(np_shape[-1])
@@ -1799,7 +1945,7 @@ def _load_quantized_state_dict(
                     data_section_offset,
                     tensors_by_name[gguf_name],
                 )
-            elif can_repack(qtype_val):
+            elif route is QuantImportRoute.AFFINE_REPACK and can_repack(qtype_val):
                 shape_2d = (int(np_shape[0]), int(np_shape[1]))
                 repacked = repack_gguf_tensor(
                     raw.ravel().view(np.uint8),

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -583,6 +583,16 @@ def build_from_gguf(
     gguf_arch = gguf_model.architecture
     logger.info("Loaded GGUF model: %s (arch=%s)", gguf_path, gguf_arch)
     preserve_quantization = keep_quantized and _has_quantized_weights(gguf_model, gguf_arch)
+    arch_spec = try_get_arch_spec(gguf_arch)
+    if (
+        preserve_quantization
+        and arch_spec is not None
+        and arch_spec.quantized_import is not Support.SUPPORTED
+    ):
+        raise ValueError(
+            f"GGUF architecture {gguf_arch!r} does not support keep_quantized=True: "
+            f"{arch_spec.reason}"
+        )
     if keep_quantized and not preserve_quantization:
         logger.info("GGUF contains no mapped quantized weights; using the float import path")
 

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -228,12 +228,30 @@ def _write_quantized_gguf(
         _add_q4_0("token_embd.weight", vocab_size, hidden_size)
     elif embedding_quantization == "q8_0":
         _add_q8_0("token_embd.weight", vocab_size, hidden_size)
+    elif embedding_quantization == "q5_1":
+        _add_q5_1("token_embd.weight", vocab_size, hidden_size)
+    elif embedding_quantization == "iq4_nl":
+        block_bytes = 18
+        n_blocks = (hidden_size + 31) // 32
+        raw = np.zeros((vocab_size, n_blocks * block_bytes), dtype=np.uint8)
+        scale = np.array([1.0], dtype=np.float16).view(np.uint8)
+        for block_index in range(n_blocks):
+            offset = block_index * block_bytes
+            raw[:, offset : offset + 2] = scale
+        writer.add_tensor(
+            "token_embd.weight",
+            raw,
+            raw_dtype=GGMLQuantizationType.IQ4_NL,
+        )
+    elif embedding_quantization is not None:
+        _add_native("token_embd.weight", vocab_size, hidden_size, embedding_quantization)
     else:
         add_float("token_embd.weight", (vocab_size, hidden_size))
 
-    if projection_quantization in {"q4_0", "q8_0"}:
+    if projection_quantization in {"q4_0", "q5_1", "q8_0"}:
         add_projection = {
             "q4_0": _add_q4_0,
+            "q5_1": _add_q5_1,
             "q8_0": _add_q8_0,
         }[projection_quantization]
     elif projection_quantization in {"f32", "f16", "bf16"}:
@@ -337,6 +355,14 @@ def q4_0_tied_embedding_gguf(tmp_path: Path) -> Path:
     """Create a GGUF with one Q4_0 table shared by embedding and LM head."""
     path = tmp_path / "test_q4_0_tied_embedding.gguf"
     _write_quantized_gguf(path, quantize_embedding=True, tie_embeddings=True)
+    return path
+
+
+@pytest.fixture
+def iq4_nl_embedding_gguf(tmp_path: Path) -> Path:
+    """Create a native-IQ embedding with ordinary Q4_0 projections."""
+    path = tmp_path / "test_iq4_nl_embedding.gguf"
+    _write_quantized_gguf(path, embedding_quantization="iq4_nl")
     return path
 
 
@@ -1044,6 +1070,12 @@ class TestReuseGgufWeights:
         assert final_model.read_bytes() == b"new model"
         assert final_manifest.read_bytes() == b"new manifest"
         assert not final_sidecar.exists()
+@pytest.fixture
+def q5_1_gguf(tmp_path: Path) -> Path:
+    """Create a GGUF whose projections require dequantize/requantize."""
+    path = tmp_path / "test_q5_1.gguf"
+    _write_quantized_gguf(path, projection_quantization="q5_1")
+    return path
 
 
 class TestBuildQuantizedGguf:
@@ -1086,6 +1118,23 @@ class TestBuildQuantizedGguf:
             .const_value
             is not None
         )
+
+    def test_decoder_backed_qtype_build_save_reload(
+        self, q5_1_gguf: Path, tmp_path: Path
+    ) -> None:
+        """A pure Q5_1 file uses the declared 4-bit requantization route."""
+        from mobius._model_package import ModelPackage
+        from mobius.integrations.gguf import build_from_gguf
+
+        output_dir = tmp_path / "saved_q5_1"
+        package = build_from_gguf(q5_1_gguf)
+        package.save(str(output_dir), progress_bar=False)
+        model = ModelPackage.load(str(output_dir))["model"]
+
+        quantized_nodes = [node for node in model.graph if node.op_type == "MatMulNBits"]
+        assert quantized_nodes
+        assert all(node.attributes["bits"].value == 4 for node in quantized_nodes)
+        assert all(node.attributes["block_size"].value == 32 for node in quantized_nodes)
 
     def test_float_only_default_uses_float_path(self, float_only_gguf: Path):
         """F32/BF16-only GGUFs do not fail when preservation is the default."""
@@ -1252,9 +1301,20 @@ class TestBuildQuantizedGguf:
             ]
         )
         np.testing.assert_allclose(actual, expected)
-
         wrong = _run_gather_block_quantized(tmp_path, zero_point=0x00).astype(np.float32)
         assert not np.allclose(wrong, expected)
+
+    def test_native_projection_abi_embedding_is_converted_to_gather(
+        self, iq4_nl_embedding_gguf: Path
+    ) -> None:
+        from mobius.integrations.gguf import build_from_gguf
+
+        model = build_from_gguf(iq4_nl_embedding_gguf)["model"]
+        gather_nodes = [node for node in model.graph if node.op_type == "GatherBlockQuantized"]
+
+        assert len(gather_nodes) == 1
+        assert "model.embed_tokens.qweight" in model.graph.initializers
+        assert "model.embed_tokens.weight" not in model.graph.initializers
 
     def test_tied_quantized_embedding_drives_matmulnbits_head(
         self, q4_0_tied_embedding_gguf: Path
@@ -1383,6 +1443,36 @@ class TestBuildQuantizedGguf:
 
         assert not _can_quantize_embedding(model, "llama", bits=4, block_size=128)
 
+    def test_decoder_backed_embedding_uses_affine_gather_target(self, monkeypatch):
+        from gguf import GGMLQuantizationType
+
+        from mobius.integrations.gguf import _tencent_q1_0
+        from mobius.integrations.gguf._builder import _can_quantize_embedding
+
+        monkeypatch.setattr(_tencent_q1_0, "is_tencent_q1_0_layout", lambda _model: False)
+        tensor = SimpleNamespace(
+            name="token_embd.weight",
+            tensor_type=GGMLQuantizationType.Q5_1,
+            shape=(64, 256),
+        )
+        model = SimpleNamespace(_reader=SimpleNamespace(tensors=[tensor]))
+
+        assert _can_quantize_embedding(model, "llama", bits=4, block_size=32)
+
+    def test_decoder_backed_output_head_stays_quantized(self):
+        from mobius.integrations.gguf._builder import _can_quantize_lm_head
+
+        class _OutputModel:
+            def tensor_items_raw(self):
+                yield (
+                    "output.weight",
+                    np.empty(0, dtype=np.uint8),
+                    SimpleNamespace(name="TQ1_0"),
+                    (256, 64),
+                )
+
+        assert _can_quantize_lm_head(_OutputModel(), "llama")
+
     def test_detect_q4_k_m_mixed_profile(self):
         """Q4_K presence selects a 4-bit target despite more Q5_0 tensors."""
         from gguf import GGMLQuantizationType
@@ -1408,8 +1498,8 @@ class TestBuildQuantizedGguf:
         bits, block_size, is_sym = _detect_quant_params(_MixedModel(), "llama")
         assert (bits, block_size, is_sym) == (4, 32, False)
 
-    def test_unsupported_quant_type_requires_explicit_dequantization(self):
-        """Unsupported quantized inputs fail instead of silently becoming float."""
+    def test_decoder_backed_qtype_selects_explicit_requantization_target(self):
+        """A decoder-backed qtype takes the declared 4-bit requantization route."""
         from gguf import GGMLQuantizationType
 
         from mobius.integrations.gguf._builder import _detect_quant_params
@@ -1423,15 +1513,61 @@ class TestBuildQuantizedGguf:
                     (64, 128),
                 )
 
+        assert _detect_quant_params(_UnsupportedModel(), "llama") == (4, 32, False)
+
+    def test_qtype_without_decoder_or_kernel_is_rejected_actionably(self):
+        import enum
+
+        from mobius.integrations.gguf._builder import _detect_quant_params
+
+        class _PinnedQType(enum.IntEnum):
+            Q2_0 = 42
+
+        class _Q20Model:
+            def tensor_items_raw(self):
+                yield (
+                    "blk.0.ffn_down.weight",
+                    np.empty(0, dtype=np.uint8),
+                    _PinnedQType.Q2_0,
+                    (64, 128),
+                )
+
         with pytest.raises(
             ValueError,
-            match=(
-                r"No supported quantized preservation target for GGUF weight "
-                r"types: Q5_K. Use keep_quantized=False \(API\) or "
-                r"--dequantize \(CLI\) for explicit float import."
-            ),
+            match=r"Q2_0: gguf-py ships no Python dequantizer.*Re-quantize",
         ):
-            _detect_quant_params(_UnsupportedModel(), "llama")
+            _detect_quant_params(_Q20Model(), "llama")
+
+    def test_out_of_census_qtype_is_rejected_before_route_selection(self):
+        import enum
+
+        from mobius.integrations.gguf._builder import _detect_quant_params
+
+        class _FutureQType(enum.IntEnum):
+            FUTURE = 99
+
+        class _FutureModel:
+            def tensor_items_raw(self):
+                yield (
+                    "blk.0.ffn_down.weight",
+                    np.empty(0, dtype=np.uint8),
+                    _FutureQType.FUTURE,
+                    (64, 128),
+                )
+
+        with pytest.raises(ValueError, match=r"outside the pinned llama\.cpp census"):
+            _detect_quant_params(_FutureModel(), "llama")
+
+    def test_architecture_without_quantized_modules_rejects_preservation(
+        self, tmp_path: Path
+    ) -> None:
+        from mobius.integrations.gguf import build_from_gguf
+
+        path = tmp_path / "internlm2_q4_0.gguf"
+        _write_quantized_gguf(path, architecture="internlm2")
+
+        with pytest.raises(ValueError, match="does not expose quantized projection"):
+            build_from_gguf(path)
 
     def test_q6_k_selects_the_asymmetric_four_bit_repack_target(self):
         """Q6_K repacks to the same 4-bit/32 target as Q4_K, with zero points.

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -1455,7 +1455,10 @@ class TestBuildQuantizedGguf:
             tensor_type=GGMLQuantizationType.Q5_1,
             shape=(64, 256),
         )
-        model = SimpleNamespace(_reader=SimpleNamespace(tensors=[tensor]))
+        model = SimpleNamespace(
+            _reader=SimpleNamespace(tensors=[tensor]),
+            reader_tensors=lambda: [tensor],
+        )
 
         assert _can_quantize_embedding(model, "llama", bits=4, block_size=32)
 

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -1566,7 +1566,10 @@ class TestBuildQuantizedGguf:
         path = tmp_path / "internlm2_q4_0.gguf"
         _write_quantized_gguf(path, architecture="internlm2")
 
-        with pytest.raises(ValueError, match="does not expose quantized projection"):
+        with pytest.raises(
+            ValueError,
+            match=r"does not support keep_quantized=True.*floating Linear modules",
+        ):
             build_from_gguf(path)
 
     def test_q6_k_selects_the_asymmetric_four_bit_repack_target(self):

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -1070,6 +1070,8 @@ class TestReuseGgufWeights:
         assert final_model.read_bytes() == b"new model"
         assert final_manifest.read_bytes() == b"new manifest"
         assert not final_sidecar.exists()
+
+
 @pytest.fixture
 def q5_1_gguf(tmp_path: Path) -> Path:
     """Create a GGUF whose projections require dequantize/requantize."""

--- a/src/mobius/integrations/gguf/_config_mapping.py
+++ b/src/mobius/integrations/gguf/_config_mapping.py
@@ -322,6 +322,13 @@ def gguf_to_config(
     mtp_block_indices: list[int] = []
     if nextn_layers is not None and int(nextn_layers) > 0:
         mtp_count = int(nextn_layers)
+        if mtp_count > 1:
+            raise ValueError(
+                f"GGUF architecture {gguf_arch!r} declares nextn_predict_layers="
+                f"{mtp_count}, but mobius can export exactly one MTP sidecar head. "
+                "Multi-head MTP export is not supported; use a checkpoint with one "
+                "nextn prediction layer."
+            )
         decoder_layers = int(hf_fields["num_hidden_layers"]) - mtp_count
         if decoder_layers <= 0:
             raise ValueError(

--- a/src/mobius/integrations/gguf/_mmproj.py
+++ b/src/mobius/integrations/gguf/_mmproj.py
@@ -365,6 +365,7 @@ def _text_gguf_to_hf_multimodal_quantized(
     import torch
 
     from mobius.integrations.gguf._builder import repack_gguf_weight_to_target
+    from mobius.integrations.gguf._spec import TensorRole
 
     quantize_embeddings = bool(getattr(config.quantization, "quantize_embeddings", False))
     quantize_lm_head = bool(getattr(config.quantization, "quantize_lm_head", False))
@@ -404,6 +405,11 @@ def _text_gguf_to_hf_multimodal_quantized(
                 target_block_size=block_size,
                 target_symmetric=symmetric,
                 tensor_name=hf_name,
+                tensor_role=(
+                    TensorRole.EMBEDDING
+                    if is_quant_embedding
+                    else TensorRole.AFFINE_PROJECTION
+                ),
             )
             stem = hf_name[: -len(".weight")]
             if is_quant_embedding:

--- a/src/mobius/integrations/gguf/_mtp.py
+++ b/src/mobius/integrations/gguf/_mtp.py
@@ -183,11 +183,10 @@ def build_mtp_head_from_gguf(
     if not mtp_blocks:
         return None
     if len(mtp_blocks) > 1:
-        logger.warning(
-            "GGUF declares %d MTP blocks; only the first (block %d) is exported "
-            "as the self-speculative head.",
-            len(mtp_blocks),
-            mtp_blocks[0],
+        raise ValueError(
+            f"GGUF declares {len(mtp_blocks)} MTP blocks, but mobius can export "
+            "exactly one MTP sidecar head. Multi-head MTP export is not supported; "
+            "no partial sidecar was produced."
         )
     mtp_block_index = int(mtp_blocks[0])
     gguf_arch = gguf_model.architecture

--- a/src/mobius/integrations/gguf/_mtp.py
+++ b/src/mobius/integrations/gguf/_mtp.py
@@ -173,6 +173,7 @@ def build_mtp_head_from_gguf(
         _load_dequantized_state_dict,
         _load_quantized_state_dict,
         _normalize_gguf_weights,
+        _replace_native_block_linears,
     )
     from mobius.integrations.gguf._tensor_processors import process_tensors
     from mobius.models.qwen35_mtp import Qwen35MtpModel
@@ -193,12 +194,20 @@ def build_mtp_head_from_gguf(
 
     mtp_config = derive_mtp_config(config)
     module = Qwen35MtpModel(mtp_config)
-    pkg = build_from_module(
-        module, mtp_config, Qwen35MtpTask(), execution_provider=execution_provider
-    )
 
     def _mapper(gguf_name: str, _arch: str) -> str | None:
         return map_gguf_mtp_to_hf_names(gguf_name, mtp_block_index)
+
+    if preserve_quantization:
+        _replace_native_block_linears(
+            module,
+            gguf_model,
+            gguf_arch,
+            name_mapper=_mapper,
+        )
+    pkg = build_from_module(
+        module, mtp_config, Qwen35MtpTask(), execution_provider=execution_provider
+    )
 
     if preserve_quantization:
         state_dict = _load_quantized_state_dict(

--- a/src/mobius/integrations/gguf/_mtp_test.py
+++ b/src/mobius/integrations/gguf/_mtp_test.py
@@ -30,7 +30,7 @@ _VOCAB = 100
 _BLOCK_COUNT = 2  # 1 decoder layer + 1 nextn head block
 
 
-def _write_qwen35_mtp_gguf(path: Path, *, quantized: bool = False) -> None:
+def _write_qwen35_mtp_gguf(path: Path, *, quantized: bool = False, mtp_count: int = 1) -> None:
     """Write a tiny ``qwen35`` GGUF with a trailing ``blk.1.nextn.*`` MTP head."""
     from gguf import GGUFWriter
 
@@ -38,14 +38,14 @@ def _write_qwen35_mtp_gguf(path: Path, *, quantized: bool = False) -> None:
     writer.add_context_length(512)
     writer.add_embedding_length(_H)
     writer.add_feed_forward_length(_FFN)
-    writer.add_block_count(_BLOCK_COUNT)
+    writer.add_block_count(1 + mtp_count)
     writer.add_head_count(_NH)
     writer.add_head_count_kv(_NKV)
     writer.add_rope_freq_base(10000.0)
     writer.add_layer_norm_rms_eps(1e-5)
     writer.add_vocab_size(_VOCAB)
     # UINT32 == GGUFValueType 4.
-    writer.add_key_value("qwen35.nextn_predict_layers", 1, 4)
+    writer.add_key_value("qwen35.nextn_predict_layers", mtp_count, 4)
     writer.add_key_value("qwen35.attention.key_length", _HD, 4)
 
     def f32(name: str, shape: tuple[int, ...]) -> None:
@@ -81,13 +81,14 @@ def _write_qwen35_mtp_gguf(path: Path, *, quantized: bool = False) -> None:
     # Decoder layer 0.
     _add_decoder_block(0)
 
-    # MTP head block (index 1): the nextn cross-conditioning tensors plus a
-    # full attention/FFN sublayer.
-    weight("blk.1.nextn.eh_proj.weight", (_H, 2 * _H))
-    f32("blk.1.nextn.enorm.weight", (_H,))
-    f32("blk.1.nextn.hnorm.weight", (_H,))
-    f32("blk.1.nextn.shared_head_norm.weight", (_H,))
-    _add_decoder_block(1)
+    # MTP head blocks: each has cross-conditioning tensors plus a full
+    # attention/FFN sublayer.
+    for index in range(1, 1 + mtp_count):
+        weight(f"blk.{index}.nextn.eh_proj.weight", (_H, 2 * _H))
+        f32(f"blk.{index}.nextn.enorm.weight", (_H,))
+        f32(f"blk.{index}.nextn.hnorm.weight", (_H,))
+        f32(f"blk.{index}.nextn.shared_head_norm.weight", (_H,))
+        _add_decoder_block(index)
 
     f32("token_embd.weight", (_VOCAB, _H))
     f32("output_norm.weight", (_H,))
@@ -221,6 +222,30 @@ class TestBuildMtpHead:
         assert op_types.count("MatMulNBits") == 8
         assert "fc.weight" in head.graph.initializers
         assert "fc.scales" in head.graph.initializers
+
+    def test_multiple_mtp_heads_reject_before_any_package_is_built(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        from mobius import _builder as core_builder
+        from mobius.integrations.gguf import build_from_gguf
+
+        path = tmp_path / "tiny_qwen35_multi_mtp.gguf"
+        _write_qwen35_mtp_gguf(path, mtp_count=2)
+
+        built = False
+
+        def _unexpected_build(*args, **kwargs):
+            nonlocal built
+            built = True
+            raise AssertionError("graph construction must not start for multi-MTP input")
+
+        monkeypatch.setattr(core_builder, "build_from_module", _unexpected_build)
+        with pytest.raises(
+            ValueError,
+            match=r"nextn_predict_layers=2.*exactly one MTP sidecar head",
+        ):
+            build_from_gguf(str(path))
+        assert built is False
 
     def test_no_head_when_gguf_lacks_nextn(self):
         # A config with no MTP metadata must not build a head.

--- a/src/mobius/integrations/gguf/_mtp_test.py
+++ b/src/mobius/integrations/gguf/_mtp_test.py
@@ -30,7 +30,7 @@ _VOCAB = 100
 _BLOCK_COUNT = 2  # 1 decoder layer + 1 nextn head block
 
 
-def _write_qwen35_mtp_gguf(path: Path) -> None:
+def _write_qwen35_mtp_gguf(path: Path, *, quantized: bool = False) -> None:
     """Write a tiny ``qwen35`` GGUF with a trailing ``blk.1.nextn.*`` MTP head."""
     from gguf import GGUFWriter
 
@@ -51,27 +51,39 @@ def _write_qwen35_mtp_gguf(path: Path) -> None:
     def f32(name: str, shape: tuple[int, ...]) -> None:
         writer.add_tensor(name, np.random.randn(*shape).astype(np.float32))
 
+    def weight(name: str, shape: tuple[int, int]) -> None:
+        if not quantized:
+            f32(name, shape)
+            return
+        from gguf import GGMLQuantizationType
+
+        n_out, k_in = shape
+        raw = np.zeros((n_out, k_in // 32 * 18), dtype=np.uint8)
+        raw[:, ::18] = np.array([0.5], dtype=np.float16).view(np.uint8)[0]
+        raw[:, 1::18] = np.array([0.5], dtype=np.float16).view(np.uint8)[1]
+        writer.add_tensor(name, raw, raw_dtype=GGMLQuantizationType.Q4_0)
+
     def _add_decoder_block(idx: int) -> None:
         # Qwen3.5 uses doubled-Q output gating: q_proj emits 2 * num_heads *
         # head_dim rows (gate + query).
-        f32(f"blk.{idx}.attn_q.weight", (2 * _NH * _HD, _H))
-        f32(f"blk.{idx}.attn_k.weight", (_NKV * _HD, _H))
-        f32(f"blk.{idx}.attn_v.weight", (_NKV * _HD, _H))
-        f32(f"blk.{idx}.attn_output.weight", (_H, _NH * _HD))
+        weight(f"blk.{idx}.attn_q.weight", (2 * _NH * _HD, _H))
+        weight(f"blk.{idx}.attn_k.weight", (_NKV * _HD, _H))
+        weight(f"blk.{idx}.attn_v.weight", (_NKV * _HD, _H))
+        weight(f"blk.{idx}.attn_output.weight", (_H, _NH * _HD))
         f32(f"blk.{idx}.attn_q_norm.weight", (_HD,))
         f32(f"blk.{idx}.attn_k_norm.weight", (_HD,))
         f32(f"blk.{idx}.attn_norm.weight", (_H,))
         f32(f"blk.{idx}.post_attention_norm.weight", (_H,))
-        f32(f"blk.{idx}.ffn_gate.weight", (_FFN, _H))
-        f32(f"blk.{idx}.ffn_up.weight", (_FFN, _H))
-        f32(f"blk.{idx}.ffn_down.weight", (_H, _FFN))
+        weight(f"blk.{idx}.ffn_gate.weight", (_FFN, _H))
+        weight(f"blk.{idx}.ffn_up.weight", (_FFN, _H))
+        weight(f"blk.{idx}.ffn_down.weight", (_H, _FFN))
 
     # Decoder layer 0.
     _add_decoder_block(0)
 
     # MTP head block (index 1): the nextn cross-conditioning tensors plus a
     # full attention/FFN sublayer.
-    f32("blk.1.nextn.eh_proj.weight", (_H, 2 * _H))
+    weight("blk.1.nextn.eh_proj.weight", (_H, 2 * _H))
     f32("blk.1.nextn.enorm.weight", (_H,))
     f32("blk.1.nextn.hnorm.weight", (_H,))
     f32("blk.1.nextn.shared_head_norm.weight", (_H,))
@@ -195,6 +207,20 @@ class TestBuildMtpHead:
             if value.const_value is None
         ]
         assert not missing, f"initializers missing weights: {missing}"
+
+    def test_quantized_head_preserves_all_projection_weights(self, tmp_path: Path):
+        from mobius.integrations.gguf import build_from_gguf
+
+        path = tmp_path / "tiny_qwen35_quantized_mtp.gguf"
+        _write_qwen35_mtp_gguf(path, quantized=True)
+
+        pkg = build_from_gguf(str(path), keep_quantized=True)
+        head = pkg.mtp_head["model"]
+        op_types = [node.op_type for node in head.graph]
+
+        assert op_types.count("MatMulNBits") == 8
+        assert "fc.weight" in head.graph.initializers
+        assert "fc.scales" in head.graph.initializers
 
     def test_no_head_when_gguf_lacks_nextn(self):
         # A config with no MTP metadata must not build a head.

--- a/src/mobius/integrations/gguf/_quant_registry.py
+++ b/src/mobius/integrations/gguf/_quant_registry.py
@@ -35,7 +35,9 @@ __all__ = [
     "iter_quant_specs",
     "lm_head_preserve_type_names",
     "native_block_format",
+    "quant_import_decision",
     "quant_spec_by_name",
+    "render_quant_support_matrix",
 ]
 
 import functools
@@ -45,8 +47,11 @@ from mobius.integrations.gguf._spec import (
     AffineRepackSpec,
     GGUFQuantSpec,
     NativeBlockSpec,
+    QuantImportRoute,
+    RepackExactness,
     StorageRole,
     Support,
+    TensorRole,
 )
 from mobius.integrations.gguf._upstream import upstream_quant_types
 
@@ -54,7 +59,8 @@ from mobius.integrations.gguf._upstream import upstream_quant_types
 # mobius capabilities, keyed by upper-case ggml type name
 # ---------------------------------------------------------------------------
 
-#: Types the runtime reads in their serialized GGUF block layout. The block
+#: Types whose serialized GGUF block layout matches ``BlockQuantizedMatMul``.
+#: This is an operator-ABI statement, not real-weight runtime evidence. The block
 #: geometry is *not* repeated here — it is asserted against the pinned census
 #: when the spec is constructed, so a wrong byte count is a test failure.
 _NATIVE_BLOCK_FORMATS: MappingProxyType[str, str] = MappingProxyType(
@@ -96,6 +102,41 @@ _AFFINE_REPACK_TARGETS: MappingProxyType[str, AffineRepackSpec] = MappingProxyTy
     }
 )
 
+# Primary projection/output route for every active stored qtype at the pin.
+# Keeping this census literal is intentional: adding an upstream qtype must fail
+# closure tests until its importer behavior is reviewed explicitly.
+_STORED_ROUTE_POLICY: MappingProxyType[
+    str, tuple[QuantImportRoute, RepackExactness | None]
+] = MappingProxyType(
+    {
+        "Q4_0": (QuantImportRoute.AFFINE_REPACK, RepackExactness.EXACT),
+        "Q4_1": (QuantImportRoute.AFFINE_REPACK, RepackExactness.LOSSY),
+        "Q5_0": (QuantImportRoute.DEQUANTIZE_REQUANTIZE, None),
+        "Q5_1": (QuantImportRoute.DEQUANTIZE_REQUANTIZE, None),
+        "Q8_0": (QuantImportRoute.AFFINE_REPACK, RepackExactness.EXACT),
+        "Q2_K": (QuantImportRoute.DEQUANTIZE_REQUANTIZE, None),
+        "Q3_K": (QuantImportRoute.DEQUANTIZE_REQUANTIZE, None),
+        "Q4_K": (QuantImportRoute.AFFINE_REPACK, RepackExactness.LOSSY),
+        "Q5_K": (QuantImportRoute.DEQUANTIZE_REQUANTIZE, None),
+        "Q6_K": (QuantImportRoute.AFFINE_REPACK, RepackExactness.LOSSY),
+        "TQ1_0": (QuantImportRoute.DEQUANTIZE_REQUANTIZE, None),
+        "TQ2_0": (QuantImportRoute.DEQUANTIZE_REQUANTIZE, None),
+        "IQ4_NL": (QuantImportRoute.NATIVE_BYTES, None),
+        "IQ4_XS": (QuantImportRoute.NATIVE_BYTES, None),
+        "IQ3_S": (QuantImportRoute.NATIVE_BYTES, None),
+        "IQ3_XXS": (QuantImportRoute.NATIVE_BYTES, None),
+        "IQ2_XXS": (QuantImportRoute.NATIVE_BYTES, None),
+        "IQ2_XS": (QuantImportRoute.NATIVE_BYTES, None),
+        "IQ2_S": (QuantImportRoute.NATIVE_BYTES, None),
+        "IQ1_S": (QuantImportRoute.NATIVE_BYTES, None),
+        "IQ1_M": (QuantImportRoute.NATIVE_BYTES, None),
+        "MXFP4": (QuantImportRoute.NATIVE_BYTES, None),
+        "NVFP4": (QuantImportRoute.DEQUANTIZE_REQUANTIZE, None),
+        "Q1_0": (QuantImportRoute.AFFINE_REPACK, RepackExactness.EXACT),
+        "Q2_0": (QuantImportRoute.REJECTED, None),
+    }
+)
+
 #: Types whose presence forces the shared graph scaffolding to carry explicit
 #: ``zero_points``, even when the file is otherwise made of runtime-native
 #: blocks. These are the formats whose GGUF dequantization uses a non-zero
@@ -121,29 +162,9 @@ _REQUIRES_EXPLICIT_ZERO_POINT: frozenset[str] = frozenset(
 #: the two tables above because the head is also allowed to ride the generic
 #: requantization path.
 _LM_HEAD_PRESERVE: frozenset[str] = frozenset(
-    {
-        "Q1_0",
-        "Q2_K",
-        "Q3_K",
-        "Q4_0",
-        "Q4_1",
-        "Q4_K",
-        "Q5_0",
-        "Q5_1",
-        "Q5_K",
-        "Q6_K",
-        "Q8_0",
-        "MXFP4",
-        "IQ4_NL",
-        "IQ4_XS",
-        "IQ3_S",
-        "IQ3_XXS",
-        "IQ2_XXS",
-        "IQ2_XS",
-        "IQ2_S",
-        "IQ1_S",
-        "IQ1_M",
-    }
+    name
+    for name, (route, _) in _STORED_ROUTE_POLICY.items()
+    if route is not QuantImportRoute.REJECTED
 )
 
 #: Upstream ``gguf_role`` strings → :class:`StorageRole`. The census stores the
@@ -229,6 +250,7 @@ def _specs() -> MappingProxyType[int, GGUFQuantSpec]:
                 bytes=upstream.block_bytes,
             )
         )
+        route, exactness = _STORED_ROUTE_POLICY.get(name, (QuantImportRoute.REJECTED, None))
         specs[type_id] = GGUFQuantSpec(
             ggml_type_id=type_id,
             name=name,
@@ -238,6 +260,8 @@ def _specs() -> MappingProxyType[int, GGUFQuantSpec]:
             dequantize=verdict,
             native_preserve=native,
             affine_repack=_AFFINE_REPACK_TARGETS.get(name),
+            import_route=route,
+            repack_exactness=exactness,
             requires_explicit_zero_point=name in _REQUIRES_EXPLICIT_ZERO_POINT,
             lm_head_preserve=name in _LM_HEAD_PRESERVE,
             reason=reason,
@@ -285,6 +309,133 @@ def native_block_format(ggml_type: object) -> str | None:
     return spec.native_preserve.format
 
 
+def quant_import_decision(
+    ggml_type: object,
+    tensor_role: TensorRole,
+    *,
+    target_bits: int | None = None,
+    target_block_size: int | None = None,
+) -> tuple[QuantImportRoute, RepackExactness | None, str]:
+    """Return the enforced importer route for a qtype and tensor role."""
+    spec = get_quant_spec(ggml_type)
+    if spec is None:
+        return (
+            QuantImportRoute.REJECTED,
+            None,
+            "The ggml type id is outside the pinned llama.cpp census.",
+        )
+    if not spec.is_quantized_storage:
+        return (
+            QuantImportRoute.REJECTED,
+            None,
+            f"{spec.name} is {spec.role.value}, not readable quantized weight storage.",
+        )
+    if spec.import_route is QuantImportRoute.REJECTED:
+        return (
+            QuantImportRoute.REJECTED,
+            None,
+            spec.reason
+            or (
+                f"{spec.name} has no trustworthy decoder or compatible runtime kernel. "
+                "Re-quantize to a supported qtype."
+            ),
+        )
+    if (
+        tensor_role
+        in {
+            TensorRole.AFFINE_PROJECTION,
+            TensorRole.EMBEDDING,
+        }
+        and spec.native_preserve is not None
+    ):
+        if spec.dequantize is Support.SUPPORTED:
+            return (
+                QuantImportRoute.DEQUANTIZE_REQUANTIZE,
+                None,
+                (
+                    "GatherBlockQuantized does not consume BlockQuantizedMatMul's "
+                    "native GGUF byte ABI; the embedding must use the affine Gather ABI."
+                    if tensor_role is TensorRole.EMBEDDING
+                    else "This graph exposes only the affine MatMulNBits ABI, not "
+                    "BlockQuantizedMatMul's native GGUF byte ABI."
+                ),
+            )
+        return (
+            QuantImportRoute.REJECTED,
+            None,
+            (
+                "The native projection ABI is not valid for GatherBlockQuantized, and "
+                "no trusted decoder is available for conversion."
+            ),
+        )
+    if tensor_role is TensorRole.NON_MATMUL:
+        if spec.dequantize is Support.SUPPORTED:
+            return (
+                QuantImportRoute.DEQUANTIZE_FLOAT,
+                None,
+                "Non-MatMul tensors are dequantized to float; no packed runtime ABI applies.",
+            )
+        return (
+            QuantImportRoute.REJECTED,
+            None,
+            "This non-MatMul tensor cannot remain quantized and has no trusted decoder.",
+        )
+    if tensor_role is TensorRole.EXPERT:
+        if spec.native_preserve is not None:
+            return (
+                QuantImportRoute.NATIVE_BYTES,
+                None,
+                (
+                    "Allowed only when the expert-major source is contiguous and maps "
+                    "to complete per-expert projection rows."
+                ),
+            )
+        return (
+            QuantImportRoute.REJECTED,
+            None,
+            (
+                "Only contiguous native expert-major blocks have a complete packed-tensor "
+                "route. Rebuild with keep_quantized=False for float expert normalization."
+            ),
+        )
+    target = (
+        None
+        if target_bits is None or target_block_size is None
+        else (target_bits, target_block_size)
+    )
+    if (
+        target is not None
+        and spec.affine_repack is not None
+        and spec.affine_repack.as_params() != target
+    ):
+        if spec.dequantize is Support.SUPPORTED:
+            return (
+                QuantImportRoute.DEQUANTIZE_REQUANTIZE,
+                RepackExactness.LOSSY,
+                (
+                    f"The exact {spec.repack_params} affine layout does not match target "
+                    f"{target}; conversion through float is lossy."
+                ),
+            )
+        return (
+            QuantImportRoute.REJECTED,
+            None,
+            (
+                f"The exact {spec.repack_params} affine layout does not match target "
+                f"{target}, and no trusted decoder is available."
+            ),
+        )
+    return (
+        spec.import_route,
+        spec.repack_exactness,
+        (
+            "The runtime operator consumes the exact GGUF block bytes."
+            if spec.import_route is QuantImportRoute.NATIVE_BYTES
+            else "The source is converted through the declared affine/runtime target."
+        ),
+    )
+
+
 def affine_repack_target(ggml_type: object) -> AffineRepackSpec | None:
     """Return the ``MatMulNBits`` repack target for a type, if it has one."""
     spec = get_quant_spec(ggml_type)
@@ -318,3 +469,28 @@ def explicit_zero_point_type_names() -> frozenset[str]:
     return frozenset(
         spec.name for spec in iter_quant_specs() if spec.requires_explicit_zero_point
     )
+
+
+def render_quant_support_matrix() -> str:
+    """Render the active stored-qtype policy table for generated documentation."""
+    rows = [
+        (
+            "| Stored qtype | ID | Projection/output route | Direct exactness | "
+            "Embedding route | Expert-major route | Non-MatMul route | Runtime |"
+        ),
+        "|---|---:|---|---|---|---|---|---|",
+    ]
+    for spec in iter_quant_specs():
+        if not spec.is_quantized_storage:
+            continue
+        projection = quant_import_decision(spec.ggml_type_id, TensorRole.PROJECTION)[0]
+        embedding = quant_import_decision(spec.ggml_type_id, TensorRole.EMBEDDING)[0]
+        expert = quant_import_decision(spec.ggml_type_id, TensorRole.EXPERT)[0]
+        other = quant_import_decision(spec.ggml_type_id, TensorRole.NON_MATMUL)[0]
+        exactness = "—" if spec.repack_exactness is None else spec.repack_exactness.value
+        rows.append(
+            f"| `{spec.name}` | {spec.ggml_type_id} | {projection.value} | "
+            f"{exactness} | {embedding.value} | {expert.value} | {other.value} | "
+            f"{spec.runtime.value} |"
+        )
+    return "\n".join(rows)

--- a/src/mobius/integrations/gguf/_quant_registry_test.py
+++ b/src/mobius/integrations/gguf/_quant_registry_test.py
@@ -16,6 +16,8 @@ Two jobs:
 
 from __future__ import annotations
 
+import pathlib
+
 import pytest
 
 from mobius.integrations.gguf import _repacker
@@ -25,9 +27,17 @@ from mobius.integrations.gguf._quant_registry import (
     get_quant_spec,
     iter_quant_specs,
     lm_head_preserve_type_names,
+    quant_import_decision,
     quant_spec_by_name,
+    render_quant_support_matrix,
 )
-from mobius.integrations.gguf._spec import StorageRole, Support
+from mobius.integrations.gguf._spec import (
+    QuantImportRoute,
+    RepackExactness,
+    StorageRole,
+    Support,
+    TensorRole,
+)
 from mobius.integrations.gguf._upstream import upstream_quant_types
 
 # --------------------------------------------------------------------------
@@ -73,8 +83,8 @@ _LEGACY_EXPLICIT_ZERO_POINT_TYPES = frozenset(
     {"Q1_0", "Q2_K", "Q4_0", "Q4_1", "Q4_K", "Q5_1", "Q5_K", "Q8_0"}
 )
 
-#: ``_builder._can_quantize_lm_head.supported_types``
-_LEGACY_LM_HEAD_PRESERVE = frozenset(
+#: Every non-rejected projection/output route may stay quantized.
+_EXPECTED_LM_HEAD_PRESERVE = frozenset(
     {
         "Q1_0",
         "Q2_K",
@@ -87,6 +97,9 @@ _LEGACY_LM_HEAD_PRESERVE = frozenset(
         "Q5_K",
         "Q6_K",
         "Q8_0",
+        "TQ1_0",
+        "TQ2_0",
+        "NVFP4",
         "MXFP4",
         "IQ4_NL",
         "IQ4_XS",
@@ -103,6 +116,34 @@ _LEGACY_LM_HEAD_PRESERVE = frozenset(
 #: ``_builder._has_quantized_weights.float_types`` — F32, F16, BF16, plus F64
 #: when the installed ``gguf`` exposes it.
 _LEGACY_FLOAT_TYPE_IDS = frozenset({0, 1, 30, 28})
+
+_PINNED_STORED_ROUTES = {
+    "Q4_0": ("affine repack", "exact"),
+    "Q4_1": ("affine repack", "lossy"),
+    "Q5_0": ("dequantize/requantize", None),
+    "Q5_1": ("dequantize/requantize", None),
+    "Q8_0": ("affine repack", "exact"),
+    "Q2_K": ("dequantize/requantize", None),
+    "Q3_K": ("dequantize/requantize", None),
+    "Q4_K": ("affine repack", "lossy"),
+    "Q5_K": ("dequantize/requantize", None),
+    "Q6_K": ("affine repack", "lossy"),
+    "TQ1_0": ("dequantize/requantize", None),
+    "TQ2_0": ("dequantize/requantize", None),
+    "IQ4_NL": ("native byte-preserved", None),
+    "IQ4_XS": ("native byte-preserved", None),
+    "IQ3_S": ("native byte-preserved", None),
+    "IQ3_XXS": ("native byte-preserved", None),
+    "IQ2_XXS": ("native byte-preserved", None),
+    "IQ2_XS": ("native byte-preserved", None),
+    "IQ2_S": ("native byte-preserved", None),
+    "IQ1_S": ("native byte-preserved", None),
+    "IQ1_M": ("native byte-preserved", None),
+    "MXFP4": ("native byte-preserved", None),
+    "NVFP4": ("dequantize/requantize", None),
+    "Q1_0": ("affine repack", "exact"),
+    "Q2_0": ("rejected", None),
+}
 
 
 class TestBehaviorPreservation:
@@ -143,7 +184,7 @@ class TestBehaviorPreservation:
         assert explicit_zero_point_type_names() == _LEGACY_EXPLICIT_ZERO_POINT_TYPES
 
     def test_lm_head_preserve_types(self) -> None:
-        assert lm_head_preserve_type_names() == _LEGACY_LM_HEAD_PRESERVE
+        assert lm_head_preserve_type_names() == _EXPECTED_LM_HEAD_PRESERVE
 
     def test_float_storage_types(self) -> None:
         assert float_storage_type_ids() == _LEGACY_FLOAT_TYPE_IDS
@@ -164,6 +205,36 @@ class TestCensusCoverage:
     def test_all_slots_are_registered(self) -> None:
         assert len(iter_quant_specs()) == 43
         assert len(upstream_quant_types()) == 43
+
+    def test_every_active_stored_qtype_has_one_pinned_route(self) -> None:
+        actual = {
+            spec.name: (
+                spec.import_route.value,
+                None if spec.repack_exactness is None else spec.repack_exactness.value,
+            )
+            for spec in iter_quant_specs()
+            if spec.is_quantized_storage
+        }
+        assert actual == _PINNED_STORED_ROUTES
+        assert len(actual) == 25
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            spec
+            for spec in iter_quant_specs()
+            if spec.import_route is QuantImportRoute.DEQUANTIZE_REQUANTIZE
+        ],
+        ids=lambda spec: spec.name,
+    )
+    def test_declared_float_decoders_execute_one_pinned_block(self, spec) -> None:
+        import numpy as np
+        from gguf import GGMLQuantizationType, quants
+
+        qtype = GGMLQuantizationType(spec.ggml_type_id)
+        values = quants.dequantize(np.zeros(spec.block_bytes, dtype=np.uint8), qtype)
+        assert values.size == spec.block_elements
+        assert np.isfinite(values).all()
 
     @pytest.mark.parametrize("spec", iter_quant_specs(), ids=lambda s: s.name)
     def test_geometry_matches_upstream(self, spec) -> None:
@@ -237,3 +308,71 @@ class TestStorageInvariants:
         assert spec.affine_repack is not None
         assert spec.repack_params == (2, 128)
         assert spec.lm_head_preserve
+
+    @pytest.mark.parametrize("spec", iter_quant_specs(), ids=lambda s: s.name)
+    def test_runtime_stays_deferred_without_real_execution_evidence(self, spec) -> None:
+        if spec.is_quantized_storage:
+            assert spec.runtime is Support.DEFERRED
+            assert "runtime" in spec.runtime_reason.lower()
+
+    def test_native_projection_does_not_imply_native_embedding(self) -> None:
+        projection = quant_import_decision(20, TensorRole.PROJECTION)
+        embedding = quant_import_decision(20, TensorRole.EMBEDDING)
+        assert projection[0] is QuantImportRoute.NATIVE_BYTES
+        assert embedding[0] is QuantImportRoute.DEQUANTIZE_REQUANTIZE
+        assert "GatherBlockQuantized" in embedding[2]
+
+    def test_native_experts_require_contiguous_expert_major_layout(self) -> None:
+        route, exactness, reason = quant_import_decision(39, TensorRole.EXPERT)
+        assert route is QuantImportRoute.NATIVE_BYTES
+        assert exactness is None
+        assert "contiguous" in reason
+
+    def test_non_matmul_q1_0_is_rejected_without_a_decoder(self) -> None:
+        route, _, reason = quant_import_decision(41, TensorRole.NON_MATMUL)
+        assert route is QuantImportRoute.REJECTED
+        assert "decoder" in reason
+
+    def test_non_native_expert_major_route_is_rejected(self) -> None:
+        route, _, reason = quant_import_decision(3, TensorRole.EXPERT)
+        assert route is QuantImportRoute.REJECTED
+        assert "keep_quantized=False" in reason
+
+    def test_exact_q8_route_becomes_lossy_for_four_bit_target(self) -> None:
+        route, exactness, reason = quant_import_decision(
+            8,
+            TensorRole.PROJECTION,
+            target_bits=4,
+            target_block_size=32,
+        )
+        assert route is QuantImportRoute.DEQUANTIZE_REQUANTIZE
+        assert exactness is RepackExactness.LOSSY
+        assert "lossy" in reason
+
+    def test_q1_route_rejects_an_incompatible_target_without_decoder(self) -> None:
+        route, _, reason = quant_import_decision(
+            41,
+            TensorRole.PROJECTION,
+            target_bits=4,
+            target_block_size=32,
+        )
+        assert route is QuantImportRoute.REJECTED
+        assert "no trusted decoder" in reason
+
+    @pytest.mark.parametrize("name", ["Q4_0", "Q8_0", "Q1_0"])
+    def test_exact_affine_routes_are_declared(self, name: str) -> None:
+        spec = quant_spec_by_name(name)
+        assert spec is not None
+        assert spec.import_route is QuantImportRoute.AFFINE_REPACK
+        assert spec.repack_exactness is RepackExactness.EXACT
+
+
+class TestDocumentedQuantizationMatrix:
+    _DOC = pathlib.Path(__file__).resolve().parents[4] / "docs" / "api" / "build_from_gguf.md"
+    _BEGIN = "<!-- BEGIN GGUF QUANTIZATION MATRIX (generated; see _quant_registry.py) -->"
+    _END = "<!-- END GGUF QUANTIZATION MATRIX -->"
+
+    def test_generated_matrix_is_current(self) -> None:
+        text = self._DOC.read_text(encoding="utf-8")
+        documented = text.split(self._BEGIN, 1)[1].split(self._END, 1)[0].strip()
+        assert documented == render_quant_support_matrix()

--- a/src/mobius/integrations/gguf/_spec.py
+++ b/src/mobius/integrations/gguf/_spec.py
@@ -209,6 +209,8 @@ class GGUFArchitectureSpec:
         tensor_map: Whether GGUF tensor names can be mapped to HuggingFace names.
         graph: Whether mobius can build the graph for ``model_type``.
         runtime: Whether a loadable runtime package can be written.
+        quantized_import: Whether the graph exposes packed projection modules
+            that can consume a preserved GGUF quantization route.
         reason: Why any non-``SUPPORTED`` verdict is what it is. Required
             whenever at least one verdict is not ``SUPPORTED``.
         config_key_map: Name of the architecture-specific GGUF-key → config-field
@@ -238,6 +240,7 @@ class GGUFArchitectureSpec:
     tensor_map: Support = Support.SUPPORTED
     graph: Support = Support.SUPPORTED
     runtime: Support = Support.SUPPORTED
+    quantized_import: Support = Support.SUPPORTED
     reason: str | None = None
     config_key_map: str | None = None
     config_postprocessor: str | None = None
@@ -255,7 +258,9 @@ class GGUFArchitectureSpec:
             raise ValueError("GGUFArchitectureSpec.gguf_arch must be non-empty")
         if self.gguf_arch in self.aliases:
             raise ValueError(f"{self.gguf_arch!r}: canonical name must not repeat in aliases")
-        _require_reason(f"GGUF architecture {self.gguf_arch!r}", self.verdicts, self.reason)
+        _require_reason(
+            f"GGUF architecture {self.gguf_arch!r}", self.capabilities, self.reason
+        )
         if self.graph is Support.SUPPORTED and not self.model_type:
             raise ValueError(
                 f"{self.gguf_arch!r}: graph=SUPPORTED requires a model_type to build with"
@@ -278,12 +283,20 @@ class GGUFArchitectureSpec:
 
     @property
     def verdicts(self) -> dict[str, Support]:
-        """The four capability verdicts, keyed by capability name."""
+        """The core float-import verdicts, keyed by capability name."""
         return {
             "config": self.config,
             "tensor_map": self.tensor_map,
             "graph": self.graph,
             "runtime": self.runtime,
+        }
+
+    @property
+    def capabilities(self) -> dict[str, Support]:
+        """All architecture verdicts, including quantized-import reachability."""
+        return {
+            **self.verdicts,
+            "quantized_import": self.quantized_import,
         }
 
     @property

--- a/src/mobius/integrations/gguf/_spec.py
+++ b/src/mobius/integrations/gguf/_spec.py
@@ -54,9 +54,12 @@ __all__ = [
     "AffineRepackSpec",
     "GGUFArchitectureSpec",
     "GGUFQuantSpec",
+    "QuantImportRoute",
+    "RepackExactness",
     "NativeBlockSpec",
     "StorageRole",
     "Support",
+    "TensorRole",
 ]
 
 import dataclasses
@@ -98,9 +101,37 @@ class StorageRole(enum.Enum):
     REMOVED = "removed-unreadable"
 
 
+class QuantImportRoute(enum.Enum):
+    """How a stored quantized tensor reaches the ONNX graph."""
+
+    NATIVE_BYTES = "native byte-preserved"
+    AFFINE_REPACK = "affine repack"
+    DEQUANTIZE_REQUANTIZE = "dequantize/requantize"
+    DEQUANTIZE_FLOAT = "dequantize to float"
+    REJECTED = "rejected"
+
+
+class RepackExactness(enum.Enum):
+    """Whether an affine conversion preserves every represented source value."""
+
+    EXACT = "exact"
+    LOSSY = "lossy"
+
+
+class TensorRole(enum.Enum):
+    """Runtime ABI selected for a mapped GGUF tensor."""
+
+    PROJECTION = "projection"
+    AFFINE_PROJECTION = "projection (affine-only graph)"
+    OUTPUT = "output"
+    EMBEDDING = "embedding"
+    EXPERT = "expert-major"
+    NON_MATMUL = "non-MatMul"
+
+
 @dataclasses.dataclass(frozen=True, slots=True)
 class NativeBlockSpec:
-    """Serialized GGUF block layout the runtime accepts without conversion.
+    """Serialized GGUF block layout matching the custom operator input ABI.
 
     Attributes:
         format: Runtime format string (e.g. ``"mxfp4"``).
@@ -287,6 +318,10 @@ class GGUFQuantSpec:
             handed to the runtime unchanged.
         affine_repack: ``MatMulNBits`` target, when the block data can be
             repacked into an affine layout.
+        import_route: Primary importer route for projection/output weights.
+        repack_exactness: Whether ``affine_repack`` preserves represented values.
+        runtime: Runtime execution verdict. Graph construction or ABI matching
+            alone is not runtime evidence.
         requires_explicit_zero_point: Whether a file containing this type forces
             the shared graph scaffolding to carry explicit ``zero_points``.
         lm_head_preserve: Whether an untied output head stored in this type may
@@ -302,6 +337,10 @@ class GGUFQuantSpec:
     dequantize: Support = Support.SUPPORTED
     native_preserve: NativeBlockSpec | None = None
     affine_repack: AffineRepackSpec | None = None
+    import_route: QuantImportRoute = QuantImportRoute.REJECTED
+    repack_exactness: RepackExactness | None = None
+    runtime: Support = Support.DEFERRED
+    runtime_reason: str = "No real-weight ONNX Runtime execution evidence is recorded."
     requires_explicit_zero_point: bool = False
     lm_head_preserve: bool = False
     reason: str | None = None
@@ -311,6 +350,7 @@ class GGUFQuantSpec:
         if not self.name:
             raise ValueError(f"GGML type id {self.ggml_type_id} must have a name")
         _require_reason(label, {"dequantize": self.dequantize}, self.reason)
+        _require_reason(label, {"runtime": self.runtime}, self.runtime_reason)
         # Upstream rejects a tensor whose type has blck_size == 0 in gguf.cpp
         # before any model logic runs, so readability is not an independent
         # choice — it is a consequence of the pinned block size.
@@ -329,6 +369,23 @@ class GGUFQuantSpec:
                 f"{label}: a type is either preserved natively or repacked into an "
                 "affine layout, never both — two paths would silently disagree"
             )
+        if self.import_route is QuantImportRoute.NATIVE_BYTES and self.native_preserve is None:
+            raise ValueError(f"{label}: native-byte route requires native_preserve")
+        if self.import_route is QuantImportRoute.AFFINE_REPACK and self.affine_repack is None:
+            raise ValueError(f"{label}: affine route requires affine_repack")
+        if (
+            self.import_route is QuantImportRoute.DEQUANTIZE_REQUANTIZE
+            and self.dequantize is not Support.SUPPORTED
+        ):
+            raise ValueError(f"{label}: dequantize/requantize route requires a dequantizer")
+        if self.import_route is QuantImportRoute.REJECTED and (
+            self.native_preserve is not None or self.affine_repack is not None
+        ):
+            raise ValueError(f"{label}: rejected route cannot expose a preservation path")
+        if self.affine_repack is None and self.repack_exactness is not None:
+            raise ValueError(f"{label}: repack exactness requires an affine repack target")
+        if self.affine_repack is not None and self.repack_exactness is None:
+            raise ValueError(f"{label}: affine repack target must declare exact or lossy")
         if self.native_preserve is not None:
             if self.native_preserve.elements != self.block_elements:
                 raise ValueError(

--- a/src/mobius/integrations/gguf/_spec_test.py
+++ b/src/mobius/integrations/gguf/_spec_test.py
@@ -16,6 +16,8 @@ from mobius.integrations.gguf._spec import (
     GGUFArchitectureSpec,
     GGUFQuantSpec,
     NativeBlockSpec,
+    QuantImportRoute,
+    RepackExactness,
     StorageRole,
     Support,
 )
@@ -88,7 +90,11 @@ class TestQuantSpecValidation:
         return GGUFQuantSpec(**fields)
 
     def test_a_minimal_quantized_spec_is_accepted(self) -> None:
-        spec = self._quantized(affine_repack=AffineRepackSpec(4, 32))
+        spec = self._quantized(
+            affine_repack=AffineRepackSpec(4, 32),
+            import_route=QuantImportRoute.AFFINE_REPACK,
+            repack_exactness=RepackExactness.LOSSY,
+        )
         assert spec.readable
         assert spec.repack_params == (4, 32)
 
@@ -120,13 +126,20 @@ class TestQuantSpecValidation:
             self._quantized(
                 native_preserve=NativeBlockSpec("q4_k", 256, 144),
                 affine_repack=AffineRepackSpec(4, 32),
+                import_route=QuantImportRoute.NATIVE_BYTES,
             )
 
     def test_native_geometry_must_match_upstream(self) -> None:
         with pytest.raises(ValueError, match="must match the upstream block size"):
-            self._quantized(native_preserve=NativeBlockSpec("q4_k", 32, 144))
+            self._quantized(
+                native_preserve=NativeBlockSpec("q4_k", 32, 144),
+                import_route=QuantImportRoute.NATIVE_BYTES,
+            )
         with pytest.raises(ValueError, match="must match the upstream type size"):
-            self._quantized(native_preserve=NativeBlockSpec("q4_k", 256, 17))
+            self._quantized(
+                native_preserve=NativeBlockSpec("q4_k", 256, 17),
+                import_route=QuantImportRoute.NATIVE_BYTES,
+            )
 
     def test_preservation_flags_require_quantized_storage(self) -> None:
         with pytest.raises(ValueError, match="lm_head_preserve only applies"):

--- a/src/mobius/models/qwen35_mtp.py
+++ b/src/mobius/models/qwen35_mtp.py
@@ -51,7 +51,7 @@ from onnxscript import OpBuilder, nn
 from mobius._configs import Qwen35MtpConfig
 from mobius.components import Linear, create_attention_bias, initialize_rope
 from mobius.components._rms_norm import OffsetRMSNorm
-from mobius.models.qwen35 import Qwen35DecoderLayer
+from mobius.models.qwen35 import Qwen35DecoderLayer, _linear_factory
 
 if TYPE_CHECKING:
     import onnx_ir as ir
@@ -90,7 +90,8 @@ class Qwen35MtpModel(nn.Module):
         # Input projection: fuse the token embedding with the target hidden.
         self.pre_fc_norm_embedding = OffsetRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.pre_fc_norm_hidden = OffsetRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.fc = Linear(2 * config.hidden_size, config.hidden_size, bias=False)
+        linear_class = _linear_factory(config) or Linear
+        self.fc = linear_class(2 * config.hidden_size, config.hidden_size, bias=False)
 
         # The single full-attention MTP decoder layer.
         self.layers = nn.ModuleList([Qwen35DecoderLayer(config, layer_idx=0)])


### PR DESCRIPTION
## Summary

- define an exhaustive importer policy for all 25 active storage-quantized GGML types at llama.cpp `8d9af256337d1a501250f9bbf4c0859a654bddd6`
- classify every qtype and tensor role as native byte preservation, affine repack (exact/lossy), decoder-backed requantization, float dequantization, or actionable rejection
- enforce target-dependent exactness, embedding and expert ABI restrictions, architecture capability checks, and quantized MTP sidecar routing
- generate the support matrix from the registry and add mutation-resistant closure, numerical formula/layout, synthetic build/save/load, and real mixed-qtype evidence

## Policy highlights

Native byte preservation is limited to compatible projection/output `BlockQuantizedMatMul` weights for IQ4_NL, IQ4_XS, IQ3_S, IQ3_XXS, IQ2_XXS, IQ2_XS, IQ2_S, IQ1_S, IQ1_M, and MXFP4. Embeddings use the separate `GatherBlockQuantized` ABI and are normalized accordingly. Non-native expert-major tensors reject in quantized mode unless their complete contiguous layout is supported. Unsupported `Q2_0` and unknown qtypes fail actionably. Runtime verdicts remain `DEFERRED` because graph construction is not runtime execution evidence.

## Real mixed-qtype evidence

- repository: `lmstudio-community/Qwen2.5-0.5B-Instruct-GGUF`
- revision: `3b32d0bf1ac136098d417677c7d757360f1ceb6b`
- file: `Qwen2.5-0.5B-Instruct-Q4_K_M.gguf`
- size: `397807936` bytes
- SHA-256: `fa4d41b65761ed565cac6b5f62e35135d050408b033114a128ab308c02b2e83a`
- inventory: 121 F32, 132 Q5_0, 12 Q4_K, 12 Q6_K, 13 Q8_0 tensors
- resulting graph: 169 `MatMulNBits`, one `GatherBlockQuantized`, zero `BlockQuantizedMatMul`

## Validation

- `1119 passed` — all `src/mobius/integrations/gguf/` tests
- `5517 passed, 52 skipped` — broad non-integration suite excluding `glm_moe_dsa`
- initialized `lintrunner` formatter and full lint pass
- two specialist review passes, with all findings resolved

The unfiltered broad suite has two pre-existing `glm_moe_dsa` failures, independently reproduced on the base branch: missing inferred `logits` shape and missing ONNX checker `value_info.type`. This PR does not modify that model.
