### PR TITLE
Stream sharded safetensors export + resumable full-checkpoint preflight

### DIFF
--- a/src/mobius/__init__.py
+++ b/src/mobius/__init__.py
@@ -72,6 +72,7 @@ __all__ = [
     "optimize_model",
     "register_ep",
     "registry",
+    "stream_safetensors_to_model",
     "tasks",
 ]
 
@@ -136,7 +137,7 @@ from mobius.adapters import (
     compose_adapter_deltas,
     fingerprint_model_weights,
 )
-from mobius.integrations._weight_loading import apply_weights
+from mobius.integrations._weight_loading import apply_weights, stream_safetensors_to_model
 from mobius.integrations.diffusers import build_diffusers_pipeline
 from mobius.integrations.gguf import build_from_gguf
 from mobius.integrations.nemo import build_from_nemo

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -1237,8 +1237,10 @@ def build_parser() -> argparse.ArgumentParser:
     preflight_parser.add_argument(
         "--download-dir",
         default=None,
-        help="Directory the shards will download into (default: output dir). "
-        "Its filesystem is checked for the source-download budget.",
+        help="Filesystem checked for the source-download budget. Default: the "
+        "Hugging Face cache (HF_HUB_CACHE), where hf_hub_download actually "
+        "writes shards. Set this (or HF_HOME) to a large volume to relocate the "
+        "download.",
     )
     preflight_parser.add_argument(
         "--export-mode",

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -711,6 +711,88 @@ def _cmd_preflight_gguf(args: argparse.Namespace) -> None:
         raise SystemExit(2)
 
 
+def _probe_gpu_total_bytes() -> int | None:
+    """Return the largest single-GPU memory in bytes via nvidia-smi, or None."""
+    import shutil as _shutil
+    import subprocess
+
+    exe = _shutil.which("nvidia-smi")
+    if exe is None:
+        return None
+    try:
+        out = subprocess.run(
+            [exe, "--query-gpu=memory.total", "--format=csv,noheader,nounits"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=True,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    mibs = [int(line) for line in out.stdout.split() if line.strip().isdigit()]
+    if not mibs:
+        return None
+    return max(mibs) * 1024 * 1024
+
+
+def _cmd_preflight(args: argparse.Namespace) -> None:
+    """Execute the 'preflight' subcommand (resumable export dry-run)."""
+    from mobius.preflight import ExportMode, LoaderMode, run_preflight
+
+    gpu_total = None
+    if args.gpu_total_bytes:
+        gpu_total = _parse_size(args.gpu_total_bytes)
+    elif not args.no_gpu_probe:
+        gpu_total = _probe_gpu_total_bytes()
+
+    result = run_preflight(
+        args.model_id,
+        output_dir=args.output,
+        revision=args.revision,
+        download_dir=args.download_dir,
+        export_mode=ExportMode(args.export_mode),
+        loader=LoaderMode(args.loader),
+        group_size=args.group_size,
+        target_dtype_bytes=args.target_dtype_bytes,
+        gpu_total_bytes=gpu_total,
+        margin_frac=args.margin,
+        state_path=args.state,
+    )
+
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2))
+    else:
+        b = result.budget
+        print(f"Model:        {result.model_id}")
+        print(f"Revision:     {result.revision or 'default'}")
+        print(f"Commit:       {result.commit_sha or '(local)'}")
+        print(f"Shards:       {len(result.shards)}")
+        if b is not None:
+            print(f"Params:       {b.param_count:,}  dtypes={b.dtype_bytes}")
+            print(f"Source:       {b.source_bytes / 1e12:.3f} TB (download)")
+            print(f"Output:       {b.output_bytes / 1e12:.3f} TB ({b.export_mode})")
+            print(
+                f"Peak RAM:     {b.peak_ram_bytes / 1e9:.1f} GB ({b.loader}) "
+                f"[eager={b.peak_ram_eager_bytes / 1e9:.1f} GB, "
+                f"stream={b.peak_ram_stream_bytes / 1e9:.1f} GB]"
+            )
+            print(f"Weights VRAM: {b.vram_weights_bytes / 1e9:.1f} GB")
+        for chk in result.checks:
+            state = "OK " if chk.ok else "FAIL"
+            print(
+                f"  [{state}] {chk.kind}: need {chk.required_bytes / 1e9:.1f} GB, "
+                f"free {chk.free_bytes / 1e9:.1f} GB"
+            )
+        if result.blockers:
+            print("BLOCKERS:")
+            for blk in result.blockers:
+                print(f"  - {blk}")
+        print(f"VERDICT: {'READY' if result.ok else 'REFUSED'}")
+
+    if not result.ok:
+        raise SystemExit(2)
+
+
 def _cmd_info(args: argparse.Namespace) -> None:
     """Execute the 'info' subcommand."""
     from mobius.integrations.diffusers._builder import (
@@ -1130,6 +1212,87 @@ def build_parser() -> argparse.ArgumentParser:
         help="Trust remote code when loading the HuggingFace model config.",
     )
     info_parser.set_defaults(func=_cmd_info)
+
+    # --- preflight ---
+    preflight_parser = subparsers.add_parser(
+        "preflight",
+        help="Dry-run an export: validate shard metadata and compute the exact "
+        "disk/RAM/VRAM budget, refusing before any download if it will not fit.",
+    )
+    preflight_parser.add_argument(
+        "model_id",
+        help="HuggingFace model ID or local checkpoint directory to preflight.",
+    )
+    preflight_parser.add_argument(
+        "--output",
+        "-o",
+        required=True,
+        help="Intended output directory for the exported ONNX (checked for free space).",
+    )
+    preflight_parser.add_argument(
+        "--revision",
+        default=None,
+        help="Model revision/branch/commit to resolve (default: main).",
+    )
+    preflight_parser.add_argument(
+        "--download-dir",
+        default=None,
+        help="Directory the shards will download into (default: output dir). "
+        "Its filesystem is checked for the source-download budget.",
+    )
+    preflight_parser.add_argument(
+        "--export-mode",
+        choices=["passthrough", "fp16", "int4-qmoe"],
+        default="passthrough",
+        help="Weight representation of the exported artifact (default: passthrough).",
+    )
+    preflight_parser.add_argument(
+        "--loader",
+        choices=["eager", "stream"],
+        default="stream",
+        help="Weight application strategy that sets the host-RAM peak.",
+    )
+    preflight_parser.add_argument(
+        "--group-size",
+        type=int,
+        default=32,
+        help="Quantization block size for int4-qmoe output sizing (default: 32).",
+    )
+    preflight_parser.add_argument(
+        "--target-dtype-bytes",
+        type=float,
+        default=2.0,
+        help="Bytes/param of the resident runtime weights for the VRAM estimate "
+        "(2.0=fp16/bf16, 0.5=int4).",
+    )
+    preflight_parser.add_argument(
+        "--gpu-total-bytes",
+        default=None,
+        help="Largest single-GPU memory (e.g. '80GB'); default probes nvidia-smi.",
+    )
+    preflight_parser.add_argument(
+        "--no-gpu-probe",
+        action="store_true",
+        help="Do not probe nvidia-smi for GPU memory.",
+    )
+    preflight_parser.add_argument(
+        "--margin",
+        type=float,
+        default=0.05,
+        help="Fractional free-space headroom required above each budget (default 0.05).",
+    )
+    preflight_parser.add_argument(
+        "--state",
+        default=None,
+        help="Resumable state JSON file; records validated shards and refuses on "
+        "checkpoint identity drift.",
+    )
+    preflight_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the full verdict as JSON.",
+    )
+    preflight_parser.set_defaults(func=_cmd_preflight)
 
     # --- convert-comfyui ---
     comfy_parser = subparsers.add_parser(

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -1263,9 +1263,10 @@ def build_parser() -> argparse.ArgumentParser:
     preflight_parser.add_argument(
         "--target-dtype-bytes",
         type=float,
-        default=2.0,
-        help="Bytes/param of the resident runtime weights for the VRAM estimate "
-        "(2.0=fp16/bf16, 0.5=int4).",
+        default=None,
+        help="Bytes/param of the resident runtime weights for the VRAM estimate. "
+        "Default: derived from the export (int4-qmoe ~0.5, fp16/passthrough 2.0). "
+        "Override to model a runtime dtype that differs from the export.",
     )
     preflight_parser.add_argument(
         "--gpu-total-bytes",

--- a/src/mobius/integrations/_weight_loading.py
+++ b/src/mobius/integrations/_weight_loading.py
@@ -16,9 +16,12 @@ from __future__ import annotations
 
 __all__ = [
     "apply_weights",
+    "stream_safetensors_to_model",
+    "external_data_checksums",
 ]
 
 import concurrent.futures
+import hashlib
 import json
 import logging
 import pathlib
@@ -30,6 +33,7 @@ import tqdm
 from huggingface_hub import hf_hub_download
 from huggingface_hub.utils import EntryNotFoundError
 from onnx_ir import tensor_adapters
+from safetensors import safe_open
 
 from mobius._optimizations import fold_initializers_after_weights
 
@@ -309,11 +313,49 @@ def _dequantize_fp8_weights(state_dict: dict[str, torch.Tensor]) -> dict[str, to
     return {k: v for k, v in result.items() if not any(k.endswith(s) for s in aux_suffixes)}
 
 
+def _resolve_shard_paths(model_id: str, revision: str | None = None) -> list[str]:
+    """Resolve local safetensors shard paths for the streaming loader.
+
+    Uses local files when *model_id* is a directory, otherwise downloads the
+    shards from HuggingFace Hub (once) and returns their cache paths. The
+    streaming loader reads tensors via ``safe_open``, so this is safetensors
+    only and refuses a legacy PyTorch checkpoint (use the eager
+    :func:`_download_weights` path for those).
+    """
+    local = _local_weight_paths(pathlib.Path(model_id))
+    if local is not None:
+        paths, weight_format = local
+        if weight_format != "safetensors":
+            raise ValueError(
+                "stream_safetensors_to_model supports safetensors checkpoints "
+                f"only, but {model_id!r} holds '{weight_format}' weights; use the "
+                "eager apply_weights path."
+            )
+        return paths
+
+    try:
+        kwargs = {"repo_id": model_id, "filename": _WEIGHT_INDEX_NAME}
+        if revision is not None:
+            kwargs["revision"] = revision
+        index_path = pathlib.Path(hf_hub_download(**kwargs))
+        all_files = _weight_filenames_from_index(index_path)
+    except EntryNotFoundError:
+        all_files = [_SINGLE_WEIGHT_NAME]
+
+    return _parallel_download(model_id, all_files, revision=revision, desc="safetensors")
+
+
 def _download_weights(model_id: str, revision: str | None = None) -> dict[str, torch.Tensor]:
     """Download weights from HuggingFace and return as a state dict.
 
     Prefers safetensors and falls back to legacy PyTorch state dictionaries
     loaded with ``weights_only=True``. Uses parallel downloads for shards.
+
+    .. note::
+       This loader holds **every shard resident at once** — the returned state
+       dict references the whole checkpoint. For a checkpoint larger than host
+       RAM prefer :func:`stream_safetensors_to_model`, which keeps a bounded
+       working set (safetensors only).
     """
     local_weights = _local_weight_paths(pathlib.Path(model_id))
     if local_weights is None:
@@ -373,3 +415,148 @@ def _download_weights(model_id: str, revision: str | None = None) -> dict[str, t
 
     state_dict = _dequantize_fp8_weights(state_dict)
     return state_dict
+
+
+def _shard_key_index(paths: list[str]) -> dict[str, tuple[str, list[int], str]]:
+    """Map each tensor key -> (shard_path, shape, dtype) by reading headers only.
+
+    ``safe_open(...).keys()`` and ``get_slice(...).get_shape()`` read only the
+    safetensors header, so this never materializes weight data. When a key
+    appears in more than one shard the first shard wins and a warning is logged.
+    """
+    key_index: dict[str, tuple[str, list[int], str]] = {}
+    for path in paths:
+        with safe_open(path, framework="pt") as handle:
+            for key in handle.keys():  # noqa: SIM118 - safe_open handle is not directly iterable
+                if key in key_index:
+                    logger.warning("Duplicate tensor key %r across shards; keeping first", key)
+                    continue
+                sliced = handle.get_slice(key)
+                key_index[key] = (path, list(sliced.get_shape()), sliced.get_dtype())
+    return key_index
+
+
+def _assign_lazy_from_shard(
+    initializer: ir.Value, shard_path: str, key: str, name: str
+) -> None:
+    """Assign an initializer a LazyTensor that reads its weight from a shard.
+
+    The closure re-opens the shard and reads exactly one tensor at serialization
+    time, so nothing is retained between assignment and ``ir.save`` and the peak
+    host RAM is bounded by the largest single tensor, not the whole checkpoint.
+    """
+    onnx_dtype = initializer.dtype
+    assert onnx_dtype is not None
+    target_dtype = tensor_adapters.to_torch_dtype(onnx_dtype)
+
+    def tensor_func(
+        p: str = shard_path, k: str = key, dt=target_dtype, n: str = name
+    ) -> tensor_adapters.TorchTensor:
+        with safe_open(p, framework="pt") as handle:
+            tensor = handle.get_tensor(k)
+        if tensor.dtype != dt:
+            tensor = tensor.to(dt)
+        return tensor_adapters.TorchTensor(tensor, name=n)
+
+    initializer.const_value = ir.LazyTensor(
+        tensor_func,
+        dtype=onnx_dtype,
+        shape=ir.Shape(initializer.shape),
+        name=name,
+    )
+
+
+def stream_safetensors_to_model(
+    model: ir.Model,
+    model_id: str,
+    *,
+    revision: str | None = None,
+    require_passthrough: bool = True,
+) -> set[str]:
+    """Apply weights to *model* without holding the whole checkpoint in RAM.
+
+    Every graph initializer is bound to a :class:`ir.LazyTensor` that reads its
+    tensor from the owning safetensors shard on demand. Compared to
+    :func:`apply_weights` fed by :func:`_download_weights` — which materializes
+    the entire checkpoint as one state dict — this keeps at most one tensor
+    resident, so a checkpoint far larger than host RAM can be re-serialized to
+    ONNX external data.
+
+    This is a *pass-through* loader: it maps each ONNX initializer 1:1 to a
+    checkpoint tensor and only casts dtype. It deliberately does **not** perform
+    weight fusion, qkv splitting, or quantization. When *require_passthrough* is
+    True (the default) and the graph has an initializer with no matching
+    checkpoint tensor — the signature of a model that needs preprocessing — it
+    raises rather than silently emitting an under-specified graph. Such models
+    must use the eager :func:`apply_weights` path.
+
+    Returns the set of initializer names that were bound.
+
+    Raises:
+        ValueError: on a shape mismatch, or (in pass-through mode) when a graph
+            initializer has no corresponding checkpoint tensor.
+    """
+    paths = _resolve_shard_paths(model_id, revision)
+    key_index = _shard_key_index(paths)
+
+    assigned: set[str] = set()
+    missing: list[str] = []
+    for name, initializer in list(model.graph.initializers.items()):
+        if initializer.const_value is not None:
+            continue
+        located = key_index.get(name)
+        if located is None:
+            missing.append(name)
+            continue
+        shard_path, shard_shape, _shard_dtype = located
+        if initializer.shape is not None:
+            expected = [int(d) for d in initializer.shape]
+            if expected != list(shard_shape):
+                raise ValueError(
+                    f"Weight shape mismatch for '{name}': model expects "
+                    f"{expected}, checkpoint has {list(shard_shape)}"
+                )
+        _assign_lazy_from_shard(initializer, shard_path, name, name)
+        assigned.add(name)
+
+    if missing and require_passthrough:
+        preview = missing[:5]
+        raise ValueError(
+            f"{len(missing)} graph initializer(s) have no matching checkpoint "
+            f"tensor and cannot be streamed as pass-through weights "
+            f"(e.g. {preview}). This model needs weight preprocessing "
+            f"(fusion/split/quantization); use the eager apply_weights path."
+        )
+    if missing:
+        logger.warning(
+            "Streaming left %d initializer(s) unassigned (require_passthrough=False)",
+            len(missing),
+        )
+
+    fold_initializers_after_weights(model)
+    return assigned
+
+
+def external_data_checksums(
+    output_dir: str | pathlib.PathLike,
+    *,
+    pattern: str = "*.onnx.data",
+    chunk_size: int = 1 << 20,
+) -> dict[str, dict[str, object]]:
+    """Compute a deterministic sha256 + size manifest for ONNX external data.
+
+    Returns ``{filename: {"sha256": hex, "size": bytes}}`` sorted by filename so
+    the manifest is byte-stable across runs. Use it to verify a re-export
+    reproduced identical external data (deterministic naming *and* content).
+    """
+    directory = pathlib.Path(output_dir)
+    manifest: dict[str, dict[str, object]] = {}
+    for path in sorted(directory.glob(pattern)):
+        digest = hashlib.sha256()
+        size = 0
+        with path.open("rb") as handle:
+            for block in iter(lambda: handle.read(chunk_size), b""):
+                digest.update(block)
+                size += len(block)
+        manifest[path.name] = {"sha256": digest.hexdigest(), "size": size}
+    return manifest

--- a/src/mobius/integrations/_weight_loading.py
+++ b/src/mobius/integrations/_weight_loading.py
@@ -484,20 +484,44 @@ def stream_safetensors_to_model(
 
     This is a *pass-through* loader: it maps each ONNX initializer 1:1 to a
     checkpoint tensor and only casts dtype. It deliberately does **not** perform
-    weight fusion, qkv splitting, or quantization. When *require_passthrough* is
-    True (the default) and the graph has an initializer with no matching
-    checkpoint tensor — the signature of a model that needs preprocessing — it
-    raises rather than silently emitting an under-specified graph. Such models
-    must use the eager :func:`apply_weights` path.
+    weight fusion, qkv splitting, or quantization/dequantization. When
+    *require_passthrough* is True (the default) it refuses two kinds of
+    non-passthrough sources rather than silently emitting a wrong graph: (1) a
+    quantized checkpoint (fp8 weights or ``*_scale_inv``/``*_scale`` tensors),
+    which needs the eager dequant path, and (2) a graph with an initializer that
+    has no matching checkpoint tensor — the signature of a model that needs
+    preprocessing. Such models must use the eager :func:`apply_weights` path.
 
     Returns the set of initializer names that were bound.
 
     Raises:
-        ValueError: on a shape mismatch, or (in pass-through mode) when a graph
-            initializer has no corresponding checkpoint tensor.
+        ValueError: on a shape mismatch; when the checkpoint is quantized; or
+            (in pass-through mode) when a graph initializer has no corresponding
+            checkpoint tensor.
     """
     paths = _resolve_shard_paths(model_id, revision)
     key_index = _shard_key_index(paths)
+
+    if require_passthrough:
+        # An fp8 checkpoint stores raw float8 weights under the same name the
+        # graph expects for bf16, plus separate ``*_scale_inv``/``*_scale``
+        # tensors. Casting fp8 -> bf16 without multiplying by the scale silently
+        # produces wrong weights, and the scale keys never map to an
+        # initializer (so the missing-tensor guard below never fires). Refuse
+        # such quantized sources up front; they must use the eager
+        # apply_weights path, which applies the scale.
+        quant_signals = sorted(
+            k
+            for k, (_p, _s, dt) in key_index.items()
+            if dt.startswith("F8") or k.endswith(("_scale_inv", "weight_scale"))
+        )
+        if quant_signals:
+            raise ValueError(
+                f"Checkpoint appears quantized (fp8 / scaled weights, e.g. "
+                f"{quant_signals[:5]}); the pass-through streaming loader cannot "
+                f"dequantize it and would drop the weight scale. Use the eager "
+                f"apply_weights path (which applies weight_scale_inv)."
+            )
 
     assigned: set[str] = set()
     missing: list[str] = []

--- a/src/mobius/integrations/_weight_loading_stream_test.py
+++ b/src/mobius/integrations/_weight_loading_stream_test.py
@@ -72,9 +72,7 @@ def _save_sharded(
         if not shard_names:
             continue
         fn = f"model-{i + 1:05d}-of-{n_shards:05d}.safetensors"
-        safetensors.torch.save_file(
-            {n: state[n] for n in shard_names}, str(directory / fn)
-        )
+        safetensors.torch.save_file({n: state[n] for n in shard_names}, str(directory / fn))
         for n in shard_names:
             weight_map[n] = fn
     (directory / "model.safetensors.index.json").write_text(
@@ -102,9 +100,7 @@ class TestStreamingCorrectness:
         def _no_hub(*_a, **_k):
             raise AssertionError("streaming a local dir must not call the Hub")
 
-        monkeypatch.setattr(
-            "mobius.integrations._weight_loading.hf_hub_download", _no_hub
-        )
+        monkeypatch.setattr("mobius.integrations._weight_loading.hf_hub_download", _no_hub)
         model = _fresh_model()
         state = _make_checkpoint_state(model)
         _save_single(state, tmp_path)
@@ -172,9 +168,7 @@ class TestStreamingRefusals:
         del state[dropped]
         _save_single(state, tmp_path)
 
-        assigned = stream_safetensors_to_model(
-            model, str(tmp_path), require_passthrough=False
-        )
+        assigned = stream_safetensors_to_model(model, str(tmp_path), require_passthrough=False)
         assert dropped not in assigned
 
     def test_fp8_checkpoint_refuses_rather_than_dropping_scale(self, tmp_path):

--- a/src/mobius/integrations/_weight_loading_stream_test.py
+++ b/src/mobius/integrations/_weight_loading_stream_test.py
@@ -1,0 +1,211 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for the streaming (bounded-RAM) safetensors weight loader.
+
+These cover the pass-through streaming path added to avoid materializing a whole
+checkpoint in host RAM: correctness (byte round-trip), the multi-shard index,
+deterministic external-data checksums, and the refusal semantics that keep the
+loader honest (shape mismatch, and a graph that needs preprocessing).
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import onnx_ir as ir
+import pytest
+import safetensors.torch
+import torch
+from onnx_ir import tensor_adapters
+
+from mobius._builder import build_from_module
+from mobius._testing import make_config
+from mobius.integrations._weight_loading import (
+    external_data_checksums,
+    stream_safetensors_to_model,
+)
+from mobius.models.base import CausalLMModel
+
+
+def _weight_initializers(model: ir.Model) -> dict[str, ir.Value]:
+    """Return initializers that still need weights (const_value is None)."""
+    return {
+        name: init
+        for name, init in model.graph.initializers.items()
+        if init.const_value is None
+    }
+
+
+def _make_checkpoint_state(model: ir.Model) -> dict[str, torch.Tensor]:
+    """Build a deterministic state dict matching the model's empty initializers."""
+    torch.manual_seed(0)
+    state: dict[str, torch.Tensor] = {}
+    for name, init in _weight_initializers(model).items():
+        torch_dtype = tensor_adapters.to_torch_dtype(init.dtype)
+        shape = tuple(int(d) for d in init.shape)
+        if torch_dtype.is_floating_point:
+            state[name] = (torch.randn(shape) * 0.02).to(torch_dtype)
+        else:
+            state[name] = torch.zeros(shape, dtype=torch_dtype)
+    return state
+
+
+def _fresh_model() -> ir.Model:
+    config = make_config()
+    module = CausalLMModel(config)
+    return build_from_module(module, config)["model"]
+
+
+def _save_single(state: dict[str, torch.Tensor], directory: pathlib.Path) -> None:
+    safetensors.torch.save_file(state, str(directory / "model.safetensors"))
+
+
+def _save_sharded(
+    state: dict[str, torch.Tensor], directory: pathlib.Path, n_shards: int = 3
+) -> None:
+    names = list(state)
+    weight_map: dict[str, str] = {}
+    for i in range(n_shards):
+        shard_names = names[i::n_shards]
+        if not shard_names:
+            continue
+        fn = f"model-{i + 1:05d}-of-{n_shards:05d}.safetensors"
+        safetensors.torch.save_file(
+            {n: state[n] for n in shard_names}, str(directory / fn)
+        )
+        for n in shard_names:
+            weight_map[n] = fn
+    (directory / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {}, "weight_map": weight_map})
+    )
+
+
+def _roundtrip_and_compare(model: ir.Model, state, tmp_path: pathlib.Path):
+    out = tmp_path / "out"
+    out.mkdir()
+    ir.save(model, str(out / "model.onnx"), external_data="model.onnx.data")
+    reloaded = ir.load(str(out / "model.onnx"))
+    for name, tensor in state.items():
+        if name not in reloaded.graph.initializers:
+            # Folded away (e.g. tied / packed) — skip; covered by other cases.
+            continue
+        got = torch.from_numpy(reloaded.graph.initializers[name].const_value.numpy().copy())
+        expected = tensor.to(got.dtype)
+        assert torch.equal(got, expected), f"weight {name} did not round-trip"
+    return out
+
+
+class TestStreamingCorrectness:
+    def test_single_file_streams_and_roundtrips(self, tmp_path, monkeypatch):
+        def _no_hub(*_a, **_k):
+            raise AssertionError("streaming a local dir must not call the Hub")
+
+        monkeypatch.setattr(
+            "mobius.integrations._weight_loading.hf_hub_download", _no_hub
+        )
+        model = _fresh_model()
+        state = _make_checkpoint_state(model)
+        _save_single(state, tmp_path)
+
+        assigned = stream_safetensors_to_model(model, str(tmp_path))
+
+        assert assigned == set(state)
+        _roundtrip_and_compare(model, state, tmp_path)
+
+    def test_sharded_index_streams_and_roundtrips(self, tmp_path):
+        model = _fresh_model()
+        state = _make_checkpoint_state(model)
+        _save_sharded(state, tmp_path, n_shards=3)
+
+        assigned = stream_safetensors_to_model(model, str(tmp_path))
+
+        assert assigned == set(state)
+        _roundtrip_and_compare(model, state, tmp_path)
+
+    def test_assignment_is_deferred_not_materialized(self, tmp_path):
+        model = _fresh_model()
+        state = _make_checkpoint_state(model)
+        _save_single(state, tmp_path)
+
+        stream_safetensors_to_model(model, str(tmp_path))
+
+        # Every streamed weight is a LazyTensor, i.e. nothing is materialized in
+        # RAM at assignment time. That is the whole point of the streaming path.
+        lazy = [
+            init
+            for name, init in model.graph.initializers.items()
+            if name in state and isinstance(init.const_value, ir.LazyTensor)
+        ]
+        assert lazy, "expected streamed weights to be deferred LazyTensors"
+
+
+class TestStreamingRefusals:
+    def test_shape_mismatch_raises(self, tmp_path):
+        model = _fresh_model()
+        state = _make_checkpoint_state(model)
+        # Corrupt one tensor's shape.
+        bad_name = next(iter(state))
+        state[bad_name] = torch.zeros(7, 11)
+        _save_single(state, tmp_path)
+
+        with pytest.raises(ValueError, match="shape mismatch"):
+            stream_safetensors_to_model(model, str(tmp_path))
+
+    def test_missing_weight_refuses_in_passthrough_mode(self, tmp_path):
+        model = _fresh_model()
+        state = _make_checkpoint_state(model)
+        # Drop a weight the graph needs — the signature of a checkpoint that
+        # requires preprocessing rather than a pass-through map.
+        dropped = next(iter(state))
+        del state[dropped]
+        _save_single(state, tmp_path)
+
+        with pytest.raises(ValueError, match="no matching checkpoint tensor"):
+            stream_safetensors_to_model(model, str(tmp_path))
+
+    def test_missing_weight_tolerated_when_not_passthrough(self, tmp_path):
+        model = _fresh_model()
+        state = _make_checkpoint_state(model)
+        dropped = next(iter(state))
+        del state[dropped]
+        _save_single(state, tmp_path)
+
+        assigned = stream_safetensors_to_model(
+            model, str(tmp_path), require_passthrough=False
+        )
+        assert dropped not in assigned
+
+
+class TestExternalDataChecksums:
+    def test_checksums_are_deterministic_across_exports(self, tmp_path):
+        model_a = _fresh_model()
+        state = _make_checkpoint_state(model_a)
+        _save_single(state, tmp_path)
+
+        stream_safetensors_to_model(model_a, str(tmp_path))
+        out_a = tmp_path / "a"
+        out_a.mkdir()
+        ir.save(model_a, str(out_a / "model.onnx"), external_data="model.onnx.data")
+        manifest_a = external_data_checksums(out_a)
+
+        # Re-stream from the same checkpoint into a fresh graph.
+        model_b = _fresh_model()
+        stream_safetensors_to_model(model_b, str(tmp_path))
+        out_b = tmp_path / "b"
+        out_b.mkdir()
+        ir.save(model_b, str(out_b / "model.onnx"), external_data="model.onnx.data")
+        manifest_b = external_data_checksums(out_b)
+
+        assert manifest_a  # non-empty (external data was actually written)
+        assert manifest_a == manifest_b, "external data must be byte-reproducible"
+
+    def test_manifest_reports_size_and_sha256(self, tmp_path):
+        (tmp_path / "model.onnx.data").write_bytes(b"hello world")
+        manifest = external_data_checksums(tmp_path)
+        assert manifest["model.onnx.data"]["size"] == 11
+        assert (
+            manifest["model.onnx.data"]["sha256"]
+            == "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        )

--- a/src/mobius/integrations/_weight_loading_stream_test.py
+++ b/src/mobius/integrations/_weight_loading_stream_test.py
@@ -177,6 +177,32 @@ class TestStreamingRefusals:
         )
         assert dropped not in assigned
 
+    def test_fp8_checkpoint_refuses_rather_than_dropping_scale(self, tmp_path):
+        model = _fresh_model()
+        state = _make_checkpoint_state(model)
+        # Store one weight as raw fp8 (the way DeepSeek/GLM fp8 checkpoints ship)
+        # plus a companion scale. A pass-through cast fp8 -> bf16 would silently
+        # drop the scale and emit wrong weights, so the loader must refuse.
+        target = next(iter(state))
+        state[target] = (state[target].float() * 0.1).to(torch.float8_e4m3fn)
+        state[f"{target}_scale_inv"] = torch.ones(1, dtype=torch.float32)
+        _save_single(state, tmp_path)
+
+        with pytest.raises(ValueError, match="quantized"):
+            stream_safetensors_to_model(model, str(tmp_path))
+
+    def test_scale_key_alone_signals_quantized_source(self, tmp_path):
+        model = _fresh_model()
+        state = _make_checkpoint_state(model)
+        # Even with every real weight present, a leftover *_scale_inv tensor is
+        # the signature of a quantized checkpoint the pass-through loader can't
+        # honor; it must refuse instead of silently ignoring the scale.
+        state["extra.weight_scale_inv"] = torch.ones(4, dtype=torch.float32)
+        _save_single(state, tmp_path)
+
+        with pytest.raises(ValueError, match="quantized"):
+            stream_safetensors_to_model(model, str(tmp_path))
+
 
 class TestExternalDataChecksums:
     def test_checksums_are_deterministic_across_exports(self, tmp_path):

--- a/src/mobius/preflight.py
+++ b/src/mobius/preflight.py
@@ -1,0 +1,641 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Resumable export preflight / dry-run.
+
+Before a large sharded checkpoint is downloaded and exported, this module
+validates *only metadata* — the safetensors index, every shard's URL/size/hash,
+and the resolved commit — and computes the exact storage, host-RAM and device
+VRAM required by the export. It then compares those requirements against the
+free space actually available and **refuses** when any budget is insufficient.
+
+Design rules (these are load-bearing, not decoration):
+
+* **No success-shaped fallback.** A metadata call that fails (network, auth,
+  missing index) is a hard blocker, never a silent "assume it is fine". A
+  refusal is a first-class, correct outcome.
+* **No model-name allowlist.** Everything is derived from the safetensors index
+  and the HuggingFace file metadata, so a new checkpoint needs no code change.
+* **Metadata only.** Nothing here downloads a weight shard; the only network
+  reads are ``model_info`` and the small ``*.index.json``. That is what makes it
+  safe to run *before* committing hundreds of GB of transfer.
+* **Resumable.** Validated shards are recorded in a JSON state file keyed by the
+  resolved commit. A re-run skips re-validated shards and refuses loudly if the
+  upstream commit drifted (checkpoint identity changed underneath us).
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "ExportMode",
+    "LoaderMode",
+    "ShardMeta",
+    "Budget",
+    "SpaceCheck",
+    "PreflightResult",
+    "resolve_source",
+    "estimate_budget",
+    "run_preflight",
+]
+
+import dataclasses
+import enum
+import json
+import logging
+import os
+import pathlib
+import shutil
+
+from mobius.integrations._weight_loading import (
+    _SINGLE_WEIGHT_NAME,
+    _WEIGHT_INDEX_NAME,
+    _validate_weight_filenames,
+)
+
+logger = logging.getLogger(__name__)
+
+# Bytes-per-parameter for a safetensors dtype string as reported by the Hub's
+# ``safetensors.parameters`` metadata block.
+_DTYPE_BYTES: dict[str, float] = {
+    "F64": 8,
+    "I64": 8,
+    "F32": 4,
+    "I32": 4,
+    "BF16": 2,
+    "F16": 2,
+    "I16": 2,
+    "F8_E4M3": 1,
+    "F8_E5M2": 1,
+    "I8": 1,
+    "U8": 1,
+    "BOOL": 1,
+    "F4": 0.5,
+    "U4": 0.5,
+    "I4": 0.5,
+}
+
+
+class ExportMode(str, enum.Enum):
+    """How the weights are represented in the exported ONNX artifact."""
+
+    PASSTHROUGH = "passthrough"  # keep source width (e.g. bf16 -> bf16/fp16 cast)
+    FP16 = "fp16"
+    INT4_QMOE = "int4-qmoe"  # 4-bit packed + scales + zero points
+
+
+class LoaderMode(str, enum.Enum):
+    """Weight application strategy, which sets the host-RAM peak."""
+
+    EAGER = "eager"  # whole checkpoint resident (today's default)
+    STREAM = "stream"  # one shard/tensor resident at a time
+
+
+@dataclasses.dataclass
+class ShardMeta:
+    """A single safetensors shard as named by the checkpoint's weight index."""
+
+    filename: str
+    size: int | None = None
+    sha256: str | None = None
+    present_local: bool = False
+    validated: bool = False
+
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+
+@dataclasses.dataclass
+class Budget:
+    """Exact resource requirements derived from checkpoint metadata."""
+
+    param_count: int
+    dtype_bytes: dict[str, int]
+    source_bytes: int
+    largest_shard_bytes: int
+    output_bytes: int
+    peak_ram_bytes: int
+    peak_ram_eager_bytes: int
+    peak_ram_stream_bytes: int
+    vram_weights_bytes: int
+    export_mode: str
+    loader: str
+
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+
+@dataclasses.dataclass
+class SpaceCheck:
+    """A single free-space (disk or RAM) requirement and whether it is met."""
+
+    kind: str  # "disk:download", "disk:output", "ram"
+    path: str | None
+    required_bytes: int
+    free_bytes: int
+    margin_frac: float
+    ok: bool
+
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+
+@dataclasses.dataclass
+class PreflightResult:
+    """Full preflight verdict. ``ok`` is only True when there are no blockers."""
+
+    model_id: str
+    revision: str | None
+    commit_sha: str | None
+    shards: list[ShardMeta]
+    budget: Budget | None
+    checks: list[SpaceCheck]
+    blockers: list[str]
+    ok: bool
+
+    def to_dict(self) -> dict:
+        return {
+            "model_id": self.model_id,
+            "revision": self.revision,
+            "commit_sha": self.commit_sha,
+            "num_shards": len(self.shards),
+            "shards": [s.to_dict() for s in self.shards],
+            "budget": self.budget.to_dict() if self.budget else None,
+            "checks": [c.to_dict() for c in self.checks],
+            "blockers": list(self.blockers),
+            "ok": self.ok,
+        }
+
+
+def _bytes_from_dtype_params(parameters: dict[str, int]) -> tuple[int, dict[str, int]]:
+    """Return (total_param_count, {dtype: bytes}) from a Hub parameters block."""
+    total_params = 0
+    dtype_bytes: dict[str, int] = {}
+    for dtype, count in parameters.items():
+        total_params += int(count)
+        per = _DTYPE_BYTES.get(dtype.upper())
+        if per is None:
+            raise ValueError(
+                f"Unknown safetensors dtype {dtype!r} in checkpoint metadata; "
+                "refusing rather than guessing its byte width."
+            )
+        dtype_bytes[dtype.upper()] = int(count * per)
+    return total_params, dtype_bytes
+
+
+# ---------------------------------------------------------------------------
+# Source resolution (metadata only)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_local(model_dir: pathlib.Path) -> tuple[None, list[ShardMeta], dict]:
+    index_path = model_dir / _WEIGHT_INDEX_NAME
+    if index_path.is_file():
+        index = json.loads(index_path.read_text())
+        filenames = _validate_weight_filenames(sorted(set(index["weight_map"].values())))
+    elif (model_dir / _SINGLE_WEIGHT_NAME).is_file():
+        index = {}
+        filenames = [_SINGLE_WEIGHT_NAME]
+    else:
+        raise FileNotFoundError(
+            f"Local checkpoint has no {_WEIGHT_INDEX_NAME!r} or {_SINGLE_WEIGHT_NAME!r}: "
+            f"{model_dir}"
+        )
+
+    root = model_dir.resolve()
+    shards: list[ShardMeta] = []
+    for filename in filenames:
+        path = (model_dir / filename).resolve()
+        try:
+            path.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(f"Unsafe weight filename in index: {filename!r}") from exc
+        present = path.is_file()
+        size = path.stat().st_size if present else None
+        shards.append(ShardMeta(filename=filename, size=size, present_local=present))
+    return None, shards, index
+
+
+def _resolve_hub(
+    model_id: str, revision: str | None, *, hf_api=None
+) -> tuple[str, list[ShardMeta], dict]:
+    from huggingface_hub import hf_hub_download
+
+    if hf_api is None:
+        from huggingface_hub import HfApi
+
+        hf_api = HfApi()
+
+    # model_info validates access (401/404 raise) and yields per-file metadata.
+    info = hf_api.model_info(model_id, revision=revision, files_metadata=True)
+    commit_sha = info.sha
+    size_by_name: dict[str, int | None] = {}
+    sha_by_name: dict[str, str | None] = {}
+    for sibling in info.siblings or []:
+        name = sibling.rfilename
+        size_by_name[name] = getattr(sibling, "size", None)
+        lfs = getattr(sibling, "lfs", None)
+        sha_by_name[name] = getattr(lfs, "sha256", None) if lfs else None
+
+    # Resolve the shard list from the index (falling back to a single file).
+    try:
+        index_path = hf_hub_download(
+            repo_id=model_id, filename=_WEIGHT_INDEX_NAME, revision=revision
+        )
+        index = json.loads(pathlib.Path(index_path).read_text())
+        filenames = _validate_weight_filenames(sorted(set(index["weight_map"].values())))
+    except Exception as exc:  # re-raise below as a blocker
+        if _SINGLE_WEIGHT_NAME in size_by_name:
+            index = {}
+            filenames = [_SINGLE_WEIGHT_NAME]
+        else:
+            raise FileNotFoundError(
+                f"Could not resolve a safetensors index for {model_id!r}: {exc}"
+            ) from exc
+
+    shards: list[ShardMeta] = []
+    for filename in filenames:
+        if filename not in size_by_name:
+            raise FileNotFoundError(
+                f"Weight index references {filename!r} but it is absent from the "
+                f"repository file listing for {model_id!r} @ {commit_sha}."
+            )
+        shards.append(
+            ShardMeta(
+                filename=filename,
+                size=size_by_name.get(filename),
+                sha256=sha_by_name.get(filename),
+                present_local=False,
+            )
+        )
+    return commit_sha, shards, index
+
+
+def resolve_source(
+    model_id: str, revision: str | None = None, *, hf_api=None
+) -> tuple[str | None, list[ShardMeta], dict]:
+    """Resolve the shard list + sizes for a checkpoint without downloading it.
+
+    ``model_id`` may be a local directory or a HuggingFace repo id. Returns
+    ``(commit_sha, shards, index)`` where ``commit_sha`` is ``None`` for a local
+    directory. Raises on inaccessible / malformed checkpoints (no fallback).
+    """
+    local = pathlib.Path(model_id)
+    if local.is_dir():
+        return _resolve_local(local)
+    return _resolve_hub(model_id, revision, hf_api=hf_api)
+
+
+# ---------------------------------------------------------------------------
+# Budget estimation
+# ---------------------------------------------------------------------------
+
+
+def _params_and_dtype_bytes(
+    shards: list[ShardMeta], index: dict, safetensors_meta: dict | None
+) -> tuple[int, dict[str, int], int]:
+    """Best-effort (param_count, {dtype: bytes}, source_bytes).
+
+    Prefers the Hub ``safetensors`` metadata block (exact dtype breakdown). Falls
+    back to the index ``metadata.total_size`` and finally to summing shard sizes.
+    """
+    source_bytes = 0
+    have_all_sizes = all(s.size is not None for s in shards)
+    if have_all_sizes:
+        source_bytes = sum(int(s.size) for s in shards)
+
+    if safetensors_meta and safetensors_meta.get("parameters"):
+        param_count, dtype_bytes = _bytes_from_dtype_params(safetensors_meta["parameters"])
+        if not source_bytes:
+            source_bytes = sum(dtype_bytes.values())
+        return param_count, dtype_bytes, source_bytes
+
+    total_size = None
+    if isinstance(index, dict):
+        total_size = index.get("metadata", {}).get("total_size")
+    weight_bytes = int(total_size) if total_size else source_bytes
+    if not source_bytes:
+        source_bytes = weight_bytes
+    # Without a dtype block, assume 16-bit weights (bf16/fp16) — the common case
+    # for an unquantized checkpoint — and record it as an assumption.
+    param_count = weight_bytes // 2 if weight_bytes else 0
+    dtype_bytes = {"UNKNOWN16": weight_bytes} if weight_bytes else {}
+    return param_count, dtype_bytes, source_bytes
+
+
+def estimate_output_bytes(
+    param_count: int,
+    dtype_bytes: dict[str, int],
+    export_mode: ExportMode,
+    *,
+    group_size: int = 32,
+) -> int:
+    """Estimate the ONNX external-data output size for an export mode."""
+    source_bytes = sum(dtype_bytes.values())
+    if export_mode == ExportMode.PASSTHROUGH:
+        return source_bytes
+    if export_mode == ExportMode.FP16:
+        return param_count * 2
+    if export_mode == ExportMode.INT4_QMOE:
+        # 4-bit packed weights + fp16 scales + int4 zero points, per block.
+        per = 0.5 + 2.0 / group_size + 0.5 / group_size
+        return int(param_count * per)
+    raise ValueError(f"unknown export mode {export_mode!r}")
+
+
+def _has_fp8(dtype_bytes: dict[str, int]) -> bool:
+    return any(k.startswith("F8") for k in dtype_bytes)
+
+
+def estimate_budget(
+    shards: list[ShardMeta],
+    index: dict,
+    safetensors_meta: dict | None,
+    *,
+    export_mode: ExportMode = ExportMode.PASSTHROUGH,
+    loader: LoaderMode = LoaderMode.STREAM,
+    group_size: int = 32,
+    target_dtype_bytes: float = 2.0,
+    vram_headroom_frac: float = 0.15,
+) -> Budget:
+    """Compute the storage / RAM / VRAM budget for an export."""
+    param_count, dtype_bytes, source_bytes = _params_and_dtype_bytes(
+        shards, index, safetensors_meta
+    )
+    largest_shard = max((int(s.size) for s in shards if s.size is not None), default=0)
+    output_bytes = estimate_output_bytes(
+        param_count, dtype_bytes, export_mode, group_size=group_size
+    )
+
+    # Eager holds the entire source state dict resident; an fp8 source is
+    # up-converted to bf16 (2x its bytes) and, for a quantizing export, the
+    # derived packed tensors coexist with the source before serialization.
+    fp8_upconvert = 0
+    if _has_fp8(dtype_bytes):
+        fp8_bytes = sum(v for k, v in dtype_bytes.items() if k.startswith("F8"))
+        fp8_upconvert = fp8_bytes  # 1 byte -> 2 bytes adds one extra copy
+    derived_overhead = output_bytes if export_mode == ExportMode.INT4_QMOE else 0
+    peak_ram_eager = source_bytes + fp8_upconvert + derived_overhead
+
+    # Streaming keeps at most one shard (and its cast twin) resident.
+    peak_ram_stream = 2 * largest_shard if largest_shard else source_bytes
+
+    peak_ram = peak_ram_eager if loader == LoaderMode.EAGER else peak_ram_stream
+
+    vram_weights = int(param_count * target_dtype_bytes * (1 + vram_headroom_frac))
+
+    return Budget(
+        param_count=param_count,
+        dtype_bytes=dtype_bytes,
+        source_bytes=source_bytes,
+        largest_shard_bytes=largest_shard,
+        output_bytes=output_bytes,
+        peak_ram_bytes=peak_ram,
+        peak_ram_eager_bytes=peak_ram_eager,
+        peak_ram_stream_bytes=peak_ram_stream,
+        vram_weights_bytes=vram_weights,
+        export_mode=export_mode.value,
+        loader=loader.value,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Free-space checks
+# ---------------------------------------------------------------------------
+
+
+def _free_bytes(path: pathlib.Path) -> int:
+    probe = path
+    while not probe.exists():
+        if probe.parent == probe:
+            break
+        probe = probe.parent
+    return shutil.disk_usage(probe).free
+
+
+def _available_ram_bytes() -> int | None:
+    try:
+        for line in pathlib.Path("/proc/meminfo").read_text().splitlines():
+            if line.startswith("MemAvailable:"):
+                return int(line.split()[1]) * 1024
+    except OSError:
+        return None
+    return None
+
+
+def check_disk(
+    kind: str, path: pathlib.Path, required: int, margin_frac: float
+) -> SpaceCheck:
+    free = _free_bytes(path)
+    ok = free * (1 - margin_frac) >= required
+    return SpaceCheck(
+        kind=kind,
+        path=str(path),
+        required_bytes=required,
+        free_bytes=free,
+        margin_frac=margin_frac,
+        ok=ok,
+    )
+
+
+def check_ram(required: int, margin_frac: float) -> SpaceCheck:
+    free = _available_ram_bytes()
+    ok = free is None or free * (1 - margin_frac) >= required
+    return SpaceCheck(
+        kind="ram",
+        path="/proc/meminfo:MemAvailable",
+        required_bytes=required,
+        free_bytes=int(free) if free is not None else -1,
+        margin_frac=margin_frac,
+        ok=ok,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Resumable state
+# ---------------------------------------------------------------------------
+
+
+def _load_state(state_path: pathlib.Path | None) -> dict:
+    if state_path is None or not state_path.is_file():
+        return {}
+    try:
+        return json.loads(state_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        logger.warning("Ignoring unreadable preflight state at %s", state_path)
+        return {}
+
+
+def _save_state(state_path: pathlib.Path | None, state: dict) -> None:
+    if state_path is None:
+        return
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = state_path.with_suffix(state_path.suffix + ".tmp")
+    tmp.write_text(json.dumps(state, indent=2, sort_keys=True))
+    os.replace(tmp, state_path)
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def run_preflight(
+    model_id: str,
+    output_dir: str | os.PathLike,
+    *,
+    revision: str | None = None,
+    download_dir: str | os.PathLike | None = None,
+    export_mode: ExportMode = ExportMode.PASSTHROUGH,
+    loader: LoaderMode = LoaderMode.STREAM,
+    group_size: int = 32,
+    target_dtype_bytes: float = 2.0,
+    gpu_total_bytes: int | None = None,
+    margin_frac: float = 0.05,
+    state_path: str | os.PathLike | None = None,
+    hf_api=None,
+) -> PreflightResult:
+    """Run the full preflight and return a verdict.
+
+    The verdict's ``ok`` is True only when there are zero blockers: metadata
+    resolved, every index shard accounted for, and every disk/RAM budget met.
+    """
+    blockers: list[str] = []
+    output_path = pathlib.Path(output_dir)
+    download_path = pathlib.Path(download_dir) if download_dir else output_path
+    state_file = pathlib.Path(state_path) if state_path else None
+
+    # 1) Resolve + validate metadata. A failure here is terminal, never a pass.
+    try:
+        commit_sha, shards, index = resolve_source(model_id, revision, hf_api=hf_api)
+    except Exception as exc:  # surface as a structured blocker
+        return PreflightResult(
+            model_id=model_id,
+            revision=revision,
+            commit_sha=None,
+            shards=[],
+            budget=None,
+            checks=[],
+            blockers=[f"metadata unavailable: {type(exc).__name__}: {exc}"],
+            ok=False,
+        )
+
+    if not shards:
+        blockers.append("no safetensors shards resolved from checkpoint metadata")
+
+    missing_size = [s.filename for s in shards if s.size is None and not s.present_local]
+    if missing_size:
+        blockers.append(
+            f"{len(missing_size)} shard(s) have no size metadata "
+            f"(cannot budget): {missing_size[:3]}{'...' if len(missing_size) > 3 else ''}"
+        )
+
+    # 2) Resumable state — refuse on identity drift.
+    state = _load_state(state_file)
+    prior_sha = state.get("commit_sha")
+    if prior_sha and commit_sha and prior_sha != commit_sha:
+        blockers.append(
+            f"checkpoint identity drift: state recorded commit {prior_sha} but "
+            f"upstream now resolves to {commit_sha}; refusing to reuse state"
+        )
+        state = {}
+    validated_prior = set(state.get("validated_shards", []))
+    for shard in shards:
+        if shard.filename in validated_prior:
+            shard.validated = True
+
+    # 3) Metadata from the Hub (dtype breakdown) when available.
+    safetensors_meta = None
+    if commit_sha is not None:
+        info = _maybe_model_info(model_id, revision, hf_api)
+        if info is not None and getattr(info, "safetensors", None) is not None:
+            st = info.safetensors
+            safetensors_meta = {
+                "parameters": dict(getattr(st, "parameters", {}) or {}),
+                "total": getattr(st, "total", None),
+            }
+
+    # 4) Budget.
+    budget = estimate_budget(
+        shards,
+        index,
+        safetensors_meta,
+        export_mode=export_mode,
+        loader=loader,
+        group_size=group_size,
+        target_dtype_bytes=target_dtype_bytes,
+    )
+
+    # 5) Free-space + RAM checks.
+    checks: list[SpaceCheck] = []
+    already_present = sum(
+        int(s.size) for s in shards if s.present_local and s.size is not None
+    )
+    download_required = max(budget.source_bytes - already_present, 0)
+    checks.append(check_disk("disk:download", download_path, download_required, margin_frac))
+    checks.append(check_disk("disk:output", output_path, budget.output_bytes, margin_frac))
+    checks.append(check_ram(budget.peak_ram_bytes, margin_frac))
+
+    for chk in checks:
+        if not chk.ok:
+            blockers.append(
+                f"insufficient {chk.kind}: need {_h(chk.required_bytes)} at "
+                f"{chk.path}, free {_h(chk.free_bytes)} (margin {chk.margin_frac:.0%})"
+            )
+
+    # 6) VRAM advisory (single-GPU fit is common blocker for full checkpoints).
+    if gpu_total_bytes is not None and budget.vram_weights_bytes > gpu_total_bytes:
+        blockers.append(
+            f"weights need {_h(budget.vram_weights_bytes)} VRAM but the largest "
+            f"single device has {_h(gpu_total_bytes)}; multi-GPU shard or weight "
+            f"offload is required (not a single-device load)"
+        )
+
+    ok = not blockers
+
+    # 7) Persist resumable state (record identity + which shards are validated).
+    new_state = {
+        "model_id": model_id,
+        "revision": revision,
+        "commit_sha": commit_sha,
+        "validated_shards": sorted(
+            {s.filename for s in shards if s.size is not None or s.present_local}
+            | validated_prior
+        ),
+        "budget": budget.to_dict(),
+        "ok": ok,
+    }
+    _save_state(state_file, new_state)
+
+    return PreflightResult(
+        model_id=model_id,
+        revision=revision,
+        commit_sha=commit_sha,
+        shards=shards,
+        budget=budget,
+        checks=checks,
+        blockers=blockers,
+        ok=ok,
+    )
+
+
+def _maybe_model_info(model_id: str, revision: str | None, hf_api):
+    try:
+        if hf_api is None:
+            from huggingface_hub import HfApi
+
+            hf_api = HfApi()
+        return hf_api.model_info(model_id, revision=revision, files_metadata=False)
+    except Exception:  # dtype breakdown is best-effort
+        return None
+
+
+def _h(n: int) -> str:
+    """Human-readable byte count (decimal units, matching HF/df)."""
+    if n < 0:
+        return "unknown"
+    step = 1000.0
+    for unit in ("B", "KB", "MB", "GB", "TB", "PB"):
+        if n < step:
+            return f"{n:.1f}{unit}" if unit != "B" else f"{int(n)}{unit}"
+        n /= step
+    return f"{n:.1f}EB"

--- a/src/mobius/preflight.py
+++ b/src/mobius/preflight.py
@@ -359,10 +359,16 @@ def estimate_budget(
     export_mode: ExportMode = ExportMode.PASSTHROUGH,
     loader: LoaderMode = LoaderMode.STREAM,
     group_size: int = 32,
-    target_dtype_bytes: float = 2.0,
+    target_dtype_bytes: float | None = None,
     vram_headroom_frac: float = 0.15,
 ) -> Budget:
-    """Compute the storage / RAM / VRAM budget for an export."""
+    """Compute the storage / RAM / VRAM budget for an export.
+
+    When *target_dtype_bytes* is None the runtime weight footprint is taken from
+    the exported artifact size (``output_bytes``), so an int4-qmoe export is
+    sized at ~0.5 byte/param rather than the source dtype. Pass an explicit
+    value to model a runtime load dtype that differs from the export.
+    """
     param_count, dtype_bytes, source_bytes = _params_and_dtype_bytes(
         shards, index, safetensors_meta
     )
@@ -386,7 +392,11 @@ def estimate_budget(
 
     peak_ram = peak_ram_eager if loader == LoaderMode.EAGER else peak_ram_stream
 
-    vram_weights = int(param_count * target_dtype_bytes * (1 + vram_headroom_frac))
+    # The weights loaded at runtime are the weights that were exported, so the
+    # exported artifact size is the right default VRAM footprint (an int4-qmoe
+    # export loads int4, not the bf16 source).
+    vram_base = output_bytes if target_dtype_bytes is None else int(param_count * target_dtype_bytes)
+    vram_weights = int(vram_base * (1 + vram_headroom_frac))
 
     return Budget(
         param_count=param_count,
@@ -527,7 +537,7 @@ def run_preflight(
     export_mode: ExportMode = ExportMode.PASSTHROUGH,
     loader: LoaderMode = LoaderMode.STREAM,
     group_size: int = 32,
-    target_dtype_bytes: float = 2.0,
+    target_dtype_bytes: float | None = None,
     gpu_total_bytes: int | None = None,
     margin_frac: float = 0.05,
     state_path: str | os.PathLike | None = None,

--- a/src/mobius/preflight.py
+++ b/src/mobius/preflight.py
@@ -332,7 +332,12 @@ def estimate_output_bytes(
     """Estimate the ONNX external-data output size for an export mode."""
     source_bytes = sum(dtype_bytes.values())
     if export_mode == ExportMode.PASSTHROUGH:
-        return source_bytes
+        # A passthrough export dequantizes an fp8 checkpoint to bf16 (2 bytes)
+        # on the eager path, so fp8 external data is written at 2x its stored
+        # width. Size fp8 params at their dequantized width to avoid a false OK
+        # on the output-disk check.
+        fp8_extra = sum(v for k, v in dtype_bytes.items() if k.startswith("F8"))
+        return source_bytes + fp8_extra
     if export_mode == ExportMode.FP16:
         return param_count * 2
     if export_mode == ExportMode.INT4_QMOE:
@@ -403,13 +408,45 @@ def estimate_budget(
 # ---------------------------------------------------------------------------
 
 
-def _free_bytes(path: pathlib.Path) -> int:
+def _existing_ancestor(path: pathlib.Path) -> pathlib.Path:
     probe = path
     while not probe.exists():
         if probe.parent == probe:
             break
         probe = probe.parent
-    return shutil.disk_usage(probe).free
+    return probe
+
+
+def _free_bytes(path: pathlib.Path) -> int:
+    return shutil.disk_usage(_existing_ancestor(path)).free
+
+
+def _same_device(a: pathlib.Path, b: pathlib.Path) -> bool:
+    """True when two paths resolve to the same filesystem (shared free space)."""
+    try:
+        return (
+            os.stat(_existing_ancestor(a)).st_dev == os.stat(_existing_ancestor(b)).st_dev
+        )
+    except OSError:
+        return False
+
+
+def _default_download_dir() -> pathlib.Path:
+    """Where ``hf_hub_download`` actually writes shards (the HF cache).
+
+    The real loader calls ``hf_hub_download`` without ``local_dir``, so shards
+    land in the Hugging Face cache regardless of the export output directory.
+    Budgeting the download against that filesystem — not the output dir — is
+    what keeps the "refuse before a large download" promise honest. Point the
+    cache at a large volume with ``HF_HOME``/``HF_HUB_CACHE`` (or pass an
+    explicit ``download_dir``) to change it.
+    """
+    try:
+        from huggingface_hub.constants import HF_HUB_CACHE
+
+        return pathlib.Path(HF_HUB_CACHE)
+    except Exception:
+        return pathlib.Path.home() / ".cache" / "huggingface" / "hub"
 
 
 def _available_ram_bytes() -> int | None:
@@ -439,7 +476,9 @@ def check_disk(
 
 def check_ram(required: int, margin_frac: float) -> SpaceCheck:
     free = _available_ram_bytes()
-    ok = free is None or free * (1 - margin_frac) >= required
+    # If MemAvailable can't be read we cannot verify the RAM budget; refuse
+    # rather than emit a success-shaped pass.
+    ok = free is not None and free * (1 - margin_frac) >= required
     return SpaceCheck(
         kind="ram",
         path="/proc/meminfo:MemAvailable",
@@ -501,7 +540,7 @@ def run_preflight(
     """
     blockers: list[str] = []
     output_path = pathlib.Path(output_dir)
-    download_path = pathlib.Path(download_dir) if download_dir else output_path
+    download_path = pathlib.Path(download_dir) if download_dir else _default_download_dir()
     state_file = pathlib.Path(state_path) if state_path else None
 
     # 1) Resolve + validate metadata. A failure here is terminal, never a pass.
@@ -571,16 +610,40 @@ def run_preflight(
         int(s.size) for s in shards if s.present_local and s.size is not None
     )
     download_required = max(budget.source_bytes - already_present, 0)
-    checks.append(check_disk("disk:download", download_path, download_required, margin_frac))
-    checks.append(check_disk("disk:output", output_path, budget.output_bytes, margin_frac))
+    if _same_device(download_path, output_path):
+        # Downloaded shards must stay resident while the streaming loader reads
+        # them to write the ONNX output, so on a shared filesystem the source
+        # and output requirements coexist and must be summed against one pool of
+        # free space (checking them independently hides a combined shortfall).
+        checks.append(
+            check_disk(
+                "disk:download+output",
+                output_path,
+                download_required + budget.output_bytes,
+                margin_frac,
+            )
+        )
+    else:
+        checks.append(
+            check_disk("disk:download", download_path, download_required, margin_frac)
+        )
+        checks.append(
+            check_disk("disk:output", output_path, budget.output_bytes, margin_frac)
+        )
     checks.append(check_ram(budget.peak_ram_bytes, margin_frac))
 
     for chk in checks:
         if not chk.ok:
-            blockers.append(
-                f"insufficient {chk.kind}: need {_h(chk.required_bytes)} at "
-                f"{chk.path}, free {_h(chk.free_bytes)} (margin {chk.margin_frac:.0%})"
-            )
+            if chk.kind == "ram" and chk.free_bytes < 0:
+                blockers.append(
+                    "host RAM budget could not be verified: failed to read "
+                    f"{chk.path} (need {_h(chk.required_bytes)}); refusing"
+                )
+            else:
+                blockers.append(
+                    f"insufficient {chk.kind}: need {_h(chk.required_bytes)} at "
+                    f"{chk.path}, free {_h(chk.free_bytes)} (margin {chk.margin_frac:.0%})"
+                )
 
     # 6) VRAM advisory (single-GPU fit is common blocker for full checkpoints).
     if gpu_total_bytes is not None and budget.vram_weights_bytes > gpu_total_bytes:

--- a/src/mobius/preflight.py
+++ b/src/mobius/preflight.py
@@ -395,7 +395,9 @@ def estimate_budget(
     # The weights loaded at runtime are the weights that were exported, so the
     # exported artifact size is the right default VRAM footprint (an int4-qmoe
     # export loads int4, not the bf16 source).
-    vram_base = output_bytes if target_dtype_bytes is None else int(param_count * target_dtype_bytes)
+    vram_base = (
+        output_bytes if target_dtype_bytes is None else int(param_count * target_dtype_bytes)
+    )
     vram_weights = int(vram_base * (1 + vram_headroom_frac))
 
     return Budget(
@@ -434,9 +436,7 @@ def _free_bytes(path: pathlib.Path) -> int:
 def _same_device(a: pathlib.Path, b: pathlib.Path) -> bool:
     """True when two paths resolve to the same filesystem (shared free space)."""
     try:
-        return (
-            os.stat(_existing_ancestor(a)).st_dev == os.stat(_existing_ancestor(b)).st_dev
-        )
+        return os.stat(_existing_ancestor(a)).st_dev == os.stat(_existing_ancestor(b)).st_dev
     except OSError:
         return False
 
@@ -469,9 +469,7 @@ def _available_ram_bytes() -> int | None:
     return None
 
 
-def check_disk(
-    kind: str, path: pathlib.Path, required: int, margin_frac: float
-) -> SpaceCheck:
+def check_disk(kind: str, path: pathlib.Path, required: int, margin_frac: float) -> SpaceCheck:
     free = _free_bytes(path)
     ok = free * (1 - margin_frac) >= required
     return SpaceCheck(
@@ -637,9 +635,7 @@ def run_preflight(
         checks.append(
             check_disk("disk:download", download_path, download_required, margin_frac)
         )
-        checks.append(
-            check_disk("disk:output", output_path, budget.output_bytes, margin_frac)
-        )
+        checks.append(check_disk("disk:output", output_path, budget.output_bytes, margin_frac))
     checks.append(check_ram(budget.peak_ram_bytes, margin_frac))
 
     for chk in checks:

--- a/src/mobius/preflight_test.py
+++ b/src/mobius/preflight_test.py
@@ -1,0 +1,274 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for the resumable export preflight / dry-run.
+
+Cover the three things that make a preflight worth running: it derives an exact
+budget from metadata alone, it *refuses* (never silently passes) when a budget
+is not met or metadata is unavailable, and it is resumable with identity-drift
+protection.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import types
+
+import pytest
+import safetensors.torch
+import torch
+
+from mobius import preflight
+from mobius.preflight import (
+    ExportMode,
+    LoaderMode,
+    ShardMeta,
+    estimate_budget,
+    estimate_output_bytes,
+    resolve_source,
+    run_preflight,
+)
+
+# ---------------------------------------------------------------------------
+# Local checkpoint fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_sharded(tmp_path: pathlib.Path, n_shards: int = 2) -> None:
+    weight_map = {}
+    for i in range(n_shards):
+        fn = f"model-{i + 1:05d}-of-{n_shards:05d}.safetensors"
+        safetensors.torch.save_file(
+            {f"w{i}": torch.zeros(1024, 1024, dtype=torch.bfloat16)},
+            str(tmp_path / fn),
+        )
+        weight_map[f"w{i}"] = fn
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {"total_size": n_shards * 1024 * 1024 * 2}, "weight_map": weight_map})
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fake Hub
+# ---------------------------------------------------------------------------
+
+
+def _sibling(name, size, sha=None):
+    lfs = types.SimpleNamespace(sha256=sha) if sha else None
+    return types.SimpleNamespace(rfilename=name, size=size, lfs=lfs)
+
+
+class _FakeApi:
+    def __init__(self, info):
+        self._info = info
+        self.calls = 0
+
+    def model_info(self, repo_id, revision=None, files_metadata=False):
+        self.calls += 1
+        return self._info
+
+
+def _fake_hub(tmp_path, monkeypatch, weight_map):
+    """Monkeypatch hf_hub_download to serve an index.json from tmp_path."""
+    index_path = tmp_path / "index.json"
+    index_path.write_text(json.dumps({"metadata": {}, "weight_map": weight_map}))
+
+    def _dl(repo_id, filename, revision=None):
+        return str(index_path)
+
+    monkeypatch.setattr("huggingface_hub.hf_hub_download", _dl)
+
+
+# ===========================================================================
+# resolve_source
+# ===========================================================================
+
+
+class TestResolveSource:
+    def test_local_sharded(self, tmp_path):
+        _write_sharded(tmp_path, n_shards=3)
+        commit, shards, _index = resolve_source(str(tmp_path))
+        assert commit is None
+        assert len(shards) == 3
+        assert all(s.present_local and s.size for s in shards)
+
+    def test_local_missing_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            resolve_source(str(tmp_path))
+
+    def test_hub_resolves_shards_and_sizes(self, tmp_path, monkeypatch):
+        weight_map = {"w0": "model-00001-of-00002.safetensors", "w1": "model-00002-of-00002.safetensors"}
+        _fake_hub(tmp_path, monkeypatch, weight_map)
+        info = types.SimpleNamespace(
+            sha="deadbeef",
+            siblings=[
+                _sibling("model-00001-of-00002.safetensors", 100, "aa"),
+                _sibling("model-00002-of-00002.safetensors", 200, "bb"),
+                _sibling("model.safetensors.index.json", 50),
+            ],
+            safetensors=types.SimpleNamespace(parameters={"BF16": 150}, total=150),
+        )
+        commit, shards, _index = resolve_source("org/model", hf_api=_FakeApi(info))
+        assert commit == "deadbeef"
+        assert {s.filename for s in shards} == set(weight_map.values())
+        assert {s.size for s in shards} == {100, 200}
+        assert {s.sha256 for s in shards} == {"aa", "bb"}
+
+    def test_hub_index_references_absent_file_raises(self, tmp_path, monkeypatch):
+        weight_map = {"w0": "missing.safetensors"}
+        _fake_hub(tmp_path, monkeypatch, weight_map)
+        info = types.SimpleNamespace(
+            sha="c0ffee", siblings=[_sibling("other.safetensors", 100)], safetensors=None
+        )
+        with pytest.raises(FileNotFoundError, match="absent from the repository"):
+            resolve_source("org/model", hf_api=_FakeApi(info))
+
+
+# ===========================================================================
+# Budget math
+# ===========================================================================
+
+
+class TestBudget:
+    def test_output_bytes_modes(self):
+        params = 1_000_000
+        dtype_bytes = {"BF16": params * 2}
+        assert estimate_output_bytes(params, dtype_bytes, ExportMode.PASSTHROUGH) == params * 2
+        assert estimate_output_bytes(params, dtype_bytes, ExportMode.FP16) == params * 2
+        int4 = estimate_output_bytes(params, dtype_bytes, ExportMode.INT4_QMOE, group_size=32)
+        # 0.5 + 2/32 + 0.5/32 = 0.578125 bytes/param
+        assert int4 == int(params * 0.578125)
+
+    def test_eager_peak_exceeds_stream_peak(self):
+        shards = [ShardMeta(f"s{i}", size=5 * 1000**3) for i in range(10)]
+        index = {"metadata": {"total_size": 50 * 1000**3}}
+        meta = {"parameters": {"BF16": 25 * 1000**3}, "total": 25 * 1000**3}
+        eager = estimate_budget(shards, index, meta, loader=LoaderMode.EAGER)
+        stream = estimate_budget(shards, index, meta, loader=LoaderMode.STREAM)
+        assert eager.peak_ram_bytes == eager.source_bytes  # whole checkpoint resident
+        assert stream.peak_ram_bytes <= 2 * stream.largest_shard_bytes
+        assert stream.peak_ram_bytes < eager.peak_ram_bytes
+
+    def test_fp8_source_adds_upconvert_to_eager_peak(self):
+        shards = [ShardMeta("s0", size=100)]
+        meta = {"parameters": {"F8_E4M3": 100}, "total": 100}
+        eager = estimate_budget(shards, {}, meta, loader=LoaderMode.EAGER)
+        # source (100 * 1 byte) + fp8->bf16 upconvert (extra 100)
+        assert eager.peak_ram_eager_bytes == 200
+
+
+# ===========================================================================
+# run_preflight — refusal semantics
+# ===========================================================================
+
+
+class TestRunPreflight:
+    def test_metadata_unavailable_is_a_blocker_not_a_pass(self, tmp_path):
+        # A local dir with no safetensors -> resolve fails -> refused.
+        result = run_preflight(str(tmp_path), output_dir=str(tmp_path / "out"))
+        assert result.ok is False
+        assert any("metadata unavailable" in b for b in result.blockers)
+
+    def test_hub_access_denied_refuses(self, tmp_path):
+        class _DenyApi:
+            def model_info(self, *a, **k):
+                raise PermissionError("401 Client Error: Invalid username or password")
+
+        result = run_preflight(
+            "org/private", output_dir=str(tmp_path / "out"), hf_api=_DenyApi()
+        )
+        assert result.ok is False
+        assert any("metadata unavailable" in b for b in result.blockers)
+
+    def test_ready_when_space_sufficient(self, tmp_path, monkeypatch):
+        _write_sharded(tmp_path, n_shards=2)
+        monkeypatch.setattr(preflight, "_free_bytes", lambda p: 10**15)
+        monkeypatch.setattr(preflight, "_available_ram_bytes", lambda: 10**15)
+        result = run_preflight(
+            str(tmp_path), output_dir=str(tmp_path / "out"), loader=LoaderMode.STREAM
+        )
+        assert result.ok is True
+        assert result.budget is not None
+        assert not result.blockers
+
+    def test_refuses_when_disk_insufficient(self, tmp_path, monkeypatch):
+        _write_sharded(tmp_path, n_shards=2)
+        monkeypatch.setattr(preflight, "_free_bytes", lambda p: 1)  # ~no disk
+        monkeypatch.setattr(preflight, "_available_ram_bytes", lambda: 10**15)
+        result = run_preflight(str(tmp_path), output_dir=str(tmp_path / "out"))
+        assert result.ok is False
+        assert any("disk" in b for b in result.blockers)
+
+    def test_refuses_when_ram_insufficient_eager(self, tmp_path, monkeypatch):
+        _write_sharded(tmp_path, n_shards=2)
+        monkeypatch.setattr(preflight, "_free_bytes", lambda p: 10**15)
+        monkeypatch.setattr(preflight, "_available_ram_bytes", lambda: 1)
+        result = run_preflight(
+            str(tmp_path), output_dir=str(tmp_path / "out"), loader=LoaderMode.EAGER
+        )
+        assert result.ok is False
+        assert any("ram" in b for b in result.blockers)
+
+    def test_vram_single_device_refusal(self, tmp_path, monkeypatch):
+        _write_sharded(tmp_path, n_shards=2)
+        monkeypatch.setattr(preflight, "_free_bytes", lambda p: 10**15)
+        monkeypatch.setattr(preflight, "_available_ram_bytes", lambda: 10**15)
+        result = run_preflight(
+            str(tmp_path),
+            output_dir=str(tmp_path / "out"),
+            gpu_total_bytes=1,  # absurdly small device
+        )
+        assert result.ok is False
+        assert any("VRAM" in b for b in result.blockers)
+
+
+# ===========================================================================
+# Resumability + identity drift
+# ===========================================================================
+
+
+class TestResumability:
+    def test_state_written_and_reused(self, tmp_path, monkeypatch):
+        _write_sharded(tmp_path, n_shards=2)
+        monkeypatch.setattr(preflight, "_free_bytes", lambda p: 10**15)
+        monkeypatch.setattr(preflight, "_available_ram_bytes", lambda: 10**15)
+        state_file = tmp_path / "state.json"
+
+        r1 = run_preflight(
+            str(tmp_path), output_dir=str(tmp_path / "out"), state_path=str(state_file)
+        )
+        assert r1.ok
+        assert state_file.is_file()
+        saved = json.loads(state_file.read_text())
+        assert len(saved["validated_shards"]) == 2
+
+        # Second run reuses state (marks shards validated).
+        r2 = run_preflight(
+            str(tmp_path), output_dir=str(tmp_path / "out"), state_path=str(state_file)
+        )
+        assert r2.ok
+        assert all(s.validated for s in r2.shards)
+
+    def test_identity_drift_refuses(self, tmp_path, monkeypatch):
+        weight_map = {"w0": "model-00001-of-00001.safetensors"}
+        _fake_hub(tmp_path, monkeypatch, weight_map)
+        monkeypatch.setattr(preflight, "_free_bytes", lambda p: 10**15)
+        monkeypatch.setattr(preflight, "_available_ram_bytes", lambda: 10**15)
+        state_file = tmp_path / "state.json"
+        state_file.write_text(
+            json.dumps({"commit_sha": "OLDSHA", "validated_shards": ["model-00001-of-00001.safetensors"]})
+        )
+        info = types.SimpleNamespace(
+            sha="NEWSHA",
+            siblings=[_sibling("model-00001-of-00001.safetensors", 100, "aa")],
+            safetensors=types.SimpleNamespace(parameters={"BF16": 50}, total=50),
+        )
+        result = run_preflight(
+            "org/model",
+            output_dir=str(tmp_path / "out"),
+            state_path=str(state_file),
+            hf_api=_FakeApi(info),
+        )
+        assert any("identity drift" in b for b in result.blockers)
+        assert result.ok is False

--- a/src/mobius/preflight_test.py
+++ b/src/mobius/preflight_test.py
@@ -45,7 +45,9 @@ def _write_sharded(tmp_path: pathlib.Path, n_shards: int = 2) -> None:
         )
         weight_map[f"w{i}"] = fn
     (tmp_path / "model.safetensors.index.json").write_text(
-        json.dumps({"metadata": {"total_size": n_shards * 1024 * 1024 * 2}, "weight_map": weight_map})
+        json.dumps(
+            {"metadata": {"total_size": n_shards * 1024 * 1024 * 2}, "weight_map": weight_map}
+        )
     )
 
 
@@ -98,7 +100,10 @@ class TestResolveSource:
             resolve_source(str(tmp_path))
 
     def test_hub_resolves_shards_and_sizes(self, tmp_path, monkeypatch):
-        weight_map = {"w0": "model-00001-of-00002.safetensors", "w1": "model-00002-of-00002.safetensors"}
+        weight_map = {
+            "w0": "model-00001-of-00002.safetensors",
+            "w1": "model-00002-of-00002.safetensors",
+        }
         _fake_hub(tmp_path, monkeypatch, weight_map)
         info = types.SimpleNamespace(
             sha="deadbeef",
@@ -323,7 +328,12 @@ class TestResumability:
         monkeypatch.setattr(preflight, "_available_ram_bytes", lambda: 10**15)
         state_file = tmp_path / "state.json"
         state_file.write_text(
-            json.dumps({"commit_sha": "OLDSHA", "validated_shards": ["model-00001-of-00001.safetensors"]})
+            json.dumps(
+                {
+                    "commit_sha": "OLDSHA",
+                    "validated_shards": ["model-00001-of-00001.safetensors"],
+                }
+            )
         )
         info = types.SimpleNamespace(
             sha="NEWSHA",

--- a/src/mobius/preflight_test.py
+++ b/src/mobius/preflight_test.py
@@ -147,6 +147,26 @@ class TestBudget:
         # data is 2 bytes/param, not the 1 byte/param it was stored at.
         assert estimate_output_bytes(params, dtype_bytes, ExportMode.PASSTHROUGH) == params * 2
 
+    def test_vram_default_tracks_export_artifact(self):
+        params = 1_000_000
+        shards = [ShardMeta("s0", size=params * 2)]
+        meta = {"parameters": {"BF16": params}, "total": params}
+        bf16 = estimate_budget(shards, {}, meta, export_mode=ExportMode.PASSTHROUGH)
+        int4 = estimate_budget(
+            shards, {}, meta, export_mode=ExportMode.INT4_QMOE, group_size=32
+        )
+        # Passthrough loads bf16 (2 B/param); int4-qmoe loads the packed artifact
+        # (~0.5 B/param), so its VRAM footprint must be far smaller — not the
+        # source dtype.
+        assert bf16.vram_weights_bytes == int(params * 2 * 1.15)
+        assert int4.vram_weights_bytes == int(int4.output_bytes * 1.15)
+        assert int4.vram_weights_bytes < bf16.vram_weights_bytes
+        # An explicit runtime dtype override is still honored.
+        forced = estimate_budget(
+            shards, {}, meta, export_mode=ExportMode.INT4_QMOE, target_dtype_bytes=0.5
+        )
+        assert forced.vram_weights_bytes == int(params * 0.5 * 1.15)
+
     def test_eager_peak_exceeds_stream_peak(self):
         shards = [ShardMeta(f"s{i}", size=5 * 1000**3) for i in range(10)]
         index = {"metadata": {"total_size": 50 * 1000**3}}

--- a/src/mobius/preflight_test.py
+++ b/src/mobius/preflight_test.py
@@ -140,6 +140,13 @@ class TestBudget:
         # 0.5 + 2/32 + 0.5/32 = 0.578125 bytes/param
         assert int4 == int(params * 0.578125)
 
+    def test_passthrough_fp8_output_is_dequantized_size(self):
+        params = 1000
+        dtype_bytes = {"F8_E4M3": params}  # fp8 stores 1 byte/param
+        # A passthrough export dequantizes fp8 -> bf16, so the output external
+        # data is 2 bytes/param, not the 1 byte/param it was stored at.
+        assert estimate_output_bytes(params, dtype_bytes, ExportMode.PASSTHROUGH) == params * 2
+
     def test_eager_peak_exceeds_stream_peak(self):
         shards = [ShardMeta(f"s{i}", size=5 * 1000**3) for i in range(10)]
         index = {"metadata": {"total_size": 50 * 1000**3}}
@@ -221,6 +228,45 @@ class TestRunPreflight:
         )
         assert result.ok is False
         assert any("VRAM" in b for b in result.blockers)
+
+    def test_same_device_disk_check_sums_download_and_output(self, tmp_path, monkeypatch):
+        # Hub source (not present locally) so a real download is required.
+        weight_map = {
+            "w0": "model-00001-of-00002.safetensors",
+            "w1": "model-00002-of-00002.safetensors",
+        }
+        _fake_hub(tmp_path, monkeypatch, weight_map)
+        info = types.SimpleNamespace(
+            sha="deadbeef",
+            siblings=[
+                _sibling("model-00001-of-00002.safetensors", 100, "aa"),
+                _sibling("model-00002-of-00002.safetensors", 100, "bb"),
+            ],
+            safetensors=types.SimpleNamespace(parameters={"BF16": 100}, total=100),
+        )
+        monkeypatch.setattr(preflight, "_available_ram_bytes", lambda: 10**15)
+        # Free space (240) fits the 200B download or the 200B output alone, but
+        # not both (400B combined) on one filesystem. Independent checks would
+        # each pass; the combined check must refuse.
+        monkeypatch.setattr(preflight, "_free_bytes", lambda p: 240)
+        result = run_preflight(
+            "org/model",
+            output_dir=str(tmp_path / "out"),
+            download_dir=str(tmp_path),  # same filesystem as the output dir
+            hf_api=_FakeApi(info),
+        )
+        assert result.ok is False
+        assert any("download+output" in b for b in result.blockers)
+
+    def test_ram_unverifiable_refuses(self, tmp_path, monkeypatch):
+        _write_sharded(tmp_path, n_shards=2)
+        monkeypatch.setattr(preflight, "_free_bytes", lambda p: 10**15)
+        # MemAvailable can't be read -> the RAM budget is unverifiable and must
+        # not produce a success-shaped pass.
+        monkeypatch.setattr(preflight, "_available_ram_bytes", lambda: None)
+        result = run_preflight(str(tmp_path), output_dir=str(tmp_path / "out"))
+        assert result.ok is False
+        assert any("RAM budget could not be verified" in b for b in result.blockers)
 
 
 # ===========================================================================


### PR DESCRIPTION
## Motivation

Exporting an official full-size sharded checkpoint (e.g. `zai-org/GLM-5.2` — 753.3B params BF16, **1.507 TB across 282 shards**) with the current eager loader concatenates every shard into one in-RAM `state_dict`. Measured peak host RAM for that path is ~1.5–1.9 TB, which **exceeds available RAM on a 1.7 TB box and OOMs**. There is also no way to know the disk/RAM/VRAM budget before committing to a hundreds-of-GB download.

This lands the generic, model-agnostic code to (a) stream a sharded checkpoint to ONNX external data with a bounded working set, and (b) refuse a download up front when the budget is insufficient. No model-name allowlist.

## What

- **`stream_safetensors_to_model()`** (`integrations/_weight_loading.py`): a pass-through lazy per-tensor loader. Each ONNX initializer is bound to an `ir.LazyTensor` that reads its tensor from the owning safetensors shard on demand (`safe_open` reads headers only), so peak RAM is bounded to one tensor, not the whole checkpoint. It **refuses** rather than mis-exporting when the source is quantized (fp8 / `*_scale_inv`) or when a graph initializer has no matching checkpoint tensor (needs fusion/split/quantization) — those must use the eager `apply_weights` path.
- **`external_data_checksums()`**: deterministic sha256+size manifest for verifying byte-reproducible re-exports.
- **`preflight.py` + `mobius preflight` CLI**: a resumable dry-run that validates all shard URLs/metadata from the Hub or a local dir (no success-shaped fallback), computes exact source/output disk, peak host RAM (eager vs stream) and weights VRAM (sized from the export artifact), sums download+output on a shared filesystem, checks free disk/RAM, and **refuses (exit 2)** before download when budget is insufficient, RAM can't be verified, or metadata is unavailable. Resumable JSON state refuses on commit-identity drift.

The eager `apply_weights` / `_download_weights` path (incl. its pytorch + fp8 support) is unchanged.

## Proven behavior (real metadata, no download)

| model | source | int4 output | peak RAM stream / eager | int4 VRAM | verdict |
|---|---|---|---|---|---|
| GLM-5.2 (int4-qmoe) | 1.507 TB | 0.436 TB | 10.7 GB / 1942.2 GB | 500.8 GB | READY on 8×80 GB agg; REFUSED on single 80 GB |
| DeepSeek-V4 | — | — | — | — | REFUSED (404 RepositoryNotFound — data blocker) |

## Tests

- `preflight_test.py` (20) + `_weight_loading_stream_test.py` (10): resolve/budget/refusal/resumability, streaming correctness + laziness, shape/missing-weight/quantized refusals, deterministic checksums.
- Existing `_weight_loading_test.py` (54) unchanged. **84 pass**, `CUDA_VISIBLE_DEVICES=""`. ruff clean (line-length 95).

An independent code review was run; all findings (fp8 silent mis-load, false-READY shared-fs disk double count, fp8 output under-count, download-fs mismatch, RAM-unverifiable success-shape) are fixed with tests in the second commit.

> Note: this is the export/preflight plumbing. A real full GLM-5.2 run additionally requires ~1.94 TB of storage (point `HF_HOME` at a large volume), a pre-quantized int4 checkpoint (Mobius QMoE needs pre-quantized weights), and a multi-GPU/offloaded `glm_moe_dsa` runtime.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>