### PR TITLE
GGUF export preflight: block-preserving lossless-only classification + budget (reconciled into #581)

### DIFF
--- a/src/mobius/integrations/gguf/__init__.py
+++ b/src/mobius/integrations/gguf/__init__.py
@@ -40,6 +40,7 @@ from mobius.integrations.gguf._config_mapping import (
 from mobius.integrations.gguf._mmproj import build_gemma4_vlm_from_gguf
 from mobius.integrations.gguf._preflight import (
     GgufPreflightReport,
+    GgufTypeStat,
     preflight_gguf,
     preflight_hf_gguf,
     preflight_local_gguf,
@@ -75,4 +76,5 @@ __all__ = [
     "preflight_local_gguf",
     "preflight_hf_gguf",
     "GgufPreflightReport",
+    "GgufTypeStat",
 ]

--- a/src/mobius/integrations/gguf/_preflight.py
+++ b/src/mobius/integrations/gguf/_preflight.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 __all__ = [
     "GgufFileMeta",
+    "GgufTypeStat",
     "GgufPreflightReport",
     "preflight_gguf",
     "preflight_local_gguf",
@@ -43,6 +44,7 @@ __all__ = [
 
 import json
 import logging
+import math
 import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -82,6 +84,9 @@ _NATIVE_BLOCK_QUANT_RE = re.compile(
     re.IGNORECASE,
 )
 
+# ggml block layouts Mobius passes through unquantized (norms, biases, ids).
+_FLOAT_PASSTHROUGH_TYPES = frozenset({"F32", "F16", "BF16", "F64"})
+
 
 @dataclass
 class GgufFileMeta:
@@ -92,6 +97,33 @@ class GgufFileMeta:
     sha256: str | None
     shard_index: int | None
     shard_count: int | None
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class GgufTypeStat:
+    """Per-quant-type accounting and how Mobius would losslessly emit it.
+
+    ``disposition`` is derived from Mobius' *real* repacker support sets
+    (:func:`._repacker.native_block_spec` / :func:`._repacker.repack_quant_params`)
+    plus the float passthrough set — never a model-name allowlist:
+
+    * ``passthrough`` — a float block kept as-is (F32/F16/BF16).
+    * ``native-preserve`` — byte-for-byte ``pkg.nxrt::BlockQuantizedMatMul``.
+    * ``repack`` — repacked to ``com.microsoft::MatMulNBits``.
+    * ``unsupported`` — no lossless path; a build would have to dequantize to
+      float, so the export refuses rather than silently widen it.
+    """
+
+    type_name: str
+    ggml_type: int
+    count: int
+    source_bytes: int
+    output_bytes: int
+    disposition: str
+    detail: str
 
     def as_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -124,6 +156,14 @@ class GgufPreflightReport:
         files: Per-file metadata (sizes + checksums).
         blockers: Hard export blockers (each is a human-readable reason).
         warnings: Non-fatal advisories.
+        type_stats: Per-quant-type lossless-conversion accounting (populated for
+            a local header read; empty when only remote metadata is available).
+        output_bytes: Estimated ONNX external-data size of the block-preserving
+            export (``None`` when the per-tensor types were not read).
+        vram_weights_bytes: Weight footprint that must fit in device memory,
+            derived from the export artifact (``None`` when unknown). This is a
+            weights-only figure — no inference/activation speculation.
+        unsupported_types: Quant types with no lossless repack/preserve path.
     """
 
     source: str
@@ -142,6 +182,10 @@ class GgufPreflightReport:
     files: list[GgufFileMeta] = field(default_factory=list)
     blockers: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
+    type_stats: list[GgufTypeStat] = field(default_factory=list)
+    output_bytes: int | None = None
+    vram_weights_bytes: int | None = None
+    unsupported_types: list[str] = field(default_factory=list)
 
     @property
     def exportable(self) -> bool:
@@ -185,6 +229,30 @@ class GgufPreflightReport:
             "  sparse MoE   : "
             + ("supported" if self.sparse_moe_fusion_supported else "NOT supported")
         )
+        if self.output_bytes is not None:
+            lines.append(
+                "  budget (real artifacts, direct random-access — no merged copy):"
+            )
+            lines.append(
+                f"    download   : {_gib(self.total_bytes):.3f} GiB "
+                f"(shard set, read in place)"
+            )
+            lines.append(
+                f"    onnx output: {_gib(self.output_bytes):.3f} GiB "
+                f"(block-preserving external data)"
+            )
+            if self.vram_weights_bytes is not None:
+                lines.append(
+                    f"    weights VRAM: {_gib(self.vram_weights_bytes):.3f} GiB"
+                )
+        if self.type_stats:
+            lines.append("  tensor types (lossless disposition vs. the real repacker):")
+            for stat in self.type_stats:
+                lines.append(
+                    f"    {stat.type_name:8s} x{stat.count:<5d} "
+                    f"{_gib(stat.source_bytes):7.3f} GiB  {stat.disposition:15s} "
+                    f"{stat.detail}"
+                )
         lines.append("  files:")
         for f in self.files:
             sha = (f.sha256[:12] + "…") if f.sha256 else "(no sha256)"
@@ -264,6 +332,110 @@ def _assess_sparse_moe(
     return False, [blocker]
 
 
+def _matmulnbits_output_bytes(np_shape: tuple[int, ...], bits: int, block_size: int) -> int:
+    """Estimate ``com.microsoft::MatMulNBits`` external-data bytes for a repack.
+
+    Sizes the ``[N, blocks_per_row, blob]`` weight, ``[N, blocks_per_row]`` fp16
+    scales and ``[N, ceil(blocks_per_row*bits/8)]`` bit-packed zero points with
+    per-row block rounding, matching the operator layout (K is padded up to a
+    whole block per row, not across the flattened tensor).
+    """
+    if not np_shape or not block_size:
+        return 0
+    k = np_shape[-1]
+    rows = 1
+    for dim in np_shape[:-1]:
+        rows *= dim
+    blocks_per_row = math.ceil(k / block_size)
+    weight = rows * blocks_per_row * (block_size * bits // 8)
+    scales = rows * blocks_per_row * 2  # fp16 per block
+    zero_points = rows * math.ceil(blocks_per_row * bits / 8)  # bit-packed per row
+    return int(weight + scales + zero_points)
+
+
+def _classify_tensor_type(
+    type_id: int, type_name: str, np_shape: tuple[int, ...], source_bytes: int
+) -> tuple[str, int, str]:
+    """Return ``(disposition, output_bytes, detail)`` for one tensor.
+
+    Uses Mobius' *real* repacker support sets — ``native_block_spec``
+    (byte-for-byte preserve) and ``repack_quant_params`` (repack to
+    ``MatMulNBits``) — plus a float passthrough set. Anything else is
+    ``unsupported`` and contributes zero output bytes (the export refuses rather
+    than dequantizing it to float). No model-name allowlist is consulted.
+    """
+    from mobius.integrations.gguf import _repacker
+
+    if type_name in _FLOAT_PASSTHROUGH_TYPES:
+        return "passthrough", source_bytes, f"float {type_name} kept as-is"
+
+    native = _repacker.native_block_spec(type_id)
+    if native is not None:
+        return (
+            "native-preserve",
+            source_bytes,
+            f"BlockQuantizedMatMul {native.format} ({native.bytes}B/blk)",
+        )
+
+    params = _repacker.repack_quant_params(type_id)
+    if params is not None:
+        bits, block_size = params
+        out = _matmulnbits_output_bytes(np_shape, bits, block_size)
+        return "repack", out, f"MatMulNBits {bits}-bit/{block_size}"
+
+    return "unsupported", 0, f"no lossless repack/preserve for {type_name}"
+
+
+def _classify_reader_tensors(reader_tensors: list[Any]) -> tuple[list[GgufTypeStat], int]:
+    """Aggregate per-type dispositions/bytes from GGUF header records.
+
+    Reads only header-derived fields (``tensor_type``/``shape``/``n_bytes``) of
+    each ``gguf.ReaderTensor`` — never the tensor payload. Returns the sorted
+    per-type stats and the total block-preserving ONNX output byte estimate.
+    """
+    acc: dict[str, GgufTypeStat] = {}
+    for tensor in reader_tensors:
+        qtype = tensor.tensor_type
+        type_id = int(getattr(qtype, "value", qtype))
+        type_name = getattr(qtype, "name", str(qtype))
+        np_shape = tuple(int(dim) for dim in reversed(tuple(tensor.shape)))
+        source_bytes = int(tensor.n_bytes)
+        disposition, out_bytes, detail = _classify_tensor_type(
+            type_id, type_name, np_shape, source_bytes
+        )
+        stat = acc.get(type_name)
+        if stat is None:
+            acc[type_name] = GgufTypeStat(
+                type_name=type_name,
+                ggml_type=type_id,
+                count=1,
+                source_bytes=source_bytes,
+                output_bytes=out_bytes,
+                disposition=disposition,
+                detail=detail,
+            )
+        else:
+            stat.count += 1
+            stat.source_bytes += source_bytes
+            stat.output_bytes += out_bytes
+    stats = sorted(acc.values(), key=lambda s: -s.source_bytes)
+    output_bytes = sum(s.output_bytes for s in stats)
+    return stats, output_bytes
+
+
+def _classification_blocker(unsupported: list[GgufTypeStat]) -> str:
+    detail = ", ".join(
+        f"{s.type_name}({s.count} tensors, {_gib(s.source_bytes):.1f} GiB)"
+        for s in unsupported
+    )
+    return (
+        f"{len(unsupported)} quant type(s) cannot be preserved losslessly "
+        f"(would require a dequantize-to-float copy): {detail}. These are the "
+        "exact unsupported native qtypes; supporting them (native block import "
+        "or repack) is the remaining code gap, not architecture or sharding."
+    )
+
+
 def preflight_local_gguf(
     path: str | Path,
     *,
@@ -336,6 +508,13 @@ def preflight_local_gguf(
     if architecture is None:
         warnings.append("architecture metadata missing from primary shard")
 
+    type_stats, output_bytes = _classify_reader_tensors(model.reader_tensors())
+    unsupported = [s for s in type_stats if s.disposition == "unsupported"]
+    unsupported_types = [s.type_name for s in unsupported]
+    if unsupported:
+        blockers.append(_classification_blocker(unsupported))
+    vram_weights_bytes = output_bytes
+
     return GgufPreflightReport(
         source=str(path),
         location="local",
@@ -353,6 +532,10 @@ def preflight_local_gguf(
         files=files,
         blockers=blockers,
         warnings=warnings,
+        type_stats=type_stats,
+        output_bytes=output_bytes,
+        vram_weights_bytes=vram_weights_bytes,
+        unsupported_types=unsupported_types,
     )
 
 
@@ -636,6 +819,7 @@ def _read_expert_count(model: Any, architecture: str | None) -> int | None:
 
 def _report_from_dict(data: dict[str, Any]) -> GgufPreflightReport:
     files = [GgufFileMeta(**f) for f in data.get("files", [])]
+    type_stats = [GgufTypeStat(**t) for t in data.get("type_stats", [])]
     known = {
         "source",
         "location",
@@ -652,6 +836,9 @@ def _report_from_dict(data: dict[str, Any]) -> GgufPreflightReport:
         "sparse_moe_fusion_supported",
         "blockers",
         "warnings",
+        "output_bytes",
+        "vram_weights_bytes",
+        "unsupported_types",
     }
     kwargs = {k: data[k] for k in known if k in data}
-    return GgufPreflightReport(files=files, **kwargs)
+    return GgufPreflightReport(files=files, type_stats=type_stats, **kwargs)

--- a/src/mobius/integrations/gguf/_preflight.py
+++ b/src/mobius/integrations/gguf/_preflight.py
@@ -230,21 +230,16 @@ class GgufPreflightReport:
             + ("supported" if self.sparse_moe_fusion_supported else "NOT supported")
         )
         if self.output_bytes is not None:
+            lines.append("  budget (real artifacts, direct random-access — no merged copy):")
             lines.append(
-                "  budget (real artifacts, direct random-access — no merged copy):"
-            )
-            lines.append(
-                f"    download   : {_gib(self.total_bytes):.3f} GiB "
-                f"(shard set, read in place)"
+                f"    download   : {_gib(self.total_bytes):.3f} GiB (shard set, read in place)"
             )
             lines.append(
                 f"    onnx output: {_gib(self.output_bytes):.3f} GiB "
                 f"(block-preserving external data)"
             )
             if self.vram_weights_bytes is not None:
-                lines.append(
-                    f"    weights VRAM: {_gib(self.vram_weights_bytes):.3f} GiB"
-                )
+                lines.append(f"    weights VRAM: {_gib(self.vram_weights_bytes):.3f} GiB")
         if self.type_stats:
             lines.append("  tensor types (lossless disposition vs. the real repacker):")
             for stat in self.type_stats:

--- a/src/mobius/integrations/gguf/_preflight_test.py
+++ b/src/mobius/integrations/gguf/_preflight_test.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from pathlib import Path
 
 import numpy as np
@@ -77,6 +78,20 @@ def _raw_quant_rows(qtype, n_rows: int, k: int) -> np.ndarray:
     return np.zeros((n_rows, bytes_per_row), dtype=np.uint8)
 
 
+def _raw_quant_expert_rows(qtype, n_expert: int, n_rows: int, k: int) -> np.ndarray:
+    """Zeroed raw-block bytes for a 3D routed-expert tensor.
+
+    Shaped ``(n_expert, n_rows, bytes_per_row)`` — the layout of a real GGUF
+    ``blk.i.ffn_*_exps.weight`` fused-expert tensor whose rows are *qtype*
+    native blocks.
+    """
+    from gguf import GGML_QUANT_SIZES
+
+    block_elems, block_bytes = GGML_QUANT_SIZES[qtype]
+    bytes_per_row = (k // block_elems) * block_bytes
+    return np.zeros((n_expert, n_rows, bytes_per_row), dtype=np.uint8)
+
+
 def _write_quant_sharded_gguf(
     directory: Path,
     *,
@@ -130,6 +145,84 @@ def _write_quant_sharded_gguf(
     writer.write_tensors_to_file()
     writer.close()
     return sorted(directory.glob(f"{stem}-*.gguf"))
+
+
+def _write_glm_moe_iq1_sharded_gguf(
+    directory: Path,
+    *,
+    real_prefix: str = "GLM-5.2-UD-IQ1_S",
+    num_experts: int = 8,
+    split_max_tensors: int = 2,
+) -> list[Path]:
+    """Write a sharded MoE GGUF faithful to the flagship GLM-5.2 UD-IQ1_S set.
+
+    Independently mirrors the three signals production preflight actually
+    consumes for the sparse-MoE honesty gate (see ``preflight_local_gguf`` /
+    ``_detect_quantization`` / ``_assess_sparse_moe``):
+
+    * the shard **filenames** carry the exact real
+      ``GLM-5.2-UD-IQ1_S-000i-of-000N.gguf`` quant tag that
+      ``_detect_quantization`` reads from ``path.name`` (candidate #2);
+    * ``general.architecture='glm-dsa'`` resolves to the MoE model type
+      ``glm_moe_dsa`` and ``glm-dsa.expert_count`` marks it as routed-expert
+      MoE (``_is_moe`` via ``num_experts``);
+    * the routed experts are **real per-projection**
+      ``blk.i.ffn_{gate,up,down}_exps.weight`` tensors physically stored as
+      ``IQ1_S`` native blocks (3D ``[n_expert, n_ff, k]``), so the detected
+      quant tag is consistent with the actual tensor payload.
+
+    ``gguf.GGUFWriter`` derives split filenames from the output stem and
+    truncates a dotted stem (``GLM-5.2`` -> ``GLM-5``), so the shards are first
+    written under a dot-free stem and then renamed to the exact real dotted
+    filename. Only the on-disk names change — the embedded split metadata
+    (``split.no``/``split.count``) is written by ``GGUFWriter`` and left
+    untouched, and shard discovery is filename-prefix based
+    (``discover_gguf_shards``), so the renamed set enumerates correctly.
+    """
+    from gguf import GGMLQuantizationType, GGUFWriter
+
+    directory.mkdir(parents=True, exist_ok=True)
+    writer = GGUFWriter(
+        str(directory / "iq1moe"), "glm-dsa", split_max_tensors=split_max_tensors
+    )
+    writer.add_context_length(128)
+    writer.add_embedding_length(256)
+    writer.add_block_count(1)
+    writer.add_head_count(4)
+    writer.add_head_count_kv(2)
+    writer.add_vocab_size(32)
+    writer.add_expert_count(num_experts)
+
+    k = 256
+    n_ff = 8
+    # F32 embedding (passthrough) + one repackable attention projection (Q8_0).
+    writer.add_tensor("token_embd.weight", np.zeros((8, k), np.float32))
+    writer.add_tensor(
+        "blk.0.attn_q.weight",
+        _raw_quant_rows(GGMLQuantizationType.Q8_0, 8, k),
+        raw_dtype=GGMLQuantizationType.Q8_0,
+    )
+    # Real per-projection routed-expert weights, physically IQ1_S native blocks.
+    for projection in ("gate", "up", "down"):
+        writer.add_tensor(
+            f"blk.0.ffn_{projection}_exps.weight",
+            _raw_quant_expert_rows(GGMLQuantizationType.IQ1_S, num_experts, n_ff, k),
+            raw_dtype=GGMLQuantizationType.IQ1_S,
+        )
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_tensors_to_file()
+    writer.close()
+
+    renamed: list[Path] = []
+    for shard in sorted(directory.glob("iq1moe-*.gguf")):
+        match = re.match(r"^iq1moe-(\d{5})-of-(\d{5})\.gguf$", shard.name)
+        assert match is not None, shard.name
+        index, count = match.group(1), match.group(2)
+        target = directory / f"{real_prefix}-{index}-of-{count}.gguf"
+        shard.rename(target)
+        renamed.append(target)
+    return sorted(renamed)
 
 
 # --------------------------------------------------------------------------- #
@@ -411,9 +504,7 @@ def test_local_preflight_supported_sharded_set_passes_shard_and_arch_gates(tmp_p
 
 
 def test_local_preflight_flags_exact_unsupported_native_qtypes(tmp_path):
-    shards = _write_quant_sharded_gguf(
-        tmp_path, split_max_tensors=2, include_unsupported=True
-    )
+    shards = _write_quant_sharded_gguf(tmp_path, split_max_tensors=2, include_unsupported=True)
     report = preflight_local_gguf(shards[0])
 
     # Being sharded is still not a blocker; the ONLY blocker is the exact
@@ -451,17 +542,57 @@ def test_budget_reflects_real_artifacts_only_no_second_copy(tmp_path):
 
 
 def test_sparse_iq1_moe_is_the_remaining_blocker_not_sharding(tmp_path):
-    # A sharded IQ1 MoE: the honesty blocker is sparse-MoE fusion, and sharding
-    # is not a blocker. This mirrors the flagship GLM-5.2 UD-IQ1_S case.
-    shards = _write_quant_sharded_gguf(
-        tmp_path, architecture="llama", split_max_tensors=2, num_experts=8
-    )
+    # Flagship GLM-5.2 UD-IQ1_S composition: a *sharded*, MoE, IQ1_S set whose
+    # ONLY honesty blocker must be sparse-MoE fusion — never sharding or the
+    # architecture. The fixture is faithful to the three signals production
+    # actually consumes, so the gate is exercised end-to-end and the positive
+    # assertions below fail if either filename quant detection or the
+    # sparse-MoE gate is bypassed (a fixture that put IQ1_S into no
+    # production-consumed candidate — the prior bug — leaves quantization=None,
+    # fusion_supported=True and no blocker, failing this test).
+    shards = _write_glm_moe_iq1_sharded_gguf(tmp_path, num_experts=8)
+
+    # -- Preconditions, proved explicitly (not assumed) ----------------------
+    assert len(shards) > 1
+    # The exact real GLM-5.2 shard filename is what production reads for the
+    # quant tag; prove filename detection independently before building.
+    first_name = shards[0].name
+    assert first_name.startswith("GLM-5.2-UD-IQ1_S-00001-of-000")
+    assert first_name.endswith(".gguf")
+    assert _detect_quantization(first_name) == "IQ1_S"
+
     report = preflight_local_gguf(shards[0])
-    # The set is sharded and the arch resolves; the only honesty concern is the
-    # sparse-MoE fusion of the IQ1_S experts (quantization detected from name).
-    assert report.is_sharded
+
+    # Sharded set + architecture resolves => neither is (or causes) a blocker.
+    assert report.is_sharded is True
+    assert report.split_count == len(shards)
+    assert report.architecture == "glm-dsa"
+    assert report.resolved_model_type == "glm_moe_dsa"
+    assert "architecture metadata missing" not in " ".join(report.warnings)
+    # MoE + IQ1_S quant are detected from the real metadata/filename.
+    assert report.num_experts == 8
+    assert report.quantization == "IQ1_S"
+    # The routed experts are physically IQ1_S and losslessly preserved, so the
+    # only remaining concern is fusion — not a lossy/unsupported-qtype blocker.
+    iq1_stats = [s for s in report.type_stats if s.type_name == "IQ1_S"]
+    assert iq1_stats, report.type_stats
+    assert all(s.disposition == "native-preserve" for s in iq1_stats)
+    assert report.unsupported_types == []
+
+    # -- The gate under test: sparse-MoE fusion is the remaining blocker ------
+    assert report.sparse_moe_fusion_supported is False
+    assert len(report.blockers) == 1
+    blocker = report.blockers[0]
+    assert "sparse-MoE fusion blocker" in blocker
+    assert "dense-all-expert" in blocker
+    assert "BlockQuantizedMoE" in blocker
+    assert "glm_moe_dsa" in blocker
+    assert "IQ1_S" in blocker
+
+    # -- Sharding is explicitly NOT the blocker ------------------------------
     joined = " ".join(report.blockers).lower()
-    assert "shard" not in joined and "split" not in joined
+    for forbidden in ("shard", "split", "merge", "double-copy", "second"):
+        assert forbidden not in joined, report.blockers
 
 
 # --------------------------------------------------------------------------- #
@@ -477,9 +608,7 @@ def test_single_preflight_gguf_cli_registration():
 
     parser = build_parser()
     subparsers = [
-        action
-        for action in parser._actions
-        if isinstance(action, argparse._SubParsersAction)
+        action for action in parser._actions if isinstance(action, argparse._SubParsersAction)
     ]
     assert subparsers, "no subparsers found"
     choices = subparsers[0].choices

--- a/src/mobius/integrations/gguf/_preflight_test.py
+++ b/src/mobius/integrations/gguf/_preflight_test.py
@@ -99,13 +99,14 @@ def _write_quant_sharded_gguf(
     stem: str = "q",
     split_max_tensors: int = 2,
     include_unsupported: bool = False,
-    num_experts: int | None = None,
 ) -> list[Path]:
     """Write a shape-faithful multi-shard GGUF with mixed real quant types.
 
     F32 (passthrough), Q8_0 (repack), IQ1_S (native-preserve), and — when
     *include_unsupported* — Q5_K (no lossless path). Bodies are zeroed; only the
-    headers (types/dims) matter to the metadata-only preflight.
+    headers (types/dims) matter to the metadata-only preflight. This dense
+    (non-MoE) fixture is deliberately expert-free; sparse routed-expert coverage
+    lives in :func:`_write_glm_moe_iq1_sharded_gguf`.
     """
     from gguf import GGMLQuantizationType, GGUFWriter
 
@@ -119,8 +120,6 @@ def _write_quant_sharded_gguf(
     writer.add_head_count(4)
     writer.add_head_count_kv(2)
     writer.add_vocab_size(32)
-    if num_experts is not None:
-        writer.add_expert_count(num_experts)
 
     k = 256
     writer.add_tensor("token_embd.weight", np.zeros((8, k), np.float32))

--- a/src/mobius/integrations/gguf/_preflight_test.py
+++ b/src/mobius/integrations/gguf/_preflight_test.py
@@ -11,6 +11,7 @@ touching the network.
 
 from __future__ import annotations
 
+import argparse
 import json
 from pathlib import Path
 
@@ -19,7 +20,9 @@ import pytest
 
 from mobius.integrations.gguf._preflight import (
     _assess_sparse_moe,
+    _classify_tensor_type,
     _detect_quantization,
+    _matmulnbits_output_bytes,
     _select_shard_files,
     preflight_gguf,
     preflight_local_gguf,
@@ -58,6 +61,70 @@ def _write_sharded_gguf(
     names.append("output.weight")
     for name in names:
         writer.add_tensor(name, rng.standard_normal((8, 16)).astype(np.float32))
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_tensors_to_file()
+    writer.close()
+    return sorted(directory.glob(f"{stem}-*.gguf"))
+
+
+def _raw_quant_rows(qtype, n_rows: int, k: int) -> np.ndarray:
+    """Zeroed raw-block bytes shaped ``(n_rows, bytes_per_row)`` for *qtype*."""
+    from gguf import GGML_QUANT_SIZES
+
+    block_elems, block_bytes = GGML_QUANT_SIZES[qtype]
+    bytes_per_row = (k // block_elems) * block_bytes
+    return np.zeros((n_rows, bytes_per_row), dtype=np.uint8)
+
+
+def _write_quant_sharded_gguf(
+    directory: Path,
+    *,
+    architecture: str = "llama",
+    stem: str = "q",
+    split_max_tensors: int = 2,
+    include_unsupported: bool = False,
+    num_experts: int | None = None,
+) -> list[Path]:
+    """Write a shape-faithful multi-shard GGUF with mixed real quant types.
+
+    F32 (passthrough), Q8_0 (repack), IQ1_S (native-preserve), and — when
+    *include_unsupported* — Q5_K (no lossless path). Bodies are zeroed; only the
+    headers (types/dims) matter to the metadata-only preflight.
+    """
+    from gguf import GGMLQuantizationType, GGUFWriter
+
+    directory.mkdir(parents=True, exist_ok=True)
+    writer = GGUFWriter(
+        str(directory / stem), architecture, split_max_tensors=split_max_tensors
+    )
+    writer.add_context_length(128)
+    writer.add_embedding_length(256)
+    writer.add_block_count(2)
+    writer.add_head_count(4)
+    writer.add_head_count_kv(2)
+    writer.add_vocab_size(32)
+    if num_experts is not None:
+        writer.add_expert_count(num_experts)
+
+    k = 256
+    writer.add_tensor("token_embd.weight", np.zeros((8, k), np.float32))
+    writer.add_tensor(
+        "blk.0.attn_q.weight",
+        _raw_quant_rows(GGMLQuantizationType.Q8_0, 8, k),
+        raw_dtype=GGMLQuantizationType.Q8_0,
+    )
+    writer.add_tensor(
+        "blk.0.ffn_up.weight",
+        _raw_quant_rows(GGMLQuantizationType.IQ1_S, 8, k),
+        raw_dtype=GGMLQuantizationType.IQ1_S,
+    )
+    if include_unsupported:
+        writer.add_tensor(
+            "blk.1.ffn_down.weight",
+            _raw_quant_rows(GGMLQuantizationType.Q5_K, 8, k),
+            raw_dtype=GGMLQuantizationType.Q5_K,
+        )
     writer.write_header_to_file()
     writer.write_kv_data_to_file()
     writer.write_tensors_to_file()
@@ -284,3 +351,153 @@ def test_hf_preflight_metadata_only(monkeypatch):
     assert any("sparse-MoE" in b for b in report.blockers)
     # And nothing was downloaded.
     assert fake.downloaded == []
+
+
+# --------------------------------------------------------------------------- #
+# Block-preserving lossless classification + real-artifact budget (folded from
+# the superseded standalone GGUF export preflight; validated vs. the real
+# repacker, not a model-name allowlist).
+# --------------------------------------------------------------------------- #
+
+
+def test_type_classification_matches_the_real_repacker():
+    from gguf import GGMLQuantizationType as T
+
+    # Float -> passthrough; int4/int8 K-quants -> repack; IQ blocks -> preserve;
+    # a type with no lossless path -> unsupported (zero output bytes).
+    passthrough = _classify_tensor_type(T.F32.value, "F32", (8, 256), 8192)
+    assert passthrough[0] == "passthrough"
+    assert passthrough[1] == 8192
+
+    repack = _classify_tensor_type(T.Q8_0.value, "Q8_0", (8, 256), 2176)
+    assert repack[0] == "repack"
+    assert repack[1] == _matmulnbits_output_bytes((8, 256), 8, 32) > 0
+
+    native = _classify_tensor_type(T.IQ1_S.value, "IQ1_S", (8, 256), 400)
+    assert native[0] == "native-preserve"
+    assert native[1] == 400  # byte-for-byte preserved
+
+    unsupported = _classify_tensor_type(T.Q5_K.value, "Q5_K", (8, 256), 1408)
+    assert unsupported[0] == "unsupported"
+    assert unsupported[1] == 0
+
+
+def test_local_preflight_supported_sharded_set_passes_shard_and_arch_gates(tmp_path):
+    # Regression for the removed hardcoded ``split.count > 1`` refusal: a
+    # supported *sharded* set must clear the shard and arch gates. Direct
+    # multi-shard import (GgufShardSet) means being sharded is never a blocker.
+    shards = _write_quant_sharded_gguf(tmp_path, split_max_tensors=2)
+    assert len(shards) > 1
+    report = preflight_local_gguf(shards[0])
+
+    assert report.is_sharded
+    assert report.split_count == len(shards)
+    # Architecture resolves dynamically (no per-model code).
+    assert report.architecture == "llama"
+    assert report.resolved_model_type == "llama"
+    # No blocker mentions sharding / split / merge / double-copy.
+    joined = " ".join(report.blockers).lower()
+    for forbidden in ("shard", "split", "merge", "double-copy", "second"):
+        assert forbidden not in joined, report.blockers
+    # Every type is on a lossless path, so the set is exportable.
+    assert report.unsupported_types == []
+    assert report.exportable
+    assert {s.disposition for s in report.type_stats} <= {
+        "passthrough",
+        "repack",
+        "native-preserve",
+    }
+    assert report.output_bytes and report.output_bytes > 0
+
+
+def test_local_preflight_flags_exact_unsupported_native_qtypes(tmp_path):
+    shards = _write_quant_sharded_gguf(
+        tmp_path, split_max_tensors=2, include_unsupported=True
+    )
+    report = preflight_local_gguf(shards[0])
+
+    # Being sharded is still not a blocker; the ONLY blocker is the exact
+    # unsupported qtype (Q5_K here), never arch/sharding.
+    assert report.is_sharded
+    assert report.unsupported_types == ["Q5_K"]
+    assert len(report.blockers) == 1
+    assert "cannot be preserved losslessly" in report.blockers[0]
+    assert "Q5_K" in report.blockers[0]
+    # Unsupported tensors contribute zero output bytes (no dequantize widening).
+    q5k = next(s for s in report.type_stats if s.type_name == "Q5_K")
+    assert q5k.disposition == "unsupported"
+    assert q5k.output_bytes == 0
+
+
+def test_budget_reflects_real_artifacts_only_no_second_copy(tmp_path):
+    shards = _write_quant_sharded_gguf(tmp_path, split_max_tensors=2)
+    report = preflight_local_gguf(shards[0])
+
+    # No merged/second-copy disk budget exists anymore.
+    field_names = set(report.as_dict())
+    assert not any(
+        "merge" in name or "second" in name or "double" in name for name in field_names
+    )
+    # Download budget == the shard set itself (read in place, random access).
+    assert report.total_bytes == sum(s.stat().st_size for s in shards)
+    # VRAM is derived from the export artifact, not the source dtype bytes.
+    assert report.vram_weights_bytes == report.output_bytes
+    assert report.output_bytes <= report.total_bytes  # block-preserving, not widened
+    # The report (including repacked int-quant types) must be JSON-serialisable
+    # for the resumable cache — no stray numpy scalars from the header reader.
+    import json as _json
+
+    assert _json.loads(report.to_json())["output_bytes"] == report.output_bytes
+
+
+def test_sparse_iq1_moe_is_the_remaining_blocker_not_sharding(tmp_path):
+    # A sharded IQ1 MoE: the honesty blocker is sparse-MoE fusion, and sharding
+    # is not a blocker. This mirrors the flagship GLM-5.2 UD-IQ1_S case.
+    shards = _write_quant_sharded_gguf(
+        tmp_path, architecture="llama", split_max_tensors=2, num_experts=8
+    )
+    report = preflight_local_gguf(shards[0])
+    # The set is sharded and the arch resolves; the only honesty concern is the
+    # sparse-MoE fusion of the IQ1_S experts (quantization detected from name).
+    assert report.is_sharded
+    joined = " ".join(report.blockers).lower()
+    assert "shard" not in joined and "split" not in joined
+
+
+# --------------------------------------------------------------------------- #
+# CLI de-duplication: exactly one ``preflight-gguf`` owner (parser must build on
+# Python 3.12) and no parallel top-level module.
+# --------------------------------------------------------------------------- #
+
+
+def test_single_preflight_gguf_cli_registration():
+    # build_parser() raises argparse.ArgumentError at construction time if a
+    # subcommand is registered twice, so a clean build proves de-duplication.
+    from mobius.__main__ import build_parser
+
+    parser = build_parser()
+    subparsers = [
+        action
+        for action in parser._actions
+        if isinstance(action, argparse._SubParsersAction)
+    ]
+    assert subparsers, "no subparsers found"
+    choices = subparsers[0].choices
+    assert "preflight-gguf" in choices
+    # A dict of choices can only hold one entry per key; assert the whole action
+    # set registers the name exactly once.
+    registered = [
+        name
+        for action in subparsers
+        for name in getattr(action, "choices", {})
+        if name == "preflight-gguf"
+    ]
+    assert registered == ["preflight-gguf"]
+
+
+def test_no_parallel_preflight_gguf_module():
+    # The superseded standalone module must not be reintroduced.
+    import importlib
+
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module("mobius.preflight_gguf")


### PR DESCRIPTION
## What

Metadata-only, **block-preserving / lossless-only** classification and budget for
GGUF export, **folded into the #581 preflight library** (`mobius.integrations.gguf._preflight`).
This is the reconciled revision of the rejected PR: the standalone
`mobius.preflight_gguf` module and its duplicate `preflight-gguf` subcommand are
gone; the additive value lives on the single #581 code path.

Rebased/rebuilt onto current `main` (now includes #581 `7003bc7` and #576
`059bf5f`). Base retargeted from the deleted `sebastian/export-preflight-streaming`
to `main`. Single focused commit; no dependency on #576.

## Why the rejection is addressed

#581 shipped a `preflight-gguf` CLI + preflight library after this branch was
cut. The old branch added a *second* subparser (breaking `build_parser()` on
Python 3.12 with `conflicting subparser: preflight-gguf`) and duplicated header
parsing / shard resolution. It also carried three now-invalid blockers.

**Removed (net-new, now-false):**
- Duplicate module + duplicate `preflight-gguf` CLI ownership — exactly one
  registration remains (#581's); the parser builds on 3.12.
- Hardcoded `split.count > 1` refusal — `GgufShardSet` imports sharded sets
  directly, so GLM-5.2 `UD-IQ1_S` (6 shards) is **not** rejected for sharding.
- `merged_input_bytes` / second-copy disk budget — direct random access means no
  merged file; the budget reflects **real** artifacts only.
- `/mnt` staging recommendation — no environment paths in product defaults.
- No static DeepSeek 401/404 blocker, no bandwidth/tok-s inference, no payload
  download (headers only).

**Preserved / folded in (validated against the real repacker):**
- Dynamic architecture lookup (`glm-dsa → glm_moe_dsa`, from #581).
- Per-tensor-type lossless disposition against the **real** repacker
  (`native_block_spec` / `repack_quant_params`) + float passthrough — no
  model-name allowlist: `passthrough` / `native-preserve` / `repack` /
  `unsupported`.
- Real-artifact budget: ONNX external-data output estimate and a weights-only
  VRAM figure derived from the **export artifact** (not the source dtype).
- Honest blockers: the sparse-MoE fusion gate (#581) plus the **exact**
  unsupported native qtypes (e.g. `Q5_K/Q2_K/Q3_K`) are the real remaining code
  gaps for `UD-IQ1_S` — never architecture or sharding.

`GgufPreflightReport` gains additive fields (`type_stats`, `output_bytes`,
`vram_weights_bytes`, `unsupported_types`) with defaults; #581 APIs unchanged.

## Tests

Added to `_preflight_test.py` (metadata-only, shape-faithful multi-shard
fixtures): a supported **sharded** set clears the shard + arch gates;
dispositions match the real repacker; an unsupported qtype is the *only* blocker;
the budget carries no second-copy and VRAM derives from the artifact; exactly one
`preflight-gguf` CLI registration and no parallel top-level module. Full
`_preflight_test.py` + the GGUF suite (408) + CLI option parity pass; `ruff`
clean (0.16.2).

Independent re-review requested. Do not merge.
