### PR TITLE
Direct multi-shard GGUF import + GLM-5.2 (glm-dsa→glm_moe_dsa) resolution

### DIFF
--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -686,6 +686,31 @@ def _cmd_convert_comfyui(args: argparse.Namespace) -> None:
         print(f"  prompt: {wf.prompt!r}")
 
 
+def _cmd_preflight_gguf(args: argparse.Namespace) -> None:
+    """Execute the 'preflight-gguf' subcommand (metadata only)."""
+    try:
+        from mobius.integrations.gguf import preflight_gguf
+    except ImportError:
+        print(
+            "GGUF support requires the gguf package. Install with: pip install mobius-onnx[gguf]"
+        )
+        raise SystemExit(1)
+
+    report = preflight_gguf(
+        args.source,
+        filename=getattr(args, "filename", None),
+        revision=getattr(args, "revision", None),
+        verify_checksums=getattr(args, "verify_checksums", False),
+        cache_path=getattr(args, "cache", None),
+    )
+    if getattr(args, "json", False):
+        print(report.to_json())
+    else:
+        print(report.render())
+    if report.blockers:
+        raise SystemExit(2)
+
+
 def _cmd_info(args: argparse.Namespace) -> None:
     """Execute the 'info' subcommand."""
     from mobius.integrations.diffusers._builder import (
@@ -1135,6 +1160,48 @@ def build_parser() -> argparse.ArgumentParser:
         help="Target an SDXL pipeline (routes the dual text-encoder conditioning edges).",
     )
     comfy_parser.set_defaults(func=_cmd_convert_comfyui)
+
+    # --- preflight-gguf ---
+    preflight_parser = subparsers.add_parser(
+        "preflight-gguf",
+        help="Metadata-only preflight of a GGUF file or split set (local path "
+        "or Hugging Face 'owner/repo[:file]'). Reports exact files, bytes, "
+        "checksums, resolved architecture, and export blockers (notably the "
+        "sparse-MoE fusion blocker) WITHOUT downloading tensor payloads.",
+    )
+    preflight_parser.add_argument(
+        "source",
+        help="Local .gguf path / split-set shard / directory, or a Hugging "
+        "Face reference 'owner/repo' or 'owner/repo:filename.gguf'.",
+    )
+    preflight_parser.add_argument(
+        "--filename",
+        default=None,
+        help="Specific shard filename when SOURCE is a bare 'owner/repo'.",
+    )
+    preflight_parser.add_argument(
+        "--revision",
+        default=None,
+        help="Pinned Hugging Face revision (sha/branch/tag).",
+    )
+    preflight_parser.add_argument(
+        "--verify-checksums",
+        action="store_true",
+        help="Compute per-shard sha256 for a local set (reads file bytes, not "
+        "tensor payloads via the model API).",
+    )
+    preflight_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the report as JSON instead of the human-readable summary.",
+    )
+    preflight_parser.add_argument(
+        "--cache",
+        default=None,
+        help="Optional JSON cache path; a resumable, idempotent preflight reads "
+        "from it when present and writes to it otherwise.",
+    )
+    preflight_parser.set_defaults(func=_cmd_preflight_gguf)
 
     return parser
 

--- a/src/mobius/_flags.py
+++ b/src/mobius/_flags.py
@@ -178,6 +178,26 @@ class _Flags:
     unchanged, so no shipped model's graph changes unless this flag is set.
     """
 
+    allow_dense_moe_experts: bool = dataclasses.field(
+        default_factory=lambda: _env_bool("MOBIUS_ALLOW_DENSE_MOE_EXPERTS", False)
+    )
+    """Opt in to exporting routed MoE experts that have no sparse top-k fusion.
+
+    Some quantized MoE checkpoints (notably GLM-5.2 UD-IQ1_{S,M}) lower their
+    routed experts as per-expert native ``pkg.nxrt::BlockQuantizedMatMul`` nodes
+    (IQ1/IQ2/… blocks), for which no sparse ``BlockQuantizedMoE`` fusion exists
+    yet — only the int4 ``MatMulNBits`` dense-fallback → ``com.microsoft::QMoE``
+    rewrite does. Exporting anyway produces a graph that recomputes **every**
+    expert for every token (full expert weight traffic), i.e. dense-all-expert
+    compute with no performance guarantee.
+
+    Default ``False``: :func:`~mobius.integrations.gguf.build_from_gguf` fails
+    closed before export with a typed capability error rather than shipping a
+    silently-dense graph. Set ``MOBIUS_ALLOW_DENSE_MOE_EXPERTS=1`` (or override
+    the flag) only for research / correctness study of the dense fallback. This
+    is **not** a performance path and makes no throughput claim.
+    """
+
 
 # Global singleton — import and use this directly.
 flags = _Flags()

--- a/src/mobius/integrations/gguf/__init__.py
+++ b/src/mobius/integrations/gguf/__init__.py
@@ -29,9 +29,29 @@ to :func:`build_gemma4_vlm_from_gguf` for the multimodal assembly.
 
 from __future__ import annotations
 
-from mobius.integrations.gguf._builder import build_from_gguf
+from mobius.integrations.gguf._builder import (
+    SparseMoEExportError,
+    build_from_gguf,
+)
+from mobius.integrations.gguf._config_mapping import (
+    GgufArchResolutionError,
+    resolve_model_type,
+)
 from mobius.integrations.gguf._mmproj import build_gemma4_vlm_from_gguf
+from mobius.integrations.gguf._preflight import (
+    GgufPreflightReport,
+    preflight_gguf,
+    preflight_hf_gguf,
+    preflight_local_gguf,
+)
 from mobius.integrations.gguf._runtime_package import write_gguf_runtime_package
+from mobius.integrations.gguf._shard_set import (
+    GgufShardError,
+    GgufShardManifest,
+    GgufShardSet,
+    discover_gguf_shards,
+    open_gguf_model,
+)
 from mobius.integrations.gguf._tokenizer import write_gguf_tokenizer_json
 
 __all__ = [
@@ -39,4 +59,20 @@ __all__ = [
     "build_gemma4_vlm_from_gguf",
     "write_gguf_runtime_package",
     "write_gguf_tokenizer_json",
+    # Multi-shard GGUF import
+    "GgufShardSet",
+    "GgufShardManifest",
+    "GgufShardError",
+    "discover_gguf_shards",
+    "open_gguf_model",
+    # Architecture resolution
+    "resolve_model_type",
+    "GgufArchResolutionError",
+    # Sparse-MoE honesty gate
+    "SparseMoEExportError",
+    # Metadata-only preflight
+    "preflight_gguf",
+    "preflight_local_gguf",
+    "preflight_hf_gguf",
+    "GgufPreflightReport",
 ]

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -145,6 +145,86 @@ def _raise_for_sharded_gguf(
     )
 
 
+class SparseMoEExportError(NotImplementedError):
+    """Routed MoE experts have no sparse fusion for their quantization.
+
+    Raised before export when a checkpoint's routed experts lower to per-expert
+    native ``pkg.nxrt::BlockQuantizedMatMul`` nodes (e.g. GLM-5.2 UD-IQ1_{S,M})
+    for which no sparse top-k ``BlockQuantizedMoE`` fusion exists — exporting
+    anyway would recompute every expert for every token (dense-all-expert
+    compute) with no performance guarantee.
+    """
+
+
+def _routed_dense_block_expert_paths(module) -> list[str]:
+    """Return module paths of routed experts lowered as native block linears.
+
+    A routed expert is a :class:`BlockQuantizedLinear` whose qualified name
+    contains a ``.moe.experts.`` (or bare ``.experts.``) segment but is *not* a
+    ``shared_expert``. These are the modules that, absent a sparse top-k MoE
+    fusion, force a dense loop over all experts.
+    """
+    from mobius.components import BlockQuantizedLinear
+
+    paths: list[str] = []
+    for name, mod in module.named_modules():
+        if not isinstance(mod, BlockQuantizedLinear):
+            continue
+        if "shared_expert" in name:
+            continue
+        if ".experts." not in name:
+            continue
+        paths.append(name)
+    return paths
+
+
+def _assert_sparse_moe_capability(module, config, *, source: str, allow_dense: bool) -> None:
+    """Fail closed when routed IQ-block experts have no sparse MoE fusion.
+
+    The int4 ``MatMulNBits`` dense-fallback → ``com.microsoft::QMoE`` rewrite is
+    the only sparse MoE path today; native IQ/MXFP4 block experts stay as
+    per-expert ``BlockQuantizedMatMul`` nodes. Exporting those yields a graph
+    that evaluates every expert for every token. Refuse by default; only proceed
+    (with a loud warning) when the caller explicitly opts in.
+    """
+    num_experts = int(getattr(config, "num_local_experts", 0) or 0)
+    if num_experts <= 0:
+        return
+    dense_paths = _routed_dense_block_expert_paths(module)
+    if not dense_paths:
+        return
+
+    example = ", ".join(sorted(dense_paths)[:3])
+    detail = (
+        f"{len(dense_paths)} routed expert projections (e.g. {example}) in "
+        f"{source!r} lower to per-expert native BlockQuantizedMatMul nodes."
+    )
+    if allow_dense:
+        logger.warning(
+            "allow_dense_moe: exporting %d routed MoE expert(s) as independent "
+            "BlockQuantizedMatMul nodes for %s. This recomputes EVERY expert for "
+            "every token (dense-all-expert compute); it is NOT a performance path "
+            "and makes no throughput claim. %s",
+            len(dense_paths),
+            source,
+            detail,
+        )
+        return
+
+    raise SparseMoEExportError(
+        "Sparse-MoE export blocker: "
+        f"{detail} No sparse top-k BlockQuantizedMoE fusion exists for these "
+        "block formats — only int4 MatMulNBits experts are fused into "
+        "com.microsoft::QMoE. Exporting anyway would build a dense-all-expert "
+        "graph (every expert evaluated for every token) with no performance "
+        "guarantee, so the build fails closed. To study the dense fallback, "
+        "re-run with allow_dense_moe=True (or set "
+        "MOBIUS_ALLOW_DENSE_MOE_EXPERTS=1); this makes no throughput claim. "
+        "The supported fix is a sparse IQ-block BlockQuantizedMoE fusion "
+        "(top-k gather over native-block expert weights)."
+    )
+
+
 def _preflight_hf_gguf(api: HfApi, repo_id: str, filename: str) -> None:
     """Use Hub metadata to reject known-bad inputs before a multi-GB download."""
     source = f"{repo_id}:{filename}"
@@ -184,8 +264,14 @@ def _preflight_hf_gguf(api: HfApi, repo_id: str, filename: str) -> None:
 
 def _validate_gguf_model(gguf_model, *, source: str) -> None:
     """Validate a parsed GGUF before config extraction or graph construction."""
-    split_count = int(gguf_model.get_metadata("split.count", 1))
-    _raise_for_sharded_gguf(source=source, split_count=split_count)
+    from mobius.integrations.gguf._shard_set import GgufShardSet
+
+    # A GgufShardSet has already assembled and structurally validated the whole
+    # split set, so the single-file "sharded input is unsupported" guard must
+    # not fire for it. Plain single-file GGUFModels still reject a lone shard.
+    if not isinstance(gguf_model, GgufShardSet):
+        split_count = int(gguf_model.get_metadata("split.count", 1))
+        _raise_for_sharded_gguf(source=source, split_count=split_count)
     _raise_for_unsupported_gguf_architecture(
         gguf_model.architecture,
         source=source,
@@ -250,6 +336,7 @@ def build_from_gguf(
     mmproj: str | Path | None = None,
     static_cache: bool = False,
     max_seq_len: int | None = None,
+    allow_dense_moe: bool | None = None,
 ) -> ModelPackage:
     """Build an ONNX :class:`ModelPackage` from a GGUF file.
 
@@ -308,6 +395,14 @@ def build_from_gguf(
         max_seq_len: Maximum sequence length for the static cache buffers.
             Only used when ``static_cache=True``. Defaults to the model's
             ``max_position_embeddings``.
+        allow_dense_moe: Opt in to exporting routed MoE experts that have no
+            sparse top-k fusion (they lower to per-expert native
+            ``BlockQuantizedMatMul`` nodes, i.e. dense-all-expert compute with
+            no performance guarantee). When ``None`` (default), the value of
+            the ``allow_dense_moe_experts`` flag is used, which defaults to
+            ``False`` — the build fails closed with a typed capability error
+            rather than silently shipping a dense graph. This is a research /
+            correctness knob and makes no throughput claim.
 
     Returns:
         A :class:`ModelPackage` containing the built model(s).
@@ -346,7 +441,7 @@ def build_from_gguf(
         GGUF_ARCH_TO_MODEL_TYPE,
         gguf_to_config,
     )
-    from mobius.integrations.gguf._reader import GGUFModel
+    from mobius.integrations.gguf._shard_set import open_gguf_model
     from mobius.integrations.gguf._tensor_processors import (
         process_tensors,
     )
@@ -360,12 +455,19 @@ def build_from_gguf(
             "override; the static cache is wired through CausalLMTask."
         )
 
-    # 1. Parse GGUF file (auto-download from HF Hub when given "owner/repo[:filename]")
+    from mobius._flags import flags as _mobius_flags
+
+    if allow_dense_moe is None:
+        allow_dense_moe = _mobius_flags.allow_dense_moe_experts
+
+    # 1. Parse GGUF file (auto-download from HF Hub when given "owner/repo[:filename]").
+    #    A ``-000i-of-000N.gguf`` split set is assembled directly from its shards
+    #    (never merged into a second on-disk GGUF); a plain file opens as before.
     gguf_path = _resolve_gguf_path(gguf_path)
-    gguf_model = GGUFModel(gguf_path)
+    gguf_model = open_gguf_model(gguf_path)
     _validate_gguf_model(gguf_model, source=str(gguf_path))
     gguf_arch = gguf_model.architecture
-    logger.info("Loaded GGUF file: %s (arch=%s)", gguf_path, gguf_arch)
+    logger.info("Loaded GGUF model: %s (arch=%s)", gguf_path, gguf_arch)
     preserve_quantization = keep_quantized and _has_quantized_weights(gguf_model, gguf_arch)
     if keep_quantized and not preserve_quantization:
         logger.info("GGUF contains no mapped quantized weights; using the float import path")
@@ -375,6 +477,16 @@ def build_from_gguf(
     model_type = getattr(config, "_gguf_model_type", None)
     if model_type is None:
         model_type = GGUF_ARCH_TO_MODEL_TYPE.get(gguf_arch, gguf_arch)
+
+    # 2b. Architecture-resolution safety rail. When the GGUF architecture string
+    # bridges to a specialised registry key, verify the metadata-derived config
+    # actually describes that architecture before selecting its model class, so
+    # a mislabelled or incomplete GGUF fails closed with precise reasons instead
+    # of silently building the wrong graph.
+    if model_type == "glm_moe_dsa":
+        from mobius.integrations.gguf._config_mapping import assert_glm_moe_dsa_resolvable
+
+        assert_glm_moe_dsa_resolvable(config, gguf_arch, source=str(gguf_path))
 
     # ``dataclasses.replace`` below (dtype / quantization) returns a fresh
     # instance that does NOT carry the private ``_gguf_*`` attributes set by
@@ -489,6 +601,13 @@ def build_from_gguf(
     module = module_class(config)
     if preserve_quantization:
         _replace_native_block_linears(module, gguf_model, gguf_arch)
+        # Sparse-MoE honesty gate: routed experts lowered as native
+        # BlockQuantizedMatMul nodes have no sparse top-k fusion yet, so the
+        # exported graph would recompute every expert for every token. Fail
+        # closed here (before export) unless the caller explicitly opts in.
+        _assert_sparse_moe_capability(
+            module, config, source=str(gguf_path), allow_dense=allow_dense_moe
+        )
     pkg = build_from_module(
         module, config, resolved_task, execution_provider=execution_provider
     )
@@ -1164,7 +1283,7 @@ def _can_quantize_embedding(
     if is_tencent_q1_0_layout(gguf_model):
         return False
 
-    for tensor in gguf_model._reader.tensors:
+    for tensor in gguf_model.reader_tensors():
         if map_gguf_to_hf_names(tensor.name, gguf_arch) != "model.embed_tokens.weight":
             continue
         shape = tuple(reversed(tensor.shape))
@@ -1314,7 +1433,7 @@ def _load_dequantized_state_dict(
     for gguf_name, np_array in tqdm.tqdm(
         gguf_model.tensor_items(),
         desc="Dequantizing tensors",
-        total=len(gguf_model._tensor_index),
+        total=gguf_model.num_tensors,
     ):
         hf_name = name_mapper(gguf_name, gguf_arch)
         if hf_name is not None:
@@ -1415,7 +1534,7 @@ def _load_quantized_state_dict(
     for gguf_name, raw, qtype, np_shape in tqdm.tqdm(
         gguf_model.tensor_items_raw(),
         desc="Repacking tensors",
-        total=len(gguf_model._tensor_index),
+        total=gguf_model.num_tensors,
     ):
         hf_name = name_mapper(gguf_name, gguf_arch)
         if hf_name is None:

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -661,7 +661,10 @@ class TestBuildQuantizedGguf:
             tensor_type=GGMLQuantizationType.Q4_0,
             shape=(64, 256),
         )
-        model = SimpleNamespace(_reader=SimpleNamespace(tensors=[tensor]))
+        model = SimpleNamespace(
+            _reader=SimpleNamespace(tensors=[tensor]),
+            reader_tensors=lambda: [tensor],
+        )
 
         assert _can_quantize_embedding(model, "llama", bits=4, block_size=32)
 

--- a/src/mobius/integrations/gguf/_config_mapping.py
+++ b/src/mobius/integrations/gguf/_config_mapping.py
@@ -20,7 +20,7 @@ Example::
 
 from __future__ import annotations
 
-__all__ = ["gguf_to_config"]
+__all__ = ["gguf_to_config", "resolve_model_type", "assert_glm_moe_dsa_resolvable"]
 
 import dataclasses
 import logging
@@ -66,6 +66,14 @@ GGUF_ARCH_TO_MODEL_TYPE: dict[str, str] = {
     "t5": "t5",
     "hunyuan-dense": "hunyuan_v1_dense",
     "deepseek4": "deepseek_v4",
+    # GLM-5.2 GGUFs (e.g. unsloth/GLM-5.2-GGUF) tag the architecture 'glm-dsa'
+    # (MLA + DeepSeek Sparse Attention + MoE). Mobius's canonical registry key
+    # is 'glm_moe_dsa'. This is an explicit format-bridge mapping keyed on the
+    # authoritative GGUF architecture string, never on the filename or model
+    # name. ``assert_glm_moe_dsa_resolvable`` verifies the head/layer/expert/DSA
+    # properties before the builder selects GlmMoeDsaCausalLMModel.
+    "glm-dsa": "glm_moe_dsa",
+    "glm_dsa": "glm_moe_dsa",
     "deci": "llama",  # DeciLM uses Llama architecture
     "muse-glimmer": "muse_glimmer_text",
     "muse_glimmer": "muse_glimmer_text",
@@ -134,6 +142,30 @@ _ARCH_KEY_MAPS: dict[str, dict[str, str]] = {
         "hash_layer_count": "num_hash_layers",
     },
 }
+
+# GLM-5.2 ('glm-dsa') shares DeepSeek's MLA + MoE + DSA-indexer metadata layout
+# but omits the DeepSeek-V4-only hyper-connection / hash-routing / output-group
+# extensions. Keep the map to the discriminating MLA/MoE/DSA keys only, so the
+# extracted config matches what GlmMoeDsaCausalLMModel (a DeepSeek-V3 subclass)
+# consumes. Both spellings of the architecture string are accepted.
+_GLM_DSA_KEY_MAP = {
+    "attention.key_length": "head_dim",
+    "rope.dimension_count": "qk_rope_head_dim",
+    "attention.q_lora_rank": "q_lora_rank",
+    "attention.kv_lora_rank": "kv_lora_rank",
+    "attention.sliding_window": "sliding_window",
+    "expert_count": "num_local_experts",
+    "expert_used_count": "num_experts_per_tok",
+    "expert_feed_forward_length": "moe_intermediate_size",
+    "expert_shared_count": "n_shared_experts",
+    "expert_weights_scale": "routed_scaling_factor",
+    "expert_weights_norm": "norm_topk_prob",
+    "attention.indexer.head_count": "index_n_heads",
+    "attention.indexer.key_length": "index_head_dim",
+    "attention.indexer.top_k": "index_topk",
+}
+_ARCH_KEY_MAPS["glm-dsa"] = _GLM_DSA_KEY_MAP
+_ARCH_KEY_MAPS["glm_dsa"] = _GLM_DSA_KEY_MAP
 
 
 # GGUF hidden_act values → HuggingFace activation function names
@@ -1027,3 +1059,111 @@ def _infer_mlp_bias(model: Any) -> bool:
         n.endswith(("ffn_up.bias", "ffn_down.bias", "ffn_gate.bias"))
         for n in model.tensor_names
     )
+
+
+class GgufArchResolutionError(ValueError):
+    """A GGUF architecture could not be resolved to a buildable model type.
+
+    Raised when the GGUF architecture string maps to a canonical registry key
+    (e.g. ``glm-dsa`` → ``glm_moe_dsa``) but the metadata-derived config is
+    missing the head/layer/expert/attention properties that model requires, so
+    dispatching to it would build the wrong graph. The message lists every
+    failed property (precise rejection reasons) rather than the first one.
+    """
+
+
+def resolve_model_type(gguf_arch: str) -> str:
+    """Resolve a GGUF architecture string to a canonical registry model type.
+
+    This is the single, explicit format-bridge lookup. It is driven purely by
+    the authoritative ``general.architecture`` metadata value — never by the
+    filename or ``general.name`` — so an arbitrarily-named GGUF cannot be
+    coerced into a different architecture. Unknown architectures fall through
+    unchanged, matching the pre-existing default behaviour.
+    """
+    return GGUF_ARCH_TO_MODEL_TYPE.get(gguf_arch, gguf_arch)
+
+
+def _positive(value: Any) -> bool:
+    try:
+        return value is not None and int(value) > 0
+    except (TypeError, ValueError):
+        return False
+
+
+def assert_glm_moe_dsa_resolvable(
+    config: ArchitectureConfig,
+    gguf_arch: str,
+    *,
+    source: str,
+) -> None:
+    """Verify a ``glm-dsa`` GGUF really is a buildable GLM-5.2 ``glm_moe_dsa``.
+
+    GLM-5.2 (``glm_moe_dsa``) is MLA + DeepSeek Sparse Attention (DSA) + MoE.
+    Before the builder selects :class:`GlmMoeDsaCausalLMModel`, confirm the
+    metadata-derived config carries the discriminating head/layer/expert/DSA
+    properties. A bare decoder GGUF mislabelled ``glm-dsa`` (or one whose DSA /
+    MoE keys use unexpected suffixes) is rejected with the exact list of missing
+    properties instead of silently building an incorrect graph.
+
+    Only invoked for the ``glm-dsa`` → ``glm_moe_dsa`` bridge; other
+    architectures are unaffected.
+    """
+    reasons: list[str] = []
+
+    if not _positive(config.num_hidden_layers):
+        reasons.append(f"num_hidden_layers must be > 0 (got {config.num_hidden_layers!r})")
+    if not _positive(config.num_attention_heads):
+        reasons.append(f"num_attention_heads must be > 0 (got {config.num_attention_heads!r})")
+    if not _positive(config.hidden_size):
+        reasons.append(f"hidden_size must be > 0 (got {config.hidden_size!r})")
+
+    # MoE expert stack.
+    if not _positive(config.num_local_experts):
+        reasons.append(
+            "missing routed-expert count (GGUF '<arch>.expert_count'); "
+            f"num_local_experts={config.num_local_experts!r}"
+        )
+    if not _positive(config.num_experts_per_tok):
+        reasons.append(
+            "missing experts-per-token (GGUF '<arch>.expert_used_count'); "
+            f"num_experts_per_tok={config.num_experts_per_tok!r}"
+        )
+    if not _positive(config.moe_intermediate_size):
+        reasons.append(
+            "missing expert FFN width (GGUF '<arch>.expert_feed_forward_length'); "
+            f"moe_intermediate_size={config.moe_intermediate_size!r}"
+        )
+
+    # MLA (latent attention) evidence: GLM-5.2 uses low-rank Q/KV projections.
+    if not (_positive(config.q_lora_rank) or _positive(config.kv_lora_rank)):
+        reasons.append(
+            "no MLA low-rank projection found (GGUF '<arch>.attention.q_lora_rank' "
+            "or '<arch>.attention.kv_lora_rank'); GLM-5.2 requires latent attention"
+        )
+
+    # DSA indexer — only required on the default sparse-attention export path.
+    if getattr(config, "use_dsa", True):
+        for field_name, gguf_key in (
+            ("index_n_heads", "attention.indexer.head_count"),
+            ("index_head_dim", "attention.indexer.key_length"),
+            ("index_topk", "attention.indexer.top_k"),
+        ):
+            if not _positive(getattr(config, field_name, None)):
+                reasons.append(
+                    f"missing DSA indexer property {field_name} "
+                    f"(GGUF '<arch>.{gguf_key}'); required for use_dsa=True "
+                    "(pass use_dsa=False / --glm-full-attention for dense MLA)"
+                )
+
+    if reasons:
+        joined = "\n  - ".join(reasons)
+        raise GgufArchResolutionError(
+            f"GGUF architecture {gguf_arch!r} in {source!r} resolves to the "
+            "canonical model type 'glm_moe_dsa' (GLM-5.2), but the metadata does "
+            "not describe a complete MLA + DSA + MoE model:\n  - "
+            f"{joined}\n"
+            "No ONNX artifacts were emitted. Re-export the GGUF from an "
+            "authoritative GLM-5.2 checkpoint, or if this file is a different "
+            "architecture, do not tag it 'glm-dsa'."
+        )

--- a/src/mobius/integrations/gguf/_glm_moe_dsa_test.py
+++ b/src/mobius/integrations/gguf/_glm_moe_dsa_test.py
@@ -1,0 +1,263 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""GLM-5.2 architecture-bridge and sparse-MoE honesty-gate tests.
+
+The ``glm-dsa`` → ``glm_moe_dsa`` bridge plus the fail-closed sparse-MoE gate.
+These cover the two safety rails added for the direct GLM-5.2 GGUF import:
+
+* :func:`resolve_model_type` / :func:`assert_glm_moe_dsa_resolvable` — the
+  explicit, metadata-driven format bridge (no filename/model-name heuristics)
+  that verifies the head/layer/expert/MLA/DSA properties before the builder
+  selects ``GlmMoeDsaCausalLMModel``.
+* :func:`_assert_sparse_moe_capability` — the fail-closed gate that refuses to
+  export routed IQ-block experts that would lower to per-expert
+  ``BlockQuantizedMatMul`` nodes (dense-all-expert compute) with no sparse
+  fusion.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class _FakeGlmDsaModel:
+    architecture = "glm-dsa"
+
+    def __init__(self, md: dict) -> None:
+        self.metadata = md
+
+    def get_metadata(self, key, default=None):
+        return self.metadata.get(key, default)
+
+    @property
+    def tensor_names(self) -> list[str]:
+        return ["output.weight", "blk.0.attn_q.weight"]
+
+
+def _valid_glm_dsa_metadata() -> dict:
+    return {
+        "glm-dsa.embedding_length": 5120,
+        "glm-dsa.block_count": 92,
+        "glm-dsa.attention.head_count": 96,
+        "glm-dsa.attention.head_count_kv": 96,
+        "glm-dsa.feed_forward_length": 12288,
+        "glm-dsa.vocab_size": 151552,
+        "glm-dsa.expert_count": 160,
+        "glm-dsa.expert_used_count": 8,
+        "glm-dsa.expert_feed_forward_length": 1536,
+        "glm-dsa.expert_shared_count": 1,
+        "glm-dsa.attention.q_lora_rank": 1536,
+        "glm-dsa.attention.kv_lora_rank": 512,
+        "glm-dsa.attention.key_length": 128,
+        "glm-dsa.rope.dimension_count": 64,
+        "glm-dsa.attention.indexer.head_count": 64,
+        "glm-dsa.attention.indexer.key_length": 128,
+        "glm-dsa.attention.indexer.top_k": 2048,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# resolve_model_type — the format bridge
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "arch,expected",
+    [
+        ("glm-dsa", "glm_moe_dsa"),
+        ("glm_dsa", "glm_moe_dsa"),
+        ("llama", "llama"),  # unknown/passthrough unchanged
+        ("qwen2", "qwen2"),
+    ],
+)
+def test_resolve_model_type(arch, expected):
+    from mobius.integrations.gguf._config_mapping import resolve_model_type
+
+    assert resolve_model_type(arch) == expected
+
+
+def test_glm_dsa_config_resolves_to_glm_moe_dsa():
+    from mobius.integrations.gguf._config_mapping import gguf_to_config, resolve_model_type
+
+    config = gguf_to_config(_FakeGlmDsaModel(_valid_glm_dsa_metadata()))
+    model_type = getattr(config, "_gguf_model_type", None) or resolve_model_type("glm-dsa")
+    assert model_type == "glm_moe_dsa"
+
+
+# --------------------------------------------------------------------------- #
+# assert_glm_moe_dsa_resolvable — valid / invalid
+# --------------------------------------------------------------------------- #
+
+
+def test_valid_glm_dsa_config_passes():
+    from mobius.integrations.gguf._config_mapping import (
+        assert_glm_moe_dsa_resolvable,
+        gguf_to_config,
+    )
+
+    config = gguf_to_config(_FakeGlmDsaModel(_valid_glm_dsa_metadata()))
+    assert_glm_moe_dsa_resolvable(config, "glm-dsa", source="valid.gguf")  # no raise
+
+
+def test_missing_expert_count_rejected():
+    from mobius.integrations.gguf._config_mapping import (
+        GgufArchResolutionError,
+        assert_glm_moe_dsa_resolvable,
+        gguf_to_config,
+    )
+
+    md = _valid_glm_dsa_metadata()
+    del md["glm-dsa.expert_count"]
+    config = gguf_to_config(_FakeGlmDsaModel(md))
+    with pytest.raises(GgufArchResolutionError, match=r"(?i)expert"):
+        assert_glm_moe_dsa_resolvable(config, "glm-dsa", source="no_experts.gguf")
+
+
+def test_missing_mla_rank_rejected():
+    from mobius.integrations.gguf._config_mapping import (
+        GgufArchResolutionError,
+        assert_glm_moe_dsa_resolvable,
+        gguf_to_config,
+    )
+
+    md = _valid_glm_dsa_metadata()
+    del md["glm-dsa.attention.q_lora_rank"]
+    del md["glm-dsa.attention.kv_lora_rank"]
+    config = gguf_to_config(_FakeGlmDsaModel(md))
+    with pytest.raises(GgufArchResolutionError, match=r"(?i)MLA|latent|lora"):
+        assert_glm_moe_dsa_resolvable(config, "glm-dsa", source="no_mla.gguf")
+
+
+def test_missing_dsa_indexer_rejected():
+    from mobius.integrations.gguf._config_mapping import (
+        GgufArchResolutionError,
+        assert_glm_moe_dsa_resolvable,
+        gguf_to_config,
+    )
+
+    md = _valid_glm_dsa_metadata()
+    del md["glm-dsa.attention.indexer.head_count"]
+    del md["glm-dsa.attention.indexer.key_length"]
+    del md["glm-dsa.attention.indexer.top_k"]
+    config = gguf_to_config(_FakeGlmDsaModel(md))
+    with pytest.raises(GgufArchResolutionError, match=r"(?i)DSA|indexer"):
+        assert_glm_moe_dsa_resolvable(config, "glm-dsa", source="no_dsa.gguf")
+
+
+def test_rejection_lists_all_reasons():
+    # A bare decoder mislabelled 'glm-dsa' should report every missing property,
+    # not just the first (precise rejection reasons).
+    from mobius.integrations.gguf._config_mapping import (
+        GgufArchResolutionError,
+        assert_glm_moe_dsa_resolvable,
+        gguf_to_config,
+    )
+
+    md = {
+        "glm-dsa.embedding_length": 4096,
+        "glm-dsa.block_count": 32,
+        "glm-dsa.attention.head_count": 32,
+        "glm-dsa.attention.head_count_kv": 8,
+        "glm-dsa.feed_forward_length": 11008,
+        "glm-dsa.vocab_size": 128000,
+    }
+    config = gguf_to_config(_FakeGlmDsaModel(md))
+    with pytest.raises(GgufArchResolutionError) as excinfo:
+        assert_glm_moe_dsa_resolvable(config, "glm-dsa", source="bare_decoder.gguf")
+    message = str(excinfo.value)
+    assert "expert" in message.lower()
+    assert "mla" in message.lower() or "latent" in message.lower()
+    assert "indexer" in message.lower()
+
+
+# --------------------------------------------------------------------------- #
+# Sparse-MoE honesty gate
+# --------------------------------------------------------------------------- #
+
+
+def _moe_module_with_block_experts(num_experts: int = 3):
+    from onnxscript import nn
+
+    from mobius.components import BlockQuantizedLinear
+
+    class _Experts(nn.Module):
+        def __init__(self, n):
+            super().__init__()
+            self.experts = nn.ModuleList(
+                [BlockQuantizedLinear(256, 8, format="iq1_s") for _ in range(n)]
+            )
+
+    class _MLP(nn.Module):
+        def __init__(self, n):
+            super().__init__()
+            self.moe = _Experts(n)
+            self.shared_experts = BlockQuantizedLinear(256, 8, format="iq1_s")
+
+    class _Root(nn.Module):
+        def __init__(self, n):
+            super().__init__()
+            self.layers = nn.ModuleList([_MLP(n)])
+
+    return _Root(num_experts)
+
+
+class _Cfg:
+    def __init__(self, num_local_experts):
+        self.num_local_experts = num_local_experts
+
+
+def test_routed_dense_block_expert_paths_finds_experts():
+    from mobius.integrations.gguf._builder import _routed_dense_block_expert_paths
+
+    module = _moe_module_with_block_experts(num_experts=3)
+    paths = _routed_dense_block_expert_paths(module)
+    assert len(paths) == 3
+    assert all(".experts." in p for p in paths)
+    # Shared experts are explicitly excluded (they are not routed).
+    assert all("shared_expert" not in p for p in paths)
+
+
+def test_honesty_gate_blocks_iq1_moe_by_default():
+    from mobius.integrations.gguf._builder import (
+        SparseMoEExportError,
+        _assert_sparse_moe_capability,
+    )
+
+    module = _moe_module_with_block_experts(num_experts=4)
+    with pytest.raises(SparseMoEExportError, match=r"(?i)sparse|dense-all-expert"):
+        _assert_sparse_moe_capability(module, _Cfg(4), source="glm52.gguf", allow_dense=False)
+
+
+def test_honesty_gate_error_points_to_next_slice():
+    from mobius.integrations.gguf._builder import (
+        SparseMoEExportError,
+        _assert_sparse_moe_capability,
+    )
+
+    module = _moe_module_with_block_experts(num_experts=2)
+    with pytest.raises(SparseMoEExportError) as excinfo:
+        _assert_sparse_moe_capability(module, _Cfg(2), source="glm52.gguf", allow_dense=False)
+    assert "BlockQuantizedMoE" in str(excinfo.value)
+
+
+def test_honesty_gate_allows_when_opted_in():
+    from mobius.integrations.gguf._builder import _assert_sparse_moe_capability
+
+    module = _moe_module_with_block_experts(num_experts=3)
+    # allow_dense=True proceeds (research/correctness path) without raising.
+    _assert_sparse_moe_capability(module, _Cfg(3), source="glm52.gguf", allow_dense=True)
+
+
+def test_honesty_gate_noop_for_non_moe():
+    from mobius.integrations.gguf._builder import _assert_sparse_moe_capability
+
+    module = _moe_module_with_block_experts(num_experts=3)
+    # num_local_experts=0 => not treated as MoE, gate is a no-op.
+    _assert_sparse_moe_capability(module, _Cfg(0), source="x.gguf", allow_dense=False)
+
+
+def test_allow_dense_moe_flag_defaults_false():
+    from mobius._flags import flags
+
+    assert flags.allow_dense_moe_experts is False

--- a/src/mobius/integrations/gguf/_preflight.py
+++ b/src/mobius/integrations/gguf/_preflight.py
@@ -1,0 +1,657 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Metadata-only preflight for GGUF split sets (local or Hugging Face Hub).
+
+A north-star checkpoint like ``unsloth/GLM-5.2-GGUF`` UD-IQ1_{S,M} is a
+six-file GGUF split set weighing 200+ GiB. Before anyone downloads a single
+tensor payload, this module answers the only questions that matter for an
+export decision:
+
+* Exactly which files make up the split set, their byte sizes, and their LFS
+  sha256 checksums.
+* The GGUF ``general.architecture`` and the canonical Mobius model type it
+  bridges to (e.g. ``glm-dsa`` → ``glm_moe_dsa``).
+* Whether the export is *blocked* — most importantly the sparse-MoE honesty
+  blocker: routed IQ/MXFP4 experts have no sparse ``BlockQuantizedMoE`` fusion,
+  so a build would be dense-all-expert.
+
+Everything here is **metadata only**. For a Hub reference it uses
+``HfApi.model_info(expand=["gguf"])`` for the architecture/expert counts and
+``HfApi.get_paths_info`` for per-file sizes + LFS sha256 — no ``hf_hub_download``
+of tensor data. For a local path it reads the (memory-mapped) GGUF headers via
+:class:`GgufShardSet`, never the tensor bodies.
+
+The report is JSON-serialisable and the computation is idempotent, so a caller
+can persist it and resume without re-hitting the network (see ``cache_path``).
+
+This is deliberately a small library of GGUF-specific functions, not a
+``_weight_loading.py`` and not a duplicate of the generic export-preflight CLI:
+it exposes :func:`preflight_gguf` / :func:`preflight_local_gguf` /
+:func:`preflight_hf_gguf` for reuse by any front-end.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "GgufFileMeta",
+    "GgufPreflightReport",
+    "preflight_gguf",
+    "preflight_local_gguf",
+    "preflight_hf_gguf",
+]
+
+import json
+import logging
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from mobius.integrations.gguf._config_mapping import (
+    resolve_model_type,
+)
+from mobius.integrations.gguf._shard_set import (
+    GgufShardManifest,
+    open_gguf_model,
+    parse_shard_filename,
+)
+
+logger = logging.getLogger(__name__)
+
+# Canonical model types whose routed-expert stack is a Mixture-of-Experts.
+# Used only to decide whether the sparse-MoE fusion blocker is relevant; the
+# authoritative signal is the GGUF ``<arch>.expert_count`` metadata when present.
+_MOE_MODEL_TYPES = frozenset(
+    {
+        "glm_moe_dsa",
+        "deepseek4",
+        "deepseek3",
+        "deepseek2",
+        "qwen3moe",
+        "qwen2moe",
+        "nemotron_h_moe",
+    }
+)
+
+# GGUF quantization tokens whose routed experts lower to native
+# ``pkg.nxrt::BlockQuantizedMatMul`` blocks (no sparse top-k fusion exists yet).
+# Only int4 ``MatMulNBits`` experts fuse into ``com.microsoft::QMoE``.
+_NATIVE_BLOCK_QUANT_RE = re.compile(
+    r"(IQ1_[SM]|IQ2_(XXS|XS|S)|IQ3_(XXS|S)|IQ4_(NL|XS)|MXFP4|TQ1_0|TQ2_0)",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class GgufFileMeta:
+    """One shard file's metadata-only descriptor (no tensor payload read)."""
+
+    filename: str
+    size_bytes: int
+    sha256: str | None
+    shard_index: int | None
+    shard_count: int | None
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class GgufPreflightReport:
+    """Metadata-only assessment of a GGUF split set.
+
+    Attributes:
+        source: The requested reference (local path or ``owner/repo[:file]``).
+        location: ``"local"`` or ``"hf"``.
+        is_sharded: True when more than one shard makes up the set.
+        architecture: GGUF ``general.architecture`` string (``None`` if the
+            architecture metadata could not be read without a download).
+        resolved_model_type: Canonical Mobius registry key the architecture
+            bridges to.
+        quantization: Detected quantization label (e.g. ``"IQ1_S"``) when it can
+            be read from metadata or the filename.
+        split_count: Declared number of shards.
+        total_files: Number of shard files found/enumerated.
+        total_bytes: Sum of shard byte sizes.
+        total_tensors: Total tensor count across the set (``None`` when only
+            remote metadata is available and it does not expose the count).
+        total_params: Total parameter count when the Hub exposes it (``None``
+            for a local-only metadata read).
+        num_experts: Routed-expert count when known (MoE detection signal).
+        sparse_moe_fusion_supported: False when routed experts would lower to
+            native block ``BlockQuantizedMatMul`` nodes with no sparse fusion.
+        files: Per-file metadata (sizes + checksums).
+        blockers: Hard export blockers (each is a human-readable reason).
+        warnings: Non-fatal advisories.
+    """
+
+    source: str
+    location: str
+    is_sharded: bool
+    architecture: str | None
+    resolved_model_type: str | None
+    quantization: str | None
+    split_count: int | None
+    total_files: int
+    total_bytes: int
+    total_tensors: int | None
+    total_params: int | None
+    num_experts: int | None
+    sparse_moe_fusion_supported: bool
+    files: list[GgufFileMeta] = field(default_factory=list)
+    blockers: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def exportable(self) -> bool:
+        """True when no hard blocker was recorded."""
+        return not self.blockers
+
+    def as_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["exportable"] = self.exportable
+        return data
+
+    def to_json(self, *, indent: int = 2) -> str:
+        return json.dumps(self.as_dict(), indent=indent, sort_keys=True)
+
+    def render(self) -> str:
+        """Human-readable multi-line summary (no tensor payloads touched)."""
+        lines: list[str] = []
+        lines.append(f"GGUF preflight: {self.source}  [{self.location}]")
+        arch = self.architecture or "?"
+        model_type = self.resolved_model_type or "?"
+        lines.append(f"  architecture : {arch}  ->  {model_type}")
+        if self.quantization:
+            lines.append(f"  quantization : {self.quantization}")
+        shard_word = "shards" if self.is_sharded else "file"
+        lines.append(
+            f"  split        : {self.total_files} {shard_word}"
+            + (f" (declared split.count={self.split_count})" if self.split_count else "")
+        )
+        lines.append(
+            f"  total bytes  : {self.total_bytes:,} ({_gib(self.total_bytes):.3f} GiB)"
+        )
+        if self.total_tensors is not None:
+            lines.append(f"  total tensors: {self.total_tensors:,}")
+        if self.total_params is not None:
+            lines.append(
+                f"  parameters   : {self.total_params:,} ({self.total_params / 1e9:.1f} B)"
+            )
+        if self.num_experts:
+            lines.append(f"  moe experts  : {self.num_experts}")
+        lines.append(
+            "  sparse MoE   : "
+            + ("supported" if self.sparse_moe_fusion_supported else "NOT supported")
+        )
+        lines.append("  files:")
+        for f in self.files:
+            sha = (f.sha256[:12] + "…") if f.sha256 else "(no sha256)"
+            lines.append(f"    - {f.filename}  {f.size_bytes:,} B  sha256:{sha}")
+        if self.blockers:
+            lines.append("  BLOCKERS:")
+            for b in self.blockers:
+                lines.append(f"    ✗ {b}")
+        else:
+            lines.append("  BLOCKERS: none")
+        if self.warnings:
+            lines.append("  warnings:")
+            for w in self.warnings:
+                lines.append(f"    ! {w}")
+        return "\n".join(lines)
+
+
+def _gib(num_bytes: int) -> float:
+    return num_bytes / (1024**3)
+
+
+def _detect_quantization(*candidates: str | None) -> str | None:
+    """Best-effort quantization label from a filename/name (reporting only).
+
+    This is used solely for the human-readable report and the fusion blocker
+    advisory — never for architecture resolution, which is driven exclusively by
+    ``general.architecture`` metadata.
+    """
+    for text in candidates:
+        if not text:
+            continue
+        match = _NATIVE_BLOCK_QUANT_RE.search(text)
+        if match is not None:
+            return match.group(0).upper()
+    return None
+
+
+def _is_moe(model_type: str | None, num_experts: int | None) -> bool:
+    if num_experts and num_experts > 0:
+        return True
+    return model_type in _MOE_MODEL_TYPES
+
+
+def _assess_sparse_moe(
+    *,
+    model_type: str | None,
+    num_experts: int | None,
+    quantization: str | None,
+    source: str,
+) -> tuple[bool, list[str]]:
+    """Return ``(fusion_supported, blockers)`` for the routed-expert stack.
+
+    Mobius has exactly one sparse MoE path: int4 ``MatMulNBits`` experts fused
+    into ``com.microsoft::QMoE``. GGUF always tags ``quant_method="gguf"``, so
+    routed experts follow the dense per-expert loop; when their block format is
+    a native IQ/MXFP4 layout they lower to ``pkg.nxrt::BlockQuantizedMatMul``
+    with no fusion, i.e. dense-all-expert compute. Report that as a blocker.
+    """
+    if not _is_moe(model_type, num_experts):
+        return True, []
+
+    native_block = _NATIVE_BLOCK_QUANT_RE.search(quantization or "") is not None
+    if not native_block:
+        # int4-class MoE experts can be repacked to MatMulNBits and fused.
+        return True, []
+
+    blocker = (
+        f"sparse-MoE fusion blocker: {source} is a MoE architecture "
+        f"('{model_type}') whose routed experts use '{quantization}' native "
+        "blocks. No sparse top-k BlockQuantizedMoE fusion exists for these "
+        "block formats — only int4 MatMulNBits experts fuse into "
+        "com.microsoft::QMoE. A default export would build a dense-all-expert "
+        "graph (every expert evaluated for every token) with no performance "
+        "guarantee, so build_from_gguf fails closed. Next slice: sparse IQ-block "
+        "BlockQuantizedMoE fusion (top-k gather over native-block expert weights)."
+    )
+    return False, [blocker]
+
+
+def preflight_local_gguf(
+    path: str | Path,
+    *,
+    verify_checksums: bool = False,
+) -> GgufPreflightReport:
+    """Metadata-only preflight of a local GGUF file or split set.
+
+    Reads only the GGUF headers (memory-mapped) to enumerate shards, sizes,
+    tensor counts, architecture, and the sparse-MoE blocker. Tensor payloads are
+    never read. When *verify_checksums* is set, per-shard sha256 is computed
+    (this reads file bytes but not through the tensor API).
+    """
+    path = Path(path)
+    model = open_gguf_model(path, verify_checksums=verify_checksums)
+
+    manifest: GgufShardManifest | None = getattr(model, "manifest", None)
+    architecture = _safe_arch(model)
+    model_type = resolve_model_type(architecture) if architecture else None
+    num_experts = _read_expert_count(model, architecture)
+    quantization = _detect_quantization(
+        _read_str_metadata(model, "general.file_type_name"),
+        path.name,
+        _read_str_metadata(model, "general.name"),
+    )
+
+    files: list[GgufFileMeta] = []
+    if manifest is not None:
+        is_sharded = True
+        split_count = manifest.split_count
+        total_tensors = manifest.total_tensors
+        total_bytes = manifest.total_bytes
+        for shard in manifest.shards:
+            files.append(
+                GgufFileMeta(
+                    filename=shard.path.name,
+                    size_bytes=shard.size_bytes,
+                    sha256=shard.sha256,
+                    shard_index=shard.split_no,
+                    shard_count=shard.split_count,
+                )
+            )
+    else:
+        is_sharded = False
+        split_count = 1
+        total_tensors = model.num_tensors
+        size_bytes = path.stat().st_size
+        total_bytes = size_bytes
+        sha = None
+        if verify_checksums:
+            from mobius.integrations.gguf._shard_set import _sha256_of
+
+            sha = _sha256_of(path)
+        files.append(
+            GgufFileMeta(
+                filename=path.name,
+                size_bytes=size_bytes,
+                sha256=sha,
+                shard_index=0,
+                shard_count=1,
+            )
+        )
+
+    fusion_ok, blockers = _assess_sparse_moe(
+        model_type=model_type,
+        num_experts=num_experts,
+        quantization=quantization,
+        source=str(path),
+    )
+    warnings: list[str] = []
+    if architecture is None:
+        warnings.append("architecture metadata missing from primary shard")
+
+    return GgufPreflightReport(
+        source=str(path),
+        location="local",
+        is_sharded=is_sharded,
+        architecture=architecture,
+        resolved_model_type=model_type,
+        quantization=quantization,
+        split_count=split_count,
+        total_files=len(files),
+        total_bytes=total_bytes,
+        total_tensors=total_tensors,
+        total_params=None,
+        num_experts=num_experts,
+        sparse_moe_fusion_supported=fusion_ok,
+        files=files,
+        blockers=blockers,
+        warnings=warnings,
+    )
+
+
+def preflight_hf_gguf(
+    repo_id: str,
+    *,
+    filename: str | None = None,
+    revision: str | None = None,
+    token: str | bool | None = None,
+) -> GgufPreflightReport:
+    """Metadata-only preflight of a GGUF split set on the Hugging Face Hub.
+
+    Uses ``HfApi.get_paths_info`` for per-file sizes + LFS sha256 and
+    ``HfApi.model_info(expand=["gguf"])`` for the architecture / expert count.
+    No tensor payload is downloaded. When *filename* names one shard of a split
+    set, its sibling shards are enumerated from the repo file listing (the
+    ``-000i-of-000N`` pattern is validated, never blindly concatenated).
+    """
+    from huggingface_hub import HfApi
+
+    api = HfApi(token=token if isinstance(token, str) else None)
+    ref, sep, inline_file = repo_id.partition(":")
+    if sep:
+        repo_id = ref
+        filename = filename or inline_file
+
+    all_files = api.list_repo_files(repo_id, revision=revision, token=token)
+    gguf_files = [f for f in all_files if f.lower().endswith(".gguf")]
+    if not gguf_files:
+        raise FileNotFoundError(f"No .gguf files found in {repo_id!r}.")
+
+    shard_files = _select_shard_files(gguf_files, filename)
+    is_sharded = len(shard_files) > 1
+
+    paths_info = api.get_paths_info(
+        repo_id, shard_files, revision=revision, token=token, expand=True
+    )
+    info_by_path = {getattr(p, "path", None): p for p in paths_info}
+
+    files: list[GgufFileMeta] = []
+    total_bytes = 0
+    for name in shard_files:
+        info = info_by_path.get(name)
+        size = int(getattr(info, "size", 0) or 0)
+        lfs = getattr(info, "lfs", None)
+        sha = getattr(lfs, "sha256", None) if lfs is not None else None
+        parsed = parse_shard_filename(name.rsplit("/", 1)[-1])
+        idx = parsed[1] if parsed else None
+        cnt = parsed[2] if parsed else None
+        total_bytes += size
+        files.append(
+            GgufFileMeta(
+                filename=name,
+                size_bytes=size,
+                sha256=sha,
+                shard_index=idx,
+                shard_count=cnt,
+            )
+        )
+
+    architecture, num_experts, total_tensors, total_params = _hf_gguf_metadata(
+        api, repo_id, revision, token
+    )
+    model_type = resolve_model_type(architecture) if architecture else None
+    quantization = _detect_quantization(filename, *shard_files)
+
+    fusion_ok, blockers = _assess_sparse_moe(
+        model_type=model_type,
+        num_experts=num_experts,
+        quantization=quantization,
+        source=f"{repo_id}{('/' + filename) if filename else ''}",
+    )
+
+    warnings: list[str] = []
+    if architecture is None:
+        warnings.append(
+            "architecture not exposed by Hub metadata; resolve after a "
+            "metadata-only header fetch of the primary shard"
+        )
+    split_count = files[0].shard_count if is_sharded and files else (1 if files else None)
+
+    return GgufPreflightReport(
+        source=repo_id if not filename else f"{repo_id}:{filename}",
+        location="hf",
+        is_sharded=is_sharded,
+        architecture=architecture,
+        resolved_model_type=model_type,
+        quantization=quantization,
+        split_count=split_count,
+        total_files=len(files),
+        total_bytes=total_bytes,
+        total_tensors=total_tensors,
+        total_params=total_params,
+        num_experts=num_experts,
+        sparse_moe_fusion_supported=fusion_ok,
+        files=files,
+        blockers=blockers,
+        warnings=warnings,
+    )
+
+
+def preflight_gguf(
+    source: str | Path,
+    *,
+    filename: str | None = None,
+    revision: str | None = None,
+    token: str | bool | None = None,
+    verify_checksums: bool = False,
+    cache_path: str | Path | None = None,
+) -> GgufPreflightReport:
+    """Preflight a GGUF split set from a local path or a Hub reference.
+
+    ``source`` is treated as a local path when it exists on disk (or its
+    directory does); otherwise it is treated as an ``owner/repo[:file]`` Hub
+    reference. The whole operation is metadata-only.
+
+    When *cache_path* is given the report is read from / written to that JSON
+    file, making repeated preflights idempotent and resumable without re-hitting
+    the network.
+    """
+    if cache_path is not None:
+        cache_path = Path(cache_path)
+        if cache_path.exists():
+            logger.info("Loading cached GGUF preflight from %s", cache_path)
+            return _report_from_dict(json.loads(cache_path.read_text()))
+
+    report = _dispatch_preflight(
+        source,
+        filename=filename,
+        revision=revision,
+        token=token,
+        verify_checksums=verify_checksums,
+    )
+
+    if cache_path is not None:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(report.to_json())
+        logger.info("Wrote GGUF preflight cache to %s", cache_path)
+    return report
+
+
+def _dispatch_preflight(
+    source: str | Path,
+    *,
+    filename: str | None,
+    revision: str | None,
+    token: str | bool | None,
+    verify_checksums: bool,
+) -> GgufPreflightReport:
+    source_path = Path(source)
+    looks_local = source_path.exists() or (
+        source_path.parent.exists() and source_path.parent != source_path
+    )
+    if looks_local:
+        return preflight_local_gguf(source, verify_checksums=verify_checksums)
+    return preflight_hf_gguf(str(source), filename=filename, revision=revision, token=token)
+
+
+def _select_shard_files(gguf_files: list[str], filename: str | None) -> list[str]:
+    """Return the shard file list for *filename* (or the whole repo's set)."""
+    if filename is not None:
+        base = filename.rsplit("/", 1)[-1]
+        parsed = parse_shard_filename(base)
+        if parsed is None:
+            # Single explicit file (not a shard); return just it.
+            match = [f for f in gguf_files if f.rsplit("/", 1)[-1] == base]
+            return match or [filename]
+        prefix, _, count = parsed
+        siblings = _shards_for_prefix(gguf_files, prefix)
+        if len(siblings) != count:
+            logger.warning(
+                "Declared split.count=%d but found %d matching shard files for "
+                "prefix %r; reporting the files that are present.",
+                count,
+                len(siblings),
+                prefix,
+            )
+        return siblings
+
+    # No filename: if the repo holds exactly one split set, return it; if it
+    # holds a single plain file, return that; otherwise report all gguf files.
+    shard_groups: dict[str, list[str]] = {}
+    plain: list[str] = []
+    for f in gguf_files:
+        parsed = parse_shard_filename(f.rsplit("/", 1)[-1])
+        if parsed is None:
+            plain.append(f)
+        else:
+            shard_groups.setdefault(parsed[0], []).append(f)
+    if len(shard_groups) == 1 and not plain:
+        return sorted(next(iter(shard_groups.values())))
+    if not shard_groups and len(plain) == 1:
+        return plain
+    return sorted(gguf_files)
+
+
+def _shards_for_prefix(gguf_files: list[str], prefix: str) -> list[str]:
+    out: list[str] = []
+    for f in gguf_files:
+        base = f.rsplit("/", 1)[-1]
+        parsed = parse_shard_filename(base)
+        if parsed is not None and parsed[0] == prefix:
+            out.append(f)
+    return sorted(out)
+
+
+def _hf_gguf_metadata(
+    api: Any, repo_id: str, revision: str | None, token: str | bool | None
+) -> tuple[str | None, int | None, int | None, int | None]:
+    """Return ``(architecture, num_experts, total_tensors, total_params)``.
+
+    Uses ``model_info(expand=["gguf"])`` which surfaces the parsed GGUF header
+    fields without downloading tensor bytes. The Hub's ``gguf.total`` is the
+    *parameter* count (not the tensor count); any field the Hub does not expose
+    comes back ``None`` (the caller records a warning).
+    """
+    architecture: str | None = None
+    num_experts: int | None = None
+    total_tensors: int | None = None
+    total_params: int | None = None
+    try:
+        info = api.model_info(repo_id, revision=revision, token=token, expand=["gguf"])
+    except Exception as error:
+        logger.info("model_info(expand=gguf) unavailable for %s: %s", repo_id, error)
+        return architecture, num_experts, total_tensors, total_params
+
+    gguf_meta = getattr(info, "gguf", None)
+    if isinstance(gguf_meta, dict):
+        architecture = gguf_meta.get("architecture") or gguf_meta.get("general.architecture")
+        total_params = gguf_meta.get("total")
+        total_tensors = gguf_meta.get("total_tensors")
+        num_experts = (
+            gguf_meta.get("expert_count")
+            or gguf_meta.get("num_local_experts")
+            or gguf_meta.get("n_expert")
+        )
+    elif gguf_meta is not None:
+        architecture = getattr(gguf_meta, "architecture", None)
+        total_params = getattr(gguf_meta, "total", None)
+        total_tensors = getattr(gguf_meta, "total_tensors", None)
+        num_experts = getattr(gguf_meta, "expert_count", None)
+    return (
+        architecture,
+        int(num_experts) if num_experts else None,
+        int(total_tensors) if total_tensors else None,
+        int(total_params) if total_params else None,
+    )
+
+
+def _safe_arch(model: Any) -> str | None:
+    try:
+        arch = model.architecture
+    except Exception:
+        return None
+    return arch or None
+
+
+def _read_str_metadata(model: Any, key: str) -> str | None:
+    try:
+        value = model.get_metadata(key)
+    except Exception:
+        return None
+    if value is None:
+        return None
+    return str(value)
+
+
+def _read_expert_count(model: Any, architecture: str | None) -> int | None:
+    if not architecture:
+        return None
+    key = f"{architecture}.expert_count"
+    try:
+        value = model.get_metadata(key)
+    except Exception:
+        return None
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _report_from_dict(data: dict[str, Any]) -> GgufPreflightReport:
+    files = [GgufFileMeta(**f) for f in data.get("files", [])]
+    known = {
+        "source",
+        "location",
+        "is_sharded",
+        "architecture",
+        "resolved_model_type",
+        "quantization",
+        "split_count",
+        "total_files",
+        "total_bytes",
+        "total_tensors",
+        "total_params",
+        "num_experts",
+        "sparse_moe_fusion_supported",
+        "blockers",
+        "warnings",
+    }
+    kwargs = {k: data[k] for k in known if k in data}
+    return GgufPreflightReport(files=files, **kwargs)

--- a/src/mobius/integrations/gguf/_preflight_test.py
+++ b/src/mobius/integrations/gguf/_preflight_test.py
@@ -1,0 +1,286 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for the metadata-only GGUF preflight (:mod:`._preflight`).
+
+All assertions here use local synthetic split sets — no network, no tensor
+downloads. The Hub path (:func:`preflight_hf_gguf`) is exercised via the shared
+helpers with a fake ``HfApi`` so the metadata-only contract is enforced without
+touching the network.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from mobius.integrations.gguf._preflight import (
+    _assess_sparse_moe,
+    _detect_quantization,
+    _select_shard_files,
+    preflight_gguf,
+    preflight_local_gguf,
+)
+
+
+def _write_sharded_gguf(
+    directory: Path,
+    *,
+    architecture: str = "llama",
+    stem: str = "tiny",
+    split_max_tensors: int = 3,
+    num_experts: int | None = None,
+) -> list[Path]:
+    from gguf import GGUFWriter
+
+    directory.mkdir(parents=True, exist_ok=True)
+    writer = GGUFWriter(
+        str(directory / stem), architecture, split_max_tensors=split_max_tensors
+    )
+    writer.add_context_length(128)
+    writer.add_embedding_length(16)
+    writer.add_feed_forward_length(32)
+    writer.add_block_count(3)
+    writer.add_head_count(4)
+    writer.add_head_count_kv(2)
+    writer.add_vocab_size(32)
+    if num_experts is not None:
+        writer.add_expert_count(num_experts)
+
+    rng = np.random.default_rng(0)
+    names = ["token_embd.weight"]
+    for i in range(3):
+        names.append(f"blk.{i}.attn_q.weight")
+        names.append(f"blk.{i}.ffn_up.weight")
+    names.append("output.weight")
+    for name in names:
+        writer.add_tensor(name, rng.standard_normal((8, 16)).astype(np.float32))
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_tensors_to_file()
+    writer.close()
+    return sorted(directory.glob(f"{stem}-*.gguf"))
+
+
+# --------------------------------------------------------------------------- #
+# Local preflight (metadata only)
+# --------------------------------------------------------------------------- #
+
+
+def test_local_preflight_reports_files_and_bytes(tmp_path):
+    shards = _write_sharded_gguf(tmp_path, split_max_tensors=3)
+    report = preflight_local_gguf(shards[0])
+    assert report.location == "local"
+    assert report.is_sharded
+    assert report.split_count == len(shards)
+    assert report.total_files == len(shards)
+    assert report.total_bytes == sum(s.stat().st_size for s in shards)
+    assert {f.filename for f in report.files} == {s.name for s in shards}
+    # No quant/MoE => nothing blocks a (hypothetical) build.
+    assert report.exportable
+    assert report.sparse_moe_fusion_supported
+
+
+def test_local_preflight_checksums_optional(tmp_path):
+    shards = _write_sharded_gguf(tmp_path, split_max_tensors=3)
+    no_sums = preflight_local_gguf(shards[0])
+    assert all(f.sha256 is None for f in no_sums.files)
+    with_sums = preflight_local_gguf(shards[0], verify_checksums=True)
+    assert all(f.sha256 and len(f.sha256) == 64 for f in with_sums.files)
+
+
+def test_local_preflight_single_file(tmp_path):
+    from gguf import GGUFWriter
+
+    path = tmp_path / "plain.gguf"
+    writer = GGUFWriter(str(path), "llama")
+    writer.add_context_length(128)
+    writer.add_embedding_length(16)
+    writer.add_block_count(1)
+    writer.add_head_count(4)
+    writer.add_head_count_kv(2)
+    writer.add_vocab_size(32)
+    writer.add_tensor("token_embd.weight", np.zeros((8, 16), np.float32))
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_tensors_to_file()
+    writer.close()
+
+    report = preflight_local_gguf(path)
+    assert not report.is_sharded
+    assert report.total_files == 1
+    assert report.split_count == 1
+
+
+def test_report_json_roundtrip_is_resumable(tmp_path):
+    shards = _write_sharded_gguf(tmp_path, split_max_tensors=3)
+    cache = tmp_path / "pf.json"
+    first = preflight_gguf(shards[0], cache_path=cache)
+    assert cache.exists()
+    # Second call loads from cache (idempotent, no re-read needed).
+    second = preflight_gguf(shards[0], cache_path=cache)
+    assert first.as_dict() == second.as_dict()
+    # The cache is valid JSON that deserialises back into a report.
+    data = json.loads(cache.read_text())
+    assert data["total_bytes"] == first.total_bytes
+
+
+# --------------------------------------------------------------------------- #
+# Sparse-MoE fusion assessment (the honesty blocker, metadata-level)
+# --------------------------------------------------------------------------- #
+
+
+def test_assess_sparse_moe_blocks_iq1_moe():
+    ok, blockers = _assess_sparse_moe(
+        model_type="glm_moe_dsa",
+        num_experts=160,
+        quantization="IQ1_S",
+        source="unsloth/GLM-5.2-GGUF",
+    )
+    assert ok is False
+    assert len(blockers) == 1
+    assert "sparse" in blockers[0].lower()
+    assert "dense-all-expert" in blockers[0]
+
+
+def test_assess_sparse_moe_allows_non_moe():
+    ok, blockers = _assess_sparse_moe(
+        model_type="llama",
+        num_experts=None,
+        quantization="IQ1_S",
+        source="x",
+    )
+    assert ok is True
+    assert blockers == []
+
+
+def test_assess_sparse_moe_allows_int4_moe():
+    # int4 experts repack to MatMulNBits and fuse into QMoE.
+    ok, blockers = _assess_sparse_moe(
+        model_type="glm_moe_dsa",
+        num_experts=160,
+        quantization=None,  # no native-block quant detected
+        source="x",
+    )
+    assert ok is True
+    assert blockers == []
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("GLM-5.2-UD-IQ1_S-00001-of-00006.gguf", "IQ1_S"),
+        ("model-UD-IQ1_M.gguf", "IQ1_M"),
+        ("q4_k_m.gguf", None),
+        ("model-IQ2_XXS.gguf", "IQ2_XXS"),
+        ("model-MXFP4.gguf", "MXFP4"),
+    ],
+)
+def test_detect_quantization(text, expected):
+    assert _detect_quantization(text) == expected
+
+
+# --------------------------------------------------------------------------- #
+# Shard file selection (remote listing logic, no network)
+# --------------------------------------------------------------------------- #
+
+
+def test_select_shard_files_expands_split_set():
+    files = [
+        "UD-IQ1_S/GLM-5.2-UD-IQ1_S-00001-of-00006.gguf",
+        "UD-IQ1_S/GLM-5.2-UD-IQ1_S-00002-of-00006.gguf",
+        "UD-IQ1_S/GLM-5.2-UD-IQ1_S-00003-of-00006.gguf",
+        "UD-IQ1_S/GLM-5.2-UD-IQ1_S-00004-of-00006.gguf",
+        "UD-IQ1_S/GLM-5.2-UD-IQ1_S-00005-of-00006.gguf",
+        "UD-IQ1_S/GLM-5.2-UD-IQ1_S-00006-of-00006.gguf",
+        "UD-IQ1_M/GLM-5.2-UD-IQ1_M-00001-of-00006.gguf",
+    ]
+    selected = _select_shard_files(files, "UD-IQ1_S/GLM-5.2-UD-IQ1_S-00001-of-00006.gguf")
+    assert len(selected) == 6
+    assert all("UD-IQ1_S" in f for f in selected)
+
+
+def test_select_shard_files_single_plain_file():
+    files = ["model-Q4_K_M.gguf"]
+    selected = _select_shard_files(files, None)
+    assert selected == ["model-Q4_K_M.gguf"]
+
+
+# --------------------------------------------------------------------------- #
+# Hub preflight with a fake API (metadata-only contract)
+# --------------------------------------------------------------------------- #
+
+
+class _FakeLfs:
+    def __init__(self, sha256):
+        self.sha256 = sha256
+
+
+class _FakeRepoFile:
+    def __init__(self, path, size, sha):
+        self.path = path
+        self.size = size
+        self.lfs = _FakeLfs(sha)
+
+
+class _FakeModelInfo:
+    def __init__(self, gguf):
+        self.gguf = gguf
+
+
+class _FakeHfApi:
+    """A stand-in that returns metadata and asserts no download is attempted."""
+
+    def __init__(self, files, sizes, arch, experts=None):
+        self._files = files
+        self._sizes = sizes
+        self._arch = arch
+        self._experts = experts
+        self.downloaded = []
+
+    def list_repo_files(self, repo_id, revision=None, token=None):
+        return self._files
+
+    def get_paths_info(self, repo_id, paths, revision=None, token=None, expand=False):
+        return [_FakeRepoFile(p, self._sizes[p], f"{i:064x}") for i, p in enumerate(paths)]
+
+    def model_info(self, repo_id, revision=None, token=None, expand=None):
+        gguf = {"architecture": self._arch, "total": 753_000_000_000}
+        if self._experts is not None:
+            gguf["expert_count"] = self._experts
+        return _FakeModelInfo(gguf)
+
+    def hf_hub_download(self, *a, **k):  # pragma: no cover - must never be called
+        raise AssertionError("preflight must not download tensor payloads")
+
+
+def test_hf_preflight_metadata_only(monkeypatch):
+    from mobius.integrations.gguf import _preflight
+
+    files = [f"UD-IQ1_S/GLM-5.2-UD-IQ1_S-{i:05d}-of-00006.gguf" for i in range(1, 7)]
+    sizes = dict.fromkeys(files, 49000000000)
+    sizes[files[0]] = 9_000_000
+    fake = _FakeHfApi(files, sizes, arch="glm-dsa", experts=160)
+
+    monkeypatch.setattr(_preflight, "HfApi", lambda *a, **k: fake, raising=False)
+    # HfApi is imported inside the function; patch the huggingface_hub symbol.
+    import huggingface_hub
+
+    monkeypatch.setattr(huggingface_hub, "HfApi", lambda *a, **k: fake)
+
+    report = _preflight.preflight_hf_gguf("unsloth/GLM-5.2-GGUF", filename=files[0])
+    assert report.location == "hf"
+    assert report.architecture == "glm-dsa"
+    assert report.resolved_model_type == "glm_moe_dsa"
+    assert report.quantization == "IQ1_S"
+    assert report.total_files == 6
+    assert report.total_bytes == sum(sizes.values())
+    assert all(f.sha256 for f in report.files)
+    # The IQ1 MoE honesty blocker must be present.
+    assert not report.exportable
+    assert any("sparse-MoE" in b for b in report.blockers)
+    # And nothing was downloaded.
+    assert fake.downloaded == []

--- a/src/mobius/integrations/gguf/_reader.py
+++ b/src/mobius/integrations/gguf/_reader.py
@@ -215,6 +215,21 @@ class GGUFModel:
         """List of all tensor names in the GGUF file."""
         return list(self._tensor_index.keys())
 
+    @property
+    def num_tensors(self) -> int:
+        """Number of tensors in the GGUF file."""
+        return len(self._tensor_index)
+
+    def reader_tensors(self):
+        """Underlying ``gguf.ReaderTensor`` records (``name``/``shape``/``tensor_type``).
+
+        Exposed so callers that previously reached into the private
+        ``_reader.tensors`` list keep working across a single file *and* a
+        multi-shard :class:`~mobius.integrations.gguf._shard_set.GgufShardSet`,
+        which yields the records of every shard in order.
+        """
+        return list(self._reader.tensors)
+
     def _dequantize_tensor(self, tensor) -> np.ndarray:
         """Dequantize a single :class:`ReaderTensor` to a numpy array.
 

--- a/src/mobius/integrations/gguf/_shard_set.py
+++ b/src/mobius/integrations/gguf/_shard_set.py
@@ -77,6 +77,17 @@ _SPLIT_TENSORS_COUNT = "split.tensors.count"
 # them. A divergence means the shards came from different exports (mixed
 # revision) or different quantization presets (mixed quant), which would build
 # a corrupt model if silently stitched together.
+#
+# NOTE ON THE RESIDUAL MIXED-QUANT GAP: in real llama.cpp/Unsloth split sets
+# these keys are carried ONLY by the primary shard (``split.no == 0``);
+# continuation shards store just ``split.*`` plus tensor data. Identity
+# validation therefore cannot, on metadata alone, distinguish a continuation
+# shard of ``…-IQ1_S`` from the same-index continuation shard of ``…-IQ1_M``
+# of the same model (identical tensor names, identical ``split.tensors.count``,
+# per-shard-consistent offsets). The byte-exact guard for that case is the
+# download manifest: pass ``expected_sha256`` / ``expected_sizes`` (both are
+# produced by :mod:`._preflight`), which are verified per shard in
+# :func:`_build_shard_infos` and fail closed on any mismatch.
 _IDENTITY_KEYS = (
     "general.architecture",
     "general.name",
@@ -280,7 +291,11 @@ class GgufShardSet:
             set is expensive; the preflight path opts in.
         expected_sha256: Optional ``{filename: sha256}`` from a download manifest
             (e.g. Hugging Face LFS metadata). When present each listed shard is
-            verified and a mismatch fails closed.
+            verified and a mismatch fails closed. This is the ONLY byte-exact
+            guard against a same-model mixed-quant continuation-shard swap
+            (``IQ1_S`` primary + ``IQ1_M`` continuation), whose continuation
+            shards carry no identity metadata to compare — supply it (from
+            :mod:`._preflight`) whenever manifest data is available.
         expected_sizes: Optional ``{filename: size_bytes}`` verified the same way.
     """
 
@@ -573,7 +588,15 @@ def _validate_shard_set(infos: list[ShardInfo], shards: list[GGUFModel]) -> None
 
 
 def _validate_identity(infos: list[ShardInfo], shards: list[GGUFModel]) -> None:
-    """Every shard that declares an identity key must agree with the others."""
+    """Every shard that declares an identity key must agree with the others.
+
+    This catches the common mixed-revision / mixed-quant cases (a shard whose
+    primary declares a different architecture, name, quantization version, or
+    tokenizer/template). It CANNOT catch a same-model ``IQ1_S`` vs ``IQ1_M``
+    continuation-shard swap, because continuation shards carry no identity
+    keys; supply a manifest (``expected_sha256`` / ``expected_sizes``) for that
+    case. See the note on :data:`_IDENTITY_KEYS`.
+    """
     for key in _IDENTITY_KEYS:
         seen: dict[Any, str] = {}
         for info, shard in zip(infos, shards):

--- a/src/mobius/integrations/gguf/_shard_set.py
+++ b/src/mobius/integrations/gguf/_shard_set.py
@@ -1,0 +1,640 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Direct multi-shard GGUF reading (``*-00001-of-000NN.gguf`` split sets).
+
+llama.cpp / Unsloth ship large GGUF checkpoints as a *split set*: N sibling
+files ``<name>-00001-of-000NN.gguf`` … ``<name>-000NN-of-000NN.gguf``. Every
+shard is itself a valid GGUF container, but the model's key-value metadata
+(architecture, hyper-parameters, tokenizer, chat template) lives only in the
+*primary* shard (``split.no == 0``); the remaining shards carry only the
+``split.*`` bookkeeping keys plus their slice of the tensor table.
+
+:class:`GgufShardSet` assembles these files into a single logical model that is
+a drop-in for :class:`~mobius.integrations.gguf._reader.GGUFModel`. It never
+concatenates the shards into a second on-disk GGUF: tensors are read on demand
+straight from the original shard that owns them (each shard is memory-mapped by
+``gguf.GGUFReader``), so memory stays bounded to one tensor/block chunk plus the
+metadata tables regardless of the total checkpoint size.
+
+Discovery is confined to the directory of the requested file — the split
+count is read from authoritative GGUF ``split.*`` metadata and cross-checked
+against the ``-000i-of-000N`` filenames, never blindly string-concatenated.
+Validation fails closed on missing, duplicate, mixed-revision, mixed-quant, or
+corrupt shards.
+
+Example::
+
+    from mobius.integrations.gguf._shard_set import open_gguf_model
+
+    model = open_gguf_model("GLM-5.2-UD-IQ1_S-00001-of-00006.gguf")
+    print(model.architecture)          # 'glm-dsa'
+    print(model.num_tensors)           # tensors across all six shards
+    w = model.get_tensor("blk.0.attn_q.weight")   # read from its owning shard
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "GgufShardError",
+    "GgufShardSet",
+    "ShardInfo",
+    "GgufShardManifest",
+    "discover_gguf_shards",
+    "parse_shard_filename",
+    "open_gguf_model",
+    "SHARD_FILENAME_RE",
+]
+
+import hashlib
+import logging
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from mobius.integrations.gguf._reader import GGUFModel
+
+logger = logging.getLogger(__name__)
+
+#: ``<name>-<index>-of-<count>.gguf`` where index/count are five-digit,
+#: one-based. Matches the llama.cpp ``SHARD_NAME_FORMAT`` and the reader's
+#: ``_GGUF_SHARD_FILENAME_RE`` in ``_builder.py``.
+SHARD_FILENAME_RE = re.compile(
+    r"^(?P<prefix>.+)-(?P<index>\d{5})-of-(?P<count>\d{5})\.gguf$",
+    re.IGNORECASE,
+)
+
+# GGUF split bookkeeping keys (llama.cpp ``Keys.Split``).
+_SPLIT_NO = "split.no"
+_SPLIT_COUNT = "split.count"
+_SPLIT_TENSORS_COUNT = "split.tensors.count"
+
+# Metadata keys whose value must be identical on every shard that declares
+# them. A divergence means the shards came from different exports (mixed
+# revision) or different quantization presets (mixed quant), which would build
+# a corrupt model if silently stitched together.
+_IDENTITY_KEYS = (
+    "general.architecture",
+    "general.name",
+    "general.quantization_version",
+    "general.file_type",
+    "tokenizer.ggml.model",
+    "tokenizer.chat_template",
+)
+
+
+class GgufShardError(ValueError):
+    """A GGUF split set failed structural validation (fail closed)."""
+
+
+def parse_shard_filename(name: str) -> tuple[str, int, int] | None:
+    """Parse ``<prefix>-<index>-of-<count>.gguf`` → ``(prefix, index, count)``.
+
+    ``index`` and ``count`` are the one-based integers from the filename.
+    Returns ``None`` when *name* is not a split-shard filename.
+    """
+    match = SHARD_FILENAME_RE.match(Path(name).name)
+    if match is None:
+        return None
+    return (
+        match.group("prefix"),
+        int(match.group("index")),
+        int(match.group("count")),
+    )
+
+
+def discover_gguf_shards(path: str | Path) -> list[Path]:
+    """Return the ordered shard files for *path*, or ``[path]`` if not sharded.
+
+    *path* may be one shard of a split set (any index is accepted) or a
+    directory containing exactly one split set. Sibling shards are found by
+    globbing the *same directory* for the ``<prefix>-*-of-<count>.gguf``
+    pattern — discovery never leaves that directory and never invents file
+    names by string concatenation.
+
+    Raises:
+        FileNotFoundError: *path* does not exist, or a directory holds no
+            ``.gguf`` files.
+        GgufShardError: a directory holds more than one distinct split set
+            (ambiguous), or the discovered files do not form a complete,
+            contiguous ``1..count`` set.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"GGUF path not found: {p}")
+
+    if p.is_dir():
+        return _discover_in_directory(p)
+
+    parsed = parse_shard_filename(p.name)
+    if parsed is None:
+        # A plain, non-sharded single-file GGUF.
+        return [p]
+    prefix, _index, count = parsed
+    return _collect_shard_group(p.parent, prefix, count)
+
+
+def _discover_in_directory(directory: Path) -> list[Path]:
+    groups: dict[tuple[str, int], list[Path]] = {}
+    single_files: list[Path] = []
+    for candidate in sorted(directory.glob("*.gguf")):
+        parsed = parse_shard_filename(candidate.name)
+        if parsed is None:
+            single_files.append(candidate)
+            continue
+        prefix, _index, count = parsed
+        groups.setdefault((prefix, count), []).append(candidate)
+
+    if not groups:
+        if len(single_files) == 1:
+            return [single_files[0]]
+        if not single_files:
+            raise FileNotFoundError(f"No *.gguf files found in {directory}")
+        raise GgufShardError(
+            f"{directory} contains multiple non-sharded .gguf files "
+            f"{[f.name for f in single_files]}; specify one explicitly."
+        )
+    if len(groups) > 1:
+        summaries = ", ".join(f"{prefix}-*-of-{count:05d}" for prefix, count in sorted(groups))
+        raise GgufShardError(
+            f"{directory} contains more than one GGUF split set ({summaries}); "
+            "point at a specific shard file to disambiguate."
+        )
+    (prefix, count), _files = next(iter(groups.items()))
+    return _collect_shard_group(directory, prefix, count)
+
+
+def _collect_shard_group(directory: Path, prefix: str, count: int) -> list[Path]:
+    """Collect and order the ``count`` shards named ``<prefix>-i-of-count``."""
+    if count < 1:
+        raise GgufShardError(f"Invalid shard count {count} in split filename")
+
+    by_index: dict[int, Path] = {}
+    for candidate in directory.glob(f"{glob_escape(prefix)}-*-of-{count:05d}.gguf"):
+        parsed = parse_shard_filename(candidate.name)
+        if parsed is None:
+            continue
+        cand_prefix, index, cand_count = parsed
+        if cand_prefix != prefix or cand_count != count:
+            continue
+        if index in by_index:
+            raise GgufShardError(
+                f"Duplicate shard index {index:05d} for split set {prefix!r}: "
+                f"{by_index[index].name} and {candidate.name}"
+            )
+        by_index[index] = candidate
+
+    missing = [i for i in range(1, count + 1) if i not in by_index]
+    if missing:
+        raise GgufShardError(
+            f"Incomplete GGUF split set {prefix!r}: declared {count} shards but "
+            f"{len(missing)} missing (indices {[f'{i:05d}' for i in missing]}). "
+            "Fetch the whole set before building."
+        )
+    extra = [i for i in by_index if i < 1 or i > count]
+    if extra:
+        raise GgufShardError(
+            f"Split set {prefix!r} has out-of-range shard indices {sorted(extra)} "
+            f"for declared count {count}."
+        )
+    return [by_index[i] for i in range(1, count + 1)]
+
+
+def glob_escape(value: str) -> str:
+    """Escape glob metacharacters in a literal filename prefix."""
+    # ``pathlib.Path.glob`` uses fnmatch semantics; escape the wildcard set so a
+    # prefix containing ``[`` / ``*`` / ``?`` is matched literally.
+    return re.sub(r"([\[\]\*\?])", r"[\1]", value)
+
+
+@dataclass(frozen=True)
+class ShardInfo:
+    """One shard's authoritative, metadata-only descriptor."""
+
+    path: Path
+    filename_index: int
+    filename_count: int
+    split_no: int | None
+    split_count: int | None
+    split_tensors_count: int | None
+    size_bytes: int
+    tensor_count: int
+    sha256: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "filename": self.path.name,
+            "filename_index": self.filename_index,
+            "filename_count": self.filename_count,
+            "split_no": self.split_no,
+            "split_count": self.split_count,
+            "split_tensors_count": self.split_tensors_count,
+            "size_bytes": self.size_bytes,
+            "tensor_count": self.tensor_count,
+            "sha256": self.sha256,
+        }
+
+
+@dataclass
+class GgufShardManifest:
+    """Validated, metadata-only summary of a GGUF split set.
+
+    Reusable by the preflight API: it captures everything needed to report the
+    exact files/bytes/checksums and the architecture without reading any tensor
+    payloads beyond the (small) GGUF headers.
+    """
+
+    architecture: str | None
+    split_count: int
+    total_tensors: int
+    total_bytes: int
+    shards: list[ShardInfo] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "architecture": self.architecture,
+            "split_count": self.split_count,
+            "total_tensors": self.total_tensors,
+            "total_bytes": self.total_bytes,
+            "shards": [s.as_dict() for s in self.shards],
+        }
+
+
+class GgufShardSet:
+    """A GGUF split set presented as a single logical :class:`GGUFModel`.
+
+    The public surface mirrors :class:`GGUFModel` exactly so every downstream
+    consumer (config mapping, tokenizer, repacker, builder) works unchanged.
+    Tensors are read on demand from the shard that owns them; nothing is
+    concatenated on disk or held fully in memory.
+
+    Args:
+        shard_paths: Ordered shard files (index ``1..count``). Usually produced
+            by :func:`discover_gguf_shards`.
+        verify_checksums: When ``True``, compute each shard's SHA-256 and store
+            it on the manifest. Off by default because hashing a multi-hundred-GB
+            set is expensive; the preflight path opts in.
+        expected_sha256: Optional ``{filename: sha256}`` from a download manifest
+            (e.g. Hugging Face LFS metadata). When present each listed shard is
+            verified and a mismatch fails closed.
+        expected_sizes: Optional ``{filename: size_bytes}`` verified the same way.
+    """
+
+    def __init__(
+        self,
+        shard_paths: list[str | Path],
+        *,
+        verify_checksums: bool = False,
+        expected_sha256: dict[str, str] | None = None,
+        expected_sizes: dict[str, int] | None = None,
+    ) -> None:
+        if not shard_paths:
+            raise GgufShardError("GgufShardSet requires at least one shard file")
+
+        self._paths = [Path(p) for p in shard_paths]
+        for path in self._paths:
+            if not path.is_file():
+                raise FileNotFoundError(f"GGUF shard not found: {path}")
+
+        # One GGUFModel per shard (each memory-maps its own file lazily).
+        shards = [GGUFModel(path) for path in self._paths]
+
+        self._infos = _build_shard_infos(
+            self._paths,
+            shards,
+            verify_checksums=verify_checksums or bool(expected_sha256),
+            expected_sha256=expected_sha256,
+            expected_sizes=expected_sizes,
+        )
+        _validate_shard_set(self._infos, shards)
+
+        # Order shards by their authoritative ``split.no`` (order independence:
+        # the caller may pass them in any order). Primary shard is split.no == 0.
+        order = sorted(
+            range(len(shards)),
+            key=lambda i: (
+                self._infos[i].split_no
+                if self._infos[i].split_no is not None
+                else self._infos[i].filename_index - 1
+            ),
+        )
+        self._shards = [shards[i] for i in order]
+        self._infos = [self._infos[i] for i in order]
+        self._primary = self._shards[0]
+
+        # Combined, order-preserving tensor index: name -> owning shard.
+        self._owner: dict[str, GGUFModel] = {}
+        self._names: list[str] = []
+        for shard in self._shards:
+            for name in shard.tensor_names:
+                if name in self._owner:
+                    raise GgufShardError(
+                        f"Duplicate tensor {name!r} across shards "
+                        f"({Path(self._owner[name]._path).name} and "
+                        f"{Path(shard._path).name}); refusing to build from an "
+                        "ambiguous split set."
+                    )
+                self._owner[name] = shard
+                self._names.append(name)
+
+        self._manifest = GgufShardManifest(
+            architecture=self._safe_architecture(),
+            split_count=len(self._shards),
+            total_tensors=len(self._names),
+            total_bytes=sum(info.size_bytes for info in self._infos),
+            shards=list(self._infos),
+        )
+        logger.info(
+            "Assembled GGUF split set: %d shards, %d tensors, %.3f GiB (arch=%s)",
+            self._manifest.split_count,
+            self._manifest.total_tensors,
+            self._manifest.total_bytes / float(1 << 30),
+            self._manifest.architecture,
+        )
+
+    # -- GGUFModel-compatible surface ------------------------------------
+
+    @property
+    def architecture(self) -> str:
+        """Model architecture, read from the primary shard's metadata."""
+        return self._primary.architecture
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """Model key-value metadata (from the primary shard)."""
+        return self._primary.metadata
+
+    def get_metadata(self, key: str, default: Any = None) -> Any:
+        return self._primary.get_metadata(key, default)
+
+    @property
+    def tensor_names(self) -> list[str]:
+        return list(self._names)
+
+    @property
+    def num_tensors(self) -> int:
+        return len(self._names)
+
+    def reader_tensors(self) -> list[Any]:
+        """Underlying ``gguf.ReaderTensor`` records across all shards, in order."""
+        records: list[Any] = []
+        for shard in self._shards:
+            records.extend(shard.reader_tensors())
+        return records
+
+    def tensor_items(self) -> Iterator[tuple[str, np.ndarray]]:
+        for shard in self._shards:
+            yield from shard.tensor_items()
+
+    def tensor_items_raw(self) -> Iterator[tuple[str, np.ndarray, Any, tuple[int, ...]]]:
+        for shard in self._shards:
+            yield from shard.tensor_items_raw()
+
+    def get_tensor(self, name: str) -> np.ndarray:
+        shard = self._owner.get(name)
+        if shard is None:
+            raise KeyError(
+                f"Tensor {name!r} not found in split set. Available: {self._names[:10]}..."
+            )
+        return shard.get_tensor(name)
+
+    def get_tensor_type(self, name: str) -> Any:
+        shard = self._owner.get(name)
+        if shard is None:
+            raise KeyError(f"Tensor {name!r} not found in split set.")
+        return shard.get_tensor_type(name)
+
+    def dequantize_raw_tensor(
+        self,
+        raw_data: np.ndarray,
+        quant_type: Any,
+        np_shape: tuple[int, ...],
+    ) -> np.ndarray:
+        return self._primary.dequantize_raw_tensor(raw_data, quant_type, np_shape)
+
+    # -- shard-set specific ---------------------------------------------
+
+    @property
+    def manifest(self) -> GgufShardManifest:
+        """The validated metadata-only manifest for this split set."""
+        return self._manifest
+
+    @property
+    def shard_paths(self) -> list[Path]:
+        return [Path(shard._path) for shard in self._shards]
+
+    def _safe_architecture(self) -> str | None:
+        try:
+            return self._primary.architecture
+        except ValueError:
+            return None
+
+    def __repr__(self) -> str:
+        return (
+            f"GgufShardSet(shards={self._manifest.split_count}, "
+            f"tensors={self._manifest.total_tensors}, "
+            f"arch='{self._manifest.architecture}')"
+        )
+
+
+def _sha256_of(path: Path, *, chunk_size: int = 1 << 20) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(chunk_size), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _build_shard_infos(
+    paths: list[Path],
+    shards: list[GGUFModel],
+    *,
+    verify_checksums: bool,
+    expected_sha256: dict[str, str] | None,
+    expected_sizes: dict[str, int] | None,
+) -> list[ShardInfo]:
+    infos: list[ShardInfo] = []
+    for path, shard in zip(paths, shards):
+        parsed = parse_shard_filename(path.name)
+        if parsed is None:
+            raise GgufShardError(
+                f"{path.name!r} is not a ``-000i-of-000N.gguf`` shard filename"
+            )
+        _prefix, index, count = parsed
+        size_bytes = path.stat().st_size
+
+        expected_size = (expected_sizes or {}).get(path.name)
+        if expected_size is not None and expected_size != size_bytes:
+            raise GgufShardError(
+                f"Shard {path.name} size mismatch: manifest expected "
+                f"{expected_size} bytes, on disk {size_bytes} bytes (truncated "
+                "or corrupt download)."
+            )
+
+        sha256: str | None = None
+        want_sha = (expected_sha256 or {}).get(path.name)
+        if verify_checksums:
+            sha256 = _sha256_of(path)
+            if want_sha is not None and sha256.lower() != want_sha.lower():
+                raise GgufShardError(
+                    f"Shard {path.name} SHA-256 mismatch: manifest expected "
+                    f"{want_sha}, computed {sha256} (corrupt shard)."
+                )
+
+        infos.append(
+            ShardInfo(
+                path=path,
+                filename_index=index,
+                filename_count=count,
+                split_no=_int_or_none(shard.get_metadata(_SPLIT_NO)),
+                split_count=_int_or_none(shard.get_metadata(_SPLIT_COUNT)),
+                split_tensors_count=_int_or_none(shard.get_metadata(_SPLIT_TENSORS_COUNT)),
+                size_bytes=size_bytes,
+                tensor_count=shard.num_tensors,
+                sha256=sha256,
+            )
+        )
+    return infos
+
+
+def _int_or_none(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _validate_shard_set(infos: list[ShardInfo], shards: list[GGUFModel]) -> None:
+    """Fail closed on any structural inconsistency in the split set."""
+    n = len(infos)
+    filename_count = infos[0].filename_count
+    if any(info.filename_count != filename_count for info in infos):
+        counts = sorted({info.filename_count for info in infos})
+        raise GgufShardError(
+            f"Shards disagree on the split count in their filenames: {counts}. "
+            "The files belong to different split sets."
+        )
+    if n != filename_count:
+        raise GgufShardError(
+            f"Split set declares {filename_count} shards but {n} were provided."
+        )
+
+    # Authoritative split.count metadata must agree with the filename count.
+    declared_counts = {info.split_count for info in infos if info.split_count is not None}
+    if declared_counts and declared_counts != {filename_count}:
+        raise GgufShardError(
+            f"GGUF split.count metadata {sorted(declared_counts)} disagrees with the "
+            f"{filename_count}-shard filenames; mixed or corrupt split set."
+        )
+
+    # split.no must be a contiguous 0..count-1 permutation when present.
+    split_nos = [info.split_no for info in infos]
+    if all(s is not None for s in split_nos):
+        if sorted(split_nos) != list(range(n)):
+            raise GgufShardError(
+                f"GGUF split.no values {sorted(split_nos)} are not the contiguous "
+                f"set 0..{n - 1} (missing, duplicate, or mixed shards)."
+            )
+    else:
+        # Fall back to filename indices, which must be the contiguous 1..count.
+        indices = sorted(info.filename_index for info in infos)
+        if indices != list(range(1, n + 1)):
+            raise GgufShardError(
+                f"Shard filename indices {indices} are not the contiguous set "
+                f"1..{n} and no split.no metadata is present to recover order."
+            )
+
+    # split.tensors.count (total across the set) must agree everywhere and equal
+    # the observed tensor total.
+    declared_tensor_totals = {
+        info.split_tensors_count for info in infos if info.split_tensors_count is not None
+    }
+    observed_total = sum(info.tensor_count for info in infos)
+    if len(declared_tensor_totals) > 1:
+        raise GgufShardError(
+            f"Shards disagree on split.tensors.count {sorted(declared_tensor_totals)}; "
+            "mixed-revision split set."
+        )
+    if declared_tensor_totals and next(iter(declared_tensor_totals)) != observed_total:
+        raise GgufShardError(
+            f"split.tensors.count={next(iter(declared_tensor_totals))} does not match "
+            f"the {observed_total} tensors actually present across the shards "
+            "(missing or extra shard)."
+        )
+
+    _validate_identity(infos, shards)
+    _validate_offsets(infos, shards)
+
+
+def _validate_identity(infos: list[ShardInfo], shards: list[GGUFModel]) -> None:
+    """Every shard that declares an identity key must agree with the others."""
+    for key in _IDENTITY_KEYS:
+        seen: dict[Any, str] = {}
+        for info, shard in zip(infos, shards):
+            value = shard.get_metadata(key)
+            if value is None:
+                continue
+            if isinstance(value, list):
+                value = tuple(value)
+            if value not in seen:
+                seen[value] = info.path.name
+            if len(seen) > 1:
+                where = ", ".join(f"{v!r} in {name}" for v, name in seen.items())
+                raise GgufShardError(
+                    f"Shards disagree on {key!r} ({where}); this is a mixed-revision "
+                    "or mixed-quant split set and cannot be stitched together."
+                )
+
+
+def _validate_offsets(infos: list[ShardInfo], shards: list[GGUFModel]) -> None:
+    """Reject shards whose tensor table points outside the file (corruption)."""
+    for info, shard in zip(infos, shards):
+        reader = shard._reader
+        alignment = getattr(reader, "alignment", 32) or 32
+        data_offset = getattr(reader, "data_offset", 0)
+        if data_offset % alignment != 0:
+            raise GgufShardError(
+                f"Shard {info.path.name} data section offset {data_offset} is not "
+                f"aligned to {alignment} bytes (corrupt header)."
+            )
+        for tensor in reader.tensors:
+            end = int(tensor.data_offset) + int(tensor.n_bytes)
+            if int(tensor.data_offset) < data_offset or end > info.size_bytes:
+                raise GgufShardError(
+                    f"Shard {info.path.name} tensor {tensor.name!r} data span "
+                    f"[{tensor.data_offset}, {end}) lies outside the file "
+                    f"(size {info.size_bytes}); shard is truncated or corrupt."
+                )
+
+
+def open_gguf_model(
+    path: str | Path,
+    *,
+    verify_checksums: bool = False,
+    expected_sha256: dict[str, str] | None = None,
+    expected_sizes: dict[str, int] | None = None,
+) -> GGUFModel | GgufShardSet:
+    """Open *path* as a single-file :class:`GGUFModel` or a :class:`GgufShardSet`.
+
+    A :class:`GgufShardSet` is returned when *path* is one shard of a split set
+    (or a directory holding a single split set); otherwise a plain
+    :class:`GGUFModel`. Callers get the same interface either way.
+    """
+    shards = discover_gguf_shards(path)
+    if len(shards) == 1:
+        single = shards[0]
+        # A lone ``-00001-of-00001`` file is a degenerate single-shard set;
+        # treat it as a plain file. GGUFModel still validates it.
+        return GGUFModel(single)
+    return GgufShardSet(
+        shards,
+        verify_checksums=verify_checksums,
+        expected_sha256=expected_sha256,
+        expected_sizes=expected_sizes,
+    )

--- a/src/mobius/integrations/gguf/_shard_set_test.py
+++ b/src/mobius/integrations/gguf/_shard_set_test.py
@@ -274,6 +274,52 @@ def test_checksum_mismatch_rejected(tmp_path):
         open_gguf_model(shards[0], verify_checksums=True, expected_sha256=bad)
 
 
+def test_manifest_rejects_swapped_continuation_shard(tmp_path):
+    """A same-model mixed-quant continuation-shard swap is caught by the manifest.
+
+    Continuation shards carry no identity metadata, so without a manifest the
+    swap passes structural validation (the documented residual gap in
+    ``_IDENTITY_KEYS``). Supplying ``expected_sizes`` / ``expected_sha256`` (as
+    :mod:`._preflight` produces from HF LFS metadata) fails closed — this is the
+    byte-exact guard the task requires "when manifest data exists".
+    """
+    # A trusted set and a differently-quantized variant of the "same" model
+    # whose continuation shards differ in byte length and content.
+    good = _write_sharded_gguf(
+        tmp_path / "good", stem="tiny", split_max_tensors=3, cols=16, seed=1
+    )
+    other = _write_sharded_gguf(
+        tmp_path / "other", stem="tiny", split_max_tensors=3, cols=24, seed=2
+    )
+
+    manifest = open_gguf_model(good[0], verify_checksums=True).manifest
+    expected_sizes = {s.path.name: s.size_bytes for s in manifest.shards}
+    expected_sha256 = {s.path.name: s.sha256 for s in manifest.shards}
+
+    # Assemble a working set: trusted primary + a continuation shard swapped in
+    # from the other (mixed-quant) export.
+    work = tmp_path / "work"
+    work.mkdir()
+    for p in good:
+        (work / p.name).write_bytes(p.read_bytes())
+    victim = other[1]  # continuation shard, same filename, different bytes/size
+    (work / victim.name).write_bytes(victim.read_bytes())
+    work_shards = sorted(work.glob("tiny-*.gguf"))
+
+    # Documented residual: metadata alone cannot detect the swap, so this must
+    # NOT raise (continuation shards carry no identity keys to compare).
+    open_gguf_model(work_shards[0])
+
+    # With the manifest it fails closed (the size guard fires before hashing).
+    with pytest.raises(GgufShardError, match=r"(?i)size|sha|checksum"):
+        open_gguf_model(
+            work_shards[0],
+            verify_checksums=True,
+            expected_sha256=expected_sha256,
+            expected_sizes=expected_sizes,
+        )
+
+
 # --------------------------------------------------------------------------- #
 # Manifest / determinism
 # --------------------------------------------------------------------------- #
@@ -324,25 +370,75 @@ def test_offsets_within_file_and_aligned(tmp_path):
 # --------------------------------------------------------------------------- #
 
 
+def _write_q8_sharded_gguf(
+    directory: Path,
+    *,
+    stem: str = "q8",
+    num_layers: int = 3,
+    split_max_tensors: int = 3,
+    rows: int = 512,
+    cols: int = 512,
+) -> list[Path]:
+    """Write a split set whose tensors are native ``Q8_0`` blocks.
+
+    Unlike F32 tensors (which ``get_tensor`` returns as a memmap-backed *view*),
+    a quantized tensor is dequantized into a fresh float32 heap array, so
+    ``tracemalloc`` actually observes the per-tensor payload and the
+    bounded-memory assertion is meaningful. ``cols`` must be a multiple of the
+    32-element ``Q8_0`` block; each block is 34 bytes (fp16 scale + 32 int8).
+    """
+    from gguf import GGMLQuantizationType, GGUFWriter
+
+    assert cols % 32 == 0, "Q8_0 requires the last dim to be a multiple of 32"
+    directory.mkdir(parents=True, exist_ok=True)
+    block_bytes = cols // 32 * 34
+    writer = GGUFWriter(str(directory / stem), "llama", split_max_tensors=split_max_tensors)
+    writer.add_context_length(128)
+    writer.add_embedding_length(cols)
+    writer.add_block_count(num_layers)
+    writer.add_head_count(4)
+    writer.add_head_count_kv(2)
+    writer.add_vocab_size(32)
+
+    rng = np.random.default_rng(3)
+    for name in _tensor_names(num_layers):
+        raw = rng.integers(0, 256, size=(rows, block_bytes), dtype=np.uint8)
+        writer.add_tensor(name, raw, raw_dtype=GGMLQuantizationType.Q8_0)
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_tensors_to_file()
+    writer.close()
+    return sorted(directory.glob(f"{stem}-*.gguf"))
+
+
 def test_bounded_memory_random_access(tmp_path):
-    # Larger tensors so the payload dominates over Python object overhead.
-    shards = _write_sharded_gguf(tmp_path, split_max_tensors=3, rows=512, cols=512)
+    # Native Q8_0 blocks so each get_tensor() dequantizes into a real float32
+    # heap array (a memmap *view* would hide the payload from tracemalloc and
+    # make this assertion vacuous).
+    rows = cols = 512
+    shards = _write_q8_sharded_gguf(tmp_path, split_max_tensors=3, rows=rows, cols=cols)
     model = open_gguf_model(shards[0])
-    one_tensor_bytes = 512 * 512 * 4
+    assert model.num_tensors == len(_tensor_names(3))
+    one_tensor_bytes = rows * cols * 4  # dequantized float32 payload
 
     tracemalloc.start()
     try:
         base = tracemalloc.get_traced_memory()[0]
-        for name in model.tensor_names:
-            block = model.get_tensor(name)
-            del block
+        # Random Q8_0 bytes can encode non-finite fp16 scales; we only measure
+        # memory here, so ignore the resulting numpy dequant warnings.
+        with np.errstate(invalid="ignore", over="ignore"):
+            for name in model.tensor_names:
+                block = model.get_tensor(name)
+                # Force materialisation of the dequantized payload.
+                assert block.nbytes == one_tensor_bytes
+                del block
         peak = tracemalloc.get_traced_memory()[1]
     finally:
         tracemalloc.stop()
 
     # Peak stays within a small multiple of a single tensor — we never
     # materialise the whole (multi-tensor) checkpoint at once.
-    assert peak - base < 6 * one_tensor_bytes
+    assert peak - base < 3 * one_tensor_bytes
 
 
 # --------------------------------------------------------------------------- #

--- a/src/mobius/integrations/gguf/_shard_set_test.py
+++ b/src/mobius/integrations/gguf/_shard_set_test.py
@@ -1,0 +1,460 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for direct multi-shard GGUF reading (:mod:`._shard_set`).
+
+Fixtures are synthetic split sets built with ``gguf.GGUFWriter(split_max_tensors=N)``
+— the same on-disk layout llama.cpp/Unsloth ship (``<name>-000i-of-000N.gguf``,
+metadata only on the primary shard). No real weights are downloaded.
+"""
+
+from __future__ import annotations
+
+import tracemalloc
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from mobius.integrations.gguf._reader import GGUFModel
+from mobius.integrations.gguf._shard_set import (
+    GgufShardError,
+    GgufShardManifest,
+    GgufShardSet,
+    discover_gguf_shards,
+    open_gguf_model,
+    parse_shard_filename,
+)
+
+
+def _tensor_names(num_layers: int) -> list[str]:
+    names = ["token_embd.weight"]
+    for i in range(num_layers):
+        names.append(f"blk.{i}.attn_q.weight")
+        names.append(f"blk.{i}.ffn_up.weight")
+    names.append("output_norm.weight")
+    names.append("output.weight")
+    return names
+
+
+def _write_sharded_gguf(
+    directory: Path,
+    *,
+    stem: str = "tiny",
+    architecture: str = "llama",
+    num_layers: int = 3,
+    split_max_tensors: int = 3,
+    rows: int = 8,
+    cols: int = 16,
+    name_override: str | None = None,
+    seed: int = 0,
+) -> list[Path]:
+    """Write a synthetic split GGUF set and return its shard paths in order.
+
+    Every tensor value is deterministic (seeded + derived from its name) so
+    tests can assert the reader returns the exact bytes from the owning shard.
+    """
+    from gguf import GGUFWriter
+
+    directory.mkdir(parents=True, exist_ok=True)
+    writer = GGUFWriter(
+        str(directory / stem), architecture, split_max_tensors=split_max_tensors
+    )
+    writer.add_context_length(128)
+    writer.add_embedding_length(cols)
+    writer.add_feed_forward_length(cols * 2)
+    writer.add_block_count(num_layers)
+    writer.add_head_count(4)
+    writer.add_head_count_kv(2)
+    writer.add_vocab_size(32)
+    if name_override is not None:
+        writer.add_name(name_override)
+
+    rng = np.random.default_rng(seed)
+    for name in _tensor_names(num_layers):
+        data = rng.standard_normal((rows, cols)).astype(np.float32)
+        writer.add_tensor(name, data)
+
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_tensors_to_file()
+    writer.close()
+    return sorted(directory.glob(f"{stem}-*.gguf"))
+
+
+def _write_single_gguf(directory: Path, *, stem: str = "single") -> Path:
+    """Write a plain (unsharded) GGUF file."""
+    from gguf import GGUFWriter
+
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{stem}.gguf"
+    writer = GGUFWriter(str(path), "llama")
+    writer.add_context_length(128)
+    writer.add_embedding_length(16)
+    writer.add_feed_forward_length(32)
+    writer.add_block_count(2)
+    writer.add_head_count(4)
+    writer.add_head_count_kv(2)
+    writer.add_vocab_size(32)
+    rng = np.random.default_rng(0)
+    for name in _tensor_names(2):
+        writer.add_tensor(name, rng.standard_normal((8, 16)).astype(np.float32))
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_tensors_to_file()
+    writer.close()
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# Filename parsing
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_shard_filename_valid():
+    assert parse_shard_filename("GLM-5.2-UD-IQ1_S-00001-of-00006.gguf") == (
+        "GLM-5.2-UD-IQ1_S",
+        1,
+        6,
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "model.gguf",
+        "model-1-of-6.gguf",
+        "model-00001-of-00006.bin",
+        "model-00001-of-00006",
+    ],
+)
+def test_parse_shard_filename_rejects_non_shard(name):
+    assert parse_shard_filename(name) is None
+
+
+# --------------------------------------------------------------------------- #
+# Happy paths
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("split_max_tensors", [3, 4])
+def test_happy_path_reads_all_tensors(tmp_path, split_max_tensors):
+    shards = _write_sharded_gguf(tmp_path, split_max_tensors=split_max_tensors)
+    assert len(shards) >= 2  # genuinely sharded
+
+    model = open_gguf_model(shards[0])
+    assert isinstance(model, GgufShardSet)
+    assert model.architecture == "llama"
+    assert set(model.tensor_names) == set(_tensor_names(3))
+    assert model.num_tensors == len(_tensor_names(3))
+
+    # Every tensor is readable and matches a direct single-shard read.
+    single_reads = {}
+    for shard in shards:
+        gm = GGUFModel(shard)
+        for name in gm.tensor_names:
+            single_reads[name] = gm.get_tensor(name)
+    for name in model.tensor_names:
+        np.testing.assert_array_equal(model.get_tensor(name), single_reads[name])
+
+
+def test_tensors_split_across_files(tmp_path):
+    shards = _write_sharded_gguf(tmp_path, split_max_tensors=3)
+    # Confirm the split actually places tensors in different shards.
+    owners = {}
+    for shard in shards:
+        for name in GGUFModel(shard).tensor_names:
+            owners[name] = shard.name
+    distinct_files = set(owners.values())
+    assert len(distinct_files) == len(shards)
+
+
+def test_order_independence(tmp_path):
+    shards = _write_sharded_gguf(tmp_path, split_max_tensors=3)
+    # Opening via ANY shard (even a continuation shard) yields the same model.
+    ref = open_gguf_model(shards[0])
+    ref_names = sorted(ref.tensor_names)
+    for shard in shards[1:]:
+        other = open_gguf_model(shard)
+        assert sorted(other.tensor_names) == ref_names
+        assert other.manifest.split_count == ref.manifest.split_count
+
+
+def test_open_directory(tmp_path):
+    _write_sharded_gguf(tmp_path, split_max_tensors=3)
+    model = open_gguf_model(tmp_path)  # a directory holding one split set
+    assert isinstance(model, GgufShardSet)
+    assert model.num_tensors == len(_tensor_names(3))
+
+
+def test_discover_confined_to_directory(tmp_path):
+    shards = _write_sharded_gguf(tmp_path, split_max_tensors=3)
+    found = discover_gguf_shards(shards[2])
+    assert sorted(p.name for p in found) == sorted(p.name for p in shards)
+    # Discovery does not escape into a sibling directory.
+    other = tmp_path / "other"
+    _write_sharded_gguf(other, stem="zzz", split_max_tensors=3)
+    found_again = discover_gguf_shards(shards[0])
+    assert all(p.parent == tmp_path for p in found_again)
+
+
+# --------------------------------------------------------------------------- #
+# Single-file behaviour is unchanged
+# --------------------------------------------------------------------------- #
+
+
+def test_single_file_returns_plain_model(tmp_path):
+    plain = _write_single_gguf(tmp_path)
+    model = open_gguf_model(plain)
+    assert isinstance(model, GGUFModel)
+    assert not isinstance(model, GgufShardSet)
+    assert model.architecture == "llama"
+
+
+# --------------------------------------------------------------------------- #
+# Fail-closed validation
+# --------------------------------------------------------------------------- #
+
+
+def test_missing_shard_rejected(tmp_path):
+    shards = _write_sharded_gguf(tmp_path, split_max_tensors=3)
+    shards[1].unlink()  # drop a middle shard
+    with pytest.raises(GgufShardError, match=r"(?i)missing|count|contiguous|shard"):
+        open_gguf_model(shards[0])
+
+
+def test_duplicate_shard_index_rejected(tmp_path):
+    shards = _write_sharded_gguf(tmp_path, split_max_tensors=3)
+    # Copy shard 2's bytes over shard 3's filename => two files claim split.no==1.
+    shards[2].write_bytes(shards[1].read_bytes())
+    with pytest.raises(GgufShardError):
+        open_gguf_model(shards[0])
+
+
+def test_mixed_shard_set_rejected(tmp_path):
+    # Shard 0 comes from a 3-layer export (7 tensors); a continuation shard is
+    # swapped in from a structurally different 4-layer export (9 tensors). Every
+    # shard records the export's total via ``split.tensors.count``, so the
+    # divergence (7 vs 9) is detected — a mixed-revision / mixed-export set.
+    set_a = _write_sharded_gguf(tmp_path, num_layers=3, split_max_tensors=3)
+    other_dir = tmp_path / "b"
+    set_b = _write_sharded_gguf(other_dir, num_layers=4, split_max_tensors=3, seed=1)
+    set_a[1].write_bytes(set_b[1].read_bytes())
+    with pytest.raises(GgufShardError, match=r"(?i)tensors|count|mismatch|conflict|identity"):
+        open_gguf_model(set_a[0])
+
+
+def test_duplicate_tensor_across_shards_rejected(tmp_path):
+    shards = _write_sharded_gguf(tmp_path, split_max_tensors=3)
+    # Overwrite shard 3 with a copy of shard 2 => a tensor name appears twice.
+    shards[2].write_bytes(shards[1].read_bytes())
+    with pytest.raises(GgufShardError):
+        open_gguf_model(shards[0])
+
+
+def test_corrupt_truncated_shard_rejected(tmp_path):
+    shards = _write_sharded_gguf(tmp_path, split_max_tensors=3)
+    # Truncate a shard mid-tensor: declared tensor extents now exceed file size.
+    target = shards[1]
+    data = target.read_bytes()
+    target.write_bytes(data[: len(data) // 2])
+    with pytest.raises((GgufShardError, ValueError)):
+        open_gguf_model(shards[0])
+
+
+def test_checksum_mismatch_rejected(tmp_path):
+    shards = _write_sharded_gguf(tmp_path, split_max_tensors=3)
+    manifest = open_gguf_model(shards[0], verify_checksums=True).manifest
+    good = {s.path.name: s.sha256 for s in manifest.shards}
+    bad = dict(good)
+    # Flip an expected checksum => verification must fail closed.
+    victim = shards[1].name
+    bad[victim] = "0" * 64
+    with pytest.raises(GgufShardError, match=r"(?i)sha|checksum|hash"):
+        open_gguf_model(shards[0], verify_checksums=True, expected_sha256=bad)
+
+
+# --------------------------------------------------------------------------- #
+# Manifest / determinism
+# --------------------------------------------------------------------------- #
+
+
+def test_manifest_is_deterministic_and_serialisable(tmp_path):
+    shards = _write_sharded_gguf(tmp_path, split_max_tensors=3)
+    m1 = open_gguf_model(shards[0]).manifest
+    m2 = open_gguf_model(shards[-1]).manifest  # opened via a different shard
+    assert isinstance(m1, GgufShardManifest)
+    assert m1.as_dict() == m2.as_dict()
+    d = m1.as_dict()
+    assert d["split_count"] == len(shards)
+    assert d["total_tensors"] == len(_tensor_names(3))
+    assert d["total_bytes"] == sum(s.stat().st_size for s in shards)
+    # Shard order in the manifest follows split.no (0..n-1).
+    assert [s["split_no"] for s in d["shards"]] == list(range(len(shards)))
+
+
+def test_checksums_are_stable(tmp_path):
+    shards = _write_sharded_gguf(tmp_path, split_max_tensors=3)
+    a = open_gguf_model(shards[0], verify_checksums=True).manifest.as_dict()
+    b = open_gguf_model(shards[0], verify_checksums=True).manifest.as_dict()
+    assert a == b
+    for shard in a["shards"]:
+        assert shard["sha256"] and len(shard["sha256"]) == 64
+
+
+# --------------------------------------------------------------------------- #
+# Offset / alignment
+# --------------------------------------------------------------------------- #
+
+
+def test_offsets_within_file_and_aligned(tmp_path):
+    shards = _write_sharded_gguf(tmp_path, split_max_tensors=3)
+    model = open_gguf_model(shards[0])  # constructor runs offset/alignment checks
+    # Independently confirm every tensor's byte-extent is inside its file.
+    for shard in shards:
+        gm = GGUFModel(shard)
+        size = shard.stat().st_size
+        for rt in gm.reader_tensors():
+            assert rt.data_offset + rt.n_bytes <= size
+    assert model.num_tensors == len(_tensor_names(3))
+
+
+# --------------------------------------------------------------------------- #
+# Bounded memory
+# --------------------------------------------------------------------------- #
+
+
+def test_bounded_memory_random_access(tmp_path):
+    # Larger tensors so the payload dominates over Python object overhead.
+    shards = _write_sharded_gguf(tmp_path, split_max_tensors=3, rows=512, cols=512)
+    model = open_gguf_model(shards[0])
+    one_tensor_bytes = 512 * 512 * 4
+
+    tracemalloc.start()
+    try:
+        base = tracemalloc.get_traced_memory()[0]
+        for name in model.tensor_names:
+            block = model.get_tensor(name)
+            del block
+        peak = tracemalloc.get_traced_memory()[1]
+    finally:
+        tracemalloc.stop()
+
+    # Peak stays within a small multiple of a single tensor — we never
+    # materialise the whole (multi-tensor) checkpoint at once.
+    assert peak - base < 6 * one_tensor_bytes
+
+
+# --------------------------------------------------------------------------- #
+# Native IQ1 block preservation
+# --------------------------------------------------------------------------- #
+
+
+def _write_iq1_sharded(directory: Path, *, quant: str = "iq1_s") -> list[Path]:
+    """Write a split set whose ``blk.*`` weights are native IQ1 blocks."""
+    from gguf import GGMLQuantizationType, GGUFWriter
+
+    directory.mkdir(parents=True, exist_ok=True)
+    qtype = GGMLQuantizationType.IQ1_S if quant == "iq1_s" else GGMLQuantizationType.IQ1_M
+    block_bytes = 50 if quant == "iq1_s" else 56
+    n_out, k = 8, 256  # one 256-element block per row
+    writer = GGUFWriter(str(directory / "iq1"), "llama", split_max_tensors=2)
+    writer.add_context_length(128)
+    writer.add_embedding_length(k)
+    writer.add_block_count(2)
+    writer.add_head_count(4)
+    writer.add_head_count_kv(2)
+    writer.add_vocab_size(32)
+
+    rng = np.random.default_rng(7)
+    tensor_names = []
+    for i in range(2):
+        for proj in ("attn_q", "ffn_up"):
+            name = f"blk.{i}.{proj}.weight"
+            raw = rng.integers(0, 256, size=(n_out, block_bytes), dtype=np.uint8)
+            writer.add_tensor(name, raw, raw_dtype=qtype)
+            tensor_names.append(name)
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_tensors_to_file()
+    writer.close()
+    return sorted(directory.glob("iq1-*.gguf"))
+
+
+def test_iq1_native_blocks_preserved_byte_for_byte(tmp_path):
+    shards = _write_iq1_sharded(tmp_path, quant="iq1_s")
+    assert len(shards) >= 2
+    model = open_gguf_model(shards[0])
+
+    # Raw block bytes read through the shard set, keyed by tensor name.
+    set_raw = {name: raw for name, raw, _qtype, _shape in model.tensor_items_raw()}
+
+    for name in ("blk.0.attn_q.weight", "blk.1.ffn_up.weight"):
+        owner = None
+        for shard in shards:
+            gm = GGUFModel(shard)
+            if name in gm.tensor_names:
+                owner = gm
+                break
+        assert owner is not None
+        # Native IQ1_S type is reported unchanged (no dequant, no repack)...
+        assert int(model.get_tensor_type(name)) == int(owner.get_tensor_type(name))
+        # ...and the raw block bytes are identical to the owning shard's.
+        owner_raw = {n: r for n, r, _q, _s in owner.tensor_items_raw()}[name]
+        np.testing.assert_array_equal(set_raw[name], owner_raw)
+
+
+def test_iq1_type_matches_single_file(tmp_path):
+    shards = _write_iq1_sharded(tmp_path, quant="iq1_m")
+    model = open_gguf_model(shards[0])
+    from gguf import GGMLQuantizationType
+
+    assert int(model.get_tensor_type("blk.0.attn_q.weight")) == int(GGMLQuantizationType.IQ1_M)
+
+
+# --------------------------------------------------------------------------- #
+# Identity-key conflict (defensive: mixed-quant / mixed-revision)
+# --------------------------------------------------------------------------- #
+
+
+def test_validate_identity_rejects_conflicting_metadata():
+    from mobius.integrations.gguf import _shard_set as ss
+
+    class _FakeInfo:
+        def __init__(self, name):
+            self.path = Path(name)
+
+    class _FakeShard:
+        def __init__(self, meta):
+            self._meta = meta
+
+        def get_metadata(self, key, default=None):
+            return self._meta.get(key, default)
+
+    infos = [_FakeInfo("a-00001-of-00002.gguf"), _FakeInfo("a-00002-of-00002.gguf")]
+    shards = [
+        _FakeShard({"general.architecture": "llama"}),
+        _FakeShard({"general.architecture": "qwen2"}),
+    ]
+    with pytest.raises(GgufShardError, match=r"(?i)general.architecture|mixed"):
+        ss._validate_identity(infos, shards)
+
+
+def test_validate_identity_accepts_primary_only_metadata():
+    from mobius.integrations.gguf import _shard_set as ss
+
+    class _FakeInfo:
+        def __init__(self, name):
+            self.path = Path(name)
+
+    class _FakeShard:
+        def __init__(self, meta):
+            self._meta = meta
+
+        def get_metadata(self, key, default=None):
+            return self._meta.get(key, default)
+
+    # Real split sets carry identity keys only on the primary; that must pass.
+    infos = [_FakeInfo("a-00001-of-00002.gguf"), _FakeInfo("a-00002-of-00002.gguf")]
+    shards = [_FakeShard({"general.architecture": "glm-dsa"}), _FakeShard({})]
+    ss._validate_identity(infos, shards)  # no raise

--- a/src/mobius/integrations/gguf/_tencent_q1_0.py
+++ b/src/mobius/integrations/gguf/_tencent_q1_0.py
@@ -103,7 +103,14 @@ def is_tencent_q1_0_layout(gguf_model) -> bool:
     """
     from gguf import GGMLQuantizationType
 
-    reader = gguf_model._reader
+    # Tencent's custom Q1_0 layout only occurs in single-file GGUFs. A
+    # :class:`~mobius.integrations.gguf._shard_set.GgufShardSet` exposes no
+    # single ``_reader`` (its tensors span several files), and the mainline
+    # repack path handles any genuinely-standard Q1_0 shard, so treat a split
+    # set as "not Tencent" rather than reaching into a reader that isn't there.
+    reader = getattr(gguf_model, "_reader", None)
+    if reader is None:
+        return False
     tensors = sorted(
         reader.tensors,
         key=_tensor_data_offset,


### PR DESCRIPTION
## Summary

Enables importing **large split-set GGUF checkpoints directly** (north star: `unsloth/GLM-5.2-GGUF` UD-IQ1_{S,M} — six-file, 201.832 / 212.801 GiB sets) without merging shards into a second on-disk file, resolves the GLM-5.2 `glm-dsa` architecture to the canonical `glm_moe_dsa` model type, and adds a fail-closed sparse-MoE honesty gate plus a metadata-only preflight.

This is independent of PR #1854. It does **not** touch PagedAttention or onnx-genai Slice7A.

### 1. Multi-shard reader — `_shard_set.py`
- `GgufShardSet` assembles a `-000i-of-000N.gguf` split set into one logical, `GGUFModel`-compatible reader. Tensors are read on demand from the **owning shard** (each memory-mapped by `gguf.GGUFReader`) — **never concatenated into a second ~228 GB GGUF**. Memory stays bounded to one tensor/block chunk + metadata.
- Native IQ blocks preserved **byte-for-byte** into the existing repacker/external-data path.
- Discovery confined to the requested directory; driven by authoritative `split.*` metadata cross-checked against filenames (no blind string concatenation).
- **Fail-closed** validation: contiguous `split.no`, declared `split.count`/`split.tensors.count` agreement, unique tensor names, tensor counts, offset/alignment bounds (catches truncated/corrupt shards), architecture/tokenizer/template identity, optional sha256/size checks. Rejects missing / duplicate / mixed-revision / mixed-quant / corrupt shards.
- `open_gguf_model()` returns a plain `GGUFModel` for single files (**behaviour unchanged**) or a `GgufShardSet` for split sets.

### 2. Architecture resolution — `_config_mapping.py`
- Explicit, **metadata-driven** `glm-dsa`/`glm_dsa` → `glm_moe_dsa` format bridge (no filename/model-name heuristics) + GLM-5.2 MLA/MoE/DSA key map.
- `assert_glm_moe_dsa_resolvable()` verifies head/layer/expert/MLA/DSA-indexer properties **before** selecting `GlmMoeDsaCausalLMModel`, accumulating **all** missing properties as precise rejection reasons. Wired into `build_from_gguf`.

### 3. Sparse-MoE honesty gate — `_builder.py`, `_flags.py`
- Routed IQ/MXFP4 experts lower to per-expert `pkg.nxrt::BlockQuantizedMatMul` with **no sparse top-k fusion** (only int4 `MatMulNBits` fuses into `com.microsoft::QMoE`) — i.e. dense-all-expert compute. `build_from_gguf` now **fails closed** before export with `SparseMoEExportError`.
- Opt in via `allow_dense_moe` / `MOBIUS_ALLOW_DENSE_MOE_EXPERTS` (non-default, research/correctness only, **no throughput claim**).

### 4. Metadata-only preflight — `_preflight.py`, CLI `preflight-gguf`
- `preflight_gguf` / `preflight_local_gguf` / `preflight_hf_gguf` report exact files, bytes, LFS sha256, resolved architecture, and export blockers **without downloading tensor payloads** (`HfApi.get_paths_info` + `model_info(expand=["gguf"])`). Resumable via a JSON cache. Exposed as reusable GGUF-specific library functions (no `_weight_loading.py`, no duplicate generic CLI machinery).

### Preflight output for the north-star repo (metadata only, pinned sha `abc55e7…`)
```
UD-IQ1_S: glm-dsa -> glm_moe_dsa | 6 shards | 216,715,360,960 B (201.832 GiB)
          753.9B params | sparse MoE NOT supported | BLOCKER: sparse-MoE fusion
UD-IQ1_M: glm-dsa -> glm_moe_dsa | 6 shards | 228,492,966,624 B (212.801 GiB)
          753.9B params | sparse MoE NOT supported | BLOCKER: sparse-MoE fusion
```
(Sizes match the task facts exactly; no tensor payloads downloaded.)

## Tests
New synthetic split-set fixtures (built with `GGUFWriter(split_max_tensors=N)`): happy 2/3 shards with tensors split across files, order independence, directory open, discovery confinement, missing/duplicate/mixed-metadata/duplicate-tensor/corrupt-offset/truncated/checksum-mismatch rejection, offset/alignment, **bounded-memory** (`tracemalloc`) instrumentation, deterministic manifest/checksums, **IQ1 native block byte-for-byte preservation**; arch-bridge valid/invalid; **sparse-MoE honesty rejection**; metadata-only preflight (local + faked Hub asserting no download). Existing single-file GGUF behaviour unchanged.

`423 passed` (full `integrations/gguf/` suite + `_flags_test.py`); `ruff check` + `ruff format` clean.

## Not in scope / next slice
No full-size performance claim and no dense-all-expert success. The exact next slice is a **sparse IQ-block `BlockQuantizedMoE` fusion** (top-k gather over native-block expert weights) so IQ1 routed experts stop lowering to per-expert dense `BlockQuantizedMatMul`.

⚠️ Do not merge without explicit approval; requires independent review (excluding Batty).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>