### PR TITLE
Add pinned GGUF mmproj capability registry

### DIFF
--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -483,6 +483,105 @@ upstream cohort, so an unsupported input is never mistaken for a broken one.
 `clip` files are multimodal projector sidecars: pass them as
 `build_from_gguf(text_gguf, mmproj=...)` rather than on their own.
 
+### Multimodal projector sidecars
+
+Projector support is pinned to llama.cpp
+`8d9af256337d1a501250f9bbf4c0859a654bddd6`. The enum has 62 entries:
+60 serialized strings below, one unserialized `MLP_NORM` compatibility entry,
+and `UNKNOWN`. `clip` has vision, audio, and generated-audio presence flags;
+there is no text-encoder presence key at this pin.
+
+Only `gemma4v` and `muse-glimmer` currently pass metadata, suffix-exact tensor
+closure, target-pairing, graph, and component-parity gates. `gemma4a` remains
+deferred: the real sidecar contains `a.pre_encode.*` tensors that the partial
+mapping does not consume. A sidecar may contain that audio tower alongside a
+supported `gemma4v` tower, but requesting an audio graph fails before graph
+construction. Packed projector tensors are rejected; supported encoder and
+projector weights must be F32, F16, or BF16, and Gemma4 clipping bounds must be
+F32. Unknown `.scale`/`.input_scale` tensors and out-of-closure weights are
+errors rather than silently dropped.
+
+<!-- BEGIN GGUF MMPROJ SUPPORT MATRIX (generated; see _mmproj_registry.py) -->
+
+| Projector string | Modality | Paired text architecture | Status | Limitation |
+|---|---|---|---|---|
+| `mlp` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | LLaVA MLP topology and class-token feature selection are not implemented by the GGUF builder. |
+| `ldp` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | MobileVLM LDP convolutional projector semantics are not implemented. |
+| `ldpv2` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | MobileVLM LDPv2 pooling/projector semantics are not implemented. |
+| `resampler` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | MiniCPM-V query resampler and positional interpolation are not implemented. |
+| `adapter` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | GLM-Edge adapter tensor closure and graph are not implemented. |
+| `qwen2vl_merger` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | The existing HF Qwen2-VL graph is not wired to the pinned GGUF merger ABI. |
+| `qwen2.5vl_merger` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | The Qwen2.5-VL merger/window ordering has no GGUF tensor-closure parity test. |
+| `qwen3vl_merger` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | The Qwen3-VL merger/window ordering has no GGUF tensor-closure parity test. |
+| `step3vl` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Step3-VL vision and projector graph are not implemented. |
+| `gemma3` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Gemma3 mmproj feature selection and projector tensor map are not implemented. |
+| `gemma3nv` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Gemma3n vision sidecar routing is not implemented. |
+| `gemma3na` | audio | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Gemma3n audio sidecar routing is not implemented. |
+| `gemma4v` | vision | `gemma4` | supported | Exact registry-backed graph, tensor closure, target pairing, and component parity. |
+| `gemma4a` | audio | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | The sidecar carries a.pre_encode tensors that the current audio map drops, and independent Conformer parity is not established. |
+| `gemma4uv` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Encoder-free unified Gemma4 vision sidecars use a different patch embedder contract. |
+| `gemma4ua` | audio | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Encoder-free unified Gemma4 waveform embedding is not wired to GGUF. |
+| `phi4` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | The Phi-4 vision projector exists for HF weights but has no pinned GGUF tensor closure. |
+| `idefics3` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Idefics3 pixel-shuffle projector GGUF routing is not implemented. |
+| `pixtral` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | The Pixtral component has no pinned mmproj tensor mapping or positional-interpolation parity. |
+| `ultravox` | audio | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Whisper encoder plus Ultravox stack projector is not implemented. |
+| `internvl` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | InternVL pixel-shuffle token ordering is not implemented for GGUF. |
+| `llama4` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Llama4 vision encoder and multimodal target package are out of scope. |
+| `qwen2a` | audio | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Qwen2 audio encoder/projector is not implemented. |
+| `qwen3a` | audio | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Qwen3 audio encoder/projector is not implemented. |
+| `glma` | audio | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | GLM audio encoder/projector is not implemented. |
+| `qwen2.5o` | audio, vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | This legacy string changes meaning by modality; accepting it would create a false alias. |
+| `voxtral` | audio | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Voxtral Whisper encoder/projector is not implemented. |
+| `meralion` | audio | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Meralion audio projector is not implemented. |
+| `musicflamingo` | audio | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Music Flamingo audio projector is not implemented. |
+| `lfm2` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | The existing LFM2-VL HF graph has no pinned mmproj tensor closure or component parity. |
+| `kimivl` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Kimi-VL vision/projector graph is not implemented. |
+| `paddleocr` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | PaddleOCR vision/projector graph is not implemented. |
+| `lightonocr` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | LightOnOCR Pixtral variant has no exact tensor mapping. |
+| `cogvlm` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | CogVLM feature output differs from LLaVA and is not implemented. |
+| `janus_pro` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Janus-Pro vision/projector graph is not implemented. |
+| `dots_ocr` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | DotsOCR vision merger is not implemented. |
+| `dots3note_v` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Dots3Note vision pyramid MoE is not implemented. |
+| `dots3note_a` | audio | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Dots3Note audio graph is not implemented. |
+| `deepseekocr` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | DeepSeek-OCR SAM/projector graph is not implemented. |
+| `deepseekocr2` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | DeepSeek-OCR2 SAM/projector graph is not implemented. |
+| `lfm2a` | audio | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | LFM2 conformer audio graph has no GGUF tensor mapping. |
+| `glm4v` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | GLM4V downsampler and projector are not implemented. |
+| `youtuvl` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | YouTu-VL vision/projector graph is not implemented. |
+| `yasa2` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | YASA2 vision/projector graph is not implemented. |
+| `kimik25` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Kimi K2.5 vision/projector graph is not implemented. |
+| `nemotron_v2_vl` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Nemotron V2 VL vision/projector graph is not implemented. |
+| `exaone4_5` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | EXAONE 4.5 vision merger is not implemented. |
+| `hunyuanvl` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | HunyuanVL vision/projector graph is not implemented. |
+| `minicpmv4_6` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | MiniCPM-V 4.6 SAM/resampler graph is not implemented. |
+| `granite_speech` | audio | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Granite Speech audio encoder/projector is not implemented. |
+| `mimovl` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | MiMo-VL vision/projector graph is not implemented. |
+| `minimax_m3` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | MiniMax M3 vision/projector graph is not implemented. |
+| `granite4_vision` | vision | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Granite 4 vision sidecar graph is not implemented. |
+| `mimo_audio` | audio | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | MiMo audio RVQ/local-transformer graph is not implemented. |
+| `parakeet` | audio | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Parakeet audio encoder graph is not implemented. |
+| `qwen3tts_spkenc` | audio | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | Qwen3-TTS speaker encoder graph is not implemented. |
+| `qwen3tts_gen` | gen.audio | — | metadata rejected; tensor_map rejected; graph rejected; runtime rejected | Generated-audio decoder sidecars are not multimodal projectors and cannot be paired with a text target package. |
+| `pockettts_spkenc` | audio | — | metadata deferred; tensor_map deferred; graph deferred; runtime deferred | PocketTTS speaker encoder graph is not implemented. |
+| `pockettts_gen` | gen.audio | — | metadata rejected; tensor_map rejected; graph rejected; runtime rejected | Generated-audio decoder sidecars are not multimodal projectors and cannot be paired with a text target package. |
+| `muse-glimmer` | vision | `muse-glimmer` | supported | Exact registry-backed graph, tensor closure, target pairing, and component parity. |
+
+<!-- END GGUF MMPROJ SUPPORT MATRIX -->
+
+Real-artifact audit pins:
+
+| Family | Revision and file | Size | LFS SHA-256 | Metadata/tensor qtypes | Paired text target |
+|---|---|---:|---|---|---|
+| Gemma4 | `unsloth/gemma-4-E2B-it-GGUF@0314792d7f1f7e229411f620751375812bb9faf2`<br>`mmproj-F16.gguf` | 985,654,080 | `337ee849e80b6169ce9d1d573d424fc1653bcafa5f0cb0cbb901beba54f4b41c` | `gemma4v` + deferred `gemma4a`; 1,163 F32 + 248 F16 tensors; vision 768→1536, audio 1024→1536 | `gemma-4-E2B-it-Q4_K_M.gguf` (`gemma4`) |
+| Muse Glimmer | `unsloth/Muse-Glimmer-30B-GGUF@faa5b025c584459c13febfa5c59883516710ae39`<br>`mmproj-Muse-Glimmer-30B-BF16.gguf` | 3,849,173,728 | `7aa788cfe25ae5e4bf4837511f64df22cabe595e58223708274a67b3136f53ab` | `muse-glimmer`; 506 F32 + 303 BF16 tensors; vision 1536, merge 2, projection 6656 | `Muse-Glimmer-30B-Q4_K_M.gguf` (`muse-glimmer`) |
+
+The Gemma4 processor contract uses tokenizer token `<|image|>` (ID 258880 in
+the audited paired GGUF) and 3×3 spatial pooling. The sidecar's image mean/std
+are metadata for preprocessing; the ONNX vision graph consumes already
+patchified `pixel_values` plus `pixel_position_ids`. Runtime callers must
+generate those inputs in the same patch order. Mobius does not currently emit
+an image-processor asset from GGUF metadata.
+
 Sharded GGUF files are rejected. A single shard has only part of the tensor
 table, and treating it as a complete checkpoint would create a corrupt model.
 

--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -573,14 +573,28 @@ Real-artifact audit pins:
 | Family | Revision and file | Size | LFS SHA-256 | Metadata/tensor qtypes | Paired text target |
 |---|---|---:|---|---|---|
 | Gemma4 | `unsloth/gemma-4-E2B-it-GGUF@0314792d7f1f7e229411f620751375812bb9faf2`<br>`mmproj-F16.gguf` | 985,654,080 | `337ee849e80b6169ce9d1d573d424fc1653bcafa5f0cb0cbb901beba54f4b41c` | `gemma4v` + deferred `gemma4a`; 1,163 F32 + 248 F16 tensors; vision 768→1536, audio 1024→1536 | `gemma-4-E2B-it-Q4_K_M.gguf` (`gemma4`) |
-| Muse Glimmer | `unsloth/Muse-Glimmer-30B-GGUF@faa5b025c584459c13febfa5c59883516710ae39`<br>`mmproj-Muse-Glimmer-30B-BF16.gguf` | 3,849,173,728 | `7aa788cfe25ae5e4bf4837511f64df22cabe595e58223708274a67b3136f53ab` | `muse-glimmer`; 506 F32 + 303 BF16 tensors; vision 1536, merge 2, projection 6656 | `Muse-Glimmer-30B-Q4_K_M.gguf` (`muse-glimmer`) |
+| Muse Glimmer | `unsloth/Muse-Glimmer-30B-GGUF@faa5b025c584459c13febfa5c59883516710ae39`<br>`mmproj-Muse-Glimmer-30B-BF16.gguf` | 3,849,173,728 | `7aa788cfe25ae5e4bf4837511f64df22cabe595e58223708274a67b3136f53ab` | `muse-glimmer`; 506 F32 + 303 BF16 tensors; vision 1536, merge 2, projection 6656 | `Muse-Glimmer-30B-UD-Q4_K_XL.gguf` (`muse-glimmer`) |
 
 The Gemma4 processor contract uses tokenizer token `<|image|>` (ID 258880 in
 the audited paired GGUF) and 3×3 spatial pooling. The sidecar's image mean/std
 are metadata for preprocessing; the ONNX vision graph consumes already
 patchified `pixel_values` plus `pixel_position_ids`. Runtime callers must
 generate those inputs in the same patch order. Mobius does not currently emit
-an image-processor asset from GGUF metadata.
+an image-processor asset from GGUF metadata. The Gemma4 vision graph has an
+explicit single-image batch contract (`pixel_values[1, N, ...]` and
+`pixel_position_ids[1, N, 2]`): each image can produce a different number of
+pooled tokens, and the current flattened output has no row-splits output with
+which to represent those variable counts. Process multiple images separately
+and concatenate their feature rows in prompt media order.
+
+Pairing is fail-closed and independent of local filenames. Both GGUF files must
+carry matching non-empty `general.name` values. If either file declares
+`general.base_model.0.name` or `general.base_model.0.repo_url`, the other must
+declare the same normalized binding. Architecture and matching tensor dimensions
+alone are not accepted as source identity. The validator also inventories every
+sidecar tensor: Gemma4's exact deferred `gemma4a` companion closure is allowed
+when declared, but unknown top-level names, near-miss prefixes/suffixes, ranks,
+and packed projector tensors are rejected before graph construction.
 
 Sharded GGUF files are rejected. A single shard has only part of the tensor
 table, and treating it as a complete checkpoint would create a corrupt model.

--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -590,11 +590,18 @@ and concatenate their feature rows in prompt media order.
 Pairing is fail-closed and independent of local filenames. Both GGUF files must
 carry matching non-empty `general.name` values. If either file declares
 `general.base_model.0.name` or `general.base_model.0.repo_url`, the other must
-declare the same normalized binding. Architecture and matching tensor dimensions
-alone are not accepted as source identity. The validator also inventories every
-sidecar tensor: Gemma4's exact deferred `gemma4a` companion closure is allowed
-when declared, but unknown top-level names, near-miss prefixes/suffixes, ranks,
-and packed projector tensors are rejected before graph construction.
+declare the same non-empty binding. Canonicalization is conservative: casing,
+outer whitespace, URL host syntax, a trailing slash, and a trailing `.git` are
+normalized, but meaningful name and path separators are preserved. Architecture
+and matching tensor dimensions alone are not accepted as source identity. The
+validator also inventories every sidecar tensor: Gemma4's exact deferred
+`gemma4a` companion closure is allowed only with all pinned active-audio
+metadata (including a positive integer `clip.audio.num_mel_bins`), but unknown
+top-level names, near-miss prefixes/suffixes, ranks, and packed projector
+tensors are rejected before graph construction. Gemma4 vision specifically
+requires an RGB Conv2d patch weight shaped `[hidden, 3, patch, patch]`; rank-5
+patch weights remain valid only for supported topologies whose graphs consume
+temporal patches.
 
 Sharded GGUF files are rejected. A single shard has only part of the tensor
 table, and treating it as a complete checkpoint would create a corrupt model.

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -700,6 +700,11 @@ def _raise_for_unsupported_auxiliary_quantization(gguf_model) -> None:
     from mobius.integrations.gguf._tensor_mapping import map_gguf_to_hf_names
 
     architecture = gguf_model.architecture
+    if architecture == MMPROJ_ARCHITECTURE:
+        # The mmproj registry validates role-specific tensor closure. Running
+        # text tensor mapping here would misclassify clip sidecars as standalone
+        # language models before the more actionable projector error can fire.
+        return
     expert_count = gguf_model.get_metadata(f"{architecture}.expert_count")
     block_count = int(gguf_model.get_metadata(f"{architecture}.block_count", 0))
     mtp_count = int(gguf_model.get_metadata(f"{architecture}.nextn_predict_layers", 0))

--- a/src/mobius/integrations/gguf/_mmproj.py
+++ b/src/mobius/integrations/gguf/_mmproj.py
@@ -292,58 +292,155 @@ def _normalized_identity(value: object) -> str:
     return "".join(character for character in str(value).lower() if character.isalnum())
 
 
+def _normalized_repository(value: object) -> str:
+    repository = str(value).strip().lower().rstrip("/")
+    if repository.endswith(".git"):
+        repository = repository[:-4]
+    for prefix in ("https://", "http://", "hf://"):
+        if repository.startswith(prefix):
+            repository = repository[len(prefix) :]
+            break
+    return repository
+
+
 def _validate_mmproj_source_identity(text_gguf: Any, mmproj_gguf: Any) -> None:
-    """Reject a sidecar whose declared base model contradicts the text GGUF."""
-    text_name = text_gguf.metadata.get("general.name")
-    sidecar_base = mmproj_gguf.metadata.get("general.base_model.0.name")
-    if text_name and sidecar_base:
-        text_identity = _normalized_identity(text_name)
-        sidecar_identity = _normalized_identity(sidecar_base)
-        if text_identity != sidecar_identity:
+    """Require stable name and repository bindings independent of file location."""
+    bindings: tuple[tuple[str, Callable[[object], str]], ...] = (
+        ("general.name", _normalized_identity),
+        ("general.base_model.0.name", _normalized_identity),
+        ("general.base_model.0.repo_url", _normalized_repository),
+    )
+    for key, normalize in bindings:
+        text_value = text_gguf.metadata.get(key)
+        sidecar_value = mmproj_gguf.metadata.get(key)
+        if key == "general.name" and (not text_value or not sidecar_value):
+            raise ValueError(
+                "Cannot establish a trusted text/mmproj pairing: both files must declare "
+                "non-empty general.name metadata."
+            )
+        if bool(text_value) != bool(sidecar_value):
+            raise ValueError(
+                "Cannot establish a trusted text/mmproj pairing: identity binding "
+                f"{key!r} is present on only one file."
+            )
+        if text_value and sidecar_value and normalize(text_value) != normalize(sidecar_value):
             raise ValueError(
                 "mmproj source identity does not match the text GGUF: "
-                f"general.base_model.0.name={sidecar_base!r}, "
-                f"text general.name={text_name!r}."
+                f"{key} is {sidecar_value!r} on the sidecar and {text_value!r} "
+                "on the text model."
             )
     general_type = mmproj_gguf.metadata.get("general.type")
     if general_type not in (None, "mmproj"):
         raise ValueError(f"clip sidecar general.type must be 'mmproj', got {general_type!r}.")
 
 
-def _mmproj_tensor_names_for_spec(mmproj_gguf: Any, spec: ProjectorSpec) -> set[str]:
-    prefixes = tuple({role_prefix for role_prefix, _ in spec.tensor_roles})
-    return {
-        name
-        for name in mmproj_gguf.tensor_names
-        if name.startswith(prefixes)
-        or name in spec.required_top_tensors
-        or name in spec.optional_top_tensors
-    }
-
-
-def _validate_mmproj_tensor_closure(mmproj_gguf: Any, spec: ProjectorSpec) -> None:
-    """Validate exact names, layers, shapes, and float storage before graph build."""
-    names = _mmproj_tensor_names_for_spec(mmproj_gguf, spec)
-    top = set(spec.required_top_tensors) | set(spec.optional_top_tensors)
-    block_names: dict[int, set[str]] = {}
-    unexpected: list[str] = []
-    prefix = spec.block_prefix
+def _collect_block_tensors(
+    names: set[str],
+    *,
+    prefix: str,
+    suffixes: tuple[str, ...],
+) -> tuple[dict[int, set[str]], set[str]]:
+    blocks: dict[int, set[str]] = {}
+    matched: set[str] = set()
+    allowed_suffixes = set(suffixes)
     for name in names:
-        if name in top:
-            continue
-        if prefix is None or not name.startswith(prefix):
-            unexpected.append(name)
+        if not name.startswith(prefix):
             continue
         remainder = name[len(prefix) :]
         index_text, separator, suffix = remainder.partition(".")
-        if not separator or not index_text.isdecimal() or suffix not in spec.block_suffixes:
-            unexpected.append(name)
+        if separator and index_text.isdecimal() and suffix in allowed_suffixes:
+            blocks.setdefault(int(index_text), set()).add(suffix)
+            matched.add(name)
+    return blocks, matched
+
+
+def _validate_block_tensor_set(
+    *,
+    projector_type: str,
+    modality: MMProjModality,
+    blocks: dict[int, set[str]],
+    block_count: int,
+    required_suffixes: tuple[str, ...],
+) -> None:
+    expected_layers = set(range(block_count))
+    if set(blocks) != expected_layers:
+        raise ValueError(
+            f"{projector_type} {modality.value} block indices are "
+            f"{sorted(blocks)}, expected {sorted(expected_layers)}."
+        )
+    required = set(required_suffixes)
+    missing = {
+        layer: sorted(required - blocks[layer])
+        for layer in sorted(blocks)
+        if required - blocks[layer]
+    }
+    if missing:
+        raise ValueError(
+            f"{projector_type} mmproj is missing required {modality.value} block "
+            f"suffixes: {missing}"
+        )
+
+
+def _validate_mmproj_tensor_closure(mmproj_gguf: Any, spec: ProjectorSpec) -> None:
+    """Validate the complete sidecar inventory, including deferred companions."""
+    names = set(mmproj_gguf.tensor_names)
+    top = set(spec.required_top_tensors) | set(spec.optional_top_tensors)
+    block_names, matched = _collect_block_tensors(
+        names,
+        prefix=spec.block_prefix or "",
+        suffixes=spec.block_suffixes,
+    )
+    matched.update(top & names)
+
+    active_companions = []
+    for companion in spec.companion_tensors:
+        presence_key = f"clip.has_{companion.modality.value.replace('.', '_')}_encoder"
+        if not mmproj_gguf.metadata.get(presence_key):
             continue
-        block_names.setdefault(int(index_text), set()).add(suffix)
+        actual_type = projector_type_for_modality(mmproj_gguf.metadata, companion.modality)
+        if actual_type != companion.projector_type:
+            raise ValueError(
+                f"{spec.projector_type} sidecar declares companion "
+                f"{companion.modality.value} projector {actual_type!r}, expected "
+                f"{companion.projector_type!r}."
+            )
+        missing_metadata = [
+            key for key in companion.required_metadata if key not in mmproj_gguf.metadata
+        ]
+        if missing_metadata:
+            raise ValueError(
+                f"{companion.projector_type} companion is missing required metadata: "
+                f"{missing_metadata}"
+            )
+        companion_top = set(companion.required_top_tensors)
+        companion_blocks, companion_matched = _collect_block_tensors(
+            names,
+            prefix=companion.block_prefix,
+            suffixes=companion.block_suffixes,
+        )
+        missing_top = sorted(companion_top - names)
+        if missing_top:
+            raise ValueError(
+                f"{companion.projector_type} companion is missing required tensor(s): "
+                f"{missing_top}"
+            )
+        block_count_key = f"clip.{companion.modality.value}.block_count"
+        _validate_block_tensor_set(
+            projector_type=companion.projector_type,
+            modality=companion.modality,
+            blocks=companion_blocks,
+            block_count=int(mmproj_gguf.metadata[block_count_key]),
+            required_suffixes=companion.block_suffixes,
+        )
+        matched.update(companion_top & names)
+        matched.update(companion_matched)
+        active_companions.append(companion)
+
+    unexpected = sorted(names - matched)
     if unexpected:
         raise ValueError(
             f"{spec.projector_type} mmproj has tensors outside the pinned suffix-exact "
-            f"loader closure: {sorted(unexpected)}. Projector tensors are never dropped."
+            f"loader closure: {unexpected}. Projector tensors are never dropped."
         )
 
     missing_top = sorted(set(spec.required_top_tensors) - names)
@@ -352,23 +449,13 @@ def _validate_mmproj_tensor_closure(mmproj_gguf: Any, spec: ProjectorSpec) -> No
             f"{spec.projector_type} mmproj is missing required tensor(s): {missing_top}"
         )
     layers = int(mmproj_gguf.metadata["clip.vision.block_count"])
-    expected_layers = set(range(layers))
-    if set(block_names) != expected_layers:
-        raise ValueError(
-            f"{spec.projector_type} mmproj block indices are "
-            f"{sorted(block_names)}, expected {sorted(expected_layers)}."
-        )
-    required_suffixes = set(spec.block_suffixes)
-    missing_by_layer = {
-        layer: sorted(required_suffixes - block_names[layer])
-        for layer in sorted(block_names)
-        if required_suffixes - block_names[layer]
-    }
-    if missing_by_layer:
-        raise ValueError(
-            f"{spec.projector_type} mmproj is missing required block suffixes: "
-            f"{missing_by_layer}"
-        )
+    _validate_block_tensor_set(
+        projector_type=spec.projector_type,
+        modality=MMProjModality.VISION,
+        blocks=block_names,
+        block_count=layers,
+        required_suffixes=spec.block_suffixes,
+    )
 
     for name in sorted(names):
         qtype = mmproj_gguf.get_tensor_type(name).name
@@ -385,12 +472,82 @@ def _validate_mmproj_tensor_closure(mmproj_gguf: Any, spec: ProjectorSpec) -> No
             )
 
     _validate_supported_mmproj_shapes(mmproj_gguf, spec)
+    for companion in active_companions:
+        if companion.projector_type == "gemma4a":
+            _validate_gemma4_audio_companion_shapes(mmproj_gguf, companion)
 
 
 def _expect_mmproj_shape(mmproj_gguf: Any, name: str, expected: tuple[int, ...]) -> None:
     actual = mmproj_gguf.get_tensor_shape(name)
     if actual != expected:
         raise ValueError(f"mmproj tensor {name!r} has shape {actual}, expected {expected}.")
+
+
+def _validate_gemma4_audio_companion_shapes(mmproj_gguf: Any, companion: Any) -> None:
+    """Validate the deferred Gemma4 audio inventory without claiming graph support."""
+    md = mmproj_gguf.metadata
+    hidden = int(md["clip.audio.embedding_length"])
+    intermediate = int(md["clip.audio.feed_forward_length"])
+    layers = int(md["clip.audio.block_count"])
+    heads = int(md["clip.audio.attention.head_count"])
+    projection = int(md["clip.audio.projection_dim"])
+    if hidden <= 0 or heads <= 0 or hidden % heads:
+        raise ValueError(
+            "gemma4a audio hidden/head dimensions are invalid: "
+            f"embedding_length={hidden}, head_count={heads}."
+        )
+    head_dim = hidden // heads
+
+    conv0_shape = mmproj_gguf.get_tensor_shape("a.conv1d.0.weight")
+    if len(conv0_shape) != 4 or conv0_shape[1:] != (1, 3, 3):
+        raise ValueError(
+            f"a.conv1d.0.weight must have shape [channels, 1, 3, 3], got {conv0_shape}."
+        )
+    conv1_shape = mmproj_gguf.get_tensor_shape("a.conv1d.1.weight")
+    if len(conv1_shape) != 4 or conv1_shape[1:] != (conv0_shape[0], 3, 3):
+        raise ValueError(
+            "a.conv1d.1.weight must have shape [channels, conv0_channels, 3, 3], "
+            f"got {conv1_shape}."
+        )
+    _expect_mmproj_shape(mmproj_gguf, "a.conv1d.0.norm.weight", (conv0_shape[0],))
+    _expect_mmproj_shape(mmproj_gguf, "a.conv1d.1.norm.weight", (conv1_shape[0],))
+    _expect_mmproj_shape(mmproj_gguf, "a.input_projection.weight", (hidden, hidden))
+    _expect_mmproj_shape(mmproj_gguf, "a.pre_encode.out.weight", (projection, hidden))
+    _expect_mmproj_shape(mmproj_gguf, "a.pre_encode.out.bias", (projection,))
+    _expect_mmproj_shape(mmproj_gguf, "mm.a.input_projection.weight", (projection, projection))
+
+    matrix_shapes = {
+        "attn_q.weight": (hidden, hidden),
+        "attn_k.weight": (hidden, hidden),
+        "attn_v.weight": (hidden, hidden),
+        "attn_out.weight": (hidden, hidden),
+        "attn_k_rel.weight": (hidden, hidden),
+        "conv_pw1.weight": (2 * hidden, hidden),
+        "conv_dw.weight": (hidden, 5),
+        "conv_pw2.weight": (hidden, hidden),
+        "ffn_up.weight": (intermediate, hidden),
+        "ffn_down.weight": (hidden, intermediate),
+        "ffn_up_1.weight": (intermediate, hidden),
+        "ffn_down_1.weight": (hidden, intermediate),
+    }
+    vector_shapes = {
+        "ffn_norm.weight": (hidden,),
+        "ffn_post_norm.weight": (hidden,),
+        "ffn_norm_1.weight": (hidden,),
+        "ffn_post_norm_1.weight": (hidden,),
+        "attn_pre_norm.weight": (hidden,),
+        "attn_post_norm.weight": (hidden,),
+        "ln2.weight": (hidden,),
+        "norm_conv.weight": (hidden,),
+        "per_dim_scale.weight": (head_dim,),
+    }
+    for layer in range(layers):
+        prefix = f"{companion.block_prefix}{layer}."
+        for suffix, shape in (*matrix_shapes.items(), *vector_shapes.items()):
+            _expect_mmproj_shape(mmproj_gguf, prefix + suffix, shape)
+        for suffix in companion.block_suffixes:
+            if suffix.endswith(_CLIPPING_BOUND_SUFFIXES):
+                _expect_mmproj_shape(mmproj_gguf, prefix + suffix, (1,))
 
 
 def _validate_supported_mmproj_shapes(mmproj_gguf: Any, spec: ProjectorSpec) -> None:

--- a/src/mobius/integrations/gguf/_mmproj.py
+++ b/src/mobius/integrations/gguf/_mmproj.py
@@ -51,6 +51,14 @@ import numpy as np
 
 from mobius._model_package import ModelPackage
 from mobius.integrations.gguf._arch_registry import MMPROJ_ARCHITECTURE
+from mobius.integrations.gguf._mmproj_registry import (
+    LLAMA_CPP_MMPROJ_SHA,
+    MMProjModality,
+    ProjectorSpec,
+    get_projector_spec,
+    projector_type_for_modality,
+)
+from mobius.integrations.gguf._spec import Support
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +67,7 @@ logger = logging.getLogger(__name__)
 _GEMMA4_VISION_ROPE_THETA = 100.0
 # Gemma4 vision pooler spatial average pooling kernel (k x k). Not present in
 # mmproj metadata; the SigLIP encoder pools N patches to N/k^2 soft tokens.
-_DEFAULT_POOLING_KERNEL_SIZE = 4
+_DEFAULT_POOLING_KERNEL_SIZE = 3
 
 # Muse Glimmer's vision tower uses ordinary 2D RoPE. The mmproj stores no
 # rope.freq_base, so use the published vision config value.
@@ -218,9 +226,9 @@ def read_mmproj_vision_config(gguf_model: Any):
         image_size=int(md["clip.vision.image_size"]),
         patch_size=int(md["clip.vision.patch_size"]),
         norm_eps=float(md.get("clip.vision.attention.layer_norm_epsilon", 1e-6)),
-        # The mmproj carries activation-range stats, not clipped-linear weights,
-        # so the encoder uses plain (non-clipped) Linear layers.
-        use_clipped_linears=False,
+        # The F16 Gemma4 sidecar carries learned activation bounds for every
+        # attention/MLP projection; they are part of ClippableLinear semantics.
+        use_clipped_linears=True,
         position_embedding_size=pos_emb_size,
         pooling_kernel_size=_DEFAULT_POOLING_KERNEL_SIZE,
         hidden_act="gelu_pytorch_tanh",
@@ -267,6 +275,332 @@ def _resolve_local_path(path: str | Path) -> str:
     from mobius.integrations.gguf._builder import _resolve_gguf_path
 
     return _resolve_gguf_path(path)
+
+
+_CLIPPING_BOUND_SUFFIXES = (".input_min", ".input_max", ".output_min", ".output_max")
+_FLOAT_MMPROJ_QTYPES = frozenset({"F32", "F16", "BF16"})
+
+
+def _canonical_text_architecture(architecture: str) -> str:
+    from mobius.integrations.gguf._arch_registry import try_get_arch_spec
+
+    arch_spec = try_get_arch_spec(architecture)
+    return architecture if arch_spec is None else arch_spec.gguf_arch
+
+
+def _normalized_identity(value: object) -> str:
+    return "".join(character for character in str(value).lower() if character.isalnum())
+
+
+def _validate_mmproj_source_identity(text_gguf: Any, mmproj_gguf: Any) -> None:
+    """Reject a sidecar whose declared base model contradicts the text GGUF."""
+    text_name = text_gguf.metadata.get("general.name")
+    sidecar_base = mmproj_gguf.metadata.get("general.base_model.0.name")
+    if text_name and sidecar_base:
+        text_identity = _normalized_identity(text_name)
+        sidecar_identity = _normalized_identity(sidecar_base)
+        if text_identity != sidecar_identity:
+            raise ValueError(
+                "mmproj source identity does not match the text GGUF: "
+                f"general.base_model.0.name={sidecar_base!r}, "
+                f"text general.name={text_name!r}."
+            )
+    general_type = mmproj_gguf.metadata.get("general.type")
+    if general_type not in (None, "mmproj"):
+        raise ValueError(f"clip sidecar general.type must be 'mmproj', got {general_type!r}.")
+
+
+def _mmproj_tensor_names_for_spec(mmproj_gguf: Any, spec: ProjectorSpec) -> set[str]:
+    prefixes = tuple({role_prefix for role_prefix, _ in spec.tensor_roles})
+    return {
+        name
+        for name in mmproj_gguf.tensor_names
+        if name.startswith(prefixes)
+        or name in spec.required_top_tensors
+        or name in spec.optional_top_tensors
+    }
+
+
+def _validate_mmproj_tensor_closure(mmproj_gguf: Any, spec: ProjectorSpec) -> None:
+    """Validate exact names, layers, shapes, and float storage before graph build."""
+    names = _mmproj_tensor_names_for_spec(mmproj_gguf, spec)
+    top = set(spec.required_top_tensors) | set(spec.optional_top_tensors)
+    block_names: dict[int, set[str]] = {}
+    unexpected: list[str] = []
+    prefix = spec.block_prefix
+    for name in names:
+        if name in top:
+            continue
+        if prefix is None or not name.startswith(prefix):
+            unexpected.append(name)
+            continue
+        remainder = name[len(prefix) :]
+        index_text, separator, suffix = remainder.partition(".")
+        if not separator or not index_text.isdecimal() or suffix not in spec.block_suffixes:
+            unexpected.append(name)
+            continue
+        block_names.setdefault(int(index_text), set()).add(suffix)
+    if unexpected:
+        raise ValueError(
+            f"{spec.projector_type} mmproj has tensors outside the pinned suffix-exact "
+            f"loader closure: {sorted(unexpected)}. Projector tensors are never dropped."
+        )
+
+    missing_top = sorted(set(spec.required_top_tensors) - names)
+    if missing_top:
+        raise ValueError(
+            f"{spec.projector_type} mmproj is missing required tensor(s): {missing_top}"
+        )
+    layers = int(mmproj_gguf.metadata["clip.vision.block_count"])
+    expected_layers = set(range(layers))
+    if set(block_names) != expected_layers:
+        raise ValueError(
+            f"{spec.projector_type} mmproj block indices are "
+            f"{sorted(block_names)}, expected {sorted(expected_layers)}."
+        )
+    required_suffixes = set(spec.block_suffixes)
+    missing_by_layer = {
+        layer: sorted(required_suffixes - block_names[layer])
+        for layer in sorted(block_names)
+        if required_suffixes - block_names[layer]
+    }
+    if missing_by_layer:
+        raise ValueError(
+            f"{spec.projector_type} mmproj is missing required block suffixes: "
+            f"{missing_by_layer}"
+        )
+
+    for name in sorted(names):
+        qtype = mmproj_gguf.get_tensor_type(name).name
+        is_calibration = name.endswith(_CLIPPING_BOUND_SUFFIXES)
+        if is_calibration and qtype != "F32":
+            raise ValueError(
+                f"{name} is a clipping-bound tensor and must be F32, got {qtype}."
+            )
+        if not is_calibration and qtype not in _FLOAT_MMPROJ_QTYPES:
+            raise NotImplementedError(
+                f"{spec.projector_type} mmproj tensor {name!r} uses packed {qtype}. "
+                "Mobius does not preserve packed vision/audio/projector tensors; use "
+                "an F16, BF16, or F32 mmproj so every role is explicitly dequantized."
+            )
+
+    _validate_supported_mmproj_shapes(mmproj_gguf, spec)
+
+
+def _expect_mmproj_shape(mmproj_gguf: Any, name: str, expected: tuple[int, ...]) -> None:
+    actual = mmproj_gguf.get_tensor_shape(name)
+    if actual != expected:
+        raise ValueError(f"mmproj tensor {name!r} has shape {actual}, expected {expected}.")
+
+
+def _validate_supported_mmproj_shapes(mmproj_gguf: Any, spec: ProjectorSpec) -> None:
+    md = mmproj_gguf.metadata
+    hidden = int(md["clip.vision.embedding_length"])
+    intermediate = int(md["clip.vision.feed_forward_length"])
+    layers = int(md["clip.vision.block_count"])
+    heads = int(md["clip.vision.attention.head_count"])
+    patch = int(md["clip.vision.patch_size"])
+    projection = int(md["clip.vision.projection_dim"])
+    if hidden <= 0 or heads <= 0 or hidden % heads:
+        raise ValueError(
+            f"{spec.projector_type} vision hidden/head dimensions are invalid: "
+            f"embedding_length={hidden}, head_count={heads}."
+        )
+
+    patch_shape = mmproj_gguf.get_tensor_shape("v.patch_embd.weight")
+    if len(patch_shape) not in (4, 5) or patch_shape[0] != hidden:
+        raise ValueError(
+            f"v.patch_embd.weight must be rank 4/5 with output {hidden}, got {patch_shape}."
+        )
+    if patch_shape[-2:] != (patch, patch):
+        raise ValueError(
+            f"v.patch_embd.weight spatial kernel {patch_shape[-2:]} does not match "
+            f"clip.vision.patch_size={patch}."
+        )
+
+    if spec.projector_type == "gemma4v":
+        position_shape = mmproj_gguf.get_tensor_shape("v.position_embd.weight")
+        if len(position_shape) != 3 or position_shape[0] != 2 or position_shape[2] != hidden:
+            raise ValueError(
+                "Gemma4 position embeddings must have shape [2, positions, hidden], "
+                f"got {position_shape}."
+            )
+        _expect_mmproj_shape(mmproj_gguf, "mm.input_projection.weight", (projection, hidden))
+        head_dim = hidden // heads
+        shapes = {
+            "ln1.weight": (hidden,),
+            "ln2.weight": (hidden,),
+            "attn_post_norm.weight": (hidden,),
+            "ffn_post_norm.weight": (hidden,),
+            "attn_q.weight": (hidden, hidden),
+            "attn_k.weight": (hidden, hidden),
+            "attn_v.weight": (hidden, hidden),
+            "attn_out.weight": (hidden, hidden),
+            "attn_q_norm.weight": (head_dim,),
+            "attn_k_norm.weight": (head_dim,),
+            "ffn_gate.weight": (intermediate, hidden),
+            "ffn_up.weight": (intermediate, hidden),
+            "ffn_down.weight": (hidden, intermediate),
+        }
+        shapes.update(dict.fromkeys(_CLIPPING_BOUND_SUFFIXES, ()))
+        for layer in range(layers):
+            for suffix, expected in shapes.items():
+                if suffix in _CLIPPING_BOUND_SUFFIXES:
+                    continue
+                _expect_mmproj_shape(mmproj_gguf, f"v.blk.{layer}.{suffix}", expected)
+            for stem in (
+                "attn_q",
+                "attn_k",
+                "attn_v",
+                "attn_out",
+                "ffn_gate",
+                "ffn_up",
+                "ffn_down",
+            ):
+                for bound in ("input_min", "input_max", "output_min", "output_max"):
+                    _expect_mmproj_shape(mmproj_gguf, f"v.blk.{layer}.{stem}.{bound}", (1,))
+        return
+
+    if spec.projector_type == "muse-glimmer":
+        merge = int(md["clip.vision.spatial_merge_size"])
+        position_shape = mmproj_gguf.get_tensor_shape("v.position_embd.weight")
+        if len(position_shape) != 2 or position_shape[1] != hidden:
+            raise ValueError(
+                "Muse Glimmer position embeddings must have shape [positions, hidden], "
+                f"got {position_shape}."
+            )
+        projector_width = mmproj_gguf.get_tensor_shape("mm.0.weight")[0]
+        _expect_mmproj_shape(
+            mmproj_gguf, "mm.0.weight", (projector_width, hidden * merge * merge)
+        )
+        _expect_mmproj_shape(mmproj_gguf, "mm.1.weight", (projector_width, projector_width))
+        _expect_mmproj_shape(mmproj_gguf, "mm.2.weight", (projection, projector_width))
+        for name in ("v.pre_ln.weight", "v.pre_ln.bias", "v.post_ln.weight", "v.post_ln.bias"):
+            _expect_mmproj_shape(mmproj_gguf, name, (hidden,))
+        for layer in range(layers):
+            for stem in ("ln1", "ln2"):
+                for kind in ("weight", "bias"):
+                    _expect_mmproj_shape(
+                        mmproj_gguf, f"v.blk.{layer}.{stem}.{kind}", (hidden,)
+                    )
+            for stem in ("attn_q", "attn_k", "attn_v", "attn_out"):
+                _expect_mmproj_shape(
+                    mmproj_gguf, f"v.blk.{layer}.{stem}.weight", (hidden, hidden)
+                )
+                _expect_mmproj_shape(mmproj_gguf, f"v.blk.{layer}.{stem}.bias", (hidden,))
+            _expect_mmproj_shape(
+                mmproj_gguf, f"v.blk.{layer}.ffn_up.weight", (intermediate, hidden)
+            )
+            _expect_mmproj_shape(mmproj_gguf, f"v.blk.{layer}.ffn_up.bias", (intermediate,))
+            _expect_mmproj_shape(
+                mmproj_gguf, f"v.blk.{layer}.ffn_down.weight", (hidden, intermediate)
+            )
+            _expect_mmproj_shape(mmproj_gguf, f"v.blk.{layer}.ffn_down.bias", (hidden,))
+
+
+def _preflight_mmproj_pair(
+    text_gguf: Any,
+    mmproj_gguf: Any,
+    *,
+    modalities: tuple[MMProjModality, ...],
+) -> dict[MMProjModality, ProjectorSpec]:
+    """Validate the pair and return supported specs before graph construction."""
+    if mmproj_gguf.architecture != MMPROJ_ARCHITECTURE:
+        raise ValueError(
+            f"Expected a {MMPROJ_ARCHITECTURE!r} mmproj GGUF, got architecture "
+            f"{mmproj_gguf.architecture!r}."
+        )
+    _validate_mmproj_source_identity(text_gguf, mmproj_gguf)
+    text_arch = _canonical_text_architecture(text_gguf.architecture)
+    resolved: dict[MMProjModality, ProjectorSpec] = {}
+    for modality in modalities:
+        presence_key = f"clip.has_{modality.value.replace('.', '_')}_encoder"
+        if not mmproj_gguf.metadata.get(presence_key):
+            raise ValueError(
+                f"mmproj GGUF has no {modality.value} encoder ({presence_key} is unset)."
+            )
+        projector_type = projector_type_for_modality(mmproj_gguf.metadata, modality)
+        spec = get_projector_spec(projector_type)
+        if modality not in spec.modalities:
+            raise ValueError(
+                f"Projector {projector_type!r} is not a {modality.value} projector."
+            )
+        if not spec.is_supported:
+            blocked = ", ".join(
+                name
+                for name, verdict in spec.verdicts.items()
+                if verdict is not Support.SUPPORTED
+            )
+            raise NotImplementedError(
+                f"clip projector {projector_type!r} is known at llama.cpp "
+                f"{LLAMA_CPP_MMPROJ_SHA} but is deferred/rejected "
+                f"({blocked} unavailable): {spec.reason}"
+            )
+        if text_arch not in spec.target_architectures:
+            raise ValueError(
+                f"clip projector {projector_type!r} targets "
+                f"{sorted(spec.target_architectures)}, not text architecture "
+                f"{text_gguf.architecture!r}."
+            )
+        missing_metadata = [
+            key for key in spec.required_metadata if key not in mmproj_gguf.metadata
+        ]
+        if missing_metadata:
+            raise ValueError(
+                f"{projector_type} mmproj is missing required metadata: {missing_metadata}"
+            )
+        _validate_mmproj_tensor_closure(mmproj_gguf, spec)
+        resolved[modality] = spec
+    return resolved
+
+
+def _token_id(text_gguf: Any, token: str) -> int | None:
+    tokens = text_gguf.metadata.get("tokenizer.ggml.tokens")
+    if not isinstance(tokens, list):
+        return None
+    try:
+        return tokens.index(token)
+    except ValueError:
+        return None
+
+
+def _validate_projector_output_and_media_tokens(
+    config: Any,
+    text_gguf: Any,
+    mmproj_gguf: Any,
+    *,
+    require_audio: bool = False,
+) -> None:
+    """Validate dimensions and tokenizer-owned media IDs before graph build."""
+    projection = int(mmproj_gguf.metadata["clip.vision.projection_dim"])
+    if projection != int(config.hidden_size):
+        raise ValueError(
+            f"mmproj projection_dim={projection} does not match text hidden_size="
+            f"{config.hidden_size}."
+        )
+    if int(config.vocab_size) <= 0:
+        raise ValueError(f"Text GGUF has invalid vocab_size={config.vocab_size}.")
+    media_ids = {"image": config.image_token_id}
+    if require_audio:
+        audio_projection = int(mmproj_gguf.metadata["clip.audio.projection_dim"])
+        if audio_projection != int(config.hidden_size):
+            raise ValueError(
+                f"audio mmproj projection_dim={audio_projection} does not match text "
+                f"hidden_size={config.hidden_size}."
+            )
+        media_ids["audio"] = config.audio_token_id
+    for modality, token_id in media_ids.items():
+        if token_id is None:
+            raise ValueError(
+                f"The paired text GGUF does not identify its {modality} media token. "
+                f"Embed tokenizer.ggml.tokens with '<|{modality}|>' or pass the "
+                "architecture-specific explicit token id."
+            )
+        if not 0 <= int(token_id) < int(config.vocab_size):
+            raise ValueError(
+                f"{modality}_token_id={token_id} is outside text vocab_size="
+                f"{config.vocab_size}."
+            )
 
 
 # Text-GGUF tensors whose names are not covered by the block ``gemma4`` text
@@ -457,6 +791,8 @@ def _mmproj_vision_to_hf(mmproj_gguf: Any) -> dict:
             # The flattening order (in_ch, kh, kw) row-major matches the
             # pre-patchified pixel_values layout consumed by the encoder.
             values = values.reshape(values.shape[0], -1)
+        elif name.endswith(_CLIPPING_BOUND_SUFFIXES):
+            values = values.reshape(())
         state_dict[hf_name] = torch.from_numpy(values)
     return state_dict
 
@@ -530,11 +866,12 @@ def build_gemma4_vlm_from_gguf(
 
     mmproj_gguf = GGUFModel(_resolve_local_path(mmproj_gguf_path))
     _validate_gguf_model(mmproj_gguf, source=str(mmproj_gguf_path))
-    if mmproj_gguf.architecture != MMPROJ_ARCHITECTURE:
-        raise ValueError(
-            f"Expected a {MMPROJ_ARCHITECTURE!r} mmproj GGUF, got architecture "
-            f"{mmproj_gguf.architecture!r} for {mmproj_gguf_path!r}."
-        )
+    modalities = (
+        (MMProjModality.VISION, MMProjModality.AUDIO)
+        if include_audio
+        else (MMProjModality.VISION,)
+    )
+    _preflight_mmproj_pair(text_gguf, mmproj_gguf, modalities=modalities)
     logger.info("Building Gemma4 VLM from text=%s mmproj=%s", text_gguf_path, mmproj_gguf_path)
 
     # 1. Text config + merged vision/audio sub-configs.
@@ -553,12 +890,24 @@ def build_gemma4_vlm_from_gguf(
         # 3-component (decoder + vision + embedding) multimodal shape.
         config = dataclasses.replace(config, audio=None)
 
-    if image_token_id is not None:
-        config = dataclasses.replace(config, image_token_id=image_token_id)
+    resolved_image_token_id = (
+        image_token_id
+        if image_token_id is not None
+        else config.image_token_id
+        if config.image_token_id is not None
+        else _token_id(text_gguf, "<|image|>")
+    )
+    updates: dict[str, Any] = {"image_token_id": resolved_image_token_id}
+    if include_audio and config.audio_token_id is None:
+        updates["audio_token_id"] = _token_id(text_gguf, "<|audio|>")
+    config = dataclasses.replace(config, **updates)
     if dtype is not None:
         resolved = resolve_dtype(dtype)
         if resolved is not None:
             config = dataclasses.replace(config, dtype=resolved)
+    _validate_projector_output_and_media_tokens(
+        config, text_gguf, mmproj_gguf, require_audio=include_audio
+    )
 
     # 1b. Quantized mode: set the module-global quantization config from the
     # text GGUF BEFORE building so the text graph emits MatMulNBits and, when
@@ -721,11 +1070,7 @@ def build_muse_glimmer_vlm_from_gguf(
 
     mmproj_gguf = GGUFModel(_resolve_local_path(mmproj_gguf_path))
     _validate_gguf_model(mmproj_gguf, source=str(mmproj_gguf_path))
-    if mmproj_gguf.architecture != MMPROJ_ARCHITECTURE:
-        raise ValueError(
-            f"Expected a {MMPROJ_ARCHITECTURE!r} mmproj GGUF, got architecture "
-            f"{mmproj_gguf.architecture!r} for {mmproj_gguf_path!r}."
-        )
+    _preflight_mmproj_pair(text_gguf, mmproj_gguf, modalities=(MMProjModality.VISION,))
     logger.info(
         "Building Muse Glimmer VLM from text=%s mmproj=%s",
         text_gguf_path,
@@ -747,6 +1092,7 @@ def build_muse_glimmer_vlm_from_gguf(
         resolved = resolve_dtype(dtype)
         if resolved is not None:
             config = dataclasses.replace(config, dtype=resolved)
+    _validate_projector_output_and_media_tokens(config, text_gguf, mmproj_gguf)
 
     preserve_quantization = keep_quantized and _has_quantized_weights(text_gguf, text_arch)
     if keep_quantized and not preserve_quantization:
@@ -837,10 +1183,17 @@ def build_vlm_from_gguf(
     The mmproj itself is always ``general.architecture = clip``, so the text
     backbone is what decides how the pair is assembled.
     """
+    from mobius.integrations.gguf._builder import _validate_gguf_model
     from mobius.integrations.gguf._reader import GGUFModel
 
-    text_arch = GGUFModel(_resolve_local_path(text_gguf_path)).architecture
-    builder = _resolve_vlm_builder(text_arch)
+    text_gguf = GGUFModel(_resolve_local_path(text_gguf_path))
+    _validate_gguf_model(text_gguf, source=str(text_gguf_path))
+    mmproj_gguf = GGUFModel(_resolve_local_path(mmproj_gguf_path))
+    _validate_gguf_model(mmproj_gguf, source=str(mmproj_gguf_path))
+    specs = _preflight_mmproj_pair(text_gguf, mmproj_gguf, modalities=(MMProjModality.VISION,))
+    builder = _resolve_vlm_builder(
+        text_gguf.architecture, specs[MMProjModality.VISION].projector_type
+    )
     return builder(
         text_gguf_path,
         mmproj_gguf_path,
@@ -863,17 +1216,32 @@ _VLM_BUILDERS: dict[str, str] = {
 }
 
 
-def _resolve_vlm_builder(text_arch: str) -> Callable[..., ModelPackage]:
-    """Return the multimodal assembly entry point for a text architecture.
-
-    Architectures with no declared ``vlm_builder`` fall back to the Gemma 4
-    assembly, which is the historical default for an unrecognized pairing.
-    """
+def _resolve_vlm_builder(text_arch: str, projector_type: str) -> Callable[..., ModelPackage]:
+    """Resolve dispatch only from an exact supported projector/target pair."""
     from mobius.integrations.gguf._arch_registry import try_get_arch_spec
 
-    spec = try_get_arch_spec(text_arch)
-    name = None if spec is None else spec.vlm_builder
-    attribute = _VLM_BUILDERS.get(name or "", "build_gemma4_vlm_from_gguf")
+    projector_spec = get_projector_spec(projector_type)
+    if not projector_spec.is_supported:
+        raise NotImplementedError(
+            f"clip projector {projector_type!r} cannot build: {projector_spec.reason}"
+        )
+    text_spec = try_get_arch_spec(text_arch)
+    canonical_text_arch = text_arch if text_spec is None else text_spec.gguf_arch
+    if canonical_text_arch not in projector_spec.target_architectures:
+        raise ValueError(
+            f"clip projector {projector_type!r} targets "
+            f"{sorted(projector_spec.target_architectures)}, not {text_arch!r}."
+        )
+    if text_spec is None or text_spec.vlm_builder != projector_spec.builder:
+        raise ValueError(
+            f"Text architecture {text_arch!r} and clip projector "
+            f"{projector_type!r} do not declare the same VLM builder."
+        )
+    attribute = _VLM_BUILDERS.get(projector_spec.builder)
+    if attribute is None:
+        raise RuntimeError(
+            f"Projector registry references unknown VLM builder {projector_spec.builder!r}."
+        )
     builder: Callable[..., ModelPackage] = globals()[attribute]
     return builder
 

--- a/src/mobius/integrations/gguf/_mmproj.py
+++ b/src/mobius/integrations/gguf/_mmproj.py
@@ -46,6 +46,7 @@ import math
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 import numpy as np
 
@@ -289,18 +290,35 @@ def _canonical_text_architecture(architecture: str) -> str:
 
 
 def _normalized_identity(value: object) -> str:
-    return "".join(character for character in str(value).lower() if character.isalnum())
+    if not isinstance(value, str):
+        return ""
+    return value.strip().casefold()
 
 
 def _normalized_repository(value: object) -> str:
-    repository = str(value).strip().lower().rstrip("/")
-    if repository.endswith(".git"):
+    if not isinstance(value, str):
+        return ""
+    repository = value.strip()
+    if not repository:
+        return ""
+    parsed = urlsplit(repository)
+    if parsed.scheme:
+        path = parsed.path.rstrip("/")
+        if path.casefold().endswith(".git"):
+            path = path[:-4]
+        return urlunsplit(
+            (
+                parsed.scheme.casefold(),
+                parsed.netloc.casefold(),
+                path.casefold(),
+                parsed.query,
+                parsed.fragment,
+            )
+        )
+    repository = repository.rstrip("/")
+    if repository.casefold().endswith(".git"):
         repository = repository[:-4]
-    for prefix in ("https://", "http://", "hf://"):
-        if repository.startswith(prefix):
-            repository = repository[len(prefix) :]
-            break
-    return repository
+    return repository.casefold()
 
 
 def _validate_mmproj_source_identity(text_gguf: Any, mmproj_gguf: Any) -> None:
@@ -311,19 +329,30 @@ def _validate_mmproj_source_identity(text_gguf: Any, mmproj_gguf: Any) -> None:
         ("general.base_model.0.repo_url", _normalized_repository),
     )
     for key, normalize in bindings:
-        text_value = text_gguf.metadata.get(key)
-        sidecar_value = mmproj_gguf.metadata.get(key)
-        if key == "general.name" and (not text_value or not sidecar_value):
+        text_present = key in text_gguf.metadata
+        sidecar_present = key in mmproj_gguf.metadata
+        if key == "general.name" and not (text_present and sidecar_present):
             raise ValueError(
                 "Cannot establish a trusted text/mmproj pairing: both files must declare "
                 "non-empty general.name metadata."
             )
-        if bool(text_value) != bool(sidecar_value):
+        if text_present != sidecar_present:
             raise ValueError(
                 "Cannot establish a trusted text/mmproj pairing: identity binding "
                 f"{key!r} is present on only one file."
             )
-        if text_value and sidecar_value and normalize(text_value) != normalize(sidecar_value):
+        if not text_present:
+            continue
+        text_value = text_gguf.metadata[key]
+        sidecar_value = mmproj_gguf.metadata[key]
+        text_identity = normalize(text_value)
+        sidecar_identity = normalize(sidecar_value)
+        if not text_identity or not sidecar_identity:
+            raise ValueError(
+                "Cannot establish a trusted text/mmproj pairing: identity binding "
+                f"{key!r} must be a non-empty string on both files."
+            )
+        if text_identity != sidecar_identity:
             raise ValueError(
                 "mmproj source identity does not match the text GGUF: "
                 f"{key} is {sidecar_value!r} on the sidecar and {text_value!r} "
@@ -381,6 +410,35 @@ def _validate_block_tensor_set(
         )
 
 
+def _validate_gemma4_audio_metadata(metadata: dict[str, Any]) -> None:
+    """Validate every pinned field required by an active Gemma4 audio encoder."""
+    if metadata["clip.has_audio_encoder"] is not True:
+        raise ValueError("clip.has_audio_encoder must be boolean true for gemma4a.")
+    positive_integer_keys = (
+        "clip.audio.embedding_length",
+        "clip.audio.feed_forward_length",
+        "clip.audio.block_count",
+        "clip.audio.projection_dim",
+        "clip.audio.attention.head_count",
+        "clip.audio.num_mel_bins",
+    )
+    for key in positive_integer_keys:
+        value = metadata[key]
+        if isinstance(value, bool) or not isinstance(value, (int, np.integer)) or value <= 0:
+            raise ValueError(f"{key} must be a positive integer, got {value!r}.")
+    epsilon = metadata["clip.audio.attention.layer_norm_epsilon"]
+    if (
+        isinstance(epsilon, bool)
+        or not isinstance(epsilon, (int, float, np.integer, np.floating))
+        or not math.isfinite(float(epsilon))
+        or epsilon <= 0
+    ):
+        raise ValueError(
+            "clip.audio.attention.layer_norm_epsilon must be a positive finite "
+            f"number, got {epsilon!r}."
+        )
+
+
 def _validate_mmproj_tensor_closure(mmproj_gguf: Any, spec: ProjectorSpec) -> None:
     """Validate the complete sidecar inventory, including deferred companions."""
     names = set(mmproj_gguf.tensor_names)
@@ -412,6 +470,8 @@ def _validate_mmproj_tensor_closure(mmproj_gguf: Any, spec: ProjectorSpec) -> No
                 f"{companion.projector_type} companion is missing required metadata: "
                 f"{missing_metadata}"
             )
+        if companion.projector_type == "gemma4a":
+            _validate_gemma4_audio_metadata(mmproj_gguf.metadata)
         companion_top = set(companion.required_top_tensors)
         companion_blocks, companion_matched = _collect_block_tensors(
             names,
@@ -565,17 +625,13 @@ def _validate_supported_mmproj_shapes(mmproj_gguf: Any, spec: ProjectorSpec) -> 
         )
 
     patch_shape = mmproj_gguf.get_tensor_shape("v.patch_embd.weight")
-    if len(patch_shape) not in (4, 5) or patch_shape[0] != hidden:
-        raise ValueError(
-            f"v.patch_embd.weight must be rank 4/5 with output {hidden}, got {patch_shape}."
-        )
-    if patch_shape[-2:] != (patch, patch):
-        raise ValueError(
-            f"v.patch_embd.weight spatial kernel {patch_shape[-2:]} does not match "
-            f"clip.vision.patch_size={patch}."
-        )
-
     if spec.projector_type == "gemma4v":
+        expected_patch_shape = (hidden, 3, patch, patch)
+        if patch_shape != expected_patch_shape:
+            raise ValueError(
+                "Gemma4 v.patch_embd.weight must have graph-compatible shape "
+                f"{expected_patch_shape}, got {patch_shape}."
+            )
         position_shape = mmproj_gguf.get_tensor_shape("v.position_embd.weight")
         if len(position_shape) != 3 or position_shape[0] != 2 or position_shape[2] != hidden:
             raise ValueError(
@@ -619,6 +675,15 @@ def _validate_supported_mmproj_shapes(mmproj_gguf: Any, spec: ProjectorSpec) -> 
         return
 
     if spec.projector_type == "muse-glimmer":
+        if (
+            len(patch_shape) not in (4, 5)
+            or patch_shape[0] != hidden
+            or patch_shape[-2:] != (patch, patch)
+        ):
+            raise ValueError(
+                "Muse Glimmer v.patch_embd.weight must be rank 4/5 with output "
+                f"{hidden} and a {patch}x{patch} spatial kernel, got {patch_shape}."
+            )
         merge = int(md["clip.vision.spatial_merge_size"])
         position_shape = mmproj_gguf.get_tensor_shape("v.position_embd.weight")
         if len(position_shape) != 2 or position_shape[1] != hidden:

--- a/src/mobius/integrations/gguf/_mmproj_mapping.py
+++ b/src/mobius/integrations/gguf/_mmproj_mapping.py
@@ -21,8 +21,8 @@ so the mmproj weights flow through the *same* tested preprocessing path as a
 real HF Gemma4 checkpoint before being applied to the ONNX graph.
 
 Companion activation-range tensors (``.input_max`` / ``.input_min`` /
-``.output_max`` / ``.output_min``) that llama.cpp stores next to each weight are
-**not** model weights and are skipped — see :func:`is_mmproj_stat_tensor`.
+``.output_max`` / ``.output_min``) are learned clipping bounds. Gemma4's
+``ClippableLinear`` graph consumes them; dropping them changes model semantics.
 
 The name derivation was verified against ``unsloth/gemma-4-E2B-it-GGUF``'s
 ``mmproj-F16.gguf`` (``clip.vision.projector_type = gemma4v``,
@@ -63,6 +63,18 @@ _VISION_BLOCK_STEMS: dict[str, str] = {
     "ffn_up.weight": "mlp.up_proj.weight",
     "ffn_down.weight": "mlp.down_proj.weight",
 }
+
+for _gguf_stem, _hf_stem in {
+    "attn_q": "self_attn.q_proj",
+    "attn_k": "self_attn.k_proj",
+    "attn_v": "self_attn.v_proj",
+    "attn_out": "self_attn.o_proj",
+    "ffn_gate": "mlp.gate_proj",
+    "ffn_up": "mlp.up_proj",
+    "ffn_down": "mlp.down_proj",
+}.items():
+    for _bound in ("input_min", "input_max", "output_min", "output_max"):
+        _VISION_BLOCK_STEMS[f"{_gguf_stem}.{_bound}"] = f"{_hf_stem}.{_bound}"
 
 # ---------------------------------------------------------------------------
 # Audio tower (a.* / mm.a.input_projection)
@@ -105,12 +117,11 @@ _STAT_SUFFIXES = (".input_max", ".input_min", ".output_max", ".output_min")
 
 
 def is_mmproj_stat_tensor(name: str) -> bool:
-    """Return ``True`` for llama.cpp activation-range stats (not weights).
+    """Return ``True`` for llama.cpp activation clipping bounds.
 
-    Each quantizable linear in the mmproj carries companion
-    ``.input_max``/``.input_min``/``.output_max``/``.output_min`` scalar
-    tensors describing the observed activation range. These are calibration
-    statistics, not learnable parameters, and must be skipped.
+    These tensors are model parameters for Gemma4 ``ClippableLinear`` layers.
+    The predicate remains public for callers that need to classify their role;
+    mapping functions decide whether a specific projector consumes them.
     """
     return name.endswith(_STAT_SUFFIXES)
 
@@ -120,14 +131,11 @@ def map_mmproj_vision_to_hf(name: str) -> str | None:
 
     Returns the HuggingFace name consumed by
     :meth:`Gemma4Model.preprocess_weights` (``vision_tower.*`` /
-    ``embed_vision.*``), or ``None`` if the tensor is skipped (activation-range
-    stats or the audio tower).
+    ``embed_vision.*``), or ``None`` if the tensor is outside the Gemma4 vision
+    closure (for example, the audio tower).
 
     The mapping mirrors :mod:`_tensor_mapping` for the text backbone.
     """
-    if is_mmproj_stat_tensor(name):
-        return None
-
     blk = _VISION_BLK.match(name)
     if blk is not None:
         idx, stem = blk.group(1), blk.group(2)

--- a/src/mobius/integrations/gguf/_mmproj_mapping_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_mapping_test.py
@@ -114,8 +114,11 @@ class TestVisionMapping:
     def test_vision_names(self, gguf_name: str, expected: str):
         assert map_mmproj_vision_to_hf(gguf_name) == expected
 
-    def test_stat_tensors_skipped(self):
-        assert map_mmproj_vision_to_hf("v.blk.0.attn_q.weight.input_max") is None
+    def test_clipping_bounds_are_mapped(self):
+        assert (
+            map_mmproj_vision_to_hf("v.blk.0.attn_q.input_max")
+            == "vision_tower.encoder.layers.0.self_attn.q_proj.input_max"
+        )
 
     def test_unknown_stem_skipped(self):
         assert map_mmproj_vision_to_hf("v.blk.0.mystery.weight") is None

--- a/src/mobius/integrations/gguf/_mmproj_registry.py
+++ b/src/mobius/integrations/gguf/_mmproj_registry.py
@@ -1,0 +1,544 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Pinned capability registry for ``general.architecture = "clip"`` sidecars.
+
+The census and metadata keys come from llama.cpp commit
+``8d9af256337d1a501250f9bbf4c0859a654bddd6``:
+
+* ``tools/mtmd/clip-impl.h`` defines the 62-value enum (60 serialized strings,
+  one unserialized ``MLP_NORM`` compatibility value, and ``UNKNOWN``).
+* ``tools/mtmd/clip.cpp`` defines metadata requirements/defaults and dispatch.
+
+Listing a projector is not a support claim. Only entries with all four
+capabilities marked ``SUPPORTED`` may reach graph construction.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "CLIP_METADATA_SCHEMA",
+    "LLAMA_CPP_MMPROJ_SHA",
+    "MMPROJ_ARTIFACT_PINS",
+    "ClipMetadataField",
+    "MMProjArtifactPin",
+    "MMProjModality",
+    "MMProjTensorRole",
+    "ProjectorSpec",
+    "get_projector_spec",
+    "iter_projector_specs",
+    "projector_type_for_modality",
+    "supported_projector_types",
+]
+
+import dataclasses
+import enum
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from mobius.integrations.gguf._spec import Support
+
+LLAMA_CPP_MMPROJ_SHA = "8d9af256337d1a501250f9bbf4c0859a654bddd6"
+
+
+class MMProjModality(enum.Enum):
+    """Modalities represented by the pinned clip loader."""
+
+    VISION = "vision"
+    AUDIO = "audio"
+    GENERATED_AUDIO = "gen.audio"
+
+
+class MMProjTensorRole(enum.Enum):
+    """Storage policy for a tensor owned by an mmproj sidecar."""
+
+    ENCODER = "encoder"
+    PROJECTOR = "projector"
+    CALIBRATION = "calibration"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ClipMetadataField:
+    """One key in the pinned ``clip.*`` metadata schema."""
+
+    key: str
+    required_for: frozenset[MMProjModality] = frozenset()
+    default: object | None = None
+    note: str = ""
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ProjectorSpec:
+    """Capabilities and exact loader closure for one serialized projector type."""
+
+    projector_type: str
+    enum_name: str
+    modalities: frozenset[MMProjModality]
+    target_architectures: frozenset[str] = frozenset()
+    metadata: Support = Support.DEFERRED
+    tensor_map: Support = Support.DEFERRED
+    graph: Support = Support.DEFERRED
+    runtime: Support = Support.DEFERRED
+    reason: str | None = None
+    builder: str | None = None
+    required_metadata: tuple[str, ...] = ()
+    required_top_tensors: tuple[str, ...] = ()
+    optional_top_tensors: tuple[str, ...] = ()
+    block_prefix: str | None = None
+    block_suffixes: tuple[str, ...] = ()
+    tensor_roles: tuple[tuple[str, MMProjTensorRole], ...] = ()
+    real_artifact_ids: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        verdicts = (self.metadata, self.tensor_map, self.graph, self.runtime)
+        if any(verdict is not Support.SUPPORTED for verdict in verdicts) and not self.reason:
+            raise ValueError(f"{self.projector_type}: unsupported capability needs a reason")
+        if self.is_supported:
+            if not self.builder or not self.target_architectures:
+                raise ValueError(
+                    f"{self.projector_type}: supported projector needs builder and target"
+                )
+            if not self.required_metadata or not self.required_top_tensors:
+                raise ValueError(
+                    f"{self.projector_type}: supported projector needs an exact loader closure"
+                )
+            if not self.real_artifact_ids:
+                raise ValueError(
+                    f"{self.projector_type}: supported projector needs real artifact evidence"
+                )
+        elif any(
+            (
+                self.builder,
+                self.required_metadata,
+                self.required_top_tensors,
+                self.optional_top_tensors,
+                self.block_prefix,
+                self.block_suffixes,
+                self.tensor_roles,
+                self.real_artifact_ids,
+            )
+        ):
+            raise ValueError(
+                f"{self.projector_type}: deferred/rejected projector cannot expose loader data"
+            )
+
+    @property
+    def verdicts(self) -> Mapping[str, Support]:
+        return MappingProxyType(
+            {
+                "metadata": self.metadata,
+                "tensor_map": self.tensor_map,
+                "graph": self.graph,
+                "runtime": self.runtime,
+            }
+        )
+
+    @property
+    def is_supported(self) -> bool:
+        return all(verdict is Support.SUPPORTED for verdict in self.verdicts.values())
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class MMProjArtifactPin:
+    """Audited real sidecar used as evidence for a supported registry entry."""
+
+    artifact_id: str
+    repository: str
+    revision: str
+    filename: str
+    size: int
+    lfs_sha256: str
+    projector_types: tuple[str, ...]
+    paired_text_architecture: str
+    paired_text_target: str
+    metadata: tuple[tuple[str, object], ...]
+    tensor_qtypes: tuple[tuple[str, int], ...]
+    tensor_count: int
+    parity_test: str
+
+
+_VISION_BASE = frozenset({MMProjModality.VISION})
+_AUDIO_BASE = frozenset({MMProjModality.AUDIO})
+_GEN_AUDIO_BASE = frozenset({MMProjModality.GENERATED_AUDIO})
+
+# ``None`` means no upstream default: the key is contextual or model-specific.
+# The loader requires the six formatted base fields for every active modality.
+CLIP_METADATA_SCHEMA: tuple[ClipMetadataField, ...] = (
+    ClipMetadataField("clip.projector_type", note="Fallback projector for every modality."),
+    ClipMetadataField("clip.has_vision_encoder", default=False),
+    ClipMetadataField("clip.has_audio_encoder", default=False),
+    ClipMetadataField("clip.has_gen_audio_encoder", default=False),
+    ClipMetadataField("clip.has_text_encoder", note="Absent from the pinned ABI; always false."),
+    ClipMetadataField("clip.use_gelu", default=False),
+    ClipMetadataField("clip.use_silu", default=False),
+    ClipMetadataField("clip.{modality}.embedding_length", _VISION_BASE | _AUDIO_BASE | _GEN_AUDIO_BASE),
+    ClipMetadataField(
+        "clip.{modality}.feed_forward_length", _VISION_BASE | _AUDIO_BASE | _GEN_AUDIO_BASE
+    ),
+    ClipMetadataField("clip.{modality}.block_count", _VISION_BASE | _AUDIO_BASE | _GEN_AUDIO_BASE),
+    ClipMetadataField("clip.{modality}.projection_dim", _VISION_BASE | _AUDIO_BASE | _GEN_AUDIO_BASE),
+    ClipMetadataField(
+        "clip.{modality}.attention.head_count", _VISION_BASE | _AUDIO_BASE | _GEN_AUDIO_BASE
+    ),
+    ClipMetadataField("clip.{modality}.attention.head_count_kv", default="attention.head_count"),
+    ClipMetadataField("clip.{modality}.attention.head_dim"),
+    ClipMetadataField(
+        "clip.{modality}.attention.layer_norm_epsilon",
+        _VISION_BASE | _AUDIO_BASE | _GEN_AUDIO_BASE,
+    ),
+    ClipMetadataField("clip.{modality}.feature_layer", default=()),
+    ClipMetadataField("clip.vision.projector_type"),
+    ClipMetadataField("clip.vision.image_size", _VISION_BASE),
+    ClipMetadataField("clip.vision.image_min_pixels"),
+    ClipMetadataField("clip.vision.image_max_pixels"),
+    ClipMetadataField("clip.vision.preproc_min_tiles"),
+    ClipMetadataField("clip.vision.preproc_max_tiles"),
+    ClipMetadataField("clip.vision.preproc_image_size"),
+    ClipMetadataField("clip.vision.patch_size", _VISION_BASE),
+    ClipMetadataField("clip.vision.image_mean", _VISION_BASE),
+    ClipMetadataField("clip.vision.image_std", _VISION_BASE),
+    ClipMetadataField("clip.vision.projector.scale_factor"),
+    ClipMetadataField("clip.vision.projector.query_side"),
+    ClipMetadataField("clip.vision.projector.window_side"),
+    ClipMetadataField("clip.vision.projector.spatial_offsets"),
+    ClipMetadataField("clip.vision.spatial_merge_size"),
+    ClipMetadataField("clip.vision.mm_patch_merge_type", default="flat"),
+    ClipMetadataField("clip.vision.image_grid_pinpoints", default=()),
+    ClipMetadataField("clip.vision.n_wa_pattern"),
+    ClipMetadataField("clip.vision.wa_layer_indexes"),
+    ClipMetadataField("clip.vision.wa_pattern_mode"),
+    ClipMetadataField("clip.vision.window_size"),
+    ClipMetadataField("clip.minicpmv_version"),
+    ClipMetadataField("clip.minicpmv_query_num", default="version-dependent"),
+    ClipMetadataField("clip.vision.sam.head_count"),
+    ClipMetadataField("clip.vision.sam.block_count"),
+    ClipMetadataField("clip.vision.sam.embedding_length"),
+    ClipMetadataField("clip.vision.expert_used_count"),
+    ClipMetadataField("clip.audio.projector_type"),
+    ClipMetadataField("clip.audio.num_mel_bins", _AUDIO_BASE),
+    ClipMetadataField("clip.audio.projector.stack_factor"),
+    ClipMetadataField("clip.audio.chunk_size"),
+    ClipMetadataField("clip.audio.conv_kernel_size"),
+    ClipMetadataField("clip.audio.max_pos_emb"),
+    ClipMetadataField("clip.audio.projector.window_size"),
+    ClipMetadataField("clip.audio.projector.downsample_rate"),
+    ClipMetadataField("clip.audio.projector.head_count"),
+    ClipMetadataField("clip.audio.rvq.num_quantizers"),
+    ClipMetadataField("clip.audio.rvq.codebook_size"),
+    ClipMetadataField("clip.audio.wa_pattern_mode"),
+    ClipMetadataField("clip.audio.window_size"),
+    ClipMetadataField("clip.audio.local_block_count"),
+    ClipMetadataField("clip.audio.local_group_size"),
+    ClipMetadataField("clip.gen.audio.projector_type"),
+    ClipMetadataField("clip.gen.audio.model_variant"),
+    ClipMetadataField("clip.audio.subsampling_factor"),
+)
+
+_RANGE_STATS = (
+    "attn_q.input_max",
+    "attn_q.input_min",
+    "attn_q.output_max",
+    "attn_q.output_min",
+    "attn_k.input_max",
+    "attn_k.input_min",
+    "attn_k.output_max",
+    "attn_k.output_min",
+    "attn_v.input_max",
+    "attn_v.input_min",
+    "attn_v.output_max",
+    "attn_v.output_min",
+    "attn_out.input_max",
+    "attn_out.input_min",
+    "attn_out.output_max",
+    "attn_out.output_min",
+    "ffn_gate.input_max",
+    "ffn_gate.input_min",
+    "ffn_gate.output_max",
+    "ffn_gate.output_min",
+    "ffn_up.input_max",
+    "ffn_up.input_min",
+    "ffn_up.output_max",
+    "ffn_up.output_min",
+    "ffn_down.input_max",
+    "ffn_down.input_min",
+    "ffn_down.output_max",
+    "ffn_down.output_min",
+)
+
+_GEMMA4V_BLOCK_SUFFIXES = (
+    "ln1.weight",
+    "ln2.weight",
+    "attn_post_norm.weight",
+    "ffn_post_norm.weight",
+    "attn_q.weight",
+    "attn_k.weight",
+    "attn_v.weight",
+    "attn_out.weight",
+    "attn_q_norm.weight",
+    "attn_k_norm.weight",
+    "ffn_gate.weight",
+    "ffn_up.weight",
+    "ffn_down.weight",
+    *_RANGE_STATS,
+)
+
+_MUSE_GLIMMER_BLOCK_SUFFIXES = tuple(
+    f"{stem}.{kind}"
+    for stem in ("ln1", "ln2", "attn_q", "attn_k", "attn_v", "attn_out", "ffn_up", "ffn_down")
+    for kind in ("weight", "bias")
+)
+
+_COMMON_REQUIRED_VISION_METADATA = (
+    "clip.has_vision_encoder",
+    "clip.vision.embedding_length",
+    "clip.vision.feed_forward_length",
+    "clip.vision.block_count",
+    "clip.vision.projection_dim",
+    "clip.vision.attention.head_count",
+    "clip.vision.attention.layer_norm_epsilon",
+    "clip.vision.image_size",
+    "clip.vision.patch_size",
+    "clip.vision.image_mean",
+    "clip.vision.image_std",
+)
+
+
+def _deferred(
+    projector_type: str,
+    enum_name: str,
+    modalities: frozenset[MMProjModality],
+    reason: str,
+) -> ProjectorSpec:
+    return ProjectorSpec(
+        projector_type=projector_type,
+        enum_name=enum_name,
+        modalities=modalities,
+        reason=reason,
+    )
+
+
+def _rejected(
+    projector_type: str,
+    enum_name: str,
+    modalities: frozenset[MMProjModality],
+    reason: str,
+) -> ProjectorSpec:
+    return ProjectorSpec(
+        projector_type=projector_type,
+        enum_name=enum_name,
+        modalities=modalities,
+        metadata=Support.REJECTED,
+        tensor_map=Support.REJECTED,
+        graph=Support.REJECTED,
+        runtime=Support.REJECTED,
+        reason=reason,
+    )
+
+
+_SPECS: tuple[ProjectorSpec, ...] = (
+    _deferred("mlp", "PROJECTOR_TYPE_MLP", _VISION_BASE, "LLaVA MLP topology and class-token feature selection are not implemented by the GGUF builder."),
+    _deferred("ldp", "PROJECTOR_TYPE_LDP", _VISION_BASE, "MobileVLM LDP convolutional projector semantics are not implemented."),
+    _deferred("ldpv2", "PROJECTOR_TYPE_LDPV2", _VISION_BASE, "MobileVLM LDPv2 pooling/projector semantics are not implemented."),
+    _deferred("resampler", "PROJECTOR_TYPE_MINICPMV", _VISION_BASE, "MiniCPM-V query resampler and positional interpolation are not implemented."),
+    _deferred("adapter", "PROJECTOR_TYPE_GLM_EDGE", _VISION_BASE, "GLM-Edge adapter tensor closure and graph are not implemented."),
+    _deferred("qwen2vl_merger", "PROJECTOR_TYPE_QWEN2VL", _VISION_BASE, "The existing HF Qwen2-VL graph is not wired to the pinned GGUF merger ABI."),
+    _deferred("qwen2.5vl_merger", "PROJECTOR_TYPE_QWEN25VL", _VISION_BASE, "The Qwen2.5-VL merger/window ordering has no GGUF tensor-closure parity test."),
+    _deferred("qwen3vl_merger", "PROJECTOR_TYPE_QWEN3VL", _VISION_BASE, "The Qwen3-VL merger/window ordering has no GGUF tensor-closure parity test."),
+    _deferred("step3vl", "PROJECTOR_TYPE_STEP3VL", _VISION_BASE, "Step3-VL vision and projector graph are not implemented."),
+    _deferred("gemma3", "PROJECTOR_TYPE_GEMMA3", _VISION_BASE, "Gemma3 mmproj feature selection and projector tensor map are not implemented."),
+    _deferred("gemma3nv", "PROJECTOR_TYPE_GEMMA3NV", _VISION_BASE, "Gemma3n vision sidecar routing is not implemented."),
+    _deferred("gemma3na", "PROJECTOR_TYPE_GEMMA3NA", _AUDIO_BASE, "Gemma3n audio sidecar routing is not implemented."),
+    ProjectorSpec(
+        projector_type="gemma4v",
+        enum_name="PROJECTOR_TYPE_GEMMA4V",
+        modalities=_VISION_BASE,
+        target_architectures=frozenset({"gemma4"}),
+        metadata=Support.SUPPORTED,
+        tensor_map=Support.SUPPORTED,
+        graph=Support.SUPPORTED,
+        runtime=Support.SUPPORTED,
+        builder="gemma4",
+        required_metadata=(*_COMMON_REQUIRED_VISION_METADATA, "clip.vision.projector_type"),
+        required_top_tensors=(
+            "v.patch_embd.weight",
+            "v.position_embd.weight",
+            "mm.input_projection.weight",
+        ),
+        block_prefix="v.blk.",
+        block_suffixes=_GEMMA4V_BLOCK_SUFFIXES,
+        tensor_roles=(
+            ("v.", MMProjTensorRole.ENCODER),
+            ("mm.input_projection.weight", MMProjTensorRole.PROJECTOR),
+        ),
+        real_artifact_ids=("gemma4-e2b-f16",),
+    ),
+    _deferred("gemma4a", "PROJECTOR_TYPE_GEMMA4A", _AUDIO_BASE, "The sidecar carries a.pre_encode tensors that the current audio map drops, and independent Conformer parity is not established."),
+    _deferred("gemma4uv", "PROJECTOR_TYPE_GEMMA4UV", _VISION_BASE, "Encoder-free unified Gemma4 vision sidecars use a different patch embedder contract."),
+    _deferred("gemma4ua", "PROJECTOR_TYPE_GEMMA4UA", _AUDIO_BASE, "Encoder-free unified Gemma4 waveform embedding is not wired to GGUF."),
+    _deferred("phi4", "PROJECTOR_TYPE_PHI4", _VISION_BASE, "The Phi-4 vision projector exists for HF weights but has no pinned GGUF tensor closure."),
+    _deferred("idefics3", "PROJECTOR_TYPE_IDEFICS3", _VISION_BASE, "Idefics3 pixel-shuffle projector GGUF routing is not implemented."),
+    _deferred("pixtral", "PROJECTOR_TYPE_PIXTRAL", _VISION_BASE, "The Pixtral component has no pinned mmproj tensor mapping or positional-interpolation parity."),
+    _deferred("ultravox", "PROJECTOR_TYPE_ULTRAVOX", _AUDIO_BASE, "Whisper encoder plus Ultravox stack projector is not implemented."),
+    _deferred("internvl", "PROJECTOR_TYPE_INTERNVL", _VISION_BASE, "InternVL pixel-shuffle token ordering is not implemented for GGUF."),
+    _deferred("llama4", "PROJECTOR_TYPE_LLAMA4", _VISION_BASE, "Llama4 vision encoder and multimodal target package are out of scope."),
+    _deferred("qwen2a", "PROJECTOR_TYPE_QWEN2A", _AUDIO_BASE, "Qwen2 audio encoder/projector is not implemented."),
+    _deferred("qwen3a", "PROJECTOR_TYPE_QWEN3A", _AUDIO_BASE, "Qwen3 audio encoder/projector is not implemented."),
+    _deferred("glma", "PROJECTOR_TYPE_GLMA", _AUDIO_BASE, "GLM audio encoder/projector is not implemented."),
+    _deferred("qwen2.5o", "PROJECTOR_TYPE_QWEN25O", _VISION_BASE | _AUDIO_BASE, "This legacy string changes meaning by modality; accepting it would create a false alias."),
+    _deferred("voxtral", "PROJECTOR_TYPE_VOXTRAL", _AUDIO_BASE, "Voxtral Whisper encoder/projector is not implemented."),
+    _deferred("meralion", "PROJECTOR_TYPE_MERALION", _AUDIO_BASE, "Meralion audio projector is not implemented."),
+    _deferred("musicflamingo", "PROJECTOR_TYPE_MUSIC_FLAMINGO", _AUDIO_BASE, "Music Flamingo audio projector is not implemented."),
+    _deferred("lfm2", "PROJECTOR_TYPE_LFM2", _VISION_BASE, "The existing LFM2-VL HF graph has no pinned mmproj tensor closure or component parity."),
+    _deferred("kimivl", "PROJECTOR_TYPE_KIMIVL", _VISION_BASE, "Kimi-VL vision/projector graph is not implemented."),
+    _deferred("paddleocr", "PROJECTOR_TYPE_PADDLEOCR", _VISION_BASE, "PaddleOCR vision/projector graph is not implemented."),
+    _deferred("lightonocr", "PROJECTOR_TYPE_LIGHTONOCR", _VISION_BASE, "LightOnOCR Pixtral variant has no exact tensor mapping."),
+    _deferred("cogvlm", "PROJECTOR_TYPE_COGVLM", _VISION_BASE, "CogVLM feature output differs from LLaVA and is not implemented."),
+    _deferred("janus_pro", "PROJECTOR_TYPE_JANUS_PRO", _VISION_BASE, "Janus-Pro vision/projector graph is not implemented."),
+    _deferred("dots_ocr", "PROJECTOR_TYPE_DOTS_OCR", _VISION_BASE, "DotsOCR vision merger is not implemented."),
+    _deferred("dots3note_v", "PROJECTOR_TYPE_DOTS3NOTE_V", _VISION_BASE, "Dots3Note vision pyramid MoE is not implemented."),
+    _deferred("dots3note_a", "PROJECTOR_TYPE_DOTS3NOTE_A", _AUDIO_BASE, "Dots3Note audio graph is not implemented."),
+    _deferred("deepseekocr", "PROJECTOR_TYPE_DEEPSEEKOCR", _VISION_BASE, "DeepSeek-OCR SAM/projector graph is not implemented."),
+    _deferred("deepseekocr2", "PROJECTOR_TYPE_DEEPSEEKOCR2", _VISION_BASE, "DeepSeek-OCR2 SAM/projector graph is not implemented."),
+    _deferred("lfm2a", "PROJECTOR_TYPE_LFM2A", _AUDIO_BASE, "LFM2 conformer audio graph has no GGUF tensor mapping."),
+    _deferred("glm4v", "PROJECTOR_TYPE_GLM4V", _VISION_BASE, "GLM4V downsampler and projector are not implemented."),
+    _deferred("youtuvl", "PROJECTOR_TYPE_YOUTUVL", _VISION_BASE, "YouTu-VL vision/projector graph is not implemented."),
+    _deferred("yasa2", "PROJECTOR_TYPE_YASA2", _VISION_BASE, "YASA2 vision/projector graph is not implemented."),
+    _deferred("kimik25", "PROJECTOR_TYPE_KIMIK25", _VISION_BASE, "Kimi K2.5 vision/projector graph is not implemented."),
+    _deferred("nemotron_v2_vl", "PROJECTOR_TYPE_NEMOTRON_V2_VL", _VISION_BASE, "Nemotron V2 VL vision/projector graph is not implemented."),
+    _deferred("exaone4_5", "PROJECTOR_TYPE_EXAONE4_5", _VISION_BASE, "EXAONE 4.5 vision merger is not implemented."),
+    _deferred("hunyuanvl", "PROJECTOR_TYPE_HUNYUANVL", _VISION_BASE, "HunyuanVL vision/projector graph is not implemented."),
+    _deferred("minicpmv4_6", "PROJECTOR_TYPE_MINICPMV4_6", _VISION_BASE, "MiniCPM-V 4.6 SAM/resampler graph is not implemented."),
+    _deferred("granite_speech", "PROJECTOR_TYPE_GRANITE_SPEECH", _AUDIO_BASE, "Granite Speech audio encoder/projector is not implemented."),
+    _deferred("mimovl", "PROJECTOR_TYPE_MIMOVL", _VISION_BASE, "MiMo-VL vision/projector graph is not implemented."),
+    _deferred("minimax_m3", "PROJECTOR_TYPE_MINIMAX_M3", _VISION_BASE, "MiniMax M3 vision/projector graph is not implemented."),
+    _deferred("granite4_vision", "PROJECTOR_TYPE_GRANITE4_VISION", _VISION_BASE, "Granite 4 vision sidecar graph is not implemented."),
+    _deferred("mimo_audio", "PROJECTOR_TYPE_MIMO_AUDIO", _AUDIO_BASE, "MiMo audio RVQ/local-transformer graph is not implemented."),
+    _deferred("parakeet", "PROJECTOR_TYPE_PARAKEET", _AUDIO_BASE, "Parakeet audio encoder graph is not implemented."),
+    _deferred("qwen3tts_spkenc", "PROJECTOR_TYPE_QWEN3TTS_SPKENC", _AUDIO_BASE, "Qwen3-TTS speaker encoder graph is not implemented."),
+    _rejected("qwen3tts_gen", "PROJECTOR_TYPE_QWEN3TTS_GEN", _GEN_AUDIO_BASE, "Generated-audio decoder sidecars are not multimodal projectors and cannot be paired with a text target package."),
+    _deferred("pockettts_spkenc", "PROJECTOR_TYPE_POCKETTTS_SPKENC", _AUDIO_BASE, "PocketTTS speaker encoder graph is not implemented."),
+    _rejected("pockettts_gen", "PROJECTOR_TYPE_POCKETTTS_GEN", _GEN_AUDIO_BASE, "Generated-audio decoder sidecars are not multimodal projectors and cannot be paired with a text target package."),
+    ProjectorSpec(
+        projector_type="muse-glimmer",
+        enum_name="PROJECTOR_TYPE_MUSE_GLIMMER",
+        modalities=_VISION_BASE,
+        target_architectures=frozenset({"muse-glimmer"}),
+        metadata=Support.SUPPORTED,
+        tensor_map=Support.SUPPORTED,
+        graph=Support.SUPPORTED,
+        runtime=Support.SUPPORTED,
+        builder="muse_glimmer",
+        required_metadata=(
+            *_COMMON_REQUIRED_VISION_METADATA,
+            "clip.projector_type",
+            "clip.vision.spatial_merge_size",
+        ),
+        required_top_tensors=(
+            "v.patch_embd.weight",
+            "v.position_embd.weight",
+            "v.pre_ln.weight",
+            "v.pre_ln.bias",
+            "v.post_ln.weight",
+            "v.post_ln.bias",
+            "mm.0.weight",
+            "mm.1.weight",
+            "mm.2.weight",
+        ),
+        block_prefix="v.blk.",
+        block_suffixes=_MUSE_GLIMMER_BLOCK_SUFFIXES,
+        tensor_roles=(
+            ("v.", MMProjTensorRole.ENCODER),
+            ("mm.", MMProjTensorRole.PROJECTOR),
+        ),
+        real_artifact_ids=("muse-glimmer-30b-bf16",),
+    ),
+)
+
+_INDEX: Mapping[str, ProjectorSpec] = MappingProxyType(
+    {spec.projector_type: spec for spec in _SPECS}
+)
+
+MMPROJ_ARTIFACT_PINS: tuple[MMProjArtifactPin, ...] = (
+    MMProjArtifactPin(
+        artifact_id="gemma4-e2b-f16",
+        repository="unsloth/gemma-4-E2B-it-GGUF",
+        revision="0314792d7f1f7e229411f620751375812bb9faf2",
+        filename="mmproj-F16.gguf",
+        size=985_654_080,
+        lfs_sha256="337ee849e80b6169ce9d1d573d424fc1653bcafa5f0cb0cbb901beba54f4b41c",
+        projector_types=("gemma4v", "gemma4a"),
+        paired_text_architecture="gemma4",
+        paired_text_target="gemma-4-E2B-it-Q4_K_M.gguf",
+        metadata=(
+            ("general.name", "Gemma-4-E2B-It"),
+            ("general.base_model.0.repo_url", "https://huggingface.co/google/gemma-4-E2B-it"),
+            ("clip.vision.embedding_length", 768),
+            ("clip.vision.projection_dim", 1536),
+            ("clip.audio.embedding_length", 1024),
+            ("clip.audio.projection_dim", 1536),
+        ),
+        tensor_qtypes=(("F32", 1163), ("F16", 248)),
+        tensor_count=1411,
+        parity_test="TestVisionEncoderBuildAndRun.test_matches_independent_numpy_reference",
+    ),
+    MMProjArtifactPin(
+        artifact_id="muse-glimmer-30b-bf16",
+        repository="unsloth/Muse-Glimmer-30B-GGUF",
+        revision="faa5b025c584459c13febfa5c59883516710ae39",
+        filename="mmproj-Muse-Glimmer-30B-BF16.gguf",
+        size=3_849_173_728,
+        lfs_sha256="7aa788cfe25ae5e4bf4837511f64df22cabe595e58223708274a67b3136f53ab",
+        projector_types=("muse-glimmer",),
+        paired_text_architecture="muse-glimmer",
+        paired_text_target="Muse-Glimmer-30B-Q4_K_M.gguf",
+        metadata=(
+            ("general.name", "Muse-Glimmer-30B"),
+            ("clip.vision.embedding_length", 1536),
+            ("clip.vision.projection_dim", 6656),
+            ("clip.vision.spatial_merge_size", 2),
+        ),
+        tensor_qtypes=(("F32", 506), ("BF16", 303)),
+        tensor_count=809,
+        parity_test="TestMuseGlimmerVisionEncoder.test_matches_independent_numpy_reference",
+    ),
+)
+
+
+def iter_projector_specs() -> tuple[ProjectorSpec, ...]:
+    """Return the exact 60-string pinned projector census."""
+
+    return _SPECS
+
+
+def get_projector_spec(projector_type: str) -> ProjectorSpec:
+    """Return one projector spec or fail with an actionable pinned-census error."""
+
+    try:
+        return _INDEX[projector_type]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unknown clip projector type {projector_type!r}; it is not one of the "
+            f"60 strings at llama.cpp {LLAMA_CPP_MMPROJ_SHA}."
+        ) from exc
+
+
+def supported_projector_types() -> tuple[str, ...]:
+    """Return projector strings that may reach graph construction."""
+
+    return tuple(spec.projector_type for spec in _SPECS if spec.is_supported)
+
+
+def projector_type_for_modality(
+    metadata: Mapping[str, Any], modality: MMProjModality
+) -> str:
+    """Resolve the pinned global-key then modality-key projector fallback."""
+
+    projector_type = metadata.get("clip.projector_type")
+    if not projector_type:
+        projector_type = metadata.get(f"clip.{modality.value}.projector_type")
+    if not isinstance(projector_type, str) or not projector_type:
+        raise ValueError(
+            f"clip mmproj has an active {modality.value} encoder but neither "
+            f"'clip.projector_type' nor 'clip.{modality.value}.projector_type' is set."
+        )
+    return projector_type

--- a/src/mobius/integrations/gguf/_mmproj_registry.py
+++ b/src/mobius/integrations/gguf/_mmproj_registry.py
@@ -390,6 +390,7 @@ _COMMON_REQUIRED_AUDIO_METADATA = (
     "clip.audio.projection_dim",
     "clip.audio.attention.head_count",
     "clip.audio.attention.layer_norm_epsilon",
+    "clip.audio.num_mel_bins",
 )
 
 

--- a/src/mobius/integrations/gguf/_mmproj_registry.py
+++ b/src/mobius/integrations/gguf/_mmproj_registry.py
@@ -21,6 +21,7 @@ __all__ = [
     "LLAMA_CPP_MMPROJ_SHA",
     "MMPROJ_ARTIFACT_PINS",
     "ClipMetadataField",
+    "CompanionTensorSpec",
     "MMProjArtifactPin",
     "MMProjModality",
     "MMProjTensorRole",
@@ -33,8 +34,9 @@ __all__ = [
 
 import dataclasses
 import enum
+from collections.abc import Mapping
 from types import MappingProxyType
-from typing import Any, Mapping
+from typing import Any
 
 from mobius.integrations.gguf._spec import Support
 
@@ -68,6 +70,18 @@ class ClipMetadataField:
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
+class CompanionTensorSpec:
+    """Exact tensor closure for a deferred modality sharing a supported sidecar."""
+
+    modality: MMProjModality
+    projector_type: str
+    required_metadata: tuple[str, ...]
+    required_top_tensors: tuple[str, ...]
+    block_prefix: str
+    block_suffixes: tuple[str, ...]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
 class ProjectorSpec:
     """Capabilities and exact loader closure for one serialized projector type."""
 
@@ -86,6 +100,7 @@ class ProjectorSpec:
     optional_top_tensors: tuple[str, ...] = ()
     block_prefix: str | None = None
     block_suffixes: tuple[str, ...] = ()
+    companion_tensors: tuple[CompanionTensorSpec, ...] = ()
     tensor_roles: tuple[tuple[str, MMProjTensorRole], ...] = ()
     real_artifact_ids: tuple[str, ...] = ()
 
@@ -114,6 +129,7 @@ class ProjectorSpec:
                 self.optional_top_tensors,
                 self.block_prefix,
                 self.block_suffixes,
+                self.companion_tensors,
                 self.tensor_roles,
                 self.real_artifact_ids,
             )
@@ -168,19 +184,29 @@ CLIP_METADATA_SCHEMA: tuple[ClipMetadataField, ...] = (
     ClipMetadataField("clip.has_vision_encoder", default=False),
     ClipMetadataField("clip.has_audio_encoder", default=False),
     ClipMetadataField("clip.has_gen_audio_encoder", default=False),
-    ClipMetadataField("clip.has_text_encoder", note="Absent from the pinned ABI; always false."),
+    ClipMetadataField(
+        "clip.has_text_encoder", note="Absent from the pinned ABI; always false."
+    ),
     ClipMetadataField("clip.use_gelu", default=False),
     ClipMetadataField("clip.use_silu", default=False),
-    ClipMetadataField("clip.{modality}.embedding_length", _VISION_BASE | _AUDIO_BASE | _GEN_AUDIO_BASE),
+    ClipMetadataField(
+        "clip.{modality}.embedding_length", _VISION_BASE | _AUDIO_BASE | _GEN_AUDIO_BASE
+    ),
     ClipMetadataField(
         "clip.{modality}.feed_forward_length", _VISION_BASE | _AUDIO_BASE | _GEN_AUDIO_BASE
     ),
-    ClipMetadataField("clip.{modality}.block_count", _VISION_BASE | _AUDIO_BASE | _GEN_AUDIO_BASE),
-    ClipMetadataField("clip.{modality}.projection_dim", _VISION_BASE | _AUDIO_BASE | _GEN_AUDIO_BASE),
+    ClipMetadataField(
+        "clip.{modality}.block_count", _VISION_BASE | _AUDIO_BASE | _GEN_AUDIO_BASE
+    ),
+    ClipMetadataField(
+        "clip.{modality}.projection_dim", _VISION_BASE | _AUDIO_BASE | _GEN_AUDIO_BASE
+    ),
     ClipMetadataField(
         "clip.{modality}.attention.head_count", _VISION_BASE | _AUDIO_BASE | _GEN_AUDIO_BASE
     ),
-    ClipMetadataField("clip.{modality}.attention.head_count_kv", default="attention.head_count"),
+    ClipMetadataField(
+        "clip.{modality}.attention.head_count_kv", default="attention.head_count"
+    ),
     ClipMetadataField("clip.{modality}.attention.head_dim"),
     ClipMetadataField(
         "clip.{modality}.attention.layer_norm_epsilon",
@@ -282,6 +308,59 @@ _GEMMA4V_BLOCK_SUFFIXES = (
     *_RANGE_STATS,
 )
 
+_GEMMA4A_CLIPPED_STEMS = (
+    "attn_q",
+    "attn_k",
+    "attn_v",
+    "attn_out",
+    "conv_pw1",
+    "conv_pw2",
+    "ffn_up",
+    "ffn_down",
+    "ffn_up_1",
+    "ffn_down_1",
+)
+
+_GEMMA4A_BLOCK_SUFFIXES = (
+    "ffn_norm.weight",
+    "ffn_up.weight",
+    "ffn_down.weight",
+    "ffn_post_norm.weight",
+    "ffn_norm_1.weight",
+    "ffn_up_1.weight",
+    "ffn_down_1.weight",
+    "ffn_post_norm_1.weight",
+    "attn_pre_norm.weight",
+    "attn_post_norm.weight",
+    "ln2.weight",
+    "attn_q.weight",
+    "attn_k.weight",
+    "attn_v.weight",
+    "attn_out.weight",
+    "attn_k_rel.weight",
+    "per_dim_scale.weight",
+    "norm_conv.weight",
+    "conv_pw1.weight",
+    "conv_dw.weight",
+    "conv_pw2.weight",
+    *(
+        f"{stem}.{bound}"
+        for stem in _GEMMA4A_CLIPPED_STEMS
+        for bound in ("input_min", "input_max", "output_min", "output_max")
+    ),
+)
+
+_GEMMA4A_TOP_TENSORS = (
+    "a.conv1d.0.norm.weight",
+    "a.conv1d.0.weight",
+    "a.conv1d.1.norm.weight",
+    "a.conv1d.1.weight",
+    "a.input_projection.weight",
+    "a.pre_encode.out.bias",
+    "a.pre_encode.out.weight",
+    "mm.a.input_projection.weight",
+)
+
 _MUSE_GLIMMER_BLOCK_SUFFIXES = tuple(
     f"{stem}.{kind}"
     for stem in ("ln1", "ln2", "attn_q", "attn_k", "attn_v", "attn_out", "ffn_up", "ffn_down")
@@ -300,6 +379,17 @@ _COMMON_REQUIRED_VISION_METADATA = (
     "clip.vision.patch_size",
     "clip.vision.image_mean",
     "clip.vision.image_std",
+)
+
+_COMMON_REQUIRED_AUDIO_METADATA = (
+    "clip.has_audio_encoder",
+    "clip.audio.projector_type",
+    "clip.audio.embedding_length",
+    "clip.audio.feed_forward_length",
+    "clip.audio.block_count",
+    "clip.audio.projection_dim",
+    "clip.audio.attention.head_count",
+    "clip.audio.attention.layer_norm_epsilon",
 )
 
 
@@ -336,18 +426,78 @@ def _rejected(
 
 
 _SPECS: tuple[ProjectorSpec, ...] = (
-    _deferred("mlp", "PROJECTOR_TYPE_MLP", _VISION_BASE, "LLaVA MLP topology and class-token feature selection are not implemented by the GGUF builder."),
-    _deferred("ldp", "PROJECTOR_TYPE_LDP", _VISION_BASE, "MobileVLM LDP convolutional projector semantics are not implemented."),
-    _deferred("ldpv2", "PROJECTOR_TYPE_LDPV2", _VISION_BASE, "MobileVLM LDPv2 pooling/projector semantics are not implemented."),
-    _deferred("resampler", "PROJECTOR_TYPE_MINICPMV", _VISION_BASE, "MiniCPM-V query resampler and positional interpolation are not implemented."),
-    _deferred("adapter", "PROJECTOR_TYPE_GLM_EDGE", _VISION_BASE, "GLM-Edge adapter tensor closure and graph are not implemented."),
-    _deferred("qwen2vl_merger", "PROJECTOR_TYPE_QWEN2VL", _VISION_BASE, "The existing HF Qwen2-VL graph is not wired to the pinned GGUF merger ABI."),
-    _deferred("qwen2.5vl_merger", "PROJECTOR_TYPE_QWEN25VL", _VISION_BASE, "The Qwen2.5-VL merger/window ordering has no GGUF tensor-closure parity test."),
-    _deferred("qwen3vl_merger", "PROJECTOR_TYPE_QWEN3VL", _VISION_BASE, "The Qwen3-VL merger/window ordering has no GGUF tensor-closure parity test."),
-    _deferred("step3vl", "PROJECTOR_TYPE_STEP3VL", _VISION_BASE, "Step3-VL vision and projector graph are not implemented."),
-    _deferred("gemma3", "PROJECTOR_TYPE_GEMMA3", _VISION_BASE, "Gemma3 mmproj feature selection and projector tensor map are not implemented."),
-    _deferred("gemma3nv", "PROJECTOR_TYPE_GEMMA3NV", _VISION_BASE, "Gemma3n vision sidecar routing is not implemented."),
-    _deferred("gemma3na", "PROJECTOR_TYPE_GEMMA3NA", _AUDIO_BASE, "Gemma3n audio sidecar routing is not implemented."),
+    _deferred(
+        "mlp",
+        "PROJECTOR_TYPE_MLP",
+        _VISION_BASE,
+        "LLaVA MLP topology and class-token feature selection are not implemented by the GGUF builder.",
+    ),
+    _deferred(
+        "ldp",
+        "PROJECTOR_TYPE_LDP",
+        _VISION_BASE,
+        "MobileVLM LDP convolutional projector semantics are not implemented.",
+    ),
+    _deferred(
+        "ldpv2",
+        "PROJECTOR_TYPE_LDPV2",
+        _VISION_BASE,
+        "MobileVLM LDPv2 pooling/projector semantics are not implemented.",
+    ),
+    _deferred(
+        "resampler",
+        "PROJECTOR_TYPE_MINICPMV",
+        _VISION_BASE,
+        "MiniCPM-V query resampler and positional interpolation are not implemented.",
+    ),
+    _deferred(
+        "adapter",
+        "PROJECTOR_TYPE_GLM_EDGE",
+        _VISION_BASE,
+        "GLM-Edge adapter tensor closure and graph are not implemented.",
+    ),
+    _deferred(
+        "qwen2vl_merger",
+        "PROJECTOR_TYPE_QWEN2VL",
+        _VISION_BASE,
+        "The existing HF Qwen2-VL graph is not wired to the pinned GGUF merger ABI.",
+    ),
+    _deferred(
+        "qwen2.5vl_merger",
+        "PROJECTOR_TYPE_QWEN25VL",
+        _VISION_BASE,
+        "The Qwen2.5-VL merger/window ordering has no GGUF tensor-closure parity test.",
+    ),
+    _deferred(
+        "qwen3vl_merger",
+        "PROJECTOR_TYPE_QWEN3VL",
+        _VISION_BASE,
+        "The Qwen3-VL merger/window ordering has no GGUF tensor-closure parity test.",
+    ),
+    _deferred(
+        "step3vl",
+        "PROJECTOR_TYPE_STEP3VL",
+        _VISION_BASE,
+        "Step3-VL vision and projector graph are not implemented.",
+    ),
+    _deferred(
+        "gemma3",
+        "PROJECTOR_TYPE_GEMMA3",
+        _VISION_BASE,
+        "Gemma3 mmproj feature selection and projector tensor map are not implemented.",
+    ),
+    _deferred(
+        "gemma3nv",
+        "PROJECTOR_TYPE_GEMMA3NV",
+        _VISION_BASE,
+        "Gemma3n vision sidecar routing is not implemented.",
+    ),
+    _deferred(
+        "gemma3na",
+        "PROJECTOR_TYPE_GEMMA3NA",
+        _AUDIO_BASE,
+        "Gemma3n audio sidecar routing is not implemented.",
+    ),
     ProjectorSpec(
         projector_type="gemma4v",
         enum_name="PROJECTOR_TYPE_GEMMA4V",
@@ -366,58 +516,298 @@ _SPECS: tuple[ProjectorSpec, ...] = (
         ),
         block_prefix="v.blk.",
         block_suffixes=_GEMMA4V_BLOCK_SUFFIXES,
+        companion_tensors=(
+            CompanionTensorSpec(
+                modality=MMProjModality.AUDIO,
+                projector_type="gemma4a",
+                required_metadata=_COMMON_REQUIRED_AUDIO_METADATA,
+                required_top_tensors=_GEMMA4A_TOP_TENSORS,
+                block_prefix="a.blk.",
+                block_suffixes=_GEMMA4A_BLOCK_SUFFIXES,
+            ),
+        ),
         tensor_roles=(
             ("v.", MMProjTensorRole.ENCODER),
             ("mm.input_projection.weight", MMProjTensorRole.PROJECTOR),
         ),
         real_artifact_ids=("gemma4-e2b-f16",),
     ),
-    _deferred("gemma4a", "PROJECTOR_TYPE_GEMMA4A", _AUDIO_BASE, "The sidecar carries a.pre_encode tensors that the current audio map drops, and independent Conformer parity is not established."),
-    _deferred("gemma4uv", "PROJECTOR_TYPE_GEMMA4UV", _VISION_BASE, "Encoder-free unified Gemma4 vision sidecars use a different patch embedder contract."),
-    _deferred("gemma4ua", "PROJECTOR_TYPE_GEMMA4UA", _AUDIO_BASE, "Encoder-free unified Gemma4 waveform embedding is not wired to GGUF."),
-    _deferred("phi4", "PROJECTOR_TYPE_PHI4", _VISION_BASE, "The Phi-4 vision projector exists for HF weights but has no pinned GGUF tensor closure."),
-    _deferred("idefics3", "PROJECTOR_TYPE_IDEFICS3", _VISION_BASE, "Idefics3 pixel-shuffle projector GGUF routing is not implemented."),
-    _deferred("pixtral", "PROJECTOR_TYPE_PIXTRAL", _VISION_BASE, "The Pixtral component has no pinned mmproj tensor mapping or positional-interpolation parity."),
-    _deferred("ultravox", "PROJECTOR_TYPE_ULTRAVOX", _AUDIO_BASE, "Whisper encoder plus Ultravox stack projector is not implemented."),
-    _deferred("internvl", "PROJECTOR_TYPE_INTERNVL", _VISION_BASE, "InternVL pixel-shuffle token ordering is not implemented for GGUF."),
-    _deferred("llama4", "PROJECTOR_TYPE_LLAMA4", _VISION_BASE, "Llama4 vision encoder and multimodal target package are out of scope."),
-    _deferred("qwen2a", "PROJECTOR_TYPE_QWEN2A", _AUDIO_BASE, "Qwen2 audio encoder/projector is not implemented."),
-    _deferred("qwen3a", "PROJECTOR_TYPE_QWEN3A", _AUDIO_BASE, "Qwen3 audio encoder/projector is not implemented."),
-    _deferred("glma", "PROJECTOR_TYPE_GLMA", _AUDIO_BASE, "GLM audio encoder/projector is not implemented."),
-    _deferred("qwen2.5o", "PROJECTOR_TYPE_QWEN25O", _VISION_BASE | _AUDIO_BASE, "This legacy string changes meaning by modality; accepting it would create a false alias."),
-    _deferred("voxtral", "PROJECTOR_TYPE_VOXTRAL", _AUDIO_BASE, "Voxtral Whisper encoder/projector is not implemented."),
-    _deferred("meralion", "PROJECTOR_TYPE_MERALION", _AUDIO_BASE, "Meralion audio projector is not implemented."),
-    _deferred("musicflamingo", "PROJECTOR_TYPE_MUSIC_FLAMINGO", _AUDIO_BASE, "Music Flamingo audio projector is not implemented."),
-    _deferred("lfm2", "PROJECTOR_TYPE_LFM2", _VISION_BASE, "The existing LFM2-VL HF graph has no pinned mmproj tensor closure or component parity."),
-    _deferred("kimivl", "PROJECTOR_TYPE_KIMIVL", _VISION_BASE, "Kimi-VL vision/projector graph is not implemented."),
-    _deferred("paddleocr", "PROJECTOR_TYPE_PADDLEOCR", _VISION_BASE, "PaddleOCR vision/projector graph is not implemented."),
-    _deferred("lightonocr", "PROJECTOR_TYPE_LIGHTONOCR", _VISION_BASE, "LightOnOCR Pixtral variant has no exact tensor mapping."),
-    _deferred("cogvlm", "PROJECTOR_TYPE_COGVLM", _VISION_BASE, "CogVLM feature output differs from LLaVA and is not implemented."),
-    _deferred("janus_pro", "PROJECTOR_TYPE_JANUS_PRO", _VISION_BASE, "Janus-Pro vision/projector graph is not implemented."),
-    _deferred("dots_ocr", "PROJECTOR_TYPE_DOTS_OCR", _VISION_BASE, "DotsOCR vision merger is not implemented."),
-    _deferred("dots3note_v", "PROJECTOR_TYPE_DOTS3NOTE_V", _VISION_BASE, "Dots3Note vision pyramid MoE is not implemented."),
-    _deferred("dots3note_a", "PROJECTOR_TYPE_DOTS3NOTE_A", _AUDIO_BASE, "Dots3Note audio graph is not implemented."),
-    _deferred("deepseekocr", "PROJECTOR_TYPE_DEEPSEEKOCR", _VISION_BASE, "DeepSeek-OCR SAM/projector graph is not implemented."),
-    _deferred("deepseekocr2", "PROJECTOR_TYPE_DEEPSEEKOCR2", _VISION_BASE, "DeepSeek-OCR2 SAM/projector graph is not implemented."),
-    _deferred("lfm2a", "PROJECTOR_TYPE_LFM2A", _AUDIO_BASE, "LFM2 conformer audio graph has no GGUF tensor mapping."),
-    _deferred("glm4v", "PROJECTOR_TYPE_GLM4V", _VISION_BASE, "GLM4V downsampler and projector are not implemented."),
-    _deferred("youtuvl", "PROJECTOR_TYPE_YOUTUVL", _VISION_BASE, "YouTu-VL vision/projector graph is not implemented."),
-    _deferred("yasa2", "PROJECTOR_TYPE_YASA2", _VISION_BASE, "YASA2 vision/projector graph is not implemented."),
-    _deferred("kimik25", "PROJECTOR_TYPE_KIMIK25", _VISION_BASE, "Kimi K2.5 vision/projector graph is not implemented."),
-    _deferred("nemotron_v2_vl", "PROJECTOR_TYPE_NEMOTRON_V2_VL", _VISION_BASE, "Nemotron V2 VL vision/projector graph is not implemented."),
-    _deferred("exaone4_5", "PROJECTOR_TYPE_EXAONE4_5", _VISION_BASE, "EXAONE 4.5 vision merger is not implemented."),
-    _deferred("hunyuanvl", "PROJECTOR_TYPE_HUNYUANVL", _VISION_BASE, "HunyuanVL vision/projector graph is not implemented."),
-    _deferred("minicpmv4_6", "PROJECTOR_TYPE_MINICPMV4_6", _VISION_BASE, "MiniCPM-V 4.6 SAM/resampler graph is not implemented."),
-    _deferred("granite_speech", "PROJECTOR_TYPE_GRANITE_SPEECH", _AUDIO_BASE, "Granite Speech audio encoder/projector is not implemented."),
-    _deferred("mimovl", "PROJECTOR_TYPE_MIMOVL", _VISION_BASE, "MiMo-VL vision/projector graph is not implemented."),
-    _deferred("minimax_m3", "PROJECTOR_TYPE_MINIMAX_M3", _VISION_BASE, "MiniMax M3 vision/projector graph is not implemented."),
-    _deferred("granite4_vision", "PROJECTOR_TYPE_GRANITE4_VISION", _VISION_BASE, "Granite 4 vision sidecar graph is not implemented."),
-    _deferred("mimo_audio", "PROJECTOR_TYPE_MIMO_AUDIO", _AUDIO_BASE, "MiMo audio RVQ/local-transformer graph is not implemented."),
-    _deferred("parakeet", "PROJECTOR_TYPE_PARAKEET", _AUDIO_BASE, "Parakeet audio encoder graph is not implemented."),
-    _deferred("qwen3tts_spkenc", "PROJECTOR_TYPE_QWEN3TTS_SPKENC", _AUDIO_BASE, "Qwen3-TTS speaker encoder graph is not implemented."),
-    _rejected("qwen3tts_gen", "PROJECTOR_TYPE_QWEN3TTS_GEN", _GEN_AUDIO_BASE, "Generated-audio decoder sidecars are not multimodal projectors and cannot be paired with a text target package."),
-    _deferred("pockettts_spkenc", "PROJECTOR_TYPE_POCKETTTS_SPKENC", _AUDIO_BASE, "PocketTTS speaker encoder graph is not implemented."),
-    _rejected("pockettts_gen", "PROJECTOR_TYPE_POCKETTTS_GEN", _GEN_AUDIO_BASE, "Generated-audio decoder sidecars are not multimodal projectors and cannot be paired with a text target package."),
+    _deferred(
+        "gemma4a",
+        "PROJECTOR_TYPE_GEMMA4A",
+        _AUDIO_BASE,
+        "The sidecar carries a.pre_encode tensors that the current audio map drops, and independent Conformer parity is not established.",
+    ),
+    _deferred(
+        "gemma4uv",
+        "PROJECTOR_TYPE_GEMMA4UV",
+        _VISION_BASE,
+        "Encoder-free unified Gemma4 vision sidecars use a different patch embedder contract.",
+    ),
+    _deferred(
+        "gemma4ua",
+        "PROJECTOR_TYPE_GEMMA4UA",
+        _AUDIO_BASE,
+        "Encoder-free unified Gemma4 waveform embedding is not wired to GGUF.",
+    ),
+    _deferred(
+        "phi4",
+        "PROJECTOR_TYPE_PHI4",
+        _VISION_BASE,
+        "The Phi-4 vision projector exists for HF weights but has no pinned GGUF tensor closure.",
+    ),
+    _deferred(
+        "idefics3",
+        "PROJECTOR_TYPE_IDEFICS3",
+        _VISION_BASE,
+        "Idefics3 pixel-shuffle projector GGUF routing is not implemented.",
+    ),
+    _deferred(
+        "pixtral",
+        "PROJECTOR_TYPE_PIXTRAL",
+        _VISION_BASE,
+        "The Pixtral component has no pinned mmproj tensor mapping or positional-interpolation parity.",
+    ),
+    _deferred(
+        "ultravox",
+        "PROJECTOR_TYPE_ULTRAVOX",
+        _AUDIO_BASE,
+        "Whisper encoder plus Ultravox stack projector is not implemented.",
+    ),
+    _deferred(
+        "internvl",
+        "PROJECTOR_TYPE_INTERNVL",
+        _VISION_BASE,
+        "InternVL pixel-shuffle token ordering is not implemented for GGUF.",
+    ),
+    _deferred(
+        "llama4",
+        "PROJECTOR_TYPE_LLAMA4",
+        _VISION_BASE,
+        "Llama4 vision encoder and multimodal target package are out of scope.",
+    ),
+    _deferred(
+        "qwen2a",
+        "PROJECTOR_TYPE_QWEN2A",
+        _AUDIO_BASE,
+        "Qwen2 audio encoder/projector is not implemented.",
+    ),
+    _deferred(
+        "qwen3a",
+        "PROJECTOR_TYPE_QWEN3A",
+        _AUDIO_BASE,
+        "Qwen3 audio encoder/projector is not implemented.",
+    ),
+    _deferred(
+        "glma",
+        "PROJECTOR_TYPE_GLMA",
+        _AUDIO_BASE,
+        "GLM audio encoder/projector is not implemented.",
+    ),
+    _deferred(
+        "qwen2.5o",
+        "PROJECTOR_TYPE_QWEN25O",
+        _VISION_BASE | _AUDIO_BASE,
+        "This legacy string changes meaning by modality; accepting it would create a false alias.",
+    ),
+    _deferred(
+        "voxtral",
+        "PROJECTOR_TYPE_VOXTRAL",
+        _AUDIO_BASE,
+        "Voxtral Whisper encoder/projector is not implemented.",
+    ),
+    _deferred(
+        "meralion",
+        "PROJECTOR_TYPE_MERALION",
+        _AUDIO_BASE,
+        "Meralion audio projector is not implemented.",
+    ),
+    _deferred(
+        "musicflamingo",
+        "PROJECTOR_TYPE_MUSIC_FLAMINGO",
+        _AUDIO_BASE,
+        "Music Flamingo audio projector is not implemented.",
+    ),
+    _deferred(
+        "lfm2",
+        "PROJECTOR_TYPE_LFM2",
+        _VISION_BASE,
+        "The existing LFM2-VL HF graph has no pinned mmproj tensor closure or component parity.",
+    ),
+    _deferred(
+        "kimivl",
+        "PROJECTOR_TYPE_KIMIVL",
+        _VISION_BASE,
+        "Kimi-VL vision/projector graph is not implemented.",
+    ),
+    _deferred(
+        "paddleocr",
+        "PROJECTOR_TYPE_PADDLEOCR",
+        _VISION_BASE,
+        "PaddleOCR vision/projector graph is not implemented.",
+    ),
+    _deferred(
+        "lightonocr",
+        "PROJECTOR_TYPE_LIGHTONOCR",
+        _VISION_BASE,
+        "LightOnOCR Pixtral variant has no exact tensor mapping.",
+    ),
+    _deferred(
+        "cogvlm",
+        "PROJECTOR_TYPE_COGVLM",
+        _VISION_BASE,
+        "CogVLM feature output differs from LLaVA and is not implemented.",
+    ),
+    _deferred(
+        "janus_pro",
+        "PROJECTOR_TYPE_JANUS_PRO",
+        _VISION_BASE,
+        "Janus-Pro vision/projector graph is not implemented.",
+    ),
+    _deferred(
+        "dots_ocr",
+        "PROJECTOR_TYPE_DOTS_OCR",
+        _VISION_BASE,
+        "DotsOCR vision merger is not implemented.",
+    ),
+    _deferred(
+        "dots3note_v",
+        "PROJECTOR_TYPE_DOTS3NOTE_V",
+        _VISION_BASE,
+        "Dots3Note vision pyramid MoE is not implemented.",
+    ),
+    _deferred(
+        "dots3note_a",
+        "PROJECTOR_TYPE_DOTS3NOTE_A",
+        _AUDIO_BASE,
+        "Dots3Note audio graph is not implemented.",
+    ),
+    _deferred(
+        "deepseekocr",
+        "PROJECTOR_TYPE_DEEPSEEKOCR",
+        _VISION_BASE,
+        "DeepSeek-OCR SAM/projector graph is not implemented.",
+    ),
+    _deferred(
+        "deepseekocr2",
+        "PROJECTOR_TYPE_DEEPSEEKOCR2",
+        _VISION_BASE,
+        "DeepSeek-OCR2 SAM/projector graph is not implemented.",
+    ),
+    _deferred(
+        "lfm2a",
+        "PROJECTOR_TYPE_LFM2A",
+        _AUDIO_BASE,
+        "LFM2 conformer audio graph has no GGUF tensor mapping.",
+    ),
+    _deferred(
+        "glm4v",
+        "PROJECTOR_TYPE_GLM4V",
+        _VISION_BASE,
+        "GLM4V downsampler and projector are not implemented.",
+    ),
+    _deferred(
+        "youtuvl",
+        "PROJECTOR_TYPE_YOUTUVL",
+        _VISION_BASE,
+        "YouTu-VL vision/projector graph is not implemented.",
+    ),
+    _deferred(
+        "yasa2",
+        "PROJECTOR_TYPE_YASA2",
+        _VISION_BASE,
+        "YASA2 vision/projector graph is not implemented.",
+    ),
+    _deferred(
+        "kimik25",
+        "PROJECTOR_TYPE_KIMIK25",
+        _VISION_BASE,
+        "Kimi K2.5 vision/projector graph is not implemented.",
+    ),
+    _deferred(
+        "nemotron_v2_vl",
+        "PROJECTOR_TYPE_NEMOTRON_V2_VL",
+        _VISION_BASE,
+        "Nemotron V2 VL vision/projector graph is not implemented.",
+    ),
+    _deferred(
+        "exaone4_5",
+        "PROJECTOR_TYPE_EXAONE4_5",
+        _VISION_BASE,
+        "EXAONE 4.5 vision merger is not implemented.",
+    ),
+    _deferred(
+        "hunyuanvl",
+        "PROJECTOR_TYPE_HUNYUANVL",
+        _VISION_BASE,
+        "HunyuanVL vision/projector graph is not implemented.",
+    ),
+    _deferred(
+        "minicpmv4_6",
+        "PROJECTOR_TYPE_MINICPMV4_6",
+        _VISION_BASE,
+        "MiniCPM-V 4.6 SAM/resampler graph is not implemented.",
+    ),
+    _deferred(
+        "granite_speech",
+        "PROJECTOR_TYPE_GRANITE_SPEECH",
+        _AUDIO_BASE,
+        "Granite Speech audio encoder/projector is not implemented.",
+    ),
+    _deferred(
+        "mimovl",
+        "PROJECTOR_TYPE_MIMOVL",
+        _VISION_BASE,
+        "MiMo-VL vision/projector graph is not implemented.",
+    ),
+    _deferred(
+        "minimax_m3",
+        "PROJECTOR_TYPE_MINIMAX_M3",
+        _VISION_BASE,
+        "MiniMax M3 vision/projector graph is not implemented.",
+    ),
+    _deferred(
+        "granite4_vision",
+        "PROJECTOR_TYPE_GRANITE4_VISION",
+        _VISION_BASE,
+        "Granite 4 vision sidecar graph is not implemented.",
+    ),
+    _deferred(
+        "mimo_audio",
+        "PROJECTOR_TYPE_MIMO_AUDIO",
+        _AUDIO_BASE,
+        "MiMo audio RVQ/local-transformer graph is not implemented.",
+    ),
+    _deferred(
+        "parakeet",
+        "PROJECTOR_TYPE_PARAKEET",
+        _AUDIO_BASE,
+        "Parakeet audio encoder graph is not implemented.",
+    ),
+    _deferred(
+        "qwen3tts_spkenc",
+        "PROJECTOR_TYPE_QWEN3TTS_SPKENC",
+        _AUDIO_BASE,
+        "Qwen3-TTS speaker encoder graph is not implemented.",
+    ),
+    _rejected(
+        "qwen3tts_gen",
+        "PROJECTOR_TYPE_QWEN3TTS_GEN",
+        _GEN_AUDIO_BASE,
+        "Generated-audio decoder sidecars are not multimodal projectors and cannot be paired with a text target package.",
+    ),
+    _deferred(
+        "pockettts_spkenc",
+        "PROJECTOR_TYPE_POCKETTTS_SPKENC",
+        _AUDIO_BASE,
+        "PocketTTS speaker encoder graph is not implemented.",
+    ),
+    _rejected(
+        "pockettts_gen",
+        "PROJECTOR_TYPE_POCKETTTS_GEN",
+        _GEN_AUDIO_BASE,
+        "Generated-audio decoder sidecars are not multimodal projectors and cannot be paired with a text target package.",
+    ),
     ProjectorSpec(
         projector_type="muse-glimmer",
         enum_name="PROJECTOR_TYPE_MUSE_GLIMMER",
@@ -490,7 +880,7 @@ MMPROJ_ARTIFACT_PINS: tuple[MMProjArtifactPin, ...] = (
         lfs_sha256="7aa788cfe25ae5e4bf4837511f64df22cabe595e58223708274a67b3136f53ab",
         projector_types=("muse-glimmer",),
         paired_text_architecture="muse-glimmer",
-        paired_text_target="Muse-Glimmer-30B-Q4_K_M.gguf",
+        paired_text_target="Muse-Glimmer-30B-UD-Q4_K_XL.gguf",
         metadata=(
             ("general.name", "Muse-Glimmer-30B"),
             ("clip.vision.embedding_length", 1536),
@@ -506,13 +896,11 @@ MMPROJ_ARTIFACT_PINS: tuple[MMProjArtifactPin, ...] = (
 
 def iter_projector_specs() -> tuple[ProjectorSpec, ...]:
     """Return the exact 60-string pinned projector census."""
-
     return _SPECS
 
 
 def get_projector_spec(projector_type: str) -> ProjectorSpec:
     """Return one projector spec or fail with an actionable pinned-census error."""
-
     try:
         return _INDEX[projector_type]
     except KeyError as exc:
@@ -524,15 +912,11 @@ def get_projector_spec(projector_type: str) -> ProjectorSpec:
 
 def supported_projector_types() -> tuple[str, ...]:
     """Return projector strings that may reach graph construction."""
-
     return tuple(spec.projector_type for spec in _SPECS if spec.is_supported)
 
 
-def projector_type_for_modality(
-    metadata: Mapping[str, Any], modality: MMProjModality
-) -> str:
+def projector_type_for_modality(metadata: Mapping[str, Any], modality: MMProjModality) -> str:
     """Resolve the pinned global-key then modality-key projector fallback."""
-
     projector_type = metadata.get("clip.projector_type")
     if not projector_type:
         projector_type = metadata.get(f"clip.{modality.value}.projector_type")

--- a/src/mobius/integrations/gguf/_mmproj_registry_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_registry_test.py
@@ -174,7 +174,6 @@ def test_documented_projector_matrix_is_generated_from_registry() -> None:
             or "Exact registry-backed graph, tensor closure, target pairing, and component parity."
         )
         expected.append(
-            f"| `{spec.projector_type}` | {modalities} | {targets} | "
-            f"{status} | {limitation} |"
+            f"| `{spec.projector_type}` | {modalities} | {targets} | {status} | {limitation} |"
         )
     assert documented == expected

--- a/src/mobius/integrations/gguf/_mmproj_registry_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_registry_test.py
@@ -1,0 +1,180 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Closure tests for the pinned clip projector capability registry."""
+
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+from types import MappingProxyType
+
+import pytest
+
+from mobius.integrations.gguf._mmproj_registry import (
+    CLIP_METADATA_SCHEMA,
+    LLAMA_CPP_MMPROJ_SHA,
+    MMPROJ_ARTIFACT_PINS,
+    get_projector_spec,
+    iter_projector_specs,
+    supported_projector_types,
+)
+from mobius.integrations.gguf._spec import Support
+
+_PINNED_PROJECTOR_STRINGS = (
+    "mlp",
+    "ldp",
+    "ldpv2",
+    "resampler",
+    "adapter",
+    "qwen2vl_merger",
+    "qwen2.5vl_merger",
+    "qwen3vl_merger",
+    "step3vl",
+    "gemma3",
+    "gemma3nv",
+    "gemma3na",
+    "gemma4v",
+    "gemma4a",
+    "gemma4uv",
+    "gemma4ua",
+    "phi4",
+    "idefics3",
+    "pixtral",
+    "ultravox",
+    "internvl",
+    "llama4",
+    "qwen2a",
+    "qwen3a",
+    "glma",
+    "qwen2.5o",
+    "voxtral",
+    "meralion",
+    "musicflamingo",
+    "lfm2",
+    "kimivl",
+    "paddleocr",
+    "lightonocr",
+    "cogvlm",
+    "janus_pro",
+    "dots_ocr",
+    "dots3note_v",
+    "dots3note_a",
+    "deepseekocr",
+    "deepseekocr2",
+    "lfm2a",
+    "glm4v",
+    "youtuvl",
+    "yasa2",
+    "kimik25",
+    "nemotron_v2_vl",
+    "exaone4_5",
+    "hunyuanvl",
+    "minicpmv4_6",
+    "granite_speech",
+    "mimovl",
+    "minimax_m3",
+    "granite4_vision",
+    "mimo_audio",
+    "parakeet",
+    "qwen3tts_spkenc",
+    "qwen3tts_gen",
+    "pockettts_spkenc",
+    "pockettts_gen",
+    "muse-glimmer",
+)
+
+
+def test_registry_is_the_exact_pinned_60_string_census() -> None:
+    specs = iter_projector_specs()
+    assert LLAMA_CPP_MMPROJ_SHA == "8d9af256337d1a501250f9bbf4c0859a654bddd6"
+    assert tuple(spec.projector_type for spec in specs) == _PINNED_PROJECTOR_STRINGS
+    assert len({spec.enum_name for spec in specs}) == 60
+
+
+def test_registry_and_verdict_views_are_immutable() -> None:
+    spec = get_projector_spec("gemma4v")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        spec.projector_type = "mlp"  # type: ignore[misc]
+    assert isinstance(spec.verdicts, MappingProxyType)
+    with pytest.raises(TypeError):
+        spec.verdicts["runtime"] = Support.DEFERRED  # type: ignore[index]
+
+
+def test_support_is_conservative_and_artifact_backed() -> None:
+    assert supported_projector_types() == ("gemma4v", "muse-glimmer")
+    pins = {pin.artifact_id: pin for pin in MMPROJ_ARTIFACT_PINS}
+    assert set(pins) == {"gemma4-e2b-f16", "muse-glimmer-30b-bf16"}
+    for projector_type in supported_projector_types():
+        spec = get_projector_spec(projector_type)
+        assert spec.is_supported
+        assert spec.real_artifact_ids
+        assert all(artifact_id in pins for artifact_id in spec.real_artifact_ids)
+        assert all(pins[artifact_id].parity_test for artifact_id in spec.real_artifact_ids)
+
+
+def test_every_non_supported_verdict_has_an_actionable_reason() -> None:
+    for spec in iter_projector_specs():
+        if spec.is_supported:
+            continue
+        assert spec.reason
+        assert len(spec.reason.split()) >= 5
+
+
+def test_metadata_schema_captures_the_pinned_absence_of_a_text_encoder() -> None:
+    assert len(CLIP_METADATA_SCHEMA) == 61
+    fields = {field.key: field for field in CLIP_METADATA_SCHEMA}
+    assert fields["clip.has_vision_encoder"].default is False
+    assert fields["clip.has_audio_encoder"].default is False
+    assert fields["clip.has_gen_audio_encoder"].default is False
+    assert "Absent from the pinned ABI" in fields["clip.has_text_encoder"].note
+
+
+@pytest.mark.parametrize("projector_type", ["mlp", "gemma4a", "qwen2.5o"])
+def test_deferred_projector_has_no_dispatch_or_loader_closure(projector_type: str) -> None:
+    spec = get_projector_spec(projector_type)
+    assert not spec.is_supported
+    assert spec.builder is None
+    assert spec.required_metadata == ()
+    assert spec.required_top_tensors == ()
+    assert spec.block_suffixes == ()
+
+
+@pytest.mark.parametrize("projector_type", ["qwen3tts_gen", "pockettts_gen"])
+def test_generated_audio_decoders_are_explicitly_rejected(projector_type: str) -> None:
+    spec = get_projector_spec(projector_type)
+    assert set(spec.verdicts.values()) == {Support.REJECTED}
+
+
+def test_documented_projector_matrix_is_generated_from_registry() -> None:
+    doc = pathlib.Path(__file__).resolve().parents[4] / "docs" / "api" / "build_from_gguf.md"
+    begin = "<!-- BEGIN GGUF MMPROJ SUPPORT MATRIX (generated; see _mmproj_registry.py) -->"
+    end = "<!-- END GGUF MMPROJ SUPPORT MATRIX -->"
+    block = doc.read_text(encoding="utf-8").split(begin, 1)[1].split(end, 1)[0]
+    documented = [line for line in block.splitlines() if line.startswith("| `")]
+    expected = []
+    for spec in iter_projector_specs():
+        modalities = ", ".join(
+            modality.value for modality in sorted(spec.modalities, key=lambda item: item.value)
+        )
+        targets = (
+            ", ".join(f"`{target}`" for target in sorted(spec.target_architectures)) or "—"
+        )
+        status = (
+            "supported"
+            if spec.is_supported
+            else "; ".join(
+                f"{name} {verdict.value}"
+                for name, verdict in spec.verdicts.items()
+                if verdict is not Support.SUPPORTED
+            )
+        )
+        limitation = (
+            spec.reason
+            or "Exact registry-backed graph, tensor closure, target pairing, and component parity."
+        )
+        expected.append(
+            f"| `{spec.projector_type}` | {modalities} | {targets} | "
+            f"{status} | {limitation} |"
+        )
+    assert documented == expected

--- a/src/mobius/integrations/gguf/_mmproj_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_test.py
@@ -45,6 +45,8 @@ def _write_clip_mmproj_gguf(
     extra_tensor: str | None = None,
     identity_name: str = "Gemma-4-E2B-It",
     identity_repo: str | None = "https://huggingface.co/google/gemma-4-E2B-it",
+    patch_weight_shape: tuple[int, ...] | None = None,
+    audio_num_mel_bins: int | None = _NUM_MEL_BINS,
 ) -> None:
     """Write a small synthetic Gemma4 ``clip`` mmproj GGUF for tests."""
     from gguf import GGUFWriter
@@ -75,7 +77,10 @@ def _write_clip_mmproj_gguf(
         writer.add_tensor(name, np.random.randn(*shape).astype(np.float32))
 
     # patch embed (conv layout) + position table + projector.
-    _f32("v.patch_embd.weight", (_VISION_HIDDEN, 3, _PATCH_SIZE, _PATCH_SIZE))
+    _f32(
+        "v.patch_embd.weight",
+        patch_weight_shape or (_VISION_HIDDEN, 3, _PATCH_SIZE, _PATCH_SIZE),
+    )
     _f32("v.position_embd.weight", (2, _POS_EMB_SIZE, _VISION_HIDDEN))
     _f32("mm.input_projection.weight", (_TEXT_HIDDEN, _VISION_HIDDEN))
     for layer in range(_VISION_LAYERS):
@@ -103,7 +108,8 @@ def _write_clip_mmproj_gguf(
         writer.add_uint32("clip.audio.feed_forward_length", _AUDIO_FFN)
         writer.add_uint32("clip.audio.block_count", _AUDIO_LAYERS)
         writer.add_uint32("clip.audio.attention.head_count", _AUDIO_HEADS)
-        writer.add_uint32("clip.audio.num_mel_bins", _NUM_MEL_BINS)
+        if audio_num_mel_bins is not None:
+            writer.add_uint32("clip.audio.num_mel_bins", audio_num_mel_bins)
         writer.add_uint32("clip.audio.projection_dim", _TEXT_HIDDEN)
         writer.add_float32("clip.audio.attention.layer_norm_epsilon", 1e-6)
         _f32("a.conv1d.0.weight", (_AUDIO_CONV0, 1, 3, 3))
@@ -510,6 +516,145 @@ class TestMultimodalPreflightGuards:
 
         resolved = _preflight_mmproj_pair(text, mmproj, modalities=(MMProjModality.VISION,))
         assert resolved[MMProjModality.VISION].projector_type == "gemma4v"
+
+    @pytest.mark.parametrize(
+        ("text_name", "sidecar_name"),
+        [
+            ("Model-A", "ModelA"),
+            ("org/model", "orgmodel"),
+            ("model_a", "model-a"),
+        ],
+    )
+    def test_identity_normalization_preserves_meaningful_separators(
+        self, tmp_path: Path, text_name: str, sidecar_name: str
+    ):
+        from mobius.integrations.gguf._mmproj import _preflight_mmproj_pair
+        from mobius.integrations.gguf._mmproj_registry import MMProjModality
+
+        text_path = tmp_path / "gemma4.gguf"
+        mmproj_path = tmp_path / "mmproj.gguf"
+        _write_minimal_gguf(text_path, "gemma4")
+        _write_clip_mmproj_gguf(mmproj_path, with_audio=False)
+        text, mmproj = self._load_pair(text_path, mmproj_path)
+        text.metadata["general.name"] = text_name
+        mmproj.metadata["general.name"] = sidecar_name
+
+        with pytest.raises(ValueError, match=r"general\.name"):
+            _preflight_mmproj_pair(text, mmproj, modalities=(MMProjModality.VISION,))
+
+    @pytest.mark.parametrize("empty_value", ["", " \t "])
+    def test_empty_identity_values_are_rejected(self, tmp_path: Path, empty_value: str):
+        from mobius.integrations.gguf._mmproj import _preflight_mmproj_pair
+        from mobius.integrations.gguf._mmproj_registry import MMProjModality
+
+        text_path = tmp_path / "gemma4.gguf"
+        mmproj_path = tmp_path / "mmproj.gguf"
+        _write_minimal_gguf(text_path, "gemma4")
+        _write_clip_mmproj_gguf(mmproj_path, with_audio=False)
+        text, mmproj = self._load_pair(text_path, mmproj_path)
+        text.metadata["general.name"] = empty_value
+        mmproj.metadata["general.name"] = empty_value
+
+        with pytest.raises(ValueError, match=r"non-empty string"):
+            _preflight_mmproj_pair(text, mmproj, modalities=(MMProjModality.VISION,))
+
+    def test_one_sided_present_empty_optional_binding_is_not_treated_absent(
+        self, tmp_path: Path
+    ):
+        from mobius.integrations.gguf._mmproj import _preflight_mmproj_pair
+        from mobius.integrations.gguf._mmproj_registry import MMProjModality
+
+        text_path = tmp_path / "gemma4.gguf"
+        mmproj_path = tmp_path / "mmproj.gguf"
+        _write_minimal_gguf(text_path, "gemma4")
+        _write_clip_mmproj_gguf(mmproj_path, with_audio=False)
+        text, mmproj = self._load_pair(text_path, mmproj_path)
+        text.metadata["general.base_model.0.repo_url"] = ""
+        mmproj.metadata.pop("general.base_model.0.repo_url")
+
+        with pytest.raises(ValueError, match=r"present on only one file"):
+            _preflight_mmproj_pair(text, mmproj, modalities=(MMProjModality.VISION,))
+
+    def test_repository_canonicalization_only_normalizes_url_syntax(self, tmp_path: Path):
+        from mobius.integrations.gguf._mmproj import _preflight_mmproj_pair
+        from mobius.integrations.gguf._mmproj_registry import MMProjModality
+
+        text_path = tmp_path / "gemma4.gguf"
+        mmproj_path = tmp_path / "mmproj.gguf"
+        _write_minimal_gguf(text_path, "gemma4")
+        _write_clip_mmproj_gguf(mmproj_path, with_audio=False)
+        text, mmproj = self._load_pair(text_path, mmproj_path)
+        text.metadata["general.base_model.0.repo_url"] = (
+            "HTTPS://HUGGINGFACE.CO/Google/Gemma-4-E2B-It.git/"
+        )
+
+        resolved = _preflight_mmproj_pair(text, mmproj, modalities=(MMProjModality.VISION,))
+        assert resolved[MMProjModality.VISION].projector_type == "gemma4v"
+
+    @pytest.mark.parametrize(
+        "patch_shape",
+        [
+            (_VISION_HIDDEN, 1, 3, _PATCH_SIZE, _PATCH_SIZE),
+            (_VISION_HIDDEN, 1, _PATCH_SIZE, _PATCH_SIZE),
+            (_VISION_HIDDEN, 3, _PATCH_SIZE, _PATCH_SIZE + 1),
+        ],
+    )
+    def test_gemma4_patch_shape_rejects_before_graph_build(
+        self, tmp_path: Path, patch_shape: tuple[int, ...]
+    ):
+        from mobius.integrations.gguf._mmproj import build_gemma4_vlm_from_gguf
+
+        text_path = tmp_path / "gemma4.gguf"
+        mmproj_path = tmp_path / "mmproj.gguf"
+        _write_minimal_gguf(text_path, "gemma4")
+        _write_clip_mmproj_gguf(
+            mmproj_path,
+            with_audio=False,
+            patch_weight_shape=patch_shape,
+        )
+
+        with (
+            mock.patch("mobius._builder.build_from_module") as build_graph,
+            pytest.raises(ValueError, match=r"graph-compatible shape"),
+        ):
+            build_gemma4_vlm_from_gguf(text_path, mmproj_path, image_token_id=0)
+        build_graph.assert_not_called()
+
+    @pytest.mark.parametrize("num_mel_bins", [None, 0])
+    def test_audio_num_mel_bins_rejects_before_graph_build(
+        self, tmp_path: Path, num_mel_bins: int | None
+    ):
+        from mobius.integrations.gguf._mmproj import build_gemma4_vlm_from_gguf
+
+        text_path = tmp_path / "gemma4.gguf"
+        mmproj_path = tmp_path / "mmproj.gguf"
+        _write_minimal_gguf(text_path, "gemma4")
+        _write_clip_mmproj_gguf(
+            mmproj_path,
+            with_audio=True,
+            audio_num_mel_bins=num_mel_bins,
+        )
+
+        with (
+            mock.patch("mobius._builder.build_from_module") as build_graph,
+            pytest.raises(ValueError, match=r"clip\.audio\.num_mel_bins"),
+        ):
+            build_gemma4_vlm_from_gguf(text_path, mmproj_path, image_token_id=0)
+        build_graph.assert_not_called()
+
+    def test_audio_num_mel_bins_wrong_type_is_rejected(self, tmp_path: Path):
+        from mobius.integrations.gguf._mmproj import _preflight_mmproj_pair
+        from mobius.integrations.gguf._mmproj_registry import MMProjModality
+
+        text_path = tmp_path / "gemma4.gguf"
+        mmproj_path = tmp_path / "mmproj.gguf"
+        _write_minimal_gguf(text_path, "gemma4")
+        _write_clip_mmproj_gguf(mmproj_path, with_audio=True)
+        text, mmproj = self._load_pair(text_path, mmproj_path)
+        mmproj.metadata["clip.audio.num_mel_bins"] = "8"
+
+        with pytest.raises(ValueError, match=r"positive integer"):
+            _preflight_mmproj_pair(text, mmproj, modalities=(MMProjModality.VISION,))
 
     def test_quantized_projector_weight_is_rejected_by_role(self, tmp_path: Path):
         from types import SimpleNamespace

--- a/src/mobius/integrations/gguf/_mmproj_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_test.py
@@ -34,7 +34,7 @@ _AUDIO_HEADS = 2
 _NUM_MEL_BINS = 8
 _AUDIO_CONV0 = 16
 _AUDIO_CONV1 = 16
-_AUDIO_PROJ_OUT = 24
+_AUDIO_PROJ_OUT = _TEXT_HIDDEN
 
 
 def _write_clip_mmproj_gguf(
@@ -43,12 +43,19 @@ def _write_clip_mmproj_gguf(
     with_audio: bool = True,
     vision_projector_type: str = "gemma4v",
     extra_tensor: str | None = None,
+    identity_name: str = "Gemma-4-E2B-It",
+    identity_repo: str | None = "https://huggingface.co/google/gemma-4-E2B-it",
 ) -> None:
     """Write a small synthetic Gemma4 ``clip`` mmproj GGUF for tests."""
     from gguf import GGUFWriter
 
     head_dim = _VISION_HIDDEN // _VISION_HEADS
     writer = GGUFWriter(str(path), "clip")
+    writer.add_string("general.name", identity_name)
+    writer.add_string("general.base_model.0.name", identity_name)
+    if identity_repo is not None:
+        writer.add_string("general.base_model.0.repo_url", identity_repo)
+    writer.add_string("general.type", "mmproj")
 
     # --- vision metadata ---
     writer.add_bool("clip.has_vision_encoder", True)
@@ -100,8 +107,52 @@ def _write_clip_mmproj_gguf(
         writer.add_uint32("clip.audio.projection_dim", _TEXT_HIDDEN)
         writer.add_float32("clip.audio.attention.layer_norm_epsilon", 1e-6)
         _f32("a.conv1d.0.weight", (_AUDIO_CONV0, 1, 3, 3))
+        _f32("a.conv1d.0.norm.weight", (_AUDIO_CONV0,))
         _f32("a.conv1d.1.weight", (_AUDIO_CONV1, _AUDIO_CONV0, 3, 3))
-        _f32("mm.a.input_projection.weight", (_AUDIO_HIDDEN, _AUDIO_PROJ_OUT))
+        _f32("a.conv1d.1.norm.weight", (_AUDIO_CONV1,))
+        _f32("a.input_projection.weight", (_AUDIO_HIDDEN, _AUDIO_HIDDEN))
+        _f32("a.pre_encode.out.weight", (_AUDIO_PROJ_OUT, _AUDIO_HIDDEN))
+        _f32("a.pre_encode.out.bias", (_AUDIO_PROJ_OUT,))
+        _f32("mm.a.input_projection.weight", (_TEXT_HIDDEN, _AUDIO_PROJ_OUT))
+        audio_head_dim = _AUDIO_HIDDEN // _AUDIO_HEADS
+        clipped_stems = (
+            "attn_q",
+            "attn_k",
+            "attn_v",
+            "attn_out",
+            "conv_pw1",
+            "conv_pw2",
+            "ffn_up",
+            "ffn_down",
+            "ffn_up_1",
+            "ffn_down_1",
+        )
+        for layer in range(_AUDIO_LAYERS):
+            prefix = f"a.blk.{layer}."
+            for norm in (
+                "ffn_norm",
+                "ffn_post_norm",
+                "ffn_norm_1",
+                "ffn_post_norm_1",
+                "attn_pre_norm",
+                "attn_post_norm",
+                "ln2",
+                "norm_conv",
+            ):
+                _f32(prefix + norm + ".weight", (_AUDIO_HIDDEN,))
+            _f32(prefix + "per_dim_scale.weight", (audio_head_dim,))
+            for stem in ("attn_q", "attn_k", "attn_v", "attn_out", "attn_k_rel"):
+                _f32(prefix + stem + ".weight", (_AUDIO_HIDDEN, _AUDIO_HIDDEN))
+            _f32(prefix + "conv_pw1.weight", (2 * _AUDIO_HIDDEN, _AUDIO_HIDDEN))
+            _f32(prefix + "conv_dw.weight", (_AUDIO_HIDDEN, 5))
+            _f32(prefix + "conv_pw2.weight", (_AUDIO_HIDDEN, _AUDIO_HIDDEN))
+            for stem in ("ffn_up", "ffn_up_1"):
+                _f32(prefix + stem + ".weight", (_AUDIO_FFN, _AUDIO_HIDDEN))
+            for stem in ("ffn_down", "ffn_down_1"):
+                _f32(prefix + stem + ".weight", (_AUDIO_HIDDEN, _AUDIO_FFN))
+            for stem in clipped_stems:
+                for bound in ("input_min", "input_max", "output_min", "output_max"):
+                    _f32(prefix + stem + "." + bound, (1,))
     if extra_tensor is not None:
         _f32(extra_tensor, (1,))
 
@@ -116,11 +167,27 @@ def _write_minimal_gguf(
     architecture: str,
     *,
     split_count: int = 1,
+    identity_name: str | None = None,
+    identity_repo: str | None = None,
 ) -> None:
     """Write only enough GGUF structure to exercise pre-config guards."""
     from gguf import GGUFWriter
 
     writer = GGUFWriter(str(path), architecture)
+    if identity_name is None:
+        identity_name = {
+            "gemma4": "Gemma-4-E2B-It",
+            "muse-glimmer": "Muse-Glimmer-30B",
+            "muse_glimmer": "Muse-Glimmer-30B",
+        }.get(architecture)
+    if identity_repo is None and architecture == "gemma4":
+        identity_repo = "https://huggingface.co/google/gemma-4-E2B-it"
+    if identity_name is not None:
+        writer.add_string("general.name", identity_name)
+        if architecture == "gemma4" or identity_repo is not None:
+            writer.add_string("general.base_model.0.name", identity_name)
+    if identity_repo is not None:
+        writer.add_string("general.base_model.0.repo_url", identity_repo)
     if split_count > 1:
         writer.add_uint16("split.no", 0)
         writer.add_uint16("split.count", split_count)
@@ -145,6 +212,12 @@ def _write_quantized_gemma4_text_gguf(path: Path) -> None:
     head_dim = hidden_size // num_heads
 
     writer = GGUFWriter(str(path), "gemma4")
+    writer.add_string("general.name", "Gemma-4-E2B-It")
+    writer.add_string("general.base_model.0.name", "Gemma-4-E2B-It")
+    writer.add_string(
+        "general.base_model.0.repo_url",
+        "https://huggingface.co/google/gemma-4-E2B-it",
+    )
     writer.add_context_length(128)
     writer.add_embedding_length(hidden_size)
     writer.add_feed_forward_length(intermediate_size)
@@ -226,6 +299,12 @@ def clip_mmproj_gguf(tmp_path: Path) -> Path:
 
 
 class TestMultimodalPreflightGuards:
+    @staticmethod
+    def _load_pair(text_path: Path, mmproj_path: Path):
+        from mobius.integrations.gguf._reader import GGUFModel
+
+        return GGUFModel(str(text_path)), GGUFModel(str(mmproj_path))
+
     def test_rejects_unsupported_text_architecture_before_config(
         self,
         tmp_path: Path,
@@ -280,8 +359,18 @@ class TestMultimodalPreflightGuards:
 
         text_path = tmp_path / "muse-glimmer.gguf"
         mmproj_path = tmp_path / "mmproj.gguf"
-        _write_minimal_gguf(text_path, "muse-glimmer")
-        _write_clip_mmproj_gguf(mmproj_path)
+        identity_repo = "https://huggingface.co/example/shared-vlm"
+        _write_minimal_gguf(
+            text_path,
+            "muse-glimmer",
+            identity_name="Shared-VLM",
+            identity_repo=identity_repo,
+        )
+        _write_clip_mmproj_gguf(
+            mmproj_path,
+            identity_name="Shared-VLM",
+            identity_repo=identity_repo,
+        )
 
         with (
             mock.patch(
@@ -306,6 +395,121 @@ class TestMultimodalPreflightGuards:
         ):
             build_gemma4_vlm_from_gguf(text_path, mmproj_path, image_token_id=0)
         build_graph.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "extra_tensor",
+        ["unexpected.weight", "vision.blk.0.attn_q.weight"],
+    )
+    def test_complete_inventory_rejects_unknown_tensor_names(
+        self, tmp_path: Path, extra_tensor: str
+    ):
+        from mobius.integrations.gguf._mmproj import _preflight_mmproj_pair
+        from mobius.integrations.gguf._mmproj_registry import MMProjModality
+
+        text_path = tmp_path / "gemma4.gguf"
+        mmproj_path = tmp_path / "mmproj.gguf"
+        _write_minimal_gguf(text_path, "gemma4")
+        _write_clip_mmproj_gguf(mmproj_path, with_audio=False, extra_tensor=extra_tensor)
+        text, mmproj = self._load_pair(text_path, mmproj_path)
+
+        with pytest.raises(ValueError, match=r"outside the pinned.*closure"):
+            _preflight_mmproj_pair(text, mmproj, modalities=(MMProjModality.VISION,))
+
+    def test_valid_deferred_audio_companion_inventory_is_explicitly_allowed(
+        self, tmp_path: Path
+    ):
+        from mobius.integrations.gguf._mmproj import _preflight_mmproj_pair
+        from mobius.integrations.gguf._mmproj_registry import MMProjModality
+
+        text_path = tmp_path / "gemma4.gguf"
+        mmproj_path = tmp_path / "mmproj.gguf"
+        _write_minimal_gguf(text_path, "gemma4")
+        _write_clip_mmproj_gguf(mmproj_path, with_audio=True)
+        text, mmproj = self._load_pair(text_path, mmproj_path)
+
+        resolved = _preflight_mmproj_pair(text, mmproj, modalities=(MMProjModality.VISION,))
+        assert resolved[MMProjModality.VISION].projector_type == "gemma4v"
+
+    def test_companion_tensor_wrong_rank_is_rejected(self, tmp_path: Path):
+        from mobius.integrations.gguf._mmproj import _preflight_mmproj_pair
+        from mobius.integrations.gguf._mmproj_registry import MMProjModality
+
+        text_path = tmp_path / "gemma4.gguf"
+        mmproj_path = tmp_path / "mmproj.gguf"
+        _write_minimal_gguf(text_path, "gemma4")
+        _write_clip_mmproj_gguf(mmproj_path, with_audio=True)
+        text, mmproj = self._load_pair(text_path, mmproj_path)
+        original = mmproj.get_tensor_shape
+
+        with (
+            mock.patch.object(
+                mmproj,
+                "get_tensor_shape",
+                side_effect=lambda name: (
+                    (1, 3, 3) if name == "a.conv1d.0.weight" else original(name)
+                ),
+            ),
+            pytest.raises(ValueError, match=r"a\.conv1d\.0\.weight must have shape"),
+        ):
+            _preflight_mmproj_pair(text, mmproj, modalities=(MMProjModality.VISION,))
+
+    @pytest.mark.parametrize("missing_side", ["text", "mmproj"])
+    def test_missing_identity_on_either_side_fails_closed(
+        self, tmp_path: Path, missing_side: str
+    ):
+        from mobius.integrations.gguf._mmproj import _preflight_mmproj_pair
+        from mobius.integrations.gguf._mmproj_registry import MMProjModality
+
+        text_path = tmp_path / "gemma4.gguf"
+        mmproj_path = tmp_path / "mmproj.gguf"
+        _write_minimal_gguf(text_path, "gemma4")
+        _write_clip_mmproj_gguf(mmproj_path, with_audio=False)
+        text, mmproj = self._load_pair(text_path, mmproj_path)
+        (text if missing_side == "text" else mmproj).metadata.pop("general.name")
+
+        with pytest.raises(ValueError, match=r"both files must declare.*general\.name"):
+            _preflight_mmproj_pair(text, mmproj, modalities=(MMProjModality.VISION,))
+
+    @pytest.mark.parametrize(
+        ("key", "mismatched"),
+        [
+            ("general.name", "Other-Gemma"),
+            (
+                "general.base_model.0.repo_url",
+                "https://huggingface.co/example/other-gemma",
+            ),
+        ],
+    )
+    def test_identity_binding_mismatch_is_rejected(
+        self, tmp_path: Path, key: str, mismatched: str
+    ):
+        from mobius.integrations.gguf._mmproj import _preflight_mmproj_pair
+        from mobius.integrations.gguf._mmproj_registry import MMProjModality
+
+        text_path = tmp_path / "gemma4.gguf"
+        mmproj_path = tmp_path / "mmproj.gguf"
+        _write_minimal_gguf(text_path, "gemma4")
+        _write_clip_mmproj_gguf(mmproj_path, with_audio=False)
+        text, mmproj = self._load_pair(text_path, mmproj_path)
+        mmproj.metadata[key] = mismatched
+
+        with pytest.raises(ValueError, match=key):
+            _preflight_mmproj_pair(text, mmproj, modalities=(MMProjModality.VISION,))
+
+    def test_matching_identity_survives_file_relocation(self, tmp_path: Path):
+        from mobius.integrations.gguf._mmproj import _preflight_mmproj_pair
+        from mobius.integrations.gguf._mmproj_registry import MMProjModality
+
+        text_path = tmp_path / "relocated" / "text" / "renamed-model.gguf"
+        mmproj_path = tmp_path / "another-root" / "renamed-sidecar.gguf"
+        text_path.parent.mkdir(parents=True)
+        mmproj_path.parent.mkdir(parents=True)
+        _write_minimal_gguf(text_path, "gemma4")
+        _write_clip_mmproj_gguf(mmproj_path, with_audio=False)
+        text, mmproj = self._load_pair(text_path, mmproj_path)
+
+        resolved = _preflight_mmproj_pair(text, mmproj, modalities=(MMProjModality.VISION,))
+        assert resolved[MMProjModality.VISION].projector_type == "gemma4v"
 
     def test_quantized_projector_weight_is_rejected_by_role(self, tmp_path: Path):
         from types import SimpleNamespace
@@ -392,6 +596,26 @@ class TestReadAudioConfig:
 
 class TestVisionEncoderBuildAndRun:
     """Build the Gemma4 vision encoder from the synthetic mmproj and run it."""
+
+    def test_declares_single_image_batch_contract(self, clip_mmproj_gguf: Path):
+        from mobius._configs import Gemma4Config
+        from mobius.integrations.gguf._mmproj import read_mmproj_vision_config
+        from mobius.integrations.gguf._reader import GGUFModel
+        from mobius.models.gemma4 import _Gemma4VisionEncoderModel
+        from mobius.tasks._gemma4 import Gemma4Task
+
+        vision_config = read_mmproj_vision_config(GGUFModel(str(clip_mmproj_gguf)))
+        config = Gemma4Config(
+            hidden_size=_TEXT_HIDDEN,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            vocab_size=64,
+            vision=vision_config,
+        )
+        model = Gemma4Task()._build_vision(_Gemma4VisionEncoderModel(config), config)
+
+        assert next(iter(model.graph.inputs[0].shape)) == 1
+        assert next(iter(model.graph.inputs[1].shape)) == 1
 
     def test_matches_independent_numpy_reference(self, tmp_path: Path):
         """Check patch, position, pooling, norm, and projection semantics."""
@@ -747,6 +971,8 @@ def _write_muse_glimmer_mmproj_gguf(path: Path) -> None:
     from gguf import GGUFWriter
 
     writer = GGUFWriter(str(path), "clip")
+    writer.add_string("general.name", "Muse-Glimmer-30B")
+    writer.add_string("general.type", "mmproj")
     writer.add_bool("clip.has_vision_encoder", True)
     writer.add_string("clip.projector_type", "muse-glimmer")
     writer.add_uint32("clip.vision.embedding_length", _MG_HIDDEN)

--- a/src/mobius/integrations/gguf/_mmproj_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_test.py
@@ -37,7 +37,13 @@ _AUDIO_CONV1 = 16
 _AUDIO_PROJ_OUT = 24
 
 
-def _write_clip_mmproj_gguf(path: Path, *, with_audio: bool = True) -> None:
+def _write_clip_mmproj_gguf(
+    path: Path,
+    *,
+    with_audio: bool = True,
+    vision_projector_type: str = "gemma4v",
+    extra_tensor: str | None = None,
+) -> None:
     """Write a small synthetic Gemma4 ``clip`` mmproj GGUF for tests."""
     from gguf import GGUFWriter
 
@@ -46,13 +52,16 @@ def _write_clip_mmproj_gguf(path: Path, *, with_audio: bool = True) -> None:
 
     # --- vision metadata ---
     writer.add_bool("clip.has_vision_encoder", True)
-    writer.add_string("clip.vision.projector_type", "gemma4v")
+    writer.add_string("clip.vision.projector_type", vision_projector_type)
     writer.add_uint32("clip.vision.embedding_length", _VISION_HIDDEN)
     writer.add_uint32("clip.vision.feed_forward_length", _VISION_FFN)
     writer.add_uint32("clip.vision.block_count", _VISION_LAYERS)
     writer.add_uint32("clip.vision.attention.head_count", _VISION_HEADS)
     writer.add_uint32("clip.vision.image_size", _IMAGE_SIZE)
     writer.add_uint32("clip.vision.patch_size", _PATCH_SIZE)
+    writer.add_uint32("clip.vision.projection_dim", _TEXT_HIDDEN)
+    writer.add_array("clip.vision.image_mean", [0.0, 0.0, 0.0])
+    writer.add_array("clip.vision.image_std", [1.0, 1.0, 1.0])
     writer.add_float32("clip.vision.attention.layer_norm_epsilon", 1e-6)
 
     def _f32(name: str, shape: tuple[int, ...]) -> None:
@@ -62,22 +71,22 @@ def _write_clip_mmproj_gguf(path: Path, *, with_audio: bool = True) -> None:
     _f32("v.patch_embd.weight", (_VISION_HIDDEN, 3, _PATCH_SIZE, _PATCH_SIZE))
     _f32("v.position_embd.weight", (2, _POS_EMB_SIZE, _VISION_HIDDEN))
     _f32("mm.input_projection.weight", (_TEXT_HIDDEN, _VISION_HIDDEN))
-    # A companion activation-range stat tensor that must be skipped.
-    _f32("mm.input_projection.weight.input_max", (1,))
-
     for layer in range(_VISION_LAYERS):
         prefix = f"v.blk.{layer}."
         for norm in ("ln1", "ln2", "attn_post_norm", "ffn_post_norm"):
             _f32(prefix + norm + ".weight", (_VISION_HIDDEN,))
         for proj in ("attn_q", "attn_k", "attn_v", "attn_out"):
             _f32(prefix + proj + ".weight", (_VISION_HIDDEN, _VISION_HIDDEN))
+            for bound in ("input_min", "input_max", "output_min", "output_max"):
+                _f32(prefix + proj + "." + bound, (1,))
         for qk_norm in ("attn_q_norm", "attn_k_norm"):
             _f32(prefix + qk_norm + ".weight", (head_dim,))
         _f32(prefix + "ffn_gate.weight", (_VISION_FFN, _VISION_HIDDEN))
         _f32(prefix + "ffn_up.weight", (_VISION_FFN, _VISION_HIDDEN))
         _f32(prefix + "ffn_down.weight", (_VISION_HIDDEN, _VISION_FFN))
-        # Stat tensor next to a quantizable linear — must be skipped.
-        _f32(prefix + "attn_q.weight.output_min", (1,))
+        for proj in ("ffn_gate", "ffn_up", "ffn_down"):
+            for bound in ("input_min", "input_max", "output_min", "output_max"):
+                _f32(prefix + proj + "." + bound, (1,))
 
     # --- audio metadata (best-effort, for config-extraction tests) ---
     if with_audio:
@@ -88,10 +97,13 @@ def _write_clip_mmproj_gguf(path: Path, *, with_audio: bool = True) -> None:
         writer.add_uint32("clip.audio.block_count", _AUDIO_LAYERS)
         writer.add_uint32("clip.audio.attention.head_count", _AUDIO_HEADS)
         writer.add_uint32("clip.audio.num_mel_bins", _NUM_MEL_BINS)
+        writer.add_uint32("clip.audio.projection_dim", _TEXT_HIDDEN)
         writer.add_float32("clip.audio.attention.layer_norm_epsilon", 1e-6)
         _f32("a.conv1d.0.weight", (_AUDIO_CONV0, 1, 3, 3))
         _f32("a.conv1d.1.weight", (_AUDIO_CONV1, _AUDIO_CONV0, 3, 3))
         _f32("mm.a.input_projection.weight", (_AUDIO_HIDDEN, _AUDIO_PROJ_OUT))
+    if extra_tensor is not None:
+        _f32(extra_tensor, (1,))
 
     writer.write_header_to_file()
     writer.write_kv_data_to_file()
@@ -245,6 +257,84 @@ class TestMultimodalPreflightGuards:
         with pytest.raises(NotImplementedError, match="cannot assemble split tensor tables"):
             build_gemma4_vlm_from_gguf(text_path, mmproj_path)
 
+    @pytest.mark.parametrize("projector_type", ["unknown-projector", "mlp", "gemma4a"])
+    def test_unknown_or_deferred_projector_fails_before_graph_construction(
+        self, tmp_path: Path, projector_type: str
+    ):
+        from mobius.integrations.gguf._mmproj import build_gemma4_vlm_from_gguf
+
+        text_path = tmp_path / "gemma4.gguf"
+        mmproj_path = tmp_path / "mmproj.gguf"
+        _write_minimal_gguf(text_path, "gemma4")
+        _write_clip_mmproj_gguf(mmproj_path, vision_projector_type=projector_type)
+
+        with (
+            mock.patch("mobius._builder.build_from_module") as build_graph,
+            pytest.raises((ValueError, NotImplementedError), match=projector_type),
+        ):
+            build_gemma4_vlm_from_gguf(text_path, mmproj_path, image_token_id=0)
+        build_graph.assert_not_called()
+
+    def test_target_mismatch_fails_before_builder_dispatch(self, tmp_path: Path):
+        from mobius.integrations.gguf._mmproj import build_vlm_from_gguf
+
+        text_path = tmp_path / "muse-glimmer.gguf"
+        mmproj_path = tmp_path / "mmproj.gguf"
+        _write_minimal_gguf(text_path, "muse-glimmer")
+        _write_clip_mmproj_gguf(mmproj_path)
+
+        with (
+            mock.patch(
+                "mobius.integrations.gguf._mmproj.build_gemma4_vlm_from_gguf"
+            ) as builder,
+            pytest.raises(ValueError, match=r"targets.*gemma4"),
+        ):
+            build_vlm_from_gguf(text_path, mmproj_path)
+        builder.assert_not_called()
+
+    def test_scale_tensor_cannot_be_silently_dropped(self, tmp_path: Path):
+        from mobius.integrations.gguf._mmproj import build_gemma4_vlm_from_gguf
+
+        text_path = tmp_path / "gemma4.gguf"
+        mmproj_path = tmp_path / "mmproj.gguf"
+        _write_minimal_gguf(text_path, "gemma4")
+        _write_clip_mmproj_gguf(mmproj_path, extra_tensor="v.blk.0.attn_q.input_scale")
+
+        with (
+            mock.patch("mobius._builder.build_from_module") as build_graph,
+            pytest.raises(ValueError, match=r"input_scale.*never dropped"),
+        ):
+            build_gemma4_vlm_from_gguf(text_path, mmproj_path, image_token_id=0)
+        build_graph.assert_not_called()
+
+    def test_quantized_projector_weight_is_rejected_by_role(self, tmp_path: Path):
+        from types import SimpleNamespace
+
+        from mobius.integrations.gguf._mmproj import (
+            _preflight_mmproj_pair,
+        )
+        from mobius.integrations.gguf._mmproj_registry import MMProjModality
+        from mobius.integrations.gguf._reader import GGUFModel
+
+        text_path = tmp_path / "gemma4.gguf"
+        mmproj_path = tmp_path / "mmproj.gguf"
+        _write_minimal_gguf(text_path, "gemma4")
+        _write_clip_mmproj_gguf(mmproj_path)
+        text = GGUFModel(str(text_path))
+        mmproj = GGUFModel(str(mmproj_path))
+        original = mmproj.get_tensor_type
+
+        def tensor_type(name: str):
+            if name == "mm.input_projection.weight":
+                return SimpleNamespace(name="Q8_0")
+            return original(name)
+
+        with (
+            mock.patch.object(mmproj, "get_tensor_type", side_effect=tensor_type),
+            pytest.raises(NotImplementedError, match="packed Q8_0"),
+        ):
+            _preflight_mmproj_pair(text, mmproj, modalities=(MMProjModality.VISION,))
+
 
 class TestReadVisionConfig:
     def test_extracts_expected_fields(self, clip_mmproj_gguf: Path):
@@ -261,7 +351,8 @@ class TestReadVisionConfig:
         assert config.image_size == _IMAGE_SIZE
         assert config.patch_size == _PATCH_SIZE
         assert config.position_embedding_size == _POS_EMB_SIZE
-        assert config.use_clipped_linears is False
+        assert config.use_clipped_linears is True
+        assert config.pooling_kernel_size == 3
         assert config.norm_eps == pytest.approx(1e-6)
 
     def test_returns_none_without_vision_encoder(self, tmp_path: Path):
@@ -302,14 +393,83 @@ class TestReadAudioConfig:
 class TestVisionEncoderBuildAndRun:
     """Build the Gemma4 vision encoder from the synthetic mmproj and run it."""
 
+    def test_matches_independent_numpy_reference(self, tmp_path: Path):
+        """Check patch, position, pooling, norm, and projection semantics."""
+        import onnx_ir as ir
+        import onnxruntime as ort
+
+        from mobius._configs import Gemma4Config, VisionConfig
+        from mobius.models.gemma4 import _Gemma4VisionEncoderModel
+        from mobius.tasks._gemma4 import Gemma4Task
+
+        rng = np.random.default_rng(41)
+        vision = VisionConfig(
+            hidden_size=4,
+            intermediate_size=8,
+            num_hidden_layers=0,
+            num_attention_heads=2,
+            image_size=2,
+            patch_size=1,
+            position_embedding_size=2,
+            position_embedding_height=2,
+            position_embedding_width=2,
+            pooling_kernel_size=1,
+            use_clipped_linears=True,
+        )
+        config = Gemma4Config(
+            hidden_size=6,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            vocab_size=8,
+            vision=vision,
+        )
+        model = Gemma4Task()._build_vision(_Gemma4VisionEncoderModel(config), config)
+        weights = {
+            "encoder.patch_embedder.position_embedding_table": rng.normal(
+                size=(2, 2, 4)
+            ).astype(np.float32),
+            "encoder.patch_embedder.input_proj.weight": rng.normal(size=(4, 3)).astype(
+                np.float32
+            ),
+            "projector_norm.weight": np.ones(4, dtype=np.float32),
+            "projector.weight": rng.normal(size=(6, 4)).astype(np.float32),
+        }
+        for name, value in weights.items():
+            model.graph.initializers[name].const_value = ir.tensor(value)
+
+        model_path = tmp_path / "gemma4-parity.onnx"
+        ir.save(model, str(model_path))
+        session = ort.InferenceSession(str(model_path), providers=["CPUExecutionProvider"])
+        pixel_values = rng.uniform(size=(1, 4, 3)).astype(np.float32)
+        positions = np.array([[[0, 0], [1, 0], [0, 1], [1, 1]]], dtype=np.int64)
+        actual = session.run(
+            None,
+            {"pixel_values": pixel_values, "pixel_position_ids": positions},
+        )[0]
+
+        projected = (2.0 * pixel_values - 1.0) @ weights[
+            "encoder.patch_embedder.input_proj.weight"
+        ].T
+        projected += (
+            weights["encoder.patch_embedder.position_embedding_table"][0, positions[..., 0]]
+            + weights["encoder.patch_embedder.position_embedding_table"][1, positions[..., 1]]
+        )
+        pooled = projected * np.sqrt(4.0)
+        normalized = pooled / np.sqrt(
+            np.mean(np.square(pooled), axis=-1, keepdims=True) + vision.norm_eps
+        )
+        expected = normalized @ weights["projector.weight"].T
+        np.testing.assert_allclose(actual, expected.reshape(4, 6), rtol=1e-5, atol=1e-5)
+
     def test_builds_applies_and_runs(self, clip_mmproj_gguf: Path, tmp_path: Path):
         import onnxruntime as ort
-        import torch
 
         from mobius._configs import Gemma4Config
         from mobius._model_package import ModelPackage
-        from mobius.integrations.gguf._mmproj import read_mmproj_vision_config
-        from mobius.integrations.gguf._mmproj_mapping import map_mmproj_vision_to_hf
+        from mobius.integrations.gguf._mmproj import (
+            _mmproj_vision_to_hf,
+            read_mmproj_vision_config,
+        )
         from mobius.integrations.gguf._reader import GGUFModel
         from mobius.models.gemma4 import _Gemma4VisionEncoderModel
         from mobius.tasks._gemma4 import Gemma4Task
@@ -330,18 +490,7 @@ class TestVisionEncoderBuildAndRun:
 
         # Map mmproj vision tensors → HF names, then through the module's own
         # preprocessing (vision_tower.* / embed_vision.* → module params).
-        state_dict: dict[str, torch.Tensor] = {}
-        for name in gguf_model.tensor_names:
-            if not (name.startswith("v.") or name == "mm.input_projection.weight"):
-                continue
-            hf_name = map_mmproj_vision_to_hf(name)
-            if hf_name is None:
-                continue
-            values = np.array(gguf_model.get_tensor(name)).astype(np.float32)
-            if name == "v.patch_embd.weight":
-                values = values.reshape(values.shape[0], -1)
-            state_dict[hf_name] = torch.from_numpy(values)
-
+        state_dict = _mmproj_vision_to_hf(gguf_model)
         state_dict = module.preprocess_weights(state_dict)
         package.apply_weights(state_dict)
 
@@ -467,7 +616,7 @@ class TestKeepQuantizedMixedPrecision:
         text_gguf = tmp_path / "gemma4-q4-f32-embedding.gguf"
         _write_quantized_gemma4_text_gguf(text_gguf)
 
-        package = build_gemma4_vlm_from_gguf(text_gguf, clip_mmproj_gguf)
+        package = build_gemma4_vlm_from_gguf(text_gguf, clip_mmproj_gguf, image_token_id=63)
         assert "MatMulNBits" in _component_op_types(package["decoder"])
         assert "GatherBlockQuantized" not in _component_op_types(package["embedding"])
         float_embedding = package["embedding"].graph.initializers[
@@ -608,6 +757,8 @@ def _write_muse_glimmer_mmproj_gguf(path: Path) -> None:
     writer.add_uint32("clip.vision.patch_size", _MG_PATCH)
     writer.add_uint32("clip.vision.projection_dim", _MG_TEXT_HIDDEN)
     writer.add_uint32("clip.vision.spatial_merge_size", _MG_MERGE)
+    writer.add_array("clip.vision.image_mean", [0.5, 0.5, 0.5])
+    writer.add_array("clip.vision.image_std", [0.5, 0.5, 0.5])
     writer.add_float32("clip.vision.attention.layer_norm_epsilon", 1e-5)
 
     def _f32(name: str, shape: tuple[int, ...]) -> None:
@@ -739,6 +890,109 @@ class TestReadMuseGlimmerVisionConfig:
         assert len(state) == _MG_LAYERS * 16 + 6 + 3
 
 
+class TestMuseGlimmerVisionEncoder:
+    """Numerical checks for the supported Muse Glimmer encoder/projector path."""
+
+    def test_matches_independent_numpy_reference(self, tmp_path: Path):
+        import math
+
+        import onnx_ir as ir
+        import onnxruntime as ort
+
+        from mobius._configs import MuseGlimmerConfig, VisionConfig
+        from mobius.models.muse_glimmer import MuseGlimmerVisionEncoderModel
+        from mobius.tasks import MuseGlimmerVLTask
+
+        rng = np.random.default_rng(42)
+        vision = VisionConfig(
+            hidden_size=4,
+            intermediate_size=8,
+            num_hidden_layers=0,
+            num_attention_heads=2,
+            image_size=2,
+            patch_size=1,
+            position_embedding_height=2,
+            position_embedding_width=2,
+            spatial_merge_size=1,
+            temporal_patch_size=1,
+            in_channels=3,
+            projector_intermediate_size=4,
+            fullatt_block_indexes=[],
+        )
+        config = MuseGlimmerConfig(
+            hidden_size=6,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=3,
+            vocab_size=8,
+            intermediate_size=8,
+            hidden_act="gelu",
+            temporal_patch_size=1,
+            vision=vision,
+        )
+        model = MuseGlimmerVLTask()._build_vision(
+            MuseGlimmerVisionEncoderModel(config), config
+        )
+        weights = {
+            "vision_tower.patch_embedder.position_embedding_table.weight": rng.normal(
+                size=(4, 4)
+            ).astype(np.float32),
+            "vision_tower.patch_embedder.patch_embedding.weight": rng.normal(
+                size=(4, 3)
+            ).astype(np.float32),
+            "vision_tower.ln_pre.weight": rng.normal(size=4).astype(np.float32),
+            "vision_tower.ln_pre.bias": rng.normal(size=4).astype(np.float32),
+            "vision_tower.ln_post.weight": rng.normal(size=4).astype(np.float32),
+            "vision_tower.ln_post.bias": rng.normal(size=4).astype(np.float32),
+            "vision_adapter.fc1.weight": rng.normal(size=(4, 4)).astype(np.float32),
+            "vision_adapter.fc2.weight": rng.normal(size=(4, 4)).astype(np.float32),
+            "vision_projection.weight": rng.normal(size=(6, 4)).astype(np.float32),
+        }
+        for name, value in weights.items():
+            model.graph.initializers[name].const_value = ir.tensor(value)
+
+        model_path = tmp_path / "muse-glimmer-parity.onnx"
+        ir.save(model, str(model_path))
+        session = ort.InferenceSession(str(model_path), providers=["CPUExecutionProvider"])
+        pixel_values = rng.normal(size=(4, 3)).astype(np.float32)
+        actual = session.run(
+            None,
+            {
+                "pixel_values": pixel_values,
+                "image_grid_thw": np.array([[1, 2, 2]], dtype=np.int64),
+            },
+        )[0]
+
+        hidden = pixel_values @ weights["vision_tower.patch_embedder.patch_embedding.weight"].T
+        hidden += weights["vision_tower.patch_embedder.position_embedding_table.weight"]
+
+        def layer_norm(values: np.ndarray, weight: np.ndarray, bias: np.ndarray) -> np.ndarray:
+            centered = values - np.mean(values, axis=-1, keepdims=True)
+            variance = np.mean(np.square(centered), axis=-1, keepdims=True)
+            return centered / np.sqrt(variance + vision.norm_eps) * weight + bias
+
+        hidden = layer_norm(
+            hidden,
+            weights["vision_tower.ln_pre.weight"],
+            weights["vision_tower.ln_pre.bias"],
+        )
+        hidden = layer_norm(
+            hidden,
+            weights["vision_tower.ln_post.weight"],
+            weights["vision_tower.ln_post.bias"],
+        )
+        hidden = hidden @ weights["vision_adapter.fc1.weight"].T
+        hidden = 0.5 * hidden * (1.0 + np.vectorize(math.erf)(hidden / np.sqrt(2.0)))
+        hidden = hidden @ weights["vision_adapter.fc2.weight"].T
+        hidden = 0.5 * hidden * (1.0 + np.vectorize(math.erf)(hidden / np.sqrt(2.0)))
+        hidden = hidden @ weights["vision_projection.weight"].T
+        expected = hidden / np.sqrt(
+            np.mean(np.square(hidden), axis=-1, keepdims=True) + config.rms_norm_eps
+        )
+        np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-5)
+
+
 class TestVlmRouting:
     """The text backbone decides which VLM builder assembles the pair."""
 
@@ -757,17 +1011,22 @@ class TestVlmRouting:
 
         text_path = tmp_path / "text.gguf"
         _write_minimal_gguf(text_path, architecture)
+        mmproj_path = tmp_path / "mmproj.gguf"
+        if expected == "build_gemma4_vlm_from_gguf":
+            _write_clip_mmproj_gguf(mmproj_path)
+        else:
+            _write_muse_glimmer_mmproj_gguf(mmproj_path)
         package = mock.sentinel.package
 
         with mock.patch(
             f"mobius.integrations.gguf._mmproj.{expected}", return_value=package
         ) as builder:
-            actual = build_vlm_from_gguf(text_path, "mmproj.gguf", keep_quantized=False)
+            actual = build_vlm_from_gguf(text_path, mmproj_path, keep_quantized=False)
 
         assert actual is package
         builder.assert_called_once_with(
             text_path,
-            "mmproj.gguf",
+            mmproj_path,
             dtype=None,
             execution_provider="default",
             keep_quantized=False,

--- a/src/mobius/integrations/gguf/_reader.py
+++ b/src/mobius/integrations/gguf/_reader.py
@@ -359,6 +359,13 @@ class GGUFModel:
             str(getattr(tensor.tensor_type, "name", tensor.tensor_type)),
         )
 
+    def get_tensor_shape(self, name: str) -> tuple[int, ...]:
+        """Get a tensor's logical numpy shape without reading its payload."""
+        if name not in self._tensor_index:
+            raise KeyError(f"Tensor '{name}' not found in GGUF file.")
+        tensor = self._reader.get_tensor(self._tensor_index[name])
+        return tuple(int(dim) for dim in reversed(tensor.shape))
+
     def __repr__(self) -> str:
         arch = self.architecture if self._reader else "?"
         n_tensors = len(self._tensor_index)

--- a/src/mobius/tasks/_gemma4.py
+++ b/src/mobius/tasks/_gemma4.py
@@ -636,17 +636,20 @@ class Gemma4Task(ModelTask):
         """Build vision encoder: pixel_values + pixel_position_ids -> image_features.
 
         Inputs:
-        - ``pixel_values [B, N, 3*P^2]``: pre-patchified image data where
-          ``B`` is the number of images and ``N`` is the number of patches
-          (padded to ``max_soft_tokens``, typically 280).
-        - ``pixel_position_ids [B, N, 2]``: (x, y) patch coordinates.
+        - ``pixel_values [1, N, 3*P^2]``: one pre-patchified image with ``N``
+          patches (padded to ``max_soft_tokens``, typically 280).
+        - ``pixel_position_ids [1, N, 2]``: (x, y) patch coordinates.
           Unused patch slots (from images smaller than the maximum) use
           ``(-1, -1)`` as a sentinel value — no explicit mask is needed.
 
         Output:
-        - ``image_features [B*N, text_hidden_size]``: projected vision features
+        - ``image_features [N_pooled, text_hidden_size]``: projected vision features
+
+        The position-based pooler emits a variable token count determined by one
+        image's valid coordinate extent. Its scalar OneHot depth cannot represent
+        different pooled counts per batch row, so the graph contract is explicitly
+        single-image rather than advertising false dynamic-batch support.
         """
-        batch = ir.SymbolicDim("batch")
         num_patches = ir.SymbolicDim("num_patches")
         patch_size = config.vision.patch_size or 16 if config.vision else 16
         pixel_dim = 3 * patch_size * patch_size
@@ -657,12 +660,12 @@ class Gemma4Task(ModelTask):
         pixel_values = builder.input(
             "pixel_values",
             dtype=config.dtype,
-            shape=[batch, num_patches, pixel_dim],
+            shape=[1, num_patches, pixel_dim],
         )
         pixel_position_ids = builder.input(
             "pixel_position_ids",
             dtype=ir.DataType.INT64,
-            shape=[batch, num_patches, 2],
+            shape=[1, num_patches, 2],
         )
 
         image_features = vision(


### PR DESCRIPTION
## Summary

- enumerate all 60 serialized llama.cpp `clip` projector types at `8d9af256337d1a501250f9bbf4c0859a654bddd6` in an immutable capability registry
- support only exact, audited Gemma4 vision (`gemma4v`) and Muse Glimmer (`muse-glimmer`) sidecars; fail before graph construction for unknown, deferred, mismatched, quantized, or out-of-closure projectors
- validate pinned metadata, tensor suffixes/shapes/qtypes, source and target identity, projector dimensions, and media-token contracts
- preserve Gemma4 clipping bounds, correct its spatial pooling to 3x3, and document audited artifacts plus all projector verdicts
- add registry closure/mutation, mixed quantized-text, early rejection, package round-trip, and independent NumPy/ORT encoder-projector parity tests

## Validation

- `PYTHONPATH=src python -m pytest src/mobius/integrations/gguf/_mmproj_registry_test.py src/mobius/integrations/gguf/_mmproj_mapping_test.py src/mobius/integrations/gguf/_mmproj_test.py src/mobius/integrations/gguf/_reader_test.py -q --tb=short` — 126 passed
- `lintrunner f --output oneline --all-files` — passed
- broad non-integration suite — 5963 passed, 52 skipped; two unrelated existing `glm_moe_dsa` symbolic-shape/checker failures remain

Stacked on #583.
