### PR TITLE
Export DeepSeek-V4 dense attention as fused GroupQueryAttention

### DIFF
--- a/.agents/skills/attention-optimization/SKILL.md
+++ b/.agents/skills/attention-optimization/SKILL.md
@@ -201,8 +201,24 @@ TRT FusedRunner → MEA → Unfused
 
 ### Contrib GroupQueryAttention (`com.microsoft`)
 
-Cascade: XQA → Flash → MEA → Unfused. **Rejects `attention_bias`
-entirely.**
+Cascade: XQA → Flash → MEA → Unfused. **None of the CUDA fused kernels
+(XQA/Flash/MEA) accept `attention_bias`**, so supplying one on CUDA
+forces the Unfused fallback.
+
+> Correction (verified against stock ORT 1.29.0, CPU EP, 2026-08):
+> despite the above, GQA is **not** a blanket-reject op — the CPU EP
+> genuinely computes with both `attention_bias` and `head_sink` when
+> supplied (not silently ignored), confirmed by direct numerical probes
+> against the bundled library. "Rejects `attention_bias` entirely" was
+> inaccurate as a general statement about the op; it only holds for the
+> CUDA fused-kernel cascade below. Separately, onnx-genai's own native
+> CPU+CUDA kernels are a *stricter* subset of what stock ORT supports:
+> historically both rejected `attention_bias`, and only the CUDA kernel
+> implemented `head_sink` (see
+> `crates/onnx-runtime-ep-cpu/src/kernels/group_query_attention.rs`,
+> which now also implements `head_sink` on CPU; `attention_bias` remains
+> unimplemented there by design, matching the CUDA fused-kernel
+> limitation above, not an oversight).
 
 | Kernel | Required conditions |
 |--------|---------------------|
@@ -297,8 +313,12 @@ use custom per-layer `GQAContext`s instead.
    `past_key`/`past_value` inputs (so it is prefill-only in the *growing*
    cache mode), but it is used at **every** step in the static-cache mode
    (full cache in the `key`/`value` slots).
-3. **GQA contrib op rejects `attention_bias`** — use standard ONNX
-   `Attention` if you need bias with GQA.
+3. **GQA's CUDA fused kernels reject `attention_bias`** (Unfused CUDA
+   still accepts it, and stock ORT's CPU EP genuinely supports it too —
+   see the correction above) — use standard ONNX `Attention` if you
+   need bias with a CUDA fused GQA kernel, or if targeting onnx-genai's
+   own native kernels (which don't implement `attention_bias` on GQA
+   either, CPU or CUDA).
 4. **SM≥8.0** (Ampere+) required for Flash on all paths.
 5. **Float bias is safer** than bool mask for complex attention patterns.
 6. **MEA requires alignment** — `total_kv % 4 == 0` for bias tensors.

--- a/src/mobius/models/deepseek_v4.py
+++ b/src/mobius/models/deepseek_v4.py
@@ -23,6 +23,7 @@ import onnx_ir as ir
 import torch
 from onnxscript import OpBuilder, nn
 
+from mobius._build_context import ep_capabilities, get_build_dtype
 from mobius._configs import ArchitectureConfig
 from mobius._weight_utils import (
     pack_qmoe_expert_weights,
@@ -35,6 +36,7 @@ from mobius.components import (
     MoELayer,
     QuantizedEmbedding,
     RMSNorm,
+    create_attention_bias,
     initialize_rope,
     make_quantized_linear_factory,
 )
@@ -45,17 +47,24 @@ from mobius.models.base import CausalLMModel
 logger = logging.getLogger(__name__)
 
 
-def _projection_class(config: ArchitectureConfig):
-    quantization = config.quantization
-    if quantization is None or quantization.quant_method == "none":
-        return Linear
-    zero_point_dtype = config.dtype if quantization.float_zero_point else ir.DataType.UINT8
-    return make_quantized_linear_factory(
-        bits=quantization.bits,
-        block_size=quantization.group_size,
-        has_zero_point=not quantization.sym,
-        zero_point_dtype=zero_point_dtype,
-    )
+def _use_fused_gqa() -> bool:
+    """Whether the active EP/build dtype supports direct ``GroupQueryAttention`` emission.
+
+    Mirrors ``TextModel.forward``'s ``use_gqa`` gate (``mobius/models/base.py``):
+    the active EP must declare GQA support for the current build dtype via
+    :func:`~mobius._build_context.ep_capabilities`. Unlike that generic path,
+    V4 always applies RoPE explicitly in-graph (``do_rotary=0``), so this
+    doesn't also need to check ``caps.supports_fused_rope`` -- V4's fused path
+    never asks ``GroupQueryAttention`` to rotate internally.
+
+    EPs such as ``"default"``, ``"onnx-standard"``, ``"qnn"``, and
+    ``"openvino"`` declare an empty ``gqa_dtypes`` specifically so their
+    exported graphs stay free of ``com.microsoft`` ops; V4 must fall back to
+    the portable decomposed attention path for those, exactly like every
+    other model in this codebase.
+    """
+    caps = ep_capabilities()
+    return get_build_dtype() in caps.gqa_dtypes
 
 
 def _gqa_kv_lengths(op: OpBuilder, attention_mask: ir.Value) -> tuple[ir.Value, ir.Value]:
@@ -79,6 +88,19 @@ def _gqa_kv_lengths(op: OpBuilder, attention_mask: ir.Value) -> tuple[ir.Value, 
         to=ir.DataType.INT32,
     )
     return seqlens_k, total_seq_len
+
+
+def _projection_class(config: ArchitectureConfig):
+    quantization = config.quantization
+    if quantization is None or quantization.quant_method == "none":
+        return Linear
+    zero_point_dtype = config.dtype if quantization.float_zero_point else ir.DataType.UINT8
+    return make_quantized_linear_factory(
+        bits=quantization.bits,
+        block_size=quantization.group_size,
+        has_zero_point=not quantization.sym,
+        zero_point_dtype=zero_point_dtype,
+    )
 
 
 def _shape_anchor(op: OpBuilder, parameters: list[ir.Value]) -> ir.Value:
@@ -461,12 +483,49 @@ class DeepSeekV4Attention(nn.Module):
         rope = op.Reshape(rope, [0, 0, num_heads, self.rope_dim])
         return op.Reshape(op.Concat(nope, rope, axis=-1), [0, 0, -1])
 
+    def _expand_kv(
+        self,
+        op: OpBuilder,
+        value: ir.Value,
+        batch: ir.Value,
+        sequence_length: ir.Value,
+    ) -> ir.Value:
+        """Broadcast the single MQA key/value head across all query heads.
+
+        Only used by the portable decomposed path below (EPs whose
+        ``gqa_dtypes`` is empty). The fused ``GroupQueryAttention`` path does
+        this broadcast internally via its own ``kv_num_heads=1`` handling, so
+        it never calls this helper.
+        """
+        value = op.Unsqueeze(value, [2])
+        value = op.Expand(
+            value,
+            op.Concat(
+                batch,
+                [1, self.num_heads],
+                sequence_length,
+                [self.head_dim],
+                axis=0,
+            ),
+        )
+        return op.Reshape(
+            value,
+            op.Concat(
+                batch,
+                [self.num_heads],
+                sequence_length,
+                [self.head_dim],
+                axis=0,
+            ),
+        )
+
     def forward(
         self,
         op: OpBuilder,
         hidden_states: ir.Value,
         position_embeddings: tuple,
         past_key_value: tuple | None = None,
+        attention_bias: ir.Value | None = None,
         seqlens_k: ir.Value | None = None,
         total_seq_len: ir.Value | None = None,
     ):
@@ -484,51 +543,97 @@ class DeepSeekV4Attention(nn.Module):
         kv = self.kv_layernorm(op, self.kv_proj(op, hidden_states))
         kv = self._rotate(op, kv, position_embeddings, 1)
 
-        past_key = past_key_value[0] if past_key_value is not None else None
-        past_value = past_key_value[1] if past_key_value is not None else None
+        if seqlens_k is not None:
+            # Fused causal attention core, used only when the active EP's
+            # `ep_capabilities().gqa_dtypes` includes the build dtype (see
+            # `_use_fused_gqa`). `query`/`kv` are already RoPE-rotated
+            # (trailing rope slice only, applied explicitly above via
+            # `_rotate`, the same convention V2/V3 MLA uses with the plain
+            # `Attention` op), so `GroupQueryAttention` only needs
+            # `do_rotary=0` (its default): cos_cache/sin_cache/position_ids
+            # stay unset. V4 is MQA (`kv_num_heads=1`): key and value are
+            # literally the same rotated `kv` tensor -- broadcasting
+            # `kv_num_heads=1` across all query heads is the fused op's own
+            # job, so `_expand_kv` isn't needed on this path. No explicit
+            # `attention_bias` is passed: this is a plain causal decoder
+            # attention (no sliding window, no KV-sharing across layers, no
+            # per-layer dual head_dim), so GQA's own implicit causal masking
+            # plus `seqlens_k`/`total_seq_len` already carries the exact same
+            # causal+padding semantics `create_attention_bias` bakes into an
+            # explicit float bias on the decomposed path below -- this is the
+            # same "direct GQA" convention `Attention._forward_gqa`
+            # (mobius/components/_attention.py) already uses for every other
+            # simple-causal model in this codebase (see the
+            # `attention-optimization` skill: "Use Contrib GQA when you don't
+            # need attention bias"). `head_sink` carries the learned per-head
+            # attention sink exactly as the decomposed path's
+            # `Concat(scores, sinks) -> Softmax -> slice` sequence does, now
+            # as a first-class op input instead of a manually broadcast
+            # Concat.
+            past_key = past_key_value[0] if past_key_value is not None else None
+            past_value = past_key_value[1] if past_key_value is not None else None
+            output, present_key, present_value = op.GroupQueryAttention(
+                query,
+                kv,
+                kv,
+                past_key,
+                past_value,
+                seqlens_k,
+                total_seq_len,
+                None,  # cos_cache: unused, RoPE already applied above
+                None,  # sin_cache: unused, RoPE already applied above
+                None,  # position_ids: unused, do_rotary=0
+                None,  # attention_bias: unused, plain causal + seqlens_k suffices
+                op.CastLike(self.attn_sink, query),  # head_sink
+                num_heads=self.num_heads,
+                kv_num_heads=1,
+                scale=self.scale,
+                _domain="com.microsoft",
+                _outputs=3,
+            )
+        else:
+            # Portable decomposed path: used whenever the active EP declares
+            # no GQA support for the build dtype (e.g. `"default"`,
+            # `"onnx-standard"`, `"qnn"`, `"openvino"` -- see
+            # `_use_fused_gqa`). Manually replicates the exact same
+            # sink-aware dense causal attention using only standard ONNX
+            # ops, so these EPs' exported graphs stay free of
+            # `com.microsoft` custom ops.
+            batch = op.Shape(query, start=0, end=1)
+            query_length = op.Shape(query, start=1, end=2)
+            query = op.Transpose(
+                op.Reshape(query, [0, 0, self.num_heads, self.head_dim]),
+                perm=[0, 2, 1, 3],
+            )
+            key = op.Transpose(op.Reshape(kv, [0, 0, 1, self.head_dim]), perm=[0, 2, 1, 3])
+            value = key
+            if past_key_value is not None:
+                key = op.Concat(past_key_value[0], key, axis=2)
+                value = op.Concat(past_key_value[1], value, axis=2)
+            present_key, present_value = key, value
 
-        # Fused causal attention core. `query`/`kv` are already RoPE-rotated
-        # (trailing rope slice only, applied explicitly above via `_rotate`,
-        # the same convention V2/V3 MLA uses with the plain `Attention` op),
-        # so `GroupQueryAttention` only needs `do_rotary=0` (its default):
-        # cos_cache/sin_cache/position_ids stay unset. V4 is MQA
-        # (`kv_num_heads=1`): key and value are literally the same rotated
-        # `kv` tensor, exactly matching the removed manual `value = key`
-        # assignment and its `_expand_kv` broadcast (now redundant --
-        # broadcasting kv_num_heads=1 across all query heads is the fused
-        # op's own job). No explicit `attention_bias` is passed: this is a
-        # plain causal decoder attention (no sliding window, no KV-sharing
-        # across layers, no per-layer dual head_dim), so GQA's own implicit
-        # causal masking plus `seqlens_k`/`total_seq_len` already carries
-        # the exact same causal+padding semantics `create_attention_bias`
-        # used to bake into an explicit float bias -- this is the same
-        # "direct GQA" convention `Attention._forward_gqa`
-        # (mobius/components/_attention.py) already uses for every other
-        # simple-causal model in this codebase (see the
-        # `attention-optimization` skill: "Use Contrib GQA when you don't
-        # need attention bias"). `head_sink` carries the learned per-head
-        # attention sink exactly as the removed
-        # `Concat(scores, sinks) -> Softmax -> slice` sequence did, now as
-        # a first-class op input instead of a manually broadcast Concat.
-        output, present_key, present_value = op.GroupQueryAttention(
-            query,
-            kv,
-            kv,
-            past_key,
-            past_value,
-            seqlens_k,
-            total_seq_len,
-            None,  # cos_cache: unused, RoPE already applied above
-            None,  # sin_cache: unused, RoPE already applied above
-            None,  # position_ids: unused, do_rotary=0
-            None,  # attention_bias: unused, plain causal + seqlens_k suffices
-            op.CastLike(self.attn_sink, query),  # head_sink
-            num_heads=self.num_heads,
-            kv_num_heads=1,
-            scale=self.scale,
-            _domain="com.microsoft",
-            _outputs=3,
-        )
+            kv_length = op.Shape(key, start=2, end=3)
+            key = self._expand_kv(op, key, batch, kv_length)
+            value = self._expand_kv(op, value, batch, kv_length)
+            scores = op.Mul(
+                op.MatMul(query, op.Transpose(key, perm=[0, 1, 3, 2])),
+                self.scale,
+            )
+            scores = op.Add(scores, attention_bias)
+            sinks = op.Expand(
+                op.Reshape(
+                    op.CastLike(self.attn_sink, scores),
+                    [1, self.num_heads, 1, 1],
+                ),
+                op.Concat(batch, [self.num_heads], query_length, [1], axis=0),
+            )
+            probabilities = op.Softmax(op.Concat(scores, sinks, axis=-1), axis=-1)
+            probabilities = op.Slice(probabilities, [0], [-1], [3])
+            output = op.Reshape(
+                op.Transpose(op.MatMul(probabilities, value), perm=[0, 2, 1, 3]),
+                [0, 0, -1],
+            )
+
         output = self._rotate(op, output, position_embeddings, self.num_heads, inverse=True)
 
         if self.compressor is not None:
@@ -638,6 +743,7 @@ class DeepSeekV4DecoderLayer(nn.Module):
         input_ids: ir.Value,
         position_embeddings: tuple,
         past_key_value: tuple | None = None,
+        attention_bias: ir.Value | None = None,
         seqlens_k: ir.Value | None = None,
         total_seq_len: ir.Value | None = None,
     ):
@@ -654,6 +760,7 @@ class DeepSeekV4DecoderLayer(nn.Module):
             self.input_layernorm(op, value),
             position_embeddings,
             past_key_value,
+            attention_bias,
             seqlens_k,
             total_seq_len,
         )
@@ -750,7 +857,17 @@ class DeepSeekV4TextModel(nn.Module):
         )
         position_embeddings = self.rotary_emb(op, position_ids)
         compressed_position_embeddings = self.compressed_rotary_emb(op, position_ids)
-        seqlens_k, total_seq_len = _gqa_kv_lengths(op, attention_mask)
+        if _use_fused_gqa():
+            attention_bias = None
+            seqlens_k, total_seq_len = _gqa_kv_lengths(op, attention_mask)
+        else:
+            attention_bias = create_attention_bias(
+                op,
+                input_ids=hidden_states if input_ids is None else input_ids,
+                attention_mask=attention_mask,
+                dtype=self._dtype,
+            )
+            seqlens_k, total_seq_len = None, None
         presents = []
         past_kvs = past_key_values or [None] * len(self.layers)
         for layer, past_kv in zip(self.layers, past_kvs):
@@ -765,6 +882,7 @@ class DeepSeekV4TextModel(nn.Module):
                 input_ids,
                 layer_position_embeddings,
                 past_kv,
+                attention_bias,
                 seqlens_k,
                 total_seq_len,
             )
@@ -824,13 +942,24 @@ class DeepSeekV4Mtp(DeepSeekV4DecoderLayer):
             self.h_proj(op, self.hnorm(op, hidden_states)),
         )
         position_embeddings = self.rotary_emb(op, position_ids)
-        seqlens_k, total_seq_len = _gqa_kv_lengths(op, attention_mask)
+        if _use_fused_gqa():
+            attention_bias = None
+            seqlens_k, total_seq_len = _gqa_kv_lengths(op, attention_mask)
+        else:
+            attention_bias = create_attention_bias(
+                op,
+                input_ids=inputs_embeds,
+                attention_mask=attention_mask,
+                dtype=self._dtype,
+            )
+            seqlens_k, total_seq_len = None, None
         hidden_states, present = super().forward(
             op,
             hidden_states,
             None,
             position_embeddings,
             past_key_value,
+            attention_bias,
             seqlens_k,
             total_seq_len,
         )

--- a/src/mobius/models/deepseek_v4.py
+++ b/src/mobius/models/deepseek_v4.py
@@ -35,7 +35,6 @@ from mobius.components import (
     MoELayer,
     QuantizedEmbedding,
     RMSNorm,
-    create_attention_bias,
     initialize_rope,
     make_quantized_linear_factory,
 )
@@ -57,6 +56,29 @@ def _projection_class(config: ArchitectureConfig):
         has_zero_point=not quantization.sym,
         zero_point_dtype=zero_point_dtype,
     )
+
+
+def _gqa_kv_lengths(op: OpBuilder, attention_mask: ir.Value) -> tuple[ir.Value, ir.Value]:
+    """Derive ``GroupQueryAttention``'s required ``seqlens_k``/``total_sequence_length``.
+
+    Same formula ``TextModel`` uses to build a ``GQAContext``
+    (``mobius/models/base.py``): ``seqlens_k[b] = sum(attention_mask[b]) - 1``
+    (last valid KV index per batch entry) and
+    ``total_seq_len = attention_mask.shape[1]`` (past + current length).
+    Computed directly here (rather than via ``GQAContext``, which also
+    bundles ``cos_cache``/``sin_cache`` for the fused-rotary ``do_rotary=1``
+    path that V4 does not use -- RoPE is applied explicitly in-graph).
+    """
+    one_i32 = op.Constant(value_int=1)
+    seqlens_k = op.Cast(
+        op.Sub(op.ReduceSum(attention_mask, [1], keepdims=0), one_i32),
+        to=ir.DataType.INT32,
+    )
+    total_seq_len = op.Cast(
+        op.Gather(op.Shape(attention_mask), 1),
+        to=ir.DataType.INT32,
+    )
+    return seqlens_k, total_seq_len
 
 
 def _shape_anchor(op: OpBuilder, parameters: list[ir.Value]) -> ir.Value:
@@ -439,42 +461,14 @@ class DeepSeekV4Attention(nn.Module):
         rope = op.Reshape(rope, [0, 0, num_heads, self.rope_dim])
         return op.Reshape(op.Concat(nope, rope, axis=-1), [0, 0, -1])
 
-    def _expand_kv(
-        self,
-        op: OpBuilder,
-        value: ir.Value,
-        batch: ir.Value,
-        sequence_length: ir.Value,
-    ) -> ir.Value:
-        value = op.Unsqueeze(value, [2])
-        value = op.Expand(
-            value,
-            op.Concat(
-                batch,
-                [1, self.num_heads],
-                sequence_length,
-                [self.head_dim],
-                axis=0,
-            ),
-        )
-        return op.Reshape(
-            value,
-            op.Concat(
-                batch,
-                [self.num_heads],
-                sequence_length,
-                [self.head_dim],
-                axis=0,
-            ),
-        )
-
     def forward(
         self,
         op: OpBuilder,
         hidden_states: ir.Value,
-        attention_bias: ir.Value,
         position_embeddings: tuple,
         past_key_value: tuple | None = None,
+        seqlens_k: ir.Value | None = None,
+        total_seq_len: ir.Value | None = None,
     ):
         query = self.q_b_proj(op, self.q_a_layernorm(op, self.q_a_proj(op, hidden_states)))
         query_4d = op.Reshape(query, [0, 0, self.num_heads, self.head_dim])
@@ -489,39 +483,51 @@ class DeepSeekV4Attention(nn.Module):
 
         kv = self.kv_layernorm(op, self.kv_proj(op, hidden_states))
         kv = self._rotate(op, kv, position_embeddings, 1)
-        batch = op.Shape(query, start=0, end=1)
-        query_length = op.Shape(query, start=1, end=2)
-        query = op.Transpose(
-            op.Reshape(query, [0, 0, self.num_heads, self.head_dim]),
-            perm=[0, 2, 1, 3],
-        )
-        key = op.Transpose(op.Reshape(kv, [0, 0, 1, self.head_dim]), perm=[0, 2, 1, 3])
-        value = key
-        if past_key_value is not None:
-            key = op.Concat(past_key_value[0], key, axis=2)
-            value = op.Concat(past_key_value[1], value, axis=2)
-        present_key, present_value = key, value
 
-        kv_length = op.Shape(key, start=2, end=3)
-        key = self._expand_kv(op, key, batch, kv_length)
-        value = self._expand_kv(op, value, batch, kv_length)
-        scores = op.Mul(
-            op.MatMul(query, op.Transpose(key, perm=[0, 1, 3, 2])),
-            self.scale,
-        )
-        scores = op.Add(scores, attention_bias)
-        sinks = op.Expand(
-            op.Reshape(
-                op.CastLike(self.attn_sink, scores),
-                [1, self.num_heads, 1, 1],
-            ),
-            op.Concat(batch, [self.num_heads], query_length, [1], axis=0),
-        )
-        probabilities = op.Softmax(op.Concat(scores, sinks, axis=-1), axis=-1)
-        probabilities = op.Slice(probabilities, [0], [-1], [3])
-        output = op.Reshape(
-            op.Transpose(op.MatMul(probabilities, value), perm=[0, 2, 1, 3]),
-            [0, 0, -1],
+        past_key = past_key_value[0] if past_key_value is not None else None
+        past_value = past_key_value[1] if past_key_value is not None else None
+
+        # Fused causal attention core. `query`/`kv` are already RoPE-rotated
+        # (trailing rope slice only, applied explicitly above via `_rotate`,
+        # the same convention V2/V3 MLA uses with the plain `Attention` op),
+        # so `GroupQueryAttention` only needs `do_rotary=0` (its default):
+        # cos_cache/sin_cache/position_ids stay unset. V4 is MQA
+        # (`kv_num_heads=1`): key and value are literally the same rotated
+        # `kv` tensor, exactly matching the removed manual `value = key`
+        # assignment and its `_expand_kv` broadcast (now redundant --
+        # broadcasting kv_num_heads=1 across all query heads is the fused
+        # op's own job). No explicit `attention_bias` is passed: this is a
+        # plain causal decoder attention (no sliding window, no KV-sharing
+        # across layers, no per-layer dual head_dim), so GQA's own implicit
+        # causal masking plus `seqlens_k`/`total_seq_len` already carries
+        # the exact same causal+padding semantics `create_attention_bias`
+        # used to bake into an explicit float bias -- this is the same
+        # "direct GQA" convention `Attention._forward_gqa`
+        # (mobius/components/_attention.py) already uses for every other
+        # simple-causal model in this codebase (see the
+        # `attention-optimization` skill: "Use Contrib GQA when you don't
+        # need attention bias"). `head_sink` carries the learned per-head
+        # attention sink exactly as the removed
+        # `Concat(scores, sinks) -> Softmax -> slice` sequence did, now as
+        # a first-class op input instead of a manually broadcast Concat.
+        output, present_key, present_value = op.GroupQueryAttention(
+            query,
+            kv,
+            kv,
+            past_key,
+            past_value,
+            seqlens_k,
+            total_seq_len,
+            None,  # cos_cache: unused, RoPE already applied above
+            None,  # sin_cache: unused, RoPE already applied above
+            None,  # position_ids: unused, do_rotary=0
+            None,  # attention_bias: unused, plain causal + seqlens_k suffices
+            op.CastLike(self.attn_sink, query),  # head_sink
+            num_heads=self.num_heads,
+            kv_num_heads=1,
+            scale=self.scale,
+            _domain="com.microsoft",
+            _outputs=3,
         )
         output = self._rotate(op, output, position_embeddings, self.num_heads, inverse=True)
 
@@ -630,9 +636,10 @@ class DeepSeekV4DecoderLayer(nn.Module):
         op: OpBuilder,
         hidden_states: ir.Value,
         input_ids: ir.Value,
-        attention_bias: ir.Value,
         position_embeddings: tuple,
         past_key_value: tuple | None = None,
+        seqlens_k: ir.Value | None = None,
+        total_seq_len: ir.Value | None = None,
     ):
         residual = hidden_states
         value, post, comb = self._hc_pre(
@@ -645,9 +652,10 @@ class DeepSeekV4DecoderLayer(nn.Module):
         value, present = self.self_attn(
             op,
             self.input_layernorm(op, value),
-            attention_bias,
             position_embeddings,
             past_key_value,
+            seqlens_k,
+            total_seq_len,
         )
         hidden_states = self._hc_post(op, value, residual, post, comb)
 
@@ -742,12 +750,7 @@ class DeepSeekV4TextModel(nn.Module):
         )
         position_embeddings = self.rotary_emb(op, position_ids)
         compressed_position_embeddings = self.compressed_rotary_emb(op, position_ids)
-        attention_bias = create_attention_bias(
-            op,
-            input_ids=hidden_states if input_ids is None else input_ids,
-            attention_mask=attention_mask,
-            dtype=self._dtype,
-        )
+        seqlens_k, total_seq_len = _gqa_kv_lengths(op, attention_mask)
         presents = []
         past_kvs = past_key_values or [None] * len(self.layers)
         for layer, past_kv in zip(self.layers, past_kvs):
@@ -760,9 +763,10 @@ class DeepSeekV4TextModel(nn.Module):
                 op,
                 hidden_states,
                 input_ids,
-                attention_bias,
                 layer_position_embeddings,
                 past_kv,
+                seqlens_k,
+                total_seq_len,
             )
             presents.append(present)
         return self.norm(op, self._hc_head(op, hidden_states)), presents, hidden_states
@@ -820,19 +824,15 @@ class DeepSeekV4Mtp(DeepSeekV4DecoderLayer):
             self.h_proj(op, self.hnorm(op, hidden_states)),
         )
         position_embeddings = self.rotary_emb(op, position_ids)
-        attention_bias = create_attention_bias(
-            op,
-            input_ids=inputs_embeds,
-            attention_mask=attention_mask,
-            dtype=self._dtype,
-        )
+        seqlens_k, total_seq_len = _gqa_kv_lengths(op, attention_mask)
         hidden_states, present = super().forward(
             op,
             hidden_states,
             None,
-            attention_bias,
             position_embeddings,
             past_key_value,
+            seqlens_k,
+            total_seq_len,
         )
         return self.norm(op, self._hc_head(op, hidden_states)), present
 

--- a/src/mobius/models/deepseek_v4_flash_test.py
+++ b/src/mobius/models/deepseek_v4_flash_test.py
@@ -127,6 +127,37 @@ def test_tiny_graph_builds_v4_backbone():
     graph = build_from_module(DeepSeekV4CausalLMModel(config), config)["model"].graph
     assert graph.num_nodes() > 0
     assert count_op_type(graph, "Attention") == 0
+    # Default EP declares an empty `gqa_dtypes` (see
+    # `mobius._execution_providers`) specifically to guarantee portable,
+    # `com.microsoft`-free graphs -- DeepSeek-V4 must fall back to the
+    # decomposed attention path here, exactly like every other model in
+    # this codebase. See `test_tiny_graph_builds_v4_backbone_fused_gqa_on_cpu_ep`
+    # below for the fused-GQA structural proof under a GQA-capable EP.
+    assert count_op_type(graph, "GroupQueryAttention") == 0
+    assert count_op_type(graph, "Softmax") >= config.num_hidden_layers
+    assert count_op_type(graph, "ScatterElements") == 0
+    assert count_op_type(graph, "Softplus") >= config.num_hidden_layers
+    assert count_op_type(graph, "TopK") >= 1
+    assert count_op_type(graph, "Gather") >= 1
+    assert count_op_type(graph, "RMSNormalization") >= 1
+    assert sum("attn_sink" in name for name in graph.initializers) == config.num_hidden_layers
+    assert "hidden_states" not in {value.name for value in graph.outputs}
+
+
+def test_tiny_graph_builds_v4_backbone_fused_gqa_on_cpu_ep():
+    """Same backbone, built under a GQA-capable EP, must fuse attention.
+
+    ``"cpu"`` declares ``gqa_dtypes={FLOAT}`` (``mobius._execution_providers``),
+    which the tiny config's default ``dtype=ir.DataType.FLOAT`` matches, so
+    this exercises ``_use_fused_gqa()``'s true branch -- the same EP-gating
+    idiom ``lfm2_test.py``/``world_model_test.py`` use for their own
+    GQA-capable-EP structural tests.
+    """
+    config = _tiny_config()
+    graph = build_from_module(
+        DeepSeekV4CausalLMModel(config), config, execution_provider="cpu"
+    )["model"].graph
+    assert count_op_type(graph, "Attention") == 0
     gqa_nodes = [node for node in graph if node.op_type == "GroupQueryAttention"]
     assert len(gqa_nodes) == config.num_hidden_layers
     assert all(node.domain == "com.microsoft" for node in gqa_nodes)
@@ -137,8 +168,8 @@ def test_tiny_graph_builds_v4_backbone():
     assert all(len(node.inputs) == 12 and node.inputs[10] is None for node in gqa_nodes)
     assert all(node.inputs[11] is not None for node in gqa_nodes)
     # Only the Hyper-Connection combination softmax (2 per layer) remains;
-    # the old manual Concat(scores, sink) -> Softmax -> slice attention
-    # softmax is gone now that GQA computes it internally.
+    # the manual Concat(scores, sink) -> Softmax -> slice attention softmax
+    # the decomposed path uses is gone now that GQA computes it internally.
     assert count_op_type(graph, "Softmax") == 2 * config.num_hidden_layers
     assert count_op_type(graph, "ScatterElements") == 0
     assert count_op_type(graph, "Softplus") >= config.num_hidden_layers
@@ -169,6 +200,28 @@ def test_csa_schedule_exports_compressor_and_indexer_tensors_with_dense_attentio
     assert "model.layers.3.self_attn.compressor.wkv.weight" in names
     assert not any("model.layers.3.self_attn.indexer" in name for name in names)
     assert count_op_type(graph, "Attention") == 0
+    assert count_op_type(graph, "GroupQueryAttention") == 0
+    assert count_op_type(graph, "ScatterElements") == 0
+    assert count_op_type(graph, "Softmax") >= config.num_hidden_layers
+
+
+def test_csa_schedule_exports_fused_gqa_regardless_of_compress_ratio_on_cpu_ep():
+    config = _tiny_config(
+        num_hidden_layers=4,
+        compress_ratios=[0, 0, 4, 128],
+    )
+    graph = build_from_module(
+        DeepSeekV4CausalLMModel(config),
+        config,
+        task="deepseek-v4",
+        execution_provider="cpu",
+    )["model"].graph
+    names = set(graph.initializers)
+
+    assert "model.layers.2.self_attn.compressor.wkv.weight" in names
+    assert "model.layers.3.self_attn.compressor.wkv.weight" in names
+    assert not any("model.layers.3.self_attn.indexer" in name for name in names)
+    assert count_op_type(graph, "Attention") == 0
     # Dense-CSA schedule attention is still a single fused GQA call per
     # layer regardless of compress_ratio: the compressor/indexer tensors
     # above are retained as a zero-valued shape anchor (see
@@ -195,8 +248,32 @@ def test_mtp_sidecar_exports_official_block_and_hyper_connection_state():
     assert "mtp.0.h_proj.weight" in names
     assert "mtp.0.hc_head_fn.weight" in names
     assert "mtp.0.self_attn.attn_sink" in names
-    assert count_op_type(mtp_graph, "GroupQueryAttention") == 1
+    assert count_op_type(mtp_graph, "GroupQueryAttention") == 0
     assert count_op_type(mtp_graph, "Softmax") >= 1
+    assert {value.name for value in mtp_graph.outputs} == {
+        "mtp_hidden",
+        "present.0.key",
+        "present.0.value",
+    }
+
+
+def test_mtp_sidecar_exports_fused_gqa_on_cpu_ep():
+    config = _tiny_config(
+        num_nextn_predict_layers=1,
+        compress_ratios=[0, 0, 0],
+    )
+    package = build_from_module(
+        DeepSeekV4CausalLMModel(config),
+        config,
+        task="deepseek-v4",
+        execution_provider="cpu",
+    )
+
+    assert set(package) == {"model", "mtp"}
+    mtp_graph = package["mtp"].graph
+    names = set(mtp_graph.initializers)
+    assert "mtp.0.self_attn.attn_sink" in names
+    assert count_op_type(mtp_graph, "GroupQueryAttention") == 1
     assert {value.name for value in mtp_graph.outputs} == {
         "mtp_hidden",
         "present.0.key",

--- a/src/mobius/models/deepseek_v4_flash_test.py
+++ b/src/mobius/models/deepseek_v4_flash_test.py
@@ -127,7 +127,19 @@ def test_tiny_graph_builds_v4_backbone():
     graph = build_from_module(DeepSeekV4CausalLMModel(config), config)["model"].graph
     assert graph.num_nodes() > 0
     assert count_op_type(graph, "Attention") == 0
-    assert count_op_type(graph, "Softmax") >= config.num_hidden_layers
+    gqa_nodes = [node for node in graph if node.op_type == "GroupQueryAttention"]
+    assert len(gqa_nodes) == config.num_hidden_layers
+    assert all(node.domain == "com.microsoft" for node in gqa_nodes)
+    # head_sink (12th positional input) carries the learned attention sink;
+    # attention_bias (11th) is intentionally omitted -- GQA's implicit
+    # causal mask + seqlens_k/total_seq_len already covers plain causal
+    # decoding, matching every other direct-GQA model in this codebase.
+    assert all(len(node.inputs) == 12 and node.inputs[10] is None for node in gqa_nodes)
+    assert all(node.inputs[11] is not None for node in gqa_nodes)
+    # Only the Hyper-Connection combination softmax (2 per layer) remains;
+    # the old manual Concat(scores, sink) -> Softmax -> slice attention
+    # softmax is gone now that GQA computes it internally.
+    assert count_op_type(graph, "Softmax") == 2 * config.num_hidden_layers
     assert count_op_type(graph, "ScatterElements") == 0
     assert count_op_type(graph, "Softplus") >= config.num_hidden_layers
     assert count_op_type(graph, "TopK") >= 1
@@ -157,8 +169,15 @@ def test_csa_schedule_exports_compressor_and_indexer_tensors_with_dense_attentio
     assert "model.layers.3.self_attn.compressor.wkv.weight" in names
     assert not any("model.layers.3.self_attn.indexer" in name for name in names)
     assert count_op_type(graph, "Attention") == 0
+    # Dense-CSA schedule attention is still a single fused GQA call per
+    # layer regardless of compress_ratio: the compressor/indexer tensors
+    # above are retained as a zero-valued shape anchor (see
+    # `_shape_anchor`/`DeepSeekV4CompressorTensors.forward`) for future
+    # sparse-runtime handoff, they do not participate in the dense
+    # attention computation this graph actually executes.
+    assert count_op_type(graph, "GroupQueryAttention") == config.num_hidden_layers
     assert count_op_type(graph, "ScatterElements") == 0
-    assert count_op_type(graph, "Softmax") >= config.num_hidden_layers
+    assert count_op_type(graph, "Softmax") == 2 * config.num_hidden_layers
 
 
 def test_mtp_sidecar_exports_official_block_and_hyper_connection_state():
@@ -176,6 +195,7 @@ def test_mtp_sidecar_exports_official_block_and_hyper_connection_state():
     assert "mtp.0.h_proj.weight" in names
     assert "mtp.0.hc_head_fn.weight" in names
     assert "mtp.0.self_attn.attn_sink" in names
+    assert count_op_type(mtp_graph, "GroupQueryAttention") == 1
     assert count_op_type(mtp_graph, "Softmax") >= 1
     assert {value.name for value in mtp_graph.outputs} == {
         "mtp_hidden",


### PR DESCRIPTION
## Summary

Rewrites DeepSeek-V4's dense attention export (`DeepSeekV4Attention`) to emit fused `com.microsoft::GroupQueryAttention` when the target execution provider supports it, replacing the decomposed manual attention (Transpose/Concat/MatMul/Softmax + explicit `attention_bias` + attention-sink Concat/slice) with a single op call — while preserving the exact same portable decomposed path as a fallback for EPs that don't support GQA.

This is Justin-authorized **Path B** from the DeepSeek-V4 native-CUDA capacity-emission investigation: rather than building a general graph-capture-safe KV-capacity-write mechanism for the decomposed attention path (Path A, previously in progress), modify the Mobius export itself to emit the existing fused GQA contract, since DeepSeek-V4's attention geometry (MQA, `kv_num_heads=1`; RoPE always applied externally via `_rotate`, never fused; plain causal decoding, no sliding window, no per-layer dual head_dim) fits GQA's contract exactly, with no lossy approximation.

## Why GQA fits with no lossy approximation

- V4 always applies RoPE explicitly in-graph (both nope/rope split + rotate), so `GroupQueryAttention`'s `do_rotary` stays at its default (0/off) in both fused and decomposed paths — no fused-rotary mode is ever requested.
- V4 is single-KV-head MQA (`kv_num_heads=1`); the fused op's own broadcast-across-query-heads handling replaces the manual `_expand_kv` broadcast.
- Plain causal decoding (no sliding window, no cross-layer KV sharing) means GQA's implicit causal mask + `seqlens_k`/`total_seq_len` already carries the exact same causal+padding semantics `create_attention_bias` bakes into an explicit float bias — the same "direct GQA" convention `Attention._forward_gqa` already uses for every other simple-causal model in this codebase.
- The learned per-head attention sink is passed as GQA's first-class `head_sink` input (12th positional), verified to be genuinely supported by stock ORT 1.29.0's CPU EP; this crate's own CPU kernel previously rejected it — see the paired onnx-genai PR ([justinchuby/onnx-genai#1956](https://github.com/justinchuby/onnx-genai/pull/1956)) which closes that gap.
- `attention_bias` (GQA's 11th input) is intentionally never passed — matches the existing `_forward_gqa` convention, and sidesteps the one real remaining gap: neither this crate's CPU nor CUDA GQA kernels implement it.

## EP-capability gating (critical correctness fix — see review history below)

An initial version of this change emitted fused GQA **unconditionally**, regardless of execution provider. Independent review caught this as a critical bug: `mobius/_execution_providers.py` deliberately declares `gqa_dtypes=frozenset()` for `"default"` (used whenever no `execution_provider` kwarg is passed — effectively all existing tests/consumers), `"onnx-standard"`, `"qnn"`, and `"openvino"`, specifically to guarantee their exported graphs stay free of `com.microsoft` custom ops — a real, load-bearing portability contract other code depends on (e.g. `glm_moe_dsa_test.py` asserts zero `GroupQueryAttention` nodes under the default build).

The fix adds `_use_fused_gqa()`, mirroring `TextModel.forward`'s `use_gqa` gate (`mobius/models/base.py`) via `ep_capabilities()`/`get_build_dtype()`, and branches `DeepSeekV4Attention.forward` accordingly:
- **Fused path** (EP declares GQA support for the build dtype, e.g. `"cpu"` with FLOAT, `"cuda"` with FLOAT16/BFLOAT16): emits the single `GroupQueryAttention` call described above.
- **Decomposed path** (all other EPs, including `"default"`): restores the original portable manual attention, byte-identical to the pre-fusion implementation.

## Tests

`deepseek_v4_flash_test.py`:
- `test_tiny_graph_builds_v4_backbone`, `test_csa_schedule_exports_compressor_and_indexer_tensors_with_dense_attention`, and `test_mtp_sidecar_exports_official_block_and_hyper_connection_state` now assert `GroupQueryAttention` count **== 0** under the default EP (in addition to their original decomposed-path assertions), proving the portability contract holds.
- Three new tests build the same tiny configs under `execution_provider="cpu"` (whose `gqa_dtypes={FLOAT}` matches the tiny config's default dtype) and assert the fused-GQA structural properties: node count == `num_hidden_layers`, `com.microsoft` domain, 12-input arity with `attention_bias` unset and `head_sink` populated, and halved `Softmax` count (only the Hyper-Connection combination softmax remains — the manual attention softmax is gone).

All 14 tests in `deepseek_v4_flash_test.py` pass, plus the 3 in `deepseek_v4_test.py` (17 total). `ruff check`/`ruff format --check` clean. `tests/synthetic_parity_test.py -k deepseek_v4` has one pre-existing, unrelated skip (`Weight transfer failed ... expects [64, 32], got [2048, 32]`), confirmed to skip identically on the pre-fusion commit — not introduced by this change.

## Review

Independently reviewed twice via a `code-review` sub-agent:
1. First pass (on the unconditional-fusion version): **REQUEST CHANGES** — found the EP-gating bypass described above.
2. Second pass (on this corrected diff): **APPROVE** — byte-diffed both branches against the pre-fusion and unconditional-fusion implementations, confirmed plumbing/argument-order consistency across `DeepSeekV4Attention`/`DeepSeekV4DecoderLayer`/`DeepSeekV4TextModel`/`DeepSeekV4Mtp`, and confirmed the new EP-gated tests genuinely exercise the fused path.

## Also included

Corrects a stale claim in `.agents/skills/attention-optimization/SKILL.md` ("GQA contrib op rejects `attention_bias` entirely") — the blanket rejection only holds for the CUDA fused-kernel cascade (XQA/Flash/MEA), not the op as a whole; clarifies onnx-genai's own kernel status per-EP.

## Out of scope

No GLM-5.2 registration, paging/residency, YaRN, or unrelated attention changes. No Mobius exporter changes beyond DeepSeek-V4 attention itself.

## Related

Pairs with [justinchuby/onnx-genai#1956](https://github.com/justinchuby/onnx-genai/pull/1956) (CPU `head_sink` kernel support — the one real onnx-genai runtime gap this export change depends on).