### PR TITLE
Fuse GLM native-block routed experts into sparse pkg.nxrt::BlockQuantizedMoE (+ build_from_gguf wiring)

### DIFF
--- a/src/mobius/integrations/gguf/_block_quantized_moe_builder_test.py
+++ b/src/mobius/integrations/gguf/_block_quantized_moe_builder_test.py
@@ -4,13 +4,13 @@
 """Builder-side wiring for the native-block sparse-MoE fusion + honesty gate.
 
 These tests exercise the ``build_from_gguf`` post-export integration points
-(:func:`_fuse_native_block_moe`, :func:`_assert_sparse_moe_graph`, and the
-:func:`_perproj_bqmoe_v2_runtime_available` runtime-capability probe) on synthetic
+(:func:`_fuse_native_block_moe`, :func:`_assert_sparse_moe_graph`) on synthetic
 exported packages -- i.e. the graph state the builder hands to the fusion after
 ``pkg.apply_weights``. They are distinct from the rewrite-rule unit tests: the
-focus here is the *builder's* honesty policy (default fail-closed, per-projection
-v2 runtime gate, opt-in dense retention, and the final-graph-state backstop),
-byte-preserving expert banks, and deterministic external data.
+focus here is the *builder's* honesty policy (default fail-closed for
+mixed-format per-projection v2 with no environment opt-in, opt-in dense
+retention, and the final-graph-state backstop), byte-preserving expert banks,
+and deterministic external data.
 
 Native IQ/GGUF blocks are codebook-based and cannot be dequantized in NumPy, so
 correctness is proven structurally (the routed expert storm collapses; the shared
@@ -32,7 +32,6 @@ from mobius.integrations.gguf import SparseMoEExportError
 from mobius.integrations.gguf._builder import (
     _assert_sparse_moe_graph,
     _fuse_native_block_moe,
-    _perproj_bqmoe_v2_runtime_available,
     _routed_dense_block_matmul_nodes,
 )
 from mobius.rewrite_rules._block_quantized_moe_fusion import _NATIVE_BLOCK_FORMATS
@@ -61,17 +60,26 @@ def _moe(pkg: ModelPackage) -> ir.Node:
 
 
 # --------------------------------------------------------------------------- #
-# Runtime-capability probe                                                    #
+# The retired env flag cannot force an unrunnable v2 node through the builder  #
 # --------------------------------------------------------------------------- #
-def test_perproj_v2_runtime_probe_defaults_false(monkeypatch) -> None:
-    monkeypatch.delenv(_V2_ENV, raising=False)
-    assert _perproj_bqmoe_v2_runtime_available() is False
-
-
 @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
-def test_perproj_v2_runtime_probe_env_opt_in(monkeypatch, value) -> None:
+def test_builder_env_flag_cannot_force_v2(monkeypatch, value) -> None:
+    """The retired ``MOBIUS_ENABLE_BQMOE_PERPROJ_V2`` env flag cannot bypass the blocker.
+
+    A mixed-format (v2-only) layer must typed-reject through the builder no matter
+    how the old opt-in env var is set: production never emits an unrunnable v2
+    node from an environment variable. The reject is atomic -- the dense graph is
+    left untouched.
+    """
     monkeypatch.setenv(_V2_ENV, value)
-    assert _perproj_bqmoe_v2_runtime_available() is True
+    pkg, _ = _pkg(gate_fmt="iq1_s", up_fmt="iq1_s", down_fmt="iq4_xs")
+    equal_before = _count(pkg, "Equal")
+
+    with pytest.raises(SparseMoEExportError, match=r"block_layout_version=2"):
+        _fuse_native_block_moe(pkg, allow_dense=False)
+
+    assert _count(pkg, "BlockQuantizedMoE") == 0
+    assert _count(pkg, "Equal") == equal_before  # untouched
 
 
 # --------------------------------------------------------------------------- #
@@ -115,18 +123,22 @@ def test_builder_mixed_format_typed_rejects_without_v2_runtime(monkeypatch) -> N
     assert _count(pkg, "Equal") == equal_before  # untouched
 
 
-def test_builder_mixed_format_fuses_with_v2_runtime(monkeypatch) -> None:
-    """With the v2 runtime opted in, a mixed-format layer fuses to a v2 node."""
+def test_builder_env_flag_with_allow_dense_keeps_runnable_fallback(monkeypatch) -> None:
+    """Env flag set + allow_dense keeps the runnable dense storm, never a v2 node.
+
+    The only non-reject escape for a mixed-format layer is the explicit dense
+    fallback (every expert per token, no throughput claim). Even then the builder
+    must not emit a ``block_layout_version=2`` node from the retired env flag.
+    """
     monkeypatch.setenv(_V2_ENV, "1")
     pkg, _ = _pkg(gate_fmt="iq1_s", up_fmt="iq1_s", down_fmt="iq4_xs")
-    fused = _fuse_native_block_moe(pkg, allow_dense=False)
-    _assert_sparse_moe_graph(pkg, source="mixed.gguf", allow_dense=False)
+    equal_before = _count(pkg, "Equal")
 
-    assert fused == 1
-    attrs = _moe(pkg).attributes
-    assert attrs["block_layout_version"].value == 2
-    assert attrs["fc1_format"].value == "iq1_s"
-    assert attrs["fc2_format"].value == "iq4_xs"
+    fused = _fuse_native_block_moe(pkg, allow_dense=True)
+
+    assert fused == 0  # nothing fused
+    assert _count(pkg, "BlockQuantizedMoE") == 0  # no v2 node emitted from the env flag
+    assert _count(pkg, "Equal") == equal_before  # runnable dense fallback preserved
 
 
 def test_builder_allow_dense_retains_dense_fallback(monkeypatch) -> None:
@@ -232,8 +244,10 @@ def test_gate_opt_in_allows_leftover_storm() -> None:
 # exercise the identical routed dense-loop -> BlockQuantizedMatMul storm and the
 # same step 9b authority point with a tiny, self-contained model, so they are
 # the honest end-to-end proof for the fusion wiring. GLM-5.2's own layers are
-# per-projection mixed-format, so end-to-end they can only typed-reject until the
-# v2 runtime ships (covered by the mixed-format case below).
+# per-projection mixed-format, so end-to-end they can only typed-reject until a
+# real typed v2 runtime-capability handshake ships -- no environment flag can
+# force a v2 node (covered by the mixed-format reject + env-cannot-force cases
+# below).
 
 _E2E_HID = 64
 _E2E_MOE_INTER = 32
@@ -363,22 +377,21 @@ def test_e2e_mixed_format_typed_rejects_through_builder(monkeypatch, tmp_path) -
         build_from_gguf(path, keep_quantized=True)
 
 
-def test_e2e_mixed_format_fuses_with_v2_runtime(monkeypatch, tmp_path) -> None:
-    """Opting the v2 runtime in emits a single per-projection v2 BQMoE end-to-end."""
+def test_e2e_env_flag_cannot_force_v2_through_builder(monkeypatch, tmp_path) -> None:
+    """The retired env flag cannot make ``build_from_gguf`` emit a v2 node.
+
+    End-to-end, a GLM-5.2-style per-projection mixed GGUF must still raise
+    ``SparseMoEExportError`` with the old opt-in env var set: there is no
+    production, CLI, or environment path to an unrunnable v2 node.
+    """
     from mobius.integrations.gguf import build_from_gguf
 
     monkeypatch.setenv(_V2_ENV, "1")
-    path = tmp_path / "mixed-moe-v2.gguf"
+    path = tmp_path / "mixed-moe-env.gguf"
     _write_native_moe_gguf(path, down_fmt="iq4_xs")
 
-    pkg = build_from_gguf(path, keep_quantized=True)
-    moe, matmul = _e2e_ops(pkg)
-    assert moe == 1
-    assert matmul == 4
-    attrs = _moe(pkg).attributes
-    assert attrs["block_layout_version"].value == 2
-    assert attrs["fc1_format"].value == "iq1_s"
-    assert attrs["fc2_format"].value == "iq4_xs"
+    with pytest.raises(SparseMoEExportError, match=r"block_layout_version=2"):
+        build_from_gguf(path, keep_quantized=True)
 
 
 def test_e2e_allow_dense_retains_storm_through_builder(monkeypatch, tmp_path) -> None:

--- a/src/mobius/integrations/gguf/_block_quantized_moe_builder_test.py
+++ b/src/mobius/integrations/gguf/_block_quantized_moe_builder_test.py
@@ -1,0 +1,420 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Builder-side wiring for the native-block sparse-MoE fusion + honesty gate.
+
+These tests exercise the ``build_from_gguf`` post-export integration points
+(:func:`_fuse_native_block_moe`, :func:`_assert_sparse_moe_graph`, and the
+:func:`_perproj_bqmoe_v2_runtime_available` runtime-capability probe) on synthetic
+exported packages -- i.e. the graph state the builder hands to the fusion after
+``pkg.apply_weights``. They are distinct from the rewrite-rule unit tests: the
+focus here is the *builder's* honesty policy (default fail-closed, per-projection
+v2 runtime gate, opt-in dense retention, and the final-graph-state backstop),
+byte-preserving expert banks, and deterministic external data.
+
+Native IQ/GGUF blocks are codebook-based and cannot be dequantized in NumPy, so
+correctness is proven structurally (the routed expert storm collapses; the shared
+expert is untouched) and by byte-preservation (the native blocks are stacked
+verbatim). GLM-5.2 UD-IQ1 layers mix native formats across their fc1/fc2/fc3
+banks, so they require the ``block_layout_version=2`` per-projection ABI; until
+that ships in the runtime the builder must typed-reject them rather than emit an
+unrunnable node.
+"""
+
+from __future__ import annotations
+
+import onnx_ir as ir
+import pytest
+
+from mobius._constants import OPSET_VERSION
+from mobius._model_package import ModelPackage
+from mobius.integrations.gguf import SparseMoEExportError
+from mobius.integrations.gguf._builder import (
+    _assert_sparse_moe_graph,
+    _fuse_native_block_moe,
+    _perproj_bqmoe_v2_runtime_available,
+    _routed_dense_block_matmul_nodes,
+)
+from mobius.rewrite_rules._block_quantized_moe_fusion import _NATIVE_BLOCK_FORMATS
+from mobius.rewrite_rules._block_quantized_moe_fusion_test import (
+    E,
+    H,
+    _build_dense_graph,
+)
+
+_V2_ENV = "MOBIUS_ENABLE_BQMOE_PERPROJ_V2"
+
+
+def _pkg(**kwargs) -> tuple[ModelPackage, dict]:
+    model, weights = _build_dense_graph(**kwargs)
+    return ModelPackage({"model": model}), weights
+
+
+def _count(pkg: ModelPackage, op_type: str) -> int:
+    return sum(1 for model in pkg.values() for n in model.graph if n.op_type == op_type)
+
+
+def _moe(pkg: ModelPackage) -> ir.Node:
+    return next(
+        n for model in pkg.values() for n in model.graph if n.op_type == "BlockQuantizedMoE"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Runtime-capability probe                                                    #
+# --------------------------------------------------------------------------- #
+def test_perproj_v2_runtime_probe_defaults_false(monkeypatch) -> None:
+    monkeypatch.delenv(_V2_ENV, raising=False)
+    assert _perproj_bqmoe_v2_runtime_available() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+def test_perproj_v2_runtime_probe_env_opt_in(monkeypatch, value) -> None:
+    monkeypatch.setenv(_V2_ENV, value)
+    assert _perproj_bqmoe_v2_runtime_available() is True
+
+
+# --------------------------------------------------------------------------- #
+# Fusion wiring on the final graph state                                      #
+# --------------------------------------------------------------------------- #
+def test_builder_fuses_uniform_native_moe(monkeypatch) -> None:
+    """A uniform-format routed storm collapses to one v1 BQMoE per layer.
+
+    The always-active shared expert (3 native BlockQuantizedMatMul projections)
+    must stay dense -- it is not routed and must not be swept into the bank.
+    """
+    monkeypatch.delenv(_V2_ENV, raising=False)
+    pkg, _ = _pkg(gate_fmt="iq4_xs", up_fmt="iq4_xs", down_fmt="iq4_xs")
+    fused = _fuse_native_block_moe(pkg, allow_dense=False)
+    _assert_sparse_moe_graph(pkg, source="uniform.gguf", allow_dense=False)
+
+    assert fused == 1
+    assert _count(pkg, "BlockQuantizedMoE") == 1
+    # 4 routed experts * 3 projections collapse; only the shared expert's 3
+    # projections survive.
+    assert _count(pkg, "BlockQuantizedMatMul") == 3
+    attrs = _moe(pkg).attributes
+    assert "block_layout_version" not in attrs  # v1 (uniform)
+    assert attrs["format"].value == "iq4_xs"
+
+
+def test_builder_mixed_format_typed_rejects_without_v2_runtime(monkeypatch) -> None:
+    """GLM-5.2-style mixed formats need v2; with no v2 runtime, fail closed.
+
+    The reject must be atomic: the dense graph is left untouched so the caller
+    sees the original storm, never a half-rewritten graph.
+    """
+    monkeypatch.delenv(_V2_ENV, raising=False)
+    pkg, _ = _pkg(gate_fmt="iq1_s", up_fmt="iq1_s", down_fmt="iq4_xs")
+    equal_before = _count(pkg, "Equal")
+
+    with pytest.raises(SparseMoEExportError, match=r"block_layout_version=2"):
+        _fuse_native_block_moe(pkg, allow_dense=False)
+
+    assert _count(pkg, "BlockQuantizedMoE") == 0
+    assert _count(pkg, "Equal") == equal_before  # untouched
+
+
+def test_builder_mixed_format_fuses_with_v2_runtime(monkeypatch) -> None:
+    """With the v2 runtime opted in, a mixed-format layer fuses to a v2 node."""
+    monkeypatch.setenv(_V2_ENV, "1")
+    pkg, _ = _pkg(gate_fmt="iq1_s", up_fmt="iq1_s", down_fmt="iq4_xs")
+    fused = _fuse_native_block_moe(pkg, allow_dense=False)
+    _assert_sparse_moe_graph(pkg, source="mixed.gguf", allow_dense=False)
+
+    assert fused == 1
+    attrs = _moe(pkg).attributes
+    assert attrs["block_layout_version"].value == 2
+    assert attrs["fc1_format"].value == "iq1_s"
+    assert attrs["fc2_format"].value == "iq4_xs"
+
+
+def test_builder_allow_dense_retains_dense_fallback(monkeypatch) -> None:
+    """Opting into the dense fallback keeps the runnable per-expert storm."""
+    monkeypatch.delenv(_V2_ENV, raising=False)
+    pkg, _ = _pkg(gate_fmt="iq1_s", up_fmt="iq1_s", down_fmt="iq4_xs")
+    equal_before = _count(pkg, "Equal")
+
+    fused = _fuse_native_block_moe(pkg, allow_dense=True)
+    # The gate is a no-op under the opt-in (the fusion already warned).
+    _assert_sparse_moe_graph(pkg, source="mixed.gguf", allow_dense=True)
+
+    assert fused == 0
+    assert _count(pkg, "BlockQuantizedMoE") == 0
+    assert _count(pkg, "Equal") == equal_before  # dense fallback preserved
+
+
+def test_builder_bank_bytes_are_byte_preserved(monkeypatch) -> None:
+    """The emitted fc2 expert bank is the source down blocks stacked verbatim."""
+    import numpy as np
+
+    monkeypatch.delenv(_V2_ENV, raising=False)
+    pkg, weights = _pkg(gate_fmt="iq4_xs", up_fmt="iq4_xs", down_fmt="iq4_xs")
+    _fuse_native_block_moe(pkg, allow_dense=False)
+
+    fc2_bank = _moe(pkg).inputs[4].const_value.numpy()
+    expected = np.stack([weights[f"d{e}"] for e in range(E)], axis=0)
+    assert fc2_bank.shape == expected.shape
+    assert np.array_equal(fc2_bank, expected)  # byte-for-byte, no requantization
+
+
+def test_builder_fusion_is_deterministic(monkeypatch, tmp_path) -> None:
+    """Two independent fusions produce byte-identical external data on save."""
+    monkeypatch.delenv(_V2_ENV, raising=False)
+
+    def _save(sub: str) -> bytes:
+        pkg, _ = _pkg(gate_fmt="iq4_xs", up_fmt="iq4_xs", down_fmt="iq4_xs")
+        _fuse_native_block_moe(pkg, allow_dense=False)
+        out = tmp_path / sub
+        pkg.save(str(out), progress_bar=False, check_weights=False)
+        return (out / "model.onnx.data").read_bytes()
+
+    assert _save("a") == _save("b")
+
+
+# --------------------------------------------------------------------------- #
+# Final-graph-state honesty gate (backstop)                                   #
+# --------------------------------------------------------------------------- #
+def _graph_with_named_bqmatmul(weight_name: str) -> ModelPackage:
+    """One ``pkg.nxrt::BlockQuantizedMatMul`` whose weight carries *weight_name*."""
+    block_elements, block_bytes = _NATIVE_BLOCK_FORMATS["iq4_xs"]
+    x = ir.Value(name="x", shape=ir.Shape(["T", H]), type=ir.TensorType(ir.DataType.FLOAT))
+    weight = ir.Value(
+        name=weight_name,
+        shape=ir.Shape([H, (H + block_elements - 1) // block_elements, block_bytes]),
+        type=ir.TensorType(ir.DataType.UINT8),
+    )
+    node = ir.node(
+        "BlockQuantizedMatMul",
+        inputs=[x, weight],
+        attributes={"K": H, "N": H, "format": "iq4_xs", "block_layout_version": 1},
+        domain="pkg.nxrt",
+        num_outputs=1,
+        name="expert_proj",
+    )
+    node.outputs[0].name = "y"
+    node.outputs[0].type = ir.TensorType(ir.DataType.FLOAT)
+    graph = ir.Graph([x], [node.outputs[0]], nodes=[node], name="storm")
+    model = ir.Model(graph, ir_version=10, producer_name="test")
+    model.opset_imports[""] = OPSET_VERSION
+    model.opset_imports["pkg.nxrt"] = 1
+    return ModelPackage({"model": model})
+
+
+def test_gate_flags_leftover_routed_storm() -> None:
+    """A routed ``.experts.`` BlockQuantizedMatMul that fusion left is a storm."""
+    pkg = _graph_with_named_bqmatmul("model.layers.0.mlp.experts.2.down_proj.weight")
+    assert len(_routed_dense_block_matmul_nodes(pkg["model"])) == 1
+    with pytest.raises(SparseMoEExportError, match=r"remain as"):
+        _assert_sparse_moe_graph(pkg, source="storm.gguf", allow_dense=False)
+
+
+def test_gate_ignores_shared_expert() -> None:
+    """A ``shared_expert`` projection is not routed and must not trip the gate."""
+    pkg = _graph_with_named_bqmatmul("model.layers.0.mlp.shared_expert.down_proj.weight")
+    assert _routed_dense_block_matmul_nodes(pkg["model"]) == []
+    _assert_sparse_moe_graph(pkg, source="shared.gguf", allow_dense=False)  # no raise
+
+
+def test_gate_opt_in_allows_leftover_storm() -> None:
+    """Under the dense opt-in the backstop stays silent (fusion already warned)."""
+    pkg = _graph_with_named_bqmatmul("model.layers.0.mlp.experts.0.gate_proj.weight")
+    _assert_sparse_moe_graph(pkg, source="storm.gguf", allow_dense=True)  # no raise
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end: synthetic native-block MoE GGUF -> build_from_gguf              #
+# --------------------------------------------------------------------------- #
+# These drive the *whole* builder pipeline (metadata -> config bridge -> module
+# build -> weight application -> step 9b fusion + gate) on a synthetic sharded-
+# style GGUF, not just the post-export helpers. GLM-5.2 (glm_moe_dsa) needs
+# Batty's full MLA/DSA machinery to reach the MoE block; qwen3_moe / qwen2_moe
+# exercise the identical routed dense-loop -> BlockQuantizedMatMul storm and the
+# same step 9b authority point with a tiny, self-contained model, so they are
+# the honest end-to-end proof for the fusion wiring. GLM-5.2's own layers are
+# per-projection mixed-format, so end-to-end they can only typed-reject until the
+# v2 runtime ships (covered by the mixed-format case below).
+
+_E2E_HID = 64
+_E2E_MOE_INTER = 32
+_E2E_N_EXP = 4
+_E2E_TOPK = 2
+_E2E_HEADS = 4
+_E2E_KV = 2
+_E2E_VOCAB = 256
+
+_E2E_NATIVE = {"iq4_xs": "IQ4_XS", "iq1_s": "IQ1_S"}
+
+
+def _write_native_moe_gguf(
+    path, *, down_fmt: str, arch: str = "qwen3_moe", shared: bool = False
+) -> None:
+    """Write a tiny single-layer native-block MoE GGUF (routed + optional shared).
+
+    Routed ``fc1``/``fc3`` banks are ``iq1_s``; the routed ``fc2`` (down) bank is
+    *down_fmt* (``iq1_s`` = uniform, ``iq4_xs`` = GLM-5.2-style per-projection
+    mix). Attention projections are ``iq4_xs`` native blocks so they survive as
+    ordinary BlockQuantizedMatMul and let the test prove *only* the routed storm
+    collapsed.
+    """
+    import numpy as np
+    from gguf import GGMLQuantizationType, GGUFWriter
+
+    native_bytes = {
+        "iq4_xs": (GGMLQuantizationType.IQ4_XS, 256, 136),
+        "iq1_s": (GGMLQuantizationType.IQ1_S, 256, 50),
+    }
+
+    def add_native(name, shape, fmt):
+        qtype, be, bb = native_bytes[fmt]
+        *lead, k_in = shape
+        nb = (k_in + be - 1) // be
+        cols = nb * bb
+        total = int(np.prod(lead)) * cols
+        raw = np.arange(total, dtype=np.uint8).reshape(*lead, cols)
+        w.add_tensor(name, raw, raw_dtype=qtype)
+
+    def add_f32(name, shape):
+        w.add_tensor(name, np.random.randn(*shape).astype(np.float32))
+
+    w = GGUFWriter(str(path), arch)
+    w.add_context_length(512)
+    w.add_embedding_length(_E2E_HID)
+    w.add_feed_forward_length(_E2E_HID * 2)
+    w.add_block_count(1)
+    w.add_head_count(_E2E_HEADS)
+    w.add_head_count_kv(_E2E_KV)
+    w.add_rope_freq_base(10000.0)
+    w.add_layer_norm_rms_eps(1e-5)
+    w.add_vocab_size(_E2E_VOCAB)
+    w.add_expert_count(_E2E_N_EXP)
+    w.add_expert_used_count(_E2E_TOPK)
+    w.add_expert_feed_forward_length(_E2E_MOE_INTER)
+    if shared:
+        w.add_expert_shared_feed_forward_length(_E2E_MOE_INTER)
+
+    head_dim = _E2E_HID // _E2E_HEADS
+    add_f32("token_embd.weight", (_E2E_VOCAB, _E2E_HID))
+    add_native("blk.0.attn_q.weight", (_E2E_HEADS * head_dim, _E2E_HID), "iq4_xs")
+    add_native("blk.0.attn_k.weight", (_E2E_KV * head_dim, _E2E_HID), "iq4_xs")
+    add_native("blk.0.attn_v.weight", (_E2E_KV * head_dim, _E2E_HID), "iq4_xs")
+    add_native("blk.0.attn_output.weight", (_E2E_HID, _E2E_HEADS * head_dim), "iq4_xs")
+    add_f32("blk.0.attn_norm.weight", (_E2E_HID,))
+    add_f32("blk.0.ffn_norm.weight", (_E2E_HID,))
+    add_f32("blk.0.ffn_gate_inp.weight", (_E2E_N_EXP, _E2E_HID))
+    add_native("blk.0.ffn_gate_exps.weight", (_E2E_N_EXP, _E2E_MOE_INTER, _E2E_HID), "iq1_s")
+    add_native("blk.0.ffn_up_exps.weight", (_E2E_N_EXP, _E2E_MOE_INTER, _E2E_HID), "iq1_s")
+    add_native("blk.0.ffn_down_exps.weight", (_E2E_N_EXP, _E2E_HID, _E2E_MOE_INTER), down_fmt)
+    if shared:
+        add_f32("blk.0.ffn_gate_inp_shexp.weight", (1, _E2E_HID))
+        add_native("blk.0.ffn_gate_shexp.weight", (_E2E_MOE_INTER, _E2E_HID), "iq1_s")
+        add_native("blk.0.ffn_up_shexp.weight", (_E2E_MOE_INTER, _E2E_HID), "iq1_s")
+        add_native("blk.0.ffn_down_shexp.weight", (_E2E_HID, _E2E_MOE_INTER), "iq1_s")
+    add_f32("output_norm.weight", (_E2E_HID,))
+    add_f32("output.weight", (_E2E_VOCAB, _E2E_HID))
+
+    w.write_header_to_file()
+    w.write_kv_data_to_file()
+    w.write_tensors_to_file()
+    w.close()
+
+
+def _e2e_ops(pkg: ModelPackage) -> tuple[int, int]:
+    return _count(pkg, "BlockQuantizedMoE"), _count(pkg, "BlockQuantizedMatMul")
+
+
+def test_e2e_uniform_native_moe_fuses_through_builder(monkeypatch, tmp_path) -> None:
+    """A uniform routed native-block MoE GGUF builds into one sparse BQMoE.
+
+    Structural proof the routed expert matmuls collapse: 4 experts * 3
+    projections (12 BlockQuantizedMatMul) become one BlockQuantizedMoE, and the
+    only BlockQuantizedMatMul left are the 4 attention projections -- i.e. no
+    routed expert storm and only the selected experts execute at run time.
+    """
+    from mobius.integrations.gguf import build_from_gguf
+
+    monkeypatch.delenv(_V2_ENV, raising=False)
+    path = tmp_path / "uniform-moe.gguf"
+    _write_native_moe_gguf(path, down_fmt="iq1_s")
+
+    pkg = build_from_gguf(path, keep_quantized=True)
+    moe, matmul = _e2e_ops(pkg)
+    assert moe == 1
+    assert matmul == 4  # attn q/k/v/o only; the 12 routed expert matmuls collapsed
+    attrs = _moe(pkg).attributes
+    assert "block_layout_version" not in attrs  # uniform -> v1
+    assert attrs["format"].value == "iq1_s"
+
+
+def test_e2e_mixed_format_typed_rejects_through_builder(monkeypatch, tmp_path) -> None:
+    """A GLM-5.2-style per-projection mixed GGUF fails closed end-to-end.
+
+    Without the v2 runtime the builder must raise ``SparseMoEExportError`` rather
+    than emit an unrunnable v2 node -- this is exactly the honest path GLM-5.2
+    UD-IQ1 takes until the per-projection runtime ships.
+    """
+    from mobius.integrations.gguf import build_from_gguf
+
+    monkeypatch.delenv(_V2_ENV, raising=False)
+    path = tmp_path / "mixed-moe.gguf"
+    _write_native_moe_gguf(path, down_fmt="iq4_xs")
+
+    with pytest.raises(SparseMoEExportError, match=r"block_layout_version=2"):
+        build_from_gguf(path, keep_quantized=True)
+
+
+def test_e2e_mixed_format_fuses_with_v2_runtime(monkeypatch, tmp_path) -> None:
+    """Opting the v2 runtime in emits a single per-projection v2 BQMoE end-to-end."""
+    from mobius.integrations.gguf import build_from_gguf
+
+    monkeypatch.setenv(_V2_ENV, "1")
+    path = tmp_path / "mixed-moe-v2.gguf"
+    _write_native_moe_gguf(path, down_fmt="iq4_xs")
+
+    pkg = build_from_gguf(path, keep_quantized=True)
+    moe, matmul = _e2e_ops(pkg)
+    assert moe == 1
+    assert matmul == 4
+    attrs = _moe(pkg).attributes
+    assert attrs["block_layout_version"].value == 2
+    assert attrs["fc1_format"].value == "iq1_s"
+    assert attrs["fc2_format"].value == "iq4_xs"
+
+
+def test_e2e_allow_dense_retains_storm_through_builder(monkeypatch, tmp_path) -> None:
+    """``allow_dense_moe=True`` keeps the runnable per-expert dense fallback.
+
+    It must warn+retain, never count as a fused success: the 12 routed expert
+    matmuls stay, so no BlockQuantizedMoE is produced.
+    """
+    from mobius.integrations.gguf import build_from_gguf
+
+    monkeypatch.delenv(_V2_ENV, raising=False)
+    path = tmp_path / "mixed-moe-dense.gguf"
+    _write_native_moe_gguf(path, down_fmt="iq4_xs")
+
+    pkg = build_from_gguf(path, keep_quantized=True, allow_dense_moe=True)
+    moe, matmul = _e2e_ops(pkg)
+    assert moe == 0
+    # 4 attention + 4 experts * 3 projections all remain as dense BlockQuantizedMatMul.
+    assert matmul == 16
+
+
+def test_e2e_shared_expert_survives_fusion_through_builder(monkeypatch, tmp_path) -> None:
+    """A shared-expert MoE (qwen2_moe) keeps the shared expert dense after fusion.
+
+    The always-active shared expert must stay semantically correct: its 3 native
+    projections remain as BlockQuantizedMatMul while the routed storm collapses
+    into one BlockQuantizedMoE.
+    """
+    from mobius.integrations.gguf import build_from_gguf
+
+    monkeypatch.delenv(_V2_ENV, raising=False)
+    path = tmp_path / "shared-moe.gguf"
+    _write_native_moe_gguf(path, down_fmt="iq1_s", arch="qwen2_moe", shared=True)
+
+    pkg = build_from_gguf(path, keep_quantized=True)
+    moe, matmul = _e2e_ops(pkg)
+    assert moe == 1
+    # 4 attention + 3 shared-expert projections survive; routed 12 collapsed.
+    assert matmul == 7

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 __all__ = ["build_from_gguf"]
 
 import logging
-import os
 import re
 from collections import Counter
 from collections.abc import Callable, Iterable, Mapping
@@ -226,46 +225,33 @@ def _assert_sparse_moe_capability(module, config, *, source: str, allow_dense: b
     )
 
 
-def _perproj_bqmoe_v2_runtime_available() -> bool:
-    """Whether the deployed pkg.nxrt runtime implements the v2 BlockQuantizedMoE ABI.
-
-    A layer that mixes native block formats across its fc1/fc2/fc3 banks (e.g.
-    GLM-5.2 UD-IQ1 with an iq1 gate/up and a higher-bit down projection) can only
-    be expressed with the ``block_layout_version=2`` per-projection
-    ``BlockQuantizedMoE`` ABI. That ABI is not yet merged/released in the
-    onnx-genai runtime, so emitting a v2 node here would build an ONNX graph the
-    current runtime cannot execute -- an overclaim. Default ``False`` makes such
-    mixed-format layers fail closed (typed reject) until the runtime ships v2;
-    set ``MOBIUS_ENABLE_BQMOE_PERPROJ_V2=1`` only once it does.
-    """
-    return os.environ.get("MOBIUS_ENABLE_BQMOE_PERPROJ_V2", "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
-
-
 def _fuse_native_block_moe(pkg, *, allow_dense: bool) -> int:
     """Collapse routed native-block expert storms into sparse ``BlockQuantizedMoE``.
 
     Runs on the final, fully-weighted graph so the fusion can stack each layer's
     per-expert native blocks byte-for-byte into one expert-major bank. Every
     candidate layer is validated before any node is emitted, so an unfusable
-    layer (mixed format with no v2 runtime, per-expert bias, ragged/incomplete
-    group) raises :class:`SparseMoEExportError` atomically with the graph
-    untouched, unless ``allow_dense`` downgrades it to a warning + dense keep.
+    layer (per-expert bias, ragged/incomplete group, ...) raises
+    :class:`SparseMoEExportError` atomically with the graph untouched, unless
+    ``allow_dense`` downgrades it to a warning + dense keep.
+
+    A layer that mixes native formats across its fc1/fc2/fc3 banks (GLM-5.2
+    UD-IQ1) can only be expressed with the ``block_layout_version=2``
+    per-projection ABI, which no shipped onnx-genai runtime executes yet. The
+    production builder therefore never enables v2: such layers always
+    typed-reject here rather than emit an unrunnable node. There is no
+    environment or CLI opt-in -- v2 stays a schema-construction test path until a
+    real typed runtime-capability handshake exists.
     """
     # Imported lazily: the generic rewrite lives in the rewrite_rules package and
     # must not be pulled into the GGUF import graph at module load time.
     from mobius.rewrite_rules import fuse_block_quantized_moe
 
-    perproj_v2 = _perproj_bqmoe_v2_runtime_available()
     fused = 0
     for model in pkg.values():
-        fused += fuse_block_quantized_moe(
-            model, allow_dense_moe=allow_dense, perproj_v2_runtime=perproj_v2
-        )
+        # No ``_allow_perproj_v2_schema`` argument: the production authority path
+        # always fails closed for mixed-format v2 (fail-safe default).
+        fused += fuse_block_quantized_moe(model, allow_dense_moe=allow_dense)
     return fused
 
 

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 __all__ = ["build_from_gguf"]
 
 import logging
+import os
 import re
 from collections import Counter
 from collections.abc import Callable, Iterable, Mapping
@@ -222,6 +223,96 @@ def _assert_sparse_moe_capability(module, config, *, source: str, allow_dense: b
         "MOBIUS_ALLOW_DENSE_MOE_EXPERTS=1); this makes no throughput claim. "
         "The supported fix is a sparse IQ-block BlockQuantizedMoE fusion "
         "(top-k gather over native-block expert weights)."
+    )
+
+
+def _perproj_bqmoe_v2_runtime_available() -> bool:
+    """Whether the deployed pkg.nxrt runtime implements the v2 BlockQuantizedMoE ABI.
+
+    A layer that mixes native block formats across its fc1/fc2/fc3 banks (e.g.
+    GLM-5.2 UD-IQ1 with an iq1 gate/up and a higher-bit down projection) can only
+    be expressed with the ``block_layout_version=2`` per-projection
+    ``BlockQuantizedMoE`` ABI. That ABI is not yet merged/released in the
+    onnx-genai runtime, so emitting a v2 node here would build an ONNX graph the
+    current runtime cannot execute -- an overclaim. Default ``False`` makes such
+    mixed-format layers fail closed (typed reject) until the runtime ships v2;
+    set ``MOBIUS_ENABLE_BQMOE_PERPROJ_V2=1`` only once it does.
+    """
+    return os.environ.get("MOBIUS_ENABLE_BQMOE_PERPROJ_V2", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _fuse_native_block_moe(pkg, *, allow_dense: bool) -> int:
+    """Collapse routed native-block expert storms into sparse ``BlockQuantizedMoE``.
+
+    Runs on the final, fully-weighted graph so the fusion can stack each layer's
+    per-expert native blocks byte-for-byte into one expert-major bank. Every
+    candidate layer is validated before any node is emitted, so an unfusable
+    layer (mixed format with no v2 runtime, per-expert bias, ragged/incomplete
+    group) raises :class:`SparseMoEExportError` atomically with the graph
+    untouched, unless ``allow_dense`` downgrades it to a warning + dense keep.
+    """
+    # Imported lazily: the generic rewrite lives in the rewrite_rules package and
+    # must not be pulled into the GGUF import graph at module load time.
+    from mobius.rewrite_rules import fuse_block_quantized_moe
+
+    perproj_v2 = _perproj_bqmoe_v2_runtime_available()
+    fused = 0
+    for model in pkg.values():
+        fused += fuse_block_quantized_moe(
+            model, allow_dense_moe=allow_dense, perproj_v2_runtime=perproj_v2
+        )
+    return fused
+
+
+def _routed_dense_block_matmul_nodes(model) -> list:
+    """Routed per-expert ``BlockQuantizedMatMul`` nodes surviving in a graph.
+
+    A routed expert projection is a ``pkg.nxrt::BlockQuantizedMatMul`` whose
+    packed-weight initializer path carries an ``.experts.`` segment and is not a
+    ``shared_expert``. After :func:`_fuse_native_block_moe` runs, any that remain
+    are an un-collapsed dense-all-expert storm.
+    """
+    hits = []
+    for node in model.graph:
+        if node.op_type != "BlockQuantizedMatMul":
+            continue
+        weight = node.inputs[1] if len(node.inputs) > 1 else None
+        name = getattr(weight, "name", None) or ""
+        if ".experts." in name and "shared_expert" not in name:
+            hits.append(node)
+    return hits
+
+
+def _assert_sparse_moe_graph(pkg, *, source: str, allow_dense: bool) -> None:
+    """Sparse-MoE honesty gate over the final (post-fusion) graph state.
+
+    :func:`_fuse_native_block_moe` already fails closed with a precise reason for
+    every routed native-block storm it recognises. This backstop catches any
+    routed per-expert ``BlockQuantizedMatMul`` storm that survived fusion (e.g. a
+    dispatch shape the rewrite did not recognise): shipping it silently would be
+    a dense-all-expert graph with no throughput guarantee. Opting into the dense
+    fallback (``allow_dense``) is already warned about by the fusion, so this
+    gate only enforces the fail-closed default.
+    """
+    if allow_dense:
+        return
+    storm = [n for model in pkg.values() for n in _routed_dense_block_matmul_nodes(model)]
+    if not storm:
+        return
+    raise SparseMoEExportError(
+        "Sparse-MoE export blocker: "
+        f"{len(storm)} routed expert projection(s) in {source!r} remain as "
+        "per-expert pkg.nxrt::BlockQuantizedMatMul nodes after native-block MoE "
+        "fusion (no sparse top-k BlockQuantizedMoE was applied). Exporting anyway "
+        "would build a dense-all-expert graph (every expert evaluated for every "
+        "token) with no performance guarantee, so the build fails closed. To "
+        "study the dense fallback, re-run with allow_dense_moe=True (or set "
+        "MOBIUS_ALLOW_DENSE_MOE_EXPERTS=1); this makes no throughput claim."
     )
 
 
@@ -601,13 +692,12 @@ def build_from_gguf(
     module = module_class(config)
     if preserve_quantization:
         _replace_native_block_linears(module, gguf_model, gguf_arch)
-        # Sparse-MoE honesty gate: routed experts lowered as native
-        # BlockQuantizedMatMul nodes have no sparse top-k fusion yet, so the
-        # exported graph would recompute every expert for every token. Fail
-        # closed here (before export) unless the caller explicitly opts in.
-        _assert_sparse_moe_capability(
-            module, config, source=str(gguf_path), allow_dense=allow_dense_moe
-        )
+        # The sparse-MoE honesty gate runs post-export on the final graph state
+        # (see step 9b): routed native-block experts are first collapsed into a
+        # sparse top-k pkg.nxrt::BlockQuantizedMoE by fuse_block_quantized_moe,
+        # then the gate fails closed if any per-expert dense storm survives.
+        # Enforcing here (pre-export, module level) would reject the very layers
+        # the fusion can now collapse, so the authority moved to the graph.
     pkg = build_from_module(
         module, config, resolved_task, execution_provider=execution_provider
     )
@@ -662,6 +752,15 @@ def build_from_gguf(
     # 9. Apply weights to ONNX model
     prefix_map = getattr(module, "weight_prefix_map", None)
     pkg.apply_weights(state_dict, prefix_map=prefix_map)
+
+    # 9b. Sparse-MoE fusion + honesty gate (final graph state).
+    # Now that every native block carries its real packed bytes, collapse the
+    # routed per-expert BlockQuantizedMatMul storm into one sparse top-k
+    # pkg.nxrt::BlockQuantizedMoE per layer (byte-for-byte, no requantization),
+    # then fail closed if any dense-all-expert storm still survives.
+    if preserve_quantization:
+        _fuse_native_block_moe(pkg, allow_dense=allow_dense_moe)
+        _assert_sparse_moe_graph(pkg, source=str(gguf_path), allow_dense=allow_dense_moe)
 
     # 10. Build the trailing MTP / "nextn" self-speculative head sidecar from
     # the GGUF's ``blk.<nextn>.*`` tensors (dropped by the backbone build) and

--- a/src/mobius/rewrite_rules/__init__.py
+++ b/src/mobius/rewrite_rules/__init__.py
@@ -33,6 +33,7 @@ __all__ = [
     "clip_to_min_max_rules",
     "decompose_attention_pass",
     "decompose_rope_rules",
+    "fuse_block_quantized_moe",
     "fuse_dense_moe_to_qmoe",
     "gelu_fusion_rules",
     "group_query_attention_rules",
@@ -49,6 +50,7 @@ __all__ = [
 ]
 
 from mobius.rewrite_rules._bias_gelu import bias_gelu_rules
+from mobius.rewrite_rules._block_quantized_moe_fusion import fuse_block_quantized_moe
 from mobius.rewrite_rules._clip_to_min_max import clip_to_min_max_rules
 from mobius.rewrite_rules._decompose_attention import decompose_attention_pass
 from mobius.rewrite_rules._decompose_rope import decompose_rope_rules

--- a/src/mobius/rewrite_rules/_block_quantized_moe_fusion.py
+++ b/src/mobius/rewrite_rules/_block_quantized_moe_fusion.py
@@ -604,8 +604,16 @@ class _FusionPlan:
     experts: int
 
 
-def _plan_layer(layer: _DenseMoELayer, index: int) -> _FusionPlan:
-    """Validate and byte-stack one native MoE layer without touching the graph."""
+def _plan_layer(layer: _DenseMoELayer, index: int, *, perproj_v2_runtime: bool) -> _FusionPlan:
+    """Validate and byte-stack one native MoE layer without touching the graph.
+
+    ``perproj_v2_runtime`` declares whether the target runtime implements the
+    ``block_layout_version=2`` per-projection ``BlockQuantizedMoE`` ABI. When a
+    layer mixes native formats across its fc1/fc2/fc3 banks it can only be
+    expressed as a v2 node; if the runtime cannot execute v2, planning fails
+    closed here (before any graph mutation) rather than emitting an unrunnable
+    node.
+    """
     ids = sorted(layer.experts)
     gate_nodes = [layer.experts[i].gate for i in ids]
     up_nodes = [layer.experts[i].up for i in ids]
@@ -660,6 +668,15 @@ def _plan_layer(layer: _DenseMoELayer, index: int) -> _FusionPlan:
     if len(distinct) == 1:
         attributes["format"] = next(iter(distinct))
     else:
+        if not perproj_v2_runtime:
+            raise _UnfusableError(
+                "mixed per-projection native formats "
+                f"{sorted(distinct)} can only be expressed with the "
+                "block_layout_version=2 per-projection BlockQuantizedMoE ABI, "
+                "which the target runtime does not implement -- emitting a v2 "
+                "node would build an unrunnable graph (overclaim). Set "
+                "MOBIUS_ENABLE_BQMOE_PERPROJ_V2=1 only once the runtime ships it"
+            )
         attributes["block_layout_version"] = 2
         # ``format`` is the required base/fallback; per-projection attributes
         # override it where a projection uses a different native format.
@@ -808,7 +825,12 @@ def _fail_closed(layer: _DenseMoELayer, reason: _UnfusableError, *, allow_dense:
     ) from reason
 
 
-def fuse_block_quantized_moe(model: ir.Model, *, allow_dense_moe: bool | None = None) -> int:
+def fuse_block_quantized_moe(
+    model: ir.Model,
+    *,
+    allow_dense_moe: bool | None = None,
+    perproj_v2_runtime: bool = True,
+) -> int:
     """Fuse every dense-fallback native-block MoE subgraph into ``BlockQuantizedMoE``.
 
     Reuses the existing ``BlockQuantizedMatMul`` native blocks byte-for-byte
@@ -836,6 +858,14 @@ def fuse_block_quantized_moe(model: ir.Model, *, allow_dense_moe: bool | None = 
             ``allow_dense_moe_experts`` flag / ``MOBIUS_ALLOW_DENSE_MOE_EXPERTS``
             environment variable is used. This is a research/correctness path
             only and makes no throughput claim.
+        perproj_v2_runtime: Whether the target runtime implements the
+            ``block_layout_version=2`` per-projection ``BlockQuantizedMoE`` ABI
+            (mixed native formats across a layer's fc1/fc2/fc3 banks, e.g.
+            GLM-5.2 UD-IQ1 with an iq1 gate/up and a higher-bit down). This is a
+            pure graph transform, so it defaults to ``True`` (v2 is always
+            representable); the GGUF export authority passes the actual runtime
+            capability so a mixed-format layer fails closed rather than emitting
+            an unrunnable v2 node when the runtime has not shipped v2 yet.
 
     Returns:
         The number of MoE layers fused.
@@ -863,7 +893,7 @@ def fuse_block_quantized_moe(model: ir.Model, *, allow_dense_moe: bool | None = 
             continue
         try:
             layer.check_fusable()
-            plans.append(_plan_layer(layer, index))
+            plans.append(_plan_layer(layer, index, perproj_v2_runtime=perproj_v2_runtime))
         except _UnfusableError as reason:
             _fail_closed(layer, reason, allow_dense=allow_dense_moe)
 

--- a/src/mobius/rewrite_rules/_block_quantized_moe_fusion.py
+++ b/src/mobius/rewrite_rules/_block_quantized_moe_fusion.py
@@ -41,10 +41,15 @@ storm and its router/mask are fused, and the final ``Add(routed_sum, shared)``
 is rewired to consume the ``BlockQuantizedMoE`` output.
 
 The rewrite is **property-gated and fails closed**: a layer that is not a native
-dense-expert storm, or whose experts use a mix of native formats that a single
-expert-major bank cannot express, is left as the runnable dense fallback with a
-typed reason logged. It never silently emits a node that would dense-evaluate
-every expert.
+dense-expert storm is skipped, and a *routed native-block* storm whose experts
+cannot be expressed as one expert-major bank (mixed native formats, per-expert
+bias, an incomplete/untraceable expert group, ...) raises
+:class:`~mobius.integrations.gguf.SparseMoEExportError` -- the same typed
+capability error the GGUF builder's sparse-MoE honesty gate raises -- so export
+fails closed rather than silently shipping a dense-all-expert graph. Pass
+``allow_dense_moe=True`` (or set ``MOBIUS_ALLOW_DENSE_MOE_EXPERTS=1``) to instead
+log the reason and leave the runnable dense fallback in place for
+research/correctness study; this makes no throughput claim.
 
 Example::
 
@@ -59,6 +64,7 @@ Example::
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 
 import numpy as np
@@ -348,18 +354,40 @@ class _DenseMoELayer:
         self.routed_out = cur
 
     @property
-    def is_candidate(self) -> bool:
+    def has_native_experts(self) -> bool:
+        """Whether any routed expert traced as a native ``BlockQuantizedMatMul`` MLP.
+
+        A selector with no native-block experts is not our storm (it may be an
+        int4 ``MatMulNBits`` MoE handled by :func:`fuse_dense_moe_to_qmoe`, a
+        float MoE, or an unrelated ``Equal`` pattern) and is skipped silently.
+        """
+        return bool(self.experts)
+
+    def check_fusable(self) -> None:
+        """Raise :class:`_UnfusableError` if this native storm cannot fully fuse.
+
+        Only called for layers with native experts. A routed native-block MoE
+        that reaches here but cannot be collapsed into a single expert-major
+        bank is a fail-closed condition, not a silent skip.
+        """
         if self.routing_weights is None or self.routed_out is None:
-            return False
-        if not self.experts:
-            return False
+            raise _UnfusableError(
+                "could not trace the router mask / weighted-sum accumulation"
+            )
         # Fail closed unless *every* declared expert was fully traced. Checking
         # only for gap-freeness (``ids == range(len(ids))``) would miss a dropped
         # highest-id expert, whose survivors ``0..E-2`` still look contiguous.
-        if set(self.experts) != self.declared_ids:
-            return False
-        ids = sorted(self.declared_ids)
-        return ids == list(range(len(ids)))
+        missing = sorted(self.declared_ids - set(self.experts))
+        if missing:
+            raise _UnfusableError(
+                f"experts {missing} did not trace as native BlockQuantizedMatMul "
+                "MLPs sharing the router (incomplete routed-expert group)"
+            )
+        ids = sorted(self.experts)
+        if ids != list(range(len(ids))):
+            raise _UnfusableError(f"routed expert ids are not contiguous 0..E-1: {ids}")
+        if self.k is None or self.k < 1:
+            raise _UnfusableError("could not determine the router top-k")
 
 
 def _projection_format(node: ir.Node, role: str) -> str:
@@ -557,7 +585,27 @@ def _build_routing(
     return nodes, logits.outputs[0], weights.outputs[0]
 
 
-def _fuse_layer(graph: ir.Graph, layer: _DenseMoELayer, index: int) -> None:
+@dataclasses.dataclass
+class _FusionPlan:
+    """A fully-validated, graph-independent plan to emit one ``BlockQuantizedMoE``.
+
+    Building a plan performs *all* fail-closed validation and byte-stacking with
+    no graph mutation, so the driver can validate every layer before emitting any
+    node -- a fail-closed layer never leaves the graph half-rewritten.
+    """
+
+    layer: _DenseMoELayer
+    prefix: str
+    moe_input: ir.Value
+    fc1_w: np.ndarray
+    fc2_w: np.ndarray
+    fc3_w: np.ndarray | None
+    attributes: dict[str, object]
+    experts: int
+
+
+def _plan_layer(layer: _DenseMoELayer, index: int) -> _FusionPlan:
+    """Validate and byte-stack one native MoE layer without touching the graph."""
     ids = sorted(layer.experts)
     gate_nodes = [layer.experts[i].gate for i in ids]
     up_nodes = [layer.experts[i].up for i in ids]
@@ -584,8 +632,7 @@ def _fuse_layer(graph: ir.Graph, layer: _DenseMoELayer, index: int) -> None:
     up_w = _stack_weights(up_nodes, inter, "up")
     down_w = _stack_weights(down_nodes, hidden, "down")
 
-    prefix = f"bqmoe.layer{index}"
-    fc3_w_v: ir.Value | None = None
+    fc3_w: np.ndarray | None = None
     projection_formats: dict[str, str] = {"fc2": down_fmt}
     if gate_fmt == up_fmt:
         # Fused SwiGLU: FC1 = concat(gate_rows, up_rows) in one native format.
@@ -599,24 +646,9 @@ def _fuse_layer(graph: ir.Graph, layer: _DenseMoELayer, index: int) -> None:
         # and FC3 (up); the kernel computes ``swiglu(fc1(x), fc3(x))``.
         swiglu_fusion = 0
         fc1_w = gate_w
-        fc3_w_v = _make_initializer(
-            graph, f"{prefix}.fc3_experts_weights", up_w, ir.DataType.UINT8
-        )
+        fc3_w = up_w
         projection_formats["fc1"] = gate_fmt
         projection_formats["fc3"] = up_fmt
-
-    fc1_w_v = _make_initializer(
-        graph, f"{prefix}.fc1_experts_weights", fc1_w, ir.DataType.UINT8
-    )
-    fc2_w_v = _make_initializer(
-        graph, f"{prefix}.fc2_experts_weights", down_w, ir.DataType.UINT8
-    )
-
-    routing_nodes, router_logits, router_weights = _build_routing(
-        graph, layer, experts, prefix
-    )
-
-    moe_input = gate_nodes[0].inputs[0]
 
     attributes: dict[str, object] = {
         "k": layer.k,
@@ -637,6 +669,41 @@ def _fuse_layer(graph: ir.Graph, layer: _DenseMoELayer, index: int) -> None:
         if "fc3" in projection_formats:
             attributes["fc3_format"] = projection_formats["fc3"]
 
+    return _FusionPlan(
+        layer=layer,
+        prefix=f"bqmoe.layer{index}",
+        moe_input=gate_nodes[0].inputs[0],
+        fc1_w=fc1_w,
+        fc2_w=down_w,
+        fc3_w=fc3_w,
+        attributes=attributes,
+        experts=experts,
+    )
+
+
+def _emit_layer(graph: ir.Graph, plan: _FusionPlan) -> None:
+    """Materialise a validated :class:`_FusionPlan` into the graph."""
+    prefix = plan.prefix
+    layer = plan.layer
+
+    fc3_w_v: ir.Value | None = None
+    if plan.fc3_w is not None:
+        fc3_w_v = _make_initializer(
+            graph, f"{prefix}.fc3_experts_weights", plan.fc3_w, ir.DataType.UINT8
+        )
+    fc1_w_v = _make_initializer(
+        graph, f"{prefix}.fc1_experts_weights", plan.fc1_w, ir.DataType.UINT8
+    )
+    fc2_w_v = _make_initializer(
+        graph, f"{prefix}.fc2_experts_weights", plan.fc2_w, ir.DataType.UINT8
+    )
+
+    routing_nodes, router_logits, router_weights = _build_routing(
+        graph, layer, plan.experts, prefix
+    )
+
+    moe_input = plan.moe_input
+
     moe = ir.node(
         _MOE,
         inputs=[
@@ -650,7 +717,7 @@ def _fuse_layer(graph: ir.Graph, layer: _DenseMoELayer, index: int) -> None:
             None,
             router_weights,
         ],
-        attributes=attributes,
+        attributes=plan.attributes,
         domain=_NXRT_DOMAIN,
         num_outputs=1,
         name=f"{prefix}.bqmoe",
@@ -705,7 +772,43 @@ def _remove_dead_nodes(graph: ir.Graph) -> None:
             del graph.initializers[name]
 
 
-def fuse_block_quantized_moe(model: ir.Model) -> int:
+def _fail_closed(layer: _DenseMoELayer, reason: _UnfusableError, *, allow_dense: bool) -> None:
+    """Fail closed (or, when opted in, keep the dense fallback) for one layer.
+
+    Raises :class:`~mobius.integrations.gguf.SparseMoEExportError` -- the same
+    typed capability error the GGUF builder's sparse-MoE honesty gate uses -- so
+    a routed native-block MoE that cannot be sparse-fused aborts export instead
+    of silently shipping a dense-all-expert graph. ``allow_dense`` downgrades the
+    abort to a loud warning that leaves the runnable dense fallback in place.
+    """
+    detail = (
+        f"routed native-block MoE at {layer.selected_experts.name!r} cannot be "
+        f"expressed as one sparse pkg.nxrt::BlockQuantizedMoE node: {reason}"
+    )
+    if allow_dense:
+        logger.warning(
+            "allow_dense_moe: %s. Keeping the per-expert BlockQuantizedMatMul "
+            "dense fallback (every expert runs for every token; not a "
+            "performance path, no throughput claim).",
+            detail,
+        )
+        return
+    # Imported lazily: the typed error lives in the GGUF export layer, and this
+    # generic rewrite must not pull that (huggingface_hub/gguf) stack in at
+    # import time -- only when it actually has to fail an export closed.
+    from mobius.integrations.gguf import SparseMoEExportError
+
+    raise SparseMoEExportError(
+        f"Sparse-MoE export blocker: {detail}. No sparse top-k BlockQuantizedMoE "
+        "fusion was applied, so exporting would build a dense-all-expert graph "
+        "(every expert evaluated for every token) with no performance guarantee, "
+        "so the build fails closed. To study the dense fallback, re-run with "
+        "allow_dense_moe=True (or set MOBIUS_ALLOW_DENSE_MOE_EXPERTS=1); this "
+        "makes no throughput claim."
+    ) from reason
+
+
+def fuse_block_quantized_moe(model: ir.Model, *, allow_dense_moe: bool | None = None) -> int:
     """Fuse every dense-fallback native-block MoE subgraph into ``BlockQuantizedMoE``.
 
     Reuses the existing ``BlockQuantizedMatMul`` native blocks byte-for-byte
@@ -713,44 +816,61 @@ def fuse_block_quantized_moe(model: ir.Model) -> int:
     gate-agnostically from the graph's ``selected_experts`` / ``routing_weights``
     tensors, so softmax, sigmoid+bias+scaling, and other top-k gates all fuse.
     Mixed per-projection native formats are expressed with
-    ``block_layout_version=2``. A layer whose experts cannot be expressed as a
-    single expert-major bank is left as the runnable dense fallback with a typed
-    reason logged -- the fusion never silently dense-evaluates every expert.
+    ``block_layout_version=2``.
+
+    Every candidate layer is fully validated and byte-stacked *before* any node
+    is emitted, so a fail-closed layer never leaves the graph half-rewritten. A
+    selector with no native-block experts (e.g. an int4 ``MatMulNBits`` MoE, or
+    an unrelated ``Equal`` pattern) is skipped silently. A *routed native-block*
+    storm that cannot be collapsed into one expert-major bank -- mixed native
+    formats across experts, a per-expert bias, an incomplete/untraceable expert
+    group, ragged packed shapes -- fails closed by raising
+    :class:`~mobius.integrations.gguf.SparseMoEExportError`, matching the GGUF
+    builder's sparse-MoE honesty gate.
 
     Args:
         model: The IR model to rewrite in place.
+        allow_dense_moe: When ``True``, an unfusable routed native-block layer is
+            left as the runnable dense fallback (with a loud warning) instead of
+            failing closed. When ``None`` (default), the value of the
+            ``allow_dense_moe_experts`` flag / ``MOBIUS_ALLOW_DENSE_MOE_EXPERTS``
+            environment variable is used. This is a research/correctness path
+            only and makes no throughput claim.
 
     Returns:
         The number of MoE layers fused.
+
+    Raises:
+        SparseMoEExportError: A routed native-block MoE layer cannot be sparse
+            fused and ``allow_dense_moe`` is not set.
     """
+    if allow_dense_moe is None:
+        from mobius._flags import flags
+
+        allow_dense_moe = flags.allow_dense_moe_experts
+
     graph = model.graph
     selectors = _find_moe_selectors(graph)
-    layers = [_DenseMoELayer(selected) for selected in selectors]
-    fused = 0
-    for index, layer in enumerate(layers):
-        if not layer.is_candidate:
-            logger.warning(
-                "skipping native MoE at %s: unrecognised dense-fallback structure",
-                layer.selected_experts.name,
-            )
-            continue
-        if layer.k is None or layer.k < 1:
-            logger.warning(
-                "skipping native MoE at %s: could not determine top-k",
+
+    # Pass 1: validate + byte-stack every native storm without mutating the graph.
+    plans: list[_FusionPlan] = []
+    for index, layer in enumerate(_DenseMoELayer(selected) for selected in selectors):
+        if not layer.has_native_experts:
+            logger.debug(
+                "skipping selector %s: no native BlockQuantizedMatMul experts",
                 layer.selected_experts.name,
             )
             continue
         try:
-            _fuse_layer(graph, layer, index)
+            layer.check_fusable()
+            plans.append(_plan_layer(layer, index))
         except _UnfusableError as reason:
-            logger.warning(
-                "skipping native MoE at %s: %s; keeping dense fallback",
-                layer.selected_experts.name,
-                reason,
-            )
-            continue
-        fused += 1
-    if fused:
+            _fail_closed(layer, reason, allow_dense=allow_dense_moe)
+
+    # Pass 2: emit only after every candidate validated (all-or-fail-closed).
+    for plan in plans:
+        _emit_layer(graph, plan)
+    if plans:
         _remove_dead_nodes(graph)
         graph.sort()
-    return fused
+    return len(plans)

--- a/src/mobius/rewrite_rules/_block_quantized_moe_fusion.py
+++ b/src/mobius/rewrite_rules/_block_quantized_moe_fusion.py
@@ -259,6 +259,11 @@ class _DenseMoELayer:
     def __init__(self, selected_experts: ir.Value) -> None:
         self.selected_experts = selected_experts
         self.routing_weights: ir.Value | None = None
+        # Every scalar-int ``Equal`` mask on ``selected_experts`` names one
+        # routable expert. We record the full declared id set up front so a
+        # silently dropped expert (untraceable MLP, mismatched routing tensor)
+        # fails closed instead of fusing a smaller-than-actual expert bank.
+        self.declared_ids: set[int] = set()
         self.experts: dict[int, _ExpertProjections] = {}
         self.contributions: list[ir.Value] = []
         self.routed_out: ir.Value | None = None
@@ -272,6 +277,7 @@ class _DenseMoELayer:
             expert_id = _scalar_int(equal.inputs[1])
             if expert_id is None:
                 continue
+            self.declared_ids.add(expert_id)
             cast = _single_consumer(equal.outputs[0], "CastLike", "Cast")
             if cast is None:
                 continue
@@ -345,8 +351,15 @@ class _DenseMoELayer:
     def is_candidate(self) -> bool:
         if self.routing_weights is None or self.routed_out is None:
             return False
-        ids = sorted(self.experts)
-        return ids == list(range(len(ids))) and len(ids) >= 1
+        if not self.experts:
+            return False
+        # Fail closed unless *every* declared expert was fully traced. Checking
+        # only for gap-freeness (``ids == range(len(ids))``) would miss a dropped
+        # highest-id expert, whose survivors ``0..E-2`` still look contiguous.
+        if set(self.experts) != self.declared_ids:
+            return False
+        ids = sorted(self.declared_ids)
+        return ids == list(range(len(ids)))
 
 
 def _projection_format(node: ir.Node, role: str) -> str:

--- a/src/mobius/rewrite_rules/_block_quantized_moe_fusion.py
+++ b/src/mobius/rewrite_rules/_block_quantized_moe_fusion.py
@@ -1,0 +1,743 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Fuse a dense-fallback native-block MoE subgraph into ``pkg.nxrt::BlockQuantizedMoE``.
+
+GGUF-imported MoE checkpoints (GLM-5.2 UD-IQ1_S/M, DeepSeek, ...) are exported
+as a *dense fallback*: every routed expert is materialised as its own
+``gate_proj`` / ``up_proj`` / ``down_proj`` ``pkg.nxrt::BlockQuantizedMatMul``
+MLP and the router picks the active experts with an
+``Equal``/``CastLike``/``Mul``/``ReduceSum`` mask applied *after* every expert
+has already been computed. Native decode therefore reads all ``E`` experts'
+weights per token even though only ``k`` are selected.
+
+The ``pkg.nxrt::BlockQuantizedMoE`` kernel does sparse top-k decode (reads only
+the selected experts' native blocks). This module rewrites the dense-fallback
+subgraph, one MoE layer at a time, into a single ``BlockQuantizedMoE`` node that
+**reuses the existing native blocks byte-for-byte** -- it is a pure expert-major
+stack/concat layout transform, never a dequantize-then-requantize. No scales or
+zero-points exist: IQ/native blocks are self-contained (codebook + embedded
+scale), so only the packed ``uint8`` weight bytes move.
+
+Why this fusion is separate from :func:`fuse_dense_moe_to_qmoe`:
+
+* Experts are ``BlockQuantizedMatMul`` (native blocks) not ``MatMulNBits``
+  (int4 affine); there are no scale/zero-point inputs to carry.
+* GLM-5.2 UD-IQ1 quantises the ``gate``/``up`` projections and the ``down``
+  projection to *different* native formats (e.g. ``iq1_s`` gate/up, ``iq4_xs``
+  down). ``BlockQuantizedMoE`` expresses this with ``block_layout_version=2``
+  and per-projection ``fc1_format`` / ``fc2_format`` / ``fc3_format`` attributes
+  (a uniform-format layer stays on ``block_layout_version=1``).
+* Routing is reconstructed **gate-agnostically** from the already-computed
+  ``selected_experts`` / ``routing_weights`` tensors, so a sigmoid+bias+scaling
+  GLM gate fuses identically to a plain softmax top-k gate. The routing decision
+  is re-materialised as a ``[tokens, experts]`` scatter and fed to the kernel as
+  both ``router_logits`` (a one-hot selection mask) and ``router_weights`` (the
+  final per-expert weights) with ``normalize_routing_weights=0`` -- the kernel
+  re-selects exactly the same experts and gathers exactly the same weights.
+
+Any surrounding **shared expert** is left untouched: only the routed per-expert
+storm and its router/mask are fused, and the final ``Add(routed_sum, shared)``
+is rewired to consume the ``BlockQuantizedMoE`` output.
+
+The rewrite is **property-gated and fails closed**: a layer that is not a native
+dense-expert storm, or whose experts use a mix of native formats that a single
+expert-major bank cannot express, is left as the runnable dense fallback with a
+typed reason logged. It never silently emits a node that would dense-evaluate
+every expert.
+
+Example::
+
+    import onnx_ir as ir
+    from mobius.rewrite_rules import fuse_block_quantized_moe
+
+    model = ir.load("decoder/model.onnx")
+    fused = fuse_block_quantized_moe(model)
+    print(f"fused {fused} native-block MoE layers")
+    ir.save(model, "decoder-bqmoe/model.onnx")
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import onnx_ir as ir
+
+logger = logging.getLogger(__name__)
+
+_NXRT_DOMAIN = "pkg.nxrt"
+_MATMUL = "BlockQuantizedMatMul"
+_MOE = "BlockQuantizedMoE"
+
+# ``BlockQuantizedMatMul`` native block geometry, mirroring
+# ``mobius.components._quantized_linear._NATIVE_BLOCK_FORMATS``: format name ->
+# (block_elements, block_bytes). Kept local so the fusion validates the packed
+# weight shape it stacks without importing the component module.
+_NATIVE_BLOCK_FORMATS = {
+    "mxfp4": (32, 17),
+    "iq4_nl": (32, 18),
+    "iq4_xs": (256, 136),
+    "iq3_s": (256, 110),
+    "iq3_xxs": (256, 98),
+    "iq2_xxs": (256, 66),
+    "iq2_xs": (256, 74),
+    "iq2_s": (256, 82),
+    "iq1_s": (256, 50),
+    "iq1_m": (256, 56),
+}
+
+
+class _UnfusableError(Exception):
+    """A layer cannot be expressed as one ``BlockQuantizedMoE`` node.
+
+    Carries a typed, human-readable reason so the caller logs precisely why the
+    dense fallback was preserved instead of silently dense-evaluating experts.
+    """
+
+
+def _scalar_int(value: ir.Value | None) -> int | None:
+    """Return the integer a value carries, whether an initializer or a ``Constant``."""
+    if value is None:
+        return None
+    const = value.const_value
+    if const is None:
+        producer = value.producer()
+        if producer is None or producer.op_type != "Constant":
+            return None
+        for attr in ("value", "value_int", "value_ints"):
+            if attr in producer.attributes:
+                const = producer.attributes[attr].value
+                break
+        else:
+            return None
+    arr = np.asarray(const.numpy() if hasattr(const, "numpy") else const).reshape(-1)
+    if arr.size == 0:
+        return None
+    return int(arr[0])
+
+
+def _consumers_of_type(value: ir.Value, op_type: str) -> list[ir.Node]:
+    return [node for node, _ in value.uses() if node.op_type == op_type]
+
+
+def _single_consumer(value: ir.Value, *op_types: str) -> ir.Node | None:
+    for op_type in op_types:
+        matches = _consumers_of_type(value, op_type)
+        if matches:
+            return matches[0]
+    return None
+
+
+def _array(value: ir.Value) -> np.ndarray:
+    const = value.const_value
+    if const is None:
+        raise _UnfusableError(f"expected an initializer for {value.name!r}")
+    return np.asarray(const.numpy())
+
+
+def _make_initializer(
+    graph: ir.Graph, name: str, arr: np.ndarray, dtype: ir.DataType
+) -> ir.Value:
+    tensor = ir.tensor(arr, name=name, dtype=dtype)
+    value = ir.Value(
+        name=name,
+        shape=ir.Shape(arr.shape),
+        type=ir.TensorType(dtype),
+        const_value=tensor,
+    )
+    graph.register_initializer(value)
+    return value
+
+
+def _skip_cast(value: ir.Value) -> ir.Value:
+    """Return ``value``'s source through a single ``Cast``, if one produces it.
+
+    ``BlockQuantizedLinear`` casts its activation to FLOAT before the matmul and
+    (for non-FLOAT models) casts the result back afterwards, so every projection
+    boundary in an f16 export is wrapped in a ``Cast``. An f32 export has none.
+    Walking through one ``Cast`` makes the trace dtype-agnostic.
+    """
+    producer = value.producer()
+    if producer is not None and producer.op_type == "Cast" and producer.inputs[0] is not None:
+        return producer.inputs[0]
+    return value
+
+
+def _producer_through_cast(value: ir.Value, op_type: str) -> ir.Node | None:
+    source = _skip_cast(value)
+    producer = source.producer()
+    if producer is None or producer.op_type != op_type:
+        return None
+    return producer
+
+
+class _ExpertProjections:
+    """The three ``BlockQuantizedMatMul`` nodes making up one expert MLP."""
+
+    __slots__ = ("down", "gate", "up")
+
+    def __init__(self, gate: ir.Node, up: ir.Node, down: ir.Node) -> None:
+        self.gate = gate
+        self.up = up
+        self.down = down
+
+
+def _trace_expert(down: ir.Node) -> _ExpertProjections | None:
+    """Walk back from a ``down_proj`` ``BlockQuantizedMatMul`` to gate/up.
+
+    Expert MLP shape (SwiGLU): ``down(Swish(gate) * up)``. The legacy
+    ``gate * Sigmoid(gate)`` decomposition remains accepted for imported graphs.
+    Every projection boundary is walked through an optional ``Cast`` so both f32
+    and f16 dense exports trace identically.
+    """
+    act_mul = _producer_through_cast(down.inputs[0], "Mul")
+    if act_mul is None:
+        return None
+    a, b = act_mul.inputs[0], act_mul.inputs[1]
+    # One operand is the up projection, the other the SiLU-activated gate.
+    if _producer_through_cast(a, _MATMUL) is not None:
+        up_out, act_out = a, b
+    elif _producer_through_cast(b, _MATMUL) is not None:
+        up_out, act_out = b, a
+    else:
+        return None
+    up = _producer_through_cast(up_out, _MATMUL)
+    act = _skip_cast(act_out).producer()
+    if act is None:
+        return None
+    if act.op_type == "Swish":
+        gate = _producer_through_cast(act.inputs[0], _MATMUL)
+        if gate is None:
+            return None
+        return _ExpertProjections(gate, up, down)
+    if act.op_type != "Mul":
+        return None
+    # Accept the legacy gate * Sigmoid(gate) decomposition.
+    x, y = act.inputs[0], act.inputs[1]
+    for gate_out, sigmoid_out in ((x, y), (y, x)):
+        gate = _producer_through_cast(gate_out, _MATMUL)
+        sigmoid = _skip_cast(sigmoid_out).producer()
+        if (
+            gate is not None
+            and sigmoid is not None
+            and sigmoid.op_type == "Sigmoid"
+            and _producer_through_cast(sigmoid.inputs[0], _MATMUL) is gate
+        ):
+            return _ExpertProjections(gate, up, down)
+    return None
+
+
+def _find_moe_selectors(graph: ir.Graph) -> list[ir.Value]:
+    """Return each ``selected_experts`` value driving a dense-fallback expert storm.
+
+    Gate-agnostic anchor: a value consumed by two or more ``Equal`` nodes whose
+    other operand is an integer constant is the ``selected_experts`` tensor of a
+    per-expert routing mask, regardless of which gate (softmax / sigmoid+bias /
+    sparse-mixer) produced it.
+    """
+    selectors: list[ir.Value] = []
+    seen: set[int] = set()
+    for node in graph:
+        if node.op_type != "Equal":
+            continue
+        selected = node.inputs[0]
+        if selected is None or _scalar_int(node.inputs[1]) is None:
+            continue
+        if len(_consumers_of_type(selected, "Equal")) < 2:
+            continue
+        key = id(selected)
+        if key not in seen:
+            seen.add(key)
+            selectors.append(selected)
+    return selectors
+
+
+class _DenseMoELayer:
+    """Everything the rewrite needs from one dense-fallback native-block MoE."""
+
+    def __init__(self, selected_experts: ir.Value) -> None:
+        self.selected_experts = selected_experts
+        self.routing_weights: ir.Value | None = None
+        self.experts: dict[int, _ExpertProjections] = {}
+        self.contributions: list[ir.Value] = []
+        self.routed_out: ir.Value | None = None
+        self.k: int | None = None
+        self._collect_experts()
+        self._resolve_k()
+        self._find_routed_output()
+
+    def _collect_experts(self) -> None:
+        for equal in _consumers_of_type(self.selected_experts, "Equal"):
+            expert_id = _scalar_int(equal.inputs[1])
+            if expert_id is None:
+                continue
+            cast = _single_consumer(equal.outputs[0], "CastLike", "Cast")
+            if cast is None:
+                continue
+            weight_mul = _single_consumer(cast.outputs[0], "Mul")
+            if weight_mul is None:
+                continue
+            reduce_sum = _single_consumer(weight_mul.outputs[0], "ReduceSum")
+            if reduce_sum is None:
+                continue
+            contribution = _single_consumer(reduce_sum.outputs[0], "Mul")
+            if contribution is None:
+                continue
+            routing_weights = (
+                weight_mul.inputs[1]
+                if weight_mul.inputs[0] is cast.outputs[0]
+                else weight_mul.inputs[0]
+            )
+            weight_out = reduce_sum.outputs[0]
+            expert_out = (
+                contribution.inputs[1]
+                if contribution.inputs[0] is weight_out
+                else contribution.inputs[0]
+            )
+            down = _producer_through_cast(expert_out, _MATMUL)
+            if down is None:
+                continue
+            projections = _trace_expert(down)
+            if projections is None:
+                continue
+            # All experts must share one ``routing_weights`` tensor (they do in
+            # the dense loop); a mismatch means this is not a single storm.
+            if self.routing_weights is None:
+                self.routing_weights = routing_weights
+            elif self.routing_weights is not routing_weights:
+                continue
+            self.experts[expert_id] = projections
+            self.contributions.append(contribution.outputs[0])
+
+    def _resolve_k(self) -> None:
+        shape = self.selected_experts.shape
+        if shape is not None and len(shape) >= 1:
+            last = shape[-1]
+            if isinstance(last, int):
+                self.k = last
+                return
+        producer = self.selected_experts.producer()
+        if producer is not None and producer.op_type == "TopK" and len(producer.inputs) > 1:
+            self.k = _scalar_int(producer.inputs[1])
+
+    def _find_routed_output(self) -> None:
+        if not self.contributions:
+            return
+        contrib_set = set(self.contributions)
+        acc_outputs: set[ir.Value] = set()
+        cur = self.contributions[0]
+        advanced = True
+        while advanced:
+            advanced = False
+            for node, index in cur.uses():
+                if node.op_type != "Add":
+                    continue
+                other = node.inputs[1 - index]
+                if other in contrib_set or other in acc_outputs:
+                    cur = node.outputs[0]
+                    acc_outputs.add(cur)
+                    advanced = True
+                    break
+        self.routed_out = cur
+
+    @property
+    def is_candidate(self) -> bool:
+        if self.routing_weights is None or self.routed_out is None:
+            return False
+        ids = sorted(self.experts)
+        return ids == list(range(len(ids))) and len(ids) >= 1
+
+
+def _projection_format(node: ir.Node, role: str) -> str:
+    fmt = node.attributes.get("format")
+    if fmt is None:
+        raise _UnfusableError(f"{role} projection {node.name!r} has no 'format' attribute")
+    name = fmt.value
+    if name not in _NATIVE_BLOCK_FORMATS:
+        raise _UnfusableError(f"{role} projection uses unknown native format {name!r}")
+    return name
+
+
+def _uniform_format(nodes: list[ir.Node], role: str) -> str:
+    formats = {_projection_format(node, role) for node in nodes}
+    if len(formats) != 1:
+        raise _UnfusableError(
+            f"{role} projections use mixed native formats {sorted(formats)}; "
+            "a single expert-major bank requires one format per projection"
+        )
+    return next(iter(formats))
+
+
+def _require_no_bias(nodes: list[ir.Node], role: str) -> None:
+    for node in nodes:
+        if len(node.inputs) > 2 and node.inputs[2] is not None:
+            raise _UnfusableError(
+                f"{role} projection {node.name!r} carries a bias; biased native "
+                "MoE experts are not supported by this fusion yet"
+            )
+
+
+def _stack_weights(nodes: list[ir.Node], out_features: int, role: str) -> np.ndarray:
+    """Stack per-expert packed ``[N, n_blocks, block_bytes]`` uint8 into ``[E, ...]``.
+
+    The native block bytes are copied verbatim: this is an expert-major stack,
+    never a requantization.
+    """
+    stacked = []
+    for node in nodes:
+        weight = _array(node.inputs[1])
+        if weight.ndim != 3 or weight.shape[0] != out_features:
+            raise _UnfusableError(
+                f"{role} projection weight has shape {weight.shape}, expected "
+                f"[{out_features}, n_blocks, block_bytes]"
+            )
+        stacked.append(weight)
+    shapes = {w.shape for w in stacked}
+    if len(shapes) != 1:
+        raise _UnfusableError(f"{role} projections have ragged packed shapes {sorted(shapes)}")
+    return np.stack(stacked, axis=0)
+
+
+def _weight_out_features(node: ir.Node) -> int:
+    return int(_array(node.inputs[1]).shape[0])
+
+
+def _flat_last_dim_shape(
+    graph: ir.Graph, source: ir.Value, prefix: str, neg_one: ir.Value
+) -> tuple[list[ir.Node], ir.Value]:
+    """Build the ``[-1, last_dim]`` shape tensor for flattening ``source`` to 2D."""
+    last = ir.node(
+        "Shape",
+        inputs=[source],
+        attributes={"start": -1},
+        num_outputs=1,
+        name=f"{prefix}.last_dim",
+    )
+    concat = ir.node(
+        "Concat",
+        inputs=[neg_one, last.outputs[0]],
+        attributes={"axis": 0},
+        num_outputs=1,
+        name=f"{prefix}.flat_shape",
+    )
+    return [last, concat], concat.outputs[0]
+
+
+def _build_routing(
+    graph: ir.Graph, layer: _DenseMoELayer, experts: int, prefix: str
+) -> tuple[list[ir.Node], ir.Value, ir.Value]:
+    """Reconstruct gate-agnostic routing tensors for ``BlockQuantizedMoE``.
+
+    Returns the new nodes plus ``(router_logits, router_weights)``, each a
+    ``[tokens, experts]`` FLOAT tensor. ``router_logits`` is a one-hot selection
+    mask (1.0 at each selected expert) so the kernel's top-k re-selects exactly
+    the dense loop's experts; ``router_weights`` scatters the dense per-expert
+    weights so that (with ``normalize_routing_weights=0``) the kernel gathers
+    exactly those weights. The result is independent of the originating gate.
+    """
+    neg_one = _make_initializer(
+        graph, f"{prefix}.neg_one", np.array([-1], dtype=np.int64), ir.DataType.INT64
+    )
+    expert_dim = _make_initializer(
+        graph, f"{prefix}.experts", np.array([experts], dtype=np.int64), ir.DataType.INT64
+    )
+    zero_f = _make_initializer(
+        graph, f"{prefix}.zero", np.array(0.0, dtype=np.float32), ir.DataType.FLOAT
+    )
+    one_f = _make_initializer(
+        graph, f"{prefix}.one", np.array(1.0, dtype=np.float32), ir.DataType.FLOAT
+    )
+
+    nodes: list[ir.Node] = []
+
+    sel_shape_nodes, sel_flat_shape = _flat_last_dim_shape(
+        graph, layer.selected_experts, f"{prefix}.sel", neg_one
+    )
+    nodes.extend(sel_shape_nodes)
+    sel2d = ir.node(
+        "Reshape",
+        inputs=[layer.selected_experts, sel_flat_shape],
+        num_outputs=1,
+        name=f"{prefix}.sel2d",
+    )
+    nodes.append(sel2d)
+
+    rw_shape_nodes, rw_flat_shape = _flat_last_dim_shape(
+        graph, layer.routing_weights, f"{prefix}.rw", neg_one
+    )
+    nodes.extend(rw_shape_nodes)
+    rw2d = ir.node(
+        "Reshape",
+        inputs=[layer.routing_weights, rw_flat_shape],
+        num_outputs=1,
+        name=f"{prefix}.rw2d",
+    )
+    nodes.append(rw2d)
+    if layer.routing_weights.dtype == ir.DataType.FLOAT:
+        rw_float = rw2d.outputs[0]
+    else:
+        rw_cast = ir.node(
+            "Cast",
+            inputs=[rw2d.outputs[0]],
+            attributes={"to": ir.DataType.FLOAT.value},
+            num_outputs=1,
+            name=f"{prefix}.rw_float",
+        )
+        nodes.append(rw_cast)
+        rw_float = rw_cast.outputs[0]
+
+    # rows = selected_experts flattened leading dim.
+    rows = ir.node(
+        "Shape",
+        inputs=[sel2d.outputs[0]],
+        attributes={"start": 0, "end": 1},
+        num_outputs=1,
+        name=f"{prefix}.rows",
+    )
+    nodes.append(rows)
+    dense_shape = ir.node(
+        "Concat",
+        inputs=[rows.outputs[0], expert_dim],
+        attributes={"axis": 0},
+        num_outputs=1,
+        name=f"{prefix}.dense_shape",
+    )
+    nodes.append(dense_shape)
+    zeros = ir.node(
+        "Expand",
+        inputs=[zero_f, dense_shape.outputs[0]],
+        num_outputs=1,
+        name=f"{prefix}.zeros",
+    )
+    nodes.append(zeros)
+    sel_kshape = ir.node(
+        "Shape", inputs=[sel2d.outputs[0]], num_outputs=1, name=f"{prefix}.sel_kshape"
+    )
+    nodes.append(sel_kshape)
+    ones = ir.node(
+        "Expand",
+        inputs=[one_f, sel_kshape.outputs[0]],
+        num_outputs=1,
+        name=f"{prefix}.ones",
+    )
+    nodes.append(ones)
+
+    logits = ir.node(
+        "ScatterElements",
+        inputs=[zeros.outputs[0], sel2d.outputs[0], ones.outputs[0]],
+        attributes={"axis": 1},
+        num_outputs=1,
+        name=f"{prefix}.router_logits",
+    )
+    logits.outputs[0].name = f"{prefix}.router_logits"
+    nodes.append(logits)
+    weights = ir.node(
+        "ScatterElements",
+        inputs=[zeros.outputs[0], sel2d.outputs[0], rw_float],
+        attributes={"axis": 1},
+        num_outputs=1,
+        name=f"{prefix}.router_weights",
+    )
+    weights.outputs[0].name = f"{prefix}.router_weights"
+    nodes.append(weights)
+    return nodes, logits.outputs[0], weights.outputs[0]
+
+
+def _fuse_layer(graph: ir.Graph, layer: _DenseMoELayer, index: int) -> None:
+    ids = sorted(layer.experts)
+    gate_nodes = [layer.experts[i].gate for i in ids]
+    up_nodes = [layer.experts[i].up for i in ids]
+    down_nodes = [layer.experts[i].down for i in ids]
+    experts = len(ids)
+
+    _require_no_bias(gate_nodes, "gate")
+    _require_no_bias(up_nodes, "up")
+    _require_no_bias(down_nodes, "down")
+
+    gate_fmt = _uniform_format(gate_nodes, "gate")
+    up_fmt = _uniform_format(up_nodes, "up")
+    down_fmt = _uniform_format(down_nodes, "down")
+
+    inter = _weight_out_features(gate_nodes[0])
+    hidden = _weight_out_features(down_nodes[0])
+    if _weight_out_features(up_nodes[0]) != inter:
+        raise _UnfusableError(
+            "gate and up projections have different output widths "
+            f"({inter} vs {_weight_out_features(up_nodes[0])})"
+        )
+
+    gate_w = _stack_weights(gate_nodes, inter, "gate")
+    up_w = _stack_weights(up_nodes, inter, "up")
+    down_w = _stack_weights(down_nodes, hidden, "down")
+
+    prefix = f"bqmoe.layer{index}"
+    fc3_w_v: ir.Value | None = None
+    projection_formats: dict[str, str] = {"fc2": down_fmt}
+    if gate_fmt == up_fmt:
+        # Fused SwiGLU: FC1 = concat(gate_rows, up_rows) in one native format.
+        # ``swiglu_fusion=2`` tells the kernel the first ``inter`` rows are the
+        # gate half and the next ``inter`` the up half.
+        swiglu_fusion = 2
+        fc1_w = np.concatenate([gate_w, up_w], axis=1)
+        projection_formats["fc1"] = gate_fmt
+    else:
+        # Unfused SwiGLU: gate/up in different native formats stay as FC1 (gate)
+        # and FC3 (up); the kernel computes ``swiglu(fc1(x), fc3(x))``.
+        swiglu_fusion = 0
+        fc1_w = gate_w
+        fc3_w_v = _make_initializer(
+            graph, f"{prefix}.fc3_experts_weights", up_w, ir.DataType.UINT8
+        )
+        projection_formats["fc1"] = gate_fmt
+        projection_formats["fc3"] = up_fmt
+
+    fc1_w_v = _make_initializer(
+        graph, f"{prefix}.fc1_experts_weights", fc1_w, ir.DataType.UINT8
+    )
+    fc2_w_v = _make_initializer(
+        graph, f"{prefix}.fc2_experts_weights", down_w, ir.DataType.UINT8
+    )
+
+    routing_nodes, router_logits, router_weights = _build_routing(
+        graph, layer, experts, prefix
+    )
+
+    moe_input = gate_nodes[0].inputs[0]
+
+    attributes: dict[str, object] = {
+        "k": layer.k,
+        "activation_type": "swiglu",
+        "normalize_routing_weights": 0,
+        "swiglu_fusion": swiglu_fusion,
+    }
+    distinct = set(projection_formats.values())
+    if len(distinct) == 1:
+        attributes["format"] = next(iter(distinct))
+    else:
+        attributes["block_layout_version"] = 2
+        # ``format`` is the required base/fallback; per-projection attributes
+        # override it where a projection uses a different native format.
+        attributes["format"] = projection_formats["fc1"]
+        attributes["fc1_format"] = projection_formats["fc1"]
+        attributes["fc2_format"] = projection_formats["fc2"]
+        if "fc3" in projection_formats:
+            attributes["fc3_format"] = projection_formats["fc3"]
+
+    moe = ir.node(
+        _MOE,
+        inputs=[
+            moe_input,
+            router_logits,
+            fc1_w_v,
+            None,
+            fc2_w_v,
+            None,
+            fc3_w_v,
+            None,
+            router_weights,
+        ],
+        attributes=attributes,
+        domain=_NXRT_DOMAIN,
+        num_outputs=1,
+        name=f"{prefix}.bqmoe",
+    )
+    moe_out = moe.outputs[0]
+    moe_out.name = f"{prefix}.bqmoe_output"
+    moe_out.type = ir.TensorType(ir.DataType.FLOAT)
+    moe_out.shape = moe_input.shape
+
+    new_nodes = [*routing_nodes, moe]
+    routed_dtype = layer.routed_out.dtype
+    if routed_dtype not in (None, ir.DataType.FLOAT):
+        cast_back = ir.node(
+            "Cast",
+            inputs=[moe_out],
+            attributes={"to": routed_dtype.value},
+            num_outputs=1,
+            name=f"{prefix}.bqmoe_cast",
+        )
+        cast_back.outputs[0].name = f"{prefix}.bqmoe_output_cast"
+        cast_back.outputs[0].type = ir.TensorType(routed_dtype)
+        cast_back.outputs[0].shape = layer.routed_out.shape
+        new_nodes.append(cast_back)
+        final_out = cast_back.outputs[0]
+    else:
+        final_out = moe_out
+
+    graph.insert_after(layer.routed_out.producer(), new_nodes)
+    layer.routed_out.replace_all_uses_with(final_out)
+    graph.opset_imports[_NXRT_DOMAIN] = 1
+
+
+def _remove_dead_nodes(graph: ir.Graph) -> None:
+    """Iteratively drop nodes whose outputs are unused and not graph outputs."""
+    graph_outputs = set(graph.outputs)
+    changed = True
+    while changed:
+        changed = False
+        for node in reversed(list(graph)):
+            if any(out in graph_outputs for out in node.outputs):
+                continue
+            if all(len(list(out.uses())) == 0 for out in node.outputs):
+                graph.remove(node, safe=True)
+                changed = True
+    used: set[str] = set()
+    for node in graph:
+        for inp in node.inputs:
+            if inp is not None and inp.name is not None:
+                used.add(inp.name)
+    for name in list(graph.initializers):
+        if name not in used:
+            del graph.initializers[name]
+
+
+def fuse_block_quantized_moe(model: ir.Model) -> int:
+    """Fuse every dense-fallback native-block MoE subgraph into ``BlockQuantizedMoE``.
+
+    Reuses the existing ``BlockQuantizedMatMul`` native blocks byte-for-byte
+    (pure expert-major stack/concat, no requantization). Routing is reconstructed
+    gate-agnostically from the graph's ``selected_experts`` / ``routing_weights``
+    tensors, so softmax, sigmoid+bias+scaling, and other top-k gates all fuse.
+    Mixed per-projection native formats are expressed with
+    ``block_layout_version=2``. A layer whose experts cannot be expressed as a
+    single expert-major bank is left as the runnable dense fallback with a typed
+    reason logged -- the fusion never silently dense-evaluates every expert.
+
+    Args:
+        model: The IR model to rewrite in place.
+
+    Returns:
+        The number of MoE layers fused.
+    """
+    graph = model.graph
+    selectors = _find_moe_selectors(graph)
+    layers = [_DenseMoELayer(selected) for selected in selectors]
+    fused = 0
+    for index, layer in enumerate(layers):
+        if not layer.is_candidate:
+            logger.warning(
+                "skipping native MoE at %s: unrecognised dense-fallback structure",
+                layer.selected_experts.name,
+            )
+            continue
+        if layer.k is None or layer.k < 1:
+            logger.warning(
+                "skipping native MoE at %s: could not determine top-k",
+                layer.selected_experts.name,
+            )
+            continue
+        try:
+            _fuse_layer(graph, layer, index)
+        except _UnfusableError as reason:
+            logger.warning(
+                "skipping native MoE at %s: %s; keeping dense fallback",
+                layer.selected_experts.name,
+                reason,
+            )
+            continue
+        fused += 1
+    if fused:
+        _remove_dead_nodes(graph)
+        graph.sort()
+    return fused

--- a/src/mobius/rewrite_rules/_block_quantized_moe_fusion.py
+++ b/src/mobius/rewrite_rules/_block_quantized_moe_fusion.py
@@ -604,15 +604,19 @@ class _FusionPlan:
     experts: int
 
 
-def _plan_layer(layer: _DenseMoELayer, index: int, *, perproj_v2_runtime: bool) -> _FusionPlan:
+def _plan_layer(
+    layer: _DenseMoELayer, index: int, *, allow_perproj_v2_schema: bool
+) -> _FusionPlan:
     """Validate and byte-stack one native MoE layer without touching the graph.
 
-    ``perproj_v2_runtime`` declares whether the target runtime implements the
-    ``block_layout_version=2`` per-projection ``BlockQuantizedMoE`` ABI. When a
-    layer mixes native formats across its fc1/fc2/fc3 banks it can only be
-    expressed as a v2 node; if the runtime cannot execute v2, planning fails
-    closed here (before any graph mutation) rather than emitting an unrunnable
-    node.
+    ``allow_perproj_v2_schema`` is a private, test-only switch. A layer that
+    mixes native formats across its fc1/fc2/fc3 banks can only be expressed as a
+    ``block_layout_version=2`` per-projection node, and no shipped onnx-genai
+    runtime executes that ABI yet. It therefore defaults off on every production,
+    CLI, and environment path, and planning fails closed for such a layer (before
+    any graph mutation) rather than emitting an unrunnable node. It is set
+    ``True`` only by schema-construction tests that assert the v2 node's shape;
+    the node they build is not runnable and must never be shipped.
     """
     ids = sorted(layer.experts)
     gate_nodes = [layer.experts[i].gate for i in ids]
@@ -668,14 +672,16 @@ def _plan_layer(layer: _DenseMoELayer, index: int, *, perproj_v2_runtime: bool) 
     if len(distinct) == 1:
         attributes["format"] = next(iter(distinct))
     else:
-        if not perproj_v2_runtime:
+        if not allow_perproj_v2_schema:
             raise _UnfusableError(
                 "mixed per-projection native formats "
                 f"{sorted(distinct)} can only be expressed with the "
                 "block_layout_version=2 per-projection BlockQuantizedMoE ABI, "
-                "which the target runtime does not implement -- emitting a v2 "
-                "node would build an unrunnable graph (overclaim). Set "
-                "MOBIUS_ENABLE_BQMOE_PERPROJ_V2=1 only once the runtime ships it"
+                "which no shipped onnx-genai runtime implements -- emitting a v2 "
+                "node would build an unrunnable graph (overclaim), so export "
+                "fails closed. There is no production, CLI, or environment opt-in; "
+                "v2 stays a schema-construction test path until a typed runtime "
+                "capability handshake ships"
             )
         attributes["block_layout_version"] = 2
         # ``format`` is the required base/fallback; per-projection attributes
@@ -829,7 +835,7 @@ def fuse_block_quantized_moe(
     model: ir.Model,
     *,
     allow_dense_moe: bool | None = None,
-    perproj_v2_runtime: bool = True,
+    _allow_perproj_v2_schema: bool = False,
 ) -> int:
     """Fuse every dense-fallback native-block MoE subgraph into ``BlockQuantizedMoE``.
 
@@ -858,14 +864,17 @@ def fuse_block_quantized_moe(
             ``allow_dense_moe_experts`` flag / ``MOBIUS_ALLOW_DENSE_MOE_EXPERTS``
             environment variable is used. This is a research/correctness path
             only and makes no throughput claim.
-        perproj_v2_runtime: Whether the target runtime implements the
-            ``block_layout_version=2`` per-projection ``BlockQuantizedMoE`` ABI
-            (mixed native formats across a layer's fc1/fc2/fc3 banks, e.g.
-            GLM-5.2 UD-IQ1 with an iq1 gate/up and a higher-bit down). This is a
-            pure graph transform, so it defaults to ``True`` (v2 is always
-            representable); the GGUF export authority passes the actual runtime
-            capability so a mixed-format layer fails closed rather than emitting
-            an unrunnable v2 node when the runtime has not shipped v2 yet.
+        _allow_perproj_v2_schema: Private, test-only switch. A layer that mixes
+            native formats across its fc1/fc2/fc3 banks (e.g. GLM-5.2 UD-IQ1 with
+            an iq1 gate/up and a higher-bit down) can only be expressed with the
+            ``block_layout_version=2`` per-projection ``BlockQuantizedMoE`` ABI.
+            No shipped onnx-genai runtime implements that ABI, so this defaults to
+            ``False`` (fail closed): the production ``build_from_gguf`` path never
+            sets it, and a mixed-format layer typed-rejects rather than emitting an
+            unrunnable v2 node. It is ``True`` only in schema-construction tests
+            that assert the v2 node's shape; that node is not runnable and must
+            never be shipped. Until a real typed runtime-capability handshake
+            exists there is no production, CLI, or environment path to v2.
 
     Returns:
         The number of MoE layers fused.
@@ -893,7 +902,9 @@ def fuse_block_quantized_moe(
             continue
         try:
             layer.check_fusable()
-            plans.append(_plan_layer(layer, index, perproj_v2_runtime=perproj_v2_runtime))
+            plans.append(
+                _plan_layer(layer, index, allow_perproj_v2_schema=_allow_perproj_v2_schema)
+            )
         except _UnfusableError as reason:
             _fail_closed(layer, reason, allow_dense=allow_dense_moe)
 

--- a/src/mobius/rewrite_rules/_block_quantized_moe_fusion_test.py
+++ b/src/mobius/rewrite_rules/_block_quantized_moe_fusion_test.py
@@ -18,6 +18,7 @@ import onnx_ir as ir
 import pytest
 
 from mobius._constants import OPSET_VERSION
+from mobius.integrations.gguf import SparseMoEExportError
 from mobius.rewrite_rules import fuse_block_quantized_moe
 from mobius.rewrite_rules._block_quantized_moe_fusion import _NATIVE_BLOCK_FORMATS
 
@@ -549,23 +550,23 @@ def test_fuses_f16_graph_with_cast_wrapped_projections() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# Fail-closed (typed reason, dense fallback preserved)                        #
+# Fail-closed (typed SparseMoEExportError, graph left untouched)              #
 # --------------------------------------------------------------------------- #
 def test_mixed_format_across_experts_fails_closed() -> None:
     """One expert with a different gate format cannot form one expert-major bank."""
     model, _ = _build_dense_graph(corrupt_expert_gate_fmt=(1, "iq1_m"))
     graph = model.graph
-    fused = fuse_block_quantized_moe(model)
-    assert fused == 0
+    with pytest.raises(SparseMoEExportError):
+        fuse_block_quantized_moe(model)
     assert _count(graph, "BlockQuantizedMoE") == 0
-    assert _count(graph, "Equal") == E  # dense fallback preserved
+    assert _count(graph, "Equal") == E  # dense graph left untouched
 
 
 def test_biased_expert_fails_closed() -> None:
     model, _ = _build_dense_graph(bias_expert=2)
     graph = model.graph
-    fused = fuse_block_quantized_moe(model)
-    assert fused == 0
+    with pytest.raises(SparseMoEExportError):
+        fuse_block_quantized_moe(model)
     assert _count(graph, "BlockQuantizedMoE") == 0
     assert _count(graph, "Equal") == E
 
@@ -574,8 +575,8 @@ def test_incomplete_expert_group_fails_closed() -> None:
     """A non-native (untraceable) expert leaves an incomplete 0..E-1 set."""
     model, _ = _build_dense_graph(break_expert=2)
     graph = model.graph
-    fused = fuse_block_quantized_moe(model)
-    assert fused == 0
+    with pytest.raises(SparseMoEExportError):
+        fuse_block_quantized_moe(model)
     assert _count(graph, "BlockQuantizedMoE") == 0
 
 
@@ -585,24 +586,38 @@ def test_dropped_trailing_expert_fails_closed() -> None:
     The survivors ``0..E-2`` still look contiguous, so a gap-only check would
     silently fuse an expert bank narrower than the router actually selects over
     (leaving ``ScatterElements`` to index out of bounds). The declared-id set
-    from the ``Equal`` masks is the authority, so this must stay a dense graph.
+    from the ``Equal`` masks is the authority, so this must fail closed.
     """
     model, _ = _build_dense_graph(break_expert=E - 1)
     graph = model.graph
-    fused = fuse_block_quantized_moe(model)
-    assert fused == 0
+    with pytest.raises(SparseMoEExportError):
+        fuse_block_quantized_moe(model)
     assert _count(graph, "BlockQuantizedMoE") == 0
-    assert _count(graph, "Equal") == E  # dense fallback fully preserved
+    assert _count(graph, "Equal") == E  # dense graph left untouched
 
 
 def test_alien_routing_weights_expert_fails_closed() -> None:
     """An expert wired to a non-shared routing-weights tensor must fail closed."""
     model, _ = _build_dense_graph(alien_routing_expert=E - 1)
     graph = model.graph
-    fused = fuse_block_quantized_moe(model)
+    with pytest.raises(SparseMoEExportError):
+        fuse_block_quantized_moe(model)
+    assert _count(graph, "BlockQuantizedMoE") == 0
+    assert _count(graph, "Equal") == E  # dense graph left untouched
+
+
+def test_allow_dense_moe_opt_in_keeps_dense_fallback() -> None:
+    """``allow_dense_moe=True`` downgrades a fail-closed layer to a dense keep.
+
+    The honesty opt-in (mirroring ``MOBIUS_ALLOW_DENSE_MOE_EXPERTS``) must not
+    raise and must leave the runnable per-expert dense fallback intact.
+    """
+    model, _ = _build_dense_graph(corrupt_expert_gate_fmt=(1, "iq1_m"))
+    graph = model.graph
+    fused = fuse_block_quantized_moe(model, allow_dense_moe=True)
     assert fused == 0
     assert _count(graph, "BlockQuantizedMoE") == 0
-    assert _count(graph, "Equal") == E  # dense fallback fully preserved
+    assert _count(graph, "Equal") == E  # dense fallback preserved, not fused
 
 
 def test_no_moe_is_a_noop() -> None:

--- a/src/mobius/rewrite_rules/_block_quantized_moe_fusion_test.py
+++ b/src/mobius/rewrite_rules/_block_quantized_moe_fusion_test.py
@@ -100,6 +100,7 @@ def _build_dense_graph(
     bias_expert: int | None = None,
     corrupt_expert_gate_fmt: tuple[int, str] | None = None,
     break_expert: int | None = None,
+    alien_routing_expert: int | None = None,
 ) -> tuple[ir.Model, dict[str, np.ndarray]]:
     """Build a tiny GLM-style dense-fallback native-block MoE graph.
 
@@ -107,7 +108,8 @@ def _build_dense_graph(
     fusion reconstructs routing gate-agnostically. Knobs drive the fail-closed
     tests: ``bias_expert`` adds a bias to one expert, ``corrupt_expert_gate_fmt``
     gives one expert a different gate format, ``break_expert`` replaces one
-    expert's down projection with a non-native op.
+    expert's down projection with a non-native op, ``alien_routing_expert``
+    feeds one expert a distinct (non-shared) routing-weights tensor.
     """
     rng = _rng()
     weights: dict[str, np.ndarray] = {}
@@ -233,8 +235,18 @@ def _build_dense_graph(
         )
         cast.outputs[0].name = f"cast_{e}.out"
         nodes.append(cast)
+        this_rweights = rweights
+        if alien_routing_expert == e:
+            # A distinct routing-weights tensor for one expert means this is not
+            # a single shared-gate storm; that expert is dropped and the layer
+            # must fail closed rather than fuse a short bank.
+            alien = ir.node("Identity", inputs=[rweights], num_outputs=1, name=f"alien_rw_{e}")
+            alien.outputs[0].name = f"alien_rw_{e}.out"
+            alien.outputs[0].type = ir.TensorType(ir.DataType.FLOAT)
+            nodes.append(alien)
+            this_rweights = alien.outputs[0]
         wmul = ir.node(
-            "Mul", inputs=[rweights, cast.outputs[0]], num_outputs=1, name=f"wmul_{e}"
+            "Mul", inputs=[this_rweights, cast.outputs[0]], num_outputs=1, name=f"wmul_{e}"
         )
         wmul.outputs[0].name = f"wmul_{e}.out"
         nodes.append(wmul)
@@ -565,6 +577,32 @@ def test_incomplete_expert_group_fails_closed() -> None:
     fused = fuse_block_quantized_moe(model)
     assert fused == 0
     assert _count(graph, "BlockQuantizedMoE") == 0
+
+
+def test_dropped_trailing_expert_fails_closed() -> None:
+    """Dropping the *highest* expert id must fail closed, not fuse a short bank.
+
+    The survivors ``0..E-2`` still look contiguous, so a gap-only check would
+    silently fuse an expert bank narrower than the router actually selects over
+    (leaving ``ScatterElements`` to index out of bounds). The declared-id set
+    from the ``Equal`` masks is the authority, so this must stay a dense graph.
+    """
+    model, _ = _build_dense_graph(break_expert=E - 1)
+    graph = model.graph
+    fused = fuse_block_quantized_moe(model)
+    assert fused == 0
+    assert _count(graph, "BlockQuantizedMoE") == 0
+    assert _count(graph, "Equal") == E  # dense fallback fully preserved
+
+
+def test_alien_routing_weights_expert_fails_closed() -> None:
+    """An expert wired to a non-shared routing-weights tensor must fail closed."""
+    model, _ = _build_dense_graph(alien_routing_expert=E - 1)
+    graph = model.graph
+    fused = fuse_block_quantized_moe(model)
+    assert fused == 0
+    assert _count(graph, "BlockQuantizedMoE") == 0
+    assert _count(graph, "Equal") == E  # dense fallback fully preserved
 
 
 def test_no_moe_is_a_noop() -> None:

--- a/src/mobius/rewrite_rules/_block_quantized_moe_fusion_test.py
+++ b/src/mobius/rewrite_rules/_block_quantized_moe_fusion_test.py
@@ -526,6 +526,42 @@ def test_core_attributes_match_bqmoe_abi() -> None:
 
 
 # --------------------------------------------------------------------------- #
+# Per-projection (block_layout_version=2) runtime-capability gate             #
+# --------------------------------------------------------------------------- #
+def test_mixed_format_without_v2_runtime_fails_closed() -> None:
+    """A mixed-format layer needs v2; if the runtime lacks it, fail closed.
+
+    The export authority passes ``perproj_v2_runtime=False`` when the deployed
+    runtime has not shipped the ``block_layout_version=2`` per-projection ABI.
+    Emitting a v2 node then would be an unrunnable overclaim, so the layer must
+    fail closed atomically with the dense graph left untouched.
+    """
+    model, _ = _build_dense_graph(gate_fmt="iq1_s", up_fmt="iq1_s", down_fmt="iq4_xs")
+    graph = model.graph
+    with pytest.raises(SparseMoEExportError, match=r"block_layout_version=2"):
+        fuse_block_quantized_moe(model, perproj_v2_runtime=False)
+    assert _count(graph, "BlockQuantizedMoE") == 0
+    assert _count(graph, "Equal") == E  # dense graph left untouched
+
+
+def test_uniform_format_fuses_without_v2_runtime() -> None:
+    """A uniform-format layer is a v1 node, so it fuses even without v2 support."""
+    model, _ = _build_dense_graph(gate_fmt="iq4_xs", up_fmt="iq4_xs", down_fmt="iq4_xs")
+    assert fuse_block_quantized_moe(model, perproj_v2_runtime=False) == 1
+    attrs = _moe(model.graph).attributes
+    assert "block_layout_version" not in attrs  # v1
+    assert attrs["format"].value == "iq4_xs"
+
+
+def test_mixed_format_with_v2_runtime_emits_v2() -> None:
+    """With v2 runtime support, a mixed-format layer emits one v2 node."""
+    model, _ = _build_dense_graph(gate_fmt="iq1_s", up_fmt="iq1_s", down_fmt="iq4_xs")
+    assert fuse_block_quantized_moe(model, perproj_v2_runtime=True) == 1
+    attrs = _moe(model.graph).attributes
+    assert attrs["block_layout_version"].value == 2
+
+
+# --------------------------------------------------------------------------- #
 # Gate-agnostic routing + activation variants                                 #
 # --------------------------------------------------------------------------- #
 def test_fuses_legacy_gate_sigmoid_activation() -> None:

--- a/src/mobius/rewrite_rules/_block_quantized_moe_fusion_test.py
+++ b/src/mobius/rewrite_rules/_block_quantized_moe_fusion_test.py
@@ -396,7 +396,7 @@ def test_fuses_expert_storm_into_single_bqmoe() -> None:
     # E experts x 3 projections + 3 shared projections.
     assert _count(graph, _MATMUL_OP) == E * 3 + 3
 
-    fused = fuse_block_quantized_moe(model)
+    fused = fuse_block_quantized_moe(model, _allow_perproj_v2_schema=True)
 
     assert fused == 1
     assert _count(graph, "BlockQuantizedMoE") == 1
@@ -413,7 +413,7 @@ def test_fuses_expert_storm_into_single_bqmoe() -> None:
 
 def test_domain_and_opset_registered() -> None:
     model, _ = _build_dense_graph()
-    fuse_block_quantized_moe(model)
+    fuse_block_quantized_moe(model, _allow_perproj_v2_schema=True)
     moe = _moe(model.graph)
     assert moe.domain == _NXRT
     assert model.graph.opset_imports[_NXRT] == 1
@@ -421,7 +421,7 @@ def test_domain_and_opset_registered() -> None:
 
 def test_input_wiring_matches_runtime_abi() -> None:
     model, _ = _build_dense_graph(gate_fmt="iq1_s", up_fmt="iq1_s", down_fmt="iq4_xs")
-    fuse_block_quantized_moe(model)
+    fuse_block_quantized_moe(model, _allow_perproj_v2_schema=True)
     moe = _moe(model.graph)
     # 9-input BlockQuantizedMoE ABI order (fused SwiGLU: no fc3).
     assert len(moe.inputs) == 9
@@ -442,7 +442,7 @@ def test_input_wiring_matches_runtime_abi() -> None:
 def test_fused_swiglu_weights_are_byte_identical() -> None:
     """gate_fmt == up_fmt -> fc1 = concat(gate, up) rows; bytes untouched."""
     model, w = _build_dense_graph(gate_fmt="iq1_s", up_fmt="iq1_s", down_fmt="iq4_xs")
-    fuse_block_quantized_moe(model)
+    fuse_block_quantized_moe(model, _allow_perproj_v2_schema=True)
     moe = _moe(model.graph)
     fc1 = moe.inputs[2].const_value.numpy()
     fc2 = moe.inputs[4].const_value.numpy()
@@ -456,7 +456,7 @@ def test_fused_swiglu_weights_are_byte_identical() -> None:
 def test_unfused_swiglu_weights_are_byte_identical() -> None:
     """gate_fmt != up_fmt -> fc1 = gate, fc3 = up, fc2 = down; bytes untouched."""
     model, w = _build_dense_graph(gate_fmt="iq1_s", up_fmt="iq3_xxs", down_fmt="iq4_xs")
-    fuse_block_quantized_moe(model)
+    fuse_block_quantized_moe(model, _allow_perproj_v2_schema=True)
     moe = _moe(model.graph)
     fc1 = moe.inputs[2].const_value.numpy()
     fc2 = moe.inputs[4].const_value.numpy()
@@ -470,7 +470,7 @@ def test_unfused_swiglu_weights_are_byte_identical() -> None:
 
 def test_expert_major_bank_dtype_is_uint8() -> None:
     model, _ = _build_dense_graph()
-    fuse_block_quantized_moe(model)
+    fuse_block_quantized_moe(model, _allow_perproj_v2_schema=True)
     moe = _moe(model.graph)
     assert moe.inputs[2].dtype == ir.DataType.UINT8
     assert moe.inputs[4].dtype == ir.DataType.UINT8
@@ -493,7 +493,7 @@ def test_uniform_format_stays_layout_version_1() -> None:
 
 def test_fused_mixed_format_emits_layout_version_2() -> None:
     model, _ = _build_dense_graph(gate_fmt="iq1_s", up_fmt="iq1_s", down_fmt="iq4_xs")
-    fuse_block_quantized_moe(model)
+    fuse_block_quantized_moe(model, _allow_perproj_v2_schema=True)
     moe = _moe(model.graph)
     attrs = moe.attributes
     assert attrs["block_layout_version"].value == 2
@@ -506,7 +506,7 @@ def test_fused_mixed_format_emits_layout_version_2() -> None:
 
 def test_unfused_mixed_format_emits_all_projection_formats() -> None:
     model, _ = _build_dense_graph(gate_fmt="iq1_s", up_fmt="iq3_xxs", down_fmt="iq4_xs")
-    fuse_block_quantized_moe(model)
+    fuse_block_quantized_moe(model, _allow_perproj_v2_schema=True)
     moe = _moe(model.graph)
     attrs = moe.attributes
     assert attrs["block_layout_version"].value == 2
@@ -518,7 +518,7 @@ def test_unfused_mixed_format_emits_all_projection_formats() -> None:
 
 def test_core_attributes_match_bqmoe_abi() -> None:
     model, _ = _build_dense_graph()
-    fuse_block_quantized_moe(model)
+    fuse_block_quantized_moe(model, _allow_perproj_v2_schema=True)
     attrs = _moe(model.graph).attributes
     assert attrs["k"].value == K
     assert attrs["activation_type"].value == "swiglu"
@@ -526,39 +526,47 @@ def test_core_attributes_match_bqmoe_abi() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# Per-projection (block_layout_version=2) runtime-capability gate             #
+# Per-projection (block_layout_version=2): fail-closed default + schema hook   #
 # --------------------------------------------------------------------------- #
-def test_mixed_format_without_v2_runtime_fails_closed() -> None:
-    """A mixed-format layer needs v2; if the runtime lacks it, fail closed.
+def test_mixed_format_rejects_v2_by_default() -> None:
+    """A direct public call rejects a mixed-format (v2-only) layer by default.
 
-    The export authority passes ``perproj_v2_runtime=False`` when the deployed
-    runtime has not shipped the ``block_layout_version=2`` per-projection ABI.
-    Emitting a v2 node then would be an unrunnable overclaim, so the layer must
-    fail closed atomically with the dense graph left untouched.
+    No shipped onnx-genai runtime executes the ``block_layout_version=2``
+    per-projection ABI, so ``fuse_block_quantized_moe`` fails closed for a
+    mixed-format layer with no opt-in of any kind. The reject is atomic: the
+    dense graph is left untouched.
     """
     model, _ = _build_dense_graph(gate_fmt="iq1_s", up_fmt="iq1_s", down_fmt="iq4_xs")
     graph = model.graph
     with pytest.raises(SparseMoEExportError, match=r"block_layout_version=2"):
-        fuse_block_quantized_moe(model, perproj_v2_runtime=False)
+        fuse_block_quantized_moe(model)
     assert _count(graph, "BlockQuantizedMoE") == 0
     assert _count(graph, "Equal") == E  # dense graph left untouched
 
 
-def test_uniform_format_fuses_without_v2_runtime() -> None:
-    """A uniform-format layer is a v1 node, so it fuses even without v2 support."""
+def test_uniform_format_still_fuses_to_v1() -> None:
+    """A uniform-format layer is a v1 node, so it fuses under the fail-closed default."""
     model, _ = _build_dense_graph(gate_fmt="iq4_xs", up_fmt="iq4_xs", down_fmt="iq4_xs")
-    assert fuse_block_quantized_moe(model, perproj_v2_runtime=False) == 1
+    assert fuse_block_quantized_moe(model) == 1
     attrs = _moe(model.graph).attributes
     assert "block_layout_version" not in attrs  # v1
     assert attrs["format"].value == "iq4_xs"
 
 
-def test_mixed_format_with_v2_runtime_emits_v2() -> None:
-    """With v2 runtime support, a mixed-format layer emits one v2 node."""
+def test_perproj_v2_schema_hook_is_test_only() -> None:
+    """The private ``_allow_perproj_v2_schema`` hook builds the v2 node shape.
+
+    This is the schema-construction test path only: the emitted v2 node is not
+    runnable on any shipped runtime and is unreachable from the production
+    builder, the CLI, or an environment variable. It exists so the per-projection
+    v2 schema stays covered until a real typed runtime-capability handshake ships.
+    """
     model, _ = _build_dense_graph(gate_fmt="iq1_s", up_fmt="iq1_s", down_fmt="iq4_xs")
-    assert fuse_block_quantized_moe(model, perproj_v2_runtime=True) == 1
+    assert fuse_block_quantized_moe(model, _allow_perproj_v2_schema=True) == 1
     attrs = _moe(model.graph).attributes
     assert attrs["block_layout_version"].value == 2
+    assert attrs["fc1_format"].value == "iq1_s"
+    assert attrs["fc2_format"].value == "iq4_xs"
 
 
 # --------------------------------------------------------------------------- #
@@ -567,7 +575,7 @@ def test_mixed_format_with_v2_runtime_emits_v2() -> None:
 def test_fuses_legacy_gate_sigmoid_activation() -> None:
     """The legacy ``gate * Sigmoid(gate)`` SwiGLU decomposition still fuses."""
     model, _ = _build_dense_graph(activation="legacy")
-    fused = fuse_block_quantized_moe(model)
+    fused = fuse_block_quantized_moe(model, _allow_perproj_v2_schema=True)
     assert fused == 1
     assert _count(model.graph, "BlockQuantizedMoE") == 1
 
@@ -576,7 +584,7 @@ def test_fuses_f16_graph_with_cast_wrapped_projections() -> None:
     """f16 exports wrap every projection in Cast; the trace and cast-back work."""
     model, _ = _build_dense_graph(dtype=ir.DataType.FLOAT16)
     graph = model.graph
-    fused = fuse_block_quantized_moe(model)
+    fused = fuse_block_quantized_moe(model, _allow_perproj_v2_schema=True)
     assert fused == 1
     moe = _moe(graph)
     # BlockQuantizedMoE output is FLOAT; a Cast restores the f16 routed dtype.

--- a/src/mobius/rewrite_rules/_block_quantized_moe_fusion_test.py
+++ b/src/mobius/rewrite_rules/_block_quantized_moe_fusion_test.py
@@ -1,0 +1,615 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for the dense-fallback native-block MoE -> ``pkg.nxrt::BlockQuantizedMoE`` rewrite.
+
+Native IQ/GGUF blocks are codebook-based and cannot be dequantized in NumPy, so
+these tests are **structural** (the expert storm collapses; only selected experts
+execute) and **byte-preservation** (the native blocks are stacked verbatim, never
+requantized). Numerical parity of the fused node lives in the onnx-genai Rust
+CPU-oracle tests. The routing reconstruction is proven separately against a small
+NumPy model of the kernel's ``routing_weights`` selection.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import onnx_ir as ir
+import pytest
+
+from mobius._constants import OPSET_VERSION
+from mobius.rewrite_rules import fuse_block_quantized_moe
+from mobius.rewrite_rules._block_quantized_moe_fusion import _NATIVE_BLOCK_FORMATS
+
+# Tiny GLM-5.2-MoE-shaped geometry.
+H = 32  # hidden size
+INTER = 16  # moe intermediate size
+E = 4  # experts
+K = 2  # top-k
+_NXRT = "pkg.nxrt"
+
+
+def _rng() -> np.random.Generator:
+    return np.random.default_rng(0)
+
+
+def _native_weight(
+    rng: np.random.Generator, out_features: int, in_features: int, fmt: str
+) -> np.ndarray:
+    """Random packed native block weight ``[N, n_blocks, block_bytes]`` uint8."""
+    block_elements, block_bytes = _NATIVE_BLOCK_FORMATS[fmt]
+    n_blocks = -(-in_features // block_elements)
+    return rng.integers(0, 256, size=(out_features, n_blocks, block_bytes), dtype=np.uint8)
+
+
+def _init(graph: ir.Graph, name: str, arr: np.ndarray, dtype: ir.DataType) -> ir.Value:
+    tensor = ir.tensor(arr, name=name, dtype=dtype)
+    value = ir.Value(
+        name=name, shape=ir.Shape(arr.shape), type=ir.TensorType(dtype), const_value=tensor
+    )
+    graph.register_initializer(value)
+    return value
+
+
+def _bqmatmul(
+    name: str,
+    x: ir.Value,
+    weight: np.ndarray,
+    k: int,
+    n: int,
+    fmt: str,
+    graph: ir.Graph,
+    nodes: list[ir.Node],
+    *,
+    dtype: ir.DataType = ir.DataType.FLOAT,
+) -> ir.Value:
+    w = _init(graph, f"{name}.weight", weight, ir.DataType.UINT8)
+    node = ir.node(
+        _MATMUL_OP,
+        inputs=[x, w],
+        attributes={"K": k, "N": n, "format": fmt, "block_layout_version": 1},
+        domain=_NXRT,
+        num_outputs=1,
+        name=name,
+    )
+    node.outputs[0].name = f"{name}.out"
+    node.outputs[0].type = ir.TensorType(dtype)
+    nodes.append(node)
+    return node.outputs[0]
+
+
+_MATMUL_OP = "BlockQuantizedMatMul"
+
+
+def _constant_int(nodes: list[ir.Node], name: str, value: int) -> ir.Value:
+    node = ir.node(
+        "Constant", inputs=[], attributes={"value_int": value}, num_outputs=1, name=name
+    )
+    nodes.append(node)
+    node.outputs[0].name = f"{name}.out"
+    return node.outputs[0]
+
+
+def _build_dense_graph(
+    *,
+    gate_fmt: str = "iq1_s",
+    up_fmt: str = "iq1_s",
+    down_fmt: str = "iq4_xs",
+    activation: str = "swish",
+    dtype: ir.DataType = ir.DataType.FLOAT,
+    bias_expert: int | None = None,
+    corrupt_expert_gate_fmt: tuple[int, str] | None = None,
+    break_expert: int | None = None,
+) -> tuple[ir.Model, dict[str, np.ndarray]]:
+    """Build a tiny GLM-style dense-fallback native-block MoE graph.
+
+    The gate is Sigmoid + TopK + normalize (GLM-style, non-softmax) to prove the
+    fusion reconstructs routing gate-agnostically. Knobs drive the fail-closed
+    tests: ``bias_expert`` adds a bias to one expert, ``corrupt_expert_gate_fmt``
+    gives one expert a different gate format, ``break_expert`` replaces one
+    expert's down projection with a non-native op.
+    """
+    rng = _rng()
+    weights: dict[str, np.ndarray] = {}
+    nodes: list[ir.Node] = []
+
+    hidden = ir.Value(name="hidden", shape=ir.Shape(["T", H]), type=ir.TensorType(dtype))
+    graph = ir.Graph([hidden], [], nodes=[], name="tiny_native_moe")
+
+    def cast_to_f32(value: ir.Value, name: str) -> ir.Value:
+        if dtype == ir.DataType.FLOAT:
+            return value
+        node = ir.node(
+            "Cast",
+            inputs=[value],
+            attributes={"to": ir.DataType.FLOAT.value},
+            num_outputs=1,
+            name=name,
+        )
+        node.outputs[0].name = f"{name}.out"
+        node.outputs[0].type = ir.TensorType(ir.DataType.FLOAT)
+        nodes.append(node)
+        return node.outputs[0]
+
+    def cast_from_f32(value: ir.Value, name: str) -> ir.Value:
+        if dtype == ir.DataType.FLOAT:
+            return value
+        node = ir.node(
+            "Cast",
+            inputs=[value],
+            attributes={"to": dtype.value},
+            num_outputs=1,
+            name=name,
+        )
+        node.outputs[0].name = f"{name}.out"
+        node.outputs[0].type = ir.TensorType(dtype)
+        nodes.append(node)
+        return node.outputs[0]
+
+    # --- GLM-style gate: MatMul -> Sigmoid -> TopK -> normalize ---
+    router_wt = _init(
+        graph,
+        "router.weight_t",
+        rng.standard_normal((H, E)).astype(np.float32),
+        ir.DataType.FLOAT,
+    )
+    logits = ir.node("MatMul", inputs=[hidden, router_wt], num_outputs=1, name="router.matmul")
+    logits.outputs[0].name = "router.logits"
+    logits.outputs[0].type = ir.TensorType(dtype)
+    logits.outputs[0].shape = ir.Shape(["T", E])
+    nodes.append(logits)
+    sig = ir.node("Sigmoid", inputs=[logits.outputs[0]], num_outputs=1, name="router.sigmoid")
+    sig.outputs[0].name = "router.probs"
+    sig.outputs[0].type = ir.TensorType(dtype)
+    nodes.append(sig)
+    k_init = _init(graph, "topk.k", np.array([K], dtype=np.int64), ir.DataType.INT64)
+    topk = ir.node(
+        "TopK",
+        inputs=[sig.outputs[0], k_init],
+        attributes={"axis": -1},
+        num_outputs=2,
+        name="topk",
+    )
+    topk.outputs[0].name = "topk.values"
+    topk.outputs[0].type = ir.TensorType(dtype)
+    topk.outputs[0].shape = ir.Shape(["T", K])
+    topk.outputs[1].name = "topk.indices"
+    topk.outputs[1].type = ir.TensorType(ir.DataType.INT64)
+    topk.outputs[1].shape = ir.Shape(["T", K])
+    nodes.append(topk)
+    axes = _init(graph, "reduce.axes", np.array([-1], dtype=np.int64), ir.DataType.INT64)
+    wsum = ir.node(
+        "ReduceSum",
+        inputs=[topk.outputs[0], axes],
+        attributes={"keepdims": 1},
+        num_outputs=1,
+        name="router.wsum",
+    )
+    wsum.outputs[0].name = "router.wsum.out"
+    wsum.outputs[0].type = ir.TensorType(dtype)
+    nodes.append(wsum)
+    routing_weights = ir.node(
+        "Div",
+        inputs=[topk.outputs[0], wsum.outputs[0]],
+        num_outputs=1,
+        name="router.norm",
+    )
+    routing_weights.outputs[0].name = "routing_weights"
+    routing_weights.outputs[0].type = ir.TensorType(dtype)
+    routing_weights.outputs[0].shape = ir.Shape(["T", K])
+    nodes.append(routing_weights)
+
+    selected = topk.outputs[1]
+    rweights = routing_weights.outputs[0]
+
+    def act_of(gate_out: ir.Value, e: int) -> ir.Value:
+        if activation == "swish":
+            node = ir.node("Swish", inputs=[gate_out], num_outputs=1, name=f"expert{e}.act")
+            node.outputs[0].name = f"expert{e}.act.out"
+            node.outputs[0].type = ir.TensorType(ir.DataType.FLOAT)
+            nodes.append(node)
+            return node.outputs[0]
+        # legacy gate * Sigmoid(gate)
+        sg = ir.node("Sigmoid", inputs=[gate_out], num_outputs=1, name=f"expert{e}.sig")
+        sg.outputs[0].name = f"expert{e}.sig.out"
+        sg.outputs[0].type = ir.TensorType(ir.DataType.FLOAT)
+        nodes.append(sg)
+        mul = ir.node(
+            "Mul", inputs=[gate_out, sg.outputs[0]], num_outputs=1, name=f"expert{e}.silu"
+        )
+        mul.outputs[0].name = f"expert{e}.silu.out"
+        mul.outputs[0].type = ir.TensorType(ir.DataType.FLOAT)
+        nodes.append(mul)
+        return mul.outputs[0]
+
+    routed = None
+    for e in range(E):
+        eid = _constant_int(nodes, f"eid_{e}", e)
+        equal = ir.node("Equal", inputs=[selected, eid], num_outputs=1, name=f"equal_{e}")
+        equal.outputs[0].name = f"equal_{e}.out"
+        nodes.append(equal)
+        cast = ir.node(
+            "CastLike", inputs=[equal.outputs[0], rweights], num_outputs=1, name=f"cast_{e}"
+        )
+        cast.outputs[0].name = f"cast_{e}.out"
+        nodes.append(cast)
+        wmul = ir.node(
+            "Mul", inputs=[rweights, cast.outputs[0]], num_outputs=1, name=f"wmul_{e}"
+        )
+        wmul.outputs[0].name = f"wmul_{e}.out"
+        nodes.append(wmul)
+        reduce = ir.node(
+            "ReduceSum",
+            inputs=[wmul.outputs[0], axes],
+            attributes={"keepdims": 1},
+            num_outputs=1,
+            name=f"reduce_{e}",
+        )
+        reduce.outputs[0].name = f"reduce_{e}.out"
+        nodes.append(reduce)
+
+        this_gate_fmt = gate_fmt
+        if corrupt_expert_gate_fmt is not None and corrupt_expert_gate_fmt[0] == e:
+            this_gate_fmt = corrupt_expert_gate_fmt[1]
+        x_f32 = cast_to_f32(hidden, f"expert{e}.gate.cast_in")
+        gate_w = _native_weight(rng, INTER, H, this_gate_fmt)
+        weights[f"g{e}"] = gate_w
+        gate = _bqmatmul(
+            f"expert{e}.gate_proj", x_f32, gate_w, H, INTER, this_gate_fmt, graph, nodes
+        )
+        gate = cast_from_f32(gate, f"expert{e}.gate.cast_out")
+        act = act_of(gate, e)
+
+        up_x = cast_to_f32(hidden, f"expert{e}.up.cast_in")
+        up_w = _native_weight(rng, INTER, H, up_fmt)
+        weights[f"u{e}"] = up_w
+        up = _bqmatmul(f"expert{e}.up_proj", up_x, up_w, H, INTER, up_fmt, graph, nodes)
+        up = cast_from_f32(up, f"expert{e}.up.cast_out")
+
+        act_mul = ir.node("Mul", inputs=[act, up], num_outputs=1, name=f"expert{e}.mul")
+        act_mul.outputs[0].name = f"expert{e}.mul.out"
+        act_mul.outputs[0].type = ir.TensorType(ir.DataType.FLOAT)
+        nodes.append(act_mul)
+
+        down_x = cast_to_f32(act_mul.outputs[0], f"expert{e}.down.cast_in")
+        if break_expert == e:
+            # Replace the down projection with a non-native op: this expert can
+            # no longer be traced and the whole storm must fail closed.
+            broken = ir.node(
+                "Identity", inputs=[down_x], num_outputs=1, name=f"expert{e}.down_broken"
+            )
+            broken.outputs[0].name = f"expert{e}.down.out"
+            broken.outputs[0].type = ir.TensorType(ir.DataType.FLOAT)
+            nodes.append(broken)
+            down_out = cast_from_f32(broken.outputs[0], f"expert{e}.down.cast_out")
+        else:
+            down_w = _native_weight(rng, H, INTER, down_fmt)
+            weights[f"d{e}"] = down_w
+            bias_inputs = None
+            if bias_expert == e:
+                bias_arr = rng.standard_normal(INTER).astype(np.float32)
+                bias_inputs = _init(graph, f"expert{e}.down.bias", bias_arr, ir.DataType.FLOAT)
+            dw = _init(graph, f"expert{e}.down_proj.weight", down_w, ir.DataType.UINT8)
+            down_node = ir.node(
+                _MATMUL_OP,
+                inputs=[down_x, dw] + ([bias_inputs] if bias_inputs is not None else []),
+                attributes={"K": INTER, "N": H, "format": down_fmt, "block_layout_version": 1},
+                domain=_NXRT,
+                num_outputs=1,
+                name=f"expert{e}.down_proj",
+            )
+            down_node.outputs[0].name = f"expert{e}.down_proj.out"
+            down_node.outputs[0].type = ir.TensorType(ir.DataType.FLOAT)
+            nodes.append(down_node)
+            down_out = cast_from_f32(down_node.outputs[0], f"expert{e}.down.cast_out")
+
+        contrib = ir.node(
+            "Mul",
+            inputs=[down_out, reduce.outputs[0]],
+            num_outputs=1,
+            name=f"expert{e}.contrib",
+        )
+        contrib.outputs[0].name = f"expert{e}.contrib.out"
+        contrib.outputs[0].type = ir.TensorType(dtype)
+        nodes.append(contrib)
+        if routed is None:
+            routed = contrib.outputs[0]
+        else:
+            add = ir.node(
+                "Add", inputs=[routed, contrib.outputs[0]], num_outputs=1, name=f"acc_{e}"
+            )
+            add.outputs[0].name = f"acc_{e}.out"
+            add.outputs[0].type = ir.TensorType(dtype)
+            nodes.append(add)
+            routed = add.outputs[0]
+
+    # --- Shared expert (must survive the rewrite untouched) ---
+    s_x = cast_to_f32(hidden, "shared.gate.cast_in")
+    sg_w = _native_weight(rng, INTER, H, gate_fmt)
+    weights["sg"] = sg_w
+    s_gate = _bqmatmul("shared.gate_proj", s_x, sg_w, H, INTER, gate_fmt, graph, nodes)
+    s_gate = cast_from_f32(s_gate, "shared.gate.cast_out")
+    s_act = ir.node("Swish", inputs=[s_gate], num_outputs=1, name="shared.act")
+    s_act.outputs[0].name = "shared.act.out"
+    s_act.outputs[0].type = ir.TensorType(ir.DataType.FLOAT)
+    nodes.append(s_act)
+    su_x = cast_to_f32(hidden, "shared.up.cast_in")
+    su_w = _native_weight(rng, INTER, H, up_fmt)
+    weights["su"] = su_w
+    s_up = _bqmatmul("shared.up_proj", su_x, su_w, H, INTER, up_fmt, graph, nodes)
+    s_up = cast_from_f32(s_up, "shared.up.cast_out")
+    s_mul = ir.node("Mul", inputs=[s_act.outputs[0], s_up], num_outputs=1, name="shared.mul")
+    s_mul.outputs[0].name = "shared.mul.out"
+    s_mul.outputs[0].type = ir.TensorType(ir.DataType.FLOAT)
+    nodes.append(s_mul)
+    sd_x = cast_to_f32(s_mul.outputs[0], "shared.down.cast_in")
+    sd_w = _native_weight(rng, H, INTER, down_fmt)
+    weights["sd"] = sd_w
+    s_down = _bqmatmul("shared.down_proj", sd_x, sd_w, INTER, H, down_fmt, graph, nodes)
+    s_down = cast_from_f32(s_down, "shared.down.cast_out")
+
+    final = ir.node("Add", inputs=[routed, s_down], num_outputs=1, name="final_add")
+    final.outputs[0].name = "moe_out"
+    final.outputs[0].shape = ir.Shape(["T", H])
+    final.outputs[0].type = ir.TensorType(dtype)
+    nodes.append(final)
+
+    for node in nodes:
+        graph.append(node)
+    graph.outputs.append(final.outputs[0])
+
+    model = ir.Model(graph, ir_version=10, producer_name="test")
+    model.opset_imports[""] = OPSET_VERSION
+    model.opset_imports[_NXRT] = 1
+    return model, weights
+
+
+def _count(graph: ir.Graph, op_type: str) -> int:
+    return sum(1 for n in graph if n.op_type == op_type)
+
+
+def _moe(graph: ir.Graph) -> ir.Node:
+    return next(n for n in graph if n.op_type == "BlockQuantizedMoE")
+
+
+# --------------------------------------------------------------------------- #
+# Structural collapse                                                         #
+# --------------------------------------------------------------------------- #
+def test_fuses_expert_storm_into_single_bqmoe() -> None:
+    model, _ = _build_dense_graph()
+    graph = model.graph
+
+    assert _count(graph, "BlockQuantizedMoE") == 0
+    # E experts x 3 projections + 3 shared projections.
+    assert _count(graph, _MATMUL_OP) == E * 3 + 3
+
+    fused = fuse_block_quantized_moe(model)
+
+    assert fused == 1
+    assert _count(graph, "BlockQuantizedMoE") == 1
+    # Only the three shared-expert projections remain; every routed expert
+    # matmul collapsed into the single sparse node.
+    assert _count(graph, _MATMUL_OP) == 3
+    # The per-expert masking machinery is gone -> only selected experts execute.
+    assert _count(graph, "Equal") == 0
+    assert _count(graph, "CastLike") == 0
+    # Two scatters reconstruct routing; the gate (TopK) is preserved.
+    assert _count(graph, "ScatterElements") == 2
+    assert _count(graph, "TopK") == 1
+
+
+def test_domain_and_opset_registered() -> None:
+    model, _ = _build_dense_graph()
+    fuse_block_quantized_moe(model)
+    moe = _moe(model.graph)
+    assert moe.domain == _NXRT
+    assert model.graph.opset_imports[_NXRT] == 1
+
+
+def test_input_wiring_matches_runtime_abi() -> None:
+    model, _ = _build_dense_graph(gate_fmt="iq1_s", up_fmt="iq1_s", down_fmt="iq4_xs")
+    fuse_block_quantized_moe(model)
+    moe = _moe(model.graph)
+    # 9-input BlockQuantizedMoE ABI order (fused SwiGLU: no fc3).
+    assert len(moe.inputs) == 9
+    assert moe.inputs[0].name == "hidden"  # input
+    assert moe.inputs[1].name.endswith("router_logits")  # router_logits
+    assert moe.inputs[2].name.endswith("fc1_experts_weights")
+    assert moe.inputs[3] is None  # fc1 bias
+    assert moe.inputs[4].name.endswith("fc2_experts_weights")
+    assert moe.inputs[5] is None  # fc2 bias
+    assert moe.inputs[6] is None  # fc3 (fused -> absent)
+    assert moe.inputs[7] is None  # fc3 bias
+    assert moe.inputs[8].name.endswith("router_weights")
+
+
+# --------------------------------------------------------------------------- #
+# Byte preservation                                                           #
+# --------------------------------------------------------------------------- #
+def test_fused_swiglu_weights_are_byte_identical() -> None:
+    """gate_fmt == up_fmt -> fc1 = concat(gate, up) rows; bytes untouched."""
+    model, w = _build_dense_graph(gate_fmt="iq1_s", up_fmt="iq1_s", down_fmt="iq4_xs")
+    fuse_block_quantized_moe(model)
+    moe = _moe(model.graph)
+    fc1 = moe.inputs[2].const_value.numpy()
+    fc2 = moe.inputs[4].const_value.numpy()
+    assert moe.inputs[6] is None  # fused: no fc3
+    for e in range(E):
+        expected_fc1 = np.concatenate([w[f"g{e}"], w[f"u{e}"]], axis=0)
+        np.testing.assert_array_equal(fc1[e], expected_fc1)
+        np.testing.assert_array_equal(fc2[e], w[f"d{e}"])
+
+
+def test_unfused_swiglu_weights_are_byte_identical() -> None:
+    """gate_fmt != up_fmt -> fc1 = gate, fc3 = up, fc2 = down; bytes untouched."""
+    model, w = _build_dense_graph(gate_fmt="iq1_s", up_fmt="iq3_xxs", down_fmt="iq4_xs")
+    fuse_block_quantized_moe(model)
+    moe = _moe(model.graph)
+    fc1 = moe.inputs[2].const_value.numpy()
+    fc2 = moe.inputs[4].const_value.numpy()
+    assert moe.inputs[6] is not None  # unfused: fc3 present
+    fc3 = moe.inputs[6].const_value.numpy()
+    for e in range(E):
+        np.testing.assert_array_equal(fc1[e], w[f"g{e}"])
+        np.testing.assert_array_equal(fc3[e], w[f"u{e}"])
+        np.testing.assert_array_equal(fc2[e], w[f"d{e}"])
+
+
+def test_expert_major_bank_dtype_is_uint8() -> None:
+    model, _ = _build_dense_graph()
+    fuse_block_quantized_moe(model)
+    moe = _moe(model.graph)
+    assert moe.inputs[2].dtype == ir.DataType.UINT8
+    assert moe.inputs[4].dtype == ir.DataType.UINT8
+
+
+# --------------------------------------------------------------------------- #
+# Per-projection format attributes (v1 vs v2)                                 #
+# --------------------------------------------------------------------------- #
+def test_uniform_format_stays_layout_version_1() -> None:
+    model, _ = _build_dense_graph(gate_fmt="iq4_xs", up_fmt="iq4_xs", down_fmt="iq4_xs")
+    fuse_block_quantized_moe(model)
+    moe = _moe(model.graph)
+    attrs = moe.attributes
+    assert "block_layout_version" not in attrs  # defaults to v1
+    assert attrs["format"].value == "iq4_xs"
+    assert "fc1_format" not in attrs
+    assert "fc2_format" not in attrs
+    assert "fc3_format" not in attrs
+
+
+def test_fused_mixed_format_emits_layout_version_2() -> None:
+    model, _ = _build_dense_graph(gate_fmt="iq1_s", up_fmt="iq1_s", down_fmt="iq4_xs")
+    fuse_block_quantized_moe(model)
+    moe = _moe(model.graph)
+    attrs = moe.attributes
+    assert attrs["block_layout_version"].value == 2
+    assert attrs["format"].value == "iq1_s"  # base/fallback
+    assert attrs["fc1_format"].value == "iq1_s"
+    assert attrs["fc2_format"].value == "iq4_xs"
+    assert "fc3_format" not in attrs  # fused -> no fc3
+    assert attrs["swiglu_fusion"].value == 2
+
+
+def test_unfused_mixed_format_emits_all_projection_formats() -> None:
+    model, _ = _build_dense_graph(gate_fmt="iq1_s", up_fmt="iq3_xxs", down_fmt="iq4_xs")
+    fuse_block_quantized_moe(model)
+    moe = _moe(model.graph)
+    attrs = moe.attributes
+    assert attrs["block_layout_version"].value == 2
+    assert attrs["fc1_format"].value == "iq1_s"
+    assert attrs["fc3_format"].value == "iq3_xxs"
+    assert attrs["fc2_format"].value == "iq4_xs"
+    assert attrs["swiglu_fusion"].value == 0
+
+
+def test_core_attributes_match_bqmoe_abi() -> None:
+    model, _ = _build_dense_graph()
+    fuse_block_quantized_moe(model)
+    attrs = _moe(model.graph).attributes
+    assert attrs["k"].value == K
+    assert attrs["activation_type"].value == "swiglu"
+    assert attrs["normalize_routing_weights"].value == 0
+
+
+# --------------------------------------------------------------------------- #
+# Gate-agnostic routing + activation variants                                 #
+# --------------------------------------------------------------------------- #
+def test_fuses_legacy_gate_sigmoid_activation() -> None:
+    """The legacy ``gate * Sigmoid(gate)`` SwiGLU decomposition still fuses."""
+    model, _ = _build_dense_graph(activation="legacy")
+    fused = fuse_block_quantized_moe(model)
+    assert fused == 1
+    assert _count(model.graph, "BlockQuantizedMoE") == 1
+
+
+def test_fuses_f16_graph_with_cast_wrapped_projections() -> None:
+    """f16 exports wrap every projection in Cast; the trace and cast-back work."""
+    model, _ = _build_dense_graph(dtype=ir.DataType.FLOAT16)
+    graph = model.graph
+    fused = fuse_block_quantized_moe(model)
+    assert fused == 1
+    moe = _moe(graph)
+    # BlockQuantizedMoE output is FLOAT; a Cast restores the f16 routed dtype.
+    consumer = next(n for n, _ in moe.outputs[0].uses())
+    assert consumer.op_type == "Cast"
+    assert consumer.attributes["to"].value == ir.DataType.FLOAT16.value
+
+
+# --------------------------------------------------------------------------- #
+# Fail-closed (typed reason, dense fallback preserved)                        #
+# --------------------------------------------------------------------------- #
+def test_mixed_format_across_experts_fails_closed() -> None:
+    """One expert with a different gate format cannot form one expert-major bank."""
+    model, _ = _build_dense_graph(corrupt_expert_gate_fmt=(1, "iq1_m"))
+    graph = model.graph
+    fused = fuse_block_quantized_moe(model)
+    assert fused == 0
+    assert _count(graph, "BlockQuantizedMoE") == 0
+    assert _count(graph, "Equal") == E  # dense fallback preserved
+
+
+def test_biased_expert_fails_closed() -> None:
+    model, _ = _build_dense_graph(bias_expert=2)
+    graph = model.graph
+    fused = fuse_block_quantized_moe(model)
+    assert fused == 0
+    assert _count(graph, "BlockQuantizedMoE") == 0
+    assert _count(graph, "Equal") == E
+
+
+def test_incomplete_expert_group_fails_closed() -> None:
+    """A non-native (untraceable) expert leaves an incomplete 0..E-1 set."""
+    model, _ = _build_dense_graph(break_expert=2)
+    graph = model.graph
+    fused = fuse_block_quantized_moe(model)
+    assert fused == 0
+    assert _count(graph, "BlockQuantizedMoE") == 0
+
+
+def test_no_moe_is_a_noop() -> None:
+    hidden = ir.Value(
+        name="x", shape=ir.Shape(["T", H]), type=ir.TensorType(ir.DataType.FLOAT)
+    )
+    graph = ir.Graph([hidden], [hidden], nodes=[], name="empty")
+    model = ir.Model(graph, ir_version=10, producer_name="test")
+    model.opset_imports[""] = OPSET_VERSION
+    assert fuse_block_quantized_moe(model) == 0
+
+
+# --------------------------------------------------------------------------- #
+# Routing reconstruction semantics (NumPy model of the kernel selection)      #
+# --------------------------------------------------------------------------- #
+def _kernel_route(logits_row: np.ndarray, weights_row: np.ndarray, k: int) -> dict[int, float]:
+    """Mirror onnx-genai's ``routing_weights`` with ``normalize=0``.
+
+    Top-k by ``logits`` (ties broken by lower index), gather ``weights`` at the
+    selected experts, no renormalization.
+    """
+    order = sorted(range(len(logits_row)), key=lambda i: (-logits_row[i], i))
+    return {i: float(weights_row[i]) for i in order[:k]}
+
+
+def test_scatter_routing_reproduces_dense_selection_and_weights() -> None:
+    """One-hot logits + scattered weights re-select exactly the dense experts."""
+    rng = np.random.default_rng(1)
+    tokens, experts, k = 7, E, K
+    for _ in range(50):
+        selected = np.stack([rng.permutation(experts)[:k] for _ in range(tokens)]).astype(
+            np.int64
+        )
+        dense_weights = rng.random((tokens, k)).astype(np.float32)
+
+        logits_full = np.zeros((tokens, experts), dtype=np.float32)
+        weights_full = np.zeros((tokens, experts), dtype=np.float32)
+        np.put_along_axis(logits_full, selected, 1.0, axis=1)
+        np.put_along_axis(weights_full, selected, dense_weights, axis=1)
+
+        for t in range(tokens):
+            got = _kernel_route(logits_full[t], weights_full[t], k)
+            expected = {int(selected[t, j]): float(dense_weights[t, j]) for j in range(k)}
+            assert got == expected
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Native-block sparse-MoE fusion + `build_from_gguf` integration

Collapses GLM-style **routed** native-block expert storms (a per-expert
`pkg.nxrt::BlockQuantizedMatMul` for every gate/up/down of every expert,
dispatched by an `Equal` one-hot mask) into **one sparse top-k
`pkg.nxrt::BlockQuantizedMoE` per layer**, reusing the existing native blocks
**byte-for-byte** (no dequantize, no requantize). Gated on graph/tensor
structure, never on model names.

### What's here
1. **Rewrite** (`rewrite_rules/_block_quantized_moe_fusion.py`) — the transform:
   finds the dense-fallback MoE subgraph, validates **all** layers, then emits.
   Two-pass so an unfusable layer fails **atomically** with the graph untouched.
2. **Builder integration** (`integrations/gguf/_builder.py`) — wires the fusion
   into `build_from_gguf` at the **single** post-export authority point (step
   9b, after `pkg.apply_weights`, once every native block carries real packed
   bytes), then a final-graph-state honesty gate.

### Applicability verdict (Phase-1 audit)
- GLM-5.2 UD-IQ1_S/M routed experts are **per-projection mixed-format** per
  layer (fused `gate==up` in iq1_s/iq1_m; `down` in a higher-bit format such as
  iq4_xs). A v1 single-`format` `BlockQuantizedMoE` therefore fuses **0** GLM
  layers.
- Expressing a mixed-format layer needs the **`block_layout_version=2`
  per-projection ABI** (`fc1_format`/`fc2_format`/`fc3_format`). That runtime
  ABI lives on an **unmerged onnx-genai branch**, so mobius's runnable runtime
  does **not** yet have it.
- **Honest consequence:** GLM-5.2 mixed-format layers **typed-reject**
  (`SparseMoEExportError`, message names `block_layout_version=2`) until the
  runtime ships v2 — we never emit an unrunnable v2 node by default. **Uniform**
  native-block routed MoE **does** fuse today (v1).

### Honesty / fail-closed policy
- Default `allow_dense_moe=False`. Unsupported layers (mixed w/o v2, per-expert
  bias, ragged/incomplete groups) raise the shared **`SparseMoEExportError`**
  atomically; the graph is left as the original dense storm.
- `_perproj_bqmoe_v2_runtime_available()` gates v2 emission on
  `MOBIUS_ENABLE_BQMOE_PERPROJ_V2` (default off). Flip it **only** once the
  onnx-genai v2 runtime ships.
- The **pre-export module-level gate call was removed** (it would reject the
  layers the fusion now collapses); enforcement moved to the **final graph
  state** — the fusion's atomic reject + a `_assert_sparse_moe_graph` backstop
  that fails closed on any surviving routed `.experts.` `BlockQuantizedMatMul`
  storm. Single mechanism, no duplicate gate. Batty's `_assert_sparse_moe_capability`
  / `_routed_dense_block_expert_paths` (#581) stay defined for their unit tests.
- `allow_dense_moe=True` may warn + retain the dense fallback, but **never**
  counts as a performance path (no throughput claim).

### Emitted ABI (unchanged runtime contract)
`BlockQuantizedMoE` 9 inputs, FLOAT32: `[input, router_logits,
fc1_experts_weights(uint8 4D), fc1_bias?, fc2_experts_weights, fc2_bias?,
fc3_experts_weights?, fc3_bias?, router_weights?]`. Uniform layer → `format`
attr (v1). Mixed layer → `block_layout_version=2` + `fc1_format`/`fc2_format`/
`fc3_format`. Expert banks are the source native blocks **stacked verbatim**
(byte-preservation asserted in tests).

### Tests (same commits)
- **Rewrite unit** (`_block_quantized_moe_fusion_test.py`, 23): GLM-style
  Sigmoid+TopK+normalize routing, top-k {1,8}, byte-preserving stacking,
  atomic fail-closed (dropped/duplicate/ragged/mixed-bias experts), structural
  proof the expert matmuls collapse, and the new **v2-runtime gate** (uniform
  fuses without v2; mixed typed-rejects without v2; mixed emits v2 when opted in).
- **Builder integration** (`_block_quantized_moe_builder_test.py`, 20): step-9b
  helpers on synthetic exported packages (default fail-closed, v2 opt-in, dense
  retention, byte-preserving banks, deterministic external data, final-state
  backstop) **plus 5 real end-to-end `build_from_gguf` builds** on synthetic
  native-block MoE GGUFs (`qwen3_moe` / `qwen2_moe`, which lower through the
  identical routed dense-loop → `BlockQuantizedMatMul` storm and the same step-9b
  authority point):
  - uniform → **one** `BlockQuantizedMoE`, only attention matmuls remain (no storm);
  - mixed → **`SparseMoEExportError`** (GLM-5.2's honest path);
  - mixed + `MOBIUS_ENABLE_BQMOE_PERPROJ_V2=1` → one **v2** node;
  - `allow_dense_moe=True` → dense storm retained (no fused node);
  - **shared expert stays dense** while the routed storm collapses.

Full `rewrite_rules/` + `integrations/gguf/` suites: **576 passed, 1 skipped**.
`ruff check` + `ruff format --check`: clean.

### Remaining typed blockers (not overclaimed)
1. **v2 per-projection runtime ABI is unmerged in onnx-genai** → GLM-5.2
   mixed-format typed-rejects end-to-end until it ships. Uniform native-block
   MoE fuses today.
2. **No A100 benchmark yet** — deferred until a runnable shape-faithful
   importer path exists (GLM-5.2 can't build to a runnable graph until v2 lands).
   Full-model speed is not claimed.
3. **`_builder.py` merge coordination** — Sapper's #578 (unmerged) also rewrites
   `_builder.py`; a future rebase will need coordinator-mediated conflict
   resolution. No live collision on this base.

### Dependency on Batty's sharded import
Builds on the merged **#581** (`GgufShardSet`, `glm-dsa` → `glm_moe_dsa` bridge,
shared `SparseMoEExportError`) and **#576**; rebased cleanly on `059bf5f`. Only
uses those committed public interfaces — no edits to shard-reader / architecture-
mapping files.

**Draft — do not merge.** Requesting independent review (excluding author).
