### PR TITLE
feat(deepseek-v4): default-off native CompressedSparseAttention (HCA ratio-128) export [C1, DRAFT]

### DIFF
--- a/src/mobius/_configs/_base.py
+++ b/src/mobius/_configs/_base.py
@@ -494,6 +494,17 @@ class ArchitectureConfig(BaseModelConfig):
     num_hash_layers: int = 0
     swiglu_limit: float = 0.0
     num_nextn_predict_layers: int = 0
+    # DeepSeek-V4 native compressed-sparse-attention export toggle. Not an
+    # upstream HF field -- a Mobius export-time opt-in (default False) that
+    # replaces the dense CSA/HCA correctness fallback with the frozen
+    # ``pkg.nxrt::CompressedSparseAttention`` v1 op for property-matching
+    # ratio-128 (HCA) layers. Off by default so every shipped graph stays
+    # byte-identical and ``pkg.nxrt``-free unless explicitly requested via
+    # ``config_overrides={"native_csa": True}``. When requested, layers that
+    # do not satisfy the frozen op contract raise a typed export error rather
+    # than silently emitting the dense fallback (see
+    # ``mobius.models._deepseek_v4_csa``).
+    native_csa: bool = False
 
     # GLM-5.2 (``glm_moe_dsa``) DeepSeek Sparse Attention (DSA).
     #
@@ -963,6 +974,11 @@ class ArchitectureConfig(BaseModelConfig):
             ),
             swiglu_limit=getattr(config, "swiglu_limit", 0.0),
             num_nextn_predict_layers=getattr(config, "num_nextn_predict_layers", 0),
+            # DeepSeek-V4 native CSA/HCA export opt-in. No HF equivalent --
+            # every checkpoint defaults to the dense correctness fallback;
+            # ``config_overrides={"native_csa": True}`` opts a build into the
+            # frozen ``pkg.nxrt::CompressedSparseAttention`` v1 ratio-128 path.
+            native_csa=getattr(config, "native_csa", False),
             # GLM-5.2 DSA. ``use_dsa`` has no HF equivalent -- every checkpoint
             # defaults to the sparse path; ``--glm-full-attention`` overrides
             # it afterwards via ``dataclasses.replace``/``config_overrides``.

--- a/src/mobius/_configs/_base.py
+++ b/src/mobius/_configs/_base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import dataclasses
 import math
+from typing import TYPE_CHECKING
 
 import onnx_ir as ir
 import torch
@@ -21,6 +22,9 @@ from mobius._configs._sub_configs import (
     TTSConfig,
     VisionConfig,
 )
+
+if TYPE_CHECKING:
+    from mobius.integrations._block_quant import BlockQuantScheme
 
 DEFAULT_INT = -42
 
@@ -631,7 +635,16 @@ class ArchitectureConfig(BaseModelConfig):
     codec_decoder: CodecDecoderConfig | None = None
     codec_encoder: CodecEncoderConfig | None = None
     quantization: QuantizationConfig | None = None
-
+    # Deferred block-scaled FP8 / packed-FP4 scheme (DeepSeek-V4-Flash native
+    # CSA). Recorded by ``from_transformers`` when ``native_csa`` opts into
+    # deferring #602's config-resolution block-quant reject so that graph
+    # construction can progress past the former generic weight-shape mismatch.
+    # The runtime-capability gate
+    # (``mobius.models._deepseek_v4_csa.assert_native_runtime_supports_block_quant``)
+    # then fails closed on the *runnable* full export until nxrt advertises real
+    # block-FP8 / planar-FP4 format strings. ``None`` for every ordinary,
+    # per-tensor-fp8, or non-native path.
+    block_quant_scheme: BlockQuantScheme | None = None
     # HuggingFace model_type and special token IDs — populated by from_transformers()
     # so that genai_config.json can be written without re-fetching the HF config.
     model_type: str | None = None
@@ -1207,8 +1220,28 @@ class ArchitectureConfig(BaseModelConfig):
         if resolved is not None:
             options["dtype"] = resolved
 
-        # Quantization config
-        quant = QuantizationConfig.from_transformers(config)
+        # Quantization config. Block-scaled FP8 / packed-FP4 checkpoints
+        # (DeepSeek-V4-Flash) are rejected here by #602's typed
+        # ``BlockQuantExportError`` (the INT4/per-tensor path cannot load them).
+        # For a native-CSA export we *defer* that reject so graph construction
+        # can progress past the former generic weight-shape mismatch; the
+        # runtime-capability gate
+        # (``mobius.models._deepseek_v4_csa.assert_native_runtime_supports_block_quant``,
+        # invoked at weight-load / full-export) then fails closed until nxrt
+        # advertises real block-FP8 / planar-FP4 format strings. Every non-native
+        # path keeps #602's early, loud reject.
+        from mobius.integrations._block_quant import (
+            BlockQuantExportError,
+            BlockQuantScheme,
+        )
+
+        try:
+            quant = QuantizationConfig.from_transformers(config)
+        except BlockQuantExportError:
+            if not getattr(config, "native_csa", False):
+                raise
+            options["block_quant_scheme"] = BlockQuantScheme.from_hf_config(config)
+            quant = None
         if quant is None and parent_config is not None:
             quant = QuantizationConfig.from_transformers(parent_config)
         if quant is not None:

--- a/src/mobius/models/_deepseek_v4_csa.py
+++ b/src/mobius/models/_deepseek_v4_csa.py
@@ -68,6 +68,14 @@ import onnx_ir as ir
 from onnxscript import OpBuilder
 
 from mobius._configs import ArchitectureConfig
+from mobius.integrations._block_quant import (
+    MXFP4_MICROSCALE_BLOCK,
+    BlockQuantExportError,
+    BlockQuantScheme,
+    QuantizedTensorDescriptor,
+    QuantKind,
+    runtime_representation_gap,
+)
 
 # Frozen op identity -------------------------------------------------------
 CSA_OP_TYPE = "CompressedSparseAttention"
@@ -412,6 +420,125 @@ def plan_native_csa(
     if ratio == HCA_COMPRESSION_RATIO:
         return _plan_ratio128(config, layer_id, num_heads, head_dim, qk_rope_head_dim)
     return _plan_ratio4(config, layer_id, num_heads, head_dim, qk_rope_head_dim)
+
+
+# Runtime-capability gate --------------------------------------------------
+#
+# Graph construction for a native-CSA export of the block-scaled-FP8 /
+# packed-FP4 DeepSeek-V4-Flash checkpoint is allowed to *progress* (the
+# ``ArchitectureConfig`` records the deferred ``block_quant_scheme`` rather than
+# rejecting at config resolution), so the CSA nodes and their compressed state
+# IO are built and inspectable. The *runnable* full export, however, must fail
+# closed until the native ``nxrt`` runtime can actually execute the block-quant
+# weights. That capability is owned by ``mobius.integrations._block_quant``
+# (#602): ``runtime_representation_gap`` returns a precise ABI-gap string while
+# ``nxrt`` lacks a block-FP8 / planar-FP4 ``BlockFormat`` and ``None`` once the
+# real format strings land -- at which point this gate opens automatically with
+# no change here.
+
+
+def _representative_block_fp8_descriptor(
+    scheme: BlockQuantScheme,
+) -> QuantizedTensorDescriptor:
+    """A property-faithful stand-in for a block-FP8 projection tensor.
+
+    Only the fields ``runtime_representation_gap`` reads for a ``BLOCK_FP8``
+    tensor need be meaningful; the shapes are placeholders (the gate is a
+    capability probe, not an emission).
+    """
+    block = tuple(int(x) for x in scheme.weight_block_size) or (128, 128)
+    return QuantizedTensorDescriptor(
+        name="model.layers.*.self_attn.kv_proj.weight",
+        kind=QuantKind.BLOCK_FP8,
+        weight_dtype=scheme.weight_fmt or "e4m3",
+        logical_shape=(0, 0),
+        packed_shape=(0, 0),
+        weight_num_bytes=0,
+        is_routed_expert=False,
+        is_shared_expert=False,
+        block_shape=block,
+        scale_dtype=scheme.scale_fmt or "ue8m0",
+        scale_shape=(0, 0),
+        scale_layout="2d_block",
+    )
+
+
+def _representative_fp4_expert_descriptor(
+    scheme: BlockQuantScheme,
+) -> QuantizedTensorDescriptor:
+    """A property-faithful stand-in for a packed-FP4 routed-expert tensor."""
+    return QuantizedTensorDescriptor(
+        name="model.layers.*.mlp.experts.*.gate_proj.weight",
+        kind=QuantKind.FP4_PACKED,
+        weight_dtype=scheme.expert_dtype or "fp4",
+        logical_shape=(0, 0),
+        packed_shape=(0, 0),
+        weight_num_bytes=0,
+        is_routed_expert=True,
+        is_shared_expert=False,
+        block_shape=(MXFP4_MICROSCALE_BLOCK,),
+        scale_dtype="ue8m0",
+        scale_shape=(0, 0),
+        scale_layout="planar_microscale",
+        microscale_kind="mxfp4",
+    )
+
+
+def native_runtime_block_quant_gap(
+    scheme: BlockQuantScheme | None, *, runtime: str = "nxrt"
+) -> str | None:
+    """Return a runtime ABI-gap string if *runtime* cannot execute *scheme*.
+
+    ``None`` means the gate is open (either there is no owned block-quant
+    scheme, or the runtime can now represent every family it needs). Consumes
+    ``mobius.integrations._block_quant.runtime_representation_gap`` so this gate
+    tracks the real ``nxrt`` format strings and opens with no change here.
+    """
+    if scheme is None or not scheme.is_owned:
+        return None
+    gaps: list[str] = []
+    if scheme.is_block_scaled_fp8:
+        gaps.append(
+            runtime_representation_gap(
+                _representative_block_fp8_descriptor(scheme), runtime=runtime
+            )
+            or ""
+        )
+    if scheme.has_packed_fp4_experts:
+        gaps.append(
+            runtime_representation_gap(
+                _representative_fp4_expert_descriptor(scheme), runtime=runtime
+            )
+            or ""
+        )
+    gaps = [g for g in gaps if g]
+    return "\n".join(gaps) if gaps else None
+
+
+def assert_native_runtime_supports_block_quant(
+    config: ArchitectureConfig, *, runtime: str = "nxrt"
+) -> None:
+    """Full-export runtime-capability gate for a deferred block-quant scheme.
+
+    No-op unless ``config.block_quant_scheme`` is set (only ``from_transformers``
+    records it, and only when ``native_csa`` deferred #602's config-resolution
+    reject). Raises the typed :class:`BlockQuantExportError` -- fail-closed,
+    never a silent dense fallback -- while *runtime* cannot execute the
+    checkpoint's block-FP8 / planar-FP4 weights.
+    """
+    scheme = getattr(config, "block_quant_scheme", None)
+    gap = native_runtime_block_quant_gap(scheme, runtime=runtime)
+    if gap is None:
+        return
+    raise BlockQuantExportError(
+        "native CSA full export requires a runtime that can execute the "
+        f"checkpoint's block-quant weights, but {runtime!r} cannot yet. Graph "
+        "construction progressed (CSA nodes + compressed state IO are built), "
+        "but the runnable export is blocked until the native block-FP8 / "
+        "planar-FP4 format strings land (mobius.integrations._block_quant."
+        "runtime_representation_gap / plan_routed_expert_bank). ABI gap:\n"
+        f"{gap}"
+    )
 
 
 def _register_domain(op: OpBuilder) -> None:

--- a/src/mobius/models/_deepseek_v4_csa.py
+++ b/src/mobius/models/_deepseek_v4_csa.py
@@ -1,0 +1,316 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Native DeepSeek-V4 CSA/HCA export gate and op emission (C1: ratio-128 HCA).
+
+The frozen ``pkg.nxrt::CompressedSparseAttention`` v1 kernel already exists,
+is merged, and is op-parity-tested in ``onnx-genai``
+(``crates/onnx-runtime-ep-cpu/src/kernels/compressed_sparse_attention.rs``).
+This module is the Mobius *export* side of the first integration slice (C1):
+it emits that op -- for the ratio-128 "Heavily Compressed Attention" (HCA)
+subset only -- in place of the dense correctness fallback, behind the
+default-off ``config.native_csa`` opt-in.
+
+Design record: ``onnx-genai/.squad/decisions/inbox/`` ``deckard-deepseek-v4-
+csa-hca-cuda-slice.md`` (§5 property ABI, §10 slice C1). The authoritative
+op contract is the Rust factory/shape-inference:
+
+* required inputs (order): ``query, current_kv, compressor_kv,
+  compressor_gate, compressor_ape, compressor_norm, past_compressed_kv,
+  past_compression_carry, seqlens_k, total_sequence_length, head_sink``;
+* ratio-128 outputs (exactly 3): ``Y, present_compressed_kv,
+  present_compression_carry``;
+* attributes ``num_heads, head_dim, qk_rope_head_dim, compression_ratio=128,
+  index_num_heads=index_head_dim=index_topk=0, causal=1,
+  cache_layout_version=1, index_layout_version=1, sink_mode='logit_only',
+  cache_format, scale`` (``scale=0`` selects ``1/sqrt(head_dim)``).
+
+This is a **property gate, not a model-name allowlist**: emission requires the
+config-derived properties to match the frozen v1 ratio-128 contract exactly.
+Anything the frozen op cannot express when the feature is requested -- ratio-4
+CSA, MTP recurrence, quantized compressor projections, an unknown per-layer
+ratio, or a carry/state shape that does not match -- raises
+:class:`NativeCsaExportError` rather than silently emitting the dense fallback.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import onnx_ir as ir
+from onnxscript import OpBuilder
+
+from mobius._configs import ArchitectureConfig
+
+# Frozen op identity -------------------------------------------------------
+CSA_OP_TYPE = "CompressedSparseAttention"
+CSA_DOMAIN = "pkg.nxrt"
+CSA_OPSET_VERSION = 1
+# Matches ``LAYOUT_VERSION`` in the Rust kernel; the op rejects any other
+# ``cache_layout_version``/``index_layout_version``.
+CSA_LAYOUT_VERSION = 1
+
+# The two compression ratios the frozen v1 op accepts.
+HCA_COMPRESSION_RATIO = 128  # compressor-only "Heavily Compressed Attention"
+CSA_COMPRESSION_RATIO = 4  # compressor + learned FP4 indexer + top-k
+
+# ``past_compression_carry`` packs two planes per slot: the FP32 pooling
+# accumulator and the FP32 running score-state (``-inf`` initialised).
+CSA_CARRY_PLANES = 2
+
+# v1 requires ``sink_mode='logit_only'`` for the learned per-head ``head_sink``
+# denominator term, and ratio-128 attention-compressor records are stored as
+# f32 (or the hybrid FP8/BF16 device format, out of scope for C1).
+CSA_SINK_MODE = "logit_only"
+HCA_CACHE_FORMAT_F32 = "f32"
+
+# ``scale=0`` is the frozen-op sentinel for ``1/sqrt(head_dim)`` (the Rust
+# kernel: ``if configured_scale == 0.0 { 1/sqrt(head_dim) }``), matching the
+# op-parity test which omits the attribute entirely.
+CSA_DEFAULT_SCALE_SENTINEL = 0.0
+
+# Authoritative required-input order for the frozen v1 ratio-128 schema.
+HCA_INPUT_NAMES: tuple[str, ...] = (
+    "query",
+    "current_kv",
+    "compressor_kv",
+    "compressor_gate",
+    "compressor_ape",
+    "compressor_norm",
+    "past_compressed_kv",
+    "past_compression_carry",
+    "seqlens_k",
+    "total_sequence_length",
+    "head_sink",
+)
+HCA_OUTPUT_NAMES: tuple[str, ...] = (
+    "Y",
+    "present_compressed_kv",
+    "present_compression_carry",
+)
+
+
+class NativeCsaExportError(ValueError):
+    """Native CSA/HCA export was requested but cannot be satisfied.
+
+    Raised (fail-closed) instead of silently emitting the dense correctness
+    fallback whenever ``config.native_csa`` is set but a layer does not match
+    the frozen ``pkg.nxrt::CompressedSparseAttention`` v1 ratio-128 contract.
+    """
+
+
+@dataclasses.dataclass(frozen=True)
+class HcaLayerPlan:
+    """Resolved, contract-checked ratio-128 emission plan for one layer.
+
+    Every field is a native-op *property*, derived from the architecture
+    config and validated against the frozen v1 ratio-128 schema. The
+    deterministic state IO names let the graph task thread
+    ``past_* -> present_*`` compressed state without guessing.
+    """
+
+    layer_id: int
+    num_heads: int
+    head_dim: int
+    qk_rope_head_dim: int
+    cache_format: str
+    stored_width: int
+    scale: float = CSA_DEFAULT_SCALE_SENTINEL
+    compression_ratio: int = HCA_COMPRESSION_RATIO
+    carry_slots: int = HCA_COMPRESSION_RATIO
+    carry_planes: int = CSA_CARRY_PLANES
+
+    @property
+    def past_compressed_kv_name(self) -> str:
+        return f"past_compressed_kv.{self.layer_id}"
+
+    @property
+    def past_compression_carry_name(self) -> str:
+        return f"past_compression_carry.{self.layer_id}"
+
+    @property
+    def present_compressed_kv_name(self) -> str:
+        return f"present_compressed_kv.{self.layer_id}"
+
+    @property
+    def present_compression_carry_name(self) -> str:
+        return f"present_compression_carry.{self.layer_id}"
+
+
+def _hca_stored_width(cache_format: str, head_dim: int, qk_rope_head_dim: int) -> int:
+    """Per-record byte/element width of ``past_compressed_kv`` for a format.
+
+    Mirrors ``CacheFormat::stored_width`` in the Rust kernel. C1 only emits
+    the ``f32`` format (records stored as full ``head_dim`` f32 rows); the
+    device FP8 hybrid format is validated by the runtime slice, not here.
+    """
+    if cache_format == HCA_CACHE_FORMAT_F32:
+        return head_dim
+    raise NativeCsaExportError(
+        f"native CSA C1 only emits cache_format='{HCA_CACHE_FORMAT_F32}' for "
+        f"ratio-{HCA_COMPRESSION_RATIO}; '{cache_format}' is a device-side "
+        "format handled by the runtime slice, not the exporter"
+    )
+
+
+def _layer_compress_ratio(config: ArchitectureConfig, layer_id: int) -> int:
+    ratios = config.compress_ratios or []
+    return ratios[layer_id] if layer_id < len(ratios) else 0
+
+
+def plan_native_csa(
+    config: ArchitectureConfig,
+    layer_id: int,
+    *,
+    is_mtp: bool = False,
+) -> HcaLayerPlan | None:
+    """Resolve a layer's native-CSA emission plan, or ``None`` for dense.
+
+    Returns ``None`` when the feature is off, or when the layer is genuinely
+    a dense (ratio-0) attention layer -- those are *not* a suppressed CSA
+    fallback, they carry no compressor at all.
+
+    Raises :class:`NativeCsaExportError` when the feature is requested but the
+    layer cannot be expressed by the frozen ratio-128 op: ratio-4 CSA, an MTP
+    layer that would need compressed-state recurrence (undefined in the pinned
+    source), quantized compressor projections, an unknown ratio, or head/rope
+    dims that violate the op contract.
+    """
+    if not config.native_csa:
+        return None
+
+    ratio = _layer_compress_ratio(config, layer_id)
+    if ratio == 0:
+        # A genuine dense/sliding layer (schedule value 0). No compressor
+        # exists to route through the op; dense emission here is correct, not
+        # a silent CSA fallback.
+        return None
+
+    if is_mtp:
+        # The pinned checkpoint's MTP block is ratio-0 dense and its
+        # recurrence/acceptance/KV-lifetime is undefined in source (design
+        # blocker B5). A compressed MTP layer must never be invented.
+        raise NativeCsaExportError(
+            f"native CSA requested for MTP layer {layer_id} with "
+            f"compression_ratio={ratio}; MTP compressed-state recurrence is "
+            "undefined in the pinned DeepSeek-V4 source and must not be "
+            "synthesised (design blocker B5). MTP stays ratio-0 dense"
+        )
+
+    if ratio == CSA_COMPRESSION_RATIO:
+        raise NativeCsaExportError(
+            f"native CSA requested for ratio-{CSA_COMPRESSION_RATIO} (learned "
+            f"FP4 indexer + top-k) layer {layer_id}; the exporter's C1 slice "
+            f"only emits the ratio-{HCA_COMPRESSION_RATIO} (HCA) subset. "
+            "ratio-4 selection/top-k tensors are a follow-up slice"
+        )
+
+    if ratio != HCA_COMPRESSION_RATIO:
+        raise NativeCsaExportError(
+            f"layer {layer_id} has compression_ratio={ratio}; the frozen "
+            f"pkg.nxrt::CompressedSparseAttention v1 op accepts only "
+            f"{CSA_COMPRESSION_RATIO} or {HCA_COMPRESSION_RATIO}"
+        )
+
+    quantization = config.quantization
+    if quantization is not None and quantization.quant_method != "none":
+        raise NativeCsaExportError(
+            f"native CSA requested for layer {layer_id} under quantization "
+            f"'{quantization.quant_method}'; the frozen op consumes f32 "
+            "compressor activations and C1 only wires unquantized compressor "
+            "projections. Quantized compressor dequant is a follow-up slice"
+        )
+
+    head_dim = config.head_dim
+    if head_dim is None or head_dim <= 0:
+        raise NativeCsaExportError(
+            f"native CSA layer {layer_id} requires a positive head_dim, got {head_dim}"
+        )
+    num_heads = config.num_attention_heads
+    if num_heads is None or num_heads <= 0:
+        raise NativeCsaExportError(
+            f"native CSA layer {layer_id} requires positive num_attention_"
+            f"heads, got {num_heads}"
+        )
+    qk_rope_head_dim = config.qk_rope_head_dim or 0
+    if qk_rope_head_dim < 0 or qk_rope_head_dim > head_dim:
+        raise NativeCsaExportError(
+            f"native CSA layer {layer_id} requires 0 <= qk_rope_head_dim <= "
+            f"head_dim ({head_dim}), got {qk_rope_head_dim}"
+        )
+
+    cache_format = HCA_CACHE_FORMAT_F32
+    stored_width = _hca_stored_width(cache_format, head_dim, qk_rope_head_dim)
+    return HcaLayerPlan(
+        layer_id=layer_id,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        qk_rope_head_dim=qk_rope_head_dim,
+        cache_format=cache_format,
+        stored_width=stored_width,
+    )
+
+
+def _register_domain(op: OpBuilder) -> None:
+    """Declare the ``pkg.nxrt`` opset import the ONNX checker requires.
+
+    Custom-domain nodes need a matching ``opset_imports`` entry (the op call
+    does not add it automatically), same as ``BlockQuantizedMatMul`` in
+    ``components/_quantized_linear.py`` and ``IndexShare`` in
+    ``models/glm_moe_dsa.py``.
+    """
+    op.builder.graph.opset_imports[CSA_DOMAIN] = CSA_OPSET_VERSION
+
+
+def emit_hca_attention(
+    op: OpBuilder,
+    plan: HcaLayerPlan,
+    *,
+    query: ir.Value,
+    current_kv: ir.Value,
+    compressor_kv: ir.Value,
+    compressor_gate: ir.Value,
+    compressor_ape: ir.Value,
+    compressor_norm: ir.Value,
+    past_compressed_kv: ir.Value,
+    past_compression_carry: ir.Value,
+    seqlens_k: ir.Value,
+    total_sequence_length: ir.Value,
+    head_sink: ir.Value,
+) -> tuple[ir.Value, ir.Value, ir.Value]:
+    """Emit one frozen ratio-128 ``pkg.nxrt::CompressedSparseAttention`` node.
+
+    Callers pass already-shaped, f32 activations in the frozen input order;
+    this only stamps the domain import and the full attribute set. Returns
+    ``(Y, present_compressed_kv, present_compression_carry)``.
+    """
+    _register_domain(op)
+    y, present_compressed_kv, present_compression_carry = op.CompressedSparseAttention(
+        query,
+        current_kv,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm,
+        past_compressed_kv,
+        past_compression_carry,
+        seqlens_k,
+        total_sequence_length,
+        head_sink,
+        num_heads=plan.num_heads,
+        head_dim=plan.head_dim,
+        qk_rope_head_dim=plan.qk_rope_head_dim,
+        compression_ratio=plan.compression_ratio,
+        index_num_heads=0,
+        index_head_dim=0,
+        index_topk=0,
+        causal=1,
+        cache_layout_version=CSA_LAYOUT_VERSION,
+        index_layout_version=CSA_LAYOUT_VERSION,
+        sink_mode=CSA_SINK_MODE,
+        cache_format=plan.cache_format,
+        scale=plan.scale,
+        _domain=CSA_DOMAIN,
+        _outputs=3,
+    )
+    return y, present_compressed_kv, present_compression_carry

--- a/src/mobius/models/_deepseek_v4_csa.py
+++ b/src/mobius/models/_deepseek_v4_csa.py
@@ -1,36 +1,63 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Native DeepSeek-V4 CSA/HCA export gate and op emission (C1: ratio-128 HCA).
+"""Native DeepSeek-V4 CSA/HCA export gate and op emission.
 
 The frozen ``pkg.nxrt::CompressedSparseAttention`` v1 kernel already exists,
 is merged, and is op-parity-tested in ``onnx-genai``
 (``crates/onnx-runtime-ep-cpu/src/kernels/compressed_sparse_attention.rs``).
-This module is the Mobius *export* side of the first integration slice (C1):
-it emits that op -- for the ratio-128 "Heavily Compressed Attention" (HCA)
-subset only -- in place of the dense correctness fallback, behind the
-default-off ``config.native_csa`` opt-in.
+This module is the Mobius *export* side of the native integration: it emits
+that op -- for both compression ratios the official ``deepseek-ai/DeepSeek-V4
+-Flash`` schedule interleaves -- in place of the dense correctness fallback,
+behind the default-off ``config.native_csa`` opt-in.
+
+* ratio-128 "Heavily Compressed Attention" (HCA): compressor-only, f32 cache,
+  11 inputs / 3 outputs;
+* ratio-4 CSA: compressor + a learned FP4 indexer with top-k selection,
+  fp8_e4m3_block64 attention cache + fp4_e2m1_block32 index cache, 19 inputs /
+  6 outputs.
 
 Design record: ``onnx-genai/.squad/decisions/inbox/`` ``deckard-deepseek-v4-
-csa-hca-cuda-slice.md`` (§5 property ABI, §10 slice C1). The authoritative
-op contract is the Rust factory/shape-inference:
+csa-hca-cuda-slice.md`` (§5 property ABI) and ``deckard-csa-hca-c2-ratio4-
+export.md`` (ratio-4 contract). The authoritative op contract is the Rust
+factory/shape-inference:
 
-* required inputs (order): ``query, current_kv, compressor_kv,
-  compressor_gate, compressor_ape, compressor_norm, past_compressed_kv,
-  past_compression_carry, seqlens_k, total_sequence_length, head_sink``;
+* required inputs (both ratios, order 0-10): ``query, current_kv,
+  compressor_kv, compressor_gate, compressor_ape, compressor_norm,
+  past_compressed_kv, past_compression_carry, seqlens_k,
+  total_sequence_length, head_sink``;
+* ratio-4 additionally appends (order 11-18): ``index_query, index_weight,
+  index_compressor_kv, index_compressor_gate, index_compressor_ape,
+  index_compressor_norm, past_index_key, past_index_carry``;
 * ratio-128 outputs (exactly 3): ``Y, present_compressed_kv,
   present_compression_carry``;
-* attributes ``num_heads, head_dim, qk_rope_head_dim, compression_ratio=128,
-  index_num_heads=index_head_dim=index_topk=0, causal=1,
+* ratio-4 outputs (6): the three above plus ``present_index_key,
+  present_index_carry, selected_indices``;
+* attributes ``num_heads, head_dim, qk_rope_head_dim, compression_ratio,
+  index_num_heads, index_head_dim, index_topk, causal=1,
   cache_layout_version=1, index_layout_version=1, sink_mode='logit_only',
-  cache_format, scale`` (``scale=0`` selects ``1/sqrt(head_dim)``).
+  cache_format, scale`` (``scale=0`` selects ``1/sqrt(head_dim)``);
+  ``index_*`` attrs are ``0`` for ratio-128.
 
 This is a **property gate, not a model-name allowlist**: emission requires the
-config-derived properties to match the frozen v1 ratio-128 contract exactly.
-Anything the frozen op cannot express when the feature is requested -- ratio-4
-CSA, MTP recurrence, quantized compressor projections, an unknown per-layer
-ratio, or a carry/state shape that does not match -- raises
-:class:`NativeCsaExportError` rather than silently emitting the dense fallback.
+config-derived properties to match the frozen v1 contract exactly. Anything the
+frozen op cannot express when the feature is requested -- MTP recurrence, an
+unknown per-layer ratio, quantized compressor projections, or a carry/state
+shape that does not match -- raises :class:`NativeCsaExportError` rather than
+silently emitting the dense fallback.
+
+Semantic conventions the exporter honours (from the frozen kernel):
+
+* ``query``/``current_kv`` are fed *pre-rotated* (compressed RoPE theta), the
+  same as every dense path; the op rotates only its *compressed records*
+  internally.
+* ALL compressor and indexer activations are fed *raw*, including
+  ``index_query``: ``finalize_index_query`` in the kernel applies the
+  compressed RoPE + Hadamard + FP4 round-trip to the index query internally.
+* Learned top-k tie ordering and the unselected-slot sentinel (``-1``) are
+  runtime-frozen; ties raise a typed ``unsupported`` error in the kernel. The
+  exporter passes learned tensors through unmodified and never influences the
+  selection, so CPU/CUDA oracle bit-parity is preserved by construction.
 """
 
 from __future__ import annotations
@@ -54,23 +81,42 @@ CSA_LAYOUT_VERSION = 1
 HCA_COMPRESSION_RATIO = 128  # compressor-only "Heavily Compressed Attention"
 CSA_COMPRESSION_RATIO = 4  # compressor + learned FP4 indexer + top-k
 
-# ``past_compression_carry`` packs two planes per slot: the FP32 pooling
-# accumulator and the FP32 running score-state (``-inf`` initialised).
+# ``past_compression_carry``/``past_index_carry`` pack two planes per slot: the
+# FP32 pooling accumulator and the FP32 running score-state (``-inf`` init).
 CSA_CARRY_PLANES = 2
+# Ratio-128 carries one pooling slot per compressed block (``ratio`` slots);
+# ratio-4 carries a fixed 8-slot overlap window for both attention and index
+# compressors (``CARRY_SLOTS`` in the Rust kernel's ``execute_ratio4``).
+RATIO4_CARRY_SLOTS = 8
 
 # v1 requires ``sink_mode='logit_only'`` for the learned per-head ``head_sink``
-# denominator term, and ratio-128 attention-compressor records are stored as
-# f32 (or the hybrid FP8/BF16 device format, out of scope for C1).
+# denominator term.
 CSA_SINK_MODE = "logit_only"
+
+# Cache formats. Ratio-128 attention-compressor records are f32; ratio-4
+# requires the packed hybrid FP8/BF16 attention record format and the packed
+# FP4 index-key format.
 HCA_CACHE_FORMAT_F32 = "f32"
+CSA_CACHE_FORMAT_FP8 = "fp8_e4m3_block64"
+CSA_INDEX_CACHE_FORMAT_FP4 = "fp4_e2m1_block32"
+
+# Packed-record block geometry, mirroring the Rust kernel constants.
+# fp8_e4m3_block64: each 64-wide non-RoPE block stores 1 E8M0 scale byte + 64
+# E4M3 bytes (= 65), plus a little-endian BF16 (2-byte) tail for each RoPE dim.
+_FP8_BLOCK = 64
+_FP8_BYTES_PER_BLOCK = _FP8_BLOCK + 1
+# fp4_e2m1_block32: each 32-wide block stores 1 E8M0 scale byte + 16
+# adjacent-nibble bytes (= 17).
+_FP4_BLOCK = 32
+_FP4_BYTES_PER_BLOCK = 17
 
 # ``scale=0`` is the frozen-op sentinel for ``1/sqrt(head_dim)`` (the Rust
 # kernel: ``if configured_scale == 0.0 { 1/sqrt(head_dim) }``), matching the
 # op-parity test which omits the attribute entirely.
 CSA_DEFAULT_SCALE_SENTINEL = 0.0
 
-# Authoritative required-input order for the frozen v1 ratio-128 schema.
-HCA_INPUT_NAMES: tuple[str, ...] = (
+# Authoritative required-input order shared by both ratios (positions 0-10).
+CSA_BASE_INPUT_NAMES: tuple[str, ...] = (
     "query",
     "current_kv",
     "compressor_kv",
@@ -83,10 +129,30 @@ HCA_INPUT_NAMES: tuple[str, ...] = (
     "total_sequence_length",
     "head_sink",
 )
+# Ratio-4 appends the learned-indexer inputs (positions 11-18).
+CSA_INDEX_INPUT_NAMES: tuple[str, ...] = (
+    "index_query",
+    "index_weight",
+    "index_compressor_kv",
+    "index_compressor_gate",
+    "index_compressor_ape",
+    "index_compressor_norm",
+    "past_index_key",
+    "past_index_carry",
+)
+HCA_INPUT_NAMES: tuple[str, ...] = CSA_BASE_INPUT_NAMES
+CSA_RATIO4_INPUT_NAMES: tuple[str, ...] = CSA_BASE_INPUT_NAMES + CSA_INDEX_INPUT_NAMES
+
 HCA_OUTPUT_NAMES: tuple[str, ...] = (
     "Y",
     "present_compressed_kv",
     "present_compression_carry",
+)
+CSA_RATIO4_OUTPUT_NAMES: tuple[str, ...] = (
+    *HCA_OUTPUT_NAMES,
+    "present_index_key",
+    "present_index_carry",
+    "selected_indices",
 )
 
 
@@ -95,31 +161,84 @@ class NativeCsaExportError(ValueError):
 
     Raised (fail-closed) instead of silently emitting the dense correctness
     fallback whenever ``config.native_csa`` is set but a layer does not match
-    the frozen ``pkg.nxrt::CompressedSparseAttention`` v1 ratio-128 contract.
+    the frozen ``pkg.nxrt::CompressedSparseAttention`` v1 contract.
     """
+
+
+def _fp8_block64_width(head_dim: int, qk_rope_head_dim: int) -> int:
+    """Packed ``fp8_e4m3_block64`` attention record width.
+
+    Mirrors ``CacheFormat::Fp8E4m3Block64::stored_width``: the non-RoPE head
+    dimension is packed in 64-wide E4M3 blocks (65 bytes each) and the RoPE
+    tail is stored as little-endian BF16 (2 bytes per dim).
+    """
+    non_rope = head_dim - qk_rope_head_dim
+    if non_rope < 0 or non_rope % _FP8_BLOCK != 0:
+        raise NativeCsaExportError(
+            f"ratio-{CSA_COMPRESSION_RATIO} cache_format='{CSA_CACHE_FORMAT_FP8}' "
+            f"requires (head_dim - qk_rope_head_dim) >= 0 and divisible by "
+            f"{_FP8_BLOCK}; got head_dim={head_dim}, qk_rope_head_dim="
+            f"{qk_rope_head_dim} (non-RoPE width {non_rope})"
+        )
+    return (non_rope // _FP8_BLOCK) * _FP8_BYTES_PER_BLOCK + qk_rope_head_dim * 2
+
+
+def _fp4_width(logical_width: int) -> int:
+    """Packed ``fp4_e2m1_block32`` record width.
+
+    Mirrors ``fp4_width``: each 32-wide block stores 1 E8M0 scale byte + 16
+    adjacent-nibble bytes (17 bytes).
+    """
+    if logical_width <= 0 or logical_width % _FP4_BLOCK != 0:
+        raise NativeCsaExportError(
+            f"ratio-{CSA_COMPRESSION_RATIO} index cache_format="
+            f"'{CSA_INDEX_CACHE_FORMAT_FP4}' requires a positive width divisible "
+            f"by {_FP4_BLOCK}; got {logical_width}"
+        )
+    return (logical_width // _FP4_BLOCK) * _FP4_BYTES_PER_BLOCK
 
 
 @dataclasses.dataclass(frozen=True)
-class HcaLayerPlan:
-    """Resolved, contract-checked ratio-128 emission plan for one layer.
+class CsaLayerPlan:
+    """Resolved, contract-checked native emission plan for one layer.
 
     Every field is a native-op *property*, derived from the architecture
-    config and validated against the frozen v1 ratio-128 schema. The
-    deterministic state IO names let the graph task thread
-    ``past_* -> present_*`` compressed state without guessing.
+    config and validated against the frozen v1 schema. The deterministic state
+    IO names let the graph task thread ``past_* -> present_*`` compressed
+    (and, for ratio-4, index) state without guessing.
+
+    ``compressor_width`` doubles as the ``past_compression_carry`` trailing
+    width: ratio-128 pools single-record blocks (``head_dim``) while ratio-4
+    pools overlapping key+value records (``2 * head_dim``). ``index_*`` fields
+    are ``0``/empty for ratio-128.
     """
 
     layer_id: int
+    compression_ratio: int
     num_heads: int
     head_dim: int
     qk_rope_head_dim: int
     cache_format: str
+    cache_dtype: ir.DataType
     stored_width: int
-    scale: float = CSA_DEFAULT_SCALE_SENTINEL
-    compression_ratio: int = HCA_COMPRESSION_RATIO
-    carry_slots: int = HCA_COMPRESSION_RATIO
+    compressor_width: int
+    carry_slots: int
     carry_planes: int = CSA_CARRY_PLANES
+    scale: float = CSA_DEFAULT_SCALE_SENTINEL
+    # Ratio-4 learned indexer properties (0/empty for ratio-128).
+    index_num_heads: int = 0
+    index_head_dim: int = 0
+    index_topk: int = 0
+    index_stored_width: int = 0
+    index_compressor_width: int = 0
+    index_cache_format: str = ""
+    index_key_dtype: ir.DataType | None = None
 
+    @property
+    def is_ratio4(self) -> bool:
+        return self.compression_ratio == CSA_COMPRESSION_RATIO
+
+    # -- shared compressed-state IO names ---------------------------------
     @property
     def past_compressed_kv_name(self) -> str:
         return f"past_compressed_kv.{self.layer_id}"
@@ -136,21 +255,26 @@ class HcaLayerPlan:
     def present_compression_carry_name(self) -> str:
         return f"present_compression_carry.{self.layer_id}"
 
+    # -- ratio-4 index-state IO names -------------------------------------
+    @property
+    def past_index_key_name(self) -> str:
+        return f"past_index_key.{self.layer_id}"
 
-def _hca_stored_width(cache_format: str, head_dim: int, qk_rope_head_dim: int) -> int:
-    """Per-record byte/element width of ``past_compressed_kv`` for a format.
+    @property
+    def past_index_carry_name(self) -> str:
+        return f"past_index_carry.{self.layer_id}"
 
-    Mirrors ``CacheFormat::stored_width`` in the Rust kernel. C1 only emits
-    the ``f32`` format (records stored as full ``head_dim`` f32 rows); the
-    device FP8 hybrid format is validated by the runtime slice, not here.
-    """
-    if cache_format == HCA_CACHE_FORMAT_F32:
-        return head_dim
-    raise NativeCsaExportError(
-        f"native CSA C1 only emits cache_format='{HCA_CACHE_FORMAT_F32}' for "
-        f"ratio-{HCA_COMPRESSION_RATIO}; '{cache_format}' is a device-side "
-        "format handled by the runtime slice, not the exporter"
-    )
+    @property
+    def present_index_key_name(self) -> str:
+        return f"present_index_key.{self.layer_id}"
+
+    @property
+    def present_index_carry_name(self) -> str:
+        return f"present_index_carry.{self.layer_id}"
+
+    @property
+    def selected_indices_name(self) -> str:
+        return f"selected_indices.{self.layer_id}"
 
 
 def _layer_compress_ratio(config: ArchitectureConfig, layer_id: int) -> int:
@@ -158,23 +282,85 @@ def _layer_compress_ratio(config: ArchitectureConfig, layer_id: int) -> int:
     return ratios[layer_id] if layer_id < len(ratios) else 0
 
 
+def _require_positive(value, name: str, layer_id: int) -> int:
+    if value is None or value <= 0:
+        raise NativeCsaExportError(
+            f"native CSA layer {layer_id} requires a positive {name}, got {value}"
+        )
+    return value
+
+
+def _plan_ratio128(
+    config: ArchitectureConfig,
+    layer_id: int,
+    num_heads: int,
+    head_dim: int,
+    qk_rope_head_dim: int,
+) -> CsaLayerPlan:
+    return CsaLayerPlan(
+        layer_id=layer_id,
+        compression_ratio=HCA_COMPRESSION_RATIO,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        qk_rope_head_dim=qk_rope_head_dim,
+        cache_format=HCA_CACHE_FORMAT_F32,
+        cache_dtype=ir.DataType.FLOAT,
+        stored_width=head_dim,
+        compressor_width=head_dim,
+        carry_slots=HCA_COMPRESSION_RATIO,
+    )
+
+
+def _plan_ratio4(
+    config: ArchitectureConfig,
+    layer_id: int,
+    num_heads: int,
+    head_dim: int,
+    qk_rope_head_dim: int,
+) -> CsaLayerPlan:
+    index_num_heads = _require_positive(config.index_n_heads, "index_n_heads", layer_id)
+    index_head_dim = _require_positive(config.index_head_dim, "index_head_dim", layer_id)
+    index_topk = _require_positive(config.index_topk, "index_topk", layer_id)
+    return CsaLayerPlan(
+        layer_id=layer_id,
+        compression_ratio=CSA_COMPRESSION_RATIO,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        qk_rope_head_dim=qk_rope_head_dim,
+        cache_format=CSA_CACHE_FORMAT_FP8,
+        cache_dtype=ir.DataType.UINT8,
+        stored_width=_fp8_block64_width(head_dim, qk_rope_head_dim),
+        compressor_width=2 * head_dim,
+        carry_slots=RATIO4_CARRY_SLOTS,
+        index_num_heads=index_num_heads,
+        index_head_dim=index_head_dim,
+        index_topk=index_topk,
+        index_stored_width=_fp4_width(index_head_dim),
+        index_compressor_width=2 * index_head_dim,
+        index_cache_format=CSA_INDEX_CACHE_FORMAT_FP4,
+        index_key_dtype=ir.DataType.UINT8,
+    )
+
+
 def plan_native_csa(
     config: ArchitectureConfig,
     layer_id: int,
     *,
     is_mtp: bool = False,
-) -> HcaLayerPlan | None:
+) -> CsaLayerPlan | None:
     """Resolve a layer's native-CSA emission plan, or ``None`` for dense.
 
-    Returns ``None`` when the feature is off, or when the layer is genuinely
-    a dense (ratio-0) attention layer -- those are *not* a suppressed CSA
+    Returns ``None`` when the feature is off, or when the layer is genuinely a
+    dense (ratio-0) attention layer -- those are *not* a suppressed CSA
     fallback, they carry no compressor at all.
 
-    Raises :class:`NativeCsaExportError` when the feature is requested but the
-    layer cannot be expressed by the frozen ratio-128 op: ratio-4 CSA, an MTP
-    layer that would need compressed-state recurrence (undefined in the pinned
-    source), quantized compressor projections, an unknown ratio, or head/rope
-    dims that violate the op contract.
+    Returns a :class:`CsaLayerPlan` for ratio-128 (HCA) or ratio-4 (CSA)
+    layers whose config matches the frozen op contract. Raises
+    :class:`NativeCsaExportError` when the feature is requested but the layer
+    cannot be expressed: an MTP layer that would need compressed-state
+    recurrence (undefined in the pinned source), quantized compressor
+    projections, an unknown ratio, or head/rope dims that violate the op
+    contract.
     """
     if not config.native_csa:
         return None
@@ -183,13 +369,13 @@ def plan_native_csa(
     if ratio == 0:
         # A genuine dense/sliding layer (schedule value 0). No compressor
         # exists to route through the op; dense emission here is correct, not
-        # a silent CSA fallback.
+        # a silent CSA fallback. MTP (ratio-0) also lands here and stays dense.
         return None
 
     if is_mtp:
-        # The pinned checkpoint's MTP block is ratio-0 dense and its
-        # recurrence/acceptance/KV-lifetime is undefined in source (design
-        # blocker B5). A compressed MTP layer must never be invented.
+        # The pinned checkpoint's MTP block is ratio-0 dense (handled above).
+        # A compressed MTP layer's recurrence/acceptance/KV-lifetime is
+        # undefined in source (design blocker B5) and must never be synthesised.
         raise NativeCsaExportError(
             f"native CSA requested for MTP layer {layer_id} with "
             f"compression_ratio={ratio}; MTP compressed-state recurrence is "
@@ -197,15 +383,7 @@ def plan_native_csa(
             "synthesised (design blocker B5). MTP stays ratio-0 dense"
         )
 
-    if ratio == CSA_COMPRESSION_RATIO:
-        raise NativeCsaExportError(
-            f"native CSA requested for ratio-{CSA_COMPRESSION_RATIO} (learned "
-            f"FP4 indexer + top-k) layer {layer_id}; the exporter's C1 slice "
-            f"only emits the ratio-{HCA_COMPRESSION_RATIO} (HCA) subset. "
-            "ratio-4 selection/top-k tensors are a follow-up slice"
-        )
-
-    if ratio != HCA_COMPRESSION_RATIO:
+    if ratio not in (CSA_COMPRESSION_RATIO, HCA_COMPRESSION_RATIO):
         raise NativeCsaExportError(
             f"layer {layer_id} has compression_ratio={ratio}; the frozen "
             f"pkg.nxrt::CompressedSparseAttention v1 op accepts only "
@@ -217,21 +395,13 @@ def plan_native_csa(
         raise NativeCsaExportError(
             f"native CSA requested for layer {layer_id} under quantization "
             f"'{quantization.quant_method}'; the frozen op consumes f32 "
-            "compressor activations and C1 only wires unquantized compressor "
-            "projections. Quantized compressor dequant is a follow-up slice"
+            "compressor/index activations and this slice only wires unquantized "
+            "compressor projections. Quantized compressor dequant is a "
+            "follow-up slice"
         )
 
-    head_dim = config.head_dim
-    if head_dim is None or head_dim <= 0:
-        raise NativeCsaExportError(
-            f"native CSA layer {layer_id} requires a positive head_dim, got {head_dim}"
-        )
-    num_heads = config.num_attention_heads
-    if num_heads is None or num_heads <= 0:
-        raise NativeCsaExportError(
-            f"native CSA layer {layer_id} requires positive num_attention_"
-            f"heads, got {num_heads}"
-        )
+    head_dim = _require_positive(config.head_dim, "head_dim", layer_id)
+    num_heads = _require_positive(config.num_attention_heads, "num_attention_heads", layer_id)
     qk_rope_head_dim = config.qk_rope_head_dim or 0
     if qk_rope_head_dim < 0 or qk_rope_head_dim > head_dim:
         raise NativeCsaExportError(
@@ -239,16 +409,9 @@ def plan_native_csa(
             f"head_dim ({head_dim}), got {qk_rope_head_dim}"
         )
 
-    cache_format = HCA_CACHE_FORMAT_F32
-    stored_width = _hca_stored_width(cache_format, head_dim, qk_rope_head_dim)
-    return HcaLayerPlan(
-        layer_id=layer_id,
-        num_heads=num_heads,
-        head_dim=head_dim,
-        qk_rope_head_dim=qk_rope_head_dim,
-        cache_format=cache_format,
-        stored_width=stored_width,
-    )
+    if ratio == HCA_COMPRESSION_RATIO:
+        return _plan_ratio128(config, layer_id, num_heads, head_dim, qk_rope_head_dim)
+    return _plan_ratio4(config, layer_id, num_heads, head_dim, qk_rope_head_dim)
 
 
 def _register_domain(op: OpBuilder) -> None:
@@ -262,9 +425,28 @@ def _register_domain(op: OpBuilder) -> None:
     op.builder.graph.opset_imports[CSA_DOMAIN] = CSA_OPSET_VERSION
 
 
-def emit_hca_attention(
+def _csa_attributes(plan: CsaLayerPlan) -> dict:
+    """The full frozen-v1 attribute set for a plan (index_* are 0 for HCA)."""
+    return dict(
+        num_heads=plan.num_heads,
+        head_dim=plan.head_dim,
+        qk_rope_head_dim=plan.qk_rope_head_dim,
+        compression_ratio=plan.compression_ratio,
+        index_num_heads=plan.index_num_heads,
+        index_head_dim=plan.index_head_dim,
+        index_topk=plan.index_topk,
+        causal=1,
+        cache_layout_version=CSA_LAYOUT_VERSION,
+        index_layout_version=CSA_LAYOUT_VERSION,
+        sink_mode=CSA_SINK_MODE,
+        cache_format=plan.cache_format,
+        scale=plan.scale,
+    )
+
+
+def emit_csa_attention(
     op: OpBuilder,
-    plan: HcaLayerPlan,
+    plan: CsaLayerPlan,
     *,
     query: ir.Value,
     current_kv: ir.Value,
@@ -277,15 +459,77 @@ def emit_hca_attention(
     seqlens_k: ir.Value,
     total_sequence_length: ir.Value,
     head_sink: ir.Value,
-) -> tuple[ir.Value, ir.Value, ir.Value]:
-    """Emit one frozen ratio-128 ``pkg.nxrt::CompressedSparseAttention`` node.
+    index_query: ir.Value | None = None,
+    index_weight: ir.Value | None = None,
+    index_compressor_kv: ir.Value | None = None,
+    index_compressor_gate: ir.Value | None = None,
+    index_compressor_ape: ir.Value | None = None,
+    index_compressor_norm: ir.Value | None = None,
+    past_index_key: ir.Value | None = None,
+    past_index_carry: ir.Value | None = None,
+) -> tuple[ir.Value, ...]:
+    """Emit one frozen ``pkg.nxrt::CompressedSparseAttention`` node for a plan.
 
-    Callers pass already-shaped, f32 activations in the frozen input order;
-    this only stamps the domain import and the full attribute set. Returns
-    ``(Y, present_compressed_kv, present_compression_carry)``.
+    Callers pass already-shaped activations in the frozen input order (f32 for
+    the float inputs; uint8 for the packed ratio-4 ``past_*_key`` state); this
+    only stamps the domain import and the full attribute set.
+
+    * ratio-128 (HCA): 11 inputs, returns ``(Y, present_compressed_kv,
+      present_compression_carry)``.
+    * ratio-4 (CSA): 19 inputs, returns the three above plus
+      ``(present_index_key, present_index_carry, selected_indices)``.
+
+    Requesting a ratio-4 emission without every learned-indexer input raises
+    :class:`NativeCsaExportError` -- fail-closed, never a partial/silent node.
     """
     _register_domain(op)
-    y, present_compressed_kv, present_compression_carry = op.CompressedSparseAttention(
+    attributes = _csa_attributes(plan)
+
+    if not plan.is_ratio4:
+        y, present_compressed_kv, present_compression_carry = op.CompressedSparseAttention(
+            query,
+            current_kv,
+            compressor_kv,
+            compressor_gate,
+            compressor_ape,
+            compressor_norm,
+            past_compressed_kv,
+            past_compression_carry,
+            seqlens_k,
+            total_sequence_length,
+            head_sink,
+            _domain=CSA_DOMAIN,
+            _outputs=3,
+            **attributes,
+        )
+        return y, present_compressed_kv, present_compression_carry
+
+    index_inputs = {
+        "index_query": index_query,
+        "index_weight": index_weight,
+        "index_compressor_kv": index_compressor_kv,
+        "index_compressor_gate": index_compressor_gate,
+        "index_compressor_ape": index_compressor_ape,
+        "index_compressor_norm": index_compressor_norm,
+        "past_index_key": past_index_key,
+        "past_index_carry": past_index_carry,
+    }
+    missing = [name for name, value in index_inputs.items() if value is None]
+    if missing:
+        raise NativeCsaExportError(
+            f"native CSA ratio-{CSA_COMPRESSION_RATIO} layer {plan.layer_id} "
+            f"requires the learned-indexer inputs {missing}; none may be "
+            "absent. The frozen op has no dense fallback for a partial indexer"
+        )
+
+    (
+        y,
+        present_compressed_kv,
+        present_compression_carry,
+        present_index_key,
+        present_index_carry,
+        selected_indices,
+    ) = op.CompressedSparseAttention(
         query,
         current_kv,
         compressor_kv,
@@ -297,20 +541,23 @@ def emit_hca_attention(
         seqlens_k,
         total_sequence_length,
         head_sink,
-        num_heads=plan.num_heads,
-        head_dim=plan.head_dim,
-        qk_rope_head_dim=plan.qk_rope_head_dim,
-        compression_ratio=plan.compression_ratio,
-        index_num_heads=0,
-        index_head_dim=0,
-        index_topk=0,
-        causal=1,
-        cache_layout_version=CSA_LAYOUT_VERSION,
-        index_layout_version=CSA_LAYOUT_VERSION,
-        sink_mode=CSA_SINK_MODE,
-        cache_format=plan.cache_format,
-        scale=plan.scale,
+        index_query,
+        index_weight,
+        index_compressor_kv,
+        index_compressor_gate,
+        index_compressor_ape,
+        index_compressor_norm,
+        past_index_key,
+        past_index_carry,
         _domain=CSA_DOMAIN,
-        _outputs=3,
+        _outputs=6,
+        **attributes,
     )
-    return y, present_compressed_kv, present_compression_carry
+    return (
+        y,
+        present_compressed_kv,
+        present_compression_carry,
+        present_index_key,
+        present_index_carry,
+        selected_indices,
+    )

--- a/src/mobius/models/deepseek_v4.py
+++ b/src/mobius/models/deepseek_v4.py
@@ -42,9 +42,26 @@ from mobius.components import (
 )
 from mobius.components._moe import _scatter_selected_to_full
 from mobius.components._rotary_embedding import apply_rotary_pos_emb
+from mobius.models._deepseek_v4_csa import (
+    HcaLayerPlan,
+    NativeCsaExportError,
+    emit_hca_attention,
+    plan_native_csa,
+)
 from mobius.models.base import CausalLMModel
 
 logger = logging.getLogger(__name__)
+
+
+def _cast_to_f32(op: OpBuilder, value: ir.Value, model_dtype: ir.DataType) -> ir.Value:
+    """Cast a model-dtype activation to FLOAT for the f32-only CSA op inputs.
+
+    No-op when the build dtype is already FLOAT so the common f32 export
+    stays Cast-free (and byte-identical to the pre-CSA graph on that path).
+    """
+    if model_dtype == ir.DataType.FLOAT:
+        return value
+    return op.Cast(value, to=ir.DataType.FLOAT)
 
 
 def _use_fused_gqa() -> bool:
@@ -155,15 +172,41 @@ class DeepSeekV4DeferredProjection(nn.Module):
                 dtype=ir.DataType.UINT8,
             )
 
-    def forward(self, op: OpBuilder) -> ir.Value:
-        return _shape_anchor(
-            op,
-            [
-                value
-                for value in (self.weight, self.scales, self.zero_points)
-                if value is not None
-            ],
-        )
+    def forward(self, op: OpBuilder, x: ir.Value | None = None) -> ir.Value:
+        """Zero-valued shape anchor (dense fallback) or the real projection.
+
+        With ``x is None`` (the deferred dense-fallback path) this emits a
+        zero-valued shape anchor that keeps the projection weight live in the
+        graph without executing it. With ``x`` supplied (the native-CSA
+        dataflow) it computes the real ``x @ weight.T`` projection so the
+        compressor activations feeding ``pkg.nxrt::CompressedSparseAttention``
+        are genuine.
+
+        Both paths run through ``forward`` (invoked via ``Module.__call__``) on
+        purpose: ``__call__`` realizes this module's parameters -- qualifies
+        each name and registers it as a graph initializer -- *before* calling
+        ``forward``. A bare helper method that used ``self.weight`` directly
+        would leave the weight unrealized (dangling, unregistered) and break
+        graph serialization. Only the unquantized weight layout is supported
+        for the real projection; a quantized compressor weight raises so
+        native CSA never silently drops the quantization.
+        """
+        if x is None:
+            return _shape_anchor(
+                op,
+                [
+                    value
+                    for value in (self.weight, self.scales, self.zero_points)
+                    if value is not None
+                ],
+            )
+        if self._gguf_quantized_linear:
+            raise NativeCsaExportError(
+                "native CSA C1 cannot project a quantized compressor weight; "
+                "the frozen op consumes f32 compressor activations. Quantized "
+                "compressor dequant is a follow-up slice"
+            )
+        return op.MatMul(x, op.Transpose(self.weight, perm=[1, 0]))
 
 
 class DeepSeekV4DeferredNorm(nn.Module):
@@ -171,7 +214,16 @@ class DeepSeekV4DeferredNorm(nn.Module):
         super().__init__()
         self.weight = nn.Parameter([hidden_size])
 
-    def forward(self, op: OpBuilder) -> ir.Value:
+    def forward(self, op: OpBuilder, *, raw: bool = False) -> ir.Value:
+        """Zero-valued shape anchor (dense fallback) or the realized weight.
+
+        ``__call__`` realizes ``self.weight`` before ``forward`` runs, so with
+        ``raw=True`` (native-CSA dataflow) the already-registered weight is
+        returned directly for the op's ``compressor_norm`` input; otherwise a
+        zero-valued shape anchor keeps the weight live without executing it.
+        """
+        if raw:
+            return self.weight
         return _shape_anchor(op, [self.weight])
 
 
@@ -366,16 +418,33 @@ class DeepSeekV4CompressorTensors(nn.Module):
         )
         self.norm = DeepSeekV4DeferredNorm(head_dim)
 
-    def forward(self, op: OpBuilder) -> ir.Value:
-        anchor = _shape_anchor(
-            op,
-            [
-                self.ape,
-            ],
-        )
-        anchor = op.Add(anchor, self.wkv(op))
-        anchor = op.Add(anchor, self.wgate(op))
-        return op.Add(anchor, self.norm(op))
+    def forward(self, op: OpBuilder, hidden_states: ir.Value | None = None):
+        """Zero-valued shape anchor (dense fallback) or live compressor tensors.
+
+        With ``hidden_states is None`` (deferred dense fallback) this emits the
+        zero-valued shape anchor that keeps ``ape``/``wkv``/``wgate``/``norm``
+        live in the graph. With ``hidden_states`` supplied (native-CSA
+        dataflow) it returns ``(compressor_kv, compressor_gate, ape,
+        norm_weight)``: ``compressor_kv``/``compressor_gate`` are the projected
+        ``W·x`` activations (``[B, S, overlap*head_dim]``) and ``ape``/the norm
+        weight are the learned parameters. Every parameter is realized here by
+        routing through each child's ``__call__`` (``self.wkv(op, ...)``,
+        ``self.norm(op, raw=True)``) and by ``__call__`` realizing ``self.ape``
+        before ``forward`` runs.
+        """
+        if hidden_states is None:
+            anchor = _shape_anchor(
+                op,
+                [
+                    self.ape,
+                ],
+            )
+            anchor = op.Add(anchor, self.wkv(op))
+            anchor = op.Add(anchor, self.wgate(op))
+            return op.Add(anchor, self.norm(op))
+        compressor_kv = self.wkv(op, hidden_states)
+        compressor_gate = self.wgate(op, hidden_states)
+        return compressor_kv, compressor_gate, self.ape, self.norm(op, raw=True)
 
 
 class DeepSeekV4IndexerTensors(nn.Module):
@@ -406,7 +475,7 @@ class DeepSeekV4IndexerTensors(nn.Module):
 class DeepSeekV4Attention(nn.Module):
     """V4 MQA projections using sink-aware dense causal attention."""
 
-    def __init__(self, config: ArchitectureConfig, layer_id: int):
+    def __init__(self, config: ArchitectureConfig, layer_id: int, *, is_mtp: bool = False):
         super().__init__()
         assert config.q_lora_rank is not None
         assert config.qk_rope_head_dim is not None
@@ -443,6 +512,7 @@ class DeepSeekV4Attention(nn.Module):
         self.eps = config.rms_norm_eps
         self.scale = self.head_dim**-0.5
         self.rope_interleave = config.rope_interleave
+        self._dtype = config.dtype
         # Official reference (`inference/model.py::Attention.forward`,
         # `get_window_topk_idxs`) unconditionally restricts every layer -
         # regardless of `compress_ratio` - to a circular-buffer local window
@@ -471,6 +541,12 @@ class DeepSeekV4Attention(nn.Module):
             else None
         )
         self.indexer = DeepSeekV4IndexerTensors(config) if self.compress_ratio == 4 else None
+        # Property gate (default off). Resolves to an HcaLayerPlan only for a
+        # ratio-128 layer whose config matches the frozen op contract, and
+        # raises NativeCsaExportError (never silent dense) for ratio-4/MTP/
+        # unsupported-quant when native CSA is requested. See
+        # mobius.models._deepseek_v4_csa.
+        self.csa_plan: HcaLayerPlan | None = plan_native_csa(config, layer_id, is_mtp=is_mtp)
 
     def _rotate(
         self,
@@ -533,6 +609,109 @@ class DeepSeekV4Attention(nn.Module):
             ),
         )
 
+    def _forward_native_hca(
+        self,
+        op: OpBuilder,
+        hidden_states: ir.Value,
+        query: ir.Value,
+        kv: ir.Value,
+        past_key_value: tuple | None,
+        past_compressed: tuple | None,
+        csa_lengths: tuple | None,
+    ) -> tuple[ir.Value, ir.Value, ir.Value, tuple[ir.Value, ir.Value]]:
+        """Emit the frozen ratio-128 HCA op for this layer (native-CSA path).
+
+        ``query``/``kv`` arrive already RoPE-rotated (compressed rope theta) by
+        the caller, exactly as the dense paths receive them; the op has no
+        cos/sin/position inputs and only rotates its *compressed records*
+        internally, so the dense-window ``query``/``current_kv`` must be
+        pre-rotated here and the shared inverse ``_rotate`` still runs on the
+        op's ``Y`` after this returns. Builds:
+
+        * ``query`` as rank-4 BSND ``[B, S, num_heads, head_dim]``;
+        * ``current_kv`` ``[B, K, head_dim]`` -- the dense sliding-window ring
+          reuses the existing dense KV IO (``past_key_values.{i}`` ->
+          ``present.{i}``), stored BNSD ``[B, 1, K, head_dim]`` (MQA, one kv
+          head) like the decomposed path, then squeezed for the op;
+        * real, *unrotated* compressor activations (the op pools then rotates
+          the compressed records internally at their block positions);
+        * the threaded ``past_* -> present_*`` compressed state.
+
+        Returns ``(output, present_key, present_value, present_compressed)``
+        with ``output`` flattened ``[B, S, num_heads*head_dim]`` in the rotated
+        frame so the caller's shared inverse ``_rotate`` + output projection
+        apply unchanged.
+        """
+        plan = self.csa_plan
+        assert plan is not None
+        if csa_lengths is None:
+            raise NativeCsaExportError(
+                f"native CSA layer {plan.layer_id} requires seqlens_k/"
+                "total_sequence_length; csa_lengths was not threaded to the "
+                "attention layer"
+            )
+        if past_compressed is None:
+            raise NativeCsaExportError(
+                f"native CSA layer {plan.layer_id} requires past_compressed_kv/"
+                "past_compression_carry state; none was threaded to the layer"
+            )
+        seqlens_k, total_seq_len = csa_lengths
+        past_compressed_kv, past_compression_carry = past_compressed
+
+        query_4d = op.Reshape(query, [0, 0, self.num_heads, self.head_dim])
+
+        # Dense sliding-window ring: present KV stored BNSD [B, 1, K, head_dim]
+        # (one MQA kv head) exactly like the decomposed path -- key and value
+        # carry identical data (MQA) but must be *distinct* graph values so the
+        # present.{i}.key/value cache outputs don't collapse onto one tensor.
+        # ``current_kv`` squeezes the head axis to [B, K, head_dim] for the op.
+        new_kv = op.Transpose(op.Reshape(kv, [0, 0, 1, self.head_dim]), perm=[0, 2, 1, 3])
+        if past_key_value is not None:
+            present_key = op.Concat(past_key_value[0], new_kv, axis=2)
+            present_value = op.Concat(past_key_value[1], new_kv, axis=2)
+        else:
+            present_key = new_kv
+            present_value = op.Identity(new_kv)
+        current_kv = op.Reshape(present_key, [0, -1, self.head_dim])
+
+        # Real, unrotated compressor activations replace the zero-valued shape
+        # anchor: wkv/wgate are live W·x projections, ape/norm are the learned
+        # parameters. Routed through the compressor's ``__call__`` so every
+        # compressor parameter is realized (named + registered as an
+        # initializer) rather than left dangling.
+        compressor_kv, compressor_gate, ape, norm_weight = self.compressor(op, hidden_states)
+
+        y, present_compressed_kv, present_compression_carry = emit_hca_attention(
+            op,
+            plan,
+            query=_cast_to_f32(op, query_4d, self._dtype),
+            current_kv=_cast_to_f32(op, current_kv, self._dtype),
+            compressor_kv=_cast_to_f32(op, compressor_kv, self._dtype),
+            compressor_gate=_cast_to_f32(op, compressor_gate, self._dtype),
+            compressor_ape=_cast_to_f32(op, ape, self._dtype),
+            compressor_norm=_cast_to_f32(op, norm_weight, self._dtype),
+            past_compressed_kv=past_compressed_kv,
+            past_compression_carry=past_compression_carry,
+            seqlens_k=seqlens_k,
+            total_sequence_length=op.Cast(total_seq_len, to=ir.DataType.INT64),
+            # ``head_sink`` is declared FLOAT but ``_cast_module_dtype`` folds
+            # it to the model dtype in a non-float build; the frozen op's
+            # ``head_sink`` is f32, so cast it back up when needed.
+            head_sink=_cast_to_f32(op, self.attn_sink, self._dtype),
+        )
+
+        # ``Y`` is [B, S, N, D] FLOAT; flatten to [B, S, N*D] and cast back to
+        # the model dtype for the shared inverse-RoPE + output projection.
+        output = op.Reshape(y, [0, 0, -1])
+        if self._dtype != ir.DataType.FLOAT:
+            output = op.Cast(output, to=self._dtype)
+        return (
+            output,
+            present_key,
+            present_value,
+            (present_compressed_kv, present_compression_carry),
+        )
+
     def forward(
         self,
         op: OpBuilder,
@@ -542,6 +721,8 @@ class DeepSeekV4Attention(nn.Module):
         attention_bias: ir.Value | None = None,
         seqlens_k: ir.Value | None = None,
         total_seq_len: ir.Value | None = None,
+        past_compressed: tuple | None = None,
+        csa_lengths: tuple | None = None,
     ):
         query = self.q_b_proj(op, self.q_a_layernorm(op, self.q_a_proj(op, hidden_states)))
         query_4d = op.Reshape(query, [0, 0, self.num_heads, self.head_dim])
@@ -557,7 +738,25 @@ class DeepSeekV4Attention(nn.Module):
         kv = self.kv_layernorm(op, self.kv_proj(op, hidden_states))
         kv = self._rotate(op, kv, position_embeddings, 1)
 
-        if seqlens_k is not None:
+        present_compressed = None
+        if self.csa_plan is not None:
+            # Native CSA/HCA path (default-off ``config.native_csa`` opt-in).
+            # Emits the frozen ratio-128 ``pkg.nxrt::CompressedSparseAttention``
+            # op instead of the dense correctness fallback; the compressor
+            # tensors are consumed as real dataflow here rather than as a
+            # zero-valued shape anchor below. ``output`` comes back flattened
+            # in the rotated frame, so the shared inverse ``_rotate`` and the
+            # output projection run unchanged.
+            output, present_key, present_value, present_compressed = self._forward_native_hca(
+                op,
+                hidden_states,
+                query,
+                kv,
+                past_key_value,
+                past_compressed,
+                csa_lengths,
+            )
+        elif seqlens_k is not None:
             # Fused causal attention core, used only when the active EP's
             # `ep_capabilities().gqa_dtypes` includes the build dtype (see
             # `_use_fused_gqa`). `query`/`kv` are already RoPE-rotated
@@ -664,7 +863,12 @@ class DeepSeekV4Attention(nn.Module):
 
         output = self._rotate(op, output, position_embeddings, self.num_heads, inverse=True)
 
-        if self.compressor is not None:
+        if self.compressor is not None and self.csa_plan is None:
+            # Zero-valued shape anchor for the dense correctness fallback,
+            # keeping the deferred compressor/indexer weights live in the
+            # graph. Skipped on the native-CSA path, where those same weights
+            # are consumed as real dataflow inside ``_forward_native_hca`` --
+            # so a native-CSA layer emits no dead anchor arithmetic.
             anchor = self.compressor(op)
             if self.indexer is not None:
                 anchor = op.Add(anchor, self.indexer(op))
@@ -689,13 +893,13 @@ class DeepSeekV4Attention(nn.Module):
                 )
             )
         output = self.o_b_proj(op, op.Concat(*projected_groups, axis=-1))
-        return output, (present_key, present_value)
+        return output, (present_key, present_value), present_compressed
 
 
 class DeepSeekV4DecoderLayer(nn.Module):
-    def __init__(self, config: ArchitectureConfig, layer_id: int):
+    def __init__(self, config: ArchitectureConfig, layer_id: int, *, is_mtp: bool = False):
         super().__init__()
-        self.self_attn = DeepSeekV4Attention(config, layer_id)
+        self.self_attn = DeepSeekV4Attention(config, layer_id, is_mtp=is_mtp)
         self.mlp = DeepSeekV4MoE(config, layer_id)
         self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
@@ -774,6 +978,8 @@ class DeepSeekV4DecoderLayer(nn.Module):
         attention_bias: ir.Value | None = None,
         seqlens_k: ir.Value | None = None,
         total_seq_len: ir.Value | None = None,
+        past_compressed: tuple | None = None,
+        csa_lengths: tuple | None = None,
     ):
         residual = hidden_states
         value, post, comb = self._hc_pre(
@@ -783,7 +989,7 @@ class DeepSeekV4DecoderLayer(nn.Module):
             self.hc_attn_scale,
             self.hc_attn_base,
         )
-        value, present = self.self_attn(
+        value, present, present_compressed = self.self_attn(
             op,
             self.input_layernorm(op, value),
             position_embeddings,
@@ -791,6 +997,8 @@ class DeepSeekV4DecoderLayer(nn.Module):
             attention_bias,
             seqlens_k,
             total_seq_len,
+            past_compressed,
+            csa_lengths,
         )
         hidden_states = self._hc_post(op, value, residual, post, comb)
 
@@ -804,7 +1012,7 @@ class DeepSeekV4DecoderLayer(nn.Module):
         )
         value = self.mlp(op, self.post_attention_layernorm(op, value), input_ids)
         hidden_states = self._hc_post(op, value, residual, post, comb)
-        return hidden_states, present
+        return hidden_states, present, present_compressed
 
 
 class DeepSeekV4TextModel(nn.Module):
@@ -851,6 +1059,7 @@ class DeepSeekV4TextModel(nn.Module):
             )
         )
         self._dtype = config.dtype
+        self.native_csa = config.native_csa
         # See `DeepSeekV4Attention.local_window_size`: the reference always
         # restricts attention to this window, so the decomposed path's
         # shared bias (built once here for every layer) must bake it in too.
@@ -879,6 +1088,7 @@ class DeepSeekV4TextModel(nn.Module):
         position_ids: ir.Value,
         past_key_values: list | None = None,
         inputs_embeds: ir.Value | None = None,
+        past_compressed_states: list | None = None,
     ):
         hidden_states = (
             inputs_embeds if inputs_embeds is not None else self.embed_tokens(op, input_ids)
@@ -901,15 +1111,30 @@ class DeepSeekV4TextModel(nn.Module):
                 dtype=self._dtype,
             )
             seqlens_k, total_seq_len = None, None
+        # The native-CSA op needs seqlens_k/total_sequence_length regardless of
+        # the dense path's fused-GQA gate. Compute them only when the feature
+        # is enabled, and reuse the fused-path lengths when that path already
+        # built them so a GQA-capable EP emits no duplicate length nodes. This
+        # intentionally does NOT feed the dense `seqlens_k` gate above: leaving
+        # it None on non-GQA EPs keeps non-CSA layers on the portable
+        # decomposed path (no stray `com.microsoft` ops on a `default` EP).
+        csa_lengths = None
+        if self.native_csa:
+            if seqlens_k is not None:
+                csa_lengths = (seqlens_k, total_seq_len)
+            else:
+                csa_lengths = _gqa_kv_lengths(op, attention_mask)
         presents = []
+        present_compressed_states = []
         past_kvs = past_key_values or [None] * len(self.layers)
-        for layer, past_kv in zip(self.layers, past_kvs):
+        past_compressed = past_compressed_states or [None] * len(self.layers)
+        for layer, past_kv, past_comp in zip(self.layers, past_kvs, past_compressed):
             layer_position_embeddings = (
                 compressed_position_embeddings
                 if layer.self_attn.compress_ratio
                 else position_embeddings
             )
-            hidden_states, present = layer(
+            hidden_states, present, present_compressed = layer(
                 op,
                 hidden_states,
                 input_ids,
@@ -918,16 +1143,24 @@ class DeepSeekV4TextModel(nn.Module):
                 attention_bias,
                 seqlens_k,
                 total_seq_len,
+                past_comp,
+                csa_lengths,
             )
             presents.append(present)
-        return self.norm(op, self._hc_head(op, hidden_states)), presents, hidden_states
+            present_compressed_states.append(present_compressed)
+        return (
+            self.norm(op, self._hc_head(op, hidden_states)),
+            presents,
+            present_compressed_states,
+            hidden_states,
+        )
 
 
 class DeepSeekV4Mtp(DeepSeekV4DecoderLayer):
     """Official single MTP block, sharing target embeddings and LM head externally."""
 
     def __init__(self, config: ArchitectureConfig, layer_id: int):
-        super().__init__(config, layer_id)
+        super().__init__(config, layer_id, is_mtp=True)
         projection = _projection_class(config)
         self.e_proj = projection(config.hidden_size, config.hidden_size, bias=False)
         self.h_proj = projection(config.hidden_size, config.hidden_size, bias=False)
@@ -991,7 +1224,7 @@ class DeepSeekV4Mtp(DeepSeekV4DecoderLayer):
                 dtype=self._dtype,
             )
             seqlens_k, total_seq_len = None, None
-        hidden_states, present = super().forward(
+        hidden_states, present, _present_compressed = super().forward(
             op,
             hidden_states,
             None,
@@ -1042,7 +1275,7 @@ class DeepSeekV4CausalLMModel(CausalLMModel):
         position_ids: ir.Value,
         past_key_values: list | None = None,
     ):
-        hidden_states, presents, _ = self.model(
+        hidden_states, presents, _present_compressed, _hc_states = self.model(
             op,
             input_ids,
             attention_mask,

--- a/src/mobius/models/deepseek_v4.py
+++ b/src/mobius/models/deepseek_v4.py
@@ -43,9 +43,9 @@ from mobius.components import (
 from mobius.components._moe import _scatter_selected_to_full
 from mobius.components._rotary_embedding import apply_rotary_pos_emb
 from mobius.models._deepseek_v4_csa import (
-    HcaLayerPlan,
+    CsaLayerPlan,
     NativeCsaExportError,
-    emit_hca_attention,
+    emit_csa_attention,
     plan_native_csa,
 )
 from mobius.models.base import CausalLMModel
@@ -455,6 +455,8 @@ class DeepSeekV4IndexerTensors(nn.Module):
         assert config.q_lora_rank is not None
         assert config.index_n_heads is not None
         assert config.index_head_dim is not None
+        self.index_n_heads = config.index_n_heads
+        self.index_head_dim = config.index_head_dim
         self.wq_b = DeepSeekV4DeferredProjection(
             config,
             config.q_lora_rank,
@@ -467,9 +469,58 @@ class DeepSeekV4IndexerTensors(nn.Module):
             config, compress_ratio=4, head_dim=config.index_head_dim
         )
 
-    def forward(self, op: OpBuilder) -> ir.Value:
-        own = op.Add(self.wq_b(op), self.weights_proj(op))
-        return op.Add(own, self.compressor(op))
+    def forward(
+        self,
+        op: OpBuilder,
+        hidden_states: ir.Value | None = None,
+        query_lora: ir.Value | None = None,
+    ):
+        """Zero-valued shape anchor (dense fallback) or live indexer tensors.
+
+        With ``hidden_states``/``query_lora`` both ``None`` (deferred dense
+        fallback) this emits the zero-valued shape anchor that keeps the
+        indexer weights live. With both supplied (native-CSA ratio-4 dataflow)
+        it returns the six frozen-op index inputs:
+        ``(index_query, index_weight, index_compressor_kv,
+        index_compressor_gate, index_compressor_ape, index_compressor_norm)``.
+
+        ``index_query`` is the *raw* ``wq_b(query_lora)`` projection reshaped to
+        ``[B, S, index_n_heads, index_head_dim]`` -- the frozen op applies the
+        compressed RoPE + Hadamard + FP4 round-trip internally
+        (``finalize_index_query``), so no rotation happens here. ``index_weight``
+        is the raw ``weights_proj(hidden_states)`` projection
+        ``[B, S, index_n_heads]``; the index compressor mirrors the attention
+        compressor (raw ``W·x`` activations + learned ``ape``/norm).
+        """
+        if hidden_states is None and query_lora is None:
+            own = op.Add(self.wq_b(op), self.weights_proj(op))
+            return op.Add(own, self.compressor(op))
+        if hidden_states is None or query_lora is None:
+            raise NativeCsaExportError(
+                "native CSA ratio-4 indexer requires both hidden_states and "
+                "query_lora for its live dataflow; got "
+                f"hidden_states={'set' if hidden_states is not None else 'None'}, "
+                f"query_lora={'set' if query_lora is not None else 'None'}"
+            )
+        index_query = op.Reshape(
+            self.wq_b(op, query_lora),
+            [0, 0, self.index_n_heads, self.index_head_dim],
+        )
+        index_weight = self.weights_proj(op, hidden_states)
+        (
+            index_compressor_kv,
+            index_compressor_gate,
+            index_ape,
+            index_norm,
+        ) = self.compressor(op, hidden_states)
+        return (
+            index_query,
+            index_weight,
+            index_compressor_kv,
+            index_compressor_gate,
+            index_ape,
+            index_norm,
+        )
 
 
 class DeepSeekV4Attention(nn.Module):
@@ -541,12 +592,12 @@ class DeepSeekV4Attention(nn.Module):
             else None
         )
         self.indexer = DeepSeekV4IndexerTensors(config) if self.compress_ratio == 4 else None
-        # Property gate (default off). Resolves to an HcaLayerPlan only for a
-        # ratio-128 layer whose config matches the frozen op contract, and
-        # raises NativeCsaExportError (never silent dense) for ratio-4/MTP/
-        # unsupported-quant when native CSA is requested. See
-        # mobius.models._deepseek_v4_csa.
-        self.csa_plan: HcaLayerPlan | None = plan_native_csa(config, layer_id, is_mtp=is_mtp)
+        # Property gate (default off). Resolves to a CsaLayerPlan for a
+        # ratio-128 (HCA) or ratio-4 (CSA) layer whose config matches the
+        # frozen op contract, and raises NativeCsaExportError (never silent
+        # dense) for MTP/unknown-ratio/unsupported-quant when native CSA is
+        # requested. See mobius.models._deepseek_v4_csa.
+        self.csa_plan: CsaLayerPlan | None = plan_native_csa(config, layer_id, is_mtp=is_mtp)
 
     def _rotate(
         self,
@@ -609,21 +660,25 @@ class DeepSeekV4Attention(nn.Module):
             ),
         )
 
-    def _forward_native_hca(
+    def _forward_native_csa(
         self,
         op: OpBuilder,
         hidden_states: ir.Value,
         query: ir.Value,
+        query_lora: ir.Value,
         kv: ir.Value,
         past_key_value: tuple | None,
         past_compressed: tuple | None,
         csa_lengths: tuple | None,
-    ) -> tuple[ir.Value, ir.Value, ir.Value, tuple[ir.Value, ir.Value]]:
-        """Emit the frozen ratio-128 HCA op for this layer (native-CSA path).
+    ) -> tuple[ir.Value, ir.Value, ir.Value, tuple[ir.Value, ...]]:
+        """Emit the frozen CSA/HCA op for this layer (native-CSA path).
 
-        ``query``/``kv`` arrive already RoPE-rotated (compressed rope theta) by
-        the caller, exactly as the dense paths receive them; the op has no
-        cos/sin/position inputs and only rotates its *compressed records*
+        Handles both ratios the schedule interleaves: ratio-128 (HCA,
+        compressor-only, 11-in/3-out) and ratio-4 (CSA, compressor + learned
+        FP4 indexer, 19-in/6-out). ``query``/``kv`` arrive already RoPE-rotated
+        (compressed rope theta) by the caller, exactly as the dense paths
+        receive them; the op has no cos/sin/position inputs and only rotates
+        its *compressed records* (and, for ratio-4, its index query/records)
         internally, so the dense-window ``query``/``current_kv`` must be
         pre-rotated here and the shared inverse ``_rotate`` still runs on the
         op's ``Y`` after this returns. Builds:
@@ -635,12 +690,19 @@ class DeepSeekV4Attention(nn.Module):
           head) like the decomposed path, then squeezed for the op;
         * real, *unrotated* compressor activations (the op pools then rotates
           the compressed records internally at their block positions);
-        * the threaded ``past_* -> present_*`` compressed state.
+        * for ratio-4, the raw learned-indexer activations (``index_query`` from
+          ``wq_b(query_lora)``, ``index_weight``, and the index compressor) --
+          the op applies the index RoPE/Hadamard/FP4 internally;
+        * the threaded ``past_* -> present_*`` compressed (and, for ratio-4,
+          index) state.
 
         Returns ``(output, present_key, present_value, present_compressed)``
         with ``output`` flattened ``[B, S, num_heads*head_dim]`` in the rotated
         frame so the caller's shared inverse ``_rotate`` + output projection
-        apply unchanged.
+        apply unchanged. ``present_compressed`` is the ratio-shaped state tuple:
+        ``(present_compressed_kv, present_compression_carry)`` for ratio-128, or
+        ``(present_compressed_kv, present_compression_carry, present_index_key,
+        present_index_carry, selected_indices)`` for ratio-4.
         """
         plan = self.csa_plan
         assert plan is not None
@@ -656,7 +718,13 @@ class DeepSeekV4Attention(nn.Module):
                 "past_compression_carry state; none was threaded to the layer"
             )
         seqlens_k, total_seq_len = csa_lengths
-        past_compressed_kv, past_compression_carry = past_compressed
+        expected_state = 4 if plan.is_ratio4 else 2
+        if len(past_compressed) != expected_state:
+            raise NativeCsaExportError(
+                f"native CSA layer {plan.layer_id} (ratio "
+                f"{plan.compression_ratio}) requires {expected_state} threaded "
+                f"past-state tensors, got {len(past_compressed)}"
+            )
 
         query_4d = op.Reshape(query, [0, 0, self.num_heads, self.head_dim])
 
@@ -681,17 +749,15 @@ class DeepSeekV4Attention(nn.Module):
         # initializer) rather than left dangling.
         compressor_kv, compressor_gate, ape, norm_weight = self.compressor(op, hidden_states)
 
-        y, present_compressed_kv, present_compression_carry = emit_hca_attention(
-            op,
-            plan,
+        common = dict(
             query=_cast_to_f32(op, query_4d, self._dtype),
             current_kv=_cast_to_f32(op, current_kv, self._dtype),
             compressor_kv=_cast_to_f32(op, compressor_kv, self._dtype),
             compressor_gate=_cast_to_f32(op, compressor_gate, self._dtype),
             compressor_ape=_cast_to_f32(op, ape, self._dtype),
             compressor_norm=_cast_to_f32(op, norm_weight, self._dtype),
-            past_compressed_kv=past_compressed_kv,
-            past_compression_carry=past_compression_carry,
+            past_compressed_kv=past_compressed[0],
+            past_compression_carry=past_compressed[1],
             seqlens_k=seqlens_k,
             total_sequence_length=op.Cast(total_seq_len, to=ir.DataType.INT64),
             # ``head_sink`` is declared FLOAT but ``_cast_module_dtype`` folds
@@ -699,6 +765,53 @@ class DeepSeekV4Attention(nn.Module):
             # ``head_sink`` is f32, so cast it back up when needed.
             head_sink=_cast_to_f32(op, self.attn_sink, self._dtype),
         )
+
+        if plan.is_ratio4:
+            assert self.indexer is not None
+            # Raw learned-indexer activations (op rotates/packs internally).
+            (
+                index_query,
+                index_weight,
+                index_compressor_kv,
+                index_compressor_gate,
+                index_ape,
+                index_norm,
+            ) = self.indexer(op, hidden_states, query_lora)
+            # ``past_index_key`` is packed uint8 state -- passed through as-is;
+            # the index carry and all index activations are f32.
+            outputs = emit_csa_attention(
+                op,
+                plan,
+                index_query=_cast_to_f32(op, index_query, self._dtype),
+                index_weight=_cast_to_f32(op, index_weight, self._dtype),
+                index_compressor_kv=_cast_to_f32(op, index_compressor_kv, self._dtype),
+                index_compressor_gate=_cast_to_f32(op, index_compressor_gate, self._dtype),
+                index_compressor_ape=_cast_to_f32(op, index_ape, self._dtype),
+                index_compressor_norm=_cast_to_f32(op, index_norm, self._dtype),
+                past_index_key=past_compressed[2],
+                past_index_carry=past_compressed[3],
+                **common,
+            )
+            (
+                y,
+                present_compressed_kv,
+                present_compression_carry,
+                present_index_key,
+                present_index_carry,
+                selected_indices,
+            ) = outputs
+            present_compressed = (
+                present_compressed_kv,
+                present_compression_carry,
+                present_index_key,
+                present_index_carry,
+                selected_indices,
+            )
+        else:
+            y, present_compressed_kv, present_compression_carry = emit_csa_attention(
+                op, plan, **common
+            )
+            present_compressed = (present_compressed_kv, present_compression_carry)
 
         # ``Y`` is [B, S, N, D] FLOAT; flatten to [B, S, N*D] and cast back to
         # the model dtype for the shared inverse-RoPE + output projection.
@@ -709,7 +822,7 @@ class DeepSeekV4Attention(nn.Module):
             output,
             present_key,
             present_value,
-            (present_compressed_kv, present_compression_carry),
+            present_compressed,
         )
 
     def forward(
@@ -724,7 +837,8 @@ class DeepSeekV4Attention(nn.Module):
         past_compressed: tuple | None = None,
         csa_lengths: tuple | None = None,
     ):
-        query = self.q_b_proj(op, self.q_a_layernorm(op, self.q_a_proj(op, hidden_states)))
+        query_lora = self.q_a_layernorm(op, self.q_a_proj(op, hidden_states))
+        query = self.q_b_proj(op, query_lora)
         query_4d = op.Reshape(query, [0, 0, self.num_heads, self.head_dim])
         query_rms = op.Sqrt(
             op.Add(
@@ -741,16 +855,17 @@ class DeepSeekV4Attention(nn.Module):
         present_compressed = None
         if self.csa_plan is not None:
             # Native CSA/HCA path (default-off ``config.native_csa`` opt-in).
-            # Emits the frozen ratio-128 ``pkg.nxrt::CompressedSparseAttention``
-            # op instead of the dense correctness fallback; the compressor
-            # tensors are consumed as real dataflow here rather than as a
-            # zero-valued shape anchor below. ``output`` comes back flattened
-            # in the rotated frame, so the shared inverse ``_rotate`` and the
-            # output projection run unchanged.
-            output, present_key, present_value, present_compressed = self._forward_native_hca(
+            # Emits the frozen ``pkg.nxrt::CompressedSparseAttention`` op
+            # (ratio-128 HCA or ratio-4 CSA) instead of the dense correctness
+            # fallback; the compressor/indexer tensors are consumed as real
+            # dataflow here rather than as a zero-valued shape anchor below.
+            # ``output`` comes back flattened in the rotated frame, so the
+            # shared inverse ``_rotate`` and the output projection run unchanged.
+            output, present_key, present_value, present_compressed = self._forward_native_csa(
                 op,
                 hidden_states,
                 query,
+                query_lora,
                 kv,
                 past_key_value,
                 past_compressed,
@@ -867,7 +982,7 @@ class DeepSeekV4Attention(nn.Module):
             # Zero-valued shape anchor for the dense correctness fallback,
             # keeping the deferred compressor/indexer weights live in the
             # graph. Skipped on the native-CSA path, where those same weights
-            # are consumed as real dataflow inside ``_forward_native_hca`` --
+            # are consumed as real dataflow inside ``_forward_native_csa`` --
             # so a native-CSA layer emits no dead anchor arithmetic.
             anchor = self.compressor(op)
             if self.indexer is not None:

--- a/src/mobius/models/deepseek_v4.py
+++ b/src/mobius/models/deepseek_v4.py
@@ -45,6 +45,7 @@ from mobius.components._rotary_embedding import apply_rotary_pos_emb
 from mobius.models._deepseek_v4_csa import (
     CsaLayerPlan,
     NativeCsaExportError,
+    assert_native_runtime_supports_block_quant,
     emit_csa_attention,
     plan_native_csa,
 )
@@ -1403,6 +1404,13 @@ class DeepSeekV4CausalLMModel(CausalLMModel):
         self, state_dict: dict[str, torch.Tensor]
     ) -> dict[str, torch.Tensor]:
         """Map the official DeepSeek checkpoint names to mobius modules."""
+        # Full-export runtime-capability gate. When a native-CSA export deferred
+        # #602's block-quant reject (so graph construction could progress), the
+        # runnable export still fails closed here -- before any weight is
+        # mapped/assigned, replacing the former generic "Weight shape mismatch"
+        # with a typed, actionable blocker -- until nxrt advertises the real
+        # block-FP8 / planar-FP4 format strings. No-op on every ordinary path.
+        assert_native_runtime_supports_block_quant(self.config)
         # Same predicate as MoELayer/_supported_qmoe_quantization so the
         # repacked weights and the emitted graph never disagree.
         use_qmoe = supported_qmoe_quantization(self.config.quantization) is not None

--- a/src/mobius/models/deepseek_v4_flash_test.py
+++ b/src/mobius/models/deepseek_v4_flash_test.py
@@ -20,13 +20,17 @@ from mobius._constants import OPSET_VERSION
 from mobius._testing import count_op_type, make_config
 from mobius.components import create_attention_bias
 from mobius.components._rotary_embedding import initialize_rope
+from mobius.integrations._block_quant import BlockQuantExportError, BlockQuantScheme
 from mobius.integrations.ort_genai import export_package
 from mobius.integrations.transformers._config_resolver import _default_task_for_model
 from mobius.models._deepseek_v4_csa import (
     CSA_COMPRESSION_RATIO,
     CSA_DOMAIN,
+    CSA_OP_TYPE,
     HCA_COMPRESSION_RATIO,
     NativeCsaExportError,
+    assert_native_runtime_supports_block_quant,
+    native_runtime_block_quant_gap,
     plan_native_csa,
 )
 from mobius.models.deepseek_v4 import (
@@ -1259,3 +1263,263 @@ def test_plan_native_csa_ratio4_layer_matches_contract():
     assert plan.past_index_key_name == "past_index_key.1"
     assert plan.present_index_carry_name == "present_index_carry.1"
     assert plan.selected_indices_name == "selected_indices.1"
+
+
+# ---------------------------------------------------------------------------
+# Composition: native CSA export (this module, #593) x the block-FP8 /
+# packed-FP4 loading contract (``mobius.integrations._block_quant``, #602, now
+# on main). The official DeepSeek-V4-Flash checkpoint @
+# 60d8d70770c6776ff598c94bb586a859a38244f1 is a *block-scaled fp8* backbone
+# (E4M3 weight + 2D UE8M0 [128, 128] block scale) with *packed-fp4* routed
+# experts (top-level ``expert_dtype=fp4``).
+#
+# The two slices compose in TWO stages, mandated by the directive
+# "graph construction should progress past the former generic shape mismatch,
+# full export must typed-reject at the runtime capability gate":
+#
+#   * A non-native export keeps #602's early, loud config-resolution reject.
+#   * A native-CSA export DEFERS that reject (records ``block_quant_scheme``)
+#     so graph construction PROGRESSES -- CSA nodes + compressed state IO are
+#     built and inspectable -- and the runnable *full export* then fails closed
+#     at the runtime-capability gate (``assert_native_runtime_supports_block_quant``
+#     / ``preprocess_weights``) until nxrt advertises the real block-FP8 /
+#     planar-FP4 format strings. Never a silent dense fallback, never a partial
+#     native + silent dense graph.
+# ---------------------------------------------------------------------------
+
+# Frozen verbatim from the official config.json @
+# 60d8d70770c6776ff598c94bb586a859a38244f1 (metadata only; no weights).
+_REAL_BLOCK_FP8_QUANT_CONFIG = {
+    "activation_scheme": "dynamic",
+    "fmt": "e4m3",
+    "quant_method": "fp8",
+    "scale_fmt": "ue8m0",
+    "weight_block_size": [128, 128],
+}
+
+
+def _v4_hf_config(**overrides):
+    """A real-shaped DeepSeek-V4-Flash HF config (mirrors the official rev).
+
+    Same field set proven to resolve by ``test_real_config_fields_extract``
+    (``compress_ratios == [0, 0, 4, 128]``); overrides layer in the block-quant
+    / ``native_csa`` properties under test.
+    """
+    values = dict(
+        model_type="deepseek_v4",
+        vocab_size=129280,
+        hidden_size=4096,
+        intermediate_size=None,
+        num_hidden_layers=43,
+        num_attention_heads=64,
+        num_key_value_heads=1,
+        head_dim=512,
+        max_position_embeddings=1048576,
+        hidden_act="silu",
+        rms_norm_eps=1e-6,
+        rope_theta=10000,
+        rope_scaling={
+            "type": "yarn",
+            "factor": 16,
+            "original_max_position_embeddings": 65536,
+            "beta_fast": 32,
+            "beta_slow": 1,
+        },
+        q_lora_rank=1024,
+        qk_rope_head_dim=64,
+        o_groups=8,
+        o_lora_rank=1024,
+        n_routed_experts=256,
+        num_experts_per_tok=6,
+        moe_intermediate_size=2048,
+        n_shared_experts=1,
+        norm_topk_prob=True,
+        routed_scaling_factor=1.5,
+        scoring_func="sqrtsoftplus",
+        num_hash_layers=None,
+        mlp_layer_types=["hash_moe", "hash_moe", "hash_moe", "moe"],
+        hc_mult=4,
+        hc_sinkhorn_iters=20,
+        hc_eps=1e-6,
+        index_n_heads=64,
+        index_head_dim=128,
+        index_topk=512,
+        compress_ratios=None,
+        layer_types=[
+            "sliding_attention",
+            "sliding_attention",
+            "compressed_sparse_attention",
+            "heavily_compressed_attention",
+        ],
+        compress_rates={
+            "compressed_sparse_attention": 4,
+            "heavily_compressed_attention": 128,
+        },
+        compress_rope_theta=160000,
+        sliding_window=128,
+        swiglu_limit=10.0,
+        tie_word_embeddings=False,
+        num_nextn_predict_layers=1,
+        attention_bias=False,
+        pad_token_id=0,
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_non_native_export_fails_closed_on_block_fp8_fp4_checkpoint():
+    # A non-native (default) export of the official block-fp8 + fp4-expert
+    # checkpoint keeps #602's early, loud config-resolution reject -- fail-closed
+    # before any graph/CSA node exists. Preserves the merged default behavior.
+    hf = _v4_hf_config(
+        quantization_config=_REAL_BLOCK_FP8_QUANT_CONFIG,
+        expert_dtype="fp4",
+    )
+    with pytest.raises(BlockQuantExportError) as exc:
+        ArchitectureConfig.from_transformers(hf)
+    msg = str(exc.value)
+    # Names the real layout, the block geometry, the property-based contract
+    # module, and the runtime ABI emission gate -- never a model-name allowlist.
+    assert "Block-scaled FP8" in msg
+    assert "[128, 128]" in msg
+    assert "expert_dtype='fp4'" in msg
+    assert "mobius.integrations._block_quant" in msg
+    assert "plan_routed_expert_bank" in msg
+
+
+def test_fp4_experts_alone_fail_closed_even_without_block_fp8():
+    # The fp4 routed-expert property alone (top-level expert_dtype, no fp8
+    # quantization_config block) still trips the fail-closed config-resolution
+    # gate for a non-native export: the packed planar-fp4 expert bank has no
+    # nxrt BlockFormat either. Proves the gate is owned by the *property*, not
+    # by the fp8 block geometry.
+    hf = _v4_hf_config(
+        quantization_config={"quant_method": "none"},
+        expert_dtype="fp4",
+    )
+    with pytest.raises(BlockQuantExportError) as exc:
+        ArchitectureConfig.from_transformers(hf)
+    assert "expert_dtype='fp4'" in str(exc.value)
+
+
+def test_native_csa_defers_block_quant_so_graph_construction_can_progress():
+    # native_csa opts into DEFERRING #602's config-resolution reject: the config
+    # resolves (rather than raising) and records the block-quant scheme so graph
+    # construction can progress. The quantization path stays None (the INT4/
+    # per-tensor path never owns these weights).
+    hf = _v4_hf_config(
+        quantization_config=_REAL_BLOCK_FP8_QUANT_CONFIG,
+        expert_dtype="fp4",
+        native_csa=True,
+    )
+    config = ArchitectureConfig.from_transformers(hf)
+    assert config.native_csa is True
+    assert config.quantization is None
+    assert config.block_quant_scheme is not None
+    assert config.block_quant_scheme.is_owned
+    assert config.block_quant_scheme.is_block_scaled_fp8
+    assert config.block_quant_scheme.has_packed_fp4_experts
+
+
+def test_native_csa_full_export_typed_rejects_at_runtime_capability_gate():
+    # The deferred config still fails closed at the runtime-capability gate:
+    # the runnable full export (assert_native_runtime_supports_block_quant, and
+    # therefore preprocess_weights) raises the typed BlockQuantExportError while
+    # nxrt cannot execute block-FP8 / planar-FP4 weights. Never silent dense.
+    hf = _v4_hf_config(
+        quantization_config=_REAL_BLOCK_FP8_QUANT_CONFIG,
+        expert_dtype="fp4",
+        native_csa=True,
+    )
+    config = ArchitectureConfig.from_transformers(hf)
+    with pytest.raises(BlockQuantExportError) as exc:
+        assert_native_runtime_supports_block_quant(config)
+    msg = str(exc.value)
+    assert "block-FP8" in msg or "block-fp8" in msg.lower()
+    assert "planar" in msg.lower()
+    # The gap string is sourced from the #602 runtime contract, so the gate
+    # tracks the real format strings and opens with no change here.
+    gap = native_runtime_block_quant_gap(config.block_quant_scheme)
+    assert gap is not None
+    assert "nxrt" in gap
+
+
+def test_native_csa_graph_construction_progresses_past_block_quant():
+    # With the deferred block-quant scheme present, graph construction PROGRESSES
+    # past the former generic weight-shape mismatch: build_from_module emits the
+    # frozen CSA node and its compressed state IO instead of raising. The gate
+    # lives on the *full export* (weight load), not on construction, so the same
+    # config that builds a graph still rejects the runnable export.
+    scheme = BlockQuantScheme.from_quantization_config(
+        _REAL_BLOCK_FP8_QUANT_CONFIG, expert_dtype="fp4"
+    )
+    assert scheme is not None and scheme.is_owned
+    config = _tiny_config(
+        num_hidden_layers=2,
+        compress_ratios=[0, 128],
+        native_csa=True,
+        block_quant_scheme=scheme,
+    )
+    graph = build_from_module(DeepSeekV4CausalLMModel(config), config, task="deepseek-v4")[
+        "model"
+    ].graph
+    csa = [n for n in _csa_nodes(graph) if n.domain == CSA_DOMAIN]
+    assert len(csa) == 1
+    assert csa[0].op_type == CSA_OP_TYPE
+    # ... but the runnable full export of that same config still fails closed.
+    with pytest.raises(BlockQuantExportError):
+        assert_native_runtime_supports_block_quant(config)
+
+
+def test_preprocess_weights_enforces_runtime_capability_gate():
+    # The weight-load hook (full export) enforces the same gate: a native-CSA
+    # module whose config carries a deferred block-quant scheme rejects in
+    # preprocess_weights before mapping a single tensor -- the typed blocker
+    # replaces the former generic "Weight shape mismatch".
+    scheme = BlockQuantScheme.from_quantization_config(
+        _REAL_BLOCK_FP8_QUANT_CONFIG, expert_dtype="fp4"
+    )
+    config = _tiny_config(
+        num_hidden_layers=2,
+        compress_ratios=[0, 128],
+        native_csa=True,
+        block_quant_scheme=scheme,
+    )
+    module = DeepSeekV4CausalLMModel(config)
+    with pytest.raises(BlockQuantExportError):
+        module.preprocess_weights({})
+
+
+def test_native_csa_is_property_gated_not_a_blanket_v4_refusal():
+    # The SAME DeepSeek-V4 schedule WITHOUT block-quant properties resolves
+    # normally, records no scheme, and still plans native CSA for both ratios --
+    # proving the deferral/gate fire on the block-quant *properties*, not on the
+    # model or on native_csa itself.
+    hf = _v4_hf_config(native_csa=True)
+    config = ArchitectureConfig.from_transformers(hf)
+    assert config.quantization is None
+    assert config.block_quant_scheme is None
+    assert config.native_csa is True
+    assert config.compress_ratios[:4] == [0, 0, 4, 128]
+    ratio4 = plan_native_csa(config, 2)
+    ratio128 = plan_native_csa(config, 3)
+    assert ratio4 is not None and ratio4.compression_ratio == CSA_COMPRESSION_RATIO
+    assert ratio128 is not None and ratio128.compression_ratio == HCA_COMPRESSION_RATIO
+    # No deferred scheme -> the full-export gate is a no-op.
+    assert_native_runtime_supports_block_quant(config)
+
+
+def test_per_tensor_fp8_v4_is_not_owned_by_block_quant_gate():
+    # Per-tensor fp8 (no weight_block_size, no fp4 experts) is NOT the
+    # block-quant contract's concern: it falls through to the normal dtype-cast
+    # path (QuantizationConfig None, no deferred scheme), so the DeepSeek-V4
+    # config resolves and native CSA still plans. Guards against over-firing.
+    hf = _v4_hf_config(
+        quantization_config={"quant_method": "fp8", "bits": 8},
+        native_csa=True,
+    )
+    config = ArchitectureConfig.from_transformers(hf)
+    assert config.quantization is None
+    assert config.block_quant_scheme is None
+    assert plan_native_csa(config, 2) is not None
+    assert_native_runtime_supports_block_quant(config)

--- a/src/mobius/models/deepseek_v4_flash_test.py
+++ b/src/mobius/models/deepseek_v4_flash_test.py
@@ -23,6 +23,7 @@ from mobius.components._rotary_embedding import initialize_rope
 from mobius.integrations.ort_genai import export_package
 from mobius.integrations.transformers._config_resolver import _default_task_for_model
 from mobius.models._deepseek_v4_csa import (
+    CSA_COMPRESSION_RATIO,
     CSA_DOMAIN,
     HCA_COMPRESSION_RATIO,
     NativeCsaExportError,
@@ -64,6 +65,29 @@ def _tiny_config(**overrides):
     )
     values.update(overrides)
     return make_config(**values)
+
+
+def _ratio4_config(**overrides):
+    """A tiny config whose head/index dims satisfy the ratio-4 fp8/fp4 packing.
+
+    Ratio-4 CSA packs its attention cache as ``fp8_e4m3_block64`` -- requiring
+    ``(head_dim - qk_rope_head_dim)`` divisible by 64 -- and its index cache as
+    ``fp4_e2m1_block32`` -- requiring ``index_head_dim`` divisible by 32. The
+    ratio-128 ``_tiny_config`` dims (head_dim=16, index_head_dim=8) cannot
+    satisfy either. These are the smallest valid dims and give
+    ``stored_width=193`` (fp8) and ``index_stored_width=17`` (fp4). A ratio-128
+    layer under the same config is unconstrained, so a mixed schedule can share
+    one config.
+    """
+    values = dict(
+        head_dim=128,
+        qk_rope_head_dim=64,
+        index_n_heads=2,
+        index_head_dim=32,
+        index_topk=4,
+    )
+    values.update(overrides)
+    return _tiny_config(**values)
 
 
 def test_real_config_fields_extract():
@@ -749,12 +773,17 @@ def test_missing_sliding_window_regression_fused_gqa_matches_windowed_decomposed
 
 
 # ---------------------------------------------------------------------------
-# Slice C1: default-off native ``pkg.nxrt::CompressedSparseAttention`` (HCA
-# ratio-128) export. These are shape-faithful/structural tests only: the
-# frozen op has no Python shape inference and no ORT runtime in this env, so
-# we assert exact op attrs, input/output names/shapes/dtypes, threaded
-# compressed state IO, real dataflow (no dead shape anchor), typed rejects,
-# and a byte-identical disabled baseline.
+# Native ``pkg.nxrt::CompressedSparseAttention`` export (default-off
+# ``config.native_csa``). The official DeepSeek-V4-Flash schedule interleaves
+# two compression ratios and both emit the frozen op: ratio-128 "Heavily
+# Compressed Attention" (HCA, compressor-only, 11-in/3-out, f32 cache) and
+# ratio-4 CSA (compressor + a learned FP4 indexer with top-k, 19-in/6-out,
+# fp8_e4m3_block64 + fp4_e2m1_block32 caches). These are shape-faithful/
+# structural tests only: the frozen op has no Python shape inference and no
+# ORT runtime in this env, so we assert exact op attrs, input/output
+# names/shapes/dtypes, threaded compressed (and, for ratio-4, index) state IO,
+# real dataflow (no dead shape anchor), typed rejects, and a byte-identical
+# disabled baseline.
 # ---------------------------------------------------------------------------
 
 _EXPECTED_HCA_ATTRS = {
@@ -770,6 +799,22 @@ _EXPECTED_HCA_ATTRS = {
     "index_layout_version": 1,
     "sink_mode": "logit_only",
     "cache_format": "f32",
+    "scale": 0.0,
+}
+
+_EXPECTED_CSA_RATIO4_ATTRS = {
+    "num_heads": 2,
+    "head_dim": 128,
+    "qk_rope_head_dim": 64,
+    "compression_ratio": 4,
+    "index_num_heads": 2,
+    "index_head_dim": 32,
+    "index_topk": 4,
+    "causal": 1,
+    "cache_layout_version": 1,
+    "index_layout_version": 1,
+    "sink_mode": "logit_only",
+    "cache_format": "fp8_e4m3_block64",
     "scale": 0.0,
 }
 
@@ -959,10 +1004,178 @@ def test_native_csa_defaults_off_and_opt_in():
     assert _tiny_config(native_csa=True).native_csa is True
 
 
-def test_native_csa_rejects_ratio4():
-    # ratio-4 CSA (learned FP4 indexer + top-k) is out of C1 scope: requesting
-    # native export for it must fail closed at construction, never emit dense.
+def test_native_csa_emits_ratio4_op_for_ratio4_layer():
+    # ratio-4 CSA (compressor + learned FP4 indexer + top-k) now emits the
+    # frozen op with the full 19-input / 6-output learned-indexer contract.
+    config = _ratio4_config(
+        num_hidden_layers=2,
+        compress_ratios=[0, 4],
+        native_csa=True,
+    )
+    graph = build_from_module(DeepSeekV4CausalLMModel(config), config, task="deepseek-v4")[
+        "model"
+    ].graph
+
+    nodes = _csa_nodes(graph)
+    assert len(nodes) == 1
+    node = nodes[0]
+    assert node.domain == CSA_DOMAIN == "pkg.nxrt"
+    assert len(node.inputs) == 19
+    assert len(node.outputs) == 6
+    assert {k: node.attributes[k].value for k in node.attributes} == _EXPECTED_CSA_RATIO4_ATTRS
+    # The native op fully replaces dense/fused attention for its layer.
+    assert count_op_type(graph, "GroupQueryAttention") == 0
+    assert count_op_type(graph, "Attention") == 0
+
+
+def test_native_csa_emits_both_ratios_for_interleaved_schedule():
+    # The official schedule interleaves ratio-4 CSA and ratio-128 HCA layers; a
+    # full ``native_csa=True`` export must emit BOTH frozen-op variants (never
+    # partial-native + silent dense), each with its own input/output arity.
+    config = _ratio4_config(
+        num_hidden_layers=3,
+        compress_ratios=[0, 4, 128],
+        native_csa=True,
+    )
+    graph = build_from_module(DeepSeekV4CausalLMModel(config), config, task="deepseek-v4")[
+        "model"
+    ].graph
+
+    nodes = _csa_nodes(graph)
+    assert len(nodes) == 2
+    by_ratio = {n.attributes["compression_ratio"].value: n for n in nodes}
+    assert set(by_ratio) == {CSA_COMPRESSION_RATIO, HCA_COMPRESSION_RATIO} == {4, 128}
+    ratio4, ratio128 = by_ratio[4], by_ratio[128]
+    assert (len(ratio4.inputs), len(ratio4.outputs)) == (19, 6)
+    assert (len(ratio128.inputs), len(ratio128.outputs)) == (11, 3)
+    # ratio-128 keeps the compressor-only f32 contract; ratio-4 the packed one.
+    assert ratio128.attributes["cache_format"].value == "f32"
+    assert ratio4.attributes["cache_format"].value == "fp8_e4m3_block64"
+    assert ratio128.attributes["index_topk"].value == 0
+    assert ratio4.attributes["index_topk"].value == 4
+
+
+def test_native_csa_ratio4_threads_index_state_io():
+    # ratio-4 threads the packed uint8 attention/index caches, the f32 carries,
+    # and the transient int32 top-k ``selected_indices`` output, all with
+    # deterministic names and dynamic record axes.
+    config = _ratio4_config(num_hidden_layers=2, compress_ratios=[0, 4], native_csa=True)
+    graph = build_from_module(DeepSeekV4CausalLMModel(config), config, task="deepseek-v4")[
+        "model"
+    ].graph
+    inputs = _named(graph.inputs)
+    outputs = _named(graph.outputs)
+
+    # Packed attention cache: uint8, fp8_e4m3_block64 stored width 193.
+    past_kv, pres_kv = inputs["past_compressed_kv.1"], outputs["present_compressed_kv.1"]
+    assert past_kv.dtype == pres_kv.dtype == ir.DataType.UINT8
+    assert int(past_kv.shape[2]) == int(pres_kv.shape[2]) == 193
+    # Attention carry: f32 [batch, 8 slots, 2 planes, 2*head_dim=256].
+    past_carry = inputs["past_compression_carry.1"]
+    assert past_carry.dtype == ir.DataType.FLOAT
+    assert [int(d) for d in past_carry.shape[1:]] == [8, 2, 256]
+
+    # Packed index cache: uint8, fp4_e2m1_block32 stored width 17.
+    past_ik, pres_ik = inputs["past_index_key.1"], outputs["present_index_key.1"]
+    assert past_ik.dtype == pres_ik.dtype == ir.DataType.UINT8
+    assert int(past_ik.shape[2]) == int(pres_ik.shape[2]) == 17
+    # Index carry: f32 [batch, 8 slots, 2 planes, 2*index_head_dim=64].
+    past_ic = inputs["past_index_carry.1"]
+    assert past_ic.dtype == ir.DataType.FLOAT
+    assert [int(d) for d in past_ic.shape[1:]] == [8, 2, 64]
+
+    # selected_indices is an inspection-only int32 output (not threaded back as
+    # a past_* input) shaped [batch, index_num_heads, sequence, selected].
+    assert "past_selected_indices.1" not in inputs
+    sel = outputs["selected_indices.1"]
+    assert sel.dtype == ir.DataType.INT32
+    assert int(sel.shape[1]) == 2  # index_num_heads
+    assert isinstance(sel.shape[3], ir.SymbolicDim)
+
+
+def test_native_csa_ratio4_wires_learned_indexer():
+    # The learned-indexer inputs must be REAL dataflow: index_query is the
+    # reshaped wq_b projection, index_weight the weights_proj projection, and
+    # the index compressor mirrors the attention compressor.
+    config = _ratio4_config(num_hidden_layers=2, compress_ratios=[0, 4], native_csa=True)
+    graph = build_from_module(DeepSeekV4CausalLMModel(config), config, task="deepseek-v4")[
+        "model"
+    ].graph
+    node = _csa_nodes(graph)[0]
+
+    # Positions 11-18 are the learned-indexer inputs (order-exact).
+    index_query = node.inputs[11]
+    assert index_query.producer().op_type == "Reshape"
+    assert index_query.producer().inputs[0].producer().op_type == "MatMul"
+    assert node.inputs[12].producer().op_type == "MatMul"  # index_weight
+    assert node.inputs[13].producer().op_type == "MatMul"  # index_compressor_kv
+    assert node.inputs[14].producer().op_type == "MatMul"  # index_compressor_gate
+    # index_compressor_ape / index_compressor_norm are the learned parameters.
+    assert node.inputs[15].name == "model.layers.1.self_attn.indexer.compressor.ape"
+    assert node.inputs[16].name == "model.layers.1.self_attn.indexer.compressor.norm.weight"
+
+
+def test_native_csa_ratio4_no_dead_index_anchor():
+    # The ratio-4 indexer weights must survive by real dataflow, not as a
+    # zero-valued shape anchor.
+    config = _ratio4_config(num_hidden_layers=2, compress_ratios=[0, 4], native_csa=True)
+    graph = build_from_module(DeepSeekV4CausalLMModel(config), config, task="deepseek-v4")[
+        "model"
+    ].graph
+    initializers = set(graph.initializers)
+    for name in (
+        "model.layers.1.self_attn.indexer.wq_b.weight",
+        "model.layers.1.self_attn.indexer.weights_proj.weight",
+        "model.layers.1.self_attn.indexer.compressor.wkv.weight",
+        "model.layers.1.self_attn.indexer.compressor.wgate.weight",
+        "model.layers.1.self_attn.indexer.compressor.ape",
+        "model.layers.1.self_attn.indexer.compressor.norm.weight",
+    ):
+        assert name in initializers
+
+
+def test_native_csa_ratio4_present_state_is_chainable_for_decode():
+    # prefill + >=16 decode: both the attention and index present record axes
+    # are dynamic and every carry is fixed-shape, so present_* names/shapes
+    # chain back into past_* inputs for any decode length.
+    config = _ratio4_config(num_hidden_layers=2, compress_ratios=[0, 4], native_csa=True)
+    graph = build_from_module(DeepSeekV4CausalLMModel(config), config, task="deepseek-v4")[
+        "model"
+    ].graph
+    inputs = _named(graph.inputs)
+    outputs = _named(graph.outputs)
+
+    for base, width in (("compressed_kv", 193), ("index_key", 17)):
+        past = inputs[f"past_{base}.1"]
+        pres = outputs[f"present_{base}.1"]
+        assert len(past.shape) == len(pres.shape) == 3
+        assert int(past.shape[2]) == int(pres.shape[2]) == width
+        assert isinstance(past.shape[1], ir.SymbolicDim)
+        assert isinstance(pres.shape[1], ir.SymbolicDim)
+    for base in ("compression_carry", "index_carry"):
+        past = inputs[f"past_{base}.1"]
+        pres = outputs[f"present_{base}.1"]
+        assert [int(d) for d in past.shape[1:]] == [int(d) for d in pres.shape[1:]]
+
+
+def test_native_csa_rejects_ratio4_invalid_packing_dims():
+    # Fail-closed at construction when the head/index dims cannot satisfy the
+    # frozen op's fp8/fp4 packing (never a silent dense fallback). The
+    # ratio-128 ``_tiny_config`` dims (head_dim=16) violate fp8_e4m3_block64.
     config = _tiny_config(num_hidden_layers=2, compress_ratios=[0, 4], native_csa=True)
+    with pytest.raises(NativeCsaExportError):
+        DeepSeekV4CausalLMModel(config)
+
+
+def test_native_csa_rejects_ratio4_missing_index_config():
+    # A ratio-4 layer requires positive index_n_heads/index_head_dim/index_topk
+    # to wire the learned indexer; a missing one fails closed.
+    config = _ratio4_config(
+        num_hidden_layers=2,
+        compress_ratios=[0, 4],
+        native_csa=True,
+        index_topk=0,
+    )
     with pytest.raises(NativeCsaExportError):
         DeepSeekV4CausalLMModel(config)
 
@@ -1016,3 +1229,33 @@ def test_plan_native_csa_ratio128_layer_matches_contract():
     assert plan.cache_format == "f32"
     assert plan.past_compressed_kv_name == "past_compressed_kv.1"
     assert plan.present_compression_carry_name == "present_compression_carry.1"
+
+
+def test_plan_native_csa_ratio4_layer_matches_contract():
+    config = _ratio4_config(num_hidden_layers=2, compress_ratios=[0, 4], native_csa=True)
+    plan = plan_native_csa(config, 1)
+    assert plan is not None
+    assert plan.is_ratio4
+    assert plan.compression_ratio == CSA_COMPRESSION_RATIO == 4
+    assert plan.head_dim == 128
+    assert plan.qk_rope_head_dim == 64
+    # fp8_e4m3_block64 attention record: (128-64)/64*65 + 64*2 = 193.
+    assert plan.cache_format == "fp8_e4m3_block64"
+    assert plan.cache_dtype == ir.DataType.UINT8
+    assert plan.stored_width == 193
+    # ratio-4 pools overlapping key+value records: carry width = 2*head_dim,
+    # and a fixed 8-slot overlap window (not ``ratio`` slots).
+    assert plan.compressor_width == 256
+    assert plan.carry_slots == 8
+    # Learned FP4 indexer: fp4_e2m1_block32 record 32/32*17 = 17, carry 2*32=64.
+    assert plan.index_num_heads == 2
+    assert plan.index_head_dim == 32
+    assert plan.index_topk == 4
+    assert plan.index_cache_format == "fp4_e2m1_block32"
+    assert plan.index_key_dtype == ir.DataType.UINT8
+    assert plan.index_stored_width == 17
+    assert plan.index_compressor_width == 64
+    # ratio-4 state IO names include the index tensors.
+    assert plan.past_index_key_name == "past_index_key.1"
+    assert plan.present_index_carry_name == "present_index_carry.1"
+    assert plan.selected_indices_name == "selected_indices.1"

--- a/src/mobius/models/deepseek_v4_flash_test.py
+++ b/src/mobius/models/deepseek_v4_flash_test.py
@@ -22,6 +22,12 @@ from mobius.components import create_attention_bias
 from mobius.components._rotary_embedding import initialize_rope
 from mobius.integrations.ort_genai import export_package
 from mobius.integrations.transformers._config_resolver import _default_task_for_model
+from mobius.models._deepseek_v4_csa import (
+    CSA_DOMAIN,
+    HCA_COMPRESSION_RATIO,
+    NativeCsaExportError,
+    plan_native_csa,
+)
 from mobius.models.deepseek_v4 import (
     DeepSeekV4Attention,
     DeepSeekV4CausalLMModel,
@@ -637,7 +643,7 @@ def _run_attention_graph(
         )
         seqlens_k, total_seq_len = None, None
 
-    output, _ = attn(
+    output, _, _ = attn(
         op, hidden_states, position_embeddings, None, attention_bias, seqlens_k, total_seq_len
     )
     output.name = "output"
@@ -740,3 +746,273 @@ def test_missing_sliding_window_regression_fused_gqa_matches_windowed_decomposed
             "restriction as the decomposed path's explicit windowed bias"
         ),
     )
+
+
+# ---------------------------------------------------------------------------
+# Slice C1: default-off native ``pkg.nxrt::CompressedSparseAttention`` (HCA
+# ratio-128) export. These are shape-faithful/structural tests only: the
+# frozen op has no Python shape inference and no ORT runtime in this env, so
+# we assert exact op attrs, input/output names/shapes/dtypes, threaded
+# compressed state IO, real dataflow (no dead shape anchor), typed rejects,
+# and a byte-identical disabled baseline.
+# ---------------------------------------------------------------------------
+
+_EXPECTED_HCA_ATTRS = {
+    "num_heads": 2,
+    "head_dim": 16,
+    "qk_rope_head_dim": 4,
+    "compression_ratio": 128,
+    "index_num_heads": 0,
+    "index_head_dim": 0,
+    "index_topk": 0,
+    "causal": 1,
+    "cache_layout_version": 1,
+    "index_layout_version": 1,
+    "sink_mode": "logit_only",
+    "cache_format": "f32",
+    "scale": 0.0,
+}
+
+
+def _csa_nodes(graph):
+    return [n for n in graph if n.op_type == "CompressedSparseAttention"]
+
+
+def _named(values):
+    return {v.name: v for v in values}
+
+
+def test_native_csa_emits_hca_op_for_ratio128_layer_only():
+    config = _tiny_config(
+        num_hidden_layers=2,
+        compress_ratios=[0, 128],
+        native_csa=True,
+    )
+    graph = build_from_module(DeepSeekV4CausalLMModel(config), config, task="deepseek-v4")[
+        "model"
+    ].graph
+
+    nodes = _csa_nodes(graph)
+    assert len(nodes) == 1, "exactly the ratio-128 layer emits the native op"
+    node = nodes[0]
+    assert node.domain == CSA_DOMAIN == "pkg.nxrt"
+    assert len(node.inputs) == 11
+    assert len(node.outputs) == 3
+    assert {k: node.attributes[k].value for k in node.attributes} == _EXPECTED_HCA_ATTRS
+    # The native op fully replaces dense/fused attention for its layer and must
+    # not silently coexist with a fused GQA/Attention path.
+    assert count_op_type(graph, "GroupQueryAttention") == 0
+    assert count_op_type(graph, "Attention") == 0
+
+
+def test_native_csa_threads_compressed_state_io():
+    config = _tiny_config(
+        num_hidden_layers=2,
+        compress_ratios=[0, 128],
+        native_csa=True,
+    )
+    graph = build_from_module(DeepSeekV4CausalLMModel(config), config, task="deepseek-v4")[
+        "model"
+    ].graph
+
+    inputs = _named(graph.inputs)
+    outputs = _named(graph.outputs)
+
+    # Compressed state is threaded as ADDITIONAL parallel IO for the enabled
+    # layer only, with deterministic names and dynamic record axes.
+    assert "past_compressed_kv.1" in inputs
+    assert "past_compression_carry.1" in inputs
+    assert "present_compressed_kv.1" in outputs
+    assert "present_compression_carry.1" in outputs
+    assert "past_compressed_kv.0" not in inputs
+    assert "past_compression_carry.0" not in inputs
+
+    past_kv = inputs["past_compressed_kv.1"]
+    pres_kv = outputs["present_compressed_kv.1"]
+    assert past_kv.dtype == ir.DataType.FLOAT
+    assert pres_kv.dtype == ir.DataType.FLOAT
+    assert [str(d) for d in past_kv.shape] == ["batch", "past_compressed_records", "16"]
+    assert [str(d) for d in pres_kv.shape] == ["batch", "present_compressed_records", "16"]
+
+    past_carry = inputs["past_compression_carry.1"]
+    pres_carry = outputs["present_compression_carry.1"]
+    assert past_carry.dtype == ir.DataType.FLOAT
+    assert [int(d) for d in past_carry.shape[1:]] == [128, 2, 16]
+    # Fixed carry planes are stable across the step (chainable decode state).
+    assert [str(d) for d in past_carry.shape] == [str(d) for d in pres_carry.shape]
+
+    # Dense sliding-window KV IO stays present and DISTINCT alongside the
+    # compressed state (MQA data identical, but must be separate values).
+    assert outputs["present.1.key"] is not outputs["present.1.value"]
+
+
+def test_native_csa_present_state_is_chainable_for_decode():
+    # Shape-faithful prefill + >=16 decode: present_* record axis is dynamic
+    # and carry planes fixed, so present_* names/shapes chain back into past_*
+    # inputs for any decode length (no static per-step sizing).
+    config = _tiny_config(num_hidden_layers=2, compress_ratios=[0, 128], native_csa=True)
+    graph = build_from_module(DeepSeekV4CausalLMModel(config), config, task="deepseek-v4")[
+        "model"
+    ].graph
+    inputs = _named(graph.inputs)
+    outputs = _named(graph.outputs)
+
+    past_kv, pres_kv = inputs["past_compressed_kv.1"], outputs["present_compressed_kv.1"]
+    # Same rank + same trailing stored width => output can feed the input.
+    assert len(past_kv.shape) == len(pres_kv.shape) == 3
+    assert int(past_kv.shape[2]) == int(pres_kv.shape[2]) == 16
+    assert isinstance(past_kv.shape[1], ir.SymbolicDim)
+    assert isinstance(pres_kv.shape[1], ir.SymbolicDim)
+    past_carry, pres_carry = (
+        inputs["past_compression_carry.1"],
+        outputs["present_compression_carry.1"],
+    )
+    assert [int(d) for d in past_carry.shape[1:]] == [int(d) for d in pres_carry.shape[1:]]
+
+
+def test_native_csa_f32_inputs_under_fp16():
+    # Mirrors GLM DSA precedent: even when the model dtype is FLOAT16, the
+    # frozen op's float inputs must be explicitly cast to FLOAT (f32 cache
+    # format); integer length inputs keep their integer dtype.
+    config = _tiny_config(
+        num_hidden_layers=2,
+        compress_ratios=[0, 128],
+        native_csa=True,
+        dtype=ir.DataType.FLOAT16,
+    )
+    graph = build_from_module(DeepSeekV4CausalLMModel(config), config, task="deepseek-v4")[
+        "model"
+    ].graph
+    node = _csa_nodes(graph)[0]
+
+    float_input_positions = [0, 1, 2, 3, 4, 5, 6, 7, 10]
+    for pos in float_input_positions:
+        assert node.inputs[pos].dtype == ir.DataType.FLOAT, (
+            f"CSA input[{pos}] must be FLOAT under a FLOAT16 model dtype"
+        )
+    assert node.inputs[8].dtype == ir.DataType.INT32  # seqlens_k
+    assert node.inputs[9].dtype == ir.DataType.INT64  # total_sequence_length
+
+
+def test_native_csa_no_dead_anchor_for_hca_layer():
+    # The enabled layer's compressor weights must feed REAL dataflow into the
+    # native op (not be retained only as a zero-valued shape anchor).
+    config = _tiny_config(
+        num_hidden_layers=2,
+        compress_ratios=[0, 128],
+        native_csa=True,
+    )
+    graph = build_from_module(DeepSeekV4CausalLMModel(config), config, task="deepseek-v4")[
+        "model"
+    ].graph
+    node = _csa_nodes(graph)[0]
+    initializers = set(graph.initializers)
+
+    # compressor_kv / compressor_gate are produced by real MatMul projections.
+    assert node.inputs[2].producer() is not None
+    assert node.inputs[2].producer().op_type == "MatMul"
+    assert node.inputs[3].producer() is not None
+    assert node.inputs[3].producer().op_type == "MatMul"
+    # compressor_ape / compressor_norm are wired straight from the preserved
+    # initializers (not zero anchors).
+    assert node.inputs[4].name == "model.layers.1.self_attn.compressor.ape"
+    assert node.inputs[5].name == "model.layers.1.self_attn.compressor.norm.weight"
+    # Weights survive by actual dataflow, not a discarded shape anchor.
+    assert "model.layers.1.self_attn.compressor.wkv.weight" in initializers
+    assert "model.layers.1.self_attn.compressor.wgate.weight" in initializers
+    assert "model.layers.1.self_attn.compressor.ape" in initializers
+    assert "model.layers.1.self_attn.compressor.norm.weight" in initializers
+
+
+def _fill_and_serialize(model):
+    for name in list(model.graph.initializers):
+        value = model.graph.initializers[name]
+        if value.const_value is None:
+            shape = tuple(int(d) for d in value.shape)
+            dtype = value.dtype.numpy() if value.dtype is not None else np.float32
+            value.const_value = ir.tensor(np.zeros(shape, dtype=dtype), name=name)
+    return ir.to_proto(model).SerializeToString()
+
+
+def test_native_csa_disabled_is_byte_identical():
+    # Feature off => byte-identical to the existing dense correctness export,
+    # and no CSA node / no compressed IO leaks in.
+    ratios = [0, 0, 4, 128]
+    cfg_unset = _tiny_config(num_hidden_layers=4, compress_ratios=ratios)
+    cfg_false = _tiny_config(num_hidden_layers=4, compress_ratios=ratios, native_csa=False)
+    model_unset = build_from_module(
+        DeepSeekV4CausalLMModel(cfg_unset), cfg_unset, task="deepseek-v4"
+    )["model"]
+    model_false = build_from_module(
+        DeepSeekV4CausalLMModel(cfg_false), cfg_false, task="deepseek-v4"
+    )["model"]
+
+    assert cfg_unset.native_csa is False
+    assert count_op_type(model_unset.graph, "CompressedSparseAttention") == 0
+    assert not any("compress" in v.name for v in model_unset.graph.inputs)
+    assert not any("compress" in v.name for v in model_unset.graph.outputs)
+    assert _fill_and_serialize(model_unset) == _fill_and_serialize(model_false)
+
+
+def test_native_csa_defaults_off_and_opt_in():
+    assert _tiny_config().native_csa is False
+    assert _tiny_config(native_csa=True).native_csa is True
+
+
+def test_native_csa_rejects_ratio4():
+    # ratio-4 CSA (learned FP4 indexer + top-k) is out of C1 scope: requesting
+    # native export for it must fail closed at construction, never emit dense.
+    config = _tiny_config(num_hidden_layers=2, compress_ratios=[0, 4], native_csa=True)
+    with pytest.raises(NativeCsaExportError):
+        DeepSeekV4CausalLMModel(config)
+
+
+def test_native_csa_rejects_quantized():
+    config = _tiny_config(
+        num_hidden_layers=2,
+        compress_ratios=[0, 128],
+        native_csa=True,
+        quantization=QuantizationConfig(bits=4, group_size=16, quant_method="gptq", sym=True),
+    )
+    with pytest.raises(NativeCsaExportError):
+        DeepSeekV4CausalLMModel(config)
+
+
+def test_plan_native_csa_rejects_mtp():
+    # MTP compressed-state recurrence is not modeled in C1.
+    config = _tiny_config(num_hidden_layers=1, compress_ratios=[128], native_csa=True)
+    with pytest.raises(NativeCsaExportError):
+        plan_native_csa(config, 0, is_mtp=True)
+
+
+def test_plan_native_csa_rejects_unknown_ratio():
+    # Unknown compression ratios cannot match the frozen v1 contract. Call the
+    # planner directly to exercise its branch (the model __init__ ValueError
+    # guard would otherwise reject an unknown ratio before planning).
+    config = _tiny_config(num_hidden_layers=1, compress_ratios=[0], native_csa=True)
+    object.__setattr__(config, "compress_ratios", [7])
+    with pytest.raises(NativeCsaExportError):
+        plan_native_csa(config, 0)
+
+
+def test_plan_native_csa_off_and_dense_layers_return_none():
+    # Fail-closed only when requested: feature off or a ratio-0 dense layer
+    # legitimately opts out (returns None), not a typed error.
+    off = _tiny_config(num_hidden_layers=1, compress_ratios=[128], native_csa=False)
+    assert plan_native_csa(off, 0) is None
+    dense = _tiny_config(num_hidden_layers=1, compress_ratios=[0], native_csa=True)
+    assert plan_native_csa(dense, 0) is None
+
+
+def test_plan_native_csa_ratio128_layer_matches_contract():
+    config = _tiny_config(num_hidden_layers=2, compress_ratios=[0, 128], native_csa=True)
+    plan = plan_native_csa(config, 1)
+    assert plan is not None
+    assert plan.layer_id == 1
+    assert plan.num_heads == 2
+    assert plan.head_dim == 16
+    assert plan.qk_rope_head_dim == 4
+    assert plan.compression_ratio == HCA_COMPRESSION_RATIO == 128
+    assert plan.cache_format == "f32"
+    assert plan.past_compressed_kv_name == "past_compressed_kv.1"
+    assert plan.present_compression_carry_name == "present_compression_carry.1"

--- a/src/mobius/tasks/_deepseek_v4.py
+++ b/src/mobius/tasks/_deepseek_v4.py
@@ -70,19 +70,23 @@ class DeepSeekV4Task(ModelTask):
 
     @staticmethod
     def _compressed_inputs(builder, module, batch):
-        """Create the native-CSA ``past_compressed_*`` graph inputs.
+        """Create the native-CSA ``past_*`` compressed/index graph inputs.
 
         Inspects each built attention layer's resolved ``csa_plan`` (the
-        property gate's output) and, for every native-CSA (ratio-128) layer,
-        registers the deterministic compressed-state inputs alongside the
-        existing dense KV cache. Returns a per-layer list aligned with
+        property gate's output) and, for every native-CSA layer, registers the
+        deterministic compressed-state inputs alongside the existing dense KV
+        cache. Ratio-128 (HCA) threads two f32 tensors
+        (``past_compressed_kv``/``past_compression_carry``); ratio-4 (CSA)
+        threads four (adding the packed uint8 ``past_index_key`` and the f32
+        ``past_index_carry``). Returns a per-layer list aligned with
         ``module.model.layers`` -- ``None`` for dense layers -- for the model's
         ``past_compressed_states`` argument.
 
         When ``config.native_csa`` is off every plan is ``None``, so no inputs
         are created and the returned list is all-``None`` (byte-identical to
-        the pre-CSA graph). The records axis is a shared dynamic symbolic dim
-        because every CSA layer advances its compressed cache in lockstep.
+        the pre-CSA graph). The compressed-record axis is a shared dynamic
+        symbolic dim because a layer's attention cache and index cache advance
+        in lockstep, and every CSA layer advances its cache together.
         """
         records = ir.SymbolicDim("past_compressed_records")
         past_compressed_states: list = []
@@ -93,43 +97,95 @@ class DeepSeekV4Task(ModelTask):
                 continue
             past_compressed_kv = builder.input(
                 plan.past_compressed_kv_name,
-                dtype=ir.DataType.FLOAT,
+                dtype=plan.cache_dtype,
                 shape=[batch, records, plan.stored_width],
             )
             past_compression_carry = builder.input(
                 plan.past_compression_carry_name,
                 dtype=ir.DataType.FLOAT,
-                shape=[batch, plan.carry_slots, plan.carry_planes, plan.head_dim],
+                shape=[batch, plan.carry_slots, plan.carry_planes, plan.compressor_width],
             )
-            past_compressed_states.append((past_compressed_kv, past_compression_carry))
+            if not plan.is_ratio4:
+                past_compressed_states.append((past_compressed_kv, past_compression_carry))
+                continue
+            past_index_key = builder.input(
+                plan.past_index_key_name,
+                dtype=plan.index_key_dtype,
+                shape=[batch, records, plan.index_stored_width],
+            )
+            past_index_carry = builder.input(
+                plan.past_index_carry_name,
+                dtype=ir.DataType.FLOAT,
+                shape=[
+                    batch,
+                    plan.carry_slots,
+                    plan.carry_planes,
+                    plan.index_compressor_width,
+                ],
+            )
+            past_compressed_states.append(
+                (
+                    past_compressed_kv,
+                    past_compression_carry,
+                    past_index_key,
+                    past_index_carry,
+                )
+            )
         return past_compressed_states
 
     @staticmethod
-    def _compressed_outputs(builder, module, present_compressed_states, batch):
-        """Register native-CSA ``present_compressed_*`` outputs with explicit shapes.
+    def _compressed_outputs(
+        builder, module, present_compressed_states, batch, sequence_length
+    ):
+        """Register native-CSA ``present_*`` outputs with explicit shapes.
 
         ``pkg.nxrt::CompressedSparseAttention`` has no Python/ONNX
         symbolic-shape-inference function (like ``pkg.nxrt::IndexShare`` in the
-        GLM DSA task), so each present compressed output is stamped with an
-        explicit type or it would export untyped. The records axis is a
-        distinct dynamic symbolic dim (present record count = past + newly
-        pooled blocks, not a simple ``past + sequence`` sum); the carry tensor
-        is records-independent ``[batch, ratio, planes, head_dim]``.
+        GLM DSA task), so each present output is stamped with an explicit type
+        or it would export untyped. The compressed-record axis is a distinct
+        dynamic symbolic dim (present record count = past + newly pooled
+        blocks, not a simple ``past + sequence`` sum); the carry tensors are
+        records-independent ``[batch, slots, planes, width]``.
+
+        Ratio-4 additionally emits the packed uint8 ``present_index_key``, the
+        f32 ``present_index_carry``, and the transient int32 ``selected_indices``
+        top-k result ``[batch, index_num_heads, sequence, min(records, topk)]``
+        (inspection-only; not threaded back as state).
         """
         present_records = ir.SymbolicDim("present_compressed_records")
+        selected_records = ir.SymbolicDim("selected_records")
         for layer, present in zip(module.model.layers, present_compressed_states):
             plan = layer.self_attn.csa_plan
             if plan is None:
                 continue
-            present_compressed_kv, present_compression_carry = present
+            present_compressed_kv = present[0]
+            present_compression_carry = present[1]
             present_compressed_kv.shape = ir.Shape([batch, present_records, plan.stored_width])
-            present_compressed_kv.type = ir.TensorType(ir.DataType.FLOAT)
+            present_compressed_kv.type = ir.TensorType(plan.cache_dtype)
             present_compression_carry.shape = ir.Shape(
-                [batch, plan.carry_slots, plan.carry_planes, plan.head_dim]
+                [batch, plan.carry_slots, plan.carry_planes, plan.compressor_width]
             )
             present_compression_carry.type = ir.TensorType(ir.DataType.FLOAT)
             builder.add_output(present_compressed_kv, plan.present_compressed_kv_name)
             builder.add_output(present_compression_carry, plan.present_compression_carry_name)
+            if not plan.is_ratio4:
+                continue
+            present_index_key, present_index_carry, selected_indices = present[2:]
+            present_index_key.shape = ir.Shape(
+                [batch, present_records, plan.index_stored_width]
+            )
+            present_index_key.type = ir.TensorType(plan.index_key_dtype)
+            present_index_carry.shape = ir.Shape(
+                [batch, plan.carry_slots, plan.carry_planes, plan.index_compressor_width]
+            )
+            present_index_carry.type = ir.TensorType(ir.DataType.FLOAT)
+            selected_indices.shape = ir.Shape(
+                [batch, plan.index_num_heads, sequence_length, selected_records]
+            )
+            selected_indices.type = ir.TensorType(ir.DataType.INT32)
+            builder.add_output(present_index_key, plan.present_index_key_name)
+            builder.add_output(present_index_carry, plan.present_index_carry_name)
+            builder.add_output(selected_indices, plan.selected_indices_name)
 
     def _build_target(self, module, config: ArchitectureConfig):
         graph, builder = _make_graph("deepseek_v4")
@@ -150,7 +206,9 @@ class DeepSeekV4Task(ModelTask):
         if len(module.mtp):
             builder.add_output(hc_states, "hidden_states")
         self._outputs(builder, presents, config, batch)
-        self._compressed_outputs(builder, module, present_compressed_states, batch)
+        self._compressed_outputs(
+            builder, module, present_compressed_states, batch, sequence_length
+        )
         return _make_model(graph)
 
     def _build_mtp(self, module, config: ArchitectureConfig):

--- a/src/mobius/tasks/_deepseek_v4.py
+++ b/src/mobius/tasks/_deepseek_v4.py
@@ -68,23 +68,89 @@ class DeepSeekV4Task(ModelTask):
             dtype=config.dtype,
         )
 
+    @staticmethod
+    def _compressed_inputs(builder, module, batch):
+        """Create the native-CSA ``past_compressed_*`` graph inputs.
+
+        Inspects each built attention layer's resolved ``csa_plan`` (the
+        property gate's output) and, for every native-CSA (ratio-128) layer,
+        registers the deterministic compressed-state inputs alongside the
+        existing dense KV cache. Returns a per-layer list aligned with
+        ``module.model.layers`` -- ``None`` for dense layers -- for the model's
+        ``past_compressed_states`` argument.
+
+        When ``config.native_csa`` is off every plan is ``None``, so no inputs
+        are created and the returned list is all-``None`` (byte-identical to
+        the pre-CSA graph). The records axis is a shared dynamic symbolic dim
+        because every CSA layer advances its compressed cache in lockstep.
+        """
+        records = ir.SymbolicDim("past_compressed_records")
+        past_compressed_states: list = []
+        for layer in module.model.layers:
+            plan = layer.self_attn.csa_plan
+            if plan is None:
+                past_compressed_states.append(None)
+                continue
+            past_compressed_kv = builder.input(
+                plan.past_compressed_kv_name,
+                dtype=ir.DataType.FLOAT,
+                shape=[batch, records, plan.stored_width],
+            )
+            past_compression_carry = builder.input(
+                plan.past_compression_carry_name,
+                dtype=ir.DataType.FLOAT,
+                shape=[batch, plan.carry_slots, plan.carry_planes, plan.head_dim],
+            )
+            past_compressed_states.append((past_compressed_kv, past_compression_carry))
+        return past_compressed_states
+
+    @staticmethod
+    def _compressed_outputs(builder, module, present_compressed_states, batch):
+        """Register native-CSA ``present_compressed_*`` outputs with explicit shapes.
+
+        ``pkg.nxrt::CompressedSparseAttention`` has no Python/ONNX
+        symbolic-shape-inference function (like ``pkg.nxrt::IndexShare`` in the
+        GLM DSA task), so each present compressed output is stamped with an
+        explicit type or it would export untyped. The records axis is a
+        distinct dynamic symbolic dim (present record count = past + newly
+        pooled blocks, not a simple ``past + sequence`` sum); the carry tensor
+        is records-independent ``[batch, ratio, planes, head_dim]``.
+        """
+        present_records = ir.SymbolicDim("present_compressed_records")
+        for layer, present in zip(module.model.layers, present_compressed_states):
+            plan = layer.self_attn.csa_plan
+            if plan is None:
+                continue
+            present_compressed_kv, present_compression_carry = present
+            present_compressed_kv.shape = ir.Shape([batch, present_records, plan.stored_width])
+            present_compressed_kv.type = ir.TensorType(ir.DataType.FLOAT)
+            present_compression_carry.shape = ir.Shape(
+                [batch, plan.carry_slots, plan.carry_planes, plan.head_dim]
+            )
+            present_compression_carry.type = ir.TensorType(ir.DataType.FLOAT)
+            builder.add_output(present_compressed_kv, plan.present_compressed_kv_name)
+            builder.add_output(present_compression_carry, plan.present_compression_carry_name)
+
     def _build_target(self, module, config: ArchitectureConfig):
         graph, builder = _make_graph("deepseek_v4")
         batch, sequence_length, attention_mask, position_ids, past_key_values = self._inputs(
             builder, config, config.num_hidden_layers
         )
         input_ids = builder.input("input_ids", ir.DataType.INT64, [batch, sequence_length])
-        hidden_states, presents, hc_states = module.model(
+        past_compressed_states = self._compressed_inputs(builder, module, batch)
+        hidden_states, presents, present_compressed_states, hc_states = module.model(
             builder.op,
             input_ids,
             attention_mask,
             position_ids,
             past_key_values,
+            past_compressed_states=past_compressed_states,
         )
         builder.add_output(module.lm_head(builder.op, hidden_states), "logits")
         if len(module.mtp):
             builder.add_output(hc_states, "hidden_states")
         self._outputs(builder, presents, config, batch)
+        self._compressed_outputs(builder, module, present_compressed_states, batch)
         return _make_model(graph)
 
     def _build_mtp(self, module, config: ArchitectureConfig):


### PR DESCRIPTION
## Summary

**Slice C1** of the DeepSeek-V4-Flash CSA/HCA custom-kernel path. Adds a **default-off, property-gated** Mobius exporter feature that emits the already-merged frozen `pkg.nxrt::CompressedSparseAttention` v1 op (**ratio-128 "Heavily Compressed Attention"** subset) for property-matching layers, replacing the zero-valued *shape-anchor* preservation with **real op dataflow** and **threaded compressed state IO**.

This is **exporter-only**. No onnx-genai runner/KV changes; **no PagedAttention-compatibility claim**.

Design: `deckard-deepseek-v4-csa-hca-cuda-slice.md` (§5 property ABI, §8 tiny-test spec, §10 C1 slice).

## What changed
- **`mobius.models._deepseek_v4_csa`** (new): `plan_native_csa` property gate + `emit_hca_attention` op emission. The gate matches native-op **properties** (compression ratio, block size, head/latent/rope dims, dtype, carry planes), **not** a model-name/shape allowlist.
- **`ArchitectureConfig.native_csa: bool = False`** — export-time opt-in (no HF equivalent; `config_overrides={"native_csa": True}`).
- **`DeepSeekV4Attention._forward_native_hca`** — emits the 11-input / 3-output op with pre-rotated `query`/`current_kv` (dense sliding-window ring over the existing dense KV IO), real *unrotated* compressor activations, f32 casts for the f32-cache-format op inputs, and threaded `past_*`/`present_*` compressed state. The shared inverse RoPE + output projection run unchanged on `Y`.
- **`DeepSeekV4Task`** — threads deterministic `past_compressed_kv.{i}` / `past_compression_carry.{i}` inputs and `present_*` outputs (explicit shapes, since the custom op has no Python shape inference), with a **dynamic record axis** and **fixed carry planes** so present state chains back into past inputs for **≥16 decode steps**.

## Fail-closed (never silent dense)
Requesting native CSA for **ratio-4 CSA**, an **MTP** layer, **quantized** compressor weights, or an **unknown ratio** raises `NativeCsaExportError`. Ratio-0 dense layers and feature-off legitimately return `None` (dense) — those are not a suppressed fallback.

## Off = byte-identical
With the feature off, the exported graph is **byte-identical** to the existing dense correctness export (verified) and emits **zero `pkg.nxrt` ops / no compressed IO**.

## Tests (shape-faithful / structural — no weight download, no ORT run)
The frozen op has no Python shape inference and no Rust EP in the Python env, so tests assert structure: exact op attrs + 11/3 IO, threaded compressed-state IO names/shapes/dtypes, decode chainability, **f32 inputs under a FLOAT16 model dtype** (GLM DSA precedent), **no dead anchor** for the HCA layer, byte-identical disabled baseline, defaults-off + opt-in, and typed rejects (ratio-4 / quantized / MTP / unknown-ratio). Existing DeepSeek-V4 tests unchanged.

Local validation (this env):
- `deepseek_v4_flash_test.py` + `deepseek_v4_test.py`: **30 passed**
- `_configs`/`tasks`/`glm_moe_dsa` related tests: **168 passed**
- `ruff check` + `ruff format --check`: clean

## Scope / non-goals
- ❌ No onnx-genai runner or KV/cache changes (later slice).
- ❌ No PagedAttention-compatibility claim.
- ❌ ratio-4 learned-indexer/top-k selection is a follow-up slice.

## Status
**DRAFT — stop for independent review. Do not merge.** CI is async; local tests above are the validation of record.