### PR TITLE
Fix DeepSeek-V4: wire mandatory sliding-window into both attention paths

### DIFF
--- a/docs/design/deepseek-v4-flash-export.md
+++ b/docs/design/deepseek-v4-flash-export.md
@@ -33,12 +33,21 @@ Hyper-Connections. A separate model module avoids forcing those semantics
 into `DeepSeekMLA`.
 
 This increment exports the V4 projections, full Hyper-Connections, V4 MoE
-routing/shared experts, and KV-cache-compatible **dense causal attention**.
-The fallback includes the official per-head attention sinks. It follows the
-checkpoint's `compress_ratios` schedule and retains every learned compressor
-and ratio-4 indexer tensor in the ONNX graph, but does not yet execute
-compressed-history selection. The dense path is therefore correct as causal
-attention, while not numerically equivalent to CSA/HCA at long context.
+routing/shared experts, and KV-cache-compatible **dense, `sliding_window`-
+restricted causal attention** (`local_window_size` on the fused GQA path,
+an explicit float bias on the decomposed path — see
+`DeepSeekV4Attention.local_window_size`). The reference model
+unconditionally restricts every layer, regardless of `compress_ratio`, to
+its most recent `sliding_window` (128) positions; this window is applied
+uniformly here too. The fallback includes the official per-head attention
+sinks. It follows the checkpoint's `compress_ratios` schedule and retains
+every learned compressor and ratio-4 indexer tensor in the ONNX graph, but
+does not yet execute compressed-history selection: ratio>0 layers get the
+correct windowed local component but are still missing the additional
+compressed/indexer-selected positions the reference unions into the same
+softmax. The dense path is therefore exactly correct for `compress_ratio=0`
+layers, and partially correct (window right, compressed history missing)
+for `compress_ratio>0` layers at long context.
 
 The official single MTP block is exported as `mtp/model.onnx`. It consumes the
 target's raw Hyper-Connection state plus the next-token embedding, runs the

--- a/src/mobius/models/deepseek_v4.py
+++ b/src/mobius/models/deepseek_v4.py
@@ -443,6 +443,20 @@ class DeepSeekV4Attention(nn.Module):
         self.eps = config.rms_norm_eps
         self.scale = self.head_dim**-0.5
         self.rope_interleave = config.rope_interleave
+        # Official reference (`inference/model.py::Attention.forward`,
+        # `get_window_topk_idxs`) unconditionally restricts every layer -
+        # regardless of `compress_ratio` - to a circular-buffer local window
+        # of `config.sliding_window` (DeepSeek-V4-Flash: 128) most-recent
+        # positions; ratio>0 layers additionally union in compressed/indexed
+        # positions (not modeled here, see `DeepSeekV4CompressorTensors`/
+        # `DeepSeekV4IndexerTensors`), but the window restriction itself
+        # applies to every layer, not just ratio-0. `-1` is GQA's documented
+        # sentinel for "no local window" (matches `_gqa_local_window_size` in
+        # `models/base.py`), used only if the config genuinely has no window.
+        sliding_window = config.sliding_window
+        self.local_window_size = (
+            int(sliding_window) if sliding_window and sliding_window > 0 else -1
+        )
         ratios = config.compress_ratios or []
         self.compress_ratio = ratios[layer_id] if layer_id < len(ratios) else 0
         if self.compress_ratio not in (0, 4, 128):
@@ -555,23 +569,39 @@ class DeepSeekV4Attention(nn.Module):
             # literally the same rotated `kv` tensor -- broadcasting
             # `kv_num_heads=1` across all query heads is the fused op's own
             # job, so `_expand_kv` isn't needed on this path. No explicit
-            # `attention_bias` is passed: this is a plain causal decoder
-            # attention (no sliding window, no KV-sharing across layers, no
-            # per-layer dual head_dim), so GQA's own implicit causal masking
-            # plus `seqlens_k`/`total_seq_len` already carries the exact same
-            # causal+padding semantics `create_attention_bias` bakes into an
-            # explicit float bias on the decomposed path below -- this is the
-            # same "direct GQA" convention `Attention._forward_gqa`
-            # (mobius/components/_attention.py) already uses for every other
-            # simple-causal model in this codebase (see the
-            # `attention-optimization` skill: "Use Contrib GQA when you don't
-            # need attention bias"). `head_sink` carries the learned per-head
-            # attention sink exactly as the decomposed path's
-            # `Concat(scores, sinks) -> Softmax -> slice` sequence does, now
-            # as a first-class op input instead of a manually broadcast
-            # Concat.
+            # `attention_bias` is passed: causal + padding is carried by
+            # `seqlens_k`/`total_seq_len` (no KV-sharing across layers, no
+            # per-layer dual head_dim), same as the "direct GQA" convention
+            # `Attention._forward_gqa` (mobius/components/_attention.py)
+            # already uses for every other simple-causal model in this
+            # codebase (see the `attention-optimization` skill: "Use Contrib
+            # GQA when you don't need attention bias"). The official
+            # reference (`inference/model.py::Attention.forward`,
+            # `get_window_topk_idxs`) unconditionally restricts every layer
+            # to the most recent `local_window_size` positions -- this is
+            # NOT optional/ratio-dependent -- so `local_window_size` is
+            # passed as a first-class GQA attribute (`-1` sentinel when the
+            # config declares no window) instead of baking it into an
+            # explicit float bias as the decomposed path below does via
+            # `create_attention_bias(sliding_window=...)`. `head_sink`
+            # carries the learned per-head attention sink exactly as the
+            # decomposed path's `Concat(scores, sinks) -> Softmax -> slice`
+            # sequence does, now as a first-class op input instead of a
+            # manually broadcast Concat.
             past_key = past_key_value[0] if past_key_value is not None else None
             past_value = past_key_value[1] if past_key_value is not None else None
+            gqa_attrs: dict = {
+                "num_heads": self.num_heads,
+                "kv_num_heads": 1,
+                "scale": self.scale,
+            }
+            # Match the shared `Attention._forward_gqa` convention (see
+            # `mobius/components/_attention.py`): only emit the attribute
+            # when a window is actually configured, so a model with no
+            # window (local_window_size == -1) keeps a graph identical to
+            # before this attribute existed.
+            if self.local_window_size > 0:
+                gqa_attrs["local_window_size"] = self.local_window_size
             output, present_key, present_value = op.GroupQueryAttention(
                 query,
                 kv,
@@ -585,11 +615,9 @@ class DeepSeekV4Attention(nn.Module):
                 None,  # position_ids: unused, do_rotary=0
                 None,  # attention_bias: unused, plain causal + seqlens_k suffices
                 op.CastLike(self.attn_sink, query),  # head_sink
-                num_heads=self.num_heads,
-                kv_num_heads=1,
-                scale=self.scale,
                 _domain="com.microsoft",
                 _outputs=3,
+                **gqa_attrs,
             )
         else:
             # Portable decomposed path: used whenever the active EP declares
@@ -823,6 +851,10 @@ class DeepSeekV4TextModel(nn.Module):
             )
         )
         self._dtype = config.dtype
+        # See `DeepSeekV4Attention.local_window_size`: the reference always
+        # restricts attention to this window, so the decomposed path's
+        # shared bias (built once here for every layer) must bake it in too.
+        self.sliding_window = config.sliding_window
 
     def _hc_head(self, op, states):
         flat = op.Reshape(states, [0, 0, -1])
@@ -865,6 +897,7 @@ class DeepSeekV4TextModel(nn.Module):
                 op,
                 input_ids=hidden_states if input_ids is None else input_ids,
                 attention_mask=attention_mask,
+                sliding_window=self.sliding_window,
                 dtype=self._dtype,
             )
             seqlens_k, total_seq_len = None, None
@@ -917,6 +950,10 @@ class DeepSeekV4Mtp(DeepSeekV4DecoderLayer):
         )
         self.rotary_emb = initialize_rope(rope_config)
         self._dtype = config.dtype
+        # See `DeepSeekV4Attention.local_window_size`: the MTP layer is a
+        # regular ratio-0 (or configured-ratio) DeepSeekV4DecoderLayer, so it
+        # is bound by the same mandatory window as the backbone.
+        self.sliding_window = config.sliding_window
 
     def _hc_head(self, op: OpBuilder, states: ir.Value) -> ir.Value:
         flat = op.Reshape(states, [0, 0, -1])
@@ -950,6 +987,7 @@ class DeepSeekV4Mtp(DeepSeekV4DecoderLayer):
                 op,
                 input_ids=inputs_embeds,
                 attention_mask=attention_mask,
+                sliding_window=self.sliding_window,
                 dtype=self._dtype,
             )
             seqlens_k, total_seq_len = None, None

--- a/src/mobius/models/deepseek_v4_flash_test.py
+++ b/src/mobius/models/deepseek_v4_flash_test.py
@@ -3,20 +3,30 @@
 
 from __future__ import annotations
 
+import dataclasses
 import json
 from types import SimpleNamespace
 
 import numpy as np
 import onnx_ir as ir
+import onnxruntime as ort
 import pytest
 import torch
+from onnxscript import GraphBuilder
 
 from mobius._builder import build_from_module
 from mobius._configs import ArchitectureConfig, QuantizationConfig
+from mobius._constants import OPSET_VERSION
 from mobius._testing import count_op_type, make_config
+from mobius.components import create_attention_bias
+from mobius.components._rotary_embedding import initialize_rope
 from mobius.integrations.ort_genai import export_package
 from mobius.integrations.transformers._config_resolver import _default_task_for_model
-from mobius.models.deepseek_v4 import DeepSeekV4CausalLMModel
+from mobius.models.deepseek_v4 import (
+    DeepSeekV4Attention,
+    DeepSeekV4CausalLMModel,
+    _gqa_kv_lengths,
+)
 
 
 def _tiny_config(**overrides):
@@ -167,6 +177,11 @@ def test_tiny_graph_builds_v4_backbone_fused_gqa_on_cpu_ep():
     # decoding, matching every other direct-GQA model in this codebase.
     assert all(len(node.inputs) == 12 and node.inputs[10] is None for node in gqa_nodes)
     assert all(node.inputs[11] is not None for node in gqa_nodes)
+    # `_tiny_config()` sets no `sliding_window`, so `local_window_size` must
+    # be entirely absent (the `Attention._forward_gqa` convention -- see
+    # `mobius/components/_attention_test.py::test_gqa_context_no_local_window_size_when_default`)
+    # rather than present with the -1 "disabled" sentinel value.
+    assert all("local_window_size" not in node.attributes for node in gqa_nodes)
     # Only the Hyper-Connection combination softmax (2 per layer) remains;
     # the manual Concat(scores, sink) -> Softmax -> slice attention softmax
     # the decomposed path uses is gone now that GQA computes it internally.
@@ -178,6 +193,30 @@ def test_tiny_graph_builds_v4_backbone_fused_gqa_on_cpu_ep():
     assert count_op_type(graph, "RMSNormalization") >= 1
     assert sum("attn_sink" in name for name in graph.initializers) == config.num_hidden_layers
     assert "hidden_states" not in {value.name for value in graph.outputs}
+
+
+def test_sliding_window_sets_local_window_size_on_fused_gqa_regardless_of_compress_ratio():
+    """The reference's mandatory per-layer window must reach GQA as an attribute.
+
+    Official DeepSeek-V4 (``inference/model.py::Attention.forward``,
+    ``get_window_topk_idxs``) unconditionally restricts *every* layer --
+    regardless of ``compress_ratio`` -- to a circular-buffer window of the
+    most recent ``sliding_window`` positions. Regression test for the bug
+    where ``DeepSeekV4Attention`` never read ``config.sliding_window`` at
+    all (see ``DeepSeekV4Attention.local_window_size``), silently computing
+    unbounded causal attention on both the fused-GQA and decomposed paths.
+    Ratio>0 layers still only get the *local* component of the reference's
+    attention correctly here -- the additional compressed/indexer-selected
+    positions those layers union in remain a separate, tracked gap (see
+    ``docs/models/DEEPSEEK_CSA_MTP_RUNTIME.md``, not addressed by this test.
+    """
+    config = _tiny_config(num_hidden_layers=3, compress_ratios=[0, 4, 128], sliding_window=8)
+    graph = build_from_module(
+        DeepSeekV4CausalLMModel(config), config, execution_provider="cpu"
+    )["model"].graph
+    gqa_nodes = [node for node in graph if node.op_type == "GroupQueryAttention"]
+    assert len(gqa_nodes) == config.num_hidden_layers
+    assert all(node.attributes["local_window_size"].as_int() == 8 for node in gqa_nodes)
 
 
 def test_csa_schedule_exports_compressor_and_indexer_tensors_with_dense_attention():
@@ -475,3 +514,214 @@ def test_preprocess_weights_accepts_hash_table_with_distinct_experts_per_token()
     weights = {"layers.0.ffn.gate.tid2eid": tid2eid}
     result = model.preprocess_weights(weights)
     assert torch.equal(result["model.layers.0.mlp.moe.gate.tid2eid"], tid2eid)
+
+
+def _attention_only_config(**overrides):
+    """A ``DeepSeekV4Attention``-sized config with a RoPE-capable ``rope_type``.
+
+    Deliberately smaller/simpler than ``_tiny_config`` (no MoE/HC fields
+    needed): only what ``DeepSeekV4Attention.__init__`` and its own
+    ``rotary_emb`` construction (mirroring ``DeepSeekV4TextModel.__init__``)
+    require.
+    """
+    values = dict(
+        model_type="deepseek_v4",
+        hidden_size=32,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=16,
+        q_lora_rank=8,
+        qk_rope_head_dim=4,
+        o_groups=2,
+        o_lora_rank=8,
+        rope_interleave=True,
+        rope_type="default",
+    )
+    values.update(overrides)
+    return make_config(**values)
+
+
+def _run_attention_graph(
+    config,
+    *,
+    hidden_values,
+    attention_mask_values,
+    state,
+    fused_gqa,
+    decomposed_sliding_window,
+):
+    """Build and execute a standalone ``DeepSeekV4Attention`` prefill graph.
+
+    A fresh ``DeepSeekV4Attention``/rotary-embedding pair is constructed
+    *inside* this call (rather than reused across invocations) because
+    ``onnxscript.nn.Parameter._realize`` is a one-shot, per-parameter-object
+    flag: reusing the same module/rotary instance across more than one
+    ``GraphBuilder``/graph would silently skip re-registering its
+    initializers (e.g. ``cos_cache``) on the second and later graphs. ``state``
+    (a ``name -> ir.tensor`` dict of fixed random weight values, built once
+    by the caller from one throwaway probe instance) is reapplied via
+    ``load_state_dict`` so every call sees byte-identical weights.
+
+    ``decomposed_sliding_window`` is the caller's explicit choice for the
+    decomposed path's bias (ignored when ``fused_gqa=True``, which instead
+    reads ``config.sliding_window`` via ``attn.local_window_size``) -- this
+    lets one attention module built with a fixed ``config.sliding_window``
+    (so the fused-GQA case is representative of that config) also produce
+    an "unbounded" decomposed baseline for comparison.
+    """
+    attn = DeepSeekV4Attention(config, layer_id=0)
+    attn.load_state_dict(state)
+    rope_config = dataclasses.replace(config, head_dim=config.qk_rope_head_dim)
+    rotary_emb = initialize_rope(
+        dataclasses.replace(
+            rope_config,
+            rope_type="default",
+            rope_scaling=None,
+            original_max_position_embeddings=None,
+        )
+    )
+
+    batch, seq_len, hidden_size = hidden_values.shape
+    graph = ir.Graph(
+        inputs=[],
+        outputs=[],
+        nodes=[],
+        name="deepseek_v4_attention_window_fixture",
+        opset_imports={"": OPSET_VERSION, "com.microsoft": 1},
+    )
+    builder = GraphBuilder(graph)
+    op = builder.op
+    hidden_states = ir.Value(
+        name="hidden_states",
+        shape=ir.Shape([batch, seq_len, hidden_size]),
+        type=ir.TensorType(ir.DataType.FLOAT),
+    )
+    attention_mask = ir.Value(
+        name="attention_mask",
+        shape=ir.Shape([batch, seq_len]),
+        type=ir.TensorType(ir.DataType.INT64),
+    )
+    position_ids = ir.Value(
+        name="position_ids",
+        shape=ir.Shape([batch, seq_len]),
+        type=ir.TensorType(ir.DataType.INT64),
+    )
+    graph.inputs.extend([hidden_states, attention_mask, position_ids])
+
+    position_embeddings = rotary_emb(op, position_ids)
+    if fused_gqa:
+        attention_bias = None
+        seqlens_k, total_seq_len = _gqa_kv_lengths(op, attention_mask)
+    else:
+        attention_bias = create_attention_bias(
+            op,
+            input_ids=hidden_states,
+            attention_mask=attention_mask,
+            sliding_window=decomposed_sliding_window,
+            dtype=ir.DataType.FLOAT,
+        )
+        seqlens_k, total_seq_len = None, None
+
+    output, _ = attn(
+        op, hidden_states, position_embeddings, None, attention_bias, seqlens_k, total_seq_len
+    )
+    output.name = "output"
+    graph.outputs.append(output)
+
+    model = ir.Model(graph, ir_version=11)
+    proto = ir.to_proto(model)
+    session = ort.InferenceSession(
+        proto.SerializeToString(), providers=["CPUExecutionProvider"]
+    )
+    (actual,) = session.run(
+        None,
+        {
+            "hidden_states": hidden_values,
+            "attention_mask": attention_mask_values,
+            "position_ids": np.arange(seq_len, dtype=np.int64)[None, :].repeat(batch, axis=0),
+        },
+    )
+    return actual
+
+
+def test_missing_sliding_window_regression_fused_gqa_matches_windowed_decomposed():
+    """Regression test for the missing mandatory sliding-window bug.
+
+    Official DeepSeek-V4 (``inference/model.py::Attention.forward``,
+    ``get_window_topk_idxs``) restricts every layer, regardless of
+    ``compress_ratio``, to a circular-buffer window of the ``sliding_window``
+    (128 in the real checkpoint) most-recent positions. Before this fix,
+    *neither* the decomposed (``create_attention_bias``) nor the fused-GQA
+    (``GroupQueryAttention.local_window_size``) path applied this
+    restriction: both silently computed full/unbounded causal attention.
+
+    This builds byte-identical weights/inputs (seq_len=6) through a module
+    configured with ``sliding_window=2`` (smaller than seq_len, so the
+    restriction actually bites), then executes three graphs:
+
+    * "unbounded": decomposed path, no window applied to the bias
+      (``create_attention_bias(sliding_window=None)``) -- the pre-fix
+      behavior for every layer, window-configured or not.
+    * "windowed": same decomposed path, but with the module's own
+      ``sliding_window=2`` baked into the bias.
+    * "fused": the fused-``GroupQueryAttention`` path, built from the same
+      module (``config.sliding_window=2``, so ``local_window_size=2`` per
+      ``DeepSeekV4Attention.__init__``).
+
+    Assertions:
+    1. unbounded vs. windowed must DIFFER -- proves ``sliding_window``
+       actually changes the decomposed path's output (sanity check that the
+       fixture is exercising the window at all).
+    2. windowed vs. fused must MATCH -- proves the fused-GQA
+       ``local_window_size`` attribute reproduces the *exact* same
+       restriction as the decomposed path's explicit float bias. This is
+       the decisive assertion: on the pre-fix code, ``local_window_size``
+       was never wired into the ``GroupQueryAttention`` call at all, so
+       "fused" would equal "unbounded", not "windowed", and this assertion
+       would fail.
+    """
+    window = 2
+    seq_len = 6  # > window, so the restriction actually bites.
+    config = _attention_only_config(sliding_window=window)
+
+    rng = np.random.default_rng(0)
+    probe = DeepSeekV4Attention(config, layer_id=0)
+    state = {}
+    for name, param in probe.named_parameters():
+        shape = [int(d) for d in param.shape]
+        state[name] = ir.tensor((rng.standard_normal(shape) * 0.1).astype(np.float32))
+
+    batch, hidden_size = 1, config.hidden_size
+    hidden_values = (
+        np.random.default_rng(1).standard_normal((batch, seq_len, hidden_size)) * 0.1
+    ).astype(np.float32)
+    attention_mask_values = np.ones((batch, seq_len), dtype=np.int64)
+
+    def _run(*, fused_gqa, decomposed_sliding_window):
+        return _run_attention_graph(
+            config,
+            hidden_values=hidden_values,
+            attention_mask_values=attention_mask_values,
+            state=state,
+            fused_gqa=fused_gqa,
+            decomposed_sliding_window=decomposed_sliding_window,
+        )
+
+    unbounded = _run(fused_gqa=False, decomposed_sliding_window=None)
+    windowed = _run(fused_gqa=False, decomposed_sliding_window=window)
+    fused = _run(fused_gqa=True, decomposed_sliding_window=None)
+
+    assert not np.allclose(unbounded, windowed, atol=1e-4), (
+        "sliding_window=2 must change the decomposed path's output for "
+        "seq_len=6 > window -- if this passes, the fixture isn't "
+        "exercising the window at all"
+    )
+    np.testing.assert_allclose(
+        windowed,
+        fused,
+        atol=1e-4,
+        err_msg=(
+            "fused-GQA local_window_size must reproduce the exact same "
+            "restriction as the decomposed path's explicit windowed bias"
+        ),
+    )

--- a/src/mobius/models/deepseek_v4_flash_test.py
+++ b/src/mobius/models/deepseek_v4_flash_test.py
@@ -209,14 +209,29 @@ def test_sliding_window_sets_local_window_size_on_fused_gqa_regardless_of_compre
     attention correctly here -- the additional compressed/indexer-selected
     positions those layers union in remain a separate, tracked gap (see
     ``docs/models/DEEPSEEK_CSA_MTP_RUNTIME.md``, not addressed by this test.
+    The MTP sidecar (``DeepSeekV4Mtp``) is a regular ratio-0 decoder layer
+    bound by the same mandatory window, so it's checked here too (a plain
+    ``compress_ratios=[0]`` layer, since MTP doesn't schedule its own
+    ratios).
     """
-    config = _tiny_config(num_hidden_layers=3, compress_ratios=[0, 4, 128], sliding_window=8)
-    graph = build_from_module(
-        DeepSeekV4CausalLMModel(config), config, execution_provider="cpu"
-    )["model"].graph
+    config = _tiny_config(
+        num_hidden_layers=3,
+        compress_ratios=[0, 4, 128],
+        sliding_window=8,
+        num_nextn_predict_layers=1,
+    )
+    package = build_from_module(
+        DeepSeekV4CausalLMModel(config), config, task="deepseek-v4", execution_provider="cpu"
+    )
+
+    graph = package["model"].graph
     gqa_nodes = [node for node in graph if node.op_type == "GroupQueryAttention"]
     assert len(gqa_nodes) == config.num_hidden_layers
     assert all(node.attributes["local_window_size"].as_int() == 8 for node in gqa_nodes)
+
+    mtp_graph = package["mtp"].graph
+    (mtp_gqa_node,) = [node for node in mtp_graph if node.op_type == "GroupQueryAttention"]
+    assert mtp_gqa_node.attributes["local_window_size"].as_int() == 8
 
 
 def test_csa_schedule_exports_compressor_and_indexer_tensors_with_dense_attention():

--- a/tests/_test_configs.py
+++ b/tests/_test_configs.py
@@ -718,6 +718,14 @@ CAUSAL_LM_CONFIGS: list[tuple[str, dict, bool]] = [
                 "beta_slow": 1,
                 "original_max_position_embeddings": 128,
             },
+            # Official reference unconditionally restricts every layer to
+            # this many most-recent positions (`get_window_topk_idxs`),
+            # regardless of `compress_ratios` -- see
+            # `DeepSeekV4Attention.local_window_size`. Deliberately smaller
+            # than the parity tests' sequence length so windowing is
+            # actually exercised (matches the `sliding_window: 8` tiny-config
+            # convention used by gemma/gemma4/muse-glimmer above).
+            "sliding_window": 8,
         },
         True,
     ),

--- a/tests/_test_configs.py
+++ b/tests/_test_configs.py
@@ -721,10 +721,15 @@ CAUSAL_LM_CONFIGS: list[tuple[str, dict, bool]] = [
             # Official reference unconditionally restricts every layer to
             # this many most-recent positions (`get_window_topk_idxs`),
             # regardless of `compress_ratios` -- see
-            # `DeepSeekV4Attention.local_window_size`. Deliberately smaller
-            # than the parity tests' sequence length so windowing is
-            # actually exercised (matches the `sliding_window: 8` tiny-config
-            # convention used by gemma/gemma4/muse-glimmer above).
+            # `DeepSeekV4Attention.local_window_size`. Matches the
+            # `sliding_window: 8` tiny-config convention used by
+            # gemma/gemma4/muse-glimmer above; exercised end-to-end by
+            # `deepseek_v4_flash_test.py`'s dedicated window tests (this
+            # entry's forward-executing consumers currently use a shorter
+            # sequence length and/or are skipped for deepseek_v4 for
+            # unrelated pre-existing reasons, so this value isn't itself
+            # numerically exercised by the generic parity/build/
+            # weight-alignment suites).
             "sliding_window": 8,
         },
         True,


### PR DESCRIPTION
## Root cause

The official DeepSeek-V4-Flash reference (`inference/model.py::Attention.forward`, `get_window_topk_idxs`) unconditionally restricts **every** layer, regardless of `compress_ratio`, to a circular-buffer window of `config.sliding_window` (128) most-recent positions. Neither of Mobius's two `DeepSeekV4Attention` forward paths applied this:

- The decomposed path's `create_attention_bias(...)` call never passed `sliding_window`.
- The fused-GQA path (added in #585) never emitted GQA's `local_window_size` attribute at all.

Both silently computed **unbounded** causal attention instead of the mandatory windowed variant. This affects every layer — `compress_ratio=0` layers were otherwise exactly correct; `compress_ratio>0` (CSA/HCA) layers were already missing their compressed/indexed component (tracked separately, see `docs/models/DEEPSEEK_CSA_MTP_RUNTIME.md` in onnx-genai) and now additionally get the window right too.

## Fix

- `DeepSeekV4Attention.__init__`: compute `self.local_window_size` from `config.sliding_window` (matching the established `-1` no-window sentinel convention).
- Fused-GQA forward branch: emit `local_window_size` as a GQA attribute only when `>0`, matching `Attention._forward_gqa`'s conditional-attributes convention in `components/_attention.py` — a config with no window keeps a byte-identical graph to before this change.
- `DeepSeekV4TextModel` / `DeepSeekV4Mtp`: thread `sliding_window=config.sliding_window` into their `create_attention_bias` calls so the decomposed path's shared bias also carries the window.

## Before/after evidence

Standalone `GraphBuilder` + plain `onnxruntime` CPUExecutionProvider execution, seq_len=6, `sliding_window=2`, seeded random weights/inputs, byte-identical weights shared across builds via `load_state_dict`:

| Comparison | Max abs diff | Meaning |
|---|---|---|
| unbounded vs. windowed (decomposed) | 0.0203 | confirms the window changes the output at all |
| **pre-fix** fused-GQA vs. unbounded | 0.0 (identical) | confirms the bug: fused path silently ignored the configured window |
| **post-fix** fused-GQA vs. windowed decomposed | 1.86e-9 (fp noise) | confirms the two paths now agree exactly |

Both new regression tests were verified to **fail** against pre-fix `deepseek_v4.py` (checked out at the parent commit) and **pass** post-fix.

## Tests

- `deepseek_v4_flash_test.py::test_sliding_window_sets_local_window_size_on_fused_gqa_regardless_of_compress_ratio` (new, extended to also cover the MTP sidecar): structural — `local_window_size==8` on every fused-GQA node (backbone, all 3 compress_ratios, and MTP) regardless of `compress_ratio`.
- `deepseek_v4_flash_test.py::test_missing_sliding_window_regression_fused_gqa_matches_windowed_decomposed` (new): numeric regression per the evidence table above.
- `deepseek_v4_flash_test.py::test_tiny_graph_builds_v4_backbone_fused_gqa_on_cpu_ep`: extended with an assertion that `local_window_size` is absent when no window is configured (backward-compat check).
- `tests/_test_configs.py`: added `sliding_window=8` to the `deepseek_v4` tiny config (matches the established `gemma`/`gemma4`/`muse-glimmer` tiny-config convention); numerically exercised by the new `deepseek_v4_flash_test.py` tests above.

**Verified:**
- `deepseek_v4_flash_test.py`: 16/16 passed.
- `deepseek_v4_test.py` + `tests/model_coverage_test.py`: 727 passed, 218 pre-existing skips.
- `tests/build_graph_test.py` + `tests/synthetic_parity_test.py` + `tests/weight_alignment_test.py` (full suite): 1722 passed, 123 skipped, 62 xfailed — all pre-existing, no regressions.
- `ruff check` + `ruff format` (the only two lintrunner-configured linters): clean.

## Independent review

Reviewed by an independent agent, which re-derived the root cause against the HF reference implementation, re-ran both new tests pre/post-fix, rebuilt graphs to confirm byte-identical backward-compat hashes, and manually verified the MTP wiring. Verdict: **APPROVE WITH NITS** (2 non-blocking findings — missing MTP test coverage for an already-correct path, and an inaccurate test-config comment). Both nits addressed in a follow-up commit (extended the structural test to cover the MTP graph; corrected the comment's coverage claim), independently re-verified fail-before/pass-after.

## Out of scope

`compress_ratio>0` (CSA/HCA) layers' compressed/indexed attention component remains unimplemented — tracked separately per `docs/models/DEEPSEEK_CSA_MTP_RUNTIME.md` in onnx-genai (parallel effort in progress). This PR only fixes the window restriction that applies uniformly to every layer.

Closes: DeepSeek-V4 attention correctness gap identified during Mobius/onnx-genai GLM-5.2 & DeepSeek-V4 audit (Sapper, Systems Dev for Models & Preprocess).

🤖 Generated with [GitHub Copilot](https://github.com/copilot)