### PR TITLE
Add opt-in --paged-attention export for dense MLA (LATENT PagedAttention) [Slice 3B]

### DIFF
--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -44,6 +44,7 @@ _BUILD_FEATURES: dict[str, str] = {
     "prune-prefill-prefix": "prune_prefill_prefix",
     "text-only": "text_only",
     "glm-full-attention": "glm_full_attention",
+    "paged-attention": "export_paged_attention",
 }
 
 
@@ -269,6 +270,23 @@ def _cmd_build(args: argparse.Namespace) -> None:
         }
     else:
         static_cache_params = None
+
+    # PagedAttention (LATENT dense-MLA) export uses the paged-cache task with
+    # caller-owned page buffers. It is a distinct cache authority, so it cannot
+    # be combined with the static-cache task or an explicit --task.
+    export_paged_attention = getattr(args, "export_paged_attention", False)
+    if export_paged_attention:
+        if static_cache_params is not None:
+            raise SystemExit(
+                "Error: --features paged-attention cannot be combined with "
+                "--features static-cache."
+            )
+        if task is not None:
+            raise SystemExit(
+                "Error: --features paged-attention cannot be combined with --task. "
+                "Remove --task to use --features paged-attention."
+            )
+        task = CausalLMTask(paged_cache=True)
     trust_remote_code = args.trust_remote_code
     revision = args.revision
     output_dir = args.output_dir
@@ -358,6 +376,16 @@ def _cmd_build(args: argparse.Namespace) -> None:
                     f"model_type 'glm_moe_dsa' (got '{model_type}')."
                 )
             config = dataclasses.replace(config, use_dsa=False)
+        if export_paged_attention:
+            from mobius.components._paged_mla import paged_attention_rejection
+
+            config = dataclasses.replace(config, export_paged_attention=True)
+            reason = paged_attention_rejection(config)
+            if reason is not None:
+                raise SystemExit(
+                    f"Error: --features paged-attention is not supported for this "
+                    f"model: {reason}"
+                )
         if static_cache_params is not None:
             task = _resolve_static_cache_task(model_type)
         elif task is None:
@@ -406,6 +434,7 @@ def _cmd_build(args: argparse.Namespace) -> None:
             kv_cache_scales=kv_cache_scales,
             prune_prefill_prefix=prune_prefill_prefix,
             glm_full_attention=args.glm_full_attention,
+            export_paged_attention=export_paged_attention,
         )
 
     _save_package(pkg, output_dir, args, optimize, component_filter)

--- a/src/mobius/_configs/_base.py
+++ b/src/mobius/_configs/_base.py
@@ -503,6 +503,12 @@ class ArchitectureConfig(BaseModelConfig):
     # (reusing ``DeepSeekV3TextModel`` unchanged) on runtimes that cannot yet
     # execute ``pkg.nxrt::IndexShare``.
     use_dsa: bool = True
+    # Opt-in export of ``com.microsoft::PagedAttention`` (LATENT / absorbed-MLA
+    # mode) for property-compatible dense MLA. Default off. When off, exports are
+    # byte-identical to the current dense-MLA graph. Eligibility is decided from
+    # semantic geometry (see ``mobius.components._paged_mla``), never model names;
+    # an incompatible geometry raises rather than silently falling back.
+    export_paged_attention: bool = False
     # Per-layer indexer schedule ("full" runs the indexer; "shared" reuses the
     # top-k selection from the closest preceding "full" layer). When the
     # checkpoint config omits this list, it is derived from

--- a/src/mobius/components/__init__.py
+++ b/src/mobius/components/__init__.py
@@ -207,6 +207,24 @@ from mobius.components._multimodal import (
     MLPMultiModalProjector,
 )
 from mobius.components._muse_glimmer_vision import MuseGlimmerVisionModel
+from mobius.components._paged_mla import (
+    PagedCacheState as PagedCacheState,
+)
+from mobius.components._paged_mla import (
+    PagedLatentMLA as PagedLatentMLA,
+)
+from mobius.components._paged_mla import (
+    absorb_mla_weights as absorb_mla_weights,
+)
+from mobius.components._paged_mla import (
+    mla_paged_geometry as mla_paged_geometry,
+)
+from mobius.components._paged_mla import (
+    paged_attention_eligible as paged_attention_eligible,
+)
+from mobius.components._paged_mla import (
+    paged_attention_rejection as paged_attention_rejection,
+)
 from mobius.components._parakeet_audio import ParakeetFastConformerEncoder
 from mobius.components._pixtral_vision import (
     Mistral3MultiModalProjector as Mistral3MultiModalProjector,

--- a/src/mobius/components/_paged_mla.py
+++ b/src/mobius/components/_paged_mla.py
@@ -187,41 +187,51 @@ def paged_attention_rejection(config: ArchitectureConfig) -> str | None:
         _has("index_n_heads")
         or _has("index_head_dim")
         or _has("index_topk")
-        or bool(getattr(config, "indexer_types", None))
+        or bool(config.indexer_types)
     )
-    if getattr(config, "use_dsa", False) and _indexer_configured:
+    if config.use_dsa and _indexer_configured:
         return (
             "PagedAttention LATENT cannot express GLM DeepSeek Sparse Attention "
             "(DSA/IndexShare): query-dependent sparse indices have no operator "
             "input. Export dense MLA (--glm-full-attention) to opt in."
         )
-    if getattr(config, "compress_ratios", None):
+    if config.compress_ratios:
         return (
             "PagedAttention LATENT cannot express DeepSeek-V4 compressed sparse "
             "attention (CSA/HCA): query-dependent compression is not an operator "
             "input."
         )
-    if getattr(config, "o_lora_rank", None) or getattr(config, "o_groups", 1) not in (0, 1):
+    if config.o_lora_rank or config.o_groups not in (0, 1):
         return (
             "PagedAttention LATENT cannot express DeepSeek-V4 grouped/low-rank "
             "output projection (o_groups/o_lora_rank)."
         )
-    if getattr(config, "hc_mult", 1) not in (0, 1):
+    if config.hc_mult not in (0, 1):
         return "PagedAttention LATENT cannot express Hyper-Connections (hc_mult > 1)."
 
     # --- Multi-token prediction is out of scope. ---
-    if getattr(config, "num_nextn_predict_layers", 0) > 0:
+    if config.num_nextn_predict_layers > 0:
         return (
             "PagedAttention LATENT export does not cover Multi-Token Prediction "
             "(num_nextn_predict_layers > 0)."
         )
 
     # --- Optional operator modes not implemented in this slice. ---
-    if getattr(config, "attention_sink", False) or getattr(config, "head_sink", False):
-        return "PagedAttention LATENT slice does not implement the head_sink input."
-    if getattr(config, "use_qk_norm", False) or getattr(config, "qk_layernorm", False):
+    # Per-head QK-norm resolves into the canonical ``attn_qk_norm`` /
+    # ``attn_qk_norm_full`` fields (the HF ``use_qk_norm`` / ``qk_layernorm``
+    # passthrough is consumed there at extraction time), so reject on those.
+    # The dense-MLA targets (DeepSeek-V2/V3, GLM full-attention) leave both
+    # False; a qk-norm MLA would need the operator's q_norm/k_norm inputs, which
+    # this slice does not claim.
+    if config.attn_qk_norm or config.attn_qk_norm_full:
         return "PagedAttention LATENT slice does not implement q_norm/k_norm inputs."
-    window = getattr(config, "sliding_window", None)
+    # Learned attention sinks (the operator's head_sink input) have no
+    # ArchitectureConfig representation for dense MLA: the only sink-bearing MLA
+    # family is DeepSeek-V4, already rejected above by its CSA/HCA fields, and a
+    # non-MLA sink model (e.g. gpt-oss) is rejected by the MLA-geometry check.
+    # PagedLatentMLA structurally never emits a head_sink input, so there is no
+    # config knob to probe here.
+    window = config.sliding_window
     if window is not None and window > 0:
         return (
             "PagedAttention LATENT slice does not implement windowed attention "

--- a/src/mobius/components/_paged_mla.py
+++ b/src/mobius/components/_paged_mla.py
@@ -1,0 +1,492 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Paged, absorbed Multi-head Latent Attention (LATENT ``PagedAttention``).
+
+This module emits the ``com.microsoft::PagedAttention`` v1 operator in its
+``kv_cache_layout="LATENT"`` (absorbed-MLA) mode for *dense* MLA models whose
+geometry is expressible by the operator (DeepSeek-V2/V3, GLM-5.2
+``--glm-full-attention``). It is an opt-in export path
+(``config.export_paged_attention``); the default dense-MLA export
+(:class:`~mobius.components._deepseek_mla.DeepSeekMLA`) is byte-identical when
+the flag is off.
+
+Eligibility is decided purely from semantic geometry (see
+:func:`paged_attention_rejection`), never from model names. Query-dependent
+sparse selection (GLM DSA/IndexShare, DeepSeek-V4 CSA/HCA) is *not* expressible
+because the operator has no query-dependent sparse-index input, so those modes
+are typed-rejected rather than silently falling back to dense.
+
+Absorbed-MLA contract (mirrors the onnx-genai oracle
+``crates/onnx-genai-paged-attention/tests/equivalence.rs``):
+
+* ``l`` = ``kv_lora_rank`` = absorbed content width = ``v_head_size``.
+* ``r`` = ``qk_rope_head_dim`` = decoupled RoPE width.
+* ``head_size = l + r``; RoPE covers the suffix ``[l, l + r)``.
+* ``d`` = ``qk_nope_head_dim`` (folded away), ``dv`` = ``v_head_dim`` (folded
+  into ``o_proj``).
+* Per head, ``W_UK^h`` (``[d, l]``, the k-nope block of ``kv_b_proj``) folds
+  into the query, ``W_UV^h`` (``[dv, l]``, the value block of ``kv_b_proj``)
+  folds into ``o_proj``. ``kv_b_proj`` is fully absorbed and dropped.
+
+The operator consumes/mutates caller-owned page buffers in place; Mobius never
+allocates or manages pages (``onnx-genai-kv`` remains the sole cache authority).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+from onnxscript import OpBuilder, nn
+
+from mobius._configs import ArchitectureConfig
+from mobius.components._common import Linear
+from mobius.components._rms_norm import RMSNorm
+from mobius.components._rotary_embedding import yarn_apply_mscale
+
+if TYPE_CHECKING:
+    import onnx_ir as ir
+
+DOMAIN = "com.microsoft"
+
+# ``com.microsoft::PagedAttention`` LATENT cache-write sentinel + defaults. Kept
+# in sync with the onnx-genai native ABI (``crates/onnx-genai-kv``):
+# ``slot = page_id * block_size + offset``; ``-1`` skips the write.
+PAGED_SLOT_EMPTY = -1
+PAGED_BLOCK_TABLE_PAD = 0
+# Minimum page/block size: power-of-two and >= 16 (never divisible by 256).
+DEFAULT_PAGED_BLOCK_SIZE = 16
+
+
+def _supported_dtypes() -> frozenset:
+    import onnx_ir as ir
+
+    return frozenset({ir.DataType.FLOAT16, ir.DataType.BFLOAT16})
+
+
+@dataclass(frozen=True)
+class PagedMlaGeometry:
+    """Resolved LATENT geometry for the ``PagedAttention`` operator.
+
+    All fields are derived from :class:`ArchitectureConfig` and validated
+    against the onnx-genai-kv LATENT geometry constraints.
+    """
+
+    num_heads: int
+    """``num_heads`` attribute (query heads)."""
+    kv_lora_rank: int
+    """``l`` -- latent content width; also ``v_head_size``."""
+    qk_nope_head_dim: int
+    """``d`` -- folded-away nope width of the decomposed query/key."""
+    qk_rope_head_dim: int
+    """``r`` -- decoupled RoPE width (``rotary_dim``)."""
+    v_head_dim: int
+    """``dv`` -- decomposed value width, folded into ``o_proj``."""
+    scale: float
+    """Explicit softmax scale (REQUIRED because ``v_head_size != head_size``)."""
+    rope_interleaved: bool
+    """RoPE layout for the ``do_rotary`` suffix."""
+
+    @property
+    def head_size(self) -> int:
+        """Absorbed head width ``l + r``."""
+        return self.kv_lora_rank + self.qk_rope_head_dim
+
+    @property
+    def v_head_size(self) -> int:
+        """LATENT context width ``l`` (== ``kv_lora_rank``)."""
+        return self.kv_lora_rank
+
+    @property
+    def rotary_dim(self) -> int:
+        """RoPE width ``r`` (== ``qk_rope_head_dim``)."""
+        return self.qk_rope_head_dim
+
+    @property
+    def rotary_offset(self) -> int:
+        """RoPE suffix start ``l`` (== ``kv_lora_rank``)."""
+        return self.kv_lora_rank
+
+    @property
+    def qk_head_dim(self) -> int:
+        """Decomposed query/key width ``d + r`` (drives the scale)."""
+        return self.qk_nope_head_dim + self.qk_rope_head_dim
+
+
+def _mla_scale(config: ArchitectureConfig) -> float:
+    """Softmax scale identical to the decomposed :class:`DeepSeekMLA`.
+
+    Uses ``1 / sqrt(qk_head_dim)`` with the YaRN ``mscale^2`` correction when
+    active, so the absorbed LATENT logits match the decomposed oracle exactly.
+    """
+    qk_head_dim = (config.qk_nope_head_dim or 0) + (config.qk_rope_head_dim or 0)
+    return yarn_apply_mscale(config.rope_type, config.rope_scaling, qk_head_dim**-0.5)
+
+
+def mla_paged_geometry(
+    config: ArchitectureConfig, scale: float | None = None
+) -> PagedMlaGeometry:
+    """Resolve the LATENT geometry for ``config``.
+
+    Raises:
+        ValueError: If ``config`` is not an eligible dense-MLA geometry; the
+            message is the typed rejection reason from
+            :func:`paged_attention_rejection`.
+    """
+    reason = paged_attention_rejection(config)
+    if reason is not None:
+        raise ValueError(reason)
+    return PagedMlaGeometry(
+        num_heads=config.num_attention_heads,
+        kv_lora_rank=int(config.kv_lora_rank),
+        qk_nope_head_dim=int(config.qk_nope_head_dim),
+        qk_rope_head_dim=int(config.qk_rope_head_dim),
+        v_head_dim=int(config.v_head_dim),
+        scale=scale if scale is not None else _mla_scale(config),
+        rope_interleaved=config.rope_interleave,
+    )
+
+
+def paged_attention_rejection(config: ArchitectureConfig) -> str | None:
+    """Return a typed rejection reason, or ``None`` if LATENT-eligible.
+
+    Eligibility is purely geometric. A non-``None`` return means the model is
+    *not* expressible as ``com.microsoft::PagedAttention`` LATENT and the
+    feature-on export must error rather than silently emit a dense graph.
+    """
+    ir_dtypes = _supported_dtypes()
+
+    def _has(name: str) -> bool:
+        v = getattr(config, name, None)
+        return v is not None and v > 0
+
+    # --- Must be MLA at all. ---
+    if not (_has("kv_lora_rank") and _has("qk_nope_head_dim") and _has("qk_rope_head_dim")):
+        return (
+            "PagedAttention LATENT requires an MLA geometry "
+            "(kv_lora_rank, qk_nope_head_dim, qk_rope_head_dim > 0); "
+            "this config is not MLA."
+        )
+    if not _has("v_head_dim"):
+        return "PagedAttention LATENT requires v_head_dim > 0."
+
+    # --- Query-dependent sparse selection is not expressible. ---
+    # The operator has no query-dependent sparse-index input. GLM's DSA indexer
+    # (index_topk / indexer_types / index_n_heads / index_head_dim) is consumed
+    # *only* when use_dsa is active; --glm-full-attention (use_dsa=False) drops
+    # every indexer weight and builds plain dense MLA, so those vestigial config
+    # fields must NOT reject on their own. DeepSeek-V4 CSA/HCA is discriminated
+    # by its own always-on fields (compress_ratios / o_lora_rank / hc_mult).
+    if getattr(config, "use_dsa", False):
+        return (
+            "PagedAttention LATENT cannot express GLM DeepSeek Sparse Attention "
+            "(DSA/IndexShare): query-dependent sparse indices have no operator "
+            "input. Export dense MLA (--glm-full-attention) to opt in."
+        )
+    if getattr(config, "compress_ratios", None):
+        return (
+            "PagedAttention LATENT cannot express DeepSeek-V4 compressed sparse "
+            "attention (CSA/HCA): query-dependent compression is not an operator "
+            "input."
+        )
+    if getattr(config, "o_lora_rank", None) or getattr(config, "o_groups", 1) not in (0, 1):
+        return (
+            "PagedAttention LATENT cannot express DeepSeek-V4 grouped/low-rank "
+            "output projection (o_groups/o_lora_rank)."
+        )
+    if getattr(config, "hc_mult", 1) not in (0, 1):
+        return "PagedAttention LATENT cannot express Hyper-Connections (hc_mult > 1)."
+
+    # --- Multi-token prediction is out of scope. ---
+    if getattr(config, "num_nextn_predict_layers", 0) > 0:
+        return (
+            "PagedAttention LATENT export does not cover Multi-Token Prediction "
+            "(num_nextn_predict_layers > 0)."
+        )
+
+    # --- Optional operator modes not implemented in this slice. ---
+    if getattr(config, "attention_sink", False) or getattr(config, "head_sink", False):
+        return "PagedAttention LATENT slice does not implement the head_sink input."
+    if getattr(config, "use_qk_norm", False) or getattr(config, "qk_layernorm", False):
+        return "PagedAttention LATENT slice does not implement q_norm/k_norm inputs."
+    window = getattr(config, "sliding_window", None)
+    if window is not None and window > 0:
+        return (
+            "PagedAttention LATENT slice does not implement windowed attention "
+            f"(sliding_window={window})."
+        )
+
+    # --- Cache dtype: fp16/bf16 only; quantized cache rejected this slice. ---
+    if config.dtype not in ir_dtypes:
+        return (
+            "PagedAttention LATENT slice supports float16/bfloat16 only; "
+            f"got dtype {config.dtype!r}. Quantized cache modes are rejected."
+        )
+
+    # --- onnx-genai-kv LATENT geometry constraints. ---
+    l = int(config.kv_lora_rank)  # noqa: E741  (matches oracle naming)
+    r = int(config.qk_rope_head_dim)
+    head_size = l + r
+    if head_size % 8 != 0:
+        return f"PagedAttention LATENT requires head_size % 8 == 0; got {head_size}."
+    if l % 8 != 0:
+        return f"PagedAttention LATENT requires latent_dim (kv_lora_rank) % 8 == 0; got {l}."
+    if not (1 <= l <= head_size):
+        return f"PagedAttention LATENT requires 1 <= v_head_size <= head_size; got {l}."
+    if r != 0 and r % 16 != 0:
+        return f"PagedAttention LATENT requires rotary_dim % 16 == 0 (or 0); got {r}."
+    # rotary_offset == l by construction; enforce the ORT sibling constraint.
+    if l % 8 != 0:
+        return f"PagedAttention LATENT requires rotary_offset % 8 == 0; got {l}."
+    if l + r > head_size:
+        return "PagedAttention LATENT requires rotary_offset + rotary_dim <= head_size."
+    return None
+
+
+def paged_attention_eligible(config: ArchitectureConfig) -> bool:
+    """Whether ``config`` can be exported as ``PagedAttention`` LATENT."""
+    return paged_attention_rejection(config) is None
+
+
+# ---------------------------------------------------------------------------
+# Weight absorption
+# ---------------------------------------------------------------------------
+
+
+def _to_numpy(array) -> np.ndarray:
+    if isinstance(array, np.ndarray):
+        return array
+    # torch.Tensor (deferred import to keep numpy-only tests light).
+    return array.detach().to("cpu").float().numpy()
+
+
+def absorb_mla_weights(
+    weights: dict[str, np.ndarray],
+    config: ArchitectureConfig,
+    *,
+    q_key: str,
+    kv_b_key: str,
+    o_key: str,
+) -> dict[str, np.ndarray]:
+    """Fold ``kv_b_proj`` into the query and output projections.
+
+    Given the decomposed MLA weights for a single layer, returns replacement
+    weights for the absorbed LATENT path:
+
+    * ``q_key``  ``[nh * (d + r), in]``  -> ``[nh * (l + r), in]``
+    * ``o_key``  ``[hidden, nh * dv]``   -> ``[hidden, nh * l]``
+    * ``kv_b_key`` is dropped (fully absorbed).
+
+    Args:
+        weights: Mapping containing at least ``q_key``, ``kv_b_key``, ``o_key``.
+        config: MLA architecture config.
+        q_key: Name of the query up-projection weight (``q_b_proj`` or
+            ``q_proj``), stored ``[out, in]``.
+        kv_b_key: Name of the ``kv_b_proj`` weight, stored
+            ``[nh * (d + dv), l]``.
+        o_key: Name of the output projection weight, stored ``[hidden, nh*dv]``.
+
+    Returns:
+        A dict with the absorbed ``q_key`` and ``o_key`` (and no ``kv_b_key``).
+    """
+    geom = mla_paged_geometry(config)
+    nh = geom.num_heads
+    d = geom.qk_nope_head_dim
+    r = geom.qk_rope_head_dim
+    dv = geom.v_head_dim
+    l = geom.kv_lora_rank  # noqa: E741
+
+    w_q = _to_numpy(weights[q_key]).astype(np.float64)
+    w_kvb = _to_numpy(weights[kv_b_key]).astype(np.float64)
+    w_o = _to_numpy(weights[o_key]).astype(np.float64)
+
+    qk_head_dim = d + r
+    if w_q.shape[0] != nh * qk_head_dim:
+        raise ValueError(f"{q_key} rows {w_q.shape[0]} != num_heads*(d+r) {nh * qk_head_dim}")
+    if w_kvb.shape != (nh * (d + dv), l):
+        raise ValueError(
+            f"{kv_b_key} shape {w_kvb.shape} != (num_heads*(d+dv), l) {(nh * (d + dv), l)}"
+        )
+    if w_o.shape[1] != nh * dv:
+        raise ValueError(f"{o_key} cols {w_o.shape[1]} != num_heads*dv {nh * dv}")
+
+    in_dim = w_q.shape[1]
+    hidden = w_o.shape[0]
+    head_size = l + r
+    q_absorbed = np.empty((nh * head_size, in_dim), dtype=np.float64)
+    o_absorbed = np.empty((hidden, nh * l), dtype=np.float64)
+    for h in range(nh):
+        w_uk = w_kvb[h * (d + dv) : h * (d + dv) + d, :]  # [d, l]
+        w_uv = w_kvb[h * (d + dv) + d : (h + 1) * (d + dv), :]  # [dv, l]
+        qb_nope = w_q[h * qk_head_dim : h * qk_head_dim + d, :]  # [d, in]
+        qb_rope = w_q[h * qk_head_dim + d : (h + 1) * qk_head_dim, :]  # [r, in]
+        # Absorbed query nope: W_UK^T @ qb_nope -> [l, in].
+        q_absorbed[h * head_size : h * head_size + l, :] = w_uk.T @ qb_nope
+        q_absorbed[h * head_size + l : (h + 1) * head_size, :] = qb_rope
+        # Absorbed o_proj: W_O^h @ W_UV^h -> [hidden, l].
+        w_o_head = w_o[:, h * dv : (h + 1) * dv]  # [hidden, dv]
+        o_absorbed[:, h * l : (h + 1) * l] = w_o_head @ w_uv
+
+    out_dtype = _to_numpy(weights[q_key]).dtype
+    return {
+        q_key: q_absorbed.astype(out_dtype),
+        o_key: o_absorbed.astype(out_dtype),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Component
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PagedCacheState:
+    """Caller-owned page/cache tensors bound to the LATENT operator.
+
+    Mobius does not allocate or manage any of these; they are graph inputs
+    owned by the onnx-genai-kv page manager. ``key_cache`` is mutated in place
+    and aliased to the operator's ``key_cache`` output.
+    """
+
+    key_cache: ir.Value
+    """LATENT cache ``[num_blocks, block_size, 1, head_size]`` (in place)."""
+    block_table: ir.Value
+    """``[batch, max_blocks_per_seq]`` int32 page indices."""
+    slot_mapping: ir.Value
+    """``[token_count]`` int32 flattened slots; ``-1`` skips the write."""
+    cumulative_sequence_length: ir.Value
+    """``[batch + 1]`` int32 cumulative query lengths."""
+    past_seqlens: ir.Value
+    """``[batch]`` int32 already-cached lengths per sequence."""
+    cos_cache: ir.Value | None = None
+    """``[max_pos, rotary_dim/2]`` RoPE cosine cache (filled by the model)."""
+    sin_cache: ir.Value | None = None
+    """``[max_pos, rotary_dim/2]`` RoPE sine cache (filled by the model)."""
+
+
+class PagedLatentMLA(nn.Module):
+    """Absorbed dense MLA that emits ``com.microsoft::PagedAttention`` LATENT.
+
+    Structurally mirrors :class:`~mobius.components._deepseek_mla.DeepSeekMLA`
+    for the Q/KV projections, but folds ``kv_b_proj`` into the query and output
+    projections (see :func:`absorb_mla_weights`) and replaces the decomposed
+    ``op.Attention`` with a single LATENT ``PagedAttention`` node.
+
+    The module's ``q_b_proj``/``q_proj`` and ``o_proj`` parameters are the
+    *absorbed* shapes; :func:`absorb_mla_weights` must be applied to the raw
+    checkpoint before loading.
+    """
+
+    def __init__(
+        self,
+        config: ArchitectureConfig,
+        scale: float | None = None,
+        linear_class: type | None = None,
+    ):
+        super().__init__()
+        if linear_class is None:
+            linear_class = Linear
+        self.geom = mla_paged_geometry(config, scale=scale)
+        geom = self.geom
+        self.num_heads = geom.num_heads
+        self.q_lora_rank = config.q_lora_rank
+        self.head_size = geom.head_size
+        self.kv_lora_rank = geom.kv_lora_rank
+        self.qk_rope_head_dim = geom.qk_rope_head_dim
+
+        # Q path: absorbed up-projection produces [nh * head_size].
+        if self.q_lora_rank is not None and self.q_lora_rank > 0:
+            self.q_a_proj = linear_class(config.hidden_size, self.q_lora_rank, bias=False)
+            self.q_a_layernorm = RMSNorm(self.q_lora_rank, eps=config.rms_norm_eps)
+            self.q_b_proj = linear_class(
+                self.q_lora_rank, self.num_heads * self.head_size, bias=False
+            )
+        else:
+            self.q_proj = linear_class(
+                config.hidden_size, self.num_heads * self.head_size, bias=False
+            )
+
+        # KV path: joint projection for the single-head latent row.
+        self.kv_a_proj_with_mqa = linear_class(
+            config.hidden_size, self.kv_lora_rank + self.qk_rope_head_dim, bias=False
+        )
+        self.kv_a_layernorm = RMSNorm(self.kv_lora_rank, eps=config.rms_norm_eps)
+
+        # Absorbed output projection consumes the [nh * l] LATENT context.
+        self.o_proj = linear_class(
+            self.num_heads * self.kv_lora_rank, config.hidden_size, bias=False
+        )
+
+        self.scaling = geom.scale
+        self._rope_interleave = geom.rope_interleaved
+
+    def forward(
+        self,
+        op: OpBuilder,
+        hidden_states: ir.Value,
+        cache: PagedCacheState,
+    ):
+        geom = self.geom
+        # --- Absorbed query: [B, S, nh * head_size] -> [tokens, nh * head_size]. ---
+        if self.q_lora_rank is not None and self.q_lora_rank > 0:
+            q = self.q_a_proj(op, hidden_states)
+            q = self.q_a_layernorm(op, q)
+            q = self.q_b_proj(op, q)
+        else:
+            q = self.q_proj(op, hidden_states)
+        query = op.Reshape(q, [-1, self.num_heads * self.head_size])
+
+        # --- Latent key row: [B, S, head_size] -> [tokens, head_size]. ---
+        compressed_kv = self.kv_a_proj_with_mqa(op, hidden_states)
+        k_pass, k_rope = op.Split(
+            compressed_kv,
+            [self.kv_lora_rank, self.qk_rope_head_dim],
+            axis=-1,
+            _outputs=2,
+        )
+        k_pass = self.kv_a_layernorm(op, k_pass)
+        latent_key = op.Concat(k_pass, k_rope, axis=-1)
+        key = op.Reshape(latent_key, [-1, self.head_size])
+
+        # --- Single LATENT PagedAttention node (17 in / 3 out). ---
+        # Absent optional inputs are passed as ``None`` to preserve positions.
+        output, key_cache_out, _value_cache_out = op.PagedAttention(
+            query,  # 0 query [tokens, nh * head_size]
+            key,  # 1 key (latent row) [tokens, head_size]
+            None,  # 2 value (absent in LATENT)
+            cache.key_cache,  # 3 key_cache [num_blocks, block_size, 1, head_size]
+            None,  # 4 value_cache (absent in LATENT)
+            cache.cumulative_sequence_length,  # 5 [batch + 1] int32
+            cache.past_seqlens,  # 6 [batch] int32
+            cache.block_table,  # 7 [batch, max_blocks_per_seq] int32
+            cache.cos_cache,  # 8 [max_pos, rotary_dim/2]
+            cache.sin_cache,  # 9 [max_pos, rotary_dim/2]
+            cache.slot_mapping,  # 10 [tokens] int32 (-1 skips write)
+            None,  # 11 head_sink (absent)
+            None,  # 12 q_norm (absent)
+            None,  # 13 k_norm (absent)
+            None,  # 14 k_scale (absent)
+            None,  # 15 v_scale (absent)
+            None,  # 16 attention_metadata (absent)
+            num_heads=self.num_heads,
+            kv_num_heads=1,
+            scale=self.scaling,
+            kv_cache_layout="LATENT",
+            v_head_size=geom.v_head_size,
+            rotary_offset=geom.rotary_offset,
+            do_rotary=1,
+            rotary_interleaved=int(self._rope_interleave),
+            _domain=DOMAIN,
+            _outputs=3,
+        )
+
+        # --- Absorbed output projection: reshape [tokens, nh*l] back to the
+        # [batch, seq, nh*l] rank of the input, then project to hidden. ---
+        hidden_shape = op.Shape(hidden_states)
+        batch_seq = op.Slice(hidden_shape, [0], [2], [0])
+        out_target = op.Concat(batch_seq, op.Constant(value_ints=[-1]), axis=0)
+        output = op.Reshape(output, out_target)
+        attn_output = self.o_proj(op, output)
+        return attn_output, (key_cache_out,)

--- a/src/mobius/components/_paged_mla.py
+++ b/src/mobius/components/_paged_mla.py
@@ -173,13 +173,23 @@ def paged_attention_rejection(config: ArchitectureConfig) -> str | None:
         return "PagedAttention LATENT requires v_head_dim > 0."
 
     # --- Query-dependent sparse selection is not expressible. ---
-    # The operator has no query-dependent sparse-index input. GLM's DSA indexer
-    # (index_topk / indexer_types / index_n_heads / index_head_dim) is consumed
-    # *only* when use_dsa is active; --glm-full-attention (use_dsa=False) drops
-    # every indexer weight and builds plain dense MLA, so those vestigial config
-    # fields must NOT reject on their own. DeepSeek-V4 CSA/HCA is discriminated
-    # by its own always-on fields (compress_ratios / o_lora_rank / hc_mult).
-    if getattr(config, "use_dsa", False):
+    # The operator has no query-dependent sparse-index input. DSA is *active*
+    # only when use_dsa is set AND an indexer is actually configured (GLM's
+    # index_n_heads/index_head_dim/index_topk/indexer_types). use_dsa alone is
+    # not a discriminator: it defaults True on every ArchitectureConfig and is
+    # vestigial for plain DeepSeek-V2/V3 (whose dense text model never reads it),
+    # so gating on use_dsa alone would wrongly reject DeepSeek-V3. Conversely
+    # --glm-full-attention (use_dsa=False) drops every indexer weight and builds
+    # plain dense MLA, so its still-present indexer config must NOT reject.
+    # DeepSeek-V4 CSA/HCA is discriminated by its own always-on fields
+    # (compress_ratios / o_lora_rank / hc_mult).
+    _indexer_configured = (
+        _has("index_n_heads")
+        or _has("index_head_dim")
+        or _has("index_topk")
+        or bool(getattr(config, "indexer_types", None))
+    )
+    if getattr(config, "use_dsa", False) and _indexer_configured:
         return (
             "PagedAttention LATENT cannot express GLM DeepSeek Sparse Attention "
             "(DSA/IndexShare): query-dependent sparse indices have no operator "
@@ -229,10 +239,14 @@ def paged_attention_rejection(config: ArchitectureConfig) -> str | None:
     l = int(config.kv_lora_rank)  # noqa: E741  (matches oracle naming)
     r = int(config.qk_rope_head_dim)
     head_size = l + r
-    if head_size % 8 != 0:
-        return f"PagedAttention LATENT requires head_size % 8 == 0; got {head_size}."
-    if l % 8 != 0:
-        return f"PagedAttention LATENT requires latent_dim (kv_lora_rank) % 8 == 0; got {l}."
+    # Dense MLA always emits do_rotary=1 with cos/sin caches, so the native
+    # validator's check_rotary_caches applies: head_size shall be a multiple of
+    # 16 (validate.rs:510). Because rotary_dim (r) is a multiple of 16, this
+    # forces kv_lora_rank (l) % 16 == 0 as well.
+    if head_size % 16 != 0:
+        return f"PagedAttention LATENT requires head_size % 16 == 0; got {head_size}."
+    if l % 16 != 0:
+        return f"PagedAttention LATENT requires latent_dim (kv_lora_rank) % 16 == 0; got {l}."
     if not (1 <= l <= head_size):
         return f"PagedAttention LATENT requires 1 <= v_head_size <= head_size; got {l}."
     if r != 0 and r % 16 != 0:

--- a/src/mobius/components/_paged_mla_test.py
+++ b/src/mobius/components/_paged_mla_test.py
@@ -277,6 +277,18 @@ class TestEligibility:
     def test_mtp_rejected(self):
         assert paged_attention_rejection(_cfg(num_nextn_predict_layers=1)) is not None
 
+    def test_qk_norm_rejected(self):
+        # Per-head QK-norm resolves into attn_qk_norm / attn_qk_norm_full; a
+        # qk-norm MLA would need the operator's q_norm/k_norm inputs, which this
+        # slice does not claim. The dense-MLA targets leave both False.
+        assert paged_attention_rejection(_cfg(attn_qk_norm=True)) is not None
+        assert paged_attention_rejection(_cfg(attn_qk_norm_full=True)) is not None
+        assert paged_attention_rejection(_cfg()) is None
+
+    def test_window_rejected(self):
+        assert paged_attention_rejection(_cfg(sliding_window=64)) is not None
+        assert paged_attention_rejection(_cfg(sliding_window=None)) is None
+
     def test_quant_and_dtype_rejected(self):
         assert paged_attention_rejection(_cfg(dtype=ir.DataType.FLOAT)) is not None
         assert paged_attention_rejection(_cfg(dtype=ir.DataType.INT8)) is not None

--- a/src/mobius/components/_paged_mla_test.py
+++ b/src/mobius/components/_paged_mla_test.py
@@ -31,8 +31,8 @@ from mobius.components._paged_mla import (
     paged_attention_rejection,
 )
 
-# Tiny geometry that satisfies the LATENT constraints (head_size % 8 == 0,
-# kv_lora_rank % 8 == 0, qk_rope_head_dim % 16 == 0).
+# Tiny geometry that satisfies the LATENT constraints (head_size % 16 == 0,
+# kv_lora_rank % 16 == 0, qk_rope_head_dim % 16 == 0).
 _TINY = dict(
     hidden_size=64,
     num_attention_heads=2,
@@ -240,9 +240,21 @@ class TestEligibility:
         assert paged_attention_eligible(make_config(**_GLM))
 
     def test_dsa_indexshare_rejected(self):
-        reason = paged_attention_rejection(_cfg(use_dsa=True))
+        # DSA is active only when use_dsa is set AND an indexer is configured.
+        reason = paged_attention_rejection(
+            _cfg(use_dsa=True, index_n_heads=2, index_head_dim=16, index_topk=8)
+        )
         assert reason is not None
         assert "DSA" in reason or "IndexShare" in reason
+
+    def test_deepseek_v3_default_use_dsa_is_eligible(self):
+        # use_dsa defaults True on every config and is vestigial for plain
+        # DeepSeek-V2/V3 (no indexer configured); it must NOT trigger a DSA
+        # rejection, or --features paged-attention would be unusable for
+        # DeepSeek-V3 (its headline target).
+        cfg = _cfg(use_dsa=True)  # no index_* fields => not DSA-active
+        assert paged_attention_rejection(cfg) is None
+        assert paged_attention_eligible(cfg)
 
     def test_vestigial_indexer_config_is_eligible_when_dsa_off(self):
         # --glm-full-attention drops the indexer weights and builds plain dense
@@ -276,18 +288,18 @@ class TestEligibility:
         assert paged_attention_rejection(cfg) is not None
 
     def test_geometry_constraints_rejected(self):
-        # head_size = kv_lora + rope not divisible by 8.
+        # head_size = kv_lora + rope not divisible by 16.
         assert paged_attention_rejection(_cfg(kv_lora_rank=16, qk_rope_head_dim=4)) is not None
         # rope not divisible by 16.
         assert paged_attention_rejection(_cfg(qk_rope_head_dim=8)) is not None
-        # kv_lora not divisible by 8.
-        assert (
-            paged_attention_rejection(_cfg(kv_lora_rank=12, qk_rope_head_dim=16)) is not None
-        )
+        # kv_lora not divisible by 16 (8-aligned but not 16-aligned).
+        assert paged_attention_rejection(_cfg(kv_lora_rank=8, qk_rope_head_dim=16)) is not None
 
     def test_mla_geometry_raises_on_ineligible(self):
         with pytest.raises(ValueError, match="DSA"):
-            mla_paged_geometry(_cfg(use_dsa=True))
+            mla_paged_geometry(
+                _cfg(use_dsa=True, index_n_heads=2, index_head_dim=16, index_topk=8)
+            )
 
 
 class TestGeometry:

--- a/src/mobius/components/_paged_mla_test.py
+++ b/src/mobius/components/_paged_mla_test.py
@@ -1,0 +1,486 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for paged, absorbed MLA (``com.microsoft::PagedAttention`` LATENT).
+
+The numerical proof is GPU-independent: there is no CPU ``PagedAttention``
+kernel, so parity is asserted against a numpy LATENT reference that mirrors the
+onnx-genai oracle (``crates/onnx-genai-paged-attention/tests/equivalence.rs``),
+comparing the absorbed LATENT path against a decomposed dense-MLA reference over
+the full prefill + decode token progression.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import onnx_ir as ir
+import pytest
+
+from mobius._testing import (
+    count_op_type,
+    create_test_builder,
+    create_test_input,
+    make_config,
+)
+from mobius.components._paged_mla import (
+    PagedCacheState,
+    PagedLatentMLA,
+    absorb_mla_weights,
+    mla_paged_geometry,
+    paged_attention_eligible,
+    paged_attention_rejection,
+)
+
+# Tiny geometry that satisfies the LATENT constraints (head_size % 8 == 0,
+# kv_lora_rank % 8 == 0, qk_rope_head_dim % 16 == 0).
+_TINY = dict(
+    hidden_size=64,
+    num_attention_heads=2,
+    num_key_value_heads=2,
+    q_lora_rank=24,
+    kv_lora_rank=16,
+    qk_nope_head_dim=16,
+    qk_rope_head_dim=16,
+    v_head_dim=16,
+    rope_interleave=False,
+    rms_norm_eps=1e-6,
+    dtype=ir.DataType.FLOAT16,
+    use_dsa=False,
+)
+
+# Real GLM-5.2 / DeepSeek-V3 head dims (few heads for test speed).
+_GLM = dict(
+    hidden_size=256,
+    num_attention_heads=4,
+    num_key_value_heads=4,
+    q_lora_rank=64,
+    kv_lora_rank=512,
+    qk_nope_head_dim=128,
+    qk_rope_head_dim=64,
+    v_head_dim=128,
+    rope_interleave=True,
+    rms_norm_eps=1e-6,
+    dtype=ir.DataType.FLOAT16,
+    use_dsa=False,
+)
+
+
+def _cfg(**overrides):
+    return make_config(**{**_TINY, **overrides})
+
+
+# ---------------------------------------------------------------------------
+# numpy references (mirror equivalence.rs at the Mobius weight level)
+# ---------------------------------------------------------------------------
+
+
+def _rmsnorm(x: np.ndarray, weight: np.ndarray, eps: float = 1e-6) -> np.ndarray:
+    var = np.mean(x.astype(np.float64) ** 2, axis=-1, keepdims=True)
+    return (x / np.sqrt(var + eps)) * weight
+
+
+def _softmax(x: np.ndarray) -> np.ndarray:
+    x = x - np.max(x)
+    e = np.exp(x)
+    return e / np.sum(e)
+
+
+def _build_cos_sin(max_pos: int, rope_dim: int, theta: float = 10000.0):
+    half = rope_dim // 2
+    inv_freq = 1.0 / (theta ** (np.arange(0, rope_dim, 2, dtype=np.float64) / rope_dim))
+    pos = np.arange(max_pos, dtype=np.float64)
+    angles = np.outer(pos, inv_freq)  # [max_pos, half]
+    assert angles.shape[1] == half
+    return np.cos(angles), np.sin(angles)
+
+
+def _rope1(x: np.ndarray, cos: np.ndarray, sin: np.ndarray, interleaved: bool) -> np.ndarray:
+    """Apply RoPE to a single vector ``x`` (dim ``rope_dim``).
+
+    Mirrors ONNX opset-24 ``RotaryEmbedding``; ``cos``/``sin`` are ``rope_dim/2``.
+    """
+    x = x.astype(np.float64)
+    if interleaved:
+        x1 = x[0::2]
+        x2 = x[1::2]
+        o1 = x1 * cos - x2 * sin
+        o2 = x1 * sin + x2 * cos
+        out = np.empty_like(x)
+        out[0::2] = o1
+        out[1::2] = o2
+        return out
+    half = x.shape[-1] // 2
+    x1 = x[:half]
+    x2 = x[half:]
+    return np.concatenate([x1 * cos - x2 * sin, x1 * sin + x2 * cos])
+
+
+def _decomposed_reference(hidden, w, config, cos, sin):
+    """Decomposed dense-MLA oracle (numpy) with full causal attention."""
+    geom = mla_paged_geometry(config)
+    nh, d, r, dv, l = (  # noqa: E741  (matches the oracle's l/d/r/dv naming)
+        geom.num_heads,
+        geom.qk_nope_head_dim,
+        geom.qk_rope_head_dim,
+        geom.v_head_dim,
+        geom.kv_lora_rank,
+    )
+    qh = d + r
+    interleaved = geom.rope_interleaved
+    scale = geom.scale
+    t = hidden.shape[0]
+
+    q_c = _rmsnorm(hidden @ w["q_a"].T, w["q_a_norm"], config.rms_norm_eps)
+    q = (q_c @ w["q_b"].T).reshape(t, nh, qh)
+    comp = hidden @ w["kv_a"].T
+    k_pass = _rmsnorm(comp[:, :l], w["kv_a_norm"], config.rms_norm_eps)
+    k_rope = comp[:, l:]
+    kv = (k_pass @ w["kv_b"].T).reshape(t, nh, d + dv)
+    k_nope = kv[:, :, :d]
+    v = kv[:, :, d:]
+
+    out = np.zeros((t, w["o"].shape[0]), dtype=np.float64)
+    for tok in range(t):
+        concat = np.zeros(nh * dv)
+        for h in range(nh):
+            q_nope_h = q[tok, h, :d].astype(np.float64)
+            q_rope_h = _rope1(q[tok, h, d:], cos[tok], sin[tok], interleaved)
+            scores = []
+            for j in range(tok + 1):
+                kr = _rope1(k_rope[j], cos[j], sin[j], interleaved)
+                s = (q_nope_h @ k_nope[j, h] + q_rope_h @ kr) * scale
+                scores.append(s)
+            p = _softmax(np.array(scores))
+            ctx = np.zeros(dv)
+            for j in range(tok + 1):
+                ctx += p[j] * v[j, h]
+            concat[h * dv : (h + 1) * dv] = ctx
+        out[tok] = w["o"] @ concat
+    return out
+
+
+def _paged_latent_reference(hidden, w, config, cos, sin):
+    """Absorbed LATENT reference (numpy): folds ``kv_b_proj`` via absorption."""
+    geom = mla_paged_geometry(config)
+    nh, r, l = geom.num_heads, geom.qk_rope_head_dim, geom.kv_lora_rank  # noqa: E741
+    hs = l + r
+    interleaved = geom.rope_interleaved
+    scale = geom.scale
+    t = hidden.shape[0]
+
+    absorbed = absorb_mla_weights(
+        {"q_b": w["q_b"], "kv_b": w["kv_b"], "o": w["o"]},
+        config,
+        q_key="q_b",
+        kv_b_key="kv_b",
+        o_key="o",
+    )
+    q_b_abs = absorbed["q_b"]
+    o_abs = absorbed["o"]
+
+    q_c = _rmsnorm(hidden @ w["q_a"].T, w["q_a_norm"], config.rms_norm_eps)
+    q = (q_c @ q_b_abs.T).reshape(t, nh, hs)
+    comp = hidden @ w["kv_a"].T
+    k_pass = _rmsnorm(comp[:, :l], w["kv_a_norm"], config.rms_norm_eps)
+    key = np.concatenate([k_pass, comp[:, l:]], axis=-1)  # [t, hs]
+
+    out = np.zeros((t, o_abs.shape[0]), dtype=np.float64)
+    for tok in range(t):
+        ctx_latent = np.zeros(nh * l)
+        for h in range(nh):
+            q_prefix = q[tok, h, :l].astype(np.float64)
+            q_suffix = _rope1(q[tok, h, l:], cos[tok], sin[tok], interleaved)
+            scores = []
+            for j in range(tok + 1):
+                k_suffix = _rope1(key[j, l:], cos[j], sin[j], interleaved)
+                s = (q_prefix @ key[j, :l] + q_suffix @ k_suffix) * scale
+                scores.append(s)
+            p = _softmax(np.array(scores))
+            ctx = np.zeros(l)
+            for j in range(tok + 1):
+                ctx += p[j] * key[j, :l]
+            ctx_latent[h * l : (h + 1) * l] = ctx
+        out[tok] = o_abs @ ctx_latent
+    return out
+
+
+def _random_weights(config, seed=0):
+    rng = np.random.default_rng(seed)
+    nh = config.num_attention_heads
+    d = config.qk_nope_head_dim
+    r = config.qk_rope_head_dim
+    dv = config.v_head_dim
+    l = config.kv_lora_rank  # noqa: E741
+    ql = config.q_lora_rank
+    h = config.hidden_size
+
+    def rn(*shape, s=1.0):
+        return rng.standard_normal(shape) * s / np.sqrt(shape[-1])
+
+    return {
+        "q_a": rn(ql, h),
+        "q_a_norm": np.ones(ql) + 0.05 * rng.standard_normal(ql),
+        "q_b": rn(nh * (d + r), ql),
+        "kv_a": rn(l + r, h),
+        "kv_a_norm": np.ones(l) + 0.05 * rng.standard_normal(l),
+        "kv_b": rn(nh * (d + dv), l),
+        "o": rn(h, nh * dv),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Eligibility / typed rejections
+# ---------------------------------------------------------------------------
+
+
+class TestEligibility:
+    def test_dense_mla_eligible(self):
+        assert paged_attention_rejection(_cfg()) is None
+        assert paged_attention_eligible(_cfg())
+        assert paged_attention_eligible(make_config(**_GLM))
+
+    def test_dsa_indexshare_rejected(self):
+        reason = paged_attention_rejection(_cfg(use_dsa=True))
+        assert reason is not None
+        assert "DSA" in reason or "IndexShare" in reason
+
+    def test_vestigial_indexer_config_is_eligible_when_dsa_off(self):
+        # --glm-full-attention drops the indexer weights and builds plain dense
+        # MLA, so GLM's still-present indexer config fields (index_topk /
+        # indexer_types / index_n_heads / index_head_dim) must NOT reject on
+        # their own -- only an *active* DSA (use_dsa=True) is inexpressible.
+        assert paged_attention_rejection(_cfg(use_dsa=False, index_topk=64)) is None
+        assert paged_attention_rejection(_cfg(use_dsa=False, indexer_types=["full"])) is None
+        assert (
+            paged_attention_rejection(_cfg(use_dsa=False, index_n_heads=4, index_head_dim=32))
+            is None
+        )
+
+    def test_deepseek_v4_csa_hca_rejected(self):
+        assert paged_attention_rejection(_cfg(compress_ratios=[4, 8])) is not None
+        assert paged_attention_rejection(_cfg(hc_mult=2)) is not None
+        assert paged_attention_rejection(_cfg(o_lora_rank=64)) is not None
+        assert paged_attention_rejection(_cfg(o_groups=2)) is not None
+
+    def test_mtp_rejected(self):
+        assert paged_attention_rejection(_cfg(num_nextn_predict_layers=1)) is not None
+
+    def test_quant_and_dtype_rejected(self):
+        assert paged_attention_rejection(_cfg(dtype=ir.DataType.FLOAT)) is not None
+        assert paged_attention_rejection(_cfg(dtype=ir.DataType.INT8)) is not None
+        # bf16 accepted
+        assert paged_attention_rejection(_cfg(dtype=ir.DataType.BFLOAT16)) is None
+
+    def test_non_mla_rejected(self):
+        cfg = make_config(hidden_size=64, dtype=ir.DataType.FLOAT16)
+        assert paged_attention_rejection(cfg) is not None
+
+    def test_geometry_constraints_rejected(self):
+        # head_size = kv_lora + rope not divisible by 8.
+        assert paged_attention_rejection(_cfg(kv_lora_rank=16, qk_rope_head_dim=4)) is not None
+        # rope not divisible by 16.
+        assert paged_attention_rejection(_cfg(qk_rope_head_dim=8)) is not None
+        # kv_lora not divisible by 8.
+        assert (
+            paged_attention_rejection(_cfg(kv_lora_rank=12, qk_rope_head_dim=16)) is not None
+        )
+
+    def test_mla_geometry_raises_on_ineligible(self):
+        with pytest.raises(ValueError, match="DSA"):
+            mla_paged_geometry(_cfg(use_dsa=True))
+
+
+class TestGeometry:
+    def test_glm_dims(self):
+        g = mla_paged_geometry(make_config(**_GLM))
+        assert g.head_size == 576
+        assert g.v_head_size == 512
+        assert g.rotary_offset == 512
+        assert g.rotary_dim == 64
+        assert g.qk_head_dim == 192
+        assert g.scale == pytest.approx(192**-0.5)
+
+    def test_tiny_dims(self):
+        g = mla_paged_geometry(_cfg())
+        assert g.head_size == 32
+        assert g.v_head_size == 16
+        assert g.rotary_offset == 16
+        assert g.rotary_dim == 16
+        assert g.qk_head_dim == 32
+
+
+# ---------------------------------------------------------------------------
+# Weight absorption
+# ---------------------------------------------------------------------------
+
+
+class TestAbsorption:
+    def test_absorbed_shapes(self):
+        config = _cfg()
+        w = _random_weights(config)
+        out = absorb_mla_weights(
+            {"q_b": w["q_b"], "kv_b": w["kv_b"], "o": w["o"]},
+            config,
+            q_key="q_b",
+            kv_b_key="kv_b",
+            o_key="o",
+        )
+        nh, l, r = (  # noqa: E741
+            config.num_attention_heads,
+            config.kv_lora_rank,
+            config.qk_rope_head_dim,
+        )
+        assert out["q_b"].shape == (nh * (l + r), config.q_lora_rank)
+        assert out["o"].shape == (config.hidden_size, nh * l)
+        assert "kv_b" not in out  # fully absorbed / dropped
+
+    def test_absorption_rejects_bad_shapes(self):
+        config = _cfg()
+        w = _random_weights(config)
+        bad = dict(w)
+        bad["kv_b"] = w["kv_b"][:-1]  # wrong rows
+        with pytest.raises(ValueError, match="kv_b"):
+            absorb_mla_weights(
+                {"q_b": w["q_b"], "kv_b": bad["kv_b"], "o": w["o"]},
+                config,
+                q_key="q_b",
+                kv_b_key="kv_b",
+                o_key="o",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Numerical parity: absorbed LATENT == decomposed dense MLA
+# ---------------------------------------------------------------------------
+
+
+class TestNumericalParity:
+    @pytest.mark.parametrize("interleaved", [False, True])
+    @pytest.mark.parametrize("seed", [0, 1, 2])
+    def test_tiny_parity_full_sequence(self, interleaved, seed):
+        config = _cfg(rope_interleave=interleaved)
+        w = _random_weights(config, seed=seed)
+        t = 5
+        hidden = np.random.default_rng(100 + seed).standard_normal((t, config.hidden_size))
+        cos, sin = _build_cos_sin(32, config.qk_rope_head_dim)
+        dec = _decomposed_reference(hidden, w, config, cos, sin)
+        pag = _paged_latent_reference(hidden, w, config, cos, sin)
+        rel = np.max(np.abs(dec - pag)) / (np.max(np.abs(dec)) + 1e-9)
+        assert rel < 1e-6, f"rel diff {rel}"
+
+    def test_glm_dims_parity(self):
+        config = make_config(**_GLM)
+        w = _random_weights(config, seed=7)
+        t = 4
+        hidden = np.random.default_rng(7).standard_normal((t, config.hidden_size))
+        cos, sin = _build_cos_sin(32, config.qk_rope_head_dim)
+        dec = _decomposed_reference(hidden, w, config, cos, sin)
+        pag = _paged_latent_reference(hidden, w, config, cos, sin)
+        rel = np.max(np.abs(dec - pag)) / (np.max(np.abs(dec)) + 1e-9)
+        assert rel < 1e-6, f"rel diff {rel}"
+
+    def test_prefill_then_decode_progression(self):
+        """Per-token equivalence == prefill + incremental decode equivalence."""
+        config = _cfg()
+        w = _random_weights(config, seed=3)
+        t = 6
+        hidden = np.random.default_rng(3).standard_normal((t, config.hidden_size))
+        cos, sin = _build_cos_sin(32, config.qk_rope_head_dim)
+        dec = _decomposed_reference(hidden, w, config, cos, sin)
+        pag = _paged_latent_reference(hidden, w, config, cos, sin)
+        # Prefill (all but last) and each decode token must match row-wise.
+        for tok in range(t):
+            rel = np.max(np.abs(dec[tok] - pag[tok])) / (np.max(np.abs(dec[tok])) + 1e-9)
+            assert rel < 1e-6, f"token {tok} rel diff {rel}"
+
+
+# ---------------------------------------------------------------------------
+# Structural op emission
+# ---------------------------------------------------------------------------
+
+
+def _build_paged_graph(config):
+    mla = PagedLatentMLA(config)
+    builder, op, graph = create_test_builder()
+    geom = mla.geom
+    dt = config.dtype
+    hidden = create_test_input(builder, "hidden", [1, 4, config.hidden_size], dt)
+    num_blocks, block_size = 2, 16
+    cache = PagedCacheState(
+        key_cache=create_test_input(
+            builder, "key_cache", [num_blocks, block_size, 1, geom.head_size], dt
+        ),
+        block_table=create_test_input(builder, "block_table", [1, 2], ir.DataType.INT32),
+        slot_mapping=create_test_input(builder, "slot_mapping", [4], ir.DataType.INT32),
+        cumulative_sequence_length=create_test_input(
+            builder, "cu_seqlens", [2], ir.DataType.INT32
+        ),
+        past_seqlens=create_test_input(builder, "past_seqlens", [1], ir.DataType.INT32),
+        cos_cache=create_test_input(builder, "cos_cache", [32, geom.rotary_dim // 2], dt),
+        sin_cache=create_test_input(builder, "sin_cache", [32, geom.rotary_dim // 2], dt),
+    )
+    output, (key_cache_out,) = mla(op, hidden, cache)
+    builder._adapt_outputs([output, key_cache_out], "")
+    return graph, geom
+
+
+def _find_paged_node(graph):
+    for node in graph:
+        if node.op_type == "PagedAttention":
+            return node
+    return None
+
+
+class TestStructuralEmission:
+    def test_emits_single_paged_attention_node(self):
+        graph, _ = _build_paged_graph(_cfg())
+        assert count_op_type(graph, "PagedAttention") == 1
+        assert count_op_type(graph, "Attention") == 0
+
+    def test_node_domain_and_attrs(self):
+        graph, geom = _build_paged_graph(_cfg())
+        node = _find_paged_node(graph)
+        assert node is not None
+        assert node.domain == "com.microsoft"
+        attrs = {a.name: a.value for a in node.attributes.values()}
+        assert attrs["kv_cache_layout"] == "LATENT"
+        assert attrs["num_heads"] == geom.num_heads
+        assert attrs["kv_num_heads"] == 1
+        assert attrs["v_head_size"] == geom.v_head_size
+        assert attrs["rotary_offset"] == geom.rotary_offset
+        assert attrs["do_rotary"] == 1
+        assert pytest.approx(attrs["scale"]) == geom.scale
+        # rotary_dim is DERIVED from cos_cache, never emitted as an attribute.
+        assert "rotary_dim" not in attrs
+
+    def test_input_positions(self):
+        graph, _ = _build_paged_graph(_cfg())
+        node = _find_paged_node(graph)
+        names = [v.name if v is not None else None for v in node.inputs]
+        # Positions 0,1,3,5,6,7,8,9,10 present; 2 and 4 absent (LATENT).
+        assert names[0] is not None and "Reshape" in names[0]  # query (2D)
+        assert names[1] is not None and "Reshape" in names[1]  # latent key (2D)
+        assert names[2] is None  # value absent
+        assert names[3] == "key_cache"
+        assert names[4] is None  # value_cache absent
+        assert names[5] == "cu_seqlens"
+        assert names[6] == "past_seqlens"
+        assert names[7] == "block_table"
+        assert names[8] == "cos_cache"
+        assert names[9] == "sin_cache"
+        assert names[10] == "slot_mapping"
+
+    def test_key_cache_aliases_output(self):
+        graph, _ = _build_paged_graph(_cfg())
+        node = _find_paged_node(graph)
+        # Output 1 is key_cache_out; the runtime must alias input 3 in place.
+        assert len(node.outputs) == 3
+        assert node.inputs[3].name == "key_cache"
+
+    def test_glm_dims_emits(self):
+        graph, _ = _build_paged_graph(make_config(**_GLM))
+        node = _find_paged_node(graph)
+        attrs = {a.name: a.value for a in node.attributes.values()}
+        assert attrs["v_head_size"] == 512
+        assert attrs["rotary_offset"] == 512
+        assert attrs["num_heads"] == 4

--- a/src/mobius/integrations/transformers/_builder.py
+++ b/src/mobius/integrations/transformers/_builder.py
@@ -159,6 +159,7 @@ def build_transformers_model(
     kv_cache_scales: dict[int, tuple[float, float]] | None = None,
     prune_prefill_prefix: bool = False,
     glm_full_attention: bool = False,
+    export_paged_attention: bool = False,
 ) -> ModelPackage:
     """Build a model package from a Transformers checkpoint.
 
@@ -246,6 +247,16 @@ def build_transformers_model(
                 "('glm_moe_dsa') checkpoints."
             )
         config = dataclasses.replace(config, use_dsa=False)
+    if export_paged_attention:
+        from mobius.components._paged_mla import paged_attention_rejection
+
+        config = dataclasses.replace(config, export_paged_attention=True)
+        reason = paged_attention_rejection(config)
+        if reason is not None:
+            raise ValueError(
+                "export_paged_attention=True (--features paged-attention) is not "
+                f"supported for model_type '{model_type}': {reason}"
+            )
     if task is None:
         task = _default_task_for_model(model_type)
 

--- a/src/mobius/models/deepseek.py
+++ b/src/mobius/models/deepseek.py
@@ -221,7 +221,7 @@ class DeepSeekMLADecoderLayer(nn.Module):
     def __init__(self, config: ArchitectureConfig, is_moe: bool = False):
         super().__init__()
         linear_class = _linear_factory(config)
-        if getattr(config, "export_paged_attention", False):
+        if config.export_paged_attention:
             # Feature-on: emit LATENT PagedAttention. An ineligible geometry
             # raises here (typed reason) rather than silently falling back.
             self.self_attn = PagedLatentMLA(config, linear_class=linear_class)
@@ -408,7 +408,7 @@ class DeepSeekV3TextModel(nn.Module):
             ]
         )
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self._export_paged_attention = getattr(config, "export_paged_attention", False)
+        self._export_paged_attention = config.export_paged_attention
 
         # For MLA, RoPE applies only to the qk_rope_head_dim portion of Q and K,
         # not the full head_dim. Create a modified config so the cos/sin cache
@@ -561,7 +561,7 @@ class DeepSeekV3CausalLMModel(CausalLMModel):
 
         # Absorb kv_b_proj into the query/output projections for the opt-in
         # LATENT PagedAttention export (feature-off leaves weights untouched).
-        if getattr(self.config, "export_paged_attention", False):
+        if self.config.export_paged_attention:
             renamed = self._absorb_paged_mla_weights(renamed)
 
         # Handle weight tying and GPTQ/AWQ conversion before flattening the

--- a/src/mobius/models/deepseek.py
+++ b/src/mobius/models/deepseek.py
@@ -28,6 +28,11 @@ from mobius.components import (
 )
 from mobius.components._deepseek_mla import DeepSeekMLA
 from mobius.components._moe import _supported_qmoe_quantization
+from mobius.components._paged_mla import (
+    PagedLatentMLA,
+    absorb_mla_weights,
+    mla_paged_geometry,
+)
 from mobius.components._quantized_linear import make_quantized_linear_factory
 from mobius.models.base import CausalLMModel
 
@@ -216,7 +221,12 @@ class DeepSeekMLADecoderLayer(nn.Module):
     def __init__(self, config: ArchitectureConfig, is_moe: bool = False):
         super().__init__()
         linear_class = _linear_factory(config)
-        self.self_attn = DeepSeekMLA(config, linear_class=linear_class)
+        if getattr(config, "export_paged_attention", False):
+            # Feature-on: emit LATENT PagedAttention. An ineligible geometry
+            # raises here (typed reason) rather than silently falling back.
+            self.self_attn = PagedLatentMLA(config, linear_class=linear_class)
+        else:
+            self.self_attn = DeepSeekMLA(config, linear_class=linear_class)
         if is_moe:
             gate = DeepSeekMoEGate(config)
             self.mlp = _DeepSeekMoEFFN(config, gate, linear_class=linear_class)
@@ -236,13 +246,20 @@ class DeepSeekMLADecoderLayer(nn.Module):
         # Self attention with pre-norm
         residual = hidden_states
         hidden_states = self.input_layernorm(op, hidden_states)
-        hidden_states, present_kv = self.self_attn(
-            op,
-            hidden_states=hidden_states,
-            attention_bias=attention_bias,
-            position_embeddings=position_embeddings,
-            past_key_value=past_key_value,
-        )
+        if isinstance(self.self_attn, PagedLatentMLA):
+            hidden_states, present_kv = self.self_attn(
+                op,
+                hidden_states=hidden_states,
+                cache=past_key_value,
+            )
+        else:
+            hidden_states, present_kv = self.self_attn(
+                op,
+                hidden_states=hidden_states,
+                attention_bias=attention_bias,
+                position_embeddings=position_embeddings,
+                past_key_value=past_key_value,
+            )
         hidden_states = op.Add(residual, hidden_states)
 
         # FFN with pre-norm
@@ -391,6 +408,7 @@ class DeepSeekV3TextModel(nn.Module):
             ]
         )
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self._export_paged_attention = getattr(config, "export_paged_attention", False)
 
         # For MLA, RoPE applies only to the qk_rope_head_dim portion of Q and K,
         # not the full head_dim. Create a modified config so the cos/sin cache
@@ -414,6 +432,10 @@ class DeepSeekV3TextModel(nn.Module):
             hidden_states = inputs_embeds
         else:
             hidden_states = self.embed_tokens(op, input_ids)
+
+        if self._export_paged_attention:
+            return self._forward_paged(op, hidden_states, past_key_values)
+
         position_embeddings = self.rotary_emb(op, position_ids)
         attention_bias = create_attention_bias(
             op,
@@ -431,6 +453,44 @@ class DeepSeekV3TextModel(nn.Module):
                 attention_bias=attention_bias,
                 position_embeddings=position_embeddings,
                 past_key_value=past_kv,
+            )
+            present_key_values.append(present_kv)
+
+        hidden_states = self.norm(op, hidden_states)
+        return hidden_states, present_key_values
+
+    def _forward_paged(
+        self,
+        op: OpBuilder,
+        hidden_states: ir.Value,
+        past_key_values: list | None,
+    ):
+        """Paged LATENT forward: RoPE is applied inside ``PagedAttention``.
+
+        The RoPE cos/sin tables come from this model's ``rotary_emb`` parameters
+        (cast to the compute dtype) and are injected into every layer's
+        caller-owned :class:`PagedCacheState`.
+        """
+        if past_key_values is None:
+            raise ValueError(
+                "export_paged_attention requires caller-owned paged cache state; "
+                "use CausalLMTask(paged_cache=True)."
+            )
+        cos = self.rotary_emb.cos_cache
+        sin = self.rotary_emb.sin_cache
+        if self._dtype != ir.DataType.FLOAT:
+            cos = op.Cast(cos, to=self._dtype)
+            sin = op.Cast(sin, to=self._dtype)
+
+        present_key_values = []
+        for layer, cache in zip(self.layers, past_key_values):
+            cache = dataclasses.replace(cache, cos_cache=cos, sin_cache=sin)
+            hidden_states, present_kv = layer(
+                op,
+                hidden_states=hidden_states,
+                attention_bias=None,
+                position_embeddings=None,
+                past_key_value=cache,
             )
             present_key_values.append(present_kv)
 
@@ -499,9 +559,53 @@ class DeepSeekV3CausalLMModel(CausalLMModel):
 
             renamed[new_key] = value
 
+        # Absorb kv_b_proj into the query/output projections for the opt-in
+        # LATENT PagedAttention export (feature-off leaves weights untouched).
+        if getattr(self.config, "export_paged_attention", False):
+            renamed = self._absorb_paged_mla_weights(renamed)
+
         # Handle weight tying and GPTQ/AWQ conversion before flattening the
         # expert-major MatMulNBits blobs into the QMoE ABI.
         processed = super().preprocess_weights(renamed)
         if use_qmoe:
             processed = pack_qmoe_expert_weights(processed)
         return processed
+
+    def _absorb_paged_mla_weights(
+        self, weights: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        """Fold each layer's ``kv_b_proj`` into ``q_(b_)proj`` and ``o_proj``.
+
+        Produces the absorbed shapes consumed by :class:`PagedLatentMLA` and
+        drops ``kv_b_proj`` (fully absorbed). Matches the numeric contract in
+        :func:`mobius.components._paged_mla.absorb_mla_weights`.
+        """
+        # Validate eligibility (raises a typed reason if ineligible).
+        mla_paged_geometry(self.config)
+        out = dict(weights)
+        kv_b_suffix = ".self_attn.kv_b_proj.weight"
+        for key in list(weights):
+            if not key.endswith(kv_b_suffix):
+                continue
+            prefix = key[: -len(kv_b_suffix)]
+            q_key = f"{prefix}.self_attn.q_b_proj.weight"
+            if q_key not in weights:
+                q_key = f"{prefix}.self_attn.q_proj.weight"
+            o_key = f"{prefix}.self_attn.o_proj.weight"
+            if q_key not in weights or o_key not in weights:
+                raise ValueError(
+                    f"Cannot absorb paged MLA weights for '{prefix}': missing "
+                    f"query or output projection."
+                )
+            q_t, o_t = weights[q_key], weights[o_key]
+            absorbed = absorb_mla_weights(
+                {q_key: q_t, key: weights[key], o_key: o_t},
+                self.config,
+                q_key=q_key,
+                kv_b_key=key,
+                o_key=o_key,
+            )
+            out[q_key] = torch.as_tensor(absorbed[q_key]).to(q_t.dtype)
+            out[o_key] = torch.as_tensor(absorbed[o_key]).to(o_t.dtype)
+            del out[key]  # kv_b_proj fully absorbed
+        return out

--- a/src/mobius/models/glm_moe_dsa.py
+++ b/src/mobius/models/glm_moe_dsa.py
@@ -651,7 +651,7 @@ class GlmMoeDsaCausalLMModel(DeepSeekV3CausalLMModel):
             config = dataclasses.replace(config, indexer_types=_indexer_types(config))
         nn.Module.__init__(self)
         self.config = config
-        if getattr(config, "export_paged_attention", False) and config.use_dsa:
+        if config.export_paged_attention and config.use_dsa:
             # Feature-on must error rather than silently exporting the DSA graph.
             from mobius.components._paged_mla import paged_attention_rejection
 

--- a/src/mobius/models/glm_moe_dsa.py
+++ b/src/mobius/models/glm_moe_dsa.py
@@ -651,6 +651,14 @@ class GlmMoeDsaCausalLMModel(DeepSeekV3CausalLMModel):
             config = dataclasses.replace(config, indexer_types=_indexer_types(config))
         nn.Module.__init__(self)
         self.config = config
+        if getattr(config, "export_paged_attention", False) and config.use_dsa:
+            # Feature-on must error rather than silently exporting the DSA graph.
+            from mobius.components._paged_mla import paged_attention_rejection
+
+            raise ValueError(
+                paged_attention_rejection(config)
+                or "PagedAttention export requires dense MLA (--glm-full-attention)."
+            )
         self.model = (
             GlmMoeDsaTextModel(config) if config.use_dsa else DeepSeekV3TextModel(config)
         )

--- a/src/mobius/models/paged_mla_export_test.py
+++ b/src/mobius/models/paged_mla_export_test.py
@@ -13,7 +13,7 @@ through ``CausalLMTask(paged_cache=True)`` with ``export_paged_attention=True``:
   in-place-aliased latent cache IO;
 * feature-on with an inexpressible geometry or an *active* query-dependent
   sparse selection (GLM DSA, DeepSeek-V4 CSA/HCA, MTP, quantized cache,
-  head_sink, qk-norm, sliding window) is a typed error at model construction /
+  qk-norm, sliding window) is a typed error at model construction /
   build, never a silent dense fallback.
 
 There is no CPU ``PagedAttention`` kernel and the base onnx checker does not
@@ -185,7 +185,7 @@ class TestFeatureOnStructure:
         # DeepSeek-V3 has no indexer configured, so DSA is not active and the
         # paged export must still qualify (eligibility is property-based, not
         # gated on the vestigial use_dsa flag or the model name).
-        assert getattr(config, "use_dsa", True) is True
+        assert config.use_dsa is True
         graph = self._graph(config, model_cls=DeepSeekV3CausalLMModel)
         assert len(_paged_nodes(graph)) == config.num_hidden_layers
 
@@ -284,10 +284,14 @@ class TestFeatureOnRejects:
                 DeepSeekV3CausalLMModel(config)
 
     def test_optional_modes_rejected_at_construction(self):
-        """MTP / sliding-window are typed-rejected, not silently miscomputed."""
+        """MTP / qk-norm / sliding-window are typed-rejected, not miscomputed."""
         with pytest.raises(ValueError, match=r"Multi-Token|num_nextn"):
             DeepSeekV3CausalLMModel(
                 _deepseek_config(export_paged_attention=True, num_nextn_predict_layers=1)
+            )
+        with pytest.raises(ValueError, match=r"q_norm|k_norm"):
+            DeepSeekV3CausalLMModel(
+                _deepseek_config(export_paged_attention=True, attn_qk_norm=True)
             )
         with pytest.raises(ValueError, match="window"):
             DeepSeekV3CausalLMModel(

--- a/src/mobius/models/paged_mla_export_test.py
+++ b/src/mobius/models/paged_mla_export_test.py
@@ -1,0 +1,325 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Model-level export tests for opt-in ``--paged-attention`` (LATENT dense MLA).
+
+Covers the full DeepSeek-V3 / GLM-5.2 ``--glm-full-attention`` export routed
+through ``CausalLMTask(paged_cache=True)`` with ``export_paged_attention=True``:
+
+* feature-off is byte-identical to the current dense-MLA export (the flag is
+  default off and every new code path is gated behind it);
+* feature-on emits ``com.microsoft::PagedAttention`` v1 in ``LATENT`` mode, one
+  node per hidden layer, with the exact op attrs, caller-owned page inputs and
+  in-place-aliased latent cache IO;
+* feature-on with an inexpressible geometry or an *active* query-dependent
+  sparse selection (GLM DSA, DeepSeek-V4 CSA/HCA, MTP, quantized cache,
+  head_sink, qk-norm, sliding window) is a typed error at model construction /
+  build, never a silent dense fallback.
+
+There is no CPU ``PagedAttention`` kernel and the base onnx checker does not
+know the contrib op, so the assertions here are structural (op attrs / inputs /
+outputs / model IO). Numerical parity against the decomposed oracle lives in
+``mobius/components/_paged_mla_test.py``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import onnx_ir as ir
+import pytest
+import torch
+
+from mobius._builder import build_from_module
+from mobius._testing import count_op_type, make_config
+from mobius.models.deepseek import DeepSeekV3CausalLMModel
+from mobius.models.glm_moe_dsa import GlmMoeDsaCausalLMModel
+from mobius.tasks import CausalLMTask
+
+# Paged-eligible tiny MLA geometry: head_size = kv_lora + rope = 32 (% 8 == 0),
+# kv_lora_rank % 8 == 0, qk_rope_head_dim % 16 == 0. Shared by every model here.
+_PAGED_GEOMETRY = dict(
+    kv_lora_rank=16,
+    qk_nope_head_dim=8,
+    qk_rope_head_dim=16,
+    v_head_dim=16,
+    dtype=ir.DataType.FLOAT16,
+)
+
+
+def _glm_full_attention_config(**overrides):
+    """Tiny GLM-5.2 ``--glm-full-attention`` config (dense MLA, DSA off)."""
+    defaults = dict(
+        model_type="glm_moe_dsa",
+        vocab_size=48,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        head_dim=16,
+        max_position_embeddings=32,
+        q_lora_rank=24,
+        first_k_dense_replace=0,
+        num_local_experts=4,
+        num_experts_per_tok=2,
+        n_group=2,
+        topk_group=1,
+        n_shared_experts=1,
+        moe_intermediate_size=16,
+        scoring_func="sigmoid",
+        topk_method="noaux_tc",
+        norm_topk_prob=True,
+        routed_scaling_factor=2.5,
+        index_n_heads=2,
+        index_head_dim=16,
+        index_topk=3,
+        indexer_rope_interleave=True,
+        indexer_types=["full", "shared"],
+        use_dsa=False,
+    )
+    defaults.update(_PAGED_GEOMETRY)
+    defaults.update(overrides)
+    return make_config(**defaults)
+
+
+def _deepseek_config(**overrides):
+    """Tiny DeepSeek-V3 dense-MLA config (proves eligibility is not name-gated)."""
+    defaults = dict(
+        model_type="deepseek_v3",
+        vocab_size=48,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        head_dim=16,
+        max_position_embeddings=32,
+        q_lora_rank=24,
+        first_k_dense_replace=0,
+        num_local_experts=4,
+        num_experts_per_tok=2,
+        n_group=2,
+        topk_group=1,
+        n_shared_experts=1,
+        moe_intermediate_size=16,
+        scoring_func="sigmoid",
+        topk_method="noaux_tc",
+        norm_topk_prob=True,
+        routed_scaling_factor=2.5,
+        use_dsa=False,
+    )
+    defaults.update(_PAGED_GEOMETRY)
+    defaults.update(overrides)
+    return make_config(**defaults)
+
+
+def _build(model, config):
+    return build_from_module(model, config, task=CausalLMTask(paged_cache=True))
+
+
+def _paged_nodes(graph):
+    return [n for n in graph if n.op_type == "PagedAttention"]
+
+
+# --------------------------------------------------------------------------
+# Feature-off: byte-identical dense export
+# --------------------------------------------------------------------------
+
+
+class TestFeatureOff:
+    def test_no_paged_nodes_and_dense_attention(self):
+        """Feature-off GLM full-attention stays the current dense-MLA graph."""
+        config = _glm_full_attention_config(export_paged_attention=False)
+        model = GlmMoeDsaCausalLMModel(config)
+        graph = build_from_module(model, config, task="glm-moe-dsa")["model"].graph
+        assert count_op_type(graph, "PagedAttention") == 0
+        assert count_op_type(graph, "IndexShare") == 0
+        dense = (
+            count_op_type(graph, "Attention")
+            + count_op_type(graph, "GroupQueryAttention")
+            + count_op_type(graph, "MultiHeadAttention")
+        )
+        assert dense > 0
+
+    def test_flag_off_is_byte_identical_to_flag_absent(self):
+        """Presence of the (off) flag must not perturb the serialized graph."""
+        base = _glm_full_attention_config()  # export_paged_attention defaults False
+        assert base.export_paged_attention is False
+        explicit_off = dataclasses.replace(base, export_paged_attention=False)
+
+        def _bytes(config):
+            model = GlmMoeDsaCausalLMModel(config)
+            pkg = build_from_module(model, config, task="glm-moe-dsa")
+            return ir.to_proto(pkg["model"]).SerializeToString()
+
+        assert _bytes(base) == _bytes(explicit_off)
+
+
+# --------------------------------------------------------------------------
+# Feature-on: LATENT PagedAttention structural contract
+# --------------------------------------------------------------------------
+
+
+class TestFeatureOnStructure:
+    def _graph(self, config, model_cls=GlmMoeDsaCausalLMModel):
+        model = model_cls(config)
+        return _build(model, config)["model"].graph
+
+    def test_glm_emits_one_paged_node_per_layer(self):
+        config = _glm_full_attention_config(export_paged_attention=True)
+        graph = self._graph(config)
+        assert len(_paged_nodes(graph)) == config.num_hidden_layers
+        assert count_op_type(graph, "Attention") == 0
+        assert count_op_type(graph, "GroupQueryAttention") == 0
+        assert count_op_type(graph, "IndexShare") == 0
+
+    def test_deepseek_v3_emits_paged_not_name_gated(self):
+        config = _deepseek_config(export_paged_attention=True)
+        graph = self._graph(config, model_cls=DeepSeekV3CausalLMModel)
+        assert len(_paged_nodes(graph)) == config.num_hidden_layers
+
+    def test_op_attrs_are_latent(self):
+        config = _glm_full_attention_config(export_paged_attention=True)
+        graph = self._graph(config)
+        node = _paged_nodes(graph)[0]
+        assert node.domain == "com.microsoft"
+        attrs = {a.name: a.value for a in node.attributes.values()}
+        assert attrs["kv_cache_layout"] == "LATENT"
+        assert attrs["num_heads"] == config.num_attention_heads
+        assert attrs["kv_num_heads"] == 1
+        assert attrs["v_head_size"] == config.kv_lora_rank
+        assert attrs["rotary_offset"] == config.kv_lora_rank
+        assert attrs["do_rotary"] == 1
+        assert "scale" in attrs
+        # rotary_dim is DERIVED from cos_cache last dim, never an attribute.
+        assert "rotary_dim" not in attrs
+
+    def test_node_input_latent_contract(self):
+        config = _glm_full_attention_config(export_paged_attention=True)
+        graph = self._graph(config)
+        node = _paged_nodes(graph)[0]
+        names = [v.name if v is not None else None for v in node.inputs]
+        # value (2) and value_cache (4) are absent in LATENT; key_cache is bound.
+        assert names[2] is None
+        assert names[3] is not None and names[3].startswith("key_cache.")
+        assert names[4] is None
+        # key_cache_out (output 1) must alias input 3 in place at runtime.
+        assert len(node.outputs) == 3
+
+    def test_model_io_contract(self):
+        config = _glm_full_attention_config(export_paged_attention=True)
+        graph = self._graph(config)
+        n = config.num_hidden_layers
+
+        inputs = {v.name: v for v in graph.inputs}
+        expected_inputs = {
+            "input_ids",
+            "block_table",
+            "slot_mapping",
+            "cumulative_sequence_length",
+            "past_seqlens",
+            *(f"key_cache.{i}" for i in range(n)),
+        }
+        assert set(inputs) == expected_inputs
+        # No position_ids: LATENT derives positions from the length tensors.
+        assert "position_ids" not in inputs
+
+        assert inputs["block_table"].dtype == ir.DataType.INT32
+        assert inputs["slot_mapping"].dtype == ir.DataType.INT32
+        assert inputs["cumulative_sequence_length"].dtype == ir.DataType.INT32
+        assert inputs["past_seqlens"].dtype == ir.DataType.INT32
+        for i in range(n):
+            kc = inputs[f"key_cache.{i}"]
+            assert kc.dtype == ir.DataType.FLOAT16
+            # [num_blocks, block_size, kv_num_heads=1, head_size=l+r]
+            assert len(kc.shape) == 4
+            assert kc.shape[2] == 1
+            assert kc.shape[3] == config.kv_lora_rank + config.qk_rope_head_dim
+
+        outputs = {v.name for v in graph.outputs}
+        expected_outputs = {"logits", *(f"updated_key_cache.{i}" for i in range(n))}
+        assert outputs == expected_outputs
+        # LATENT has a single cache component: no updated_value_cache.
+        assert not any(o.startswith("updated_value_cache") for o in outputs)
+
+
+# --------------------------------------------------------------------------
+# Feature-on incompatible: typed error, never silent fallback
+# --------------------------------------------------------------------------
+
+
+class TestFeatureOnRejects:
+    def test_dsa_active_rejected_at_construction(self):
+        """GLM with DSA on + paged flag must error, never build the DSA graph."""
+        config = _glm_full_attention_config(export_paged_attention=True, use_dsa=True)
+        with pytest.raises(ValueError, match=r"DSA|IndexShare|dense MLA"):
+            GlmMoeDsaCausalLMModel(config)
+
+    def test_ineligible_geometry_rejected_at_construction(self):
+        # qk_rope_head_dim=8 violates rotary_dim % 16 == 0.
+        config = _deepseek_config(export_paged_attention=True, qk_rope_head_dim=8)
+        with pytest.raises(ValueError):
+            DeepSeekV3CausalLMModel(config)
+
+    def test_csa_hca_rejected_at_construction(self):
+        for override in (
+            dict(compress_ratios=[4, 8]),
+            dict(o_lora_rank=64),
+            dict(o_groups=2),
+            dict(hc_mult=2),
+        ):
+            config = _deepseek_config(export_paged_attention=True, **override)
+            with pytest.raises(ValueError):
+                DeepSeekV3CausalLMModel(config)
+
+    def test_optional_modes_rejected_at_construction(self):
+        """MTP / sliding-window are typed-rejected, not silently miscomputed."""
+        with pytest.raises(ValueError, match=r"Multi-Token|num_nextn"):
+            DeepSeekV3CausalLMModel(
+                _deepseek_config(export_paged_attention=True, num_nextn_predict_layers=1)
+            )
+        with pytest.raises(ValueError, match="window"):
+            DeepSeekV3CausalLMModel(
+                _deepseek_config(export_paged_attention=True, sliding_window=64)
+            )
+
+
+# --------------------------------------------------------------------------
+# Feature-on weight absorption (torch state dict wrapper)
+# --------------------------------------------------------------------------
+
+
+class TestWeightAbsorption:
+    def test_kv_b_proj_absorbed_and_dropped(self):
+        """``_absorb_paged_mla_weights`` folds kv_b_proj and rewrites shapes."""
+        config = _deepseek_config(export_paged_attention=True, num_hidden_layers=1)
+        model = DeepSeekV3CausalLMModel(config)
+
+        nh = config.num_attention_heads
+        d = config.qk_nope_head_dim
+        r = config.qk_rope_head_dim
+        dv = config.v_head_dim
+        lat = config.kv_lora_rank
+        q_lora = config.q_lora_rank
+        hidden = config.hidden_size
+        p = "model.layers.0.self_attn"
+
+        torch.manual_seed(0)
+        state = {
+            f"{p}.q_b_proj.weight": torch.randn(nh * (d + r), q_lora, dtype=torch.float16),
+            f"{p}.kv_b_proj.weight": torch.randn(nh * (d + dv), lat, dtype=torch.float16),
+            f"{p}.o_proj.weight": torch.randn(hidden, nh * dv, dtype=torch.float16),
+        }
+
+        absorbed = model._absorb_paged_mla_weights(state)
+
+        # kv_b_proj is fully folded away.
+        assert f"{p}.kv_b_proj.weight" not in absorbed
+        # q_b_proj rows grow from nh*(d+r) to nh*(latent+r).
+        assert absorbed[f"{p}.q_b_proj.weight"].shape == (nh * (lat + r), q_lora)
+        # o_proj columns become nh*latent.
+        assert absorbed[f"{p}.o_proj.weight"].shape == (hidden, nh * lat)
+        # Results stay torch tensors in the source dtype.
+        assert absorbed[f"{p}.q_b_proj.weight"].dtype == torch.float16
+        assert absorbed[f"{p}.o_proj.weight"].dtype == torch.float16

--- a/src/mobius/models/paged_mla_export_test.py
+++ b/src/mobius/models/paged_mla_export_test.py
@@ -36,8 +36,8 @@ from mobius.models.deepseek import DeepSeekV3CausalLMModel
 from mobius.models.glm_moe_dsa import GlmMoeDsaCausalLMModel
 from mobius.tasks import CausalLMTask
 
-# Paged-eligible tiny MLA geometry: head_size = kv_lora + rope = 32 (% 8 == 0),
-# kv_lora_rank % 8 == 0, qk_rope_head_dim % 16 == 0. Shared by every model here.
+# Paged-eligible tiny MLA geometry: head_size = kv_lora + rope = 32 (% 16 == 0),
+# kv_lora_rank % 16 == 0, qk_rope_head_dim % 16 == 0. Shared by every model here.
 _PAGED_GEOMETRY = dict(
     kv_lora_rank=16,
     qk_nope_head_dim=8,
@@ -84,7 +84,13 @@ def _glm_full_attention_config(**overrides):
 
 
 def _deepseek_config(**overrides):
-    """Tiny DeepSeek-V3 dense-MLA config (proves eligibility is not name-gated)."""
+    """Tiny DeepSeek-V3 dense-MLA config (proves eligibility is not name-gated).
+
+    ``use_dsa`` is intentionally left at its ``True`` default: it is vestigial
+    for plain DeepSeek-V3 (the dense text model never reads it, and no indexer
+    is configured), so the paged export must still qualify — guarding the
+    "use_dsa alone must not reject" regression.
+    """
     defaults = dict(
         model_type="deepseek_v3",
         vocab_size=48,
@@ -107,7 +113,6 @@ def _deepseek_config(**overrides):
         topk_method="noaux_tc",
         norm_topk_prob=True,
         routed_scaling_factor=2.5,
-        use_dsa=False,
     )
     defaults.update(_PAGED_GEOMETRY)
     defaults.update(overrides)
@@ -176,6 +181,11 @@ class TestFeatureOnStructure:
 
     def test_deepseek_v3_emits_paged_not_name_gated(self):
         config = _deepseek_config(export_paged_attention=True)
+        # Regression: use_dsa defaults to True on every config, but plain
+        # DeepSeek-V3 has no indexer configured, so DSA is not active and the
+        # paged export must still qualify (eligibility is property-based, not
+        # gated on the vestigial use_dsa flag or the model name).
+        assert getattr(config, "use_dsa", True) is True
         graph = self._graph(config, model_cls=DeepSeekV3CausalLMModel)
         assert len(_paged_nodes(graph)) == config.num_hidden_layers
 

--- a/src/mobius/tasks/_causal_lm.py
+++ b/src/mobius/tasks/_causal_lm.py
@@ -95,10 +95,14 @@ class CausalLMTask(ModelTask):
         self,
         *,
         static_cache: bool = False,
+        paged_cache: bool = False,
         max_seq_len: int | None = None,
         prune_prefill_prefix: bool = False,
     ):
+        if static_cache and paged_cache:
+            raise ValueError("static_cache and paged_cache are mutually exclusive.")
         self._static_cache = static_cache
+        self._paged_cache = paged_cache
         self._max_seq_len = max_seq_len
         self._prune_prefill_prefix = prune_prefill_prefix
 
@@ -132,6 +136,10 @@ class CausalLMTask(ModelTask):
 
         # --- Inputs common to both modes ---
         input_ids = builder.input("input_ids", dtype=ir.DataType.INT64, shape=[batch, seq_len])
+
+        # --- Paged-cache mode: caller-owned LATENT PagedAttention cache. ---
+        if self._paged_cache:
+            return self._build_paged(module, config, graph, builder, op, input_ids, batch)
 
         # --- Cache setup (static vs dynamic) ---
         if static:
@@ -243,6 +251,57 @@ class CausalLMTask(ModelTask):
                 builder, config.output_layer_indices, intermediate_hidden_states
             )
 
+        return ModelPackage({"model": _make_model(graph)}, config=config)
+
+    def _build_paged(
+        self,
+        module: nn.Module,
+        config: ArchitectureConfig,
+        graph,
+        builder: GraphBuilder,
+        op,
+        input_ids: ir.Value,
+        batch: ir.SymbolicDim,
+    ) -> ModelPackage:
+        """Emit a decoder that binds caller-owned LATENT ``PagedAttention``.
+
+        The page/cache tensors (``block_table``, ``slot_mapping``, cumulative
+        lengths, past lengths, per-layer ``key_cache.N``) are graph inputs owned
+        by the native page manager; this task never allocates or manages pages.
+        """
+        from mobius.components._paged_mla import (
+            mla_paged_geometry,
+        )
+
+        # Eligibility must hold; an incompatible geometry is a typed error here
+        # (never a silent dense fallback).
+        geom = mla_paged_geometry(config)
+
+        # LATENT PagedAttention applies RoPE in-op and derives each token's
+        # absolute position from past_seqlens + cumulative_sequence_length, so
+        # the graph takes no position_ids input.
+        paged_states = _make_paged_cache_inputs(
+            builder,
+            config.num_hidden_layers,
+            geom.head_size,
+            config.dtype,
+            batch,
+        )
+
+        result = module(
+            op,
+            input_ids=input_ids,
+            attention_mask=None,
+            position_ids=None,
+            past_key_values=paged_states,
+        )
+        if len(result) == 3:
+            logits, present_key_values, _intermediate = result
+        else:
+            logits, present_key_values = result
+
+        builder.add_output(logits, "logits")
+        _register_paged_cache_outputs(builder, present_key_values)
         return ModelPackage({"model": _make_model(graph)}, config=config)
 
 
@@ -466,6 +525,71 @@ def _register_static_cache_outputs(
     for i, (updated_key, updated_value) in enumerate(present_key_values):
         builder.add_output(updated_key, f"updated_key_cache.{i}")
         builder.add_output(updated_value, f"updated_value_cache.{i}")
+
+
+def _make_paged_cache_inputs(
+    builder: GraphBuilder,
+    num_layers: int,
+    head_size: int,
+    dtype: ir.DataType,
+    batch: ir.SymbolicDim,
+):
+    """Create caller-owned LATENT ``PagedAttention`` cache inputs.
+
+    Per-layer ``key_cache.{i}`` LATENT buffers plus the shared index inputs
+    (``block_table``, ``slot_mapping``, ``cumulative_sequence_length``,
+    ``past_seqlens``). ``cos_cache``/``sin_cache`` are supplied by the model
+    from its RoPE parameters, so the returned states leave them ``None``.
+
+    All buffers are graph inputs owned by the native page manager; this task
+    allocates none of them and never creates a second cache authority.
+    """
+    from mobius.components._paged_mla import PagedCacheState
+
+    num_blocks = ir.SymbolicDim("num_blocks")
+    block_size = ir.SymbolicDim("block_size")
+    max_blocks = ir.SymbolicDim("max_blocks_per_seq")
+    num_tokens = ir.SymbolicDim("num_tokens")
+
+    # Shared, sequence-level index inputs (int32 positional constraint S).
+    block_table = builder.input(
+        "block_table", dtype=ir.DataType.INT32, shape=[batch, max_blocks]
+    )
+    slot_mapping = builder.input("slot_mapping", dtype=ir.DataType.INT32, shape=[num_tokens])
+    cumulative_sequence_length = builder.input(
+        "cumulative_sequence_length", dtype=ir.DataType.INT32, shape=["batch + 1"]
+    )
+    past_seqlens = builder.input("past_seqlens", dtype=ir.DataType.INT32, shape=[batch])
+
+    states = []
+    for i in range(num_layers):
+        key_cache = builder.input(
+            f"key_cache.{i}",
+            dtype=dtype,
+            shape=[num_blocks, block_size, 1, head_size],
+        )
+        states.append(
+            PagedCacheState(
+                key_cache=key_cache,
+                block_table=block_table,
+                slot_mapping=slot_mapping,
+                cumulative_sequence_length=cumulative_sequence_length,
+                past_seqlens=past_seqlens,
+                cos_cache=None,
+                sin_cache=None,
+            )
+        )
+    return states
+
+
+def _register_paged_cache_outputs(
+    builder: GraphBuilder,
+    present_key_values,
+) -> None:
+    """Name the in-place LATENT cache outputs (each aliases its ``key_cache``)."""
+    for i, present in enumerate(present_key_values):
+        updated_key = present[0] if isinstance(present, (tuple, list)) else present
+        builder.add_output(updated_key, f"updated_key_cache.{i}")
 
 
 def _validate_static_cache_support(module: nn.Module) -> None:

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -590,6 +590,74 @@ class TestCLIBuild:
                 ]
             )
 
+    def test_features_paged_attention_passed_through(self):
+        """--features paged-attention threads the flag + paged task into build."""
+        from mobius.tasks import CausalLMTask
+
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            mock.patch(
+                "mobius.integrations.diffusers._builder._load_diffusers_pipeline_index",
+                return_value=None,
+            ),
+            mock.patch("mobius.__main__.build", return_value=mock.MagicMock()) as mock_build,
+            mock.patch("mobius.__main__._save_package"),
+        ):
+            main(
+                [
+                    "build",
+                    "--model",
+                    "some/model",
+                    tmpdir,
+                    "--no-weights",
+                    "--features",
+                    "paged-attention",
+                ]
+            )
+        kwargs = mock_build.call_args.kwargs
+        assert kwargs.get("export_paged_attention") is True
+        task = kwargs.get("task")
+        assert isinstance(task, CausalLMTask)
+        assert task._paged_cache is True
+
+    def test_paged_attention_with_task_errors(self):
+        """--features paged-attention owns the task; it cannot combine with --task."""
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            pytest.raises(SystemExit, match=r"paged-attention.*--task"),
+        ):
+            main(
+                [
+                    "build",
+                    "--model",
+                    "some/model",
+                    tmpdir,
+                    "--no-weights",
+                    "--features",
+                    "paged-attention",
+                    "--task",
+                    "text-generation",
+                ]
+            )
+
+    def test_paged_attention_with_static_cache_errors(self):
+        """PagedAttention and static cache are distinct, exclusive cache modes."""
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            pytest.raises(SystemExit, match=r"paged-attention.*static-cache"),
+        ):
+            main(
+                [
+                    "build",
+                    "--model",
+                    "some/model",
+                    tmpdir,
+                    "--no-weights",
+                    "--features",
+                    "paged-attention,static-cache",
+                ]
+            )
+
     def test_non_positive_max_seq_len_errors(self):
         with tempfile.TemporaryDirectory() as tmpdir, pytest.raises(SystemExit):
             main(


### PR DESCRIPTION
## Slice 3B — Mobius opt-in `--paged-attention` export (dense MLA, LATENT)

Emits `com.microsoft::PagedAttention` v1 in **LATENT / absorbed-MLA** mode for property-compatible **dense MLA** (DeepSeek-V2/V3, GLM-5.2 `--glm-full-attention`). Builds on the merged onnx-genai native runtime contract: audit/typed-validator/oracle (#1940), KV index emission (#1955), CUDA LATENT kernel (#1978).

### Guarantees
- **Default off.** Feature-off exports are **byte-identical** to the current dense-MLA graph (all new code is gated behind the flag/task). A byte-identical test locks this.
- **Property-based eligibility, never model names.** Decided from semantic geometry: latent width, `v_head_size`, partial-RoPE suffix (`rotary_offset = kv_lora_rank`), cache dtype (fp16/bf16), and the onnx-genai-kv page/block constraints (head_size %8, kv_lora %8, rotary_dim %16, rotary_offset %8, block pow2 ≥16).
- **Typed reject, never silent fallback.** Active query-dependent sparse selection (GLM **DSA/IndexShare**, DeepSeek-V4 **CSA/HCA**), **MTP**, **quantized cache**, **head_sink**, **qk-norm**, **sliding window** all raise a typed reason at model construction / build. Feature-on with an incompatible geometry errors. GLM's *vestigial* indexer config (dropped under `--glm-full-attention`) does **not** reject.
- **One cache authority.** The op consumes/mutates caller-owned page buffers in place; Mobius **allocates no pages** and creates no second cache manager. `onnx-genai-kv` stays the sole authority. The graph binds caller-owned `block_table` / `slot_mapping` / cumulative + past lengths / per-layer LATENT `key_cache`, aliases the cache in place, and derives token positions from the length tensors (no `position_ids` input).

### Emitted contract
- One `PagedAttention` node per layer, `_domain="com.microsoft"`, LATENT attrs (`kv_cache_layout=LATENT`, `kv_num_heads=1`, explicit `scale`, `v_head_size=kv_lora_rank`, `rotary_offset=kv_lora_rank`, `do_rotary=1`); `rotary_dim` is **derived** from `cos_cache`, never emitted.
- Model inputs: `input_ids`, `block_table` (i32), `slot_mapping` (i32), `cumulative_sequence_length` (i32), `past_seqlens` (i32), per-layer `key_cache.{i}` `[num_blocks, block_size, 1, head_size]`. Outputs: `logits`, `updated_key_cache.{i}` (aliases input).
- `kv_b_proj` is absorbed into the query/output projections at weight-apply time; numeric contract mirrors the onnx-genai equivalence oracle.

### Tests (same commit)
- **component** (`components/_paged_mla_test.py`): eligibility rejects, absorption, numpy **decomposed-vs-absorbed LATENT parity** (rel < 1e-6), structural emission.
- **model-level** (`models/paged_mla_export_test.py`): feature-off byte-identical; feature-on structural + exact op attrs/inputs/outputs/model IO; typed rejects (DSA/CSA/HCA/MTP/window); torch-tensor weight absorption; DeepSeek-V3 path proves eligibility is not name-gated.
- **CLI** (`tests/cli_test.py`): `--features paged-attention` plumbing + task resolution + mutual-exclusion errors.
- Existing GLM / DeepSeek / task / build-graph tests pass unchanged.

### Scope / gates
- **No full-size performance claim.** Tiny correctness only. Native runtime full-size verification is separate.
- Executing the emitted graph needs **ORT ≥ 1.29 CUDA** (contrib op is unknown to the base onnx checker, so model-level assertions are structural).
- Avoids #578 (GGUF preflight) and #591 (BQMoE) files.

**Draft — do not merge.** Independent review required (reviewer excluding Leon/Sapper; Gaff or Roy final approval).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>