### PR TITLE
Close pinned GGUF MTP and NextN support

### DIFF
--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -616,15 +616,60 @@ covered synthetically, but publication still requires independent real-weight
 full-logit parity and deterministic stateful generation parity. Mobius exposes
 only the latest recurrent state, not llama.cpp's optional bounded rollback
 snapshot planes; rollback/reorder-capable runtime packaging must remain
-disabled until that ABI is represented explicitly. Dense Qwen3.5 MTP sidecars
-use the post-final-norm `mtp_seed` output while preserving pre-norm
-`hidden_states.N` captures. Optional dedicated `nextn.embed_tokens`,
-`nextn.shared_head_norm`, and `nextn.shared_head_head` tensors are consumed
-when present; otherwise the sidecar explicitly falls back to the backbone
-embedding, final norm, and tied or untied output head. Qwen3.5-MoE and
-Qwen3-Next MTP blocks are rejected because the current sidecar builder cannot
-represent routed experts without dropping tensors. Separate MTP-only files
-are outside this cohort.
+disabled until that ABI is represented explicitly. The pinned NextN metadata key is exactly
+`{general.architecture}.nextn_predict_layers` (GGUF `UINT32`). `block_count`
+includes the appended heads, whose indices are
+`[block_count-nextn_predict_layers, block_count)`. Mobius represents exactly
+one head and rejects larger counts rather than truncating them.
+
+The modern tensor namespace is:
+
+- required: `blk.N.nextn.{eh_proj,enorm,hnorm}.weight`
+- optional dedicated ownership:
+  `blk.N.nextn.{embed_tokens,shared_head_norm,shared_head_head}.weight`
+- decoder-block weights: the architecture's ordinary attention, norm, and FFN
+  tensors at the same `blk.N`
+
+The generic loader can additionally consume `.scale` and `.input_scale`
+sidecars for MTP projections. Mobius rejects those sidecars before graph
+construction because its MTP quantization ABI cannot represent them.
+`nextn.pre_projection.weight` and `nextn.post_projection.weight` are the
+distinct legacy/global namespace of `gemma4-assistant`; they are never accepted
+as Qwen-style appended-head tensors. Unknown `nextn.*`/`mtp.*`, dotted
+`nextn.predict_layers` metadata, mismatched architecture namespaces, missing
+required tensors, non-trailing or out-of-range block indices, recurrent MTP
+markers, and mixed routed-expert forms also fail closed.
+
+The pinned loader/converter census is closed as follows:
+
+| Mobius verdict | Pinned architectures | Reason |
+|---|---|---|
+| Export supported | `qwen35` | One dense, full-attention Qwen3.5 decoder block exactly matches the existing text block |
+| Rejected, executable upstream sidecar | `bailingmoe3`, `cohere2moe`, `deepseek2`, `deepseek32`, `deepseek4`, `glm-dsa`, `hy_v3`, `mimo2`, `nemotron_h_moe`, `qwen35moe`, `qwen3next`, `step35` | Routed experts, MLA/DSA/KDA, hyper-connections, compressed state, or hybrid recurrent state are not represented |
+| Rejected, preserved/skipped upstream | `bailingmoe2`, `dots3note`, `exaone-moe`, `exaone4`, `glm4`, `glm4moe` | The pinned loader consumes or preserves metadata/tensors but has no executable MTP graph |
+| Rejected special cases | `gemma4-assistant`, `nemotron_h`, `graniteswitch` | Standalone legacy assistant; converter-conditional MoE ownership; or non-MTP router-layer metadata re-emission |
+
+Dense Qwen3.5 uses the target's dedicated post-final-norm `mtp_seed`; ordinary
+`hidden_states.N` remains the distinct pre-final-norm layer capture. The
+sidecar normalizes the next-token embedding and seed independently,
+concatenates them, projects `2H -> H`, runs one full-attention Qwen3.5 decoder
+layer with its own dynamic KV cache, applies the dedicated or target final
+norm, and scores through a dedicated head or the target's tied/untied head.
+Dedicated embeddings consume `input_ids`; shared embeddings consume
+`inputs_embeds`. Static-cache exports are rejected because silently dropping
+the sidecar or its independent state is invalid. Packed target embedding/head
+ownership remains with the target graph; dedicated sidecar tables are
+dequantized to mathematically ordinary MatMul weights, so no target/MTP
+initializer is duplicated. `ModelPackage.save()` persists the sidecar under
+`mtp/` with weight checks, and `ModelPackage.load()` restores it as
+`package.mtp_head`; ordinary API saves cannot silently lose the auxiliary head.
+
+**MTP runtime status: DEFERRED.** The emitted graph and workflow metadata are
+an export contract, not evidence that a downstream runtime executes it.
+Runtime support requires a pinned real artifact, independent full-vocabulary
+logit parity, and deterministic end-to-end speculative/MTP generation with
+correct proposal rejection and cache rollback. None has yet been established,
+so no runtime-support claim is made.
 
 ### Pure recurrent Mamba evidence
 

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -669,15 +669,10 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
         print(f"Saved {name} to {path}")
 
     # Save the trailing MTP / "nextn" self-speculative head sidecar (when the
-    # GGUF shipped one) into a ``mtp/`` subdirectory next to the backbone.
+    # GGUF shipped one). ModelPackage.save() persisted it into ``mtp/``.
     mtp_head = getattr(pkg, "mtp_head", None)
     if mtp_head is not None:
         mtp_dir = os.path.join(output_dir, "mtp")
-        mtp_head.save(
-            mtp_dir,
-            external_data=args.external_data,
-            max_workers=args.max_workers,
-        )
         print(f"Saved mtp head to {os.path.join(mtp_dir, 'model.onnx')}")
 
     draft_manifest = getattr(pkg, "draft_manifest", None)

--- a/src/mobius/_model_package.py
+++ b/src/mobius/_model_package.py
@@ -80,6 +80,8 @@ class ModelPackage(UserDict[str, ir.Model]):
     Attributes:
         config: The architecture configuration used to build the models,
             or ``None`` if not available (e.g. after :meth:`load`).
+        mtp_head: Optional nested MTP sidecar package. :meth:`save` persists it
+            under ``mtp/`` and :meth:`load` restores it automatically.
     """
 
     def __init__(
@@ -95,6 +97,7 @@ class ModelPackage(UserDict[str, ir.Model]):
         self.config = config
         # Optional persistence policy attached by the GGUF importer.
         self.gguf_reuse_plan: Any = None
+        self.mtp_head: ModelPackage | None = None
         self.policy_components = dict(policy_components or {})
         self.adapter_target_manifest = adapter_target_manifest
         self.adapter_service_options = adapter_service_options or AdapterServiceOptions()
@@ -140,7 +143,8 @@ class ModelPackage(UserDict[str, ir.Model]):
 
         When the package contains a single model, it is saved directly as
         ``model.onnx`` in *directory*.  When multiple models are present,
-        each is saved in its own subfolder as ``{name}/model.onnx``.
+        each is saved in its own subfolder as ``{name}/model.onnx``. An attached
+        :attr:`mtp_head` package is always saved under ``mtp/``.
 
         .. note::
             This method writes ONNX files only.  If you need a directory that
@@ -274,6 +278,17 @@ class ModelPackage(UserDict[str, ir.Model]):
             self.save_policy_components(directory, check_weights=check_weights)
         if include_adapter_artifacts:
             self.save_adapter_artifacts(directory)
+        if self.mtp_head is not None:
+            self.mtp_head.save(
+                os.path.join(directory, "mtp"),
+                external_data=external_data,
+                max_shard_size_bytes=max_shard_size_bytes,
+                max_workers=max_workers,
+                progress_bar=progress_bar,
+                check_weights=check_weights,
+                include_policy_components=include_policy_components,
+                include_adapter_artifacts=include_adapter_artifacts,
+            )
 
     def add_policy_component(self, name: str, component: PolicyComponent) -> None:
         """Attach a reusable generation-policy graph to this package."""
@@ -582,6 +597,9 @@ class ModelPackage(UserDict[str, ir.Model]):
         - **Subfolder**: each subdirectory contains ``model.onnx`` → multi-
           component package keyed by subfolder name.
 
+        A nested ``mtp/model.onnx`` is restored as :attr:`mtp_head`, never as a
+        primary model component.
+
         Args:
             directory: Path to the directory containing models.
 
@@ -589,23 +607,25 @@ class ModelPackage(UserDict[str, ir.Model]):
             A new ``ModelPackage`` with one entry per model found.
         """
         models: dict[str, ir.Model] = {}
-        # Check for subfolder layout first
+        # Preserve the established multi-component precedence while excluding
+        # the nested MTP auxiliary package from the primary component scan.
         for entry in sorted(os.listdir(directory)):
+            if entry == "mtp":
+                continue
             subdir = os.path.join(directory, entry)
             model_path = os.path.join(subdir, "model.onnx")
             if os.path.isdir(subdir) and os.path.isfile(model_path):
                 models[entry] = ir.load(model_path)
-        if models:
-            package = cls(models)
-            package._load_policy_components(directory)
-            return package
-        # Fall back to flat layout
-        for filename in sorted(os.listdir(directory)):
-            if filename.endswith(".onnx"):
-                name = filename.removesuffix(".onnx")
-                models[name] = ir.load(os.path.join(directory, filename))
+        if not models:
+            for filename in sorted(os.listdir(directory)):
+                if filename.endswith(".onnx"):
+                    name = filename.removesuffix(".onnx")
+                    models[name] = ir.load(os.path.join(directory, filename))
         package = cls(models)
         package._load_policy_components(directory)
+        mtp_dir = os.path.join(directory, "mtp")
+        if os.path.isfile(os.path.join(mtp_dir, "model.onnx")):
+            package.mtp_head = cls.load(mtp_dir)
         return package
 
     def _load_policy_components(self, directory: str) -> None:

--- a/src/mobius/_model_package_test.py
+++ b/src/mobius/_model_package_test.py
@@ -364,6 +364,34 @@ class TestModelPackageSaveLoad:
         loaded = ModelPackage.load(str(tmp_path))
         assert sorted(loaded) == ["a", "b"]
 
+    def test_mtp_head_roundtrip_with_flat_target(self, tmp_path):
+        pkg = ModelPackage({"model": _make_simple_model("target")})
+        pkg.mtp_head = ModelPackage({"model": _make_simple_model("mtp")})
+
+        pkg.save(str(tmp_path))
+        loaded = ModelPackage.load(str(tmp_path))
+
+        assert sorted(loaded) == ["model"]
+        assert loaded.mtp_head is not None
+        assert sorted(loaded.mtp_head) == ["model"]
+        assert (tmp_path / "mtp" / "model.onnx").exists()
+
+    def test_mtp_head_roundtrip_with_multicomponent_target(self, tmp_path):
+        pkg = ModelPackage(
+            {
+                "decoder": _make_simple_model("decoder"),
+                "embedding": _make_simple_model("embedding"),
+            }
+        )
+        pkg.mtp_head = ModelPackage({"model": _make_simple_model("mtp")})
+
+        pkg.save(str(tmp_path))
+        loaded = ModelPackage.load(str(tmp_path))
+
+        assert sorted(loaded) == ["decoder", "embedding"]
+        assert loaded.mtp_head is not None
+        assert sorted(loaded.mtp_head) == ["model"]
+
     def test_save_creates_directory(self, tmp_path):
         outdir = tmp_path / "nested" / "dir"
         pkg = ModelPackage({"m": _make_simple_model()})

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -474,12 +474,14 @@ def _gguf_architecture_from_header_prefix(data: bytes, *, source: str) -> str:
         raise ValueError(f"{source!r} has a non-UTF-8 general.architecture value.") from error
 
 
-def _preflight_hf_mmproj_companion_file(
+def _preflight_hf_gguf_file(
     repo_id: str,
     filename: str,
     *,
     revision: str = "main",
-) -> str | None:
+    allow_mmproj_companion: bool = False,
+    expected_architecture: str | None = None,
+) -> str:
     """Validate the exact selected Hub file header and return its immutable revision."""
     source = f"{repo_id}@{revision}:{filename}"
     _raise_for_sharded_gguf(source=source, filename=filename)
@@ -487,17 +489,18 @@ def _preflight_hf_mmproj_companion_file(
     try:
         metadata = get_hf_file_metadata(url)
     except _HUB_PREFLIGHT_TRANSPORT_ERRORS as error:
-        logger.warning(
-            "Exact-file mmproj header preflight failed for %s (%s); continuing to "
-            "hf_hub_download so a cached file can still be used. The downloaded "
-            "local header will be validated before builder dispatch.",
-            source,
-            error,
-        )
-        return None
+        raise RuntimeError(
+            f"Cannot resolve the exact selected GGUF file {source!r} to an immutable "
+            "revision; refusing repository-level metadata or mutable-revision fallback"
+        ) from error
     commit_hash = metadata.commit_hash
-    if not commit_hash:
-        raise ValueError(f"Hub did not resolve an immutable revision for {source!r}.")
+    if (
+        not isinstance(commit_hash, str)
+        or re.fullmatch(r"[0-9a-fA-F]{40}", commit_hash) is None
+    ):
+        raise ValueError(
+            f"Hub did not resolve a 40-character immutable commit SHA for {source!r}."
+        )
 
     headers = build_hf_headers()
     if urlparse(url).netloc != urlparse(metadata.location).netloc:
@@ -534,22 +537,53 @@ def _preflight_hf_mmproj_companion_file(
                 chunks = read_response(response)
     except _HUB_PREFLIGHT_TRANSPORT_ERRORS as error:
         logger.warning(
-            "Bounded mmproj header range read failed for %s (%s); downloading the "
+            "Bounded GGUF header range read failed for %s (%s); downloading the "
             "same immutable revision and validating its local header before dispatch.",
             source,
             error,
         )
         return commit_hash
-    architecture = _gguf_architecture_from_header_prefix(
-        b"".join(chunks),
-        source=source,
-    )
-    if architecture != MMPROJ_ARCHITECTURE:
+    try:
+        architecture = _gguf_architecture_from_header_prefix(
+            b"".join(chunks),
+            source=source,
+        )
+    except ValueError as error:
+        if "truncated GGUF metadata" not in str(error):
+            raise
+        logger.warning(
+            "The selected GGUF metadata header for %s exceeds the bounded range; "
+            "downloading the same immutable revision for full local validation.",
+            source,
+        )
+        return commit_hash
+    if expected_architecture is not None and architecture != expected_architecture:
         raise ValueError(
-            f"Expected a {MMPROJ_ARCHITECTURE!r} mmproj GGUF for {source!r}, "
+            f"Expected a {expected_architecture!r} mmproj GGUF for {source!r}, "
             f"got architecture {architecture!r}. No payload was downloaded."
         )
+    _raise_for_unsupported_gguf_architecture(
+        architecture,
+        source=source,
+        allow_mmproj_companion=allow_mmproj_companion,
+    )
     return commit_hash
+
+
+def _preflight_hf_mmproj_companion_file(
+    repo_id: str,
+    filename: str,
+    *,
+    revision: str = "main",
+) -> str:
+    """Validate one exact Hub mmproj file and pin its immutable revision."""
+    return _preflight_hf_gguf_file(
+        repo_id,
+        filename,
+        revision=revision,
+        allow_mmproj_companion=True,
+        expected_architecture=MMPROJ_ARCHITECTURE,
+    )
 
 
 def _validate_gguf_model(
@@ -564,6 +598,9 @@ def _validate_gguf_model(
     if not isinstance(gguf_model, GgufShardSet):
         split_count = int(gguf_model.get_metadata("split.count", 1))
         _raise_for_sharded_gguf(source=source, split_count=split_count)
+    from mobius.integrations.gguf._mtp import validate_mtp_tensor_contract
+
+    validate_mtp_tensor_contract(gguf_model)
     _raise_for_unsupported_gguf_architecture(
         gguf_model.architecture,
         source=source,
@@ -1047,6 +1084,12 @@ def _raise_for_invalid_hybrid_tensor_contract(gguf_model) -> None:
         mtp_layer = trunk_layers
         prefix = f"blk.{mtp_layer}."
         layer_names = {name[len(prefix) :] for name in actual if name.startswith(prefix)}
+        wrong_mixer = sorted(layer_names & recurrent_suffixes)
+        if wrong_mixer:
+            raise ValueError(
+                f"{architecture} MTP block contains recurrent-mixer tensor(s) "
+                f"{wrong_mixer}; appended MTP blocks must be full attention"
+            )
         required_block = set(common_suffixes) | set(full_suffixes)
         if architecture in {"qwen35moe", "qwen3next"}:
             fused = "ffn_gate_up_exps.weight" in layer_names
@@ -1702,7 +1745,7 @@ def _resolve_gguf_path_impl(gguf_path: str | Path, *, allow_mmproj_companion: bo
             )
         filename = files[0]
 
-    resolved_revision: str | None = None
+    resolved_revision: str | None
     if allow_mmproj_companion:
         resolved_revision = _preflight_hf_mmproj_companion_file(
             repo_id,
@@ -1710,15 +1753,21 @@ def _resolve_gguf_path_impl(gguf_path: str | Path, *, allow_mmproj_companion: bo
             revision="main",
         )
     else:
-        _preflight_hf_gguf(api, repo_id, filename)
-    logger.info("Downloading %s from %s", filename, repo_id)
-    if resolved_revision is not None:
-        return hf_hub_download(
-            repo_id=repo_id,
-            filename=filename,
-            revision=resolved_revision,
+        resolved_revision = _preflight_hf_gguf_file(
+            repo_id,
+            filename,
+            revision="main",
         )
-    return hf_hub_download(repo_id=repo_id, filename=filename)
+    logger.info("Downloading %s from %s", filename, repo_id)
+    if resolved_revision is None:
+        raise RuntimeError(
+            f"Hub did not resolve an immutable revision for {repo_id}:{filename}"
+        )
+    return hf_hub_download(
+        repo_id=repo_id,
+        filename=filename,
+        revision=resolved_revision,
+    )
 
 
 def _resolve_gguf_path(gguf_path: str | Path) -> str:
@@ -1898,6 +1947,11 @@ def build_from_gguf(
             "Build without reuse to convert this file."
         )
     gguf_arch = gguf_model.architecture
+    if static_cache and int(gguf_model.metadata.get(f"{gguf_arch}.nextn_predict_layers", 0)):
+        raise ValueError(
+            "static_cache=True cannot represent the GGUF MTP head's independent "
+            "dynamic concat-grow KV cache; refusing to silently omit the sidecar"
+        )
     logger.info("Loaded GGUF model: %s (arch=%s)", gguf_path, gguf_arch)
     preserve_quantization = keep_quantized and _has_quantized_weights(gguf_model, gguf_arch)
     arch_spec = try_get_arch_spec(gguf_arch)
@@ -2109,9 +2163,8 @@ def build_from_gguf(
     # the final layer's ordinary ``hidden_states.N`` capture as the distinct
     # pre-final-norm ABI; neither output may stand in for the other. These fields
     # must be set before graph construction. Direct assignment preserves the
-    # ``_gguf_*`` metadata attributes on the config. Skipped under static_cache
-    # (the head needs the dynamic concat-grow cache), leaving those exports
-    # byte-identical to today.
+    # ``_gguf_*`` metadata attributes on the config. Static-cache requests fail
+    # closed because the sidecar requires its own dynamic concat-grow cache.
     from mobius.integrations.gguf._mtp import build_mtp_head_from_gguf, has_mtp_head
 
     # Re-attach the GGUF metadata dropped by the dtype/quantization
@@ -2124,11 +2177,11 @@ def build_from_gguf(
     config._gguf_model_type = model_type
     config._gguf_nextn_predict_layers = mtp_predict_layers
     config._gguf_mtp_block_indices = mtp_block_indices
-    emit_mtp_head = has_mtp_head(config) and not static_cache
+    emit_mtp_head = has_mtp_head(config)
     if has_mtp_head(config) and static_cache:
-        logger.info(
-            "GGUF ships an MTP/nextn head but static_cache=True is incompatible "
-            "with the head's dynamic cache; skipping the self-speculative sidecar."
+        raise ValueError(
+            "static_cache=True cannot represent the GGUF MTP head's independent "
+            "dynamic concat-grow KV cache; refusing to silently omit the sidecar"
         )
 
     if emit_mtp_head:

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -22,7 +22,7 @@ import logging
 import re
 import struct
 from collections import Counter
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Collection, Iterable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
@@ -3337,6 +3337,7 @@ def _load_quantized_state_dict(
     name_mapper: Callable[[str, str], str | None] | None = None,
     warn_unmapped: bool = True,
     reuse_candidates: dict | None = None,
+    dequantize_float_linear_types: Mapping[str, Collection[str]] | None = None,
 ) -> dict:
     """Load tensors, preserving native blocks or normalizing to MatMulNBits.
 
@@ -3554,6 +3555,11 @@ def _load_quantized_state_dict(
                 }
                 and not should_repack
                 and not fused_projection_targets
+                and (
+                    dequantize_float_linear_types is None
+                    or module_stem not in dequantize_float_linear_types
+                    or quant_spec.name not in dequantize_float_linear_types[module_stem]
+                )
             ):
                 raise ValueError(
                     f"Cannot keep {quant_spec.name} {tensor_role.value} {hf_name} "

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -4316,18 +4316,16 @@ class TestGGUFPreflightGuards:
 
         filename = "NVIDIA-Nemotron-3.5-Lightning-30B-A3B-Q8_0.gguf"
         with (
-            mock.patch("mobius.integrations.gguf._builder.HfApi") as api_type,
+            mock.patch(
+                "mobius.integrations.gguf._builder._preflight_hf_gguf_file",
+                side_effect=NotImplementedError("nemotron_h_moe"),
+            ) as preflight,
             mock.patch("mobius.integrations.gguf._builder.hf_hub_download") as download,
             pytest.raises(NotImplementedError, match="nemotron_h_moe"),
         ):
-            api_type.return_value.model_info.return_value = SimpleNamespace(
-                gguf={"architecture": "nemotron_h_moe"}
-            )
             _resolve_gguf_path(f"unsloth/nemotron:{filename}")
 
-        api_type.return_value.model_info.assert_called_once_with(
-            "unsloth/nemotron", expand=["gguf"]
-        )
+        preflight.assert_called_once_with("unsloth/nemotron", filename, revision="main")
         download.assert_not_called()
 
     def test_remote_deferred_audio_architecture_fails_before_download(self):
@@ -4336,21 +4334,20 @@ class TestGGUFPreflightGuards:
 
         filename = "talkie-f16.gguf"
         with (
-            mock.patch("mobius.integrations.gguf._builder.HfApi") as api_type,
+            mock.patch(
+                "mobius.integrations.gguf._builder._preflight_hf_gguf_file",
+                side_effect=UnsupportedGGUFArchitectureError(
+                    "talkie before config extraction"
+                ),
+            ),
             mock.patch("mobius.integrations.gguf._builder.hf_hub_download") as download,
             pytest.raises(
                 UnsupportedGGUFArchitectureError,
                 match=r"talkie.*before config extraction",
             ),
         ):
-            api_type.return_value.model_info.return_value = SimpleNamespace(
-                gguf={"architecture": "talkie"}
-            )
             _resolve_gguf_path(f"example/talkie:{filename}")
 
-        api_type.return_value.model_info.assert_called_once_with(
-            "example/talkie", expand=["gguf"]
-        )
         download.assert_not_called()
 
     def test_remote_standalone_clip_fails_before_download(self):
@@ -4359,21 +4356,18 @@ class TestGGUFPreflightGuards:
 
         filename = "mmproj-f16.gguf"
         with (
-            mock.patch("mobius.integrations.gguf._builder.HfApi") as api_type,
+            mock.patch(
+                "mobius.integrations.gguf._builder._preflight_hf_gguf_file",
+                side_effect=DisabledGGUFArchitectureError("clip intentionally disabled"),
+            ),
             mock.patch("mobius.integrations.gguf._builder.hf_hub_download") as download,
             pytest.raises(
                 DisabledGGUFArchitectureError,
                 match=r"clip.*intentionally disabled",
             ),
         ):
-            api_type.return_value.model_info.return_value = SimpleNamespace(
-                gguf={"architecture": "clip"}
-            )
             _resolve_gguf_path(f"example/mmproj:{filename}")
 
-        api_type.return_value.model_info.assert_called_once_with(
-            "example/mmproj", expand=["gguf"]
-        )
         download.assert_not_called()
 
     def test_exact_selected_clip_header_returns_immutable_revision(self) -> None:
@@ -4433,6 +4427,62 @@ class TestGGUFPreflightGuards:
         assert stream_args.kwargs["headers"]["authorization"] == "Bearer test-token"
         response.raise_for_status.assert_called_once_with()
 
+    def test_exact_selected_primary_header_pins_download_revision(self) -> None:
+        from mobius.integrations.gguf._builder import (
+            _preflight_hf_gguf_file,
+            _resolve_gguf_path,
+        )
+
+        response = mock.MagicMock()
+        response.iter_bytes.return_value = [_gguf_header_prefix("qwen35")]
+        response_context = mock.MagicMock()
+        response_context.__enter__.return_value = response
+        session = mock.MagicMock()
+        session.stream.return_value = response_context
+        commit_hash = "a" * 40
+        with (
+            mock.patch(
+                "mobius.integrations.gguf._builder.hf_hub_url",
+                return_value="https://huggingface.co/exact-primary",
+            ),
+            mock.patch(
+                "mobius.integrations.gguf._builder.get_hf_file_metadata",
+                return_value=SimpleNamespace(
+                    commit_hash=commit_hash,
+                    location="https://huggingface.co/model.gguf",
+                ),
+            ),
+            mock.patch(
+                "mobius.integrations.gguf._builder.get_session",
+                return_value=session,
+            ),
+        ):
+            assert (
+                _preflight_hf_gguf_file(
+                    "example/qwen35",
+                    "model.gguf",
+                    revision="requested-revision",
+                )
+                == commit_hash
+            )
+
+        with (
+            mock.patch(
+                "mobius.integrations.gguf._builder._preflight_hf_gguf_file",
+                return_value=commit_hash,
+            ),
+            mock.patch(
+                "mobius.integrations.gguf._builder.hf_hub_download",
+                return_value="cached-model.gguf",
+            ) as download,
+        ):
+            assert _resolve_gguf_path("example/qwen35:model.gguf") == "cached-model.gguf"
+        download.assert_called_once_with(
+            repo_id="example/qwen35",
+            filename="model.gguf",
+            revision=commit_hash,
+        )
+
     def test_exact_selected_non_clip_header_rejects_without_payload(self) -> None:
         from mobius.integrations.gguf._builder import (
             _preflight_hf_mmproj_companion_file,
@@ -4489,22 +4539,24 @@ class TestGGUFPreflightGuards:
                 source="duplicate.gguf",
             )
 
-    def test_exact_companion_preflight_falls_back_for_offline_cache(self) -> None:
+    def test_exact_companion_preflight_rejects_unresolved_mutable_revision(self) -> None:
         from mobius.integrations.gguf._builder import (
             _preflight_hf_mmproj_companion_file,
         )
 
-        with mock.patch(
-            "mobius.integrations.gguf._builder.get_hf_file_metadata",
-            side_effect=OfflineModeIsEnabled("offline"),
+        with (
+            mock.patch(
+                "mobius.integrations.gguf._builder.get_hf_file_metadata",
+                side_effect=OfflineModeIsEnabled("offline"),
+            ),
+            pytest.raises(RuntimeError, match="immutable revision"),
         ):
-            assert (
+            (
                 _preflight_hf_mmproj_companion_file(
                     "example/offline",
                     "mmproj.gguf",
                     revision="main",
                 )
-                is None
             )
 
     def test_exact_companion_range_read_supports_requests_hub_sessions(self) -> None:
@@ -4598,35 +4650,27 @@ class TestGGUFPreflightGuards:
     @pytest.mark.parametrize(
         "preflight_error",
         [
-            pytest.param(
-                OfflineModeIsEnabled("offline"),
-                id="offline-cache",
-            ),
-            pytest.param(
-                TypeError("model_info() got an unexpected keyword argument 'expand'"),
-                id="older-huggingface-hub",
-            ),
-            pytest.param(
-                httpx.ConnectError("disconnected"),
-                id="transport-error",
-            ),
+            pytest.param(OfflineModeIsEnabled("offline"), id="offline-cache"),
+            pytest.param(httpx.ConnectError("disconnected"), id="transport-error"),
         ],
     )
-    def test_unavailable_hub_preflight_falls_back_to_download(self, preflight_error):
+    def test_unavailable_exact_file_preflight_rejects_mutable_download(self, preflight_error):
         from mobius.integrations.gguf._builder import _resolve_gguf_path
 
         with (
-            mock.patch("mobius.integrations.gguf._builder.HfApi") as api_type,
+            mock.patch(
+                "mobius.integrations.gguf._builder.get_hf_file_metadata",
+                side_effect=preflight_error,
+            ),
             mock.patch(
                 "mobius.integrations.gguf._builder.hf_hub_download",
                 return_value="cached-model.gguf",
             ) as download,
+            pytest.raises(RuntimeError, match="immutable revision"),
         ):
-            api_type.return_value.model_info.side_effect = preflight_error
-            result = _resolve_gguf_path("owner/repo:model.gguf")
+            _resolve_gguf_path("owner/repo:model.gguf")
 
-        assert result == "cached-model.gguf"
-        download.assert_called_once_with(repo_id="owner/repo", filename="model.gguf")
+        download.assert_not_called()
 
     def test_remote_shard_fails_before_hub_calls(self):
         from mobius.integrations.gguf._builder import _resolve_gguf_path

--- a/src/mobius/integrations/gguf/_mtp.py
+++ b/src/mobius/integrations/gguf/_mtp.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Emit the Qwen3.5/3.8 multi-token-prediction (MTP) self-speculative head from GGUF.
+"""Validate and emit GGUF multi-token-prediction (MTP) auxiliary heads.
 
 The dense ``unsloth/Qwen3.8-27B`` (and ``Qwen/Qwen3.6-27B``) GGUF ships a
 trained MTP head as the trailing ``blk.<N>`` block, tagged by the
@@ -36,12 +36,186 @@ from __future__ import annotations
 import dataclasses
 import logging
 import re
+from types import MappingProxyType
 from typing import TYPE_CHECKING
+
+from mobius.integrations.gguf._spec import Support
 
 if TYPE_CHECKING:
     from mobius._model_package import ModelPackage
 
 logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class MtpArchitectureCapability:
+    """Pinned llama.cpp MTP capability for one ``general.architecture`` value."""
+
+    support: Support
+    loader_behavior: str
+    block_kind: str
+    reason: str
+
+
+_DENSE_QWEN35_MTP = MtpArchitectureCapability(
+    support=Support.SUPPORTED,
+    loader_behavior="executed-sidecar",
+    block_kind="dense-full-attention",
+    reason=(
+        "The appended block is exactly one dense Qwen3.5 full-attention decoder layer "
+        "with the standard per-block nextn conditioning tensors."
+    ),
+)
+
+_PINNED_MTP_CAPABILITIES = MappingProxyType(
+    {
+        # Exact dense sidecar supported by this module.
+        "qwen35": _DENSE_QWEN35_MTP,
+        # Pinned loaders execute these heads, but their routed/stateful decoder
+        # blocks are not represented by Qwen35MtpModel.
+        "bailingmoe3": MtpArchitectureCapability(
+            Support.REJECTED,
+            "executed-sidecar",
+            "routed-kda-mla",
+            "the MTP block carries routed experts and KDA/MLA state semantics",
+        ),
+        "cohere2moe": MtpArchitectureCapability(
+            Support.REJECTED,
+            "executed-sidecar",
+            "routed-full-attention",
+            "the MTP block carries Cohere2 routed and shared experts",
+        ),
+        "deepseek2": MtpArchitectureCapability(
+            Support.REJECTED,
+            "executed-sidecar",
+            "routed-mla",
+            "the MTP block carries DeepSeek MLA and routed-expert semantics",
+        ),
+        "deepseek32": MtpArchitectureCapability(
+            Support.REJECTED,
+            "executed-sidecar",
+            "routed-dsa-mla",
+            "the MTP block carries DSA/MLA attention and routed experts",
+        ),
+        "deepseek4": MtpArchitectureCapability(
+            Support.REJECTED,
+            "executed-sidecar",
+            "routed-hyperconnection",
+            "the MTP block carries hyper-connections, compressed state, and routed experts",
+        ),
+        "glm-dsa": MtpArchitectureCapability(
+            Support.REJECTED,
+            "executed-sidecar",
+            "routed-dsa-mla",
+            "the MTP block carries GLM DSA/MLA and routed-expert semantics",
+        ),
+        "hy_v3": MtpArchitectureCapability(
+            Support.REJECTED,
+            "executed-sidecar",
+            "routed-hyperconnection",
+            "the MTP block carries HY-V3 hyper-connections and routed experts",
+        ),
+        "mimo2": MtpArchitectureCapability(
+            Support.REJECTED,
+            "executed-sidecar",
+            "routed-full-attention",
+            "the MTP block carries MiMo2 routed experts and layer-output norm fallback",
+        ),
+        "nemotron_h_moe": MtpArchitectureCapability(
+            Support.REJECTED,
+            "executed-sidecar",
+            "routed-hybrid",
+            "the MTP block carries Nemotron-H routed experts and hybrid-state semantics",
+        ),
+        "qwen35moe": MtpArchitectureCapability(
+            Support.REJECTED,
+            "executed-sidecar",
+            "routed-full-attention",
+            "MTP blocks use routed experts and a shared expert that are not represented",
+        ),
+        "qwen3next": MtpArchitectureCapability(
+            Support.REJECTED,
+            "executed-sidecar",
+            "routed-hybrid",
+            "the MTP block carries Qwen3-Next routed experts and hybrid-state semantics",
+        ),
+        "step35": MtpArchitectureCapability(
+            Support.REJECTED,
+            "executed-sidecar",
+            "routed-full-attention",
+            "the MTP block carries Step3.5 routed and shared experts",
+        ),
+        # These pinned loaders consume/preserve NextN metadata or tensors but do
+        # not expose an executable decoder-MTP graph for the serialized head.
+        "bailingmoe2": MtpArchitectureCapability(
+            Support.REJECTED,
+            "preserved-unused",
+            "routed-full-attention",
+            "the pinned loader skips the appended NextN blocks during execution",
+        ),
+        "dots3note": MtpArchitectureCapability(
+            Support.REJECTED,
+            "preserved-unused",
+            "routed-dsa",
+            "the pinned loader marks MTP tensors skipped and has no MTP graph",
+        ),
+        "exaone-moe": MtpArchitectureCapability(
+            Support.REJECTED,
+            "preserved-unused",
+            "routed-full-attention",
+            "the pinned loader preserves NextN tensors without an MTP graph",
+        ),
+        "exaone4": MtpArchitectureCapability(
+            Support.REJECTED,
+            "preserved-unused",
+            "dense-full-attention",
+            "the pinned loader preserves NextN tensors without an MTP graph",
+        ),
+        "glm4": MtpArchitectureCapability(
+            Support.REJECTED,
+            "preserved-unused",
+            "dense-full-attention",
+            "the pinned loader preserves NextN tensors without an MTP graph",
+        ),
+        "glm4moe": MtpArchitectureCapability(
+            Support.REJECTED,
+            "preserved-unused",
+            "routed-full-attention",
+            "the pinned loader preserves NextN tensors without an MTP graph",
+        ),
+        "nemotron_h": MtpArchitectureCapability(
+            Support.REJECTED,
+            "converter-conditional",
+            "hybrid",
+            "only the distinct nemotron_h_moe loader owns the routed MTP graph",
+        ),
+        # Gemma4 Assistant is a standalone drafter with global projection
+        # tensors, not an appended target-owned sidecar.
+        "gemma4-assistant": MtpArchitectureCapability(
+            Support.REJECTED,
+            "standalone-drafter",
+            "legacy-global-projections",
+            "nextn.pre_projection/post_projection describe a standalone assistant model",
+        ),
+        # Granite Switch repurposes n_layer_nextn for its router-cache layer.
+        # llama.cpp's generic saver can therefore re-emit this metadata, but it
+        # never denotes an MTP head for this architecture.
+        "graniteswitch": MtpArchitectureCapability(
+            Support.REJECTED,
+            "metadata-reemitted-non-mtp",
+            "router-cache-sentinel",
+            "nextn_predict_layers is a round-trip artifact for the extra router layer",
+        ),
+    }
+)
+
+_MTP_METADATA_SUFFIXES = (".nextn_predict_layers", ".nextn.predict_layers")
+_LEGACY_NEXTN_TENSORS = frozenset(
+    {
+        "nextn.pre_projection.weight",
+        "nextn.post_projection.weight",
+    }
+)
 
 # GGUF ``blk.<N>.<stem>`` -> Qwen35MtpModel-internal parameter stem. Keys are
 # the GGUF stems (without ``.weight``); values are the head module's own
@@ -68,6 +242,9 @@ _MTP_STEM_MAP: dict[str, str] = {
     "ffn_up": "layers.0.mlp.up_proj",
     "ffn_down": "layers.0.mlp.down_proj",
 }
+_SUPPORTED_MTP_BLOCK_TENSORS: frozenset[str] = frozenset(
+    f"{stem}.weight" for stem in _MTP_STEM_MAP
+)
 
 # Head norms that are ``OffsetRMSNorm`` (``1 + weight``) but whose target name
 # does not end in ``norm.weight`` — the generic offset-strip in
@@ -77,6 +254,206 @@ _MTP_EXTRA_OFFSET_NORMS: frozenset[str] = frozenset(
 )
 
 _BLK_PATTERN = re.compile(r"^blk\.(\d+)\.(.+)$")
+
+
+def mtp_architecture_capabilities() -> MappingProxyType[str, MtpArchitectureCapability]:
+    """Return the immutable pinned architecture-by-MTP capability policy."""
+    return _PINNED_MTP_CAPABILITIES
+
+
+def validate_mtp_tensor_contract(gguf_model) -> None:
+    """Reject unsupported or incomplete MTP metadata/tensors before graph construction."""
+    architecture = gguf_model.architecture
+    metadata = gguf_model.metadata
+    tensor_names = set(gguf_model.tensor_names)
+    exact_key = f"{architecture}.nextn_predict_layers"
+
+    mtp_metadata_keys = sorted(
+        key
+        for key in metadata
+        if isinstance(key, str)
+        and (key.endswith(_MTP_METADATA_SUFFIXES) or ".mtp" in key.lower())
+    )
+    unexpected_metadata = [key for key in mtp_metadata_keys if key != exact_key]
+    if unexpected_metadata:
+        raise ValueError(
+            f"{architecture} GGUF contains unsupported MTP metadata key(s): "
+            f"{unexpected_metadata}; pinned llama.cpp uses only {exact_key!r}"
+        )
+
+    modern_tensors: dict[int, set[str]] = {}
+    unknown_mtp_tensors: list[str] = []
+    auxiliary_tensors: list[str] = []
+    for name in tensor_names:
+        if name in _LEGACY_NEXTN_TENSORS:
+            continue
+        match = _BLK_PATTERN.match(name)
+        if match is not None and match.group(2).startswith("nextn."):
+            block_index = int(match.group(1))
+            suffix = match.group(2)
+            if suffix.endswith((".scale", ".input_scale")):
+                auxiliary_tensors.append(name)
+                continue
+            if not suffix.endswith(".weight"):
+                unknown_mtp_tensors.append(name)
+                continue
+            stem = suffix[: -len(".weight")]
+            if stem not in _MTP_STEM_MAP:
+                unknown_mtp_tensors.append(name)
+                continue
+            modern_tensors.setdefault(block_index, set()).add(stem)
+            continue
+        if name.startswith(("nextn.", "mtp.")) or ".nextn." in name or ".mtp." in name:
+            unknown_mtp_tensors.append(name)
+
+    if auxiliary_tensors:
+        raise ValueError(
+            f"{sorted(auxiliary_tensors)}: Mobius cannot represent GGUF scale/input_scale "
+            "sidecars in the MTP quantization ABI"
+        )
+    if unknown_mtp_tensors:
+        raise ValueError(
+            f"{architecture} GGUF contains unsupported nextn tensor(s) or mtp tensor(s): "
+            f"{sorted(unknown_mtp_tensors)}"
+        )
+
+    legacy_tensors = sorted(tensor_names & _LEGACY_NEXTN_TENSORS)
+    raw_count = metadata.get(exact_key, 0)
+    if isinstance(raw_count, bool) or not isinstance(raw_count, int):
+        raise TypeError(f"{exact_key} must be an integer, got {raw_count!r}")
+    count = raw_count
+    if count < 0:
+        raise ValueError(f"{exact_key} must be non-negative, got {count}")
+    if count == 0 and (modern_tensors or legacy_tensors):
+        raise ValueError(
+            f"{architecture} GGUF contains MTP tensors but does not declare a positive "
+            f"{exact_key}"
+        )
+    if count == 0:
+        return
+
+    capability = _PINNED_MTP_CAPABILITIES.get(architecture)
+    if capability is None:
+        raise ValueError(
+            f"{architecture} GGUF declares MTP, but that architecture is absent from the "
+            "pinned llama.cpp MTP loader/converter census"
+        )
+    if capability.support is not Support.SUPPORTED:
+        raise NotImplementedError(
+            f"{architecture} GGUF MTP is rejected: {capability.reason}; "
+            f"pinned loader behavior={capability.loader_behavior}, "
+            f"block kind={capability.block_kind}"
+        )
+    if not (modern_tensors or legacy_tensors):
+        raise ValueError(
+            f"{architecture} GGUF declares {exact_key}={count} but contains no MTP tensors"
+        )
+    if count != 1:
+        raise ValueError(
+            f"{architecture} GGUF declares {count} MTP heads; ModelPackage can represent "
+            "exactly one and will not silently truncate the remaining heads"
+        )
+    if legacy_tensors:
+        raise ValueError(
+            f"{architecture} GGUF mixes unsupported legacy global NextN tensors "
+            f"{legacy_tensors} with the modern per-block namespace"
+        )
+
+    block_count_key = f"{architecture}.block_count"
+    raw_block_count = metadata.get(block_count_key, 0)
+    if isinstance(raw_block_count, bool) or not isinstance(raw_block_count, int):
+        raise TypeError(f"{block_count_key} must be an integer, got {raw_block_count!r}")
+    block_count = raw_block_count
+    expected_block = block_count - 1
+    if block_count <= count:
+        raise ValueError(
+            f"{architecture} GGUF block_count={block_count} must exceed MTP head count {count}"
+        )
+    if set(modern_tensors) != {expected_block}:
+        raise ValueError(
+            f"{architecture} GGUF MTP tensors must all belong to trailing block "
+            f"{expected_block}, got blocks {sorted(modern_tensors)}"
+        )
+    block_prefix = f"blk.{expected_block}."
+    unexpected_block_tensors = sorted(
+        name
+        for name in tensor_names
+        if name.startswith(block_prefix)
+        and name.removeprefix(block_prefix) not in _SUPPORTED_MTP_BLOCK_TENSORS
+    )
+    if unexpected_block_tensors:
+        raise ValueError(
+            f"{architecture} GGUF MTP block contains unsupported tensor(s): "
+            f"{unexpected_block_tensors}"
+        )
+
+    required = {"nextn.eh_proj", "nextn.enorm", "nextn.hnorm"}
+    missing = sorted(required - modern_tensors[expected_block])
+    if missing:
+        raise ValueError(
+            f"{architecture} GGUF MTP block {expected_block} is missing required tensor "
+            f"stem(s): {missing}"
+        )
+
+    hidden = int(metadata[f"{architecture}.embedding_length"])
+    vocab = int(metadata.get(f"{architecture}.vocab_size", 0))
+    if not vocab:
+        vocab = len(metadata.get("tokenizer.ggml.tokens", ()))
+    num_heads = int(metadata[f"{architecture}.attention.head_count"])
+    num_kv_heads = int(metadata.get(f"{architecture}.attention.head_count_kv", num_heads))
+    head_dim = int(metadata.get(f"{architecture}.attention.key_length", hidden // num_heads))
+    raw_ffn = metadata[f"{architecture}.feed_forward_length"]
+    if isinstance(raw_ffn, (list, tuple)):
+        if len(raw_ffn) != block_count:
+            raise ValueError(
+                f"{architecture}.feed_forward_length must contain {block_count} entries, "
+                f"got {len(raw_ffn)}"
+            )
+        ffn = int(raw_ffn[expected_block])
+    else:
+        ffn = int(raw_ffn)
+
+    prefix = f"blk.{expected_block}."
+    expected_shapes: dict[str, tuple[int, ...]] = {
+        "token_embd.weight": (vocab, hidden),
+        "output_norm.weight": (hidden,),
+        f"{prefix}nextn.eh_proj.weight": (hidden, 2 * hidden),
+        f"{prefix}nextn.enorm.weight": (hidden,),
+        f"{prefix}nextn.hnorm.weight": (hidden,),
+        f"{prefix}attn_norm.weight": (hidden,),
+        f"{prefix}attn_q.weight": (2 * num_heads * head_dim, hidden),
+        f"{prefix}attn_k.weight": (num_kv_heads * head_dim, hidden),
+        f"{prefix}attn_v.weight": (num_kv_heads * head_dim, hidden),
+        f"{prefix}attn_output.weight": (hidden, num_heads * head_dim),
+        f"{prefix}attn_q_norm.weight": (head_dim,),
+        f"{prefix}attn_k_norm.weight": (head_dim,),
+        f"{prefix}post_attention_norm.weight": (hidden,),
+        f"{prefix}ffn_gate.weight": (ffn, hidden),
+        f"{prefix}ffn_up.weight": (ffn, hidden),
+        f"{prefix}ffn_down.weight": (hidden, ffn),
+    }
+    optional_shapes = {
+        "output.weight": (vocab, hidden),
+        f"{prefix}nextn.embed_tokens.weight": (vocab, hidden),
+        f"{prefix}nextn.shared_head_norm.weight": (hidden,),
+        f"{prefix}nextn.shared_head_head.weight": (vocab, hidden),
+    }
+    actual_shapes = {
+        name: tuple(int(dimension) for dimension in shape)
+        for name, _raw, _qtype, shape in gguf_model.tensor_items_raw()
+        if name in expected_shapes or name in optional_shapes
+    }
+    missing_shapes = sorted(set(expected_shapes) - set(actual_shapes))
+    malformed_shapes = {
+        name: (expected_shapes.get(name, optional_shapes.get(name)), actual)
+        for name, actual in actual_shapes.items()
+        if actual != expected_shapes.get(name, optional_shapes.get(name))
+    }
+    if missing_shapes or malformed_shapes:
+        raise ValueError(
+            f"Invalid {architecture} GGUF MTP tensor shapes: missing={missing_shapes}, "
+            f"malformed={malformed_shapes}"
+        )
 
 
 def map_gguf_mtp_to_hf_names(gguf_name: str, mtp_block_index: int) -> str | None:
@@ -197,11 +574,12 @@ def build_mtp_head_from_gguf(
     mtp_blocks = getattr(config, "_gguf_mtp_block_indices", None)
     if not mtp_blocks:
         return None
-    if len(mtp_blocks) > 1:
+    validate_mtp_tensor_contract(gguf_model)
+    if len(mtp_blocks) != 1:
         raise ValueError(
-            f"GGUF declares {len(mtp_blocks)} MTP blocks, but mobius can export "
-            "exactly one MTP sidecar head. Multi-head MTP export is not supported; "
-            "no partial sidecar was produced."
+            f"GGUF declares {len(mtp_blocks)} MTP blocks, but ModelPackage can "
+            "represent exactly one MTP sidecar head. Multi-head MTP export is not "
+            f"supported; got blocks {list(mtp_blocks)} and produced no partial sidecar."
         )
     mtp_block_index = int(mtp_blocks[0])
     gguf_arch = gguf_model.architecture

--- a/src/mobius/integrations/gguf/_mtp.py
+++ b/src/mobius/integrations/gguf/_mtp.py
@@ -350,8 +350,9 @@ def validate_mtp_tensor_contract(gguf_model) -> None:
         )
     if count != 1:
         raise ValueError(
-            f"{architecture} GGUF declares {count} MTP heads; ModelPackage can represent "
-            "exactly one and will not silently truncate the remaining heads"
+            f"{architecture} GGUF declares {count} MTP heads and has {count} MTP blocks, "
+            "but only exactly one appended MTP block can be represented; refusing to "
+            "silently truncate the remaining heads"
         )
     if legacy_tensors:
         raise ValueError(
@@ -620,6 +621,7 @@ def build_mtp_head_from_gguf(
             mtp_config,
             name_mapper=_mapper,
             warn_unmapped=False,
+            dequantize_float_linear_types={"lm_head": {"Q4_1"}},
         )
         # Mirror the backbone (build_from_gguf steps 7/7b): run process_tensors
         # over only the float tensors (native quant blocks were already

--- a/src/mobius/integrations/gguf/_mtp_test.py
+++ b/src/mobius/integrations/gguf/_mtp_test.py
@@ -5,7 +5,10 @@
 
 from __future__ import annotations
 
+import json
+import re
 import typing
+from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
@@ -16,7 +19,10 @@ from mobius.integrations.gguf._mtp import (
     derive_mtp_config,
     has_mtp_head,
     map_gguf_mtp_to_hf_names,
+    mtp_architecture_capabilities,
+    validate_mtp_tensor_contract,
 )
+from mobius.integrations.gguf._spec import Support
 
 # Tiny dimensions for a Qwen3.5-style GGUF that ships a single trailing MTP
 # ("nextn") block. ``block_count`` includes the MTP block, so decoder=1 and
@@ -28,6 +34,13 @@ _NKV = 2
 _HD = 16
 _VOCAB = 100
 _BLOCK_COUNT = 2  # 1 decoder layer + 1 nextn head block
+
+
+@dataclass
+class _ContractGGUF:
+    architecture: str
+    metadata: dict[str, object]
+    tensor_names: list[str]
 
 
 def _write_qwen35_mtp_gguf(
@@ -43,6 +56,13 @@ def _write_qwen35_mtp_gguf(
     tied_output: bool = True,
     unknown_nextn: bool = False,
     quantized_backbone_embedding: bool = False,
+    nextn_count: int | None = None,
+    mtp_block_index: int = 1,
+    omit_nextn_stem: str | None = None,
+    metadata_key: str | None = None,
+    extra_mtp_tensor: str | None = None,
+    asymmetric_dedicated_head: bool = False,
+    shape_overrides: dict[str, tuple[int, ...]] | None = None,
 ) -> None:
     """Write a tiny Qwen3.5 GGUF with a trailing ``blk.1.nextn.*`` MTP head."""
     from gguf import GGMLQuantizationType, GGUFWriter
@@ -58,7 +78,11 @@ def _write_qwen35_mtp_gguf(
     writer.add_layer_norm_rms_eps(1e-5)
     writer.add_vocab_size(_VOCAB)
     # UINT32 == GGUFValueType 4.
-    writer.add_key_value(f"{architecture}.nextn_predict_layers", mtp_count, 4)
+    writer.add_key_value(
+        metadata_key or f"{architecture}.nextn_predict_layers",
+        mtp_count if nextn_count is None else nextn_count,
+        4,
+    )
     writer.add_key_value(f"{architecture}.attention.key_length", _HD, 4)
     writer.add_array(
         f"{architecture}.attention.recurrent_layers",
@@ -72,22 +96,36 @@ def _write_qwen35_mtp_gguf(
     writer.add_ssm_group_count(2)
 
     def f32(name: str, shape: tuple[int, ...]) -> None:
+        if shape_overrides is not None:
+            shape = shape_overrides.get(name, shape)
         writer.add_tensor(name, np.random.randn(*shape).astype(np.float32))
 
-    def matrix(name: str, shape: tuple[int, ...]) -> None:
+    def matrix(name: str, shape: tuple[int, ...], *, asymmetric: bool = False) -> None:
+        if shape_overrides is not None:
+            shape = shape_overrides.get(name, shape)
         if not quantized:
             f32(name, shape)
             return
         rows = int(np.prod(shape[:-1]))
         k_in = shape[-1]
         assert k_in % 32 == 0
-        raw = np.zeros((rows, (k_in // 32) * 18), dtype=np.uint8)
-        raw[:, 0::18] = 0x00
-        raw[:, 1::18] = 0x3C
+        block_size = 20 if asymmetric else 18
+        raw = np.zeros((rows, (k_in // 32) * block_size), dtype=np.uint8)
+        if asymmetric:
+            # Q4_1: fp16 scale, fp16 minimum, then 16 packed 4-bit pairs.
+            scale = np.float16(0.25).tobytes()
+            minimum = np.float16(-1.0).tobytes()
+            for offset in range(0, raw.shape[1], block_size):
+                raw[:, offset : offset + 2] = np.frombuffer(scale, dtype=np.uint8)
+                raw[:, offset + 2 : offset + 4] = np.frombuffer(minimum, dtype=np.uint8)
+                raw[:, offset + 4 : offset + block_size] = 0xD2
+        else:
+            raw[:, 0::block_size] = 0x00
+            raw[:, 1::block_size] = 0x3C
         writer.add_tensor(
             name,
             raw.reshape(*shape[:-1], -1),
-            raw_dtype=GGMLQuantizationType.Q4_0,
+            raw_dtype=(GGMLQuantizationType.Q4_1 if asymmetric else GGMLQuantizationType.Q4_0),
         )
 
     def _add_decoder_block(idx: int) -> None:
@@ -110,21 +148,32 @@ def _write_qwen35_mtp_gguf(
 
     # MTP head blocks: each has cross-conditioning tensors plus a full
     # attention/FFN sublayer.
-    for index in range(1, 1 + mtp_count):
-        matrix(f"blk.{index}.nextn.eh_proj.weight", (_H, 2 * _H))
+    block_indices = range(1, 1 + mtp_count) if mtp_count > 1 else (mtp_block_index,)
+    for index in block_indices:
+        prefix = f"blk.{index}"
+        if omit_nextn_stem != "eh_proj":
+            matrix(f"{prefix}.nextn.eh_proj.weight", (_H, 2 * _H))
         if mtp_aux_suffix is not None:
             assert mtp_aux_suffix in {"scale", "input_scale"}
-            f32(f"blk.{index}.nextn.eh_proj.{mtp_aux_suffix}", (1,))
-        f32(f"blk.{index}.nextn.enorm.weight", (_H,))
-        f32(f"blk.{index}.nextn.hnorm.weight", (_H,))
+            f32(f"{prefix}.nextn.eh_proj.{mtp_aux_suffix}", (1,))
+        if omit_nextn_stem != "enorm":
+            f32(f"{prefix}.nextn.enorm.weight", (_H,))
+        if omit_nextn_stem != "hnorm":
+            f32(f"{prefix}.nextn.hnorm.weight", (_H,))
         if dedicated_embedding:
-            matrix(f"blk.{index}.nextn.embed_tokens.weight", (_VOCAB, _H))
+            matrix(f"{prefix}.nextn.embed_tokens.weight", (_VOCAB, _H))
         if dedicated_norm:
-            f32(f"blk.{index}.nextn.shared_head_norm.weight", (_H,))
+            f32(f"{prefix}.nextn.shared_head_norm.weight", (_H,))
         if dedicated_head:
-            matrix(f"blk.{index}.nextn.shared_head_head.weight", (_VOCAB, _H))
+            matrix(
+                f"{prefix}.nextn.shared_head_head.weight",
+                (_VOCAB, _H),
+                asymmetric=asymmetric_dedicated_head,
+            )
         if unknown_nextn:
-            f32(f"blk.{index}.nextn.unknown.weight", (_H,))
+            f32(f"{prefix}.nextn.unknown.weight", (_H,))
+        if extra_mtp_tensor is not None:
+            f32(extra_mtp_tensor, (_H,))
         _add_decoder_block(index)
 
     if quantized_backbone_embedding:
@@ -198,6 +247,116 @@ class TestMtpNameMapping:
         assert map_gguf_mtp_to_hf_names("output_norm.weight", 1) is None
         # Unknown stem inside the MTP block is skipped rather than mis-mapped.
         assert map_gguf_mtp_to_hf_names("blk.1.unknown_tensor.weight", 1) is None
+
+
+class TestPinnedMtpCensus:
+    def test_policy_closes_exact_pinned_loader_converter_union(self):
+        pin_path = Path(__file__).parent / "_upstream_data" / "llamacpp_pin.json"
+        census = json.loads(pin_path.read_text(encoding="utf-8"))["mtp_nextn"]
+        upstream_union = set().union(
+            census["loader_metadata_consumers"],
+            census["loader_executed_sidecars"],
+            census["loader_preserved_or_skipped"],
+            census["standalone_assistant"],
+            census["converter_metadata_emitters"],
+            census["non_mtp_metadata_reemitters"],
+        )
+        capabilities = mtp_architecture_capabilities()
+
+        assert set(capabilities) == upstream_union
+        assert {
+            architecture
+            for architecture, capability in capabilities.items()
+            if capability.support is Support.SUPPORTED
+        } == {"qwen35"}
+        assert census["mobius_supported_sidecars"] == ["qwen35"]
+        assert census["mobius_runtime_status"] == "DEFERRED"
+
+    def test_exact_pinned_metadata_and_tensor_names(self):
+        pin_path = Path(__file__).parent / "_upstream_data" / "llamacpp_pin.json"
+        census = json.loads(pin_path.read_text(encoding="utf-8"))["mtp_nextn"]
+
+        assert census["metadata_key_template"] == "{arch}.nextn_predict_layers"
+        assert census["metadata_type"] == "uint32"
+        assert census["modern_tensor_names"] == [
+            "blk.{bid}.nextn.eh_proj.weight",
+            "blk.{bid}.nextn.embed_tokens.weight",
+            "blk.{bid}.nextn.enorm.weight",
+            "blk.{bid}.nextn.hnorm.weight",
+            "blk.{bid}.nextn.shared_head_head.weight",
+            "blk.{bid}.nextn.shared_head_norm.weight",
+        ]
+        assert census["legacy_tensor_names"] == [
+            "nextn.pre_projection.weight",
+            "nextn.post_projection.weight",
+        ]
+        assert census["generic_loader_extra_suffixes"] == ["scale", "input_scale"]
+
+    @pytest.mark.parametrize(
+        "architecture",
+        sorted(
+            architecture
+            for architecture, capability in mtp_architecture_capabilities().items()
+            if capability.support is not Support.SUPPORTED
+        ),
+    )
+    def test_every_unsupported_pinned_architecture_rejects_specifically(
+        self, architecture: str
+    ):
+        model = _ContractGGUF(
+            architecture=architecture,
+            metadata={
+                f"{architecture}.nextn_predict_layers": 1,
+                f"{architecture}.block_count": 2,
+            },
+            tensor_names=[
+                "blk.1.nextn.eh_proj.weight",
+                "blk.1.nextn.enorm.weight",
+                "blk.1.nextn.hnorm.weight",
+            ],
+        )
+
+        with pytest.raises(NotImplementedError, match=rf"^{re.escape(architecture)} GGUF MTP"):
+            validate_mtp_tensor_contract(model)
+
+    @pytest.mark.parametrize("invalid_count", [True, -1, 1.5, "1"])
+    def test_head_count_metadata_requires_nonnegative_integer(self, invalid_count):
+        model = _ContractGGUF(
+            architecture="qwen35",
+            metadata={
+                "qwen35.nextn_predict_layers": invalid_count,
+                "qwen35.block_count": 2,
+            },
+            tensor_names=[],
+        )
+
+        with pytest.raises(
+            (TypeError, ValueError), match=r"must be (an integer|non-negative)"
+        ):
+            validate_mtp_tensor_contract(model)
+
+    def test_tensor_without_positive_metadata_is_rejected(self):
+        model = _ContractGGUF(
+            architecture="qwen35",
+            metadata={"qwen35.block_count": 2},
+            tensor_names=["blk.1.nextn.eh_proj.weight"],
+        )
+
+        with pytest.raises(ValueError, match="does not declare a positive"):
+            validate_mtp_tensor_contract(model)
+
+    def test_foreign_architecture_metadata_namespace_is_rejected(self):
+        model = _ContractGGUF(
+            architecture="qwen35",
+            metadata={
+                "qwen35.block_count": 2,
+                "qwen35moe.nextn_predict_layers": 1,
+            },
+            tensor_names=[],
+        )
+
+        with pytest.raises(ValueError, match="unsupported MTP metadata key"):
+            validate_mtp_tensor_contract(model)
 
 
 class TestMtpConfigSurfacing:
@@ -412,6 +571,82 @@ class TestBuildMtpHead:
         }.issubset(initializers)
         assert not any(name.startswith("lm_head.") for name in initializers)
 
+    def test_target_and_sidecar_save_with_weight_checks_and_reload(
+        self, qwen35_mtp_gguf: Path, tmp_path: Path
+    ):
+        from mobius._model_package import ModelPackage
+        from mobius.integrations.gguf import build_from_gguf
+
+        package = build_from_gguf(qwen35_mtp_gguf)
+        target_dir = tmp_path / "target"
+        package.save(target_dir, progress_bar=False, check_weights=True)
+        reloaded = ModelPackage.load(target_dir)
+        target = reloaded["model"]
+        assert reloaded.mtp_head is not None
+        sidecar = reloaded.mtp_head["model"]
+        assert all(
+            value.const_value is not None for value in target.graph.initializers.values()
+        )
+        assert all(
+            value.const_value is not None for value in sidecar.graph.initializers.values()
+        )
+        assert "model.embed_tokens.weight" in target.graph.initializers
+        assert "embed_tokens.weight" not in sidecar.graph.initializers
+        assert not any("nextn" in name for name in target.graph.initializers)
+
+    def test_asymmetric_dedicated_head_full_logits_match_explicit_dequantization(
+        self, tmp_path: Path
+    ):
+        import onnxruntime as ort
+
+        from mobius.integrations.gguf import build_from_gguf
+        from mobius.integrations.gguf._reader import GGUFModel
+
+        shared_path = tmp_path / "shared-head-q4_1.gguf"
+        dedicated_path = tmp_path / "dedicated-head-q4_1.gguf"
+        np.random.seed(7)
+        _write_qwen35_mtp_gguf(shared_path, quantized=True)
+        np.random.seed(7)
+        _write_qwen35_mtp_gguf(
+            dedicated_path,
+            quantized=True,
+            dedicated_head=True,
+            asymmetric_dedicated_head=True,
+        )
+        shared = build_from_gguf(shared_path, keep_quantized=True).mtp_head
+        dedicated = build_from_gguf(dedicated_path, keep_quantized=True).mtp_head
+        shared_dir = tmp_path / "shared"
+        dedicated_dir = tmp_path / "dedicated"
+        shared.save(shared_dir, progress_bar=False, check_weights=True)
+        dedicated.save(dedicated_dir, progress_bar=False, check_weights=True)
+
+        rng = np.random.default_rng(11)
+        feeds = {
+            "inputs_embeds": rng.standard_normal((1, 2, _H), dtype=np.float32),
+            "hidden_states": rng.standard_normal((1, 2, _H), dtype=np.float32),
+            "attention_mask": np.ones((1, 2), dtype=np.int64),
+            "position_ids": np.array([[0, 1]], dtype=np.int64),
+            "past_key_values.0.key": np.empty((1, _NKV, 0, _HD), dtype=np.float32),
+            "past_key_values.0.value": np.empty((1, _NKV, 0, _HD), dtype=np.float32),
+        }
+        shared_session = ort.InferenceSession(
+            str(shared_dir / "model.onnx"), providers=["CPUExecutionProvider"]
+        )
+        dedicated_session = ort.InferenceSession(
+            str(dedicated_dir / "model.onnx"), providers=["CPUExecutionProvider"]
+        )
+        mtp_hidden = shared_session.run(["mtp_hidden"], feeds)[0]
+        logits = dedicated_session.run(["logits"], feeds)[0]
+
+        # The dedicated Q4_1 table is intentionally asymmetric. The sidecar
+        # dequantizes it for a mathematically ordinary MatMul.
+        explicit_table = GGUFModel(dedicated_path).get_tensor(
+            "blk.1.nextn.shared_head_head.weight"
+        )
+        assert abs(float(explicit_table.mean())) > 0.1
+        expected = mtp_hidden @ explicit_table.T
+        np.testing.assert_allclose(logits, expected, rtol=1e-5, atol=1e-5)
+
 
 class TestMtpAutoDetect:
     """MTP is emitted iff the source GGUF ships the nextn head (no user flag)."""
@@ -537,6 +772,128 @@ class TestMtpAutoDetect:
 
         with pytest.raises(ValueError, match="unsupported nextn tensor"):
             build_from_gguf(path)
+
+    @pytest.mark.parametrize(
+        ("kwargs", "message"),
+        [
+            ({"nextn_count": 2}, "declares 2 MTP heads"),
+            ({"omit_nextn_stem": "hnorm"}, "missing required tensor stem"),
+            ({"mtp_block_index": 2}, "trailing block 1"),
+            (
+                {"metadata_key": "qwen35.nextn.predict_layers"},
+                "unsupported MTP metadata key",
+            ),
+            (
+                {"extra_mtp_tensor": "nextn.pre_projection.weight"},
+                "legacy global NextN tensors",
+            ),
+            ({"extra_mtp_tensor": "mtp.unknown.weight"}, "unsupported nextn tensor"),
+            (
+                {"extra_mtp_tensor": "blk.1.ssm_a"},
+                "unsupported tensor",
+            ),
+            (
+                {"extra_mtp_tensor": "blk.1.ffn_gate_exps.weight"},
+                "unsupported tensor",
+            ),
+            (
+                {"extra_mtp_tensor": "blk.1.attn_qkv.weight"},
+                "unsupported tensor",
+            ),
+            (
+                {"extra_mtp_tensor": "blk.1.unknown_state.weight"},
+                "unsupported tensor",
+            ),
+        ],
+    )
+    def test_malformed_mtp_contracts_fail_before_graph_build(
+        self,
+        kwargs: dict[str, object],
+        message: str,
+        tmp_path: Path,
+        monkeypatch,
+    ):
+        from mobius import _builder as core_builder
+        from mobius.integrations.gguf import build_from_gguf
+
+        path = tmp_path / "malformed-mtp.gguf"
+        _write_qwen35_mtp_gguf(path, **kwargs)
+        monkeypatch.setattr(
+            core_builder,
+            "build_from_module",
+            lambda *_args, **_kwargs: pytest.fail("graph construction must not run"),
+        )
+
+        with pytest.raises(ValueError, match=message):
+            build_from_gguf(path)
+
+    @pytest.mark.parametrize(
+        ("tensor_name", "wrong_shape", "table_kwargs"),
+        [
+            ("blk.1.nextn.eh_proj.weight", (_H, _H), {}),
+            ("blk.1.nextn.enorm.weight", (_H + 1,), {}),
+            (
+                "blk.1.nextn.embed_tokens.weight",
+                (_VOCAB + 1, _H),
+                {"dedicated_embedding": True},
+            ),
+            (
+                "blk.1.nextn.shared_head_norm.weight",
+                (_H + 1,),
+                {"dedicated_norm": True},
+            ),
+            (
+                "blk.1.nextn.shared_head_head.weight",
+                (_VOCAB + 1, _H),
+                {"dedicated_head": True},
+            ),
+            ("blk.1.attn_q.weight", (_NH * _HD, _H), {}),
+            ("blk.1.ffn_down.weight", (_H, _FFN + 1), {}),
+        ],
+    )
+    def test_malformed_mtp_shapes_fail_before_graph_build(
+        self,
+        tensor_name: str,
+        wrong_shape: tuple[int, ...],
+        table_kwargs: dict[str, bool],
+        tmp_path: Path,
+        monkeypatch,
+    ):
+        from mobius import _builder as core_builder
+        from mobius.integrations.gguf import build_from_gguf
+
+        path = tmp_path / "malformed-mtp-shape.gguf"
+        _write_qwen35_mtp_gguf(
+            path,
+            shape_overrides={tensor_name: wrong_shape},
+            **table_kwargs,
+        )
+        monkeypatch.setattr(
+            core_builder,
+            "build_from_module",
+            lambda *_args, **_kwargs: pytest.fail("graph construction must not run"),
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=rf"Invalid qwen35 GGUF MTP tensor shapes.*{re.escape(tensor_name)}",
+        ):
+            build_from_gguf(path)
+
+    def test_static_cache_rejects_instead_of_omitting_sidecar(
+        self, qwen35_mtp_gguf: Path, monkeypatch
+    ):
+        from mobius import _builder as core_builder
+        from mobius.integrations.gguf import build_from_gguf
+
+        monkeypatch.setattr(
+            core_builder,
+            "build_from_module",
+            lambda *_args, **_kwargs: pytest.fail("graph construction must not run"),
+        )
+
+        with pytest.raises(ValueError, match=r"static_cache=True.*refusing to silently omit"):
+            build_from_gguf(qwen35_mtp_gguf, static_cache=True)
 
     def test_mtp_survives_dtype_replace(self, qwen35_mtp_gguf: Path):
         # Regression: an explicit dtype triggers dataclasses.replace on the

--- a/src/mobius/integrations/gguf/_mtp_test.py
+++ b/src/mobius/integrations/gguf/_mtp_test.py
@@ -164,17 +164,17 @@ def _write_qwen35_mtp_gguf(
             matrix(f"{prefix}.nextn.embed_tokens.weight", (_VOCAB, _H))
         if dedicated_norm:
             f32(f"{prefix}.nextn.shared_head_norm.weight", (_H,))
+        if unknown_nextn:
+            f32(f"{prefix}.nextn.unknown.weight", (_H,))
+        if extra_mtp_tensor is not None:
+            f32(extra_mtp_tensor, (_H,))
+        _add_decoder_block(index)
         if dedicated_head:
             matrix(
                 f"{prefix}.nextn.shared_head_head.weight",
                 (_VOCAB, _H),
                 asymmetric=asymmetric_dedicated_head,
             )
-        if unknown_nextn:
-            f32(f"{prefix}.nextn.unknown.weight", (_H,))
-        if extra_mtp_tensor is not None:
-            f32(extra_mtp_tensor, (_H,))
-        _add_decoder_block(index)
 
     if quantized_backbone_embedding:
         matrix("token_embd.weight", (_VOCAB, _H))

--- a/src/mobius/integrations/gguf/_upstream_data/llamacpp_pin.json
+++ b/src/mobius/integrations/gguf/_upstream_data/llamacpp_pin.json
@@ -1,6 +1,23 @@
 {
 "source": "https://github.com/ggml-org/llama.cpp",
 "commit": "8d9af256337d1a501250f9bbf4c0859a654bddd6",
+"mtp_nextn": {
+  "metadata_key_template": "{arch}.nextn_predict_layers",
+  "metadata_type": "uint32",
+  "head_count_semantics": "block_count includes the trailing appended MTP blocks; their indices are [block_count-nextn_predict_layers, block_count)",
+  "modern_tensor_names": ["blk.{bid}.nextn.eh_proj.weight", "blk.{bid}.nextn.embed_tokens.weight", "blk.{bid}.nextn.enorm.weight", "blk.{bid}.nextn.hnorm.weight", "blk.{bid}.nextn.shared_head_head.weight", "blk.{bid}.nextn.shared_head_norm.weight"],
+  "legacy_tensor_names": ["nextn.pre_projection.weight", "nextn.post_projection.weight"],
+  "generic_loader_extra_suffixes": ["scale", "input_scale"],
+  "loader_metadata_consumers": ["bailingmoe2", "bailingmoe3", "cohere2moe", "deepseek2", "deepseek32", "deepseek4", "dots3note", "exaone-moe", "exaone4", "gemma4-assistant", "glm-dsa", "glm4", "glm4moe", "hy_v3", "mimo2", "nemotron_h", "nemotron_h_moe", "qwen35", "qwen35moe", "qwen3next", "step35"],
+  "loader_executed_sidecars": ["bailingmoe3", "cohere2moe", "deepseek2", "deepseek32", "deepseek4", "glm-dsa", "hy_v3", "mimo2", "nemotron_h_moe", "qwen35", "qwen35moe", "qwen3next", "step35"],
+  "loader_preserved_or_skipped": ["bailingmoe2", "dots3note", "exaone-moe", "exaone4", "glm4", "glm4moe"],
+  "standalone_assistant": ["gemma4-assistant"],
+  "converter_metadata_emitters": ["bailingmoe2", "bailingmoe3", "cohere2moe", "deepseek2", "deepseek32", "deepseek4", "dots3note", "exaone-moe", "exaone4", "gemma4-assistant", "glm-dsa", "glm4", "glm4moe", "hy_v3", "mimo2", "nemotron_h_moe", "qwen35", "qwen35moe", "qwen3next", "step35"],
+  "converter_mtp_only_opt_in": ["bailingmoe3", "deepseek2", "deepseek32", "deepseek4", "dots3note", "glm-dsa", "hy_v3", "nemotron_h_moe", "qwen35", "qwen35moe", "qwen3next", "step35"],
+  "non_mtp_metadata_reemitters": ["graniteswitch"],
+  "mobius_supported_sidecars": ["qwen35"],
+  "mobius_runtime_status": "DEFERRED"
+},
 "architectures": {
   "afmoe": {"cohort": "C02-moe-dense-attn", "cpp_loader": true, "dual_moe": true},
   "apertus": {"cohort": "C01-dense-transformer", "cpp_loader": true, "dual_moe": false, "tensor_families": ["token_embd", "output_norm", "output", "rope_freqs", "blk.{bid}.attn_norm", "blk.{bid}.attn_q", "blk.{bid}.attn_k", "blk.{bid}.attn_v", "blk.{bid}.attn_output", "blk.{bid}.attn_rot_embd", "blk.{bid}.attn_q_norm", "blk.{bid}.attn_k_norm", "blk.{bid}.ffn_norm", "blk.{bid}.ffn_gate", "blk.{bid}.ffn_down", "blk.{bid}.ffn_up"]},

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -6012,7 +6012,8 @@ _SPECIALIZED_TEST_MODEL_TYPES: set[str] = {
     # inputs_embeds + the target's hidden_states instead of input_ids;
     # borrows the target's embed/lm_head), so the generic
     # ALL_CAUSAL_LM_CONFIGS matrix can't drive it. Covered by
-    # src/mobius/models/_qwen35_mtp_test.py.
+    # src/mobius/models/_qwen35_mtp_test.py and the registered dense-qwen35
+    # GGUF capability in src/mobius/integrations/gguf/_mtp_test.py.
     "Qwen35MtpModel",
     # EAGLE-3 drafter: bespoke IO contract (inputs_embeds, fused_hidden,
     # recycled_hidden and draft-vocab logits). Covered by _eagle3_test.py.

--- a/tests/model_coverage_test.py
+++ b/tests/model_coverage_test.py
@@ -306,7 +306,7 @@ _COVERAGE_SKIP: dict[str, str] = {
     "Gemma4AssistantForCausalLM": "Drafter alias of gemma4_assistant — covered by _gemma4_assistant_test.py + L4/L5 golden",
     "gemma4_unified_assistant": "Drafter (unified variant) — covered by _gemma4_assistant_test.py + L4/L5 golden",
     "Gemma4UnifiedAssistantForCausalLM": "Drafter alias of gemma4_unified_assistant — covered by _gemma4_assistant_test.py + L4/L5 golden",
-    "Qwen35MtpModel": "Drafter (inputs_embeds + target hidden_states IO; borrows target embed/lm_head) — covered by src/mobius/models/_qwen35_mtp_test.py + L4 golden (qwen35-mtp)",
+    "Qwen35MtpModel": "Drafter (inputs_embeds + post-final-norm target hidden_states IO; dedicated/shared embed, norm, and head ownership) — covered by src/mobius/models/_qwen35_mtp_test.py, src/mobius/integrations/gguf/_mtp_test.py, and L4 golden (qwen35-mtp)",
     "Eagle3LlamaForCausalLM": "Drafter (inputs_embeds + fused/recycled hidden IO; own draft-vocab lm_head) — covered by src/mobius/models/_eagle3_test.py",
     "LlamaForCausalLMEagle3": "Drafter (EAGLE-3 arch alias used by the Qwen3-8B checkpoint) — covered by src/mobius/models/_eagle3_test.py",
     "Eagle3Speculator": "Drafter (speculators-format EAGLE-3, RedHat Qwen3) — covered by src/mobius/models/_eagle3_test.py",


### PR DESCRIPTION
## Summary

- make the pinned llama.cpp `8d9af256337d1a501250f9bbf4c0859a654bddd6` MTP/NextN loader and converter census authoritative across dense, routed, hybrid, draft, and multimodal architecture namespaces
- export the exact one-head dense Qwen3.5 auxiliary sidecar while failing closed before graph construction for routed/MoE/hybrid, multi-head, partial, unknown, legacy, scale/state, malformed, and out-of-range contracts
- preserve exact target/sidecar embedding, norm, head, packed-weight, and initializer ownership; persist and reload the MTP sidecar as a first-class `ModelPackage` attachment
- require immutable selected-file Hub revisions and exact header architecture validation; document downstream runtime support as `DEFERRED`

## Validation

- focused MTP suite: 103 passed
- affected MTP/GGUF/package/CLI/coverage suites: 817 passed, 225 skipped
- broad non-integration suite: 6,525 passed, 52 skipped
- full initialized lintrunner format and lint
- two independent high-confidence full-diff reviews clean after all findings were fixed

## Runtime status

`DEFERRED`: runtime support is not claimed without a pinned real artifact, independent full-logit parity, and deterministic end-to-end speculative/MTP generation.
