### PR TITLE
Add small-model GGUF runtime evidence

### DIFF
--- a/.github/workflows/gpu_l4_golden_parity.yml
+++ b/.github/workflows/gpu_l4_golden_parity.yml
@@ -8,7 +8,13 @@ on:
     inputs:
       affected_models:
         description: >-
-          JSON array of model names. Empty string or empty array runs all models.
+          JSON array of model types.
+          Empty string or empty array runs all models.
+        required: false
+        type: string
+        default: ""
+      affected_cases:
+        description: JSON array of exact golden case IDs.
         required: false
         type: string
         default: ""
@@ -16,8 +22,13 @@ on:
     inputs:
       affected_models:
         description: >-
-          JSON array of affected model names (e.g. '["qwen2", "llama"]').
+          JSON array of affected model types (e.g. '["qwen2", "llama"]').
           Empty string or empty array means run all models.
+        required: false
+        type: string
+        default: ""
+      affected_cases:
+        description: JSON array of exact golden case IDs.
         required: false
         type: string
         default: ""
@@ -84,9 +95,13 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           MOBIUS_TEST_DEVICE: cuda
+          AFFECTED_MODELS: ${{ inputs.affected_models }}
+          AFFECTED_CASES: ${{ inputs.affected_cases }}
         run: |
-          AFFECTED='${{ inputs.affected_models }}'
-          if [ -z "$AFFECTED" ] || [ "$AFFECTED" = "[]" ]; then
+          AFFECTED="$AFFECTED_MODELS"
+          CASES="$AFFECTED_CASES"
+          if { [ -z "$AFFECTED" ] || [ "$AFFECTED" = "[]" ]; } && \
+             { [ -z "$CASES" ] || [ "$CASES" = "[]" ]; }; then
             echo "Running all L4 golden comparison tests"
             pytest tests/e2e_golden_test.py \
               -m golden \
@@ -96,21 +111,31 @@ jobs:
               --cov=src --cov-report=xml --cov-branch \
               --tb=short
           else
-            echo "Running L4 golden tests for affected models: $AFFECTED"
-            # Convert JSON array to comma-separated list for --models
-            MODELS=$(echo "$AFFECTED" | python -c "import json, sys; print(','.join(json.load(sys.stdin)))")
-            if [ -n "$MODELS" ]; then
-              pytest tests/e2e_golden_test.py \
+            if [ -n "$AFFECTED" ] && [ "$AFFECTED" != "[]" ]; then
+              echo "Running L4 golden tests for affected models: $AFFECTED"
+              # Convert JSON array to comma-separated list for --models
+              MODELS=$(echo "$AFFECTED" | python -c "import json, sys; print(','.join(json.load(sys.stdin)))")
+              if [ -n "$MODELS" ]; then
+                pytest tests/e2e_golden_test.py \
+                  -m golden \
+                  -v \
+                  --models "$MODELS" \
+                  --timeout=300 \
+                  --junitxml=junit-l4-models.xml \
+                  --cov=src --cov-report=xml --cov-branch \
+                  --tb=short \
+                  || { rc=$?; if [ $rc -eq 5 ]; then echo "No matching tests found — skipping"; else exit $rc; fi; }
+              fi
+            fi
+            if [ -n "$CASES" ] && [ "$CASES" != "[]" ]; then
+              echo "Running L4 golden tests for exact cases: $CASES"
+              MOBIUS_GOLDEN_CASES="$CASES" pytest tests/e2e_golden_test.py \
                 -m golden \
                 -v \
-                --models "$MODELS" \
                 --timeout=300 \
-                --junitxml=junit-l4.xml \
-                --cov=src --cov-report=xml --cov-branch \
-                --tb=short \
-                || { rc=$?; if [ $rc -eq 5 ]; then echo "No matching tests found — skipping"; else exit $rc; fi; }
-            else
-              echo "No affected models — skipping"
+                --junitxml=junit-l4-cases.xml \
+                --cov=src --cov-append --cov-report=xml --cov-branch \
+                --tb=short
             fi
           fi
         timeout-minutes: 60
@@ -128,12 +153,12 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: gpu-l4
           report-type: test_results
-          files: junit-l4.xml
+          files: junit-l4*.xml
 
       - name: Upload test results
         if: always() && steps.check_golden.outputs.has_golden == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: gpu-l4-test-results
-          path: junit-l4.xml
+          path: junit-l4*.xml
           retention-days: 30

--- a/.github/workflows/gpu_l5_generation_e2e.yml
+++ b/.github/workflows/gpu_l5_generation_e2e.yml
@@ -8,7 +8,13 @@ on:
     inputs:
       affected_models:
         description: >-
-          JSON array of model names. Empty string or empty array runs all models.
+          JSON array of model types.
+          Empty string or empty array runs all models.
+        required: false
+        type: string
+        default: ""
+      affected_cases:
+        description: JSON array of exact golden case IDs.
         required: false
         type: string
         default: ""
@@ -16,8 +22,13 @@ on:
     inputs:
       affected_models:
         description: >-
-          JSON array of affected model names (e.g. '["qwen2", "llama"]').
+          JSON array of affected model types (e.g. '["qwen2", "llama"]').
           Empty string or empty array means run all models.
+        required: false
+        type: string
+        default: ""
+      affected_cases:
+        description: JSON array of exact golden case IDs.
         required: false
         type: string
         default: ""
@@ -72,9 +83,13 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           MOBIUS_TEST_DEVICE: cuda
+          AFFECTED_MODELS: ${{ inputs.affected_models }}
+          AFFECTED_CASES: ${{ inputs.affected_cases }}
         run: |
-          AFFECTED='${{ inputs.affected_models }}'
-          if [ -z "$AFFECTED" ] || [ "$AFFECTED" = "[]" ]; then
+          AFFECTED="$AFFECTED_MODELS"
+          CASES="$AFFECTED_CASES"
+          if { [ -z "$AFFECTED" ] || [ "$AFFECTED" = "[]" ]; } && \
+             { [ -z "$CASES" ] || [ "$CASES" = "[]" ]; }; then
             echo "Running all L5 generation E2E tests"
             pytest tests/e2e_golden_test.py \
               -m generation \
@@ -84,21 +99,31 @@ jobs:
               --cov=src --cov-report=xml --cov-branch \
               --tb=short
           else
-            echo "Running L5 generation tests for affected models: $AFFECTED"
-            # Convert JSON array to comma-separated list for --models
-            MODELS=$(echo "$AFFECTED" | python -c "import json, sys; print(','.join(json.load(sys.stdin)))")
-            if [ -n "$MODELS" ]; then
-              pytest tests/e2e_golden_test.py \
+            if [ -n "$AFFECTED" ] && [ "$AFFECTED" != "[]" ]; then
+              echo "Running L5 generation tests for affected models: $AFFECTED"
+              # Convert JSON array to comma-separated list for --models
+              MODELS=$(echo "$AFFECTED" | python -c "import json, sys; print(','.join(json.load(sys.stdin)))")
+              if [ -n "$MODELS" ]; then
+                pytest tests/e2e_golden_test.py \
+                  -m generation \
+                  -v \
+                  --models "$MODELS" \
+                  --timeout=300 \
+                  --junitxml=junit-l5-models.xml \
+                  --cov=src --cov-report=xml --cov-branch \
+                  --tb=short \
+                  || { rc=$?; if [ $rc -eq 5 ]; then echo "No matching tests found — skipping"; else exit $rc; fi; }
+              fi
+            fi
+            if [ -n "$CASES" ] && [ "$CASES" != "[]" ]; then
+              echo "Running L5 generation tests for exact cases: $CASES"
+              MOBIUS_GOLDEN_CASES="$CASES" pytest tests/e2e_golden_test.py \
                 -m generation \
                 -v \
-                --models "$MODELS" \
                 --timeout=300 \
-                --junitxml=junit-l5.xml \
-                --cov=src --cov-report=xml --cov-branch \
-                --tb=short \
-                || { rc=$?; if [ $rc -eq 5 ]; then echo "No matching tests found — skipping"; else exit $rc; fi; }
-            else
-              echo "No affected models — skipping"
+                --junitxml=junit-l5-cases.xml \
+                --cov=src --cov-append --cov-report=xml --cov-branch \
+                --tb=short
             fi
           fi
         timeout-minutes: 60
@@ -116,12 +141,12 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: gpu-l5
           report-type: test_results
-          files: junit-l5.xml
+          files: junit-l5*.xml
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: gpu-l5-test-results
-          path: junit-l5.xml
+          path: junit-l5*.xml
           retention-days: 30

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,8 +32,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       affected: ${{ steps.detect.outputs.affected }}
+      golden_l4_cases: ${{ steps.detect.outputs.golden_l4_cases }}
+      golden_l5_cases: ${{ steps.detect.outputs.golden_l5_cases }}
       run_all: ${{ steps.detect.outputs.run_all }}
       has_affected: ${{ steps.detect.outputs.has_affected }}
+      has_l4_affected: ${{ steps.detect.outputs.has_l4_affected }}
+      has_l5_affected: ${{ steps.detect.outputs.has_l5_affected }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -124,7 +128,7 @@ jobs:
     if: >-
       always() && !cancelled() &&
       (needs.detect-affected.result == 'failure' ||
-       needs.detect-affected.outputs.has_affected == 'true')
+       needs.detect-affected.outputs.has_l4_affected == 'true')
     steps:
       - uses: actions/checkout@v7
       - name: Setup Python
@@ -190,10 +194,11 @@ jobs:
     if: >-
       always() && !cancelled() &&
       (needs.detect-affected.result == 'failure' ||
-       needs.detect-affected.outputs.has_affected == 'true')
+       needs.detect-affected.outputs.has_l4_affected == 'true')
     uses: ./.github/workflows/gpu_l4_golden_parity.yml
     with:
       affected_models: ${{ needs.detect-affected.outputs.affected }}
+      affected_cases: ${{ needs.detect-affected.outputs.golden_l4_cases }}
     secrets:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -204,10 +209,11 @@ jobs:
     if: >-
       always() && !cancelled() &&
       (needs.detect-affected.result == 'failure' ||
-       needs.detect-affected.outputs.has_affected == 'true')
+       needs.detect-affected.outputs.has_l5_affected == 'true')
     uses: ./.github/workflows/gpu_l5_generation_e2e.yml
     with:
       affected_models: ${{ needs.detect-affected.outputs.affected }}
+      affected_cases: ${{ needs.detect-affected.outputs.golden_l5_cases }}
     secrets:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -273,7 +279,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cache/huggingface
-          key: hf-integration-fast-${{ hashFiles('tests/integration_test.py') }}
+          key: hf-integration-fast-${{ hashFiles('tests/integration_test.py', 'tests/gguf_small_model_runtime_integration_test.py') }}
           restore-keys: |
             hf-integration-fast-
       - name: Install PyTorch CUDA
@@ -290,8 +296,8 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
-          pytest tests/integration_test.py -m integration_fast -v \
-            -k "smollm-135m or albert-base or t5-small or dinov2-small or wav2vec2-base or whisper-tiny or test_gemma3_multimodal or test_qwen35 or test_qwen3_next or test_deepseek or test_sam_vit or test_ocr2" \
+          pytest tests/integration_test.py tests/gguf_small_model_runtime_integration_test.py -m integration_fast -v \
+            -k "smollm-135m or smollm2-135m-instruct-f16 or albert-base or t5-small or dinov2-small or wav2vec2-base or whisper-tiny or test_gemma3_multimodal or test_qwen35 or test_qwen3_next or test_deepseek or test_sam_vit or test_ocr2" \
             --cov=src --cov-report=xml --cov-branch --junitxml junit.xml
         timeout-minutes: 15
       - name: Upload coverage to Codecov

--- a/scripts/detect_affected_models.py
+++ b/scripts/detect_affected_models.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-r"""Detect which model_types are affected by a set of changed files.
+r"""Detect which model or golden-case selectors are affected by changed files.
 
 Uses AST-based static import analysis (no actual imports) to determine
 which model types need testing when source files change. Designed for
@@ -58,7 +58,7 @@ def classify_file(path: str) -> str:
     """Classify a changed file path.
 
     Returns one of: 'model', 'traceable', 'shared_infra',
-    'test_config', 'test', 'other'.
+    'test_config', 'golden_case', 'golden_data', 'test', 'other'.
     """
     normalized = path.replace("\\", "/")
 
@@ -71,6 +71,10 @@ def classify_file(path: str) -> str:
             # add an entry here. Defer the run-all decision until model files
             # have been collected so those PRs can use import-graph scoping.
             return "test_config"
+        if normalized.startswith("testdata/cases/") and normalized.endswith(".yaml"):
+            return "golden_case"
+        if normalized.startswith("testdata/golden/") and normalized.endswith(".json"):
+            return "golden_data"
         if normalized.endswith("_test.py") or normalized.startswith("tests/"):
             return "test"
         return "other"
@@ -430,6 +434,10 @@ def detect_affected_models(
     affected: set[str] = set()
     run_all = False
     test_config_changed = False
+    golden_case_files: list[str] = []
+    _, _, golden_detection_failed = _detect_changed_golden_cases(changed_files)
+    if golden_detection_failed:
+        return {"affected": [], "run_all": True}
 
     # Classify files
     model_files: list[str] = []
@@ -441,6 +449,8 @@ def detect_affected_models(
             break
         elif category == "test_config":
             test_config_changed = True
+        elif category == "golden_case":
+            golden_case_files.append(path)
         elif category == "model":
             # Deleted model files could break dependents — run all
             full_path = _PROJECT_ROOT / path
@@ -461,8 +471,13 @@ def detect_affected_models(
     if test_config_changed and not model_files:
         return {"affected": [], "run_all": True}
 
+    for path in golden_case_files:
+        full_path = _PROJECT_ROOT / path
+        if not full_path.exists():
+            return {"affected": [], "run_all": True}
+
     if not model_files and not traceable_files:
-        return {"affected": [], "run_all": False}
+        return {"affected": sorted(affected), "run_all": False}
 
     # Build the registry map: source_module → [model_types]
     registry_map = _build_source_module_to_types()
@@ -530,6 +545,64 @@ def detect_affected_models(
     return {"affected": sorted(affected), "run_all": False}
 
 
+def _read_golden_case_levels(yaml_path: Path) -> set[str] | None:
+    """Read one top-level L4/L5 declaration without requiring PyYAML."""
+    for line in yaml_path.read_text(encoding="utf-8").splitlines():
+        if not line.startswith("level:"):
+            continue
+        value = line.partition(":")[2].strip().strip("\"'")
+        if value == "L4":
+            return {"L4"}
+        if value == "L5":
+            return {"L5"}
+        if value == "L4+L5":
+            return {"L4", "L5"}
+        return None
+    return None
+
+
+def _detect_changed_golden_cases(
+    changed_files: list[str],
+) -> tuple[list[str], list[str], bool]:
+    """Return level-specific exact case IDs and whether detection failed closed."""
+    l4_cases: set[str] = set()
+    l5_cases: set[str] = set()
+    cases_root = _PROJECT_ROOT / "testdata" / "cases"
+
+    for path in changed_files:
+        category = classify_file(path)
+        if category not in {"golden_case", "golden_data"}:
+            continue
+        full_path = _PROJECT_ROOT / path
+        if not full_path.exists():
+            return [], [], True
+
+        if category == "golden_case":
+            yaml_path = full_path
+            case_id = full_path.stem
+            is_generation_data = False
+            if len(list(cases_root.rglob(f"{case_id}.yaml"))) != 1:
+                return [], [], True
+        else:
+            stem = full_path.stem
+            is_generation_data = stem.endswith("_generation")
+            case_id = stem.removesuffix("_generation")
+            matches = sorted(cases_root.rglob(f"{case_id}.yaml"))
+            if len(matches) != 1:
+                return [], [], True
+            yaml_path = matches[0]
+
+        levels = _read_golden_case_levels(yaml_path)
+        if levels is None or (is_generation_data and "L5" not in levels):
+            return [], [], True
+        if "L4" in levels and not is_generation_data:
+            l4_cases.add(case_id)
+        if "L5" in levels:
+            l5_cases.add(case_id)
+
+    return sorted(l4_cases), sorted(l5_cases), False
+
+
 def main() -> None:
     """CLI entry point."""
     parser = argparse.ArgumentParser(
@@ -562,17 +635,47 @@ def main() -> None:
         changed = [line.strip() for line in args.changed_files.split("\n") if line.strip()]
 
     result = detect_affected_models(changed)
+    golden_l4_cases, golden_l5_cases, golden_detection_failed = _detect_changed_golden_cases(
+        changed
+    )
+    if golden_detection_failed:
+        result = {"affected": [], "run_all": True}
+    if result["run_all"]:
+        golden_l4_cases = []
+        golden_l5_cases = []
 
     if args.output_format == "github":
         # Output for GitHub Actions
         affected_json = json.dumps(result["affected"])
+        golden_l4_cases_json = json.dumps(golden_l4_cases)
+        golden_l5_cases_json = json.dumps(golden_l5_cases)
         run_all = "true" if result["run_all"] else "false"
-        has_affected = "true" if (result["run_all"] or result["affected"]) else "false"
+        has_model_affected = bool(result["run_all"] or result["affected"])
+        has_l4_affected = "true" if has_model_affected or golden_l4_cases else "false"
+        has_l5_affected = "true" if has_model_affected or golden_l5_cases else "false"
+        has_affected = (
+            "true"
+            if (result["run_all"] or result["affected"] or golden_l4_cases or golden_l5_cases)
+            else "false"
+        )
         print(f"affected={affected_json}")
+        print(f"golden_l4_cases={golden_l4_cases_json}")
+        print(f"golden_l5_cases={golden_l5_cases_json}")
         print(f"run_all={run_all}")
         print(f"has_affected={has_affected}")
+        print(f"has_l4_affected={has_l4_affected}")
+        print(f"has_l5_affected={has_l5_affected}")
     else:
-        print(json.dumps(result, indent=2))
+        print(
+            json.dumps(
+                {
+                    **result,
+                    "golden_l4_cases": golden_l4_cases,
+                    "golden_l5_cases": golden_l5_cases,
+                },
+                indent=2,
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/detect_affected_models_test.py
+++ b/scripts/detect_affected_models_test.py
@@ -25,6 +25,7 @@ from detect_affected_models import (  # noqa: E402
     _build_reexport_map,
     _build_registry_class_to_types,
     _build_source_module_to_types,
+    _detect_changed_golden_cases,
     _find_reverse_dependents,
     _parse_imports,
     classify_file,
@@ -73,6 +74,12 @@ class TestClassifyFile:
 
     def test_test_infra_configs(self):
         assert classify_file("tests/_test_configs.py") == "test_config"
+
+    def test_golden_case(self):
+        assert classify_file("testdata/cases/causal-lm/gpt2.yaml") == "golden_case"
+
+    def test_golden_data(self):
+        assert classify_file("testdata/golden/causal-lm/gpt2_generation.json") == "golden_data"
 
     def test_readme(self):
         assert classify_file("README.md") == "other"
@@ -176,6 +183,40 @@ class TestImportGraph:
 
 
 class TestDetectAffectedModels:
+    def test_golden_case_does_not_expand_model_scope(self):
+        changed = ["testdata/cases/causal-lm/smollm-135m-gguf-f16.yaml"]
+        assert detect_affected_models(changed) == {"affected": [], "run_all": False}
+        assert _detect_changed_golden_cases(changed) == (
+            ["smollm-135m-gguf-f16"],
+            ["smollm-135m-gguf-f16"],
+            False,
+        )
+
+    def test_golden_cases_are_split_by_level(self):
+        assert _detect_changed_golden_cases(
+            ["testdata/cases/encoder/camembert-base.yaml"]
+        ) == (["camembert-base"], [], False)
+        assert _detect_changed_golden_cases(
+            ["testdata/cases/causal-lm/muse-glimmer-30b-text.yaml"]
+        ) == ([], ["muse-glimmer-30b-text"], False)
+
+    def test_golden_json_selects_every_workflow_that_consumes_it(self):
+        assert _detect_changed_golden_cases(
+            ["testdata/golden/causal-lm/smollm-135m-gguf-f16.json"]
+        ) == (
+            ["smollm-135m-gguf-f16"],
+            ["smollm-135m-gguf-f16"],
+            False,
+        )
+        assert _detect_changed_golden_cases(
+            ["testdata/golden/causal-lm/smollm-135m-gguf-f16_generation.json"]
+        ) == ([], ["smollm-135m-gguf-f16"], False)
+
+    def test_deleted_golden_data_fails_closed(self):
+        changed = ["testdata/golden/causal-lm/deleted_generation.json"]
+        assert _detect_changed_golden_cases(changed) == ([], [], True)
+        assert detect_affected_models(changed) == {"affected": [], "run_all": True}
+
     def test_component_change_traces_affected_models(self):
         """A component change traces through the import graph to find affected models."""
         result = detect_affected_models(["src/mobius/components/_attention.py"])
@@ -576,8 +617,37 @@ class TestCLI:
         assert result.returncode == 0
         lines = result.stdout.strip().split("\n")
         assert any(line.startswith("affected=") for line in lines)
+        assert any(line.startswith("golden_l4_cases=") for line in lines)
+        assert any(line.startswith("golden_l5_cases=") for line in lines)
         assert any(line.startswith("run_all=") for line in lines)
         assert any(line.startswith("has_affected=") for line in lines)
+        assert any(line.startswith("has_l4_affected=") for line in lines)
+        assert any(line.startswith("has_l5_affected=") for line in lines)
+
+    def test_github_output_activates_only_the_changed_level(self):
+        def outputs(path: str) -> dict[str, str]:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(_SCRIPTS_DIR / "detect_affected_models.py"),
+                    "--changed-files",
+                    path,
+                    "--output-format",
+                    "github",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode == 0
+            return dict(line.split("=", 1) for line in result.stdout.strip().splitlines())
+
+        l4 = outputs("testdata/cases/encoder/camembert-base.yaml")
+        assert l4["has_l4_affected"] == "true"
+        assert l4["has_l5_affected"] == "false"
+
+        l5 = outputs("testdata/cases/causal-lm/muse-glimmer-30b-text.yaml")
+        assert l5["has_l4_affected"] == "false"
+        assert l5["has_l5_affected"] == "true"
 
     def test_stdin_mode(self):
         result = subprocess.run(

--- a/scripts/generate_golden.py
+++ b/scripts/generate_golden.py
@@ -267,7 +267,10 @@ def _generate_causal_lm(case: TestCase, json_path: Path, device: str) -> None:
         )
     else:
         model, tokenizer = load_torch_model(
-            case.model_id, device=device, trust_remote_code=case.trust_remote_code
+            case.model_id,
+            device=device,
+            trust_remote_code=case.trust_remote_code,
+            revision=case.revision,
         )
 
     encoded = tokenizer(case.prompts[0], return_tensors="np", padding=False)
@@ -318,6 +321,14 @@ def _generate_causal_lm(case: TestCase, json_path: Path, device: str) -> None:
                 )
         generated_ids = gen_output[0, seq_len:].cpu().numpy()
 
+    provenance = (
+        {
+            "reference": {"repository": case.model_id, "revision": case.revision},
+            "gguf": case.gguf_source,
+        }
+        if case.gguf_source is not None
+        else None
+    )
     save_golden_ref(
         json_path,
         top1_id=golden["top1_id"],
@@ -326,6 +337,7 @@ def _generate_causal_lm(case: TestCase, json_path: Path, device: str) -> None:
         top10_logits=golden["top10_logits"],
         logits_summary=golden["logits_summary"],
         input_ids=input_ids,
+        provenance=provenance,
     )
 
     # Save a separate *_generation.json marker for L5 dashboard detection.
@@ -338,6 +350,7 @@ def _generate_causal_lm(case: TestCase, json_path: Path, device: str) -> None:
             prompt=case.prompts[0],
             generated_tokens=generated_ids.tolist(),
             generated_text=generated_text,
+            provenance=provenance,
         )
 
 

--- a/src/mobius/_testing/golden.py
+++ b/src/mobius/_testing/golden.py
@@ -132,6 +132,13 @@ class GoldenTestCase:
     (DFlash, MTP) that share a base checkpoint whose ``architectures`` field
     would otherwise auto-route to the base model.  ``None`` = auto-detect."""
 
+    gguf_source: dict[str, object] | None
+    """Pinned GGUF artifact used instead of HuggingFace weights.
+
+    ``model_id`` and ``revision`` still identify the independent HuggingFace
+    tokenizer/reference checkpoint used to create the golden data.
+    """
+
     yaml_path: Path
     """Absolute path to the source YAML file."""
 
@@ -259,6 +266,7 @@ def load_test_case(yaml_path: Path) -> GoldenTestCase:
         ci_skip_reason=data.get("ci_skip_reason"),
         min_token_match_ratio=data.get("min_token_match_ratio"),
         architecture=data.get("architecture"),
+        gguf_source=data.get("gguf"),
         yaml_path=yaml_path,
     )
 
@@ -320,6 +328,7 @@ def save_golden_ref(
     input_ids: np.ndarray | list[int],
     component_norms: dict[str, float] | None = None,
     component_shapes: dict[str, tuple[int, ...]] | None = None,
+    provenance: dict[str, object] | None = None,
 ) -> None:
     """Save golden reference data to a ``.json`` file (L4 only).
 
@@ -345,6 +354,7 @@ def save_golden_ref(
         input_ids: Tokenized input array.
         component_norms: L2 norms for multi-model component outputs.
         component_shapes: Output shapes for multi-model components.
+        provenance: Immutable source identities used to generate the golden.
     """
     json_path = Path(json_path)
     json_path.parent.mkdir(parents=True, exist_ok=True)
@@ -379,6 +389,8 @@ def save_golden_ref(
         data["component_shapes"] = {
             k: [int(x) for x in v] for k, v in component_shapes.items()
         }
+    if provenance:
+        data["provenance"] = provenance
 
     with open(json_path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
@@ -392,6 +404,7 @@ def save_generation_json(
     prompt: str,
     generated_tokens: list[int],
     generated_text: str | None = None,
+    provenance: dict[str, object] | None = None,
 ) -> None:
     """Save a ``*_generation.json`` L5 marker file alongside the main golden.
 
@@ -405,6 +418,7 @@ def save_generation_json(
         generated_tokens: Token IDs produced by greedy generation (prompt excluded).
         generated_text: Decoded string of ``generated_tokens``. ``None`` if
             the tokenizer was not available at generation time.
+        provenance: Immutable source identities used to generate the golden.
     """
     json_path = Path(json_path)
     json_path.parent.mkdir(parents=True, exist_ok=True)
@@ -416,6 +430,8 @@ def save_generation_json(
     }
     if generated_text is not None:
         data["generated_text"] = generated_text
+    if provenance:
+        data["provenance"] = provenance
 
     with open(json_path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)

--- a/src/mobius/_testing/torch_reference.py
+++ b/src/mobius/_testing/torch_reference.py
@@ -113,7 +113,9 @@ def _install_dynamic_cache_legacy_shims() -> None:
         transformers.DynamicCache.get_usable_length = _get_usable_length  # type: ignore[method-assign]
 
 
-def _fix_nemotron_h_init_weights(model: torch.nn.Module, model_id: str) -> None:
+def _fix_nemotron_h_init_weights(
+    model: torch.nn.Module, model_id: str, revision: str | None = None
+) -> None:
     """Restore Mamba2 params from checkpoint after HF clobbers them.
 
     The NemotronH remote-code ``_init_weights`` re-initialises several
@@ -145,7 +147,7 @@ def _fix_nemotron_h_init_weights(model: torch.nn.Module, model_id: str) -> None:
     # Resolve the exact snapshot directory used by HF for this model,
     # avoiding lexicographic guessing across multiple cached revisions.
     try:
-        snapshot = snapshot_download(model_id, local_files_only=True)
+        snapshot = snapshot_download(model_id, revision=revision, local_files_only=True)
     except Exception:
         logger.warning(
             "NemotronH init_weights fix: could not resolve snapshot for %s",
@@ -198,6 +200,7 @@ def load_torch_model(
     dtype: torch.dtype = torch.float32,
     device: str = "cpu",
     trust_remote_code: bool = True,
+    revision: str | None = None,
 ):
     """Load a HuggingFace causal LM model for reference inference.
 
@@ -211,6 +214,8 @@ def load_torch_model(
             natively supported by the installed transformers, so the
             transformers-5.x-compatible implementation is used instead of an
             older bundled ``modeling_*.py`` that relies on removed cache APIs.
+        revision: Immutable HuggingFace revision used for the tokenizer,
+            config, weights, and any Nemotron-H weight repair.
 
     Returns:
         Tuple of (model, tokenizer).
@@ -220,14 +225,14 @@ def load_torch_model(
     _install_dynamic_cache_legacy_shims()
 
     tokenizer = transformers.AutoTokenizer.from_pretrained(
-        model_id, trust_remote_code=trust_remote_code
+        model_id, revision=revision, trust_remote_code=trust_remote_code
     )
 
     # NemotronH: disable rescale_prenorm_residual before loading to
     # prevent _init_weights from corrupting out_proj.weight with
     # random kaiming_uniform_ initialization after checkpoint loading.
     config = transformers.AutoConfig.from_pretrained(
-        model_id, trust_remote_code=trust_remote_code
+        model_id, revision=revision, trust_remote_code=trust_remote_code
     )
     if getattr(config, "model_type", None) == "nemotron_h":
         config.rescale_prenorm_residual = False
@@ -237,9 +242,10 @@ def load_torch_model(
         config=config,
         dtype=dtype,
         device_map=device,
+        revision=revision,
         trust_remote_code=trust_remote_code,
     )
-    _fix_nemotron_h_init_weights(model, model_id)
+    _fix_nemotron_h_init_weights(model, model_id, revision)
     model.eval()
 
     if tokenizer.pad_token is None:

--- a/src/mobius/_testing/torch_reference_test.py
+++ b/src/mobius/_testing/torch_reference_test.py
@@ -1,0 +1,66 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+import transformers
+
+from mobius._testing import torch_reference
+
+
+def test_load_torch_model_pins_every_huggingface_resource() -> None:
+    revision = "a" * 40
+    tokenizer = SimpleNamespace(pad_token="<pad>", eos_token="</s>")
+    config = SimpleNamespace(model_type="llama")
+    model = mock.Mock()
+
+    with (
+        mock.patch.object(torch_reference, "_install_dynamic_cache_legacy_shims"),
+        mock.patch.object(
+            transformers.AutoTokenizer,
+            "from_pretrained",
+            return_value=tokenizer,
+        ) as load_tokenizer,
+        mock.patch.object(
+            transformers.AutoConfig,
+            "from_pretrained",
+            return_value=config,
+        ) as load_config,
+        mock.patch.object(
+            transformers.AutoModelForCausalLM,
+            "from_pretrained",
+            return_value=model,
+        ) as load_model,
+        mock.patch.object(torch_reference, "_fix_nemotron_h_init_weights") as fix_weights,
+    ):
+        loaded_model, loaded_tokenizer = torch_reference.load_torch_model(
+            "owner/model",
+            revision=revision,
+        )
+
+    assert loaded_model is model
+    assert loaded_tokenizer is tokenizer
+    load_tokenizer.assert_called_once_with(
+        "owner/model",
+        revision=revision,
+        trust_remote_code=True,
+    )
+    load_config.assert_called_once_with(
+        "owner/model",
+        revision=revision,
+        trust_remote_code=True,
+    )
+    load_model.assert_called_once_with(
+        "owner/model",
+        config=config,
+        dtype=torch.float32,
+        device_map="cpu",
+        revision=revision,
+        trust_remote_code=True,
+    )
+    fix_weights.assert_called_once_with(model, "owner/model", revision)
+    model.eval.assert_called_once_with()

--- a/testdata/cases/causal-lm/smollm-135m-gguf-f16.yaml
+++ b/testdata/cases/causal-lm/smollm-135m-gguf-f16.yaml
@@ -1,0 +1,33 @@
+model_id: "HuggingFaceTB/SmolLM-135M"
+model_type: "llama"
+revision: "1d461723eec654e65efdc40cf49301c89c0c92f4"
+task_type: "text-generation"
+dtype: "float32"
+
+gguf:
+  repository: "neopolita/smollm-135m-gguf"
+  revision: "22cca988936eafe92908e7558907c3964e10bba7"
+  filename: "ggml-model-f16.gguf"
+  size: 270885504
+  lfs_sha256: "ec8c775c16944a7e4b5251f97b3f848500dcc3e701b0d492ce9055cea42138a2"
+  tensor_count: 272
+  tensor_qtypes:
+    F16: 211
+    F32: 61
+  execution_provider: "cpu"
+  config_sha256: "134f95e6a635d978737d712ed61ac8959acebdf080eafae838cf97f12c416430"
+  preserve_quantization: false
+  keep_quantized: true
+
+inputs:
+  prompts:
+    - "Once upon a time,"
+
+level: "L4+L5"
+
+generation:
+  max_new_tokens: 20
+  do_sample: false
+  exact_match: true
+
+notes: "Pinned F16 GGUF import; independent HuggingFace reference and tokenizer use the pinned top-level revision."

--- a/testdata/cases/causal-lm/smollm2-135m-gguf-f16.yaml
+++ b/testdata/cases/causal-lm/smollm2-135m-gguf-f16.yaml
@@ -1,0 +1,33 @@
+model_id: "HuggingFaceTB/SmolLM2-135M-Instruct"
+model_type: "llama"
+revision: "12fd25f77366fa6b3b4b768ec3050bf629380bac"
+task_type: "text-generation"
+dtype: "float32"
+
+gguf:
+  repository: "unsloth/SmolLM2-135M-Instruct-GGUF"
+  revision: "9e6855bc4be717fca1ef21360a1db4b29d5c559a"
+  filename: "SmolLM2-135M-Instruct-F16.gguf"
+  size: 270885952
+  lfs_sha256: "5157ca60744d21631818364854ac8e4452e1b8022d2ab4c8a2f9cda2344afb30"
+  tensor_count: 272
+  tensor_qtypes:
+    F16: 211
+    F32: 61
+  execution_provider: "cpu"
+  config_sha256: "c62123baf4e95656cdc9f5b798c14319bbaafec594526c462b10555f561969f9"
+  preserve_quantization: false
+  keep_quantized: true
+
+inputs:
+  prompts:
+    - "Here is my poem:"
+
+level: "L4+L5"
+
+generation:
+  max_new_tokens: 20
+  do_sample: false
+  exact_match: true
+
+notes: "Pinned F16 GGUF import; independent HuggingFace reference and tokenizer use the pinned top-level revision."

--- a/testdata/cases/schema.json
+++ b/testdata/cases/schema.json
@@ -75,6 +75,88 @@
       ],
       "description": "Weight and activation dtype."
     },
+    "gguf": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository",
+        "revision",
+        "filename",
+        "size",
+        "lfs_sha256",
+        "tensor_count",
+        "tensor_qtypes",
+        "execution_provider",
+        "config_sha256",
+        "preserve_quantization"
+      ],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1,
+          "description": "HuggingFace repository containing the GGUF artifact."
+        },
+        "revision": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$",
+          "description": "Immutable GGUF repository revision."
+        },
+        "filename": {
+          "type": "string",
+          "pattern": "\\.gguf$",
+          "description": "Exact Hub-relative GGUF filename."
+        },
+        "size": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Expected GGUF byte size."
+        },
+        "lfs_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$",
+          "description": "Expected LFS object SHA-256."
+        },
+        "tensor_count": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Expected number of GGUF tensors."
+        },
+        "tensor_qtypes": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "description": "Expected GGUF tensor census keyed by qtype name."
+        },
+        "execution_provider": {
+          "type": "string",
+          "enum": [
+            "cpu",
+            "cuda",
+            "dml",
+            "default"
+          ],
+          "description": "Exact execution provider used when constructing the evidenced route."
+        },
+        "config_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$",
+          "description": "Expected canonical hash of the config extracted from GGUF metadata."
+        },
+        "preserve_quantization": {
+          "type": "boolean",
+          "description": "Expected import-route result after considering the source qtypes."
+        },
+        "keep_quantized": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to preserve supported GGUF quantization."
+        }
+      },
+      "description": "Pinned GGUF import source. The top-level model_id remains the independent HuggingFace reference."
+    },
     "level": {
       "type": "string",
       "enum": [

--- a/testdata/golden/causal-lm/smollm-135m-gguf-f16.json
+++ b/testdata/golden/causal-lm/smollm-135m-gguf-f16.json
@@ -1,0 +1,63 @@
+{
+  "top1_id": 665,
+  "top2_id": 281,
+  "top10_ids": [
+    665,
+    281,
+    253,
+    2276,
+    827,
+    981,
+    986,
+    335,
+    2973,
+    1296
+  ],
+  "top10_logits": [
+    "0x1.86b3140000000p+3",
+    "0x1.81ea560000000p+3",
+    "0x1.40f8320000000p+3",
+    "0x1.1c6d740000000p+3",
+    "0x1.1c3ee40000000p+3",
+    "0x1.0907c60000000p+3",
+    "0x1.069c440000000p+3",
+    "0x1.f31e640000000p+2",
+    "0x1.e567460000000p+2",
+    "0x1.ba6bcc0000000p+2"
+  ],
+  "logits_summary": [
+    "0x1.86b3140000000p+3",
+    "-0x1.3be0520000000p+4",
+    "-0x1.a1d25df16feabp+2",
+    "0x1.984a8941db932p+1"
+  ],
+  "input_ids": [
+    6403,
+    1980,
+    253,
+    655,
+    28
+  ],
+  "provenance": {
+    "reference": {
+      "repository": "HuggingFaceTB/SmolLM-135M",
+      "revision": "1d461723eec654e65efdc40cf49301c89c0c92f4"
+    },
+    "gguf": {
+      "repository": "neopolita/smollm-135m-gguf",
+      "revision": "22cca988936eafe92908e7558907c3964e10bba7",
+      "filename": "ggml-model-f16.gguf",
+      "size": 270885504,
+      "lfs_sha256": "ec8c775c16944a7e4b5251f97b3f848500dcc3e701b0d492ce9055cea42138a2",
+      "tensor_count": 272,
+      "tensor_qtypes": {
+        "F16": 211,
+        "F32": 61
+      },
+      "execution_provider": "cpu",
+      "config_sha256": "134f95e6a635d978737d712ed61ac8959acebdf080eafae838cf97f12c416430",
+      "preserve_quantization": false,
+      "keep_quantized": true
+    }
+  }
+}

--- a/testdata/golden/causal-lm/smollm-135m-gguf-f16_generation.json
+++ b/testdata/golden/causal-lm/smollm-135m-gguf-f16_generation.json
@@ -1,0 +1,49 @@
+{
+  "model_id": "HuggingFaceTB/SmolLM-135M",
+  "prompt": "Once upon a time,",
+  "generated_tokens": [
+    665,
+    436,
+    253,
+    7436,
+    1838,
+    8180,
+    3365,
+    14176,
+    30,
+    2306,
+    5732,
+    3415,
+    874,
+    18064,
+    284,
+    4464,
+    351,
+    874,
+    2428,
+    30
+  ],
+  "generated_text": " there was a curious little girl named Lily. She loved exploring her backyard and playing with her friends.",
+  "provenance": {
+    "reference": {
+      "repository": "HuggingFaceTB/SmolLM-135M",
+      "revision": "1d461723eec654e65efdc40cf49301c89c0c92f4"
+    },
+    "gguf": {
+      "repository": "neopolita/smollm-135m-gguf",
+      "revision": "22cca988936eafe92908e7558907c3964e10bba7",
+      "filename": "ggml-model-f16.gguf",
+      "size": 270885504,
+      "lfs_sha256": "ec8c775c16944a7e4b5251f97b3f848500dcc3e701b0d492ce9055cea42138a2",
+      "tensor_count": 272,
+      "tensor_qtypes": {
+        "F16": 211,
+        "F32": 61
+      },
+      "execution_provider": "cpu",
+      "config_sha256": "134f95e6a635d978737d712ed61ac8959acebdf080eafae838cf97f12c416430",
+      "preserve_quantization": false,
+      "keep_quantized": true
+    }
+  }
+}

--- a/testdata/golden/causal-lm/smollm2-135m-gguf-f16.json
+++ b/testdata/golden/causal-lm/smollm2-135m-gguf-f16.json
@@ -1,0 +1,63 @@
+{
+  "top1_id": 198,
+  "top2_id": 1116,
+  "top10_ids": [
+    198,
+    1116,
+    476,
+    3717,
+    11181,
+    3805,
+    39892,
+    1004,
+    216,
+    472
+  ],
+  "top10_logits": [
+    "0x1.4353c40000000p+4",
+    "0x1.1d22ce0000000p+4",
+    "0x1.02e7000000000p+4",
+    "0x1.feca880000000p+3",
+    "0x1.e76e560000000p+3",
+    "0x1.d72a2e0000000p+3",
+    "0x1.d3545e0000000p+3",
+    "0x1.d33bd40000000p+3",
+    "0x1.d0dd6c0000000p+3",
+    "0x1.c5bda00000000p+3"
+  ],
+  "logits_summary": [
+    "0x1.4353c40000000p+4",
+    "-0x1.5917ae0000000p+3",
+    "0x1.089493e7a6f7dp+0",
+    "0x1.5407af8e34ca9p+1"
+  ],
+  "input_ids": [
+    4590,
+    314,
+    957,
+    8216,
+    42
+  ],
+  "provenance": {
+    "reference": {
+      "repository": "HuggingFaceTB/SmolLM2-135M-Instruct",
+      "revision": "12fd25f77366fa6b3b4b768ec3050bf629380bac"
+    },
+    "gguf": {
+      "repository": "unsloth/SmolLM2-135M-Instruct-GGUF",
+      "revision": "9e6855bc4be717fca1ef21360a1db4b29d5c559a",
+      "filename": "SmolLM2-135M-Instruct-F16.gguf",
+      "size": 270885952,
+      "lfs_sha256": "5157ca60744d21631818364854ac8e4452e1b8022d2ab4c8a2f9cda2344afb30",
+      "tensor_count": 272,
+      "tensor_qtypes": {
+        "F16": 211,
+        "F32": 61
+      },
+      "execution_provider": "cpu",
+      "config_sha256": "c62123baf4e95656cdc9f5b798c14319bbaafec594526c462b10555f561969f9",
+      "preserve_quantization": false,
+      "keep_quantized": true
+    }
+  }
+}

--- a/testdata/golden/causal-lm/smollm2-135m-gguf-f16_generation.json
+++ b/testdata/golden/causal-lm/smollm2-135m-gguf-f16_generation.json
@@ -1,0 +1,49 @@
+{
+  "model_id": "HuggingFaceTB/SmolLM2-135M-Instruct",
+  "prompt": "Here is my poem:",
+  "generated_tokens": [
+    198,
+    198,
+    18,
+    504,
+    2388,
+    13685,
+    281,
+    260,
+    6376,
+    28,
+    198,
+    49,
+    3091,
+    10286,
+    28,
+    198,
+    1589,
+    506,
+    253,
+    9154
+  ],
+  "generated_text": "\n\n\"The sun rises in the sky,\nA warm embrace,\nIt's a gentle",
+  "provenance": {
+    "reference": {
+      "repository": "HuggingFaceTB/SmolLM2-135M-Instruct",
+      "revision": "12fd25f77366fa6b3b4b768ec3050bf629380bac"
+    },
+    "gguf": {
+      "repository": "unsloth/SmolLM2-135M-Instruct-GGUF",
+      "revision": "9e6855bc4be717fca1ef21360a1db4b29d5c559a",
+      "filename": "SmolLM2-135M-Instruct-F16.gguf",
+      "size": 270885952,
+      "lfs_sha256": "5157ca60744d21631818364854ac8e4452e1b8022d2ab4c8a2f9cda2344afb30",
+      "tensor_count": 272,
+      "tensor_qtypes": {
+        "F16": 211,
+        "F32": 61
+      },
+      "execution_provider": "cpu",
+      "config_sha256": "c62123baf4e95656cdc9f5b798c14319bbaafec594526c462b10555f561969f9",
+      "preserve_quantization": false,
+      "keep_quantized": true
+    }
+  }
+}

--- a/tests/e2e_golden_test.py
+++ b/tests/e2e_golden_test.py
@@ -28,10 +28,12 @@ import ast
 import contextlib
 import dataclasses
 import functools
+import hashlib
 import json
 import os
 import shutil
 import warnings
+from collections import Counter
 from pathlib import Path
 from unittest import mock
 
@@ -428,6 +430,23 @@ _L5_ONLY_XFAIL_REASONS: dict[str, str] = {
 }
 
 
+@functools.cache
+def _selected_golden_case_ids() -> set[str] | None:
+    """Return exact case IDs requested by CI, rejecting malformed selectors."""
+    raw = os.environ.get("MOBIUS_GOLDEN_CASES")
+    if raw is None:
+        return None
+    try:
+        selected = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise pytest.UsageError("MOBIUS_GOLDEN_CASES must be a JSON array") from error
+    if not isinstance(selected, list) or not all(
+        isinstance(case_id, str) and case_id for case_id in selected
+    ):
+        raise pytest.UsageError("MOBIUS_GOLDEN_CASES must be a JSON array of case IDs")
+    return set(selected)
+
+
 def _discover_cases(
     level: str,
     xfails: dict[str, str] | None = None,
@@ -439,6 +458,14 @@ def _discover_cases(
     rather than failing at run time.
     """
     cases = discover_test_cases(level=level)
+    selected = _selected_golden_case_ids()
+    if selected is not None:
+        known_case_ids = {case.case_id for case in discover_test_cases()}
+        if unknown := selected - known_case_ids:
+            raise pytest.UsageError(
+                f"Unknown MOBIUS_GOLDEN_CASES selectors: {sorted(unknown)}"
+            )
+        cases = [case for case in cases if case.case_id in selected]
     params: list[pytest.ParameterSet] = []
     for case in cases:
         marks: list[pytest.MarkDecorator] = []
@@ -493,6 +520,51 @@ def test_huggingface_artifact_loads_are_revision_pinned():
 
 def _build_model_package(case: GoldenTestCase) -> ModelPackage:
     """Build an ONNX ModelPackage with real weights from HuggingFace."""
+    if case.gguf_source is not None:
+        from huggingface_hub import hf_hub_download
+
+        from mobius.integrations.gguf import build_from_gguf
+        from mobius.integrations.gguf._reader import GGUFModel
+
+        source = case.gguf_source
+        gguf_path = Path(
+            hf_hub_download(
+                repo_id=str(source["repository"]),
+                revision=str(source["revision"]),
+                filename=str(source["filename"]),
+            )
+        )
+        assert gguf_path.stat().st_size == source["size"], (
+            f"GGUF size changed for {source['repository']}:{source['filename']}"
+        )
+        digest = hashlib.sha256()
+        with gguf_path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+        assert digest.hexdigest() == source["lfs_sha256"], (
+            f"GGUF SHA-256 changed for {source['repository']}:{source['filename']}"
+        )
+        artifact = GGUFModel(gguf_path)
+        qtypes = Counter(qtype.name for _, _, qtype, _ in artifact.tensor_items_raw())
+        assert len(artifact._reader.tensors) == source["tensor_count"]
+        assert dict(sorted(qtypes.items())) == source["tensor_qtypes"]
+        dtype = {
+            "float32": "f32",
+            "float16": "f16",
+            "bfloat16": "bf16",
+        }[case.dtype]
+        package = build_from_gguf(
+            gguf_path,
+            dtype=dtype,
+            keep_quantized=bool(source.get("keep_quantized", True)),
+            execution_provider=str(source["execution_provider"]),
+        )
+        route = json.loads(package.gguf_import_route)
+        assert route["execution_provider"] == source["execution_provider"]
+        assert route["config_sha256"] == source["config_sha256"]
+        assert route["preserve_quantization"] == source["preserve_quantization"]
+        return package
+
     module_class = None
     task = None
     if case.architecture:
@@ -629,6 +701,16 @@ def _prepare_image_to_text_inputs(
     )
     pixel_values = processed["pixel_values"].float().cpu().numpy()
     return pixel_values, processed["input_ids"].cpu().numpy().astype(np.int64)
+
+
+def _assert_gguf_golden_provenance(case: GoldenTestCase, golden_path: Path) -> None:
+    if case.gguf_source is None:
+        return
+    data = json.loads(golden_path.read_text(encoding="utf-8"))
+    assert data.get("provenance") == {
+        "reference": {"repository": case.model_id, "revision": case.revision},
+        "gguf": case.gguf_source,
+    }, f"Golden provenance does not match the pinned GGUF case: {golden_path}"
 
 
 def _run_image_to_text_prefill(
@@ -2115,6 +2197,7 @@ class TestL4CheckpointVerified:
         golden = load_golden_ref(golden_path)
         if golden is None:
             pytest.skip(f"Golden file missing: {golden_path}")
+        _assert_gguf_golden_provenance(case, golden_path)
 
         tolerances = load_tolerances("L4", case.dtype)
         pkg = _build_model_package(case)
@@ -2932,9 +3015,11 @@ class TestL5GenerationE2E:
         golden = load_golden_ref(golden_path)
         if golden is None:
             pytest.skip(f"Golden file missing: {golden_path}")
+        _assert_gguf_golden_provenance(case, golden_path)
 
         # L5 generation golden is stored in the separate *_generation.json file.
         gen_path = generation_json_path_for_case(case)
+        _assert_gguf_golden_provenance(case, gen_path)
         expected_token_ids = load_generation_golden(case)
         if expected_token_ids is None:
             pytest.skip(f"Generation golden file missing: {gen_path}")

--- a/tests/gguf_small_model_runtime_integration_test.py
+++ b/tests/gguf_small_model_runtime_integration_test.py
@@ -1,0 +1,307 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Real-artifact GGUF parity for the smallest reproducible checkpoints.
+
+The pinned SmolLM2 Q4_K_M companion (105,454,144 bytes, LFS SHA-256
+ed5fa30c487b282ec156c29062f1222e5c20875a944ac98289dbd242e947f747) is intentionally
+not an L4/L5 case: its preserved MatMulNBits route diverges from the same artifact
+under llama.cpp, while Mobius's dequantized route matches llama.cpp. Comparing that
+quantized artifact to the unquantized HuggingFace checkpoint would not establish
+same-weight provenance.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+import onnxruntime as ort
+import pytest
+import torch
+from huggingface_hub import hf_hub_download
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from mobius import ModelPackage
+from mobius.__main__ import main
+from mobius.integrations.gguf._reader import GGUFModel
+
+
+@dataclass(frozen=True)
+class _RuntimeCase:
+    name: str
+    gguf_repository: str
+    gguf_revision: str
+    gguf_filename: str
+    gguf_size: int
+    gguf_sha256: str
+    reference_repository: str
+    reference_revision: str
+    prompt: str
+    tensor_qtypes: dict[str, int]
+    config_sha256: str
+    generated_tokens: tuple[int, ...]
+
+
+_CASES = (
+    _RuntimeCase(
+        name="smollm-135m-f16",
+        gguf_repository="neopolita/smollm-135m-gguf",
+        gguf_revision="22cca988936eafe92908e7558907c3964e10bba7",
+        gguf_filename="ggml-model-f16.gguf",
+        gguf_size=270_885_504,
+        gguf_sha256="ec8c775c16944a7e4b5251f97b3f848500dcc3e701b0d492ce9055cea42138a2",
+        reference_repository="HuggingFaceTB/SmolLM-135M",
+        reference_revision="1d461723eec654e65efdc40cf49301c89c0c92f4",
+        prompt="Once upon a time,",
+        tensor_qtypes={"F16": 211, "F32": 61},
+        config_sha256="134f95e6a635d978737d712ed61ac8959acebdf080eafae838cf97f12c416430",
+        generated_tokens=(
+            665,
+            436,
+            253,
+            7436,
+            1838,
+            8180,
+            3365,
+            14176,
+            30,
+            2306,
+            5732,
+            3415,
+            874,
+            18064,
+            284,
+            4464,
+            351,
+            874,
+            2428,
+            30,
+        ),
+    ),
+    _RuntimeCase(
+        name="smollm2-135m-instruct-f16",
+        gguf_repository="unsloth/SmolLM2-135M-Instruct-GGUF",
+        gguf_revision="9e6855bc4be717fca1ef21360a1db4b29d5c559a",
+        gguf_filename="SmolLM2-135M-Instruct-F16.gguf",
+        gguf_size=270_885_952,
+        gguf_sha256="5157ca60744d21631818364854ac8e4452e1b8022d2ab4c8a2f9cda2344afb30",
+        reference_repository="HuggingFaceTB/SmolLM2-135M-Instruct",
+        reference_revision="12fd25f77366fa6b3b4b768ec3050bf629380bac",
+        prompt="Here is my poem:",
+        tensor_qtypes={"F16": 211, "F32": 61},
+        config_sha256="c62123baf4e95656cdc9f5b798c14319bbaafec594526c462b10555f561969f9",
+        generated_tokens=(
+            198,
+            198,
+            18,
+            504,
+            2388,
+            13685,
+            281,
+            260,
+            6376,
+            28,
+            198,
+            49,
+            3091,
+            10286,
+            28,
+            198,
+            1589,
+            506,
+            253,
+            9154,
+        ),
+    ),
+)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _empty_cache(session: ort.InferenceSession) -> dict[str, np.ndarray]:
+    return {
+        value.name: np.empty([1, value.shape[1], 0, value.shape[3]], dtype=np.float32)
+        for value in session.get_inputs()
+        if value.name.endswith((".key", ".value"))
+    }
+
+
+def _run_ort(
+    session: ort.InferenceSession,
+    input_ids: np.ndarray,
+    cache: dict[str, np.ndarray],
+    past_length: int,
+) -> dict[str, np.ndarray]:
+    sequence_length = input_ids.shape[1]
+    candidates = {
+        "input_ids": input_ids,
+        "attention_mask": np.ones((1, past_length + sequence_length), dtype=np.int64),
+        "position_ids": np.arange(past_length, past_length + sequence_length, dtype=np.int64)[
+            None
+        ],
+        **cache,
+    }
+    input_names = {value.name for value in session.get_inputs()}
+    output_names = [value.name for value in session.get_outputs()]
+    feeds = {name: value for name, value in candidates.items() if name in input_names}
+    return dict(zip(output_names, session.run(output_names, feeds), strict=True))
+
+
+def _next_cache(outputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+    return {
+        name.replace("present.", "past_key_values."): value
+        for name, value in outputs.items()
+        if name.startswith("present.")
+    }
+
+
+@pytest.mark.integration
+@pytest.mark.integration_fast
+@pytest.mark.parametrize("case", _CASES, ids=lambda case: case.name)
+def test_small_f16_gguf_cli_full_logit_and_generation_parity(
+    case: _RuntimeCase, tmp_path: Path
+) -> None:
+    """Pinned GGUFs survive CLI save/reload and match HF through cached decode."""
+    gguf_path = Path(
+        hf_hub_download(
+            repo_id=case.gguf_repository,
+            revision=case.gguf_revision,
+            filename=case.gguf_filename,
+        )
+    )
+    assert gguf_path.stat().st_size == case.gguf_size
+    assert _sha256(gguf_path) == case.gguf_sha256
+    gguf_model = GGUFModel(gguf_path)
+    qtypes = Counter(qtype.name for _, _, qtype, _ in gguf_model.tensor_items_raw())
+    assert dict(sorted(qtypes.items())) == case.tensor_qtypes
+
+    output_dir = tmp_path / case.name
+    captured: list[ModelPackage] = []
+    original_save = ModelPackage.save
+
+    def capture_save(package: ModelPackage, *args: object, **kwargs: object) -> None:
+        captured.append(package)
+        original_save(package, *args, **kwargs)
+
+    with mock.patch.object(ModelPackage, "save", capture_save):
+        main(
+            [
+                "build-gguf",
+                str(gguf_path),
+                "--output",
+                str(output_dir),
+                "--dtype",
+                "f32",
+                "--execution-provider",
+                "cpu",
+            ]
+        )
+
+    assert len(captured) == 1
+    route = json.loads(captured[0].gguf_import_route)
+    assert route == {
+        "architecture": "llama",
+        "config_sha256": case.config_sha256,
+        "execution_provider": "cpu",
+        "model_type": "llama",
+        "module_type": "llama",
+        "preserve_quantization": False,
+        "registry_import": {
+            "config_key_map": None,
+            "config_postprocessor": None,
+            "llama_qk_permute": True,
+            "offset_norm": False,
+            "required_metadata": [],
+            "rope_interleave": False,
+            "tensor_processor": "llama",
+            "v_head_reorder": False,
+            "vlm_builder": None,
+        },
+        "route_schema": 1,
+        "static_cache": False,
+        "task": {"class": "builtins.str", "state": "text-generation"},
+        "tensor_map_recipe": ["llama"],
+    }
+    package = ModelPackage.load(output_dir)
+    assert tuple(package) == ("model",)
+    assert sorted(path.name for path in output_dir.iterdir()) == [
+        "model.onnx",
+        "model.onnx.data",
+    ]
+    session = ort.InferenceSession(
+        str(output_dir / "model.onnx"), providers=["CPUExecutionProvider"]
+    )
+    assert {value.name for value in session.get_inputs()} >= {
+        "input_ids",
+        "attention_mask",
+    }
+    assert {value.name for value in session.get_outputs()} >= {"logits"}
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        case.reference_repository, revision=case.reference_revision
+    )
+    reference = AutoModelForCausalLM.from_pretrained(
+        case.reference_repository,
+        revision=case.reference_revision,
+        dtype=torch.float32,
+    ).eval()
+    prompt_ids = tokenizer(case.prompt, return_tensors="pt").input_ids
+    with torch.no_grad():
+        reference_output = reference(prompt_ids, use_cache=True)
+
+    input_ids = prompt_ids.numpy()
+    ort_output = _run_ort(session, input_ids, _empty_cache(session), 0)
+    ort_logits = ort_output["logits"]
+    reference_logits = reference_output.logits.numpy()
+    np.testing.assert_allclose(ort_logits, reference_logits, rtol=1e-4, atol=2e-4)
+
+    cache = _next_cache(ort_output)
+    reference_cache = reference_output.past_key_values
+    generated: list[int] = []
+    for step in range(len(case.generated_tokens)):
+        token = int(ort_logits[0, -1].argmax())
+        generated.append(token)
+        token_ids = np.array([[token]], dtype=np.int64)
+        ort_output = _run_ort(session, token_ids, cache, input_ids.shape[1] + step)
+        cache = _next_cache(ort_output)
+        with torch.no_grad():
+            reference_output = reference(
+                torch.from_numpy(token_ids),
+                past_key_values=reference_cache,
+                use_cache=True,
+            )
+        reference_cache = reference_output.past_key_values
+        ort_logits = ort_output["logits"]
+        reference_logits = reference_output.logits.numpy()
+        np.testing.assert_allclose(ort_logits, reference_logits, rtol=1e-4, atol=2e-4)
+
+    expected = np.asarray(case.generated_tokens, dtype=np.int64)
+    actual = np.asarray(generated, dtype=np.int64)
+    assert len(actual) == len(expected)
+    np.testing.assert_array_equal(actual, expected)
+
+    repeated = []
+    repeated_output = _run_ort(session, input_ids, _empty_cache(session), 0)
+    cache = _next_cache(repeated_output)
+    ort_logits = repeated_output["logits"]
+    for step in range(len(expected)):
+        token = int(ort_logits[0, -1].argmax())
+        repeated.append(token)
+        token_ids = np.array([[token]], dtype=np.int64)
+        output = _run_ort(session, token_ids, cache, input_ids.shape[1] + step)
+        cache = _next_cache(output)
+        ort_logits = output["logits"]
+    assert len(repeated) == len(expected)
+    np.testing.assert_array_equal(repeated, expected)


### PR DESCRIPTION
## Summary

- add first-class pinned GGUF sources to the L4/L5 YAML harness, including immutable GGUF/reference revisions, byte size, LFS SHA-256, tensor census/qtypes, CPU import route, config hash, and golden provenance
- add reproducible F16 L4/L5 coverage for `HuggingFaceTB/SmolLM-135M` and `HuggingFaceTB/SmolLM2-135M-Instruct` through real CLI build, save/reload, ORT prefill, 20 cache-threaded decode steps, full-logit HF parity, and deterministic generation
- make GGUF case changes select `llama` in affected-model detection and run the real-artifact tests in fast integration CI

## Evidence

| Artifact | Identity | Tensor census | Max full-logit abs diff | Generation |
|---|---|---:|---:|---|
| `neopolita/smollm-135m-gguf@22cca988936eafe92908e7558907c3964e10bba7/ggml-model-f16.gguf` | 270,885,504 bytes; `ec8c775c16944a7e4b5251f97b3f848500dcc3e701b0d492ce9055cea42138a2` | 272 (`F16=211`, `F32=61`) | 1.277e-4 | exact 20/20 |
| `unsloth/SmolLM2-135M-Instruct-GGUF@9e6855bc4be717fca1ef21360a1db4b29d5c559a/SmolLM2-135M-Instruct-F16.gguf` | 270,885,952 bytes; `5157ca60744d21631818364854ac8e4452e1b8022d2ab4c8a2f9cda2344afb30` | 272 (`F16=211`, `F32=61`) | 7.176e-5 observed in the initial probe; committed test gates at 2e-4 | exact 20/20 |

Both routes are CPU, dynamic-cache, `llama_qk_permute=true`, and `preserve_quantization=false`. Runtime packaging remains **deferred**: the public GGUFs use compiled llama.cpp `smollm` pre-tokenizer metadata and do not embed `tokenizer.huggingface.json`, so no architecture-wide or runtime-package support is claimed.

The pinned SmolLM2 Q4_K_M artifact (`105,454,144` bytes, `ed5fa30c487b282ec156c29062f1222e5c20875a944ac98289dbd242e947f747`) was exercised but is not promoted or compared against mismatched unquantized weights. Its preserved MatMulNBits route diverges from the same artifact under llama.cpp, while Mobius dequantization matches llama.cpp; this exact blocker is documented in the integration test.

## Validation

- real-artifact GGUF integration: 2 passed
- targeted L4/L5: 4 passed
- schema/golden/detector infrastructure: 352 passed
- dashboard/model coverage: 810 passed, 225 skipped
- Ruff formatting and lint: passed
- two independent reviews completed; CI selection, dashboard aggregation, provenance, and route-hash findings fixed

The broad non-integration suite remains at 7,054 passed with two pre-existing `glm_moe_dsa` shape-inference failures unrelated to this diff. CI was not awaited.