### PR TITLE
Add GraniteHybrid routed-MoE GGUF support

### DIFF
--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -396,7 +396,7 @@ before graph construction or durable output.
 | `gptneox` | — | none (fails before config extraction) | audited-direct-loader-conditional-union | config=deferred; tensor_map=deferred; graph=deferred; runtime=deferred; quantized_import=supported | GPT-NeoX GGUF requires fused biased QKV, bias-bearing LayerNorm/GELU blocks, partial RoPE, and metadata-selected parallel versus sequential residual topology. Mobius implements only the parallel MHA subset and cannot admit the full loader union. |
 | `granite` | — | none (fails before config extraction) | audited-direct-loader-conditional-union | config=deferred; tensor_map=deferred; graph=deferred; runtime=deferred; quantized_import=supported | The granite architecture is a conditional dense-or-MoE union with residual, embedding, attention, and inverse-logit scales, optional biases/RoPE factors, shared experts, and optional deep-stack inputs. It is not the GraniteMoE or GraniteHybrid GGUF contract. |
 | `granite_swa` | — | none (fails before config extraction) | audited-direct-loader-conditional-union | config=deferred; tensor_map=deferred; graph=deferred; runtime=deferred; quantized_import=supported | Granite SWA requires attention sinks, a complete interleaved sliding-window schedule, residual/logit scaling, fused routed gate-up experts, and optional fused shared experts/deep-stack injection. Mobius owns neither that cache ABI nor its fused expert sidecars. |
-| `granitehybrid` | — | model=`granitemoehybrid`; tensor=`granitehybrid` | not claimed | config=supported; tensor_map=supported; graph=supported; runtime=deferred; quantized_import=rejected | Config extraction, exact pinned tensor-name closure, GGUF value transforms, and synthetic recurrent-state execution are covered, but no representative real-weight GGUF has yet passed independent full-logit parity and deterministic multi-token stateful ORT generation. Runtime packaging remains deferred until that evidence exists. The mobius graph uses floating Linear modules for this architecture, so no MatMulNBits or BlockQuantizedMatMul target can consume preserved GGUF projection weights. Use keep_quantized=False for explicit float import. |
+| `granitehybrid` | — | model=`granitemoehybrid`; tensor=`granitehybrid` | not claimed | config=supported; tensor_map=supported; graph=supported; runtime=deferred; quantized_import=rejected | Exact mixed attention/Mamba2 scheduling, architecture-wide dense or routed MoE feed-forward selection, optional shared experts, Granite scaling, value-preserving float expert fusion, and strict pinned tensor closure are supported. Quantized sources require explicit dequantization because the current graph has no exact packed 3-D expert ABI; use keep_quantized=False. Generic ORT GenAI runtime packaging remains deferred because its released cache schema cannot represent heterogeneous KV, convolution, and recurrent state slots; tracked by onnxruntime/mobius#605. |
 | `granitemoe` | — | model=`granitemoe`; tensor=`llama`+`moe_extras` | not claimed | config=supported; tensor_map=supported; graph=supported; runtime=deferred; quantized_import=supported | Config extraction, exact tensor-name closure, and a full synthetic GGUF graph build are covered, but no representative real-weight GGUF has yet passed ORT parity or generation validation. Runtime packaging remains deferred until that evidence exists. |
 | `graniteswitch` | — | none (fails before config extraction) | audited-direct-loader-conditional-union | config=deferred; tensor_map=deferred; graph=deferred; runtime=deferred; quantized_import=supported | GraniteSwitch repurposes an appended synthetic layer as a token-history-driven adapter router and carries fourteen switched-LoRA tensors per block in addition to decoder KV state. It is not MTP, and Mobius has no switched-LoRA graph, MUL_MAT_ID quantization contract, or package ABI. |
 | `grok` | — | none (fails before config extraction) | not claimed | config=deferred; tensor_map=deferred; graph=deferred; runtime=deferred; quantized_import=supported | The pinned Grok graph applies embedding, attention-output, and logit scales; attention, and optional final-logit softcaps; post-attention and post-FFN norms; and a dense-plus-routed expert residual scaled by sqrt(2)/2. Mobius's generic MoE graph has none of that combined topology, so the Hugging Face-style expert names are not evidence that a GGUF alias is safe. |
@@ -556,8 +556,9 @@ independent full-logit and generation parity.
 ### Second hybrid cohort
 
 `jamba`, `nemotron_h`, and `granitehybrid` have graph-import support for exact
-pinned subsets. Jamba includes routed MoE layers; Nemotron-H and GraniteHybrid
-remain dense-only. Runtime packaging remains deferred pending independent
+pinned subsets. All three include their routed-MoE forms; GraniteHybrid selects
+dense or routed feed-forward globally and may add one always-active shared
+expert on every layer. Runtime packaging remains deferred pending independent
 real-artifact full-logit and stateful-generation parity.
 
 - Schedules come from suffix-exact per-layer metadata. Jamba and GraniteHybrid
@@ -568,14 +569,19 @@ real-artifact full-logit and stateful-generation parity.
   Mamba-1 with biased depthwise convolution and bias-free projections, and
   softmax-first top-k routing without post-top-k renormalization. Routed layers
   are inferred exactly from `ffn_gate_inp`; stacked expert tensors are split in
-  numeric order. There are no shared experts. Nemotron-H rejects MTP and all MoE
-  files. GraniteHybrid rejects routed-MoE files until 3-D expert fusion,
-  ordering, and quantized preservation have independent value tests.
+  numeric order. There are no shared experts. Nemotron-H supports its exact
+  mixed dense/MoE schedule, correction-biased sigmoid routing, shared expert,
+  and optional latent projections while rejecting unsupported MTP blocks.
+  GraniteHybrid uses normalized softmax top-k routing on every layer, fuses
+  separate GGUF expert gate/up tensors in gate-then-up order, and adds the
+  optional shared SwiGLU branch.
 - Every layer must provide exactly its pinned loader tensor family. Missing,
   wrong-mixer, partial, auxiliary, scale/input-scale, and out-of-range tensors
   are rejected before graph construction. Compatible attention, dense-FFN, and
-  expert MatMul weights may remain quantized; Mamba and other state-sensitive
-  tensors are dequantized. GGUF Mamba decay values are inverted
+  expert MatMul weights may remain quantized where the graph owns an exact
+  packed ABI. GraniteHybrid and Nemotron-H quantized sources require explicit
+  dequantization; neither silently drops or rewrites packed expert semantics.
+  GGUF Mamba decay values are inverted
   from `-exp(A_log)`; convolution and grouped Mamba2 tensors are restored to
   graph shapes.
 - State inputs and outputs are caller-owned. Mamba1 uses conv

--- a/src/mobius/integrations/gguf/_arch_registry.py
+++ b/src/mobius/integrations/gguf/_arch_registry.py
@@ -1135,7 +1135,16 @@ _SPECS: tuple[GGUFArchitectureSpec, ...] = (
         ),
         runtime=Support.DEFERRED,
         quantized_import=Support.REJECTED,
-        reason=_RECURRENT_RUNTIME_VALIDATION_PENDING + " " + _NO_QUANTIZED_PROJECTION_REASON,
+        reason=(
+            "Exact mixed attention/Mamba2 scheduling, architecture-wide dense or routed "
+            "MoE feed-forward selection, optional shared experts, Granite scaling, "
+            "value-preserving float expert fusion, and strict pinned tensor closure are "
+            "supported. Quantized sources require explicit dequantization because the "
+            "current graph has no exact packed 3-D expert ABI; use keep_quantized=False. "
+            "Generic ORT GenAI runtime packaging remains deferred because its released cache "
+            "schema cannot represent heterogeneous KV, convolution, and recurrent state "
+            "slots; tracked by onnxruntime/mobius#605."
+        ),
     ),
     GGUFArchitectureSpec(
         gguf_arch="bailingmoe3",

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -1796,13 +1796,30 @@ def _raise_for_invalid_mamba_hybrid_tensor_contract(gguf_model) -> None:
             },
         }
     else:
-        common = {
-            "attn_norm.weight",
-            "ffn_norm.weight",
-            "ffn_gate.weight",
-            "ffn_up.weight",
-            "ffn_down.weight",
+        common = {"attn_norm.weight", "ffn_norm.weight"}
+        num_experts = int(metadata.get("granitehybrid.expert_count", 0))
+        top_k = int(metadata.get("granitehybrid.expert_used_count", 0))
+        if bool(num_experts) != bool(top_k):
+            raise ValueError(
+                "GraniteHybrid expert_count and expert_used_count must both be zero "
+                "or both positive"
+            )
+        dense_ffn = {"ffn_gate.weight", "ffn_up.weight", "ffn_down.weight"}
+        routed_ffn = {
+            "ffn_gate_inp.weight",
+            "ffn_gate_exps.weight",
+            "ffn_up_exps.weight",
+            "ffn_down_exps.weight",
         }
+        shared_ffn = {
+            "ffn_gate_shexp.weight",
+            "ffn_up_shexp.weight",
+            "ffn_down_shexp.weight",
+        }
+        shared_width = int(metadata.get("granitehybrid.expert_shared_feed_forward_length", 0))
+        common |= routed_ffn if num_experts else dense_ffn
+        if num_experts and shared_width > 0:
+            common |= shared_ffn
         required_by_type = {
             "mamba2": {
                 "ssm_in.weight",
@@ -1830,6 +1847,18 @@ def _raise_for_invalid_mamba_hybrid_tensor_contract(gguf_model) -> None:
                 "rope_freqs.weight",
             },
         }
+        forbidden_ffn = dense_ffn if num_experts else routed_ffn | shared_ffn
+        present_forbidden = sorted(
+            f"blk.{index}.{suffix}"
+            for index in range(layer_count)
+            for suffix in forbidden_ffn
+            if f"blk.{index}.{suffix}" in actual
+        )
+        if present_forbidden:
+            raise ValueError(
+                "GraniteHybrid GGUF mixes dense and routed/shared MoE representations: "
+                f"{present_forbidden}"
+            )
 
     expected = set(required_global)
     allowed = required_global | optional_global
@@ -1855,6 +1884,11 @@ def _raise_for_invalid_mamba_hybrid_tensor_contract(gguf_model) -> None:
         "recurrent convolution",
         [f"blk.{index}.ssm_conv1d.bias" for index in recurrent_layers],
     )
+    if architecture in {"nemotron_h", "nemotron_h_moe", "granitehybrid"}:
+        require_all_or_none(
+            "attention output projection",
+            [f"blk.{index}.attn_output.bias" for index in attention_layers],
+        )
     if architecture == "granitehybrid":
         require_all_or_none(
             "attention Q/K/V projection",
@@ -1864,10 +1898,16 @@ def _raise_for_invalid_mamba_hybrid_tensor_contract(gguf_model) -> None:
                 for projection in ("q", "k", "v")
             ],
         )
-    if architecture in {"nemotron_h", "nemotron_h_moe", "granitehybrid"}:
+    if architecture == "granitehybrid" and not int(
+        metadata.get("granitehybrid.expert_count", 0)
+    ):
         require_all_or_none(
-            "attention output projection",
-            [f"blk.{index}.attn_output.bias" for index in attention_layers],
+            "dense shared-MLP",
+            [
+                f"blk.{index}.ffn_{projection}.bias"
+                for index in range(layer_count)
+                for projection in ("gate", "up", "down")
+            ],
         )
     if architecture in {"nemotron_h", "nemotron_h_moe"}:
         mlp_layers = [
@@ -1949,9 +1989,7 @@ def _raise_for_invalid_mamba_hybrid_tensor_contract(gguf_model) -> None:
             f"unexpected={unexpected}, out_of_range={out_of_range}"
         )
 
-    if architecture not in {"jamba", "nemotron_h", "nemotron_h_moe"} or not hasattr(
-        gguf_model, "tensor_items_raw"
-    ):
+    if not hasattr(gguf_model, "tensor_items_raw"):
         return
 
     shapes = {
@@ -1960,6 +1998,9 @@ def _raise_for_invalid_mamba_hybrid_tensor_contract(gguf_model) -> None:
     }
     if architecture in {"nemotron_h", "nemotron_h_moe"}:
         _validate_nemotron_h_tensor_shapes(gguf_model, layer_types, actual)
+        return
+    if architecture == "granitehybrid":
+        _validate_granitehybrid_tensor_shapes(gguf_model, layer_types, actual)
         return
 
     hidden = int(metadata["jamba.embedding_length"])
@@ -2196,6 +2237,148 @@ def _validate_nemotron_h_tensor_shapes(gguf_model, layer_types, actual: set[str]
     )
     if malformed:
         raise ValueError(f"Invalid Nemotron-H GGUF tensor shape(s): {malformed}")
+
+
+def _validate_granitehybrid_tensor_shapes(gguf_model, layer_types, actual: set[str]) -> None:
+    """Validate logical GraniteHybrid tensor shapes before graph construction."""
+    metadata = gguf_model.metadata
+    arch = gguf_model.architecture
+    shapes = {
+        name: tuple(int(dimension) for dimension in shape)
+        for name, _raw, _qtype, shape in gguf_model.tensor_items_raw()
+    }
+    hidden = int(metadata[f"{arch}.embedding_length"])
+    vocab = int(metadata.get(f"{arch}.vocab_size", 0))
+    if not vocab:
+        vocab = len(metadata.get("tokenizer.ggml.tokens", ()))
+    heads_raw = metadata[f"{arch}.attention.head_count"]
+    heads_by_layer = (
+        [int(value) for value in heads_raw]
+        if isinstance(heads_raw, (list, tuple, np.ndarray))
+        else [int(heads_raw)] * len(layer_types)
+    )
+    kv_by_layer = [int(value) for value in metadata[f"{arch}.attention.head_count_kv"]]
+    attention_heads = next(
+        (
+            heads_by_layer[index]
+            for index, kind in enumerate(layer_types)
+            if kind == "full_attention"
+        ),
+        0,
+    )
+    head_dim = int(
+        metadata.get(
+            f"{arch}.attention.key_length",
+            hidden // attention_heads if attention_heads else 0,
+        )
+    )
+    state = int(metadata[f"{arch}.ssm.state_size"])
+    inner = int(metadata[f"{arch}.ssm.inner_size"])
+    groups = int(metadata[f"{arch}.ssm.group_count"])
+    ssm_heads = int(metadata[f"{arch}.ssm.time_step_rank"])
+    conv = int(metadata[f"{arch}.ssm.conv_kernel"])
+    expert_count = int(metadata.get(f"{arch}.expert_count", 0))
+    expert_width = int(metadata[f"{arch}.feed_forward_length"])
+    shared_width = int(metadata.get(f"{arch}.expert_shared_feed_forward_length", 0))
+
+    expected: dict[str, tuple[int, ...]] = {
+        "token_embd.weight": (vocab, hidden),
+        "output_norm.weight": (hidden,),
+    }
+    if "output.weight" in actual:
+        expected["output.weight"] = (vocab, hidden)
+    for layer, layer_type in enumerate(layer_types):
+        prefix = f"blk.{layer}."
+        expected[prefix + "attn_norm.weight"] = (hidden,)
+        expected[prefix + "ffn_norm.weight"] = (hidden,)
+        if layer_type == "mamba2":
+            conv_width = inner + 2 * groups * state
+            expected.update(
+                {
+                    prefix + "ssm_in.weight": (
+                        2 * inner + 2 * groups * state + ssm_heads,
+                        hidden,
+                    ),
+                    prefix + "ssm_conv1d.weight": (conv_width, conv),
+                    prefix + "ssm_dt.bias": (ssm_heads,),
+                    prefix + "ssm_a": (ssm_heads, 1),
+                    prefix + "ssm_d": (ssm_heads, 1),
+                    prefix + "ssm_norm.weight": (groups, inner // groups),
+                    prefix + "ssm_out.weight": (hidden, inner),
+                }
+            )
+            if prefix + "ssm_conv1d.bias" in actual:
+                expected[prefix + "ssm_conv1d.bias"] = (conv_width,)
+        else:
+            heads = heads_by_layer[layer]
+            kv_heads = kv_by_layer[layer]
+            expected.update(
+                {
+                    prefix + "attn_q.weight": (heads * head_dim, hidden),
+                    prefix + "attn_q.bias": (heads * head_dim,),
+                    prefix + "attn_k.weight": (kv_heads * head_dim, hidden),
+                    prefix + "attn_k.bias": (kv_heads * head_dim,),
+                    prefix + "attn_v.weight": (kv_heads * head_dim, hidden),
+                    prefix + "attn_v.bias": (kv_heads * head_dim,),
+                    prefix + "attn_output.weight": (hidden, heads * head_dim),
+                }
+            )
+            if prefix + "attn_output.bias" in actual:
+                expected[prefix + "attn_output.bias"] = (hidden,)
+
+        if expert_count:
+            expected.update(
+                {
+                    prefix + "ffn_gate_inp.weight": (expert_count, hidden),
+                    prefix + "ffn_gate_exps.weight": (
+                        expert_count,
+                        expert_width,
+                        hidden,
+                    ),
+                    prefix + "ffn_up_exps.weight": (
+                        expert_count,
+                        expert_width,
+                        hidden,
+                    ),
+                    prefix + "ffn_down_exps.weight": (
+                        expert_count,
+                        hidden,
+                        expert_width,
+                    ),
+                }
+            )
+            if shared_width:
+                expected.update(
+                    {
+                        prefix + "ffn_gate_shexp.weight": (shared_width, hidden),
+                        prefix + "ffn_up_shexp.weight": (shared_width, hidden),
+                        prefix + "ffn_down_shexp.weight": (hidden, shared_width),
+                    }
+                )
+        else:
+            expected.update(
+                {
+                    prefix + "ffn_gate.weight": (expert_width, hidden),
+                    prefix + "ffn_up.weight": (expert_width, hidden),
+                    prefix + "ffn_down.weight": (hidden, expert_width),
+                }
+            )
+            for projection, size in (
+                ("gate", expert_width),
+                ("up", expert_width),
+                ("down", hidden),
+            ):
+                name = prefix + f"ffn_{projection}.bias"
+                if name in actual:
+                    expected[name] = (size,)
+
+    malformed = sorted(
+        f"{name}: expected {expected_shape}, got {shapes[name]}"
+        for name, expected_shape in expected.items()
+        if name in shapes and shapes[name] != expected_shape
+    )
+    if malformed:
+        raise ValueError(f"Invalid GraniteHybrid GGUF tensor shape(s): {malformed}")
 
 
 def _raise_for_invalid_t5_tensor_contract(gguf_model) -> None:

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -1103,6 +1103,174 @@ def _write_jamba_gguf(
     writer.close()
 
 
+def _write_granitehybrid_moe_gguf(
+    path: Path,
+    *,
+    quantized: bool,
+    omit: str | None = None,
+    extra: str | None = None,
+    expert_count: int = 2,
+    expert_used_count: int = 1,
+    shared_width: int = 16,
+    attention_biases: bool = True,
+    malformed_shape: str | None = None,
+) -> None:
+    """Write a tiny mixed GraniteHybrid GGUF with routed and shared experts."""
+    from gguf import GGMLQuantizationType, GGUFWriter
+
+    hidden = 32
+    expert_width = 32
+    vocab = 64
+    heads = 4
+    kv_heads = 2
+    inner = 64
+    ssm_heads = 4
+    groups = 1
+    state = 4
+    kernel = 4
+    rng = np.random.default_rng(614)
+
+    writer = GGUFWriter(str(path), "granitehybrid")
+    writer.add_context_length(32)
+    writer.add_embedding_length(hidden)
+    writer.add_feed_forward_length(expert_width)
+    writer.add_block_count(2)
+    writer.add_head_count(heads)
+    writer.add_head_count_kv([0, kv_heads])
+    writer.add_layer_norm_rms_eps(1e-5)
+    writer.add_vocab_size(vocab)
+    writer.add_ssm_conv_kernel(kernel)
+    writer.add_ssm_inner_size(inner)
+    writer.add_ssm_state_size(state)
+    writer.add_ssm_time_step_rank(ssm_heads)
+    writer.add_ssm_group_count(groups)
+    writer.add_expert_count(expert_count)
+    writer.add_expert_used_count(expert_used_count)
+    if shared_width:
+        writer.add_expert_shared_feed_forward_length(shared_width)
+    writer.add_embedding_scale(12.0)
+    writer.add_residual_scale(0.5)
+    writer.add_attention_scale(0.125)
+    writer.add_logit_scale(16.0)
+    writer.add_bool("granitehybrid.rope.scaling.finetuned", False)
+    writer.add_string("granitehybrid.feed_forward.activation", "silu")
+
+    def adjusted_shape(name: str, shape: tuple[int, ...]) -> tuple[int, ...]:
+        if name == malformed_shape:
+            return (*shape[:-1], shape[-1] + 1)
+        return shape
+
+    def add_float(
+        name: str,
+        shape: tuple[int, ...],
+        *,
+        fill: float | None = None,
+        expert_base: float | None = None,
+        negative: bool = False,
+    ) -> None:
+        if name == omit:
+            return
+        shape = adjusted_shape(name, shape)
+        values = rng.normal(0.0, 0.03, size=shape).astype(np.float32)
+        if fill is not None:
+            values.fill(fill)
+        if expert_base is not None:
+            for expert in range(shape[0]):
+                values[expert].fill(expert_base + expert)
+        if negative:
+            values = -np.exp(values)
+        writer.add_tensor(name, values)
+
+    def add_q4(name: str, shape: tuple[int, ...]) -> None:
+        if name == omit:
+            return
+        shape = adjusted_shape(name, shape)
+        assert shape[-1] % 32 == 0
+        byte_shape = (*shape[:-1], shape[-1] // 32 * 18)
+        raw = np.zeros(byte_shape, dtype=np.uint8)
+        for index in np.ndindex(shape[:-1]):
+            for block in range(shape[-1] // 32):
+                offset = block * 18
+                raw[(*index, slice(offset, offset + 2))] = np.array(
+                    [rng.uniform(0.01, 0.05)], dtype=np.float16
+                ).view(np.uint8)
+                raw[(*index, slice(offset + 2, offset + 18))] = rng.integers(
+                    0, 256, size=16, dtype=np.uint8
+                )
+        writer.add_tensor(name, raw, raw_dtype=GGMLQuantizationType.Q4_0)
+
+    add_float("token_embd.weight", (vocab, hidden))
+    add_float("output_norm.weight", (hidden,))
+    for layer in range(2):
+        prefix = f"blk.{layer}."
+        add_float(prefix + "attn_norm.weight", (hidden,))
+        add_float(prefix + "ffn_norm.weight", (hidden,))
+        add_float(prefix + "ffn_gate_inp.weight", (expert_count, hidden))
+        expert_projection = add_q4 if quantized else add_float
+        if quantized:
+            expert_projection(
+                prefix + "ffn_gate_exps.weight",
+                (expert_count, expert_width, hidden),
+            )
+            expert_projection(
+                prefix + "ffn_up_exps.weight",
+                (expert_count, expert_width, hidden),
+            )
+            expert_projection(
+                prefix + "ffn_down_exps.weight",
+                (expert_count, hidden, expert_width),
+            )
+        else:
+            add_float(
+                prefix + "ffn_gate_exps.weight",
+                (expert_count, expert_width, hidden),
+                expert_base=11.0,
+            )
+            add_float(
+                prefix + "ffn_up_exps.weight",
+                (expert_count, expert_width, hidden),
+                expert_base=21.0,
+            )
+            add_float(
+                prefix + "ffn_down_exps.weight",
+                (expert_count, hidden, expert_width),
+                expert_base=31.0,
+            )
+        if shared_width:
+            add_float(prefix + "ffn_gate_shexp.weight", (shared_width, hidden))
+            add_float(prefix + "ffn_up_shexp.weight", (shared_width, hidden))
+            add_float(prefix + "ffn_down_shexp.weight", (hidden, shared_width))
+
+    add_float(
+        "blk.0.ssm_in.weight",
+        (2 * inner + 2 * groups * state + ssm_heads, hidden),
+    )
+    add_float("blk.0.ssm_conv1d.weight", (inner + 2 * groups * state, kernel))
+    add_float("blk.0.ssm_conv1d.bias", (inner + 2 * groups * state,))
+    add_float("blk.0.ssm_dt.bias", (ssm_heads,))
+    add_float("blk.0.ssm_a", (ssm_heads, 1), negative=True)
+    add_float("blk.0.ssm_d", (ssm_heads, 1))
+    add_float("blk.0.ssm_norm.weight", (groups, inner // groups))
+    add_float("blk.0.ssm_out.weight", (hidden, inner))
+
+    head_dim = hidden // heads
+    add_float("blk.1.attn_q.weight", (heads * head_dim, hidden))
+    add_float("blk.1.attn_k.weight", (kv_heads * head_dim, hidden))
+    add_float("blk.1.attn_v.weight", (kv_heads * head_dim, hidden))
+    if attention_biases:
+        add_float("blk.1.attn_q.bias", (heads * head_dim,))
+        add_float("blk.1.attn_k.bias", (kv_heads * head_dim,))
+        add_float("blk.1.attn_v.bias", (kv_heads * head_dim,))
+    add_float("blk.1.attn_output.weight", (hidden, heads * head_dim))
+    if extra is not None:
+        add_float(extra, (1,))
+
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_tensors_to_file()
+    writer.close()
+
+
 def _write_nemotron_h_moe_gguf(
     path: Path,
     *,
@@ -5135,6 +5303,182 @@ class TestJambaGGUFBuild:
         assert not graph_build_started
 
 
+class TestGraniteHybridMoEGGUFBuild:
+    """GraniteHybrid GGUF import preserves mixed state and routed expert order."""
+
+    @staticmethod
+    def _inputs(tokens: np.ndarray) -> dict[str, np.ndarray]:
+        batch, sequence = tokens.shape
+        return {
+            "input_ids": tokens,
+            "position_ids": np.broadcast_to(
+                np.arange(sequence, dtype=np.int64),
+                (batch, sequence),
+            ).copy(),
+            "attention_mask": np.ones((batch, sequence), np.int64),
+            "past_key_values.0.conv_state": np.zeros((batch, 72, 3), np.float32),
+            "past_key_values.0.ssm_state": np.zeros((batch, 4, 4, 16), np.float32),
+            "past_key_values.1.key": np.zeros((batch, 2, 0, 8), np.float32),
+            "past_key_values.1.value": np.zeros((batch, 2, 0, 8), np.float32),
+        }
+
+    def test_float_import_preserves_expert_order_and_round_trips(self, tmp_path: Path) -> None:
+        from mobius._model_package import ModelPackage
+        from mobius._testing.ort_inference import OnnxModelSession
+        from mobius.integrations.gguf import build_from_gguf
+
+        path = tmp_path / "granitehybrid-moe-f32.gguf"
+        _write_granitehybrid_moe_gguf(path, quantized=False)
+        package = build_from_gguf(path)
+        model = package["model"]
+        assert [value.name for value in model.graph.outputs] == [
+            "logits",
+            "present.0.conv_state",
+            "present.0.ssm_state",
+            "present.1.key",
+            "present.1.value",
+        ]
+        for layer in range(2):
+            fused = model.graph.initializers[
+                f"model.layers.{layer}.block_sparse_moe.input_linear.weight"
+            ].const_value.numpy()
+            down = model.graph.initializers[
+                f"model.layers.{layer}.block_sparse_moe.output_linear.weight"
+            ].const_value.numpy()
+            for expert in range(2):
+                np.testing.assert_array_equal(fused[expert, :32], 11.0 + expert)
+                np.testing.assert_array_equal(fused[expert, 32:], 21.0 + expert)
+                np.testing.assert_array_equal(down[expert], 31.0 + expert)
+
+        output_dir = tmp_path / "saved-granitehybrid"
+        package.save(output_dir, progress_bar=False)
+        session = OnnxModelSession(ModelPackage.load(output_dir)["model"])
+        outputs = session.run(self._inputs(np.asarray([[1, 2], [3, 4]], np.int64)))
+        assert outputs["logits"].shape == (2, 2, 64)
+        assert outputs["present.0.conv_state"].shape == (2, 72, 3)
+        assert outputs["present.0.ssm_state"].shape == (2, 4, 4, 16)
+
+    def test_prefill_decode_reorder_rollback_and_replay(self, tmp_path: Path) -> None:
+        from mobius._testing.ort_inference import OnnxModelSession
+        from mobius.integrations.gguf import build_from_gguf
+
+        path = tmp_path / "granitehybrid-moe-state.gguf"
+        _write_granitehybrid_moe_gguf(path, quantized=False)
+        session = OnnxModelSession(build_from_gguf(path)["model"])
+        histories = np.asarray([[1, 2], [3, 4]], np.int64)
+        prefill = session.run(self._inputs(histories))
+        snapshot = {name: np.array(value, copy=True) for name, value in prefill.items()}
+
+        order = np.asarray([1, 0], np.int64)
+        next_tokens = np.asarray([[5], [6]], np.int64)
+        decode_inputs = {
+            "input_ids": next_tokens,
+            "position_ids": np.full((2, 1), 2, np.int64),
+            "attention_mask": np.ones((2, 3), np.int64),
+            "past_key_values.0.conv_state": snapshot["present.0.conv_state"][order],
+            "past_key_values.0.ssm_state": snapshot["present.0.ssm_state"][order],
+            "past_key_values.1.key": snapshot["present.1.key"][order],
+            "past_key_values.1.value": snapshot["present.1.value"][order],
+        }
+        decoded = session.run(decode_inputs)
+        replayed = session.run(decode_inputs)
+        for name in decoded:
+            np.testing.assert_array_equal(decoded[name], replayed[name])
+
+        full_tokens = np.concatenate([histories[order], next_tokens], axis=1)
+        full = session.run(self._inputs(full_tokens))
+        np.testing.assert_allclose(
+            decoded["logits"][:, -1],
+            full["logits"][:, -1],
+            atol=2e-5,
+            rtol=2e-5,
+        )
+
+    def test_optional_shared_expert_can_be_absent(self, tmp_path: Path) -> None:
+        from mobius.integrations.gguf import build_from_gguf
+
+        path = tmp_path / "granitehybrid-moe-no-shared.gguf"
+        _write_granitehybrid_moe_gguf(path, quantized=False, shared_width=0)
+        model = build_from_gguf(path)["model"]
+        assert not any("shared_mlp" in name for name in model.graph.initializers)
+
+    def test_attention_biases_can_be_absent(self, tmp_path: Path) -> None:
+        from mobius.integrations.gguf import build_from_gguf
+
+        path = tmp_path / "granitehybrid-moe-no-attention-bias.gguf"
+        _write_granitehybrid_moe_gguf(path, quantized=False, attention_biases=False)
+        model = build_from_gguf(path)["model"]
+        assert not any(
+            name.startswith("model.layers.1.self_attn.")
+            and name.endswith((".q_proj.bias", ".k_proj.bias", ".v_proj.bias"))
+            for name in model.graph.initializers
+        )
+
+    def test_quantized_source_requires_explicit_dequantization(self, tmp_path: Path) -> None:
+        from mobius.integrations.gguf import build_from_gguf
+
+        path = tmp_path / "granitehybrid-moe-q4.gguf"
+        _write_granitehybrid_moe_gguf(path, quantized=True)
+        with pytest.raises(ValueError, match=r"keep_quantized=False"):
+            build_from_gguf(path, keep_quantized=True)
+
+        model = build_from_gguf(path, keep_quantized=False)["model"]
+        assert all(node.op_type != "MatMulNBits" for node in model.graph)
+        assert model.graph.initializers[
+            "model.layers.0.block_sparse_moe.input_linear.weight"
+        ].shape == [2, 64, 32]
+
+    def test_cli_builds_dequantized_package(self, tmp_path: Path) -> None:
+        from mobius.__main__ import main
+        from mobius._model_package import ModelPackage
+
+        path = tmp_path / "granitehybrid-moe-cli.gguf"
+        output_dir = tmp_path / "cli-output"
+        _write_granitehybrid_moe_gguf(path, quantized=False)
+
+        main(["build-gguf", str(path), "--output", str(output_dir), "--dequantize"])
+
+        package = ModelPackage.load(output_dir)
+        assert set(package) == {"model"}
+        assert (output_dir / "model.onnx").is_file()
+
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            ({"omit": "blk.1.ffn_up_exps.weight"}, "tensor closure"),
+            ({"extra": "blk.0.ffn_gate.weight"}, "mixes dense and routed"),
+            (
+                {"malformed_shape": "blk.1.ffn_gate_exps.weight"},
+                "tensor shape",
+            ),
+            ({"expert_count": 0, "expert_used_count": 1}, "both be zero or both positive"),
+            ({"expert_count": 1, "expert_used_count": 1}, "not a routed-MoE"),
+            ({"expert_count": 2, "expert_used_count": 3}, "must be in"),
+            ({"omit": "blk.1.attn_q.bias"}, "partial attention Q/K/V projection"),
+            ({"extra": "blk.0.ffn_gate_up_exps.weight"}, "unexpected|Malformed"),
+            ({"extra": "blk.0.ffn_gate_exps.scale"}, "auxiliary quantization"),
+            ({"extra": "blk.2.ffn_gate_inp.weight"}, "out_of_range"),
+        ],
+    )
+    def test_malformed_sources_fail_before_graph(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+        kwargs: dict[str, object],
+        match: str,
+    ) -> None:
+        from mobius import _builder as core_builder
+        from mobius.integrations.gguf import build_from_gguf
+
+        path = tmp_path / "granitehybrid-moe-invalid.gguf"
+        _write_granitehybrid_moe_gguf(path, quantized=False, **kwargs)
+        graph_build = mock.Mock(side_effect=AssertionError("graph construction reached"))
+        monkeypatch.setattr(core_builder, "build_from_module", graph_build)
+        with pytest.raises(ValueError, match=match):
+            build_from_gguf(path)
+        graph_build.assert_not_called()
+
+
 class TestNemotronHMoEGGUFBuild:
     """Nemotron-H GGUF import preserves hybrid state and exact expert semantics."""
 
@@ -6352,7 +6696,12 @@ class TestHybridTensorContract:
                     "ssm_d",
                     "ssm_out.weight",
                 ],
-                ["attn_q.weight", "attn_k.weight", "attn_v.weight", "attn_output.weight"],
+                [
+                    "attn_q.weight",
+                    "attn_k.weight",
+                    "attn_v.weight",
+                    "attn_output.weight",
+                ],
             ]
         elif architecture == "nemotron_h":
             common = ["attn_norm.weight"]
@@ -6386,7 +6735,15 @@ class TestHybridTensorContract:
                     "ssm_norm.weight",
                     "ssm_out.weight",
                 ],
-                ["attn_q.weight", "attn_k.weight", "attn_v.weight", "attn_output.weight"],
+                [
+                    "attn_q.weight",
+                    "attn_q.bias",
+                    "attn_k.weight",
+                    "attn_k.bias",
+                    "attn_v.weight",
+                    "attn_v.bias",
+                    "attn_output.weight",
+                ],
             ]
         for layer, mixer in enumerate(mixers):
             names.extend(f"blk.{layer}.{suffix}" for suffix in [*common, *mixer])
@@ -6439,7 +6796,6 @@ class TestHybridTensorContract:
             )
         partial_bias = {
             "nemotron_h": "blk.1.ffn_up.bias",
-            "granitehybrid": "blk.1.attn_q.bias",
         }.get(architecture)
         if partial_bias is not None:
             with pytest.raises(ValueError, match=r"partial .* bias family"):

--- a/src/mobius/integrations/gguf/_config_mapping.py
+++ b/src/mobius/integrations/gguf/_config_mapping.py
@@ -24,6 +24,7 @@ __all__ = ["gguf_to_config", "resolve_model_type", "assert_glm_moe_dsa_resolvabl
 
 import dataclasses
 import logging
+import math
 import re
 from collections.abc import Iterable
 from types import MappingProxyType
@@ -1604,12 +1605,8 @@ def _granitehybrid_postprocess(
     metadata: dict[str, Any],
     model: Any,
 ) -> GraniteMoeHybridConfig:
-    """Build the dense GraniteHybrid subset with exact scaling metadata."""
-    if int(metadata.get("granitehybrid.expert_count", 0)):
-        raise ValueError(
-            "GraniteHybrid MoE GGUF import is deferred until 3-D expert fusion and "
-            "quantized expert ordering have independent value tests"
-        )
+    """Build GraniteHybrid with its exact shared-MLP and routed-expert geometry."""
+    arch = "granitehybrid"
     inner_size = int(metadata["granitehybrid.ssm.inner_size"])
     num_heads = int(metadata["granitehybrid.ssm.time_step_rank"])
     groups = int(metadata["granitehybrid.ssm.group_count"])
@@ -1618,21 +1615,84 @@ def _granitehybrid_postprocess(
     if min(num_heads, groups) <= 0 or inner_size % num_heads or num_heads % groups:
         raise ValueError("GraniteHybrid Mamba2 head and group dimensions are inconsistent")
 
+    num_experts = int(metadata.get(f"{arch}.expert_count", 0))
+    top_k = int(metadata.get(f"{arch}.expert_used_count", 0))
+    if bool(num_experts) != bool(top_k):
+        raise ValueError(
+            "GraniteHybrid expert_count and expert_used_count must both be zero "
+            "or both positive"
+        )
+    expert_width = config.intermediate_size
+    if expert_width <= 0:
+        raise ValueError("granitehybrid.feed_forward_length must be greater than zero")
+    if num_experts:
+        if num_experts <= 1:
+            raise ValueError(
+                "GraniteHybrid expert_count=1 is not a routed-MoE layout; "
+                "use the dense shared-MLP tensors"
+            )
+        if not 1 <= top_k <= num_experts:
+            raise ValueError(
+                f"GraniteHybrid expert_used_count must be in [1, {num_experts}], got {top_k}"
+            )
+        shared_width = int(metadata.get(f"{arch}.expert_shared_feed_forward_length", 0))
+        if shared_width < 0:
+            raise ValueError(
+                "granitehybrid.expert_shared_feed_forward_length must be non-negative"
+            )
+        if not bool(metadata.get(f"{arch}.expert_weights_norm", True)):
+            raise ValueError("GraniteHybrid requires normalized top-k routing weights")
+        routed_scale = float(metadata.get(f"{arch}.expert_weights_scale", 1.0))
+        if not math.isclose(routed_scale, 1.0, rel_tol=0.0, abs_tol=0.0):
+            raise ValueError(
+                "GraniteHybrid does not define an additional routed-expert output scale; "
+                f"got expert_weights_scale={routed_scale}"
+            )
+    else:
+        shared_width = config.intermediate_size
+        if f"{arch}.expert_shared_feed_forward_length" in metadata:
+            raise ValueError(
+                "granitehybrid.expert_shared_feed_forward_length requires routed experts"
+            )
+
+    if config.hidden_act not in (None, "silu"):
+        raise ValueError(
+            f"granitehybrid.hidden_activation must be silu, got {config.hidden_act!r}"
+        )
+    logit_scale = float(metadata.get(f"{arch}.logit_scale", 1.0))
+    if math.isclose(logit_scale, 0.0, rel_tol=0.0, abs_tol=0.0):
+        raise ValueError("granitehybrid.logit_scale must be nonzero")
+    tensor_names = set(model.tensor_names)
+    has_attention_bias = any(".attn_q.bias" in name for name in tensor_names)
+    has_attention_output_bias = any(".attn_output.bias" in name for name in tensor_names)
+    has_mlp_bias = any(
+        name.endswith((".ffn_gate.bias", ".ffn_up.bias", ".ffn_down.bias"))
+        for name in tensor_names
+    )
     fields = _shallow_fields(config)
     fields.update(
-        num_local_experts=None,
-        num_experts_per_tok=None,
+        hidden_act="silu",
+        intermediate_size=int(expert_width),
+        num_local_experts=num_experts or None,
+        num_experts_per_tok=top_k or None,
+        norm_topk_prob=True,
+        routed_scaling_factor=1.0,
+        attn_qkv_bias=has_attention_bias,
+        attn_o_bias=has_attention_output_bias,
+        mlp_bias=has_mlp_bias,
         rope_type=(
             fields["rope_type"]
             if bool(metadata.get("granitehybrid.rope.scaling.finetuned", True))
             else None
         ),
-        embedding_multiplier=float(metadata.get("granitehybrid.embedding_scale", 0.0)) or 1.0,
-        residual_multiplier=float(metadata.get("granitehybrid.residual_scale", 0.0)) or 1.0,
+        embedding_multiplier=float(metadata.get("granitehybrid.embedding_scale", 1.0)),
+        residual_multiplier=float(metadata.get("granitehybrid.residual_scale", 1.0)),
         attention_multiplier=(
-            float(metadata.get("granitehybrid.attention.scale", 0.0)) or None
+            float(metadata["granitehybrid.attention.scale"]) or None
+            if "granitehybrid.attention.scale" in metadata
+            else None
         ),
-        logits_scaling=float(metadata.get("granitehybrid.logit_scale", 0.0)) or 1.0,
+        logits_scaling=logit_scale,
     )
     return GraniteMoeHybridConfig(
         **fields,
@@ -1644,7 +1704,7 @@ def _granitehybrid_postprocess(
         mamba_expand=2,
         mamba_conv_bias=any(".ssm_conv1d.bias" in name for name in model.tensor_names),
         mamba_proj_bias=False,
-        shared_intermediate_size=config.intermediate_size,
+        shared_intermediate_size=int(shared_width),
     )
 
 

--- a/src/mobius/integrations/gguf/_config_mapping_test.py
+++ b/src/mobius/integrations/gguf/_config_mapping_test.py
@@ -145,15 +145,81 @@ class TestSecondHybridCohortConfig:
         with pytest.raises(ValueError, match=r"exactly 3|each contain exactly 3"):
             gguf_to_config(_FakeDenseGGUF(architecture, metadata, ["token_embd.weight"]))
 
-    @pytest.mark.parametrize("architecture", ["granitehybrid"])
-    def test_moe_modes_fail_closed(self, architecture: str) -> None:
+    def test_granitehybrid_moe_extracts_exact_geometry_and_scaling(self) -> None:
         from mobius.integrations.gguf._config_mapping import gguf_to_config
 
-        metadata = self._metadata(architecture)
-        metadata[f"{architecture}.expert_count"] = 4
-        metadata[f"{architecture}.expert_used_count"] = 2
-        with pytest.raises(ValueError, match="MoE"):
-            gguf_to_config(_FakeDenseGGUF(architecture, metadata, ["token_embd.weight"]))
+        metadata = self._metadata("granitehybrid")
+        metadata.update(
+            {
+                "granitehybrid.expert_count": 4,
+                "granitehybrid.expert_used_count": 2,
+                "granitehybrid.expert_shared_feed_forward_length": 96,
+                "granitehybrid.embedding_scale": 12.0,
+                "granitehybrid.residual_scale": 0.5,
+                "granitehybrid.attention.scale": 0.125,
+                "granitehybrid.logit_scale": 16.0,
+                "granitehybrid.rope.scaling.finetuned": False,
+            }
+        )
+        config = gguf_to_config(
+            _FakeDenseGGUF(
+                "granitehybrid",
+                metadata,
+                [
+                    "token_embd.weight",
+                    "blk.1.attn_q.bias",
+                    "blk.1.attn_output.bias",
+                ],
+            )
+        )
+        assert config.layer_types == ["mamba2", "full_attention", "mamba2"]
+        assert config.num_local_experts == 4
+        assert config.num_experts_per_tok == 2
+        assert config.intermediate_size == 128
+        assert config.shared_intermediate_size == 96
+        assert config.norm_topk_prob is True
+        assert config.routed_scaling_factor == pytest.approx(1.0)
+        assert config.embedding_multiplier == pytest.approx(12.0)
+        assert config.residual_multiplier == pytest.approx(0.5)
+        assert config.attention_multiplier == pytest.approx(0.125)
+        assert config.logits_scaling == pytest.approx(16.0)
+        assert config.rope_type is None
+        assert config.attn_qkv_bias is True
+        assert config.attn_o_bias is True
+
+    @pytest.mark.parametrize(
+        ("updates", "match"),
+        [
+            ({"expert_count": 4}, "both be zero or both positive"),
+            ({"expert_count": 1, "expert_used_count": 1}, "not a routed-MoE"),
+            ({"expert_count": 4, "expert_used_count": 5}, "must be in"),
+            (
+                {
+                    "expert_count": 4,
+                    "expert_used_count": 2,
+                    "expert_weights_norm": False,
+                },
+                "normalized top-k",
+            ),
+            (
+                {
+                    "expert_count": 4,
+                    "expert_used_count": 2,
+                    "expert_weights_scale": 2.0,
+                },
+                "does not define",
+            ),
+            ({"logit_scale": 0.0}, "must be nonzero"),
+            ({"feed_forward_length": 0}, "must be greater than zero"),
+        ],
+    )
+    def test_granitehybrid_invalid_moe_config_rejects(self, updates, match) -> None:
+        from mobius.integrations.gguf._config_mapping import gguf_to_config
+
+        metadata = self._metadata("granitehybrid")
+        metadata.update({f"granitehybrid.{key}": value for key, value in updates.items()})
+        with pytest.raises(ValueError, match=match):
+            gguf_to_config(_FakeDenseGGUF("granitehybrid", metadata, ["token_embd.weight"]))
 
     def test_nemotron_h_moe_derives_exact_routed_schedule_and_defaults(self) -> None:
         from mobius.integrations.gguf._config_mapping import gguf_to_config

--- a/src/mobius/integrations/gguf/_tensor_mapping.py
+++ b/src/mobius/integrations/gguf/_tensor_mapping.py
@@ -441,6 +441,13 @@ _GRANITEHYBRID_MAPPING: dict[str, str] = {
     "blk.{bid}.ffn_gate": "model.layers.{bid}.shared_mlp.gate_proj",
     "blk.{bid}.ffn_up": "model.layers.{bid}.shared_mlp.up_proj",
     "blk.{bid}.ffn_down": "model.layers.{bid}.shared_mlp.output_linear",
+    "blk.{bid}.ffn_gate_inp": "model.layers.{bid}.block_sparse_moe.gate",
+    "blk.{bid}.ffn_gate_exps": "model.layers.{bid}.block_sparse_moe.gate_proj",
+    "blk.{bid}.ffn_up_exps": "model.layers.{bid}.block_sparse_moe.up_proj",
+    "blk.{bid}.ffn_down_exps": "model.layers.{bid}.block_sparse_moe.output_linear",
+    "blk.{bid}.ffn_gate_shexp": "model.layers.{bid}.shared_mlp.gate_proj",
+    "blk.{bid}.ffn_up_shexp": "model.layers.{bid}.shared_mlp.up_proj",
+    "blk.{bid}.ffn_down_shexp": "model.layers.{bid}.shared_mlp.output_linear",
 }
 
 _BERT_MAPPING: dict[str, str] = {

--- a/src/mobius/integrations/gguf/_tensor_mapping_test.py
+++ b/src/mobius/integrations/gguf/_tensor_mapping_test.py
@@ -112,6 +112,31 @@ class TestMapGGUFToHFNames:
                 "blk.0.ffn_gate.weight",
                 "model.layers.0.shared_mlp.gate_proj.weight",
             ),
+            (
+                "granitehybrid",
+                "blk.0.ffn_gate_inp.weight",
+                "model.layers.0.block_sparse_moe.gate.weight",
+            ),
+            (
+                "granitehybrid",
+                "blk.0.ffn_gate_exps.weight",
+                "model.layers.0.block_sparse_moe.gate_proj.weight",
+            ),
+            (
+                "granitehybrid",
+                "blk.0.ffn_up_exps.weight",
+                "model.layers.0.block_sparse_moe.up_proj.weight",
+            ),
+            (
+                "granitehybrid",
+                "blk.0.ffn_down_exps.weight",
+                "model.layers.0.block_sparse_moe.output_linear.weight",
+            ),
+            (
+                "granitehybrid",
+                "blk.0.ffn_gate_shexp.weight",
+                "model.layers.0.shared_mlp.gate_proj.weight",
+            ),
         ],
     )
     def test_second_hybrid_cohort_mapping(

--- a/src/mobius/integrations/gguf/_tensor_processors.py
+++ b/src/mobius/integrations/gguf/_tensor_processors.py
@@ -337,19 +337,32 @@ def _process_granitehybrid(
     state_dict: dict[str, torch.Tensor],
     config: Any,
 ) -> dict[str, torch.Tensor]:
-    """Invert Granite attention/Mamba transforms and fuse its dense gate/up input."""
+    """Invert Granite transforms and reconstruct fused shared/expert gate-up weights."""
     state_dict = _process_llama(state_dict, config)
     state_dict = _process_mamba(state_dict, config)
     for name in list(state_dict):
-        if not name.endswith(".shared_mlp.gate_proj.weight"):
-            continue
-        prefix = name.removesuffix("gate_proj.weight")
-        up_name = f"{prefix}up_proj.weight"
-        if up_name not in state_dict:
-            raise ValueError(f"GraniteHybrid dense FFN is missing paired tensor {up_name!r}")
-        state_dict[f"{prefix}input_linear.weight"] = torch.cat(
-            (state_dict.pop(name), state_dict.pop(up_name)), dim=0
-        )
+        if name.endswith(".shared_mlp.gate_proj.weight"):
+            prefix = name.removesuffix("gate_proj.weight")
+            up_name = f"{prefix}up_proj.weight"
+            if up_name not in state_dict:
+                raise ValueError(
+                    f"GraniteHybrid shared FFN is missing paired tensor {up_name!r}"
+                )
+            state_dict[f"{prefix}input_linear.weight"] = torch.cat(
+                (state_dict.pop(name), state_dict.pop(up_name)), dim=0
+            )
+        elif name.endswith(".block_sparse_moe.gate_proj.weight"):
+            prefix = name.removesuffix("gate_proj.weight")
+            up_name = f"{prefix}up_proj.weight"
+            if up_name not in state_dict:
+                raise ValueError(
+                    f"GraniteHybrid routed experts are missing paired tensor {up_name!r}"
+                )
+            # GGUF stores [E, F, H] gate and up tensors separately while the
+            # Transformers/Mobius module stores [E, 2F, H] in gate-then-up order.
+            state_dict[f"{prefix}input_linear.weight"] = torch.cat(
+                (state_dict.pop(name), state_dict.pop(up_name)), dim=1
+            )
     return state_dict
 
 

--- a/src/mobius/integrations/gguf/_tensor_processors_test.py
+++ b/src/mobius/integrations/gguf/_tensor_processors_test.py
@@ -422,6 +422,29 @@ class TestProcessTensorsMamba:
         assert result["model.layers.0.mamba.D"].shape == (2,)
         assert result["model.layers.0.mamba.norm.weight"].shape == (4,)
 
+    def test_granitehybrid_expert_gate_up_fusion_preserves_expert_order(self) -> None:
+        config = SimpleNamespace(
+            model_type="granitemoehybrid",
+            _gguf_arch="granitehybrid",
+            layer_types=["mamba2"],
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            head_dim=2,
+        )
+        gate = torch.stack((torch.full((2, 4), 11.0), torch.full((2, 4), 12.0)))
+        up = torch.stack((torch.full((2, 4), 21.0), torch.full((2, 4), 22.0)))
+        state_dict = {
+            "model.layers.0.block_sparse_moe.gate_proj.weight": gate,
+            "model.layers.0.block_sparse_moe.up_proj.weight": up,
+        }
+
+        result = process_tensors(state_dict, config)
+
+        fused = result["model.layers.0.block_sparse_moe.input_linear.weight"]
+        assert fused.shape == (2, 4, 4)
+        torch.testing.assert_close(fused[:, :2], gate)
+        torch.testing.assert_close(fused[:, 2:], up)
+
 
 class TestProcessTensorsNoop:
     """Test that unknown architectures pass through."""

--- a/src/mobius/models/granitemoehybrid.py
+++ b/src/mobius/models/granitemoehybrid.py
@@ -100,7 +100,10 @@ class _FusedMoEBlock(nn.Module):
 
         # Routing gate: HF name is router.layer, renamed to gate in preprocess_weights
         self.gate = TopKGate(
-            config.hidden_size, config.num_local_experts, config.num_experts_per_tok
+            config.hidden_size,
+            config.num_local_experts,
+            config.num_experts_per_tok,
+            routed_scaling_factor=config.routed_scaling_factor,
         )
 
         # Fused 3D expert weights — names match HF directly
@@ -192,7 +195,7 @@ def _feedforward(
     op: OpBuilder,
     hidden_states: ir.Value,
     block_sparse_moe: nn.Module | None,
-    shared_mlp: nn.Module,
+    shared_mlp: nn.Module | None,
 ) -> ir.Value:
     """Combined routed-MoE + shared-MLP feedforward.
 
@@ -200,10 +203,12 @@ def _feedforward(
     variants with ``num_local_experts == 0`` (e.g. granite-4.0-1b) only the
     dense shared MLP runs. Mirrors HF ``GraniteMoeHybridDecoderLayer``.
     """
-    shared_out = shared_mlp(op, hidden_states)
+    shared_out = shared_mlp(op, hidden_states) if shared_mlp is not None else None
     if block_sparse_moe is None:
+        assert shared_out is not None
         return shared_out
-    return op.Add(block_sparse_moe(op, hidden_states), shared_out)
+    routed_out = block_sparse_moe(op, hidden_states)
+    return op.Add(routed_out, shared_out) if shared_out is not None else routed_out
 
 
 class _GraniteMoeHybridMambaDecoderLayer(nn.Module):
@@ -243,7 +248,9 @@ class _GraniteMoeHybridMambaDecoderLayer(nn.Module):
         self.block_sparse_moe = _FusedMoEBlock(config) if self._has_experts else None
 
         # Dense shared MLP with fused gate+up weight
-        self.shared_mlp = _FusedSharedMLP(config)
+        self.shared_mlp = (
+            _FusedSharedMLP(config) if config.shared_intermediate_size > 0 else None
+        )
 
         self._residual_multiplier = config.residual_multiplier
 
@@ -309,7 +316,9 @@ class _GraniteMoeHybridAttentionDecoderLayer(nn.Module):
         self.block_sparse_moe = _FusedMoEBlock(config) if self._has_experts else None
 
         # Dense shared MLP with fused gate+up weight
-        self.shared_mlp = _FusedSharedMLP(config)
+        self.shared_mlp = (
+            _FusedSharedMLP(config) if config.shared_intermediate_size > 0 else None
+        )
 
         self._residual_multiplier = config.residual_multiplier
 

--- a/tests/synthetic_parity_test.py
+++ b/tests/synthetic_parity_test.py
@@ -590,15 +590,12 @@ def _create_hf_config(model_type: str, config_overrides: dict):
             for lt in hf_kwargs["layer_types"]
         ]
 
-    # GraniteMoeHybrid uses layers_block_type (HF field) with layer-type values.
-    # Convert our internal "mamba2"/"full_attention" names to the current HF values
-    # ("linear_attention"/"full_attention"); the legacy "mamba"/"attention" names
-    # are no longer accepted by HF's layer-type validator.
+    # GraniteMoeHybrid's current constructor consumes layer_types and selects
+    # the recurrent path only for the literal "mamba" layer type.
     if hf_model_type in ("granitemoehybrid",) and "layer_types" in hf_kwargs:
-        layer_types = hf_kwargs.pop("layer_types")
-        hf_kwargs["layers_block_type"] = [
-            "full_attention" if lt in ("full_attention", "attention") else "linear_attention"
-            for lt in layer_types
+        hf_kwargs["layer_types"] = [
+            "attention" if lt in ("full_attention", "attention") else "mamba"
+            for lt in hf_kwargs["layer_types"]
         ]
 
     # NemotronH uses its public layer-type vocabulary rather than Mobius names.


### PR DESCRIPTION
## Summary

- add exact GraniteMoeHybrid GGUF config extraction for mixed Mamba2/attention schedules, routed experts, optional shared experts, and Granite scaling/norm metadata
- map and fuse separate routed/shared gate+up tensors with value-tested gate-then-up ordering while keeping quantized expert preservation fail-closed
- enforce strict tensor closure and logical shapes, including optional all-or-none attention biases matching official Granite 4 H GGUFs
- cover ORT prefill/decode/reorder/replay, package save/reload, CLI import, Transformers synthetic parity, and malformed sources
- update the generated GGUF support census from dense-only to routed-MoE support

## Stack

- Depends on #614

## Validation

- `python -m pytest tests/build_graph_test.py tests/cli_test.py src/ -q -k 'not phi4mm and not apply_weights_unknown and not glm_moe_dsa' --tb=short -n auto` — 7141 passed, 54 skipped
- `python -m pytest tests/synthetic_parity_test.py -k granitemoehybrid -q --tb=short` — 1 passed
- `python -m pytest tests/weight_alignment_test.py -k granitemoehybrid -q --tb=short` — 1 passed
- focused GraniteHybrid GGUF closure/build tests — 19 passed
- changed-file `lintrunner` — clean

The unfiltered suite additionally reached 7164 passed and 54 skipped; its only failures were two reproducible pre-existing `glm_moe_dsa` shape-inference/checker failures unrelated to this diff.
