### PR TITLE
Validate real PLaMo2 GGUF import

### DIFF
--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -1109,14 +1109,47 @@ def _raise_for_invalid_plamo2_tensor_contract(gguf_model) -> None:
 
     head_counts = metadata[f"{arch}.attention.head_count"]
     kv_counts = metadata[f"{arch}.attention.head_count_kv"]
-    if not isinstance(head_counts, (list, tuple, np.ndarray)) or not isinstance(
-        kv_counts, (list, tuple, np.ndarray)
-    ):
-        raise TypeError("PLaMo2 attention head counts must be per-layer arrays")
+    head_counts_are_arrays = isinstance(head_counts, (list, tuple, np.ndarray))
+    kv_counts_are_arrays = isinstance(kv_counts, (list, tuple, np.ndarray))
+    if head_counts_are_arrays and len(head_counts) != layers:
+        raise ValueError("PLaMo2 attention head arrays must match block_count")
+    if kv_counts_are_arrays and len(kv_counts) != layers:
+        raise ValueError("PLaMo2 attention head arrays must match block_count")
+    if kv_counts_are_arrays:
+        attention_layers = [int(value) > 0 for value in kv_counts]
+    elif head_counts_are_arrays:
+        attention_layers = [int(value) > 0 for value in head_counts]
+    else:
+        # Early llama.cpp PLaMo2 converters serialized the attention dimensions
+        # as scalars. The mutually exclusive tensor families still encode the
+        # exact layer schedule, so expand it only when every layer is unambiguous.
+        tensor_names = set(gguf_model.tensor_names)
+        attention_layers = []
+        for layer in range(layers):
+            has_attention = f"blk.{layer}.attn_qkv.weight" in tensor_names
+            has_mamba = f"blk.{layer}.ssm_in.weight" in tensor_names
+            if has_attention == has_mamba:
+                raise ValueError(
+                    "PLaMo2 scalar head metadata requires exactly one attention or "
+                    f"Mamba tensor family in layer {layer}"
+                )
+            attention_layers.append(has_attention)
+    if not head_counts_are_arrays:
+        attention_heads = int(head_counts)
+        if attention_heads <= 0:
+            raise ValueError("PLaMo2 scalar attention head_count must be positive")
+        head_counts = metadata[f"{arch}.attention.head_count"] = [
+            attention_heads if is_attention else 0 for is_attention in attention_layers
+        ]
+    if not kv_counts_are_arrays:
+        attention_kv_heads = int(kv_counts)
+        if attention_kv_heads <= 0:
+            raise ValueError("PLaMo2 scalar attention head_count_kv must be positive")
+        kv_counts = metadata[f"{arch}.attention.head_count_kv"] = [
+            attention_kv_heads if is_attention else 0 for is_attention in attention_layers
+        ]
     head_counts = [int(value) for value in head_counts]
     kv_counts = [int(value) for value in kv_counts]
-    if len(head_counts) != layers or len(kv_counts) != layers:
-        raise ValueError("PLaMo2 attention head arrays must match block_count")
 
     actual_shapes = {
         name: tuple(int(dim) for dim in gguf_model.get_tensor_shape(name))

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -837,6 +837,7 @@ def _write_plamo2_gguf(
     predefined_state: bool = False,
     head_counts: list[int] | None = None,
     kv_head_counts: list[int] | None = None,
+    legacy_scalar_heads: bool = False,
     quantized_embedding: bool = False,
     include_output: bool = False,
 ) -> None:
@@ -861,8 +862,10 @@ def _write_plamo2_gguf(
     writer.add_embedding_length(hidden)
     writer.add_feed_forward_length(intermediate)
     writer.add_block_count(2)
-    writer.add_head_count(head_counts or [0, heads])
-    writer.add_head_count_kv(kv_head_counts or [0, kv_heads])
+    writer.add_head_count(heads if legacy_scalar_heads else head_counts or [0, heads])
+    writer.add_head_count_kv(
+        kv_heads if legacy_scalar_heads else kv_head_counts or [0, kv_heads]
+    )
     writer.add_layer_norm_rms_eps(epsilon)
     writer.add_rope_freq_base(10_000.0)
     writer.add_vocab_size(vocab)
@@ -4546,6 +4549,16 @@ class TestPlamo2GGUFBuild:
         outputs = session.run(self._inputs(2))
         assert outputs["logits"].shape == (2, 2, 64)
         assert outputs["present.0.ssm_state"].dtype == np.float32
+
+    def test_legacy_scalar_heads_infer_exact_tensor_schedule(self, tmp_path: Path) -> None:
+        from mobius.integrations.gguf import build_from_gguf
+
+        path = tmp_path / "plamo2-legacy-scalar-heads.gguf"
+        _write_plamo2_gguf(path, quantized=False, legacy_scalar_heads=True)
+        package = build_from_gguf(path)
+        assert package.config.layer_types == ["mamba", "full_attention"]
+        assert package.config.attention_head_counts == (0, 4)
+        assert package.config.attention_kv_head_counts == (0, 2)
 
     def test_quantized_source_preserves_exact_projection_roles(self, tmp_path: Path) -> None:
         from mobius.integrations.gguf import build_from_gguf

--- a/src/mobius/integrations/gguf/_tokenizer.py
+++ b/src/mobius/integrations/gguf/_tokenizer.py
@@ -252,10 +252,15 @@ def inspect_gguf_tokenizer(
         if policy is None:
             raise ValueError(f"{source} declares unknown tokenizer.ggml.pre {pre_value!r}")
     elif pre_value is not None:
-        raise ValueError(
-            f"{source} declares tokenizer.ggml.pre for non-BPE model {model!r}; "
-            "the pinned loader does not consume that combination"
-        )
+        # The public PLaMo2 F32 conversion predates per-model tokenizer cleanup
+        # and carries the inert legacy value "default". Validate that exact
+        # known identifier, but keep tokenizer materialization deferred below.
+        if model != "plamo2" or pre_value != "default":
+            raise ValueError(
+                f"{source} declares tokenizer.ggml.pre for non-BPE model {model!r}; "
+                "the pinned loader does not consume that combination"
+            )
+        policy = tokenizer_pre_policies()[pre_value]
     else:
         policy = None
 

--- a/src/mobius/integrations/gguf/_tokenizer_test.py
+++ b/src/mobius/integrations/gguf/_tokenizer_test.py
@@ -179,6 +179,15 @@ class TestInspectGgufTokenizer:
         assert verdict.pre == "hunyuan-dense"
         assert "compiled llama.cpp behavior" in verdict.reason
 
+    def test_plamo2_legacy_default_pre_is_validated_but_deferred(self):
+        metadata = _metadata(pre="default")
+        metadata["tokenizer.ggml.model"] = "plamo2"
+        metadata.pop("tokenizer.ggml.merges")
+        verdict = inspect_gguf_tokenizer(metadata)
+        assert verdict.route == "deferred"
+        assert verdict.pre == "default"
+        assert verdict.canonical_pre == "default"
+
     def test_exact_embedded_json_is_copy_route(self):
         verdict = inspect_gguf_tokenizer(_metadata(embedded=True))
         assert verdict.route == "copy"

--- a/testdata/cases/causal-lm/plamo2-1b.yaml
+++ b/testdata/cases/causal-lm/plamo2-1b.yaml
@@ -15,5 +15,5 @@ generation:
   max_new_tokens: 20
   do_sample: false
 
-notes: "Dedicated alternating Mamba1 and local-attention graph with mixed recurrent/KV state."
-skip_reason: "The smallest public checkpoint is 5.16 GB, and released ORT GenAI cannot represent the heterogeneous state ABI; runtime validation is deferred to onnxruntime/mobius#605."
+notes: "The exact public checkpoint/GGUF route was exercised; see testdata/evidence/causal-lm/plamo2-1b-real.json."
+skip_reason: "Real CPU validation found cached-decode divergence, and ORT GenAI 0.15.2 cannot bind the heterogeneous recurrent/KV state ABI; do not claim L4/L5 yet."

--- a/testdata/evidence/causal-lm/plamo2-1b-real.json
+++ b/testdata/evidence/causal-lm/plamo2-1b-real.json
@@ -1,0 +1,189 @@
+{
+  "schema_version": 1,
+  "validated_at_utc": "2026-08-25T06:14:35Z",
+  "validated_parent_commit": "64aa8fb55d10d3097d944e44231f0301d2527113",
+  "validation_change_set": "the compatibility and evidence changes committed with this record",
+  "status": "runtime-deferred",
+  "source_checkpoint": {
+    "repository": "pfnet/plamo-2-1b",
+    "revision": "92c75fd6eea9018bcb9c33ee8921589febe071fa",
+    "files": [
+      {
+        "filename": "model-00001-of-00007.safetensors",
+        "bytes": 4060618320,
+        "lfs_sha256": "306bfd09ff22b5c044abfbc310b0a916a85a450ff52beaa90e245bb67b4cb1e9"
+      },
+      {
+        "filename": "model-00002-of-00007.safetensors",
+        "bytes": 285214592,
+        "lfs_sha256": "759d54a62b8f8124031bf4048b2b7e9b9fe3439e75ce772e48562369768836a8"
+      },
+      {
+        "filename": "model-00003-of-00007.safetensors",
+        "bytes": 819200136,
+        "lfs_sha256": "c7172210250c2b4030b1bc9c75a68224844e770838159e939bb6c68593d2e235"
+      },
+      {
+        "filename": "model-00004-of-00007.safetensors",
+        "bytes": 621448,
+        "lfs_sha256": "017d164149a8e31acdde2f8c6dd45568d7a8900951f83cb5fbcebac64c662695"
+      },
+      {
+        "filename": "model-00005-of-00007.safetensors",
+        "bytes": 131976,
+        "lfs_sha256": "6bfe7b7d45c40c75d7ff7b362fd88bf34e23aedf6a637df4eafc9f7d6231f8ca"
+      },
+      {
+        "filename": "model-00006-of-00007.safetensors",
+        "bytes": 5296,
+        "lfs_sha256": "3dadc185925d0be7f495c51924546b0f07f93550cf4222da96dedd335beb3b8f"
+      },
+      {
+        "filename": "model-00007-of-00007.safetensors",
+        "bytes": 40,
+        "lfs_sha256": "60d95b10b6e140a9626a7058d5038528f2ff80148dc4569b881db56052046509"
+      }
+    ],
+    "config_sha256": "7cd00447566283be63bf20efac313f02423129586c5b348466f09d15082053e9",
+    "tokenizer_jsonl_sha256": "9fa8276a87dd2440bb9496f1d569c05ded6274fd2854de802e12dc6545804b95",
+    "tokenizer_config_sha256": "3472dc70138f3d98161b0d54ca424519f031d865882e85efc75e30c349879050",
+    "tokenization_code_sha256": "ebddaf4cd8c4f7cde47d9e94a227a1cec7eccfbf303a70f520a3fda7c060abef",
+    "modeling_code_sha256": "21c0e1d8ba2f777c69305259254da865cf79145c1e06fee4fd26ed926b82451e"
+  },
+  "gguf": {
+    "repository": "yt-koike/plamo-2-1b-gguf",
+    "revision": "184326afcef7232d94df09a33279598255890325",
+    "filename": "plamo-2-1B-F32.gguf",
+    "bytes": 5168220288,
+    "lfs_sha256": "c5deb94bcd21f516db2b00ba4e923e02cc1dede4b7531ef81a15899130b0e5ef",
+    "format_version": 3,
+    "tensor_count": 218,
+    "qtypes": {
+      "F32": 218
+    }
+  },
+  "provenance_comparison": {
+    "method": "streamed comparison of every GGUF tensor against the pinned safetensors after documented norm-offset, convolution-shape, and Mamba-decay transforms",
+    "compared_tensors": 218,
+    "exact_tensors": 213,
+    "missing_tensors": 0,
+    "elements": 1291441920,
+    "max_abs_error": 9.5367431640625e-07,
+    "mean_abs_error": 3.323056466858475e-15,
+    "non_exact_tensors": "five ssm_a tensors differ only by float32 -exp(A_log) rounding"
+  },
+  "architecture": {
+    "layers": 16,
+    "schedule": "alternating mamba and attention, starting with mamba",
+    "hidden_size": 2048,
+    "feed_forward_size": 8192,
+    "attention_heads": 16,
+    "kv_heads": 1,
+    "mamba_inner_size": 4096,
+    "mamba_heads": 32,
+    "mamba_state_size": 64,
+    "mamba_conv_kernel": 4
+  },
+  "mobius_package": {
+    "import": "passed",
+    "save_check_reload": "passed",
+    "files": [
+      "model.onnx",
+      "model.onnx.data"
+    ],
+    "sha256": "5a9a6638087d4b76fff79e102e665fb963e505cd17812f909cfc33e42a29b640",
+    "state_interfaces": 16,
+    "state_abi": "even layers: conv_state+ssm_state; odd layers: key+value"
+  },
+  "independent_reference": {
+    "implementation": "pinned HuggingFace remote model with upstream pure-PyTorch causal_conv1d_ref and selective_state_update_ref equivalents",
+    "transformers_version": "5.12.1",
+    "torch_version": "2.12.1",
+    "compatibility_shims": [
+      "adapt Transformers 5 tied-weight metadata and tie lm_head to embed_tokens",
+      "rebuild non-persistent RoPE caches after meta-device loading",
+      "provide pure-PyTorch causal convolution and selective state update"
+    ],
+    "prompt": "Hello",
+    "prompt_tokens": [
+      1,
+      6721
+    ],
+    "generated_tokens": [
+      44,
+      24514,
+      45119,
+      7982,
+      45114,
+      2166,
+      353,
+      1468,
+      15658,
+      1090,
+      2596,
+      1031,
+      73,
+      1170,
+      1090,
+      2596,
+      45114,
+      2166,
+      353,
+      1468
+    ],
+    "generated_text": ", my name is Alex and I'm a software engineer at Google.\n\nI work at Google and I'm a software",
+    "generated_length": 20,
+    "rollback_replay_exact": true
+  },
+  "ort_cpu": {
+    "onnxruntime_version": "1.29.0",
+    "execution_provider": "CPUExecutionProvider",
+    "fused_and_portable_results_equal": true,
+    "prefill_max_abs_error": 0.011388778686523438,
+    "prefill_mean_abs_error": 0.000737154199364013,
+    "decode_steps": 19,
+    "decode_max_abs_error": 23.476438999176025,
+    "decode_mean_abs_error": 1.668023172595157,
+    "generated_tokens": [
+      44,
+      2268,
+      1101,
+      1080,
+      1087,
+      8789,
+      45114,
+      2002,
+      2569,
+      3035,
+      8435,
+      46,
+      7525,
+      2004,
+      1078,
+      1652,
+      290,
+      15143,
+      45116,
+      2057
+    ],
+    "generated_length": 20,
+    "token_equality": false,
+    "rollback_replay_exact": true,
+    "promotion_decision": "blocked: cached decode does not meet numerical or token-equality gates"
+  },
+  "ort_genai": {
+    "released_version": "0.15.2",
+    "generated_model_type": "plamo2",
+    "generated_state_schema": "homogeneous past_key_names/past_value_names templates",
+    "model_load": "failed: Unsupported model_type in config.json: plamo2",
+    "tokenizer_load_after_forcing_llama": "failed: Invalid file: tokenizer.json",
+    "generation_after_forcing_llama_and_supplying_prompt_tokens": "failed: Model input was not found: past_key_values.0.recurrent_state",
+    "upstream_main_commit": "a8e0fdf81b061e67c1c3f9485bfdc06735ccd473",
+    "upstream_main_install": "not feasible from the Python source package: pip built UNKNOWN-0.0.0 without an onnxruntime_genai module",
+    "promotion_decision": "blocked: no released heterogeneous-state schema, no compatible tokenizer artifact, and no successful end-to-end generation"
+  },
+  "l4_l5": {
+    "goldens_committed": false,
+    "reason": "real prefill exceeds the parity gate and cached generation diverges; committing passing goldens would misrepresent support"
+  }
+}

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -22,7 +22,9 @@ Run only prefill tests::
 from __future__ import annotations
 
 import gc
+import hashlib
 import os
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -45,6 +47,50 @@ from mobius._testing.torch_reference import (
     load_torch_multimodal_model,
     torch_forward,
 )
+
+
+@pytest.mark.integration
+@pytest.mark.integration_slow
+def test_plamo2_pinned_real_gguf_import_roundtrip(tmp_path: Path):
+    """Import and serialize the exact public PLaMo2 F32 artifact on explicit opt-in."""
+    source = os.environ.get("MOBIUS_PLAMO2_REAL_GGUF")
+    if source is None:
+        pytest.skip("set MOBIUS_PLAMO2_REAL_GGUF to the pinned 5.16 GB F32 artifact")
+
+    from mobius._model_package import ModelPackage
+    from mobius.integrations.gguf import build_from_gguf
+
+    source_path = Path(source)
+    expected_sha256 = "c5deb94bcd21f516db2b00ba4e923e02cc1dede4b7531ef81a15899130b0e5ef"
+    digest = hashlib.sha256()
+    with source_path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    assert digest.hexdigest() == expected_sha256
+
+    package = build_from_gguf(
+        source_path,
+        keep_quantized=False,
+        execution_provider="cpu",
+    )
+    assert (
+        package.config.layer_types
+        == [
+            "mamba",
+            "full_attention",
+        ]
+        * 8
+    )
+    assert package.gguf_tokenizer_verdict.route == "deferred"
+
+    output_dir = tmp_path / "plamo2-real"
+    package.save(str(output_dir), progress_bar=False)
+    reloaded = ModelPackage.load(str(output_dir))
+    graph = reloaded["model"].graph
+    assert len(graph.inputs) == 34
+    assert len(graph.outputs) == 33
+    assert graph.inputs[2].name == "past_key_values.0.conv_state"
+    assert graph.inputs[4].name == "past_key_values.1.key"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- accept the exact legacy scalar-head and tokenizer metadata used by the pinned public PLaMo2 F32 GGUF
- add an explicit opt-in 5.16 GB import/save/reload integration test
- record immutable source provenance, full tensor comparison, raw ORT parity results, and ORT GenAI blockers
- keep L4/L5 and packaged runtime support deferred because cached decode diverges

## Historical evidence
- full 218-tensor provenance comparison completed against the pinned checkpoint and GGUF revisions
- exact artifact size/SHA, tensor census, package identity, reference generation, raw ORT CPU results, and ORT GenAI 0.15.2 blockers remain recorded in `testdata/evidence/causal-lm/plamo2-1b-real.json`
- the opt-in real-artifact round trip previously passed; the exact artifact is required through `MOBIUS_PLAMO2_REAL_GGUF`

## Post-rebase validation
- rebased as one patch-identical commit onto `c98ee9e` after #612 was squash-merged
- focused import/tokenizer/cache/schema/evidence selection: 255 passed, 1 expected env-gated skip
- broad non-integration suite: 7,522 passed, 54 skipped, 1 subtest passed
- initialized pinned `lintrunner` tools: clean
- GPT-only post-rebase review: no actionable findings