### PR TITLE
Fix multi-component export portability

### DIFF
--- a/src/mobius/_configs/_base.py
+++ b/src/mobius/_configs/_base.py
@@ -771,17 +771,64 @@ class ArchitectureConfig(BaseModelConfig):
         if rope_config is not None:
             rope_config = dataclasses.replace(rope_config, rope_interleave=rope_interleave)
 
+        per_layer_config = getattr(config, "per_layer_config", None)
+        layer_configs = []
+        layer_types = getattr(config, "layer_types", None)
+        if per_layer_config:
+            layer_configs = list(
+                per_layer_config.values()
+                if isinstance(per_layer_config, dict)
+                else per_layer_config
+            )
+
+        def _per_layer_value(attribute: str) -> int | None:
+            values = set()
+            values_by_layer_type: dict[str, set[int]] = {}
+            for index, layer_config in enumerate(layer_configs):
+                value = (
+                    layer_config.get(attribute)
+                    if isinstance(layer_config, dict)
+                    else getattr(layer_config, attribute, None)
+                )
+                if value is None:
+                    continue
+                values.add(value)
+                if layer_types and len(layer_types) == len(layer_configs):
+                    values_by_layer_type.setdefault(layer_types[index], set()).add(value)
+            if not values:
+                return None
+            if len(values) == 1:
+                return next(iter(values))
+            supported_layer_types = {"sliding_attention", "full_attention"}
+            if (
+                model_type not in {"gemma4_text", "gemma4_unified_text"}
+                or set(values_by_layer_type) != supported_layer_types
+                or any(len(type_values) != 1 for type_values in values_by_layer_type.values())
+            ):
+                raise ValueError(
+                    f"Mobius does not support these heterogeneous per-layer {attribute} "
+                    f"values: {sorted(values)}."
+                )
+            return next(iter(values_by_layer_type["sliding_attention"]))
+
+        head_dim = _per_layer_value("head_dim")
+        if head_dim is None:
+            head_dim = getattr(config, "head_dim", None)
+        num_key_value_heads = _per_layer_value("num_key_value_heads")
+        if num_key_value_heads is None:
+            num_key_value_heads = getattr(config, "num_key_value_heads", None)
+
         options = dict(
             head_dim=(
-                config.head_dim
-                if (hasattr(config, "head_dim") and config.head_dim is not None)
+                head_dim
+                if head_dim is not None
                 else getattr(config, "d_kv", None)
                 or getattr(config, "kv_channels", None)
                 or _as_int(hidden_size) // _as_int(num_attention_heads)
             ),
             num_attention_heads=_as_int(num_attention_heads),
             num_key_value_heads=_as_int(
-                getattr(config, "num_key_value_heads", None)
+                num_key_value_heads
                 or getattr(config, "n_kv_heads", None)
                 or (
                     getattr(config, "multi_query_group_num", None)
@@ -2540,15 +2587,50 @@ class Gemma4Config(VisionLanguageConfig):
             # Override with the correct sliding-attention theta (e.g. 10_000 for E2B/E4B).
             base = dataclasses.replace(base, rope_theta=float(sliding_rope["rope_theta"]))
 
-        # num_global_key_value_heads: only set when attention_k_eq_v is True
-        # (full-attention layers use fewer KV heads than sliding layers).
-        num_global_kv = None
-        if getattr(config, "attention_k_eq_v", False):
-            num_global_kv = getattr(config, "num_global_key_value_heads", None)
+        num_global_kv = getattr(config, "num_global_key_value_heads", None)
+        global_head_dim = getattr(config, "global_head_dim", None)
+        if global_head_dim is None or num_global_kv is None:
+            per_layer_config = getattr(config, "per_layer_config", None)
+            layer_types = getattr(config, "layer_types", None)
+            if per_layer_config and layer_types:
+                layer_configs = list(
+                    per_layer_config.values()
+                    if isinstance(per_layer_config, dict)
+                    else per_layer_config
+                )
+                if len(layer_types) == len(layer_configs):
+                    full_head_dims = {
+                        (
+                            layer_config.get("head_dim")
+                            if isinstance(layer_config, dict)
+                            else getattr(layer_config, "head_dim", None)
+                        )
+                        for layer_type, layer_config in zip(
+                            layer_types, layer_configs, strict=True
+                        )
+                        if layer_type == "full_attention"
+                    }
+                    full_head_dims.discard(None)
+                    if global_head_dim is None and len(full_head_dims) == 1:
+                        global_head_dim = next(iter(full_head_dims))
+                    full_kv_heads = {
+                        (
+                            layer_config.get("num_key_value_heads")
+                            if isinstance(layer_config, dict)
+                            else getattr(layer_config, "num_key_value_heads", None)
+                        )
+                        for layer_type, layer_config in zip(
+                            layer_types, layer_configs, strict=True
+                        )
+                        if layer_type == "full_attention"
+                    }
+                    full_kv_heads.discard(None)
+                    if num_global_kv is None and len(full_kv_heads) == 1:
+                        num_global_kv = next(iter(full_kv_heads))
 
         return cls(
             **_shallow_fields(base),
-            global_head_dim=getattr(config, "global_head_dim", None),
+            global_head_dim=global_head_dim,
             global_rope_theta=float(full_rope.get("rope_theta", 1_000_000.0)),
             global_partial_rotary_factor=float(full_rope.get("partial_rotary_factor", 0.25)),
             num_global_key_value_heads=num_global_kv,

--- a/src/mobius/_configs/_quantization.py
+++ b/src/mobius/_configs/_quantization.py
@@ -33,6 +33,9 @@ class QuantizationConfig:
     # When True, the LM head projection is block-wise quantized (MatMulNBits).
     # Used by Olive RTN exports and quantized GGUF imports.
     quantize_lm_head: bool = False
+    # When True, multimodal vision projections are block-wise quantized.
+    # Olive RTN records this when ``quantize_vision`` is enabled.
+    quantize_vision: bool = False
     # When True, the input embedding and LM head share one weight table. Olive
     # RTN records this in its own config (``tie_word_embeddings``) and may clear
     # the model's top-level flag, so it is tracked here independently.
@@ -120,5 +123,6 @@ class QuantizationConfig:
             sym=qc.get("sym", qc.get("symmetric", True)),
             quantize_embeddings=bool(qc.get("embeds", False)),
             quantize_lm_head=bool(qc.get("lm_head", False)),
+            quantize_vision=bool(qc.get("quantize_vision", False)),
             tie_word_embeddings=bool(qc.get("tie_word_embeddings", False)),
         )

--- a/src/mobius/_configs_test.py
+++ b/src/mobius/_configs_test.py
@@ -1036,8 +1036,8 @@ class TestQuantizationConfig:
         assert qc is not None
         assert qc.sym is False
 
-    def test_from_transformers_olive_embeds_and_lm_head(self):
-        """Olive RTN exports flag quantized embeddings and LM head."""
+    def test_from_transformers_olive_component_flags(self):
+        """Olive RTN exports flags for quantized tables and vision projections."""
         hf = type(
             "HFConfig",
             (),
@@ -1048,6 +1048,7 @@ class TestQuantizationConfig:
                     "group_size": 32,
                     "embeds": True,
                     "lm_head": True,
+                    "quantize_vision": True,
                 }
             },
         )()
@@ -1055,11 +1056,13 @@ class TestQuantizationConfig:
         assert qc is not None
         assert qc.quantize_embeddings is True
         assert qc.quantize_lm_head is True
+        assert qc.quantize_vision is True
 
-    def test_quantize_embed_lm_head_default_false(self):
+    def test_quantize_component_flags_default_false(self):
         qc = QuantizationConfig()
         assert qc.quantize_embeddings is False
         assert qc.quantize_lm_head is False
+        assert qc.quantize_vision is False
 
     def test_architecture_config_has_quantization_field(self):
         config = ArchitectureConfig()

--- a/src/mobius/_configs_test.py
+++ b/src/mobius/_configs_test.py
@@ -1182,6 +1182,93 @@ class TestArchitectureConfigValidate:
 class TestGemma4Config:
     """Tests for Gemma4Config.from_transformers."""
 
+    @staticmethod
+    def _heterogeneous_config(*head_dims, layer_types=None, kv_heads=None):
+        class FakeConfig:
+            model_type = "gemma4_text"
+            num_attention_heads = 8
+            num_hidden_layers = len(head_dims)
+            vocab_size = 262144
+            hidden_size = 1536
+            intermediate_size = 6144
+            hidden_act = "silu"
+            max_position_embeddings = 131072
+            rms_norm_eps = 1e-6
+            rope_theta = 10_000.0
+
+            def __init__(self):
+                layer_kv_heads = kv_heads or [1] * len(head_dims)
+                self.per_layer_config = [
+                    type(
+                        "LayerConfig",
+                        (),
+                        {
+                            "head_dim": head_dim,
+                            "num_key_value_heads": num_kv_heads,
+                        },
+                    )()
+                    for head_dim, num_kv_heads in zip(head_dims, layer_kv_heads, strict=True)
+                ]
+                self.layer_types = layer_types
+
+            @property
+            def head_dim(self):
+                raise RuntimeError("global per-layer attribute access is ambiguous")
+
+            @property
+            def num_key_value_heads(self):
+                raise RuntimeError("global per-layer attribute access is ambiguous")
+
+        return FakeConfig()
+
+    def test_uniform_per_layer_head_dim_avoids_ambiguous_global_access(self):
+        from mobius._configs import Gemma4Config
+
+        config = Gemma4Config.from_transformers(self._heterogeneous_config(256, 256))
+
+        assert config.head_dim == 256
+
+    def test_heterogeneous_per_layer_head_dim_fails_loudly(self):
+        from mobius._configs import Gemma4Config
+
+        with pytest.raises(ValueError, match="heterogeneous per-layer head_dim"):
+            Gemma4Config.from_transformers(self._heterogeneous_config(128, 256))
+
+    def test_dual_head_dim_maps_sliding_and_full_attention(self):
+        from mobius._configs import Gemma4Config
+
+        config = Gemma4Config.from_transformers(
+            self._heterogeneous_config(
+                256,
+                512,
+                layer_types=["sliding_attention", "full_attention"],
+                kv_heads=[8, 2],
+            )
+        )
+
+        assert config.head_dim == 256
+        assert config.global_head_dim == 512
+        assert config.num_key_value_heads == 8
+        assert config.num_global_key_value_heads == 2
+
+    def test_unsupported_third_heterogeneous_layer_type_fails(self):
+        from mobius._configs import Gemma4Config
+
+        with pytest.raises(ValueError, match="heterogeneous per-layer head_dim"):
+            Gemma4Config.from_transformers(
+                self._heterogeneous_config(
+                    256,
+                    512,
+                    128,
+                    layer_types=[
+                        "sliding_attention",
+                        "full_attention",
+                        "window_attention",
+                    ],
+                    kv_heads=[8, 2, 4],
+                )
+            )
+
     def test_boa_token_id_extracted_from_parent(self):
         """boa_token_id lives on the parent HF config, not text_config."""
         from mobius._configs import Gemma4Config

--- a/src/mobius/_optimizations.py
+++ b/src/mobius/_optimizations.py
@@ -704,6 +704,9 @@ def optimize_model(
                     "so the decoder fuses to GroupQueryAttention."
                 )
 
+    # Rewrites may insert producers after existing consumers.
+    model.graph.sort()
+
 
 def fold_initializers_after_weights(model: ir.Model) -> None:
     """Fold weight ``Transpose`` and ``Concat`` nodes after weights are loaded.

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -2343,6 +2343,28 @@ def mixed_native_q5_q8_gguf(tmp_path: Path) -> Path:
 class TestReuseGgufWeights:
     """Tests for mixed GGUF references plus converted ONNX sidecar weights."""
 
+    def test_fsync_file_uses_writable_descriptor_on_windows(
+        self, tmp_path: Path, monkeypatch
+    ):
+        from mobius.integrations.gguf import _reuse
+
+        path = tmp_path / "artifact.bin"
+        path.write_bytes(b"artifact")
+        opened_modes = []
+        real_open = Path.open
+
+        def tracking_open(self, *args, **kwargs):
+            if self == path:
+                opened_modes.append(args[0] if args else kwargs.get("mode", "r"))
+            return real_open(self, *args, **kwargs)
+
+        monkeypatch.setattr(_reuse.os, "name", "nt")
+        monkeypatch.setattr(Path, "open", tracking_open)
+
+        _reuse._fsync_file(path)
+
+        assert opened_modes == ["r+b"]
+
     def test_mixed_save_preserves_ranges_and_runs(self, tmp_path: Path):
         from mobius._model_package import ModelPackage
         from mobius.integrations.gguf import (

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -2343,9 +2343,7 @@ def mixed_native_q5_q8_gguf(tmp_path: Path) -> Path:
 class TestReuseGgufWeights:
     """Tests for mixed GGUF references plus converted ONNX sidecar weights."""
 
-    def test_fsync_file_uses_writable_descriptor_on_windows(
-        self, tmp_path: Path, monkeypatch
-    ):
+    def test_fsync_file_uses_writable_descriptor_on_windows(self, tmp_path: Path, monkeypatch):
         from mobius.integrations.gguf import _reuse
 
         path = tmp_path / "artifact.bin"

--- a/src/mobius/integrations/gguf/_reuse.py
+++ b/src/mobius/integrations/gguf/_reuse.py
@@ -565,7 +565,8 @@ def _verification_lock(root: Path) -> Iterator[None]:
 
 
 def _fsync_file(path: Path) -> None:
-    with path.open("rb") as stream:
+    mode = "r+b" if os.name == "nt" else "rb"
+    with path.open(mode) as stream:
         os.fsync(stream.fileno())
 
 

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -115,6 +115,8 @@ _ORT_GENAI_MODEL_TYPE: dict[str, str] = {
     "plamo2": "decoder",
     # Qwen VL model families have separate ORT GenAI model types.
     "qwen2_vl": "qwen2_5_vl",
+    "qwen2_vl_text": "qwen2_5_vl",
+    "qwen2_5_vl_text": "qwen2_5_vl",
     "qwen3_vl": "qwen3_vl",
     "qwen3_vl_text": "qwen3_vl",
     # Preserve Qwen3.5 / Qwen3.6 source architecture identities here so package
@@ -217,7 +219,9 @@ _QWEN_VL_MODEL_TYPES = frozenset(
         "muse_glimmer",
         "muse_glimmer_text",
         "qwen2_vl",
+        "qwen2_vl_text",
         "qwen2_5_vl",
+        "qwen2_5_vl_text",
         "qwen3_vl",
         "mage_vl",
         "glm_ocr",

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -242,11 +242,6 @@ _QWEN35_VL_MODEL_TYPES = frozenset(
         "qwen3_5_moe_vl",
     }
 )
-_QWEN35_TRT_RTX_EMBEDDING_PROVIDER_OPTIONS = {
-    "nv_profile_min_shapes": "input_ids:1x1,image_features:0x1024",
-    "nv_profile_opt_shapes": "input_ids:1x226,image_features:192x1024",
-    "nv_profile_max_shapes": "input_ids:1x1024,image_features:2520x1024",
-}
 _QWEN35_TRT_RTX_VISION_PROVIDER_OPTIONS = {
     "nv_profile_min_shapes": "pixel_values:600x1536",
     "nv_profile_opt_shapes": "pixel_values:600x1536",
@@ -573,6 +568,31 @@ def _introspect_outputs(pkg: ModelPackage, key: str) -> dict[str, str] | None:
     if model is None:
         return None
     return {out.name: out.name for out in model.graph.outputs if out.name is not None}
+
+
+def _qwen35_trt_rtx_embedding_provider_options(pkg: ModelPackage) -> dict[str, str]:
+    embedding = pkg.get("embedding")
+    if embedding is None:
+        raise ValueError("Qwen3.5 TRT-RTX export requires an embedding component.")
+    image_features = next(
+        (value for value in embedding.graph.inputs if value.name == "image_features"),
+        None,
+    )
+    if (
+        image_features is None
+        or image_features.shape is None
+        or not isinstance(image_features.shape[-1], int)
+    ):
+        raise ValueError(
+            "Qwen3.5 TRT-RTX export requires a static image_features width "
+            "to generate optimization profiles."
+        )
+    width = image_features.shape[-1]
+    return {
+        "nv_profile_min_shapes": f"input_ids:1x1,image_features:0x{width}",
+        "nv_profile_opt_shapes": f"input_ids:1x226,image_features:192x{width}",
+        "nv_profile_max_shapes": f"input_ids:1x1024,image_features:2520x{width}",
+    }
 
 
 def _copy_tokenizer_files(
@@ -1647,7 +1667,7 @@ def _write_genai_config(
                     )
                 if ep == "trt-rtx" and model_type in _QWEN35_VL_MODEL_TYPES:
                     vision_kwargs["embedding_provider_options"] = (
-                        _QWEN35_TRT_RTX_EMBEDDING_PROVIDER_OPTIONS
+                        _qwen35_trt_rtx_embedding_provider_options(pkg)
                     )
                     vision_kwargs["vision_provider_options"] = (
                         _QWEN35_TRT_RTX_VISION_PROVIDER_OPTIONS
@@ -1655,10 +1675,9 @@ def _write_genai_config(
 
             if vision_input_mapping is not None:
                 vision_kwargs["input_names"] = vision_input_mapping
-            # Introspect vision outputs so extra maps (e.g. Qwen3-VL
-            # ``deepstack_features``) are forwarded to the embedding model
-            # via genai_config.json; defaulting to ``image_features`` alone
-            # would silently drop DeepStack at runtime.
+            # Introspect runtime-semantic vision outputs from the ONNX graph.
+            # Model-specific auxiliary features must be packed into a supported
+            # output by the task rather than emitted as arbitrary config keys.
             vision_output_mapping = _introspect_outputs(pkg, "vision_encoder")
             if vision_output_mapping is not None:
                 vision_kwargs["output_names"] = vision_output_mapping

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -570,28 +570,53 @@ def _introspect_outputs(pkg: ModelPackage, key: str) -> dict[str, str] | None:
     return {out.name: out.name for out in model.graph.outputs if out.name is not None}
 
 
-def _qwen35_trt_rtx_embedding_provider_options(pkg: ModelPackage) -> dict[str, str]:
-    embedding = pkg.get("embedding")
-    if embedding is None:
-        raise ValueError("Qwen3.5 TRT-RTX export requires an embedding component.")
-    image_features = next(
-        (value for value in embedding.graph.inputs if value.name == "image_features"),
+def _get_static_graph_input_dim(
+    pkg: ModelPackage,
+    component_name: str,
+    input_name: str,
+    axis: int,
+) -> int:
+    component = pkg.get(component_name)
+    if component is None:
+        raise ValueError(f"Component {component_name!r} is required.")
+    value = next(
+        (value for value in component.graph.inputs if value.name == input_name),
         None,
     )
-    if (
-        image_features is None
-        or image_features.shape is None
-        or not isinstance(image_features.shape[-1], int)
-    ):
+    if value is None or value.shape is None:
         raise ValueError(
-            "Qwen3.5 TRT-RTX export requires a static image_features width "
-            "to generate optimization profiles."
+            f"Component {component_name!r} requires input {input_name!r} with a known rank."
         )
-    width = image_features.shape[-1]
+    normalized_axis = axis if axis >= 0 else len(value.shape) + axis
+    if not 0 <= normalized_axis < len(value.shape):
+        raise ValueError(
+            f"Axis {axis} is out of range for {component_name!r} input "
+            f"{input_name!r} with rank {len(value.shape)}."
+        )
+    dimension = value.shape[normalized_axis]
+    if not isinstance(dimension, int):
+        raise TypeError(
+            f"Component {component_name!r} input {input_name!r} axis {axis} must be static."
+        )
+    return dimension
+
+
+def _make_trt_rtx_embedding_provider_options(
+    *,
+    image_feature_width: int,
+    input_id_lengths: tuple[int, int, int],
+    image_feature_lengths: tuple[int, int, int],
+) -> dict[str, str]:
     return {
-        "nv_profile_min_shapes": f"input_ids:1x1,image_features:0x{width}",
-        "nv_profile_opt_shapes": f"input_ids:1x226,image_features:192x{width}",
-        "nv_profile_max_shapes": f"input_ids:1x1024,image_features:2520x{width}",
+        f"nv_profile_{profile}_shapes": (
+            f"input_ids:1x{input_length},image_features:{feature_length}x{image_feature_width}"
+        )
+        for profile, input_length, feature_length in zip(
+            ("min", "opt", "max"),
+            input_id_lengths,
+            image_feature_lengths,
+            strict=True,
+        )
     }
 
 
@@ -1666,8 +1691,18 @@ def _write_genai_config(
                         getattr(config, "tokens_per_second", 2.0)
                     )
                 if ep == "trt-rtx" and model_type in _QWEN35_VL_MODEL_TYPES:
+                    image_feature_width = _get_static_graph_input_dim(
+                        pkg,
+                        "embedding",
+                        "image_features",
+                        -1,
+                    )
                     vision_kwargs["embedding_provider_options"] = (
-                        _qwen35_trt_rtx_embedding_provider_options(pkg)
+                        _make_trt_rtx_embedding_provider_options(
+                            image_feature_width=image_feature_width,
+                            input_id_lengths=(1, 226, 1024),
+                            image_feature_lengths=(0, 192, 2520),
+                        )
                     )
                     vision_kwargs["vision_provider_options"] = (
                         _QWEN35_TRT_RTX_VISION_PROVIDER_OPTIONS

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -1463,6 +1463,21 @@ def _write_audio_processor_config(
     return path
 
 
+def _uses_compact_sliding_kv_cache(decoder_model: ir.Model | None, ep: str) -> bool:
+    """Whether the graph and EP can keep sliding layers in a compact KV cache."""
+    if ep == "trt-rtx":
+        return True
+    if decoder_model is None or ep not in {"cpu", "cuda"}:
+        return False
+    return any(
+        node.op_type == "GroupQueryAttention"
+        and node.domain == "com.microsoft"
+        and (attribute := node.attributes.get("sliding_window_cache")) is not None
+        and attribute.as_int() == 1
+        for node in decoder_model.graph
+    )
+
+
 def _write_genai_config(
     config: Any,
     output_dir: str,
@@ -1572,7 +1587,13 @@ def _write_genai_config(
 
     sliding_window = None
     window_size = getattr(config, "sliding_window", None)
-    if isinstance(window_size, int) and window_size > 0:
+    # ORT GenAI uses this block to allocate a compact present cache. A
+    # local_window_size mask alone does not compact GQA outputs.
+    if (
+        isinstance(window_size, int)
+        and window_size > 0
+        and _uses_compact_sliding_kv_cache(decoder_model, ep)
+    ):
         layer_types = getattr(config, "layer_types", None)
         local_types = {"local", "sliding_attention", "window_attention"}
         layers = (

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -1333,9 +1333,22 @@ class TestExportForOrtGenai:
 
         pkg = ModelPackage(
             {
-                "decoder": _mock_model(),
-                "vision_encoder": _mock_model(),
-                "embedding": _mock_model(),
+                "decoder": _mock_model(
+                    inputs=[
+                        "inputs_embeds",
+                        "attention_mask",
+                        "position_ids",
+                        "per_layer_inputs",
+                    ]
+                ),
+                "vision_encoder": _mock_model(
+                    inputs=["pixel_values", "image_grid_thw"],
+                    outputs=["image_features"],
+                ),
+                "embedding": _mock_model(
+                    inputs=["input_ids", "image_features"],
+                    outputs=["inputs_embeds", "per_layer_inputs"],
+                ),
             },
             config=FakeConfig(),
         )
@@ -1351,6 +1364,10 @@ class TestExportForOrtGenai:
         assert model["vision"]["tokens_per_second"] == pytest.approx(2.0)
         assert model["vision"]["patch_size"] == 16
         assert model["vision"]["window_size"] == 64
+        assert model["decoder"]["inputs"]["per_layer_inputs"] == "per_layer_inputs"
+        assert model["embedding"]["outputs"]["per_layer_inputs"] == "per_layer_inputs"
+        assert model["vision"]["outputs"] == {"image_features": "image_features"}
+        assert "deepstack" not in json.dumps(data)
 
     def test_qwen35_vl_uses_native_qwen35_runtime_type(self, tmp_path):
         import dataclasses
@@ -1381,11 +1398,16 @@ class TestExportForOrtGenai:
             temporal_patch_size: int = 2
             vision: FakeVision = dataclasses.field(default_factory=FakeVision)
 
+        embedding = _mock_model(
+            inputs=["input_ids", "image_features"],
+            outputs=["inputs_embeds", "per_layer_inputs"],
+        )
+        embedding.graph.inputs[1].shape = ir.Shape(["num_tokens", 4096])
         pkg = ModelPackage(
             {
                 "decoder": _mock_model(),
                 "vision_encoder": _mock_model(),
-                "embedding": _mock_model(),
+                "embedding": embedding,
             },
             config=FakeConfig(),
         )
@@ -1424,19 +1446,19 @@ class TestExportForOrtGenai:
             model["embedding"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
                 "nv_profile_min_shapes"
             ]
-            == "input_ids:1x1,image_features:0x1024"
+            == "input_ids:1x1,image_features:0x4096"
         )
         assert (
             model["embedding"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
                 "nv_profile_opt_shapes"
             ]
-            == "input_ids:1x226,image_features:192x1024"
+            == "input_ids:1x226,image_features:192x4096"
         )
         assert (
             model["embedding"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
                 "nv_profile_max_shapes"
             ]
-            == "input_ids:1x1024,image_features:2520x1024"
+            == "input_ids:1x1024,image_features:2520x4096"
         )
         assert (
             model["vision"]["session_options"]["provider_options"][0]["NvTensorRtRtx"][
@@ -3335,25 +3357,19 @@ class TestGraphInputNames:
 
 
 class TestIntrospectVisionOutputs:
-    """_introspect_outputs surfaces extra vision outputs (DeepStack)."""
+    """_introspect_outputs surfaces graph outputs."""
 
-    def test_vision_deepstack_output_is_surfaced(self):
-        """A Qwen3-VL vision encoder's deepstack_features output is mapped."""
+    def test_vision_image_output_is_surfaced(self):
         from mobius._model_package import ModelPackage
 
         pkg = ModelPackage(
             {
-                "vision_encoder": _mock_model_with_outputs(
-                    ["image_features", "deepstack_features"]
-                ),
+                "vision_encoder": _mock_model_with_outputs(["image_features"]),
             },
             config=mock.MagicMock(),
         )
         mapping = _introspect_outputs(pkg, "vision_encoder")
-        assert mapping == {
-            "image_features": "image_features",
-            "deepstack_features": "deepstack_features",
-        }
+        assert mapping == {"image_features": "image_features"}
 
     def test_missing_key_returns_none(self):
         from mobius._model_package import ModelPackage

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -21,10 +21,12 @@ from mobius.integrations.ort_genai.auto_export import (
     _count_cache_layer_slots,
     _fix_chat_template,
     _fix_tokenizer_config,
+    _get_static_graph_input_dim,
     _graph_input_names,
     _inspect_decoder_abi,
     _introspect_outputs,
     _is_single_model_decoder_package,
+    _make_trt_rtx_embedding_provider_options,
     _resolve_ort_genai_model_type,
     _select_ort_model_type,
     _write_audio_processor_config,
@@ -3354,6 +3356,40 @@ class TestGraphInputNames:
             "attention_mask",
             "position_ids",
         ]
+
+
+class TestTrtRtxProfileHelpers:
+    def test_static_graph_input_dimension_is_component_agnostic(self):
+        from mobius._model_package import ModelPackage
+
+        encoder = _mock_model(inputs=["features"])
+        encoder.graph.inputs[0].shape = ir.Shape(["tokens", 3072])
+        pkg = ModelPackage({"encoder": encoder}, config=mock.MagicMock())
+
+        assert _get_static_graph_input_dim(pkg, "encoder", "features", -1) == 3072
+
+    def test_symbolic_graph_input_dimension_is_rejected(self):
+        from mobius._model_package import ModelPackage
+
+        encoder = _mock_model(inputs=["features"])
+        encoder.graph.inputs[0].shape = ir.Shape(["tokens", "width"])
+        pkg = ModelPackage({"encoder": encoder}, config=mock.MagicMock())
+
+        with pytest.raises(TypeError, match="must be static"):
+            _get_static_graph_input_dim(pkg, "encoder", "features", -1)
+
+    def test_embedding_profiles_use_supplied_bounds(self):
+        options = _make_trt_rtx_embedding_provider_options(
+            image_feature_width=4096,
+            input_id_lengths=(1, 128, 512),
+            image_feature_lengths=(0, 64, 1024),
+        )
+
+        assert options == {
+            "nv_profile_min_shapes": "input_ids:1x1,image_features:0x4096",
+            "nv_profile_opt_shapes": "input_ids:1x128,image_features:64x4096",
+            "nv_profile_max_shapes": "input_ids:1x512,image_features:1024x4096",
+        }
 
 
 class TestIntrospectVisionOutputs:

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -170,6 +170,9 @@ class TestResolveOrtGenaiModelType:
         # fallback still supplies the Qwen3 reasoning-token IDs.
         assert _resolve_ort_genai_model_type("qwen3_moe") == "qwen3"
 
+    def test_qwen25_text_subconfig_maps_to_multimodal_runtime(self):
+        assert _resolve_ort_genai_model_type("qwen2_5_vl_text") == "qwen2_5_vl"
+
     def test_gemma4_unified_model_types(self):
         # The gemma-4-12B unified checkpoint (model_type "gemma4_unified")
         # reuses the multimodal "gemma4" ORT GenAI pipeline; its standalone
@@ -328,6 +331,43 @@ class TestWriteProcessorConfig:
         norm_attrs = transforms[3]["operation"]["attrs"]
         assert len(norm_attrs["mean"]) == 3
         assert len(norm_attrs["std"]) == 3
+
+    def test_qwen25_text_config_writes_packed_patch_processor(self, tmp_path):
+        vision = types.SimpleNamespace(
+            image_size=448,
+            patch_size=14,
+            spatial_merge_size=2,
+            model_type="qwen2_5_vl",
+        )
+        config = types.SimpleNamespace(
+            vision=vision,
+            model_type="qwen2_5_vl_text",
+            spatial_merge_size=2,
+            temporal_patch_size=2,
+        )
+
+        path = _write_vision_processor_config(config, str(tmp_path))
+
+        assert path is not None
+        with open(path) as f:
+            data = json.load(f)
+        assert data["processor"]["name"] == "qwen2_5_image_processor"
+        transforms = data["processor"]["transforms"]
+        assert transforms[-1]["operation"] == {
+            "name": "patch_image",
+            "type": "PatchImage",
+            "attrs": {
+                "patch_size": 14,
+                "temporal_patch_size": 2,
+                "merge_size": 2,
+            },
+        }
+        normalize = next(
+            transform["operation"]
+            for transform in transforms
+            if transform["operation"]["type"] == "Normalize"
+        )
+        assert normalize["attrs"]["qwen2_5_vl"] == 1
 
     def test_mage_vl_writes_packed_patch_processor(self, tmp_path):
         vision = types.SimpleNamespace(

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -29,6 +29,7 @@ from mobius.integrations.ort_genai.auto_export import (
     _make_trt_rtx_embedding_provider_options,
     _resolve_ort_genai_model_type,
     _select_ort_model_type,
+    _uses_compact_sliding_kv_cache,
     _write_audio_processor_config,
     _write_genai_config,
     _write_vision_processor_config,
@@ -59,6 +60,24 @@ def _mock_model_with_inputs(names: list[str]) -> ir.Model:
 def _mock_model_with_outputs(names: list[str]) -> ir.Model:
     """Create a minimal ir.Model whose graph outputs have the given names."""
     return _mock_model(outputs=names)
+
+
+def test_compact_sliding_kv_cache_requires_matching_graph_contract():
+    model = _mock_model()
+    gqa = ir.Node(
+        op_type="GroupQueryAttention",
+        domain="com.microsoft",
+        inputs=[],
+        num_outputs=1,
+    )
+    model.graph.append(gqa)
+
+    assert not _uses_compact_sliding_kv_cache(model, "cpu")
+    gqa.attributes["sliding_window_cache"] = ir.AttrInt64("sliding_window_cache", 1)
+    assert _uses_compact_sliding_kv_cache(model, "cpu")
+    assert _uses_compact_sliding_kv_cache(model, "cuda")
+    assert not _uses_compact_sliding_kv_cache(model, "dml")
+    assert _uses_compact_sliding_kv_cache(None, "trt-rtx")
 
 
 def _mock_decoder_model(
@@ -3852,12 +3871,7 @@ class TestGemma4RealModel:
         assert "vision" not in data["model"]
         assert "audio" not in data["model"]
         assert "input_ids" in data["model"]["decoder"]["inputs"]
-        assert data["model"]["decoder"]["sliding_window"] == {
-            "window_size": 8,
-            "slide_key_value_cache": False,
-            "slide_inputs": False,
-            "layers": [0],
-        }
+        assert "sliding_window" not in data["model"]["decoder"]
         # No multimodal processor artifacts.
         assert "processor_config" not in result
         assert "audio_processor" not in result

--- a/src/mobius/models/cosmos3_omni.py
+++ b/src/mobius/models/cosmos3_omni.py
@@ -104,15 +104,14 @@ class Cosmos3OmniReasonerModel(Qwen3VL3ModelCausalLMModel):
     towers.
 
     .. note::
-       **DeepStack is preserved.**  The Qwen3-VL 3-model split threads the
-       intermediate DeepStack feature maps (from vision layers
-       ``deepstack_visual_indexes`` — ``[8, 16, 24]`` for Cosmos3) through an
-       extra ``deepstack_features`` / ``deepstack_embeds`` I/O channel:
-       ``vision_encoder`` emits a stacked ``[D, ...]`` tensor, ``embedding``
-       scatters each map to full sequence length, and the ``decoder`` adds
-       them into the hidden states of its first ``D`` layers — matching
-       HuggingFace's per-layer injection.  The 18 ``deepstack_merger_list.*``
-       weights are therefore exported and routed to ``vision_encoder``.
+       **DeepStack is preserved.** The Qwen3-VL 3-model split packs the
+       intermediate maps (from ``deepstack_visual_indexes`` — ``[8, 16, 24]``
+       for Cosmos3) into ``image_features``. The embedding model scatters and
+       flattens them into ORT GenAI's rank-3 ``per_layer_inputs`` contract,
+       and the decoder restores and injects one map into each of its first
+       ``D`` layers — matching HuggingFace's per-layer injection. The 18
+       ``deepstack_merger_list.*`` weights are therefore exported and routed
+       to ``vision_encoder``.
     """
 
     default_task: str = "qwen-vl"

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -35,6 +35,7 @@ from onnxscript import OpBuilder, nn
 from mobius._build_context import ep_capabilities, is_prefill_prefix_pruning_enabled
 from mobius._configs import ArchitectureConfig, Gemma4Config
 from mobius._weight_utils import (
+    is_packed_quant_key,
     preprocess_quantized_weights,
     vlm_decoder_weights,
     vlm_embedding_weights,
@@ -343,6 +344,30 @@ def _remap_moe_expert_weights(
     Shared by ``Gemma4CausalLMModel`` and ``Gemma4Model`` to avoid
     duplicating the rename/fold logic.
     """
+    packed_expert_key = next(
+        (
+            key
+            for key in state_dict
+            if is_packed_quant_key(key)
+            and any(
+                expert_name in key
+                for expert_name in (
+                    ".experts.gate_up_proj",
+                    ".experts.down_proj",
+                    ".fc1_experts_weights",
+                    ".fc2_experts_weights",
+                )
+            )
+        ),
+        None,
+    )
+    if packed_expert_key is not None:
+        raise NotImplementedError(
+            "Quantized Gemma4 MoE experts are not yet supported: the graph "
+            "currently requires float fc1_experts_weights and fc2_experts_weights "
+            f"parameters, but packed checkpoint key {packed_expert_key!r} was found."
+        )
+
     # experts.gate_up_proj → fc1_experts_weights
     # experts.down_proj    → fc2_experts_weights
     for key in list(state_dict.keys()):

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -34,7 +34,11 @@ from onnxscript import OpBuilder, nn
 
 from mobius._build_context import ep_capabilities, is_prefill_prefix_pruning_enabled
 from mobius._configs import ArchitectureConfig, Gemma4Config
-from mobius._weight_utils import vlm_decoder_weights, vlm_embedding_weights
+from mobius._weight_utils import (
+    preprocess_quantized_weights,
+    vlm_decoder_weights,
+    vlm_embedding_weights,
+)
 from mobius.components import (
     MLP,
     ClippableLinear,
@@ -3320,6 +3324,9 @@ class Gemma4Model(nn.Module):
                         # embeddings route correctly.
                         renamed["embedding." + suffix] = value
 
+            elif key.startswith("lm_head."):
+                renamed["decoder." + key] = value
+
             elif key.startswith("vision_tower."):
                 new_key = "vision_encoder.encoder." + key[len("vision_tower.") :]
                 # HF wraps encoder layers under an extra "encoder." sub-module; strip it
@@ -3380,6 +3387,30 @@ class Gemma4Model(nn.Module):
 
         # Map HF expert weight names and fold router scale
         _remap_moe_expert_weights(renamed, self.config)
+
+        quantization = self.config.quantization
+        if quantization is not None and quantization.quant_method in {
+            "olive",
+            "gptq",
+            "awq",
+        }:
+            tie = self.config.tie_word_embeddings
+            apply_tie = tie and any(
+                key in renamed
+                for key in (
+                    "embedding.embed_tokens.weight",
+                    "decoder.lm_head.weight",
+                )
+            )
+            renamed = preprocess_quantized_weights(
+                renamed,
+                quantization,
+                tie_embeddings=apply_tie,
+                embed_key="embedding.embed_tokens.weight",
+                head_key="decoder.lm_head.weight",
+                qmoe_target_path=None,
+                reject_quantized_embeddings_lm_head=True,
+            )
 
         # For WebGPU: the fused [V, L*D] embed_tokens_per_layer exceeds the 256 MiB
         # per-buffer limit.  Split it into L separate [V, D] tables in the decoder.

--- a/src/mobius/models/gemma4.py
+++ b/src/mobius/models/gemma4.py
@@ -146,13 +146,8 @@ def _text_quantization_config(config: Gemma4Config):
     return quantization_config
 
 
-def _text_linear_class(config: Gemma4Config) -> type | None:
-    """Return a QuantizedLinear factory for text projections, or ``None``.
-
-    ``None`` means "use a plain float :class:`Linear`". Only the text decoder
-    projections (attention Q/K/V/O + MLP + LM head) use this; vision and audio
-    linears are always float.
-    """
+def _quantized_linear_class(config: Gemma4Config) -> type | None:
+    """Return the checkpoint's QuantizedLinear factory, or ``None`` when off."""
     quantization_config = _text_quantization_config(config)
     if quantization_config is None:
         return None
@@ -167,6 +162,43 @@ def _text_linear_class(config: Gemma4Config) -> type | None:
         has_zero_point=not quantization_config.sym,
         zero_point_dtype=zero_point_dtype,
     )
+
+
+def _text_linear_class(config: Gemma4Config) -> type | None:
+    """Return a QuantizedLinear factory for text projections, or ``None``."""
+    return _quantized_linear_class(config)
+
+
+def _vision_linear_classes(config: Gemma4Config) -> tuple[type, type]:
+    """Return plain and activation-clipped Linear classes for the vision graph."""
+    quantization_config = _text_quantization_config(config)
+    quantized_linear = _quantized_linear_class(config)
+    if (
+        quantization_config is None
+        or not quantization_config.quantize_vision
+        or quantized_linear is None
+    ):
+        return Linear, ClippableLinear
+
+    class QuantizedClippableLinear(quantized_linear):
+        """MatMulNBits projection with Gemma4's learned activation clipping."""
+
+        def __init__(self, in_features: int, out_features: int, bias: bool = False):
+            super().__init__(in_features, out_features, bias=bias)
+            self.input_min = nn.Parameter([])
+            self.input_max = nn.Parameter([])
+            self.output_min = nn.Parameter([])
+            self.output_max = nn.Parameter([])
+
+        def forward(self, op: OpBuilder, x: ir.Value) -> ir.Value:
+            x = op.Clip(x, self.input_min, self.input_max)
+            return op.Clip(
+                super().forward(op, x),
+                self.output_min,
+                self.output_max,
+            )
+
+    return quantized_linear, QuantizedClippableLinear
 
 
 def _text_embeddings_quantized(config: Gemma4Config) -> bool:
@@ -386,11 +418,12 @@ class Gemma4VisionSelfAttention(nn.Module):
         rope_theta: float = 100.0,
         max_position: int = 128,
         use_clipped_linears: bool = True,
+        linear_class: type | None = None,
     ):
         super().__init__()
         self.num_heads = num_heads
         self.head_dim = hidden_size // num_heads
-        linear_class = ClippableLinear if use_clipped_linears else Linear
+        linear_class = linear_class or (ClippableLinear if use_clipped_linears else Linear)
         self.q_proj = linear_class(hidden_size, num_heads * self.head_dim, bias=False)
         self.k_proj = linear_class(hidden_size, num_heads * self.head_dim, bias=False)
         self.v_proj = linear_class(hidden_size, num_heads * self.head_dim, bias=False)
@@ -554,8 +587,10 @@ class Gemma4VisionEncoderLayer(nn.Module):
         rope_theta: float = 100.0,
         max_position: int = 128,
         use_clipped_linears: bool = True,
+        linear_class: type | None = None,
     ):
         super().__init__()
+        linear_class = linear_class or (ClippableLinear if use_clipped_linears else Linear)
         self.self_attn = Gemma4VisionSelfAttention(
             hidden_size,
             num_heads,
@@ -563,6 +598,7 @@ class Gemma4VisionEncoderLayer(nn.Module):
             rope_theta=rope_theta,
             max_position=max_position,
             use_clipped_linears=use_clipped_linears,
+            linear_class=linear_class,
         )
         self.input_layernorm = RMSNorm(hidden_size, eps=norm_eps)
         self.post_attention_layernorm = RMSNorm(hidden_size, eps=norm_eps)
@@ -571,7 +607,6 @@ class Gemma4VisionEncoderLayer(nn.Module):
         # Gated MLP: activation(gate_proj) * up_proj -> down_proj (SwiGLU/GEGLU style)
         # HF uses gelu_pytorch_tanh (GELU with tanh approximation); read from config.
         # Use ClippableLinear only when the checkpoint has clipping weights.
-        linear_class = ClippableLinear if use_clipped_linears else Linear
         self.mlp = MLP(
             ArchitectureConfig(
                 hidden_size=hidden_size,
@@ -719,9 +754,15 @@ class _Gemma4VisionPatchEmbedder(nn.Module):
     - ``position_embedding_table`` (Parameter ``[2, pos_emb_size, hidden_size]``)
     """
 
-    def __init__(self, patch_size: int, hidden_size: int, position_embedding_size: int):
+    def __init__(
+        self,
+        patch_size: int,
+        hidden_size: int,
+        position_embedding_size: int,
+        linear_class: type = Linear,
+    ):
         super().__init__()
-        self.input_proj = Linear(3 * patch_size * patch_size, hidden_size, bias=False)
+        self.input_proj = linear_class(3 * patch_size * patch_size, hidden_size, bias=False)
         # Position embedding table: [2, pos_emb_size, hidden] — x and y tables
         self.position_embedding_table = nn.Parameter([2, position_embedding_size, hidden_size])
         self.position_embedding_size = position_embedding_size
@@ -782,10 +823,12 @@ class _Gemma4VisionEncoderCore(nn.Module):
     def __init__(self, config: ArchitectureConfig):
         super().__init__()
         vc = config.vision  # VisionConfig for the SigLIP encoder
+        linear_class, clippable_linear_class = _vision_linear_classes(config)
         self.patch_embedder = _Gemma4VisionPatchEmbedder(
             patch_size=vc.patch_size or 16,
             hidden_size=vc.hidden_size,
             position_embedding_size=vc.position_embedding_size or 128,
+            linear_class=linear_class,
         )
         self.layers = nn.ModuleList(
             [
@@ -798,6 +841,9 @@ class _Gemma4VisionEncoderCore(nn.Module):
                     rope_theta=vc.rope_theta or 100.0,
                     max_position=vc.position_embedding_size or 128,
                     use_clipped_linears=vc.use_clipped_linears,
+                    linear_class=(
+                        clippable_linear_class if vc.use_clipped_linears else linear_class
+                    ),
                 )
                 for _ in range(vc.num_hidden_layers)
             ]
@@ -2611,7 +2657,8 @@ class _Gemma4VisionEncoderModel(nn.Module):
         # Reduces N patches to N/9 before projection.
         self.pooler = Gemma4VisionPooler(vc.hidden_size, vc.pooling_kernel_size or 3)
         self.projector_norm = ScaleFreeRMSNorm(vc.hidden_size, eps=vc.norm_eps)
-        self.projector = Linear(vc.hidden_size, config.hidden_size, bias=False)
+        linear_class, _ = _vision_linear_classes(config)
+        self.projector = linear_class(vc.hidden_size, config.hidden_size, bias=False)
 
     def forward(
         self,

--- a/src/mobius/models/gemma4_test.py
+++ b/src/mobius/models/gemma4_test.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import dataclasses
+
 import onnx_ir as ir
 import pytest
 import torch
@@ -135,6 +137,45 @@ class TestGemma4ModelPreprocessWeights:
             is fake_sd["model.language_model.layers.0.self_attn.q_proj.weight_scales"]
         )
 
+    def test_olive_quantized_vision_sidecars_are_preprocessed(self):
+        config = _tiny_gemma4_config(
+            enable_moe_block=False,
+            quantization=QuantizationConfig(
+                bits=4,
+                group_size=16,
+                quant_method="olive",
+                sym=True,
+                quantize_vision=True,
+            ),
+        )
+        model = Gemma4Model(config)
+        fake_sd = {
+            "model.vision_tower.encoder.layers.0.self_attn.q_proj.linear.weight_qweight": torch.zeros(
+                32, 16, dtype=torch.uint8
+            ),
+            "model.vision_tower.encoder.layers.0.self_attn.q_proj.linear.weight_scales": torch.ones(
+                32, 2
+            ),
+            "model.embed_vision.embedding_projection.weight_qweight": torch.zeros(
+                64, 16, dtype=torch.uint8
+            ),
+            "model.embed_vision.embedding_projection.weight_scales": torch.ones(64, 2),
+        }
+
+        result = model.preprocess_weights(fake_sd)
+
+        assert result["vision_encoder.encoder.layers.0.self_attn.q_proj.weight"].shape == (
+            32,
+            2,
+            8,
+        )
+        assert result["vision_encoder.encoder.layers.0.self_attn.q_proj.scales"].shape == (
+            32,
+            2,
+        )
+        assert result["vision_encoder.projector.weight"].shape == (64, 2, 8)
+        assert result["vision_encoder.projector.scales"].shape == (64, 2)
+
     def test_top_level_lm_head_routes_to_decoder(self):
         model = Gemma4Model(_tiny_gemma4_config(tie_word_embeddings=False))
         weight = torch.randn(256, 64)
@@ -227,6 +268,49 @@ class TestGemma4EmbeddingModel:
         assert model.audio_token_id == 200011
         assert not hasattr(model, "_image_token_id_mask")
         assert not hasattr(model, "_audio_token_id_mask")
+
+
+class TestGemma4VisionQuantization:
+    def test_quantize_vision_emits_matmulnbits_and_keeps_activation_clipping(self):
+        from mobius.tasks._gemma4 import Gemma4Task
+
+        config = _tiny_gemma4_config(
+            enable_moe_block=False,
+            vision=dataclasses.replace(
+                _tiny_gemma4_config().vision,
+                use_clipped_linears=True,
+            ),
+            quantization=QuantizationConfig(
+                bits=4,
+                group_size=16,
+                quant_method="olive",
+                sym=True,
+                quantize_vision=True,
+            ),
+        )
+
+        graph = Gemma4Task().build(Gemma4Model(config), config)["vision_encoder"].graph
+        op_types = [node.op_type for node in graph]
+
+        assert op_types.count("MatMulNBits") == 9
+        assert op_types.count("Clip") >= 16
+
+    def test_quantized_decoder_does_not_quantize_vision_by_default(self):
+        from mobius.tasks._gemma4 import Gemma4Task
+
+        config = _tiny_gemma4_config(
+            enable_moe_block=False,
+            quantization=QuantizationConfig(
+                bits=4,
+                group_size=16,
+                quant_method="olive",
+                sym=True,
+            ),
+        )
+
+        graph = Gemma4Task().build(Gemma4Model(config), config)["vision_encoder"].graph
+
+        assert not any(node.op_type == "MatMulNBits" for node in graph)
 
 
 class TestScaleFreeRMSNormOverflow:

--- a/src/mobius/models/gemma4_test.py
+++ b/src/mobius/models/gemma4_test.py
@@ -9,7 +9,7 @@ import onnx_ir as ir
 import pytest
 import torch
 
-from mobius._configs import AudioConfig, Gemma4Config
+from mobius._configs import AudioConfig, Gemma4Config, QuantizationConfig
 from mobius.models.gemma4 import Gemma4CausalLMModel, Gemma4EmbeddingModel, Gemma4Model
 
 
@@ -105,6 +105,100 @@ class TestGemma4ModelPreprocessWeights:
         key = "decoder.model.layers.0.router.scale"
         assert key in result
         assert abs(result[key].item() - expected) < 1e-6
+
+    def test_olive_quantized_decoder_sidecars_are_preprocessed(self):
+        config = _tiny_gemma4_config(
+            enable_moe_block=False,
+            quantization=QuantizationConfig(
+                bits=4,
+                group_size=16,
+                quant_method="olive",
+                sym=True,
+            ),
+        )
+        model = Gemma4Model(config)
+        fake_sd = {
+            "model.language_model.layers.0.self_attn.q_proj.weight_qweight": torch.zeros(
+                64, 32, dtype=torch.uint8
+            ),
+            "model.language_model.layers.0.self_attn.q_proj.weight_scales": torch.ones(64, 4),
+        }
+
+        result = model.preprocess_weights(fake_sd)
+
+        weight_key = "decoder.model.layers.0.self_attn.q_proj.weight"
+        scales_key = "decoder.model.layers.0.self_attn.q_proj.scales"
+        assert result[weight_key].shape == (64, 4, 8)
+        assert result[weight_key].dtype == torch.uint8
+        assert (
+            result[scales_key]
+            is fake_sd["model.language_model.layers.0.self_attn.q_proj.weight_scales"]
+        )
+
+    def test_top_level_lm_head_routes_to_decoder(self):
+        model = Gemma4Model(_tiny_gemma4_config(tie_word_embeddings=False))
+        weight = torch.randn(256, 64)
+
+        result = model.preprocess_weights({"lm_head.weight": weight})
+
+        assert result["decoder.lm_head.weight"] is weight
+
+    @pytest.mark.parametrize(
+        ("quantize_embeddings", "quantize_lm_head", "state_dict"),
+        [
+            (
+                True,
+                False,
+                {
+                    "model.language_model.embed_tokens.weight_qweight": torch.zeros(
+                        256, 32, dtype=torch.uint8
+                    )
+                },
+            ),
+            (
+                False,
+                True,
+                {"lm_head.weight_qweight": torch.zeros(256, 32, dtype=torch.uint8)},
+            ),
+        ],
+    )
+    def test_quantized_embedding_or_lm_head_fails_closed(
+        self,
+        quantize_embeddings,
+        quantize_lm_head,
+        state_dict,
+    ):
+        config = _tiny_gemma4_config(
+            tie_word_embeddings=False,
+            quantization=QuantizationConfig(
+                bits=4,
+                group_size=16,
+                quant_method="olive",
+                sym=True,
+                quantize_embeddings=quantize_embeddings,
+                quantize_lm_head=quantize_lm_head,
+            ),
+        )
+
+        with pytest.raises(
+            NotImplementedError,
+            match="Quantized embeddings and LM heads are not yet supported",
+        ):
+            Gemma4Model(config).preprocess_weights(state_dict)
+
+    def test_gguf_quantized_tables_keep_canonical_weight_path(self):
+        config = _tiny_gemma4_config(
+            quantization=QuantizationConfig(
+                bits=4,
+                group_size=16,
+                quant_method="gguf",
+                sym=True,
+                quantize_embeddings=True,
+                quantize_lm_head=True,
+            ),
+        )
+
+        assert Gemma4Model(config).preprocess_weights({}) == {}
 
     def test_per_expert_scale_not_folded(self):
         """router.per_expert_scale should NOT be multiplied by scale_factor."""

--- a/src/mobius/models/gemma4_test.py
+++ b/src/mobius/models/gemma4_test.py
@@ -78,6 +78,24 @@ class TestGemma4CausalLMPreprocessWeights:
         expected = 2.0 * (64**-0.5)  # hidden_size=64
         assert abs(result["model.layers.0.router.scale"].item() - expected) < 1e-6
 
+    def test_quantized_moe_experts_fail_closed(self):
+        config = _tiny_gemma4_config(
+            quantization=QuantizationConfig(
+                bits=4,
+                group_size=16,
+                quant_method="olive",
+                sym=True,
+            )
+        )
+        state_dict = {
+            "model.layers.0.experts.gate_up_proj_qweight": torch.zeros(
+                4, 64, 32, dtype=torch.uint8
+            )
+        }
+
+        with pytest.raises(NotImplementedError, match="Quantized Gemma4 MoE experts"):
+            Gemma4CausalLMModel(config).preprocess_weights(state_dict)
+
 
 class TestGemma4ModelPreprocessWeights:
     """Test Gemma4Model.preprocess_weights (multimodal path)."""
@@ -107,6 +125,24 @@ class TestGemma4ModelPreprocessWeights:
         key = "decoder.model.layers.0.router.scale"
         assert key in result
         assert abs(result[key].item() - expected) < 1e-6
+
+    def test_quantized_moe_experts_fail_closed(self):
+        config = _tiny_gemma4_config(
+            quantization=QuantizationConfig(
+                bits=4,
+                group_size=16,
+                quant_method="olive",
+                sym=True,
+            )
+        )
+        state_dict = {
+            "model.language_model.layers.0.experts.down_proj.weight_scales": torch.ones(
+                4, 64, 2
+            )
+        }
+
+        with pytest.raises(NotImplementedError, match="Quantized Gemma4 MoE experts"):
+            Gemma4Model(config).preprocess_weights(state_dict)
 
     def test_olive_quantized_decoder_sidecars_are_preprocessed(self):
         config = _tiny_gemma4_config(

--- a/src/mobius/models/qwen35.py
+++ b/src/mobius/models/qwen35.py
@@ -34,7 +34,7 @@ from mobius.models.qwen_vl import (
     Qwen3VLEmbeddingModel,
     Qwen3VLVisionEncoderModel,
     _QwenVLTextMixin,
-    split_deepstack_embeds,
+    split_per_layer_inputs,
 )
 
 # ---------------------------------------------------------------------------
@@ -704,7 +704,7 @@ class Qwen35VLDecoderModel(nn.Module):
         attention_mask: ir.Value,
         position_ids: ir.Value,
         past_key_values: list | None = None,
-        deepstack_embeds: ir.Value | None = None,
+        per_layer_inputs: ir.Value | None = None,
     ):
         hidden_states, present_key_values = self.model(
             op,
@@ -713,7 +713,7 @@ class Qwen35VLDecoderModel(nn.Module):
             position_ids=position_ids,
             past_key_values=past_key_values,
             inputs_embeds=inputs_embeds,
-            deepstack_embeds=split_deepstack_embeds(op, deepstack_embeds, self.config),
+            deepstack_embeds=split_per_layer_inputs(op, per_layer_inputs, self.config),
         )
         logits = self.lm_head(op, hidden_states)
         return logits, present_key_values
@@ -768,7 +768,7 @@ class Qwen35MoEVLDecoderModel(nn.Module):
         attention_mask: ir.Value,
         position_ids: ir.Value,
         past_key_values: list | None = None,
-        deepstack_embeds: ir.Value | None = None,
+        per_layer_inputs: ir.Value | None = None,
     ):
         hidden_states, present_key_values = self.model(
             op,
@@ -777,7 +777,7 @@ class Qwen35MoEVLDecoderModel(nn.Module):
             position_ids=position_ids,
             past_key_values=past_key_values,
             inputs_embeds=inputs_embeds,
-            deepstack_embeds=split_deepstack_embeds(op, deepstack_embeds, self.config),
+            deepstack_embeds=split_per_layer_inputs(op, per_layer_inputs, self.config),
         )
         logits = self.lm_head(op, hidden_states)
         return logits, present_key_values

--- a/src/mobius/models/qwen_vl.py
+++ b/src/mobius/models/qwen_vl.py
@@ -30,24 +30,29 @@ if TYPE_CHECKING:
     import onnx_ir as ir
 
 
-def split_deepstack_embeds(
+def split_per_layer_inputs(
     op: OpBuilder,
-    deepstack_embeds: ir.Value | None,
+    per_layer_inputs: ir.Value | None,
     config: ArchitectureConfig,
 ) -> list[ir.Value] | None:
-    """Split stacked DeepStack embeddings into a per-layer list.
+    """Split flattened per-layer inputs into one DeepStack tensor per layer.
 
-    The embedding model exposes DeepStack maps as a single stacked
-    ``[D, batch, seq, hidden]`` tensor.  The decoder injects one map into
-    each of its first ``D`` layers, so split the stack into ``D`` tensors
-    of shape ``[batch, seq, hidden]``.  Returns ``None`` when DeepStack is
-    inactive so non-DeepStack decoders remain unaffected.
+    ORT GenAI forwards one rank-3 ``[batch, seq, D * hidden]`` tensor from
+    embedding to decoder. Restore ``[D, batch, seq, hidden]`` and return the
+    per-layer list consumed by the Qwen text model.
     """
-    if deepstack_embeds is None:
+    if per_layer_inputs is None:
         return None
     num_deepstack = len(config.deepstack_visual_indexes or [])
     if num_deepstack == 0:
         return None
+    deepstack_embeds = op.Transpose(
+        op.Reshape(
+            per_layer_inputs,
+            op.Constant(value_ints=[0, 0, num_deepstack, config.hidden_size]),
+        ),
+        perm=[2, 0, 1, 3],
+    )
     return [
         op.Gather(deepstack_embeds, op.Constant(value_int=i), axis=0)
         for i in range(num_deepstack)
@@ -800,12 +805,11 @@ class Qwen3VL3ModelCausalLMModel(nn.Module):
 
     .. note::
        When ``deepstack_visual_indexes`` is set, DeepStack intermediate
-       features are carried through the split via an extra
-       ``deepstack_features`` / ``deepstack_embeds`` channel: the vision
-       encoder emits a stacked ``[D, ...]`` tensor, the embedding model
-       scatters each map to full sequence length, and the decoder adds them
-       into its first ``D`` layers (matching HuggingFace per-layer
-       injection).  Models without DeepStack indices are unaffected.
+       features are packed into ``image_features`` by the vision encoder.
+       The embedding model scatters and flattens them into the generic
+       rank-3 ``per_layer_inputs`` contract consumed by ORT GenAI, and the
+       decoder restores and injects one map into each of its first ``D``
+       layers. Models without DeepStack indices are unaffected.
     """
 
     default_task: str = "qwen-vl"
@@ -906,7 +910,7 @@ class Qwen3VLDecoderModel(nn.Module):
         attention_mask: ir.Value,
         position_ids: ir.Value,
         past_key_values: list | None = None,
-        deepstack_embeds: ir.Value | None = None,
+        per_layer_inputs: ir.Value | None = None,
     ):
         hidden_states, present_key_values = self.model(
             op,
@@ -915,7 +919,7 @@ class Qwen3VLDecoderModel(nn.Module):
             position_ids=position_ids,
             past_key_values=past_key_values,
             inputs_embeds=inputs_embeds,
-            deepstack_embeds=split_deepstack_embeds(op, deepstack_embeds, self.config),
+            deepstack_embeds=split_per_layer_inputs(op, per_layer_inputs, self.config),
         )
         logits = self.lm_head(op, hidden_states)
         return logits, present_key_values
@@ -951,16 +955,17 @@ class Qwen3VLVisionEncoderModel(nn.Module):
     """Qwen3-VL vision encoder for the 3-model split.
 
     Processes packed image patches through the Qwen3-VL ViT and outputs
-    merged features.  When ``deepstack_visual_indexes`` is set, it also
-    emits the stacked DeepStack intermediate features as a second output.
+    merged features. When ``deepstack_visual_indexes`` is set, intermediate
+    features are packed with the final features into one runtime-compatible
+    output.
 
     Inputs:
         - pixel_values: (total_patches, C*T_p*P*P)
         - image_grid_thw: (num_images, 3) INT64
     Outputs:
-        - image_features: (num_merged_patches, out_hidden_size)
-        - deepstack_features: (D, num_merged_patches, out_hidden_size)
-          (only when ``deepstack_visual_indexes`` is non-empty)
+        - image_features: (num_merged_patches, (D + 1) * out_hidden_size)
+          when DeepStack is active, otherwise
+          (num_merged_patches, out_hidden_size)
     """
 
     def __init__(self, config: ArchitectureConfig):
@@ -1037,19 +1042,17 @@ class Qwen3VLEmbeddingModel(Qwen25VLEmbeddingModel):
 
     Scatters merged image features at image-token positions (like
     Qwen2.5-VL) and, when the vision encoder produces DeepStack features,
-    also scatters each intermediate DeepStack map into a full-length
-    ``[batch, seq, hidden]`` tensor (zero at non-image positions).  The
-    stacked ``deepstack_embeds`` output is consumed by the decoder, which
-    adds them to the hidden states of its first ``D`` layers.
+    also scatters each intermediate DeepStack map into a full-length tensor
+    (zero at non-image positions). The maps are flattened into the generic
+    rank-3 ``per_layer_inputs`` output consumed by ORT GenAI.
 
     Inputs:
         - input_ids: (batch, seq_len) INT64
-        - image_features: (num_image_tokens, hidden_size) FLOAT
-        - deepstack_features: (D, num_image_tokens, hidden_size) FLOAT
-          (only when ``deepstack_visual_indexes`` is non-empty)
+        - image_features: (num_image_tokens, (D + 1) * hidden_size) FLOAT
+          when DeepStack is active
     Outputs:
         - inputs_embeds: (batch, seq_len, hidden_size) FLOAT
-        - deepstack_embeds: (D, batch, seq_len, hidden_size) FLOAT
+        - per_layer_inputs: (batch, seq_len, D * hidden_size) FLOAT
           (only when DeepStack is active)
     """
 

--- a/src/mobius/preflight.py
+++ b/src/mobius/preflight.py
@@ -524,13 +524,15 @@ def _parse_vm_stat_available_bytes(output: str) -> int | None:
         "Pages speculative",
     }
     available_pages = 0
+    parsed_fields = 0
     for line in output.splitlines():
         name, separator, raw_value = line.partition(":")
-        if separator and name in available_page_names:
-            value = raw_value.strip().rstrip(".")
+        if separator and name.strip() in available_page_names:
+            value = raw_value.strip().rstrip(".").replace(",", "")
             if value.isdigit():
                 available_pages += int(value)
-    return available_pages * page_size
+                parsed_fields += 1
+    return available_pages * page_size if parsed_fields else None
 
 
 def _sysconf_available_ram_bytes() -> int | None:
@@ -574,7 +576,7 @@ def check_disk(kind: str, path: pathlib.Path, required: int, margin_frac: float)
 
 def check_ram(required: int, margin_frac: float) -> SpaceCheck:
     free, source = _probe_available_ram()
-    # If MemAvailable can't be read we cannot verify the RAM budget; refuse
+    # If available RAM can't be probed we cannot verify the RAM budget; refuse
     # rather than emit a success-shaped pass.
     ok = free is not None and free * (1 - margin_frac) >= required
     return SpaceCheck(

--- a/src/mobius/preflight.py
+++ b/src/mobius/preflight.py
@@ -38,13 +38,18 @@ __all__ = [
     "run_preflight",
 ]
 
+import ctypes
 import dataclasses
 import enum
 import json
 import logging
 import os
 import pathlib
+import re
 import shutil
+import subprocess
+import sys
+from ctypes import wintypes
 
 from mobius.integrations._weight_loading import (
     _SINGLE_WEIGHT_NAME,
@@ -459,7 +464,32 @@ def _default_download_dir() -> pathlib.Path:
         return pathlib.Path.home() / ".cache" / "huggingface" / "hub"
 
 
-def _available_ram_bytes() -> int | None:
+class _MemoryStatusEx(ctypes.Structure):
+    _fields_ = [
+        ("dwLength", wintypes.DWORD),
+        ("dwMemoryLoad", wintypes.DWORD),
+        ("ullTotalPhys", ctypes.c_ulonglong),
+        ("ullAvailPhys", ctypes.c_ulonglong),
+        ("ullTotalPageFile", ctypes.c_ulonglong),
+        ("ullAvailPageFile", ctypes.c_ulonglong),
+        ("ullTotalVirtual", ctypes.c_ulonglong),
+        ("ullAvailVirtual", ctypes.c_ulonglong),
+        ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+    ]
+
+
+def _windows_available_ram_bytes() -> int | None:
+    status = _MemoryStatusEx()
+    status.dwLength = ctypes.sizeof(status)
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.GlobalMemoryStatusEx.argtypes = [ctypes.POINTER(_MemoryStatusEx)]
+    kernel32.GlobalMemoryStatusEx.restype = wintypes.BOOL
+    if kernel32.GlobalMemoryStatusEx(ctypes.byref(status)):
+        return int(status.ullAvailPhys)
+    return None
+
+
+def _proc_available_ram_bytes() -> int | None:
     try:
         for line in pathlib.Path("/proc/meminfo").read_text().splitlines():
             if line.startswith("MemAvailable:"):
@@ -467,6 +497,66 @@ def _available_ram_bytes() -> int | None:
     except OSError:
         return None
     return None
+
+
+def _darwin_available_ram_bytes() -> int | None:
+    try:
+        result = subprocess.run(
+            ["vm_stat"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+    return _parse_vm_stat_available_bytes(result.stdout)
+
+
+def _parse_vm_stat_available_bytes(output: str) -> int | None:
+    page_size_match = re.search(r"page size of (\d+) bytes", output)
+    if page_size_match is None:
+        return None
+    page_size = int(page_size_match.group(1))
+    available_page_names = {
+        "Pages free",
+        "Pages inactive",
+        "Pages speculative",
+    }
+    available_pages = 0
+    for line in output.splitlines():
+        name, separator, raw_value = line.partition(":")
+        if separator and name in available_page_names:
+            value = raw_value.strip().rstrip(".")
+            if value.isdigit():
+                available_pages += int(value)
+    return available_pages * page_size
+
+
+def _sysconf_available_ram_bytes() -> int | None:
+    try:
+        pages = os.sysconf("SC_AVPHYS_PAGES")
+        page_size = os.sysconf("SC_PAGE_SIZE")
+    except (AttributeError, OSError, ValueError):
+        return None
+    return int(pages * page_size) if pages > 0 and page_size > 0 else None
+
+
+def _probe_available_ram() -> tuple[int | None, str]:
+    if os.name == "nt":
+        return _windows_available_ram_bytes(), "GlobalMemoryStatusEx:ullAvailPhys"
+    if sys.platform == "darwin":
+        if (available := _darwin_available_ram_bytes()) is not None:
+            return available, "vm_stat:available pages"
+    if (available := _proc_available_ram_bytes()) is not None:
+        return available, "/proc/meminfo:MemAvailable"
+    if (available := _sysconf_available_ram_bytes()) is not None:
+        return available, "os.sysconf:SC_AVPHYS_PAGES"
+    return None, "unavailable"
+
+
+def _available_ram_bytes() -> int | None:
+    return _probe_available_ram()[0]
 
 
 def check_disk(kind: str, path: pathlib.Path, required: int, margin_frac: float) -> SpaceCheck:
@@ -483,13 +573,13 @@ def check_disk(kind: str, path: pathlib.Path, required: int, margin_frac: float)
 
 
 def check_ram(required: int, margin_frac: float) -> SpaceCheck:
-    free = _available_ram_bytes()
+    free, source = _probe_available_ram()
     # If MemAvailable can't be read we cannot verify the RAM budget; refuse
     # rather than emit a success-shaped pass.
     ok = free is not None and free * (1 - margin_frac) >= required
     return SpaceCheck(
         kind="ram",
-        path="/proc/meminfo:MemAvailable",
+        path=source,
         required_bytes=required,
         free_bytes=int(free) if free is not None else -1,
         margin_frac=margin_frac,

--- a/src/mobius/preflight_test.py
+++ b/src/mobius/preflight_test.py
@@ -196,11 +196,10 @@ class TestBudget:
 
 
 class TestRunPreflight:
-    def test_available_ram_probe_returns_positive_value(self):
-        available = preflight._available_ram_bytes()
+    def test_available_ram_bytes_forwards_probe_value(self, monkeypatch):
+        monkeypatch.setattr(preflight, "_probe_available_ram", lambda: (123, "test"))
 
-        assert available is not None
-        assert available > 0
+        assert preflight._available_ram_bytes() == 123
 
     def test_ram_probe_reports_windows_source(self, monkeypatch):
         monkeypatch.setattr(preflight.os, "name", "nt")
@@ -218,13 +217,21 @@ class TestRunPreflight:
     def test_vm_stat_parser_does_not_double_count_purgeable_pages(self):
         output = """\
 Mach Virtual Memory Statistics: (page size of 4096 bytes)
-Pages free:                                  10.
+  Pages free:                             1,000.
 Pages inactive:                              20.
 Pages speculative:                            3.
 Pages purgeable:                            100.
 """
 
-        assert preflight._parse_vm_stat_available_bytes(output) == 33 * 4096
+        assert preflight._parse_vm_stat_available_bytes(output) == 1023 * 4096
+
+    def test_vm_stat_parser_returns_none_without_available_fields(self):
+        output = """\
+Mach Virtual Memory Statistics: (page size of 4096 bytes)
+Pages wired down:                           100.
+"""
+
+        assert preflight._parse_vm_stat_available_bytes(output) is None
 
     def test_ram_probe_reports_sysconf_fallback_source(self, monkeypatch):
         monkeypatch.setattr(preflight.os, "name", "posix")

--- a/src/mobius/preflight_test.py
+++ b/src/mobius/preflight_test.py
@@ -196,6 +196,44 @@ class TestBudget:
 
 
 class TestRunPreflight:
+    def test_available_ram_probe_returns_positive_value(self):
+        available = preflight._available_ram_bytes()
+
+        assert available is not None
+        assert available > 0
+
+    def test_ram_probe_reports_windows_source(self, monkeypatch):
+        monkeypatch.setattr(preflight.os, "name", "nt")
+        monkeypatch.setattr(preflight, "_windows_available_ram_bytes", lambda: 123)
+
+        assert preflight._probe_available_ram() == (123, "GlobalMemoryStatusEx:ullAvailPhys")
+
+    def test_ram_probe_reports_darwin_source(self, monkeypatch):
+        monkeypatch.setattr(preflight.os, "name", "posix")
+        monkeypatch.setattr(preflight.sys, "platform", "darwin")
+        monkeypatch.setattr(preflight, "_darwin_available_ram_bytes", lambda: 456)
+
+        assert preflight._probe_available_ram() == (456, "vm_stat:available pages")
+
+    def test_vm_stat_parser_does_not_double_count_purgeable_pages(self):
+        output = """\
+Mach Virtual Memory Statistics: (page size of 4096 bytes)
+Pages free:                                  10.
+Pages inactive:                              20.
+Pages speculative:                            3.
+Pages purgeable:                            100.
+"""
+
+        assert preflight._parse_vm_stat_available_bytes(output) == 33 * 4096
+
+    def test_ram_probe_reports_sysconf_fallback_source(self, monkeypatch):
+        monkeypatch.setattr(preflight.os, "name", "posix")
+        monkeypatch.setattr(preflight.sys, "platform", "linux")
+        monkeypatch.setattr(preflight, "_proc_available_ram_bytes", lambda: None)
+        monkeypatch.setattr(preflight, "_sysconf_available_ram_bytes", lambda: 789)
+
+        assert preflight._probe_available_ram() == (789, "os.sysconf:SC_AVPHYS_PAGES")
+
     def test_metadata_unavailable_is_a_blocker_not_a_pass(self, tmp_path):
         # A local dir with no safetensors -> resolve fails -> refused.
         result = run_preflight(str(tmp_path), output_dir=str(tmp_path / "out"))
@@ -216,7 +254,7 @@ class TestRunPreflight:
     def test_ready_when_space_sufficient(self, tmp_path, monkeypatch):
         _write_sharded(tmp_path, n_shards=2)
         monkeypatch.setattr(preflight, "_free_bytes", lambda p: 10**15)
-        monkeypatch.setattr(preflight, "_available_ram_bytes", lambda: 10**15)
+        monkeypatch.setattr(preflight, "_probe_available_ram", lambda: (10**15, "test"))
         result = run_preflight(
             str(tmp_path), output_dir=str(tmp_path / "out"), loader=LoaderMode.STREAM
         )
@@ -227,7 +265,7 @@ class TestRunPreflight:
     def test_refuses_when_disk_insufficient(self, tmp_path, monkeypatch):
         _write_sharded(tmp_path, n_shards=2)
         monkeypatch.setattr(preflight, "_free_bytes", lambda p: 1)  # ~no disk
-        monkeypatch.setattr(preflight, "_available_ram_bytes", lambda: 10**15)
+        monkeypatch.setattr(preflight, "_probe_available_ram", lambda: (10**15, "test"))
         result = run_preflight(str(tmp_path), output_dir=str(tmp_path / "out"))
         assert result.ok is False
         assert any("disk" in b for b in result.blockers)
@@ -235,7 +273,7 @@ class TestRunPreflight:
     def test_refuses_when_ram_insufficient_eager(self, tmp_path, monkeypatch):
         _write_sharded(tmp_path, n_shards=2)
         monkeypatch.setattr(preflight, "_free_bytes", lambda p: 10**15)
-        monkeypatch.setattr(preflight, "_available_ram_bytes", lambda: 1)
+        monkeypatch.setattr(preflight, "_probe_available_ram", lambda: (1, "test"))
         result = run_preflight(
             str(tmp_path), output_dir=str(tmp_path / "out"), loader=LoaderMode.EAGER
         )
@@ -245,7 +283,7 @@ class TestRunPreflight:
     def test_vram_single_device_refusal(self, tmp_path, monkeypatch):
         _write_sharded(tmp_path, n_shards=2)
         monkeypatch.setattr(preflight, "_free_bytes", lambda p: 10**15)
-        monkeypatch.setattr(preflight, "_available_ram_bytes", lambda: 10**15)
+        monkeypatch.setattr(preflight, "_probe_available_ram", lambda: (10**15, "test"))
         result = run_preflight(
             str(tmp_path),
             output_dir=str(tmp_path / "out"),
@@ -269,7 +307,7 @@ class TestRunPreflight:
             ],
             safetensors=types.SimpleNamespace(parameters={"BF16": 100}, total=100),
         )
-        monkeypatch.setattr(preflight, "_available_ram_bytes", lambda: 10**15)
+        monkeypatch.setattr(preflight, "_probe_available_ram", lambda: (10**15, "test"))
         # Free space (240) fits the 200B download or the 200B output alone, but
         # not both (400B combined) on one filesystem. Independent checks would
         # each pass; the combined check must refuse.
@@ -288,7 +326,7 @@ class TestRunPreflight:
         monkeypatch.setattr(preflight, "_free_bytes", lambda p: 10**15)
         # MemAvailable can't be read -> the RAM budget is unverifiable and must
         # not produce a success-shaped pass.
-        monkeypatch.setattr(preflight, "_available_ram_bytes", lambda: None)
+        monkeypatch.setattr(preflight, "_probe_available_ram", lambda: (None, "unavailable"))
         result = run_preflight(str(tmp_path), output_dir=str(tmp_path / "out"))
         assert result.ok is False
         assert any("RAM budget could not be verified" in b for b in result.blockers)
@@ -303,7 +341,7 @@ class TestResumability:
     def test_state_written_and_reused(self, tmp_path, monkeypatch):
         _write_sharded(tmp_path, n_shards=2)
         monkeypatch.setattr(preflight, "_free_bytes", lambda p: 10**15)
-        monkeypatch.setattr(preflight, "_available_ram_bytes", lambda: 10**15)
+        monkeypatch.setattr(preflight, "_probe_available_ram", lambda: (10**15, "test"))
         state_file = tmp_path / "state.json"
 
         r1 = run_preflight(
@@ -325,7 +363,7 @@ class TestResumability:
         weight_map = {"w0": "model-00001-of-00001.safetensors"}
         _fake_hub(tmp_path, monkeypatch, weight_map)
         monkeypatch.setattr(preflight, "_free_bytes", lambda p: 10**15)
-        monkeypatch.setattr(preflight, "_available_ram_bytes", lambda: 10**15)
+        monkeypatch.setattr(preflight, "_probe_available_ram", lambda: (10**15, "test"))
         state_file = tmp_path / "state.json"
         state_file.write_text(
             json.dumps(

--- a/src/mobius/tasks/_base.py
+++ b/src/mobius/tasks/_base.py
@@ -221,9 +221,9 @@ def build_decoder_from_embeds(
         hybrid: If ``True``, uses hybrid KV + DeltaNet cache inputs/outputs
             (for Qwen3.5-VL and similar).  Requires ``config.layer_types``.
         deepstack: If ``True`` (Qwen3-VL family with
-            ``deepstack_visual_indexes``), adds a ``deepstack_embeds`` input
-            ``[D, batch, seq_len, hidden_size]`` that the decoder injects into
-            its first ``D`` layers.
+            ``deepstack_visual_indexes``), adds a ``per_layer_inputs`` input
+            ``[batch, seq_len, D * hidden_size]`` that the decoder reshapes and
+            injects into its first ``D`` layers.
 
     Returns:
         A built :class:`ir.Model` for the decoder.
@@ -262,15 +262,16 @@ def build_decoder_from_embeds(
         shape=[3, batch, seq_len] if mrope else [batch, seq_len],
     )
 
-    # DeepStack intermediate vision features, pre-scattered to full sequence
-    # length by the embedding model.  Shape [D, batch, seq_len, hidden_size].
-    deepstack_embeds = None
+    # DeepStack intermediate vision features, pre-scattered and flattened by
+    # the embedding model. Shape [batch, seq_len, D * hidden_size], matching
+    # ORT GenAI's generic per_layer_inputs contract.
+    per_layer_inputs = None
     num_deepstack = len(getattr(config, "deepstack_visual_indexes", None) or [])
     if deepstack and num_deepstack > 0:
-        deepstack_embeds = builder.input(
-            "deepstack_embeds",
+        per_layer_inputs = builder.input(
+            "per_layer_inputs",
             dtype=config.dtype,
-            shape=[num_deepstack, batch, seq_len, config.hidden_size],
+            shape=[batch, seq_len, num_deepstack * config.hidden_size],
         )
 
     if hybrid:
@@ -293,8 +294,8 @@ def build_decoder_from_embeds(
         )
 
     decoder_kwargs = {}
-    if deepstack_embeds is not None:
-        decoder_kwargs["deepstack_embeds"] = deepstack_embeds
+    if per_layer_inputs is not None:
+        decoder_kwargs["per_layer_inputs"] = per_layer_inputs
 
     logits, present_key_values = decoder(
         builder.op,
@@ -342,9 +343,11 @@ def build_embedding_from_features(
             ``"audio_features"``).
         feature_dim: Feature dimension for the second input's last axis.
         deepstack: If ``True`` (Qwen3-VL family with
-            ``deepstack_visual_indexes``), adds a ``deepstack_features`` input
-            ``[D, num_feature_tokens, feature_dim]`` and emits a second
-            ``deepstack_embeds`` output ``[D, batch, seq_len, hidden_size]``.
+            ``deepstack_visual_indexes``), expects ``image_features`` to pack
+            the final and intermediate maps as
+            ``[num_feature_tokens, (D + 1) * feature_dim]`` and emits a second
+            ``per_layer_inputs`` output
+            ``[batch, seq_len, D * hidden_size]``.
 
     Returns:
         A built :class:`ir.Model` for the embedding model.
@@ -359,21 +362,40 @@ def build_embedding_from_features(
         dtype=ir.DataType.INT64,
         shape=[batch, seq_len],
     )
-    features = builder.input(
+    num_deepstack = len(getattr(config, "deepstack_visual_indexes", None) or [])
+    has_deepstack = deepstack and num_deepstack > 0
+    packed_feature_dim = (num_deepstack + 1) * feature_dim if has_deepstack else feature_dim
+    packed_features = builder.input(
         feature_name,
         dtype=config.dtype,
-        shape=[num_feature_tokens, feature_dim],
+        shape=[num_feature_tokens, packed_feature_dim],
     )
 
-    embedding_kwargs = {feature_name: features}
-    num_deepstack = len(getattr(config, "deepstack_visual_indexes", None) or [])
-    if deepstack and num_deepstack > 0:
-        deepstack_features = builder.input(
-            "deepstack_features",
-            dtype=config.dtype,
-            shape=[num_deepstack, num_feature_tokens, feature_dim],
+    embedding_kwargs = {}
+    if has_deepstack:
+        features = builder.op.Slice(
+            packed_features,
+            builder.op.Constant(value_ints=[0]),
+            builder.op.Constant(value_ints=[feature_dim]),
+            builder.op.Constant(value_ints=[1]),
+        )
+        deepstack_flat = builder.op.Slice(
+            packed_features,
+            builder.op.Constant(value_ints=[feature_dim]),
+            builder.op.Constant(value_ints=[packed_feature_dim]),
+            builder.op.Constant(value_ints=[1]),
+        )
+        deepstack_features = builder.op.Transpose(
+            builder.op.Reshape(
+                deepstack_flat,
+                builder.op.Constant(value_ints=[0, num_deepstack, feature_dim]),
+            ),
+            perm=[1, 0, 2],
         )
         embedding_kwargs["deepstack_features"] = deepstack_features
+    else:
+        features = packed_features
+    embedding_kwargs[feature_name] = features
 
     outputs = embedding(
         builder.op,
@@ -384,7 +406,11 @@ def build_embedding_from_features(
     if isinstance(outputs, tuple):
         inputs_embeds, deepstack_embeds = outputs
         builder.add_output(inputs_embeds, "inputs_embeds")
-        builder.add_output(deepstack_embeds, "deepstack_embeds")
+        per_layer_inputs = builder.op.Reshape(
+            builder.op.Transpose(deepstack_embeds, perm=[1, 2, 0, 3]),
+            builder.op.Constant(value_ints=[0, 0, num_deepstack * config.hidden_size]),
+        )
+        builder.add_output(per_layer_inputs, "per_layer_inputs")
     else:
         builder.add_output(outputs, "inputs_embeds")
     return _make_model(graph)

--- a/src/mobius/tasks/_vision_language_3model.py
+++ b/src/mobius/tasks/_vision_language_3model.py
@@ -203,9 +203,9 @@ class QwenVLTask(VisionLanguageTask):
     ) -> ir.Model:
         """Build Qwen VL vision encoder with packed patches and grid_thw.
 
-        When ``deepstack_visual_indexes`` is set (Qwen3-VL family), the vision
-        encoder emits an extra ``deepstack_features`` output stacking the
-        intermediate DeepStack maps: ``[D, num_merged_patches, out_hidden]``.
+        When ``deepstack_visual_indexes`` is set (Qwen3-VL family), the final
+        and intermediate maps are packed into the single ``image_features``
+        output as ``[num_merged_patches, (D + 1) * out_hidden]``.
         """
         total_patches = ir.SymbolicDim("total_patches")
         num_images = ir.SymbolicDim("num_images")
@@ -236,8 +236,13 @@ class QwenVLTask(VisionLanguageTask):
 
         if isinstance(outputs, tuple):
             image_features, deepstack_features = outputs
-            builder.add_output(image_features, "image_features")
-            builder.add_output(deepstack_features, "deepstack_features")
+            num_deepstack = len(config.deepstack_visual_indexes or [])
+            deepstack_flat = op.Reshape(
+                op.Transpose(deepstack_features, perm=[1, 0, 2]),
+                op.Constant(value_ints=[0, num_deepstack * config.hidden_size]),
+            )
+            packed_features = op.Concat(image_features, deepstack_flat, axis=1)
+            builder.add_output(packed_features, "image_features")
         else:
             builder.add_output(outputs, "image_features")
         return _make_model(graph)

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -1305,6 +1305,32 @@ class TestBuildGraphVisionLanguage:
         decoder = pkg["decoder"]
         assert "logits" in {out.name for out in decoder.graph.outputs}
         assert "inputs_embeds" in {inp.name for inp in decoder.graph.inputs}
+        assert "per_layer_inputs" in {inp.name for inp in decoder.graph.inputs}
+        assert "deepstack_embeds" not in {inp.name for inp in decoder.graph.inputs}
+        num_deepstack = len(config.deepstack_visual_indexes)
+        per_layer_input = next(
+            inp for inp in decoder.graph.inputs if inp.name == "per_layer_inputs"
+        )
+        assert per_layer_input.shape[-1] == num_deepstack * config.hidden_size
+
+        vision_outputs = {out.name for out in pkg["vision_encoder"].graph.outputs}
+        assert vision_outputs == {"image_features"}
+        assert (
+            pkg["vision_encoder"].graph.outputs[0].shape[-1]
+            == (num_deepstack + 1) * config.hidden_size
+        )
+        embedding_inputs = {inp.name for inp in pkg["embedding"].graph.inputs}
+        embedding_outputs = {out.name for out in pkg["embedding"].graph.outputs}
+        assert embedding_inputs == {"input_ids", "image_features"}
+        assert embedding_outputs == {"inputs_embeds", "per_layer_inputs"}
+        image_features = next(
+            inp for inp in pkg["embedding"].graph.inputs if inp.name == "image_features"
+        )
+        per_layer_output = next(
+            out for out in pkg["embedding"].graph.outputs if out.name == "per_layer_inputs"
+        )
+        assert image_features.shape[-1] == (num_deepstack + 1) * config.hidden_size
+        assert per_layer_output.shape[-1] == num_deepstack * config.hidden_size
 
         vision_encoder = pkg["vision_encoder"]
         node_order = {id(node): index for index, node in enumerate(vision_encoder.graph)}
@@ -1356,6 +1382,12 @@ class TestBuildGraphVisionLanguage:
         decoder = pkg["decoder"]
         assert "logits" in {out.name for out in decoder.graph.outputs}
         assert "inputs_embeds" in {inp.name for inp in decoder.graph.inputs}
+        assert "per_layer_inputs" in {inp.name for inp in decoder.graph.inputs}
+        assert {out.name for out in pkg["vision_encoder"].graph.outputs} == {"image_features"}
+        assert {out.name for out in pkg["embedding"].graph.outputs} == {
+            "inputs_embeds",
+            "per_layer_inputs",
+        }
 
         # Verify hybrid cache: linear_attention layer gets conv_state/recurrent_state,
         # full_attention layer gets key/value

--- a/tests/build_graph_test.py
+++ b/tests/build_graph_test.py
@@ -1294,8 +1294,7 @@ class TestBuildGraphVisionLanguage:
         model_cls = registry.get("qwen3_vl")
         module = model_cls(config)
         task_name = _default_task_for_model("qwen3_vl")
-        task = get_task(task_name)
-        pkg = task.build(module, config)
+        pkg = build_from_module(module, config, task=task_name, execution_provider="cpu")
 
         # 3-model split produces decoder, vision, embedding
         assert "decoder" in pkg
@@ -1306,6 +1305,14 @@ class TestBuildGraphVisionLanguage:
         decoder = pkg["decoder"]
         assert "logits" in {out.name for out in decoder.graph.outputs}
         assert "inputs_embeds" in {inp.name for inp in decoder.graph.inputs}
+
+        vision_encoder = pkg["vision_encoder"]
+        node_order = {id(node): index for index, node in enumerate(vision_encoder.graph)}
+        for index, node in enumerate(vision_encoder.graph):
+            for input_value in node.inputs:
+                producer = input_value.producer() if input_value is not None else None
+                if producer is not None and producer.graph is vision_encoder.graph:
+                    assert node_order[id(producer)] < index
 
     def test_qwen35_vl_graph(self):
         """Build Qwen3.5-VL with its auto-detected 3-model task."""

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1202,7 +1202,10 @@ class TestQwen3VL3Model:
 
         # Run ONNX: first embedding, then decoder
         embed_sess = _make_session(pkg["embedding"])
-        image_features = np.zeros((0, config.hidden_size), dtype=np.float32)
+        num_deepstack = len(config.deepstack_visual_indexes or [])
+        image_features = np.zeros(
+            (0, (num_deepstack + 1) * config.hidden_size), dtype=np.float32
+        )
         embed_out = embed_sess.run(
             {
                 "input_ids": input_ids.numpy(),
@@ -1210,6 +1213,7 @@ class TestQwen3VL3Model:
             }
         )
         inputs_embeds = embed_out["inputs_embeds"]
+        per_layer_inputs = embed_out["per_layer_inputs"]
 
         decoder_sess = _make_session(pkg["decoder"])
         past_kv = {}
@@ -1226,6 +1230,7 @@ class TestQwen3VL3Model:
                 "inputs_embeds": inputs_embeds,
                 "attention_mask": attention_mask.numpy(),
                 "position_ids": position_ids.numpy(),
+                "per_layer_inputs": per_layer_inputs,
                 **past_kv,
             }
         )
@@ -1297,6 +1302,7 @@ class TestQwen3VL3Model:
         )
         embedding_session.close()
         inputs_embeds = embed_out["inputs_embeds"]
+        per_layer_inputs = embed_out["per_layer_inputs"]
 
         # Step 3: Decoder with MRoPE position_ids from HF
         with torch.no_grad():
@@ -1319,6 +1325,7 @@ class TestQwen3VL3Model:
             "inputs_embeds": inputs_embeds,
             "attention_mask": attention_mask,
             "position_ids": position_ids,
+            "per_layer_inputs": per_layer_inputs,
         }
         for i in range(config.num_hidden_layers):
             kv_shape = (1, config.num_key_value_heads, 0, config.head_dim)
@@ -3345,6 +3352,7 @@ def test_qwen35_vl_3model_builds_and_runs():
         linear_num_value_heads=4,
         linear_value_head_dim=8,
         linear_conv_kernel_dim=4,
+        deepstack_visual_indexes=[0],
         # Vision config (Qwen VL uses packed-attention ViT)
         vision=VisionConfig(
             hidden_size=32,
@@ -3357,7 +3365,6 @@ def test_qwen35_vl_3model_builds_and_runs():
             out_hidden_size=64,
             spatial_merge_size=2,
             num_position_embeddings=16,
-            deepstack_visual_indexes=[0],
             mrope_section=[8, 12, 12],
         ),
         image_token_id=248056,
@@ -3387,6 +3394,7 @@ def test_qwen35_vl_3model_builds_and_runs():
     assert "inputs_embeds" in decoder_inputs
     assert "attention_mask" in decoder_inputs
     assert "position_ids" in decoder_inputs
+    assert "per_layer_inputs" in decoder_inputs
 
     # Verify vision model I/O
     vision_inputs = {i.name for i in pkg["vision_encoder"].graph.inputs}
@@ -3396,6 +3404,10 @@ def test_qwen35_vl_3model_builds_and_runs():
     embed_inputs = {i.name for i in pkg["embedding"].graph.inputs}
     assert "input_ids" in embed_inputs
     assert "image_features" in embed_inputs
+    assert {o.name for o in pkg["embedding"].graph.outputs} == {
+        "inputs_embeds",
+        "per_layer_inputs",
+    }
 
     # Run through ORT: fill initializers with random weights
     rng = np.random.default_rng(42)
@@ -3408,7 +3420,13 @@ def test_qwen35_vl_3model_builds_and_runs():
     # Run embedding model with a single token (DeltaNet = decode-only)
     embed_sess = _make_session(pkg["embedding"])
     input_ids = np.array([[1]], dtype=np.int64)
-    image_features = np.zeros((0, config.hidden_size), dtype=np.float32)
+    image_features = np.zeros(
+        (
+            0,
+            (len(config.deepstack_visual_indexes) + 1) * config.hidden_size,
+        ),
+        dtype=np.float32,
+    )
     embed_out = embed_sess.run({"input_ids": input_ids, "image_features": image_features})
     embed_sess.close()
     assert "inputs_embeds" in embed_out
@@ -3418,6 +3436,7 @@ def test_qwen35_vl_3model_builds_and_runs():
     decoder_sess = _make_session(pkg["decoder"])
     feeds: dict[str, np.ndarray] = {
         "inputs_embeds": embed_out["inputs_embeds"],
+        "per_layer_inputs": embed_out["per_layer_inputs"],
         "attention_mask": np.ones((1, 1), dtype=np.int64),
         # MRoPE: 3D position IDs (3, batch, seq)
         "position_ids": np.zeros((3, 1, 1), dtype=np.int64),


### PR DESCRIPTION
This pull request enhances the cross-platform detection and reporting of available RAM in the `mobius.preflight` module. It introduces platform-specific implementations for Windows, macOS, and Linux, improves test coverage for these changes, and updates related tests to use the new probing mechanism. Additionally, it includes a small fix in a build graph test to ensure node ordering is validated.

**Improvements to RAM detection and reporting:**

* Added platform-specific functions for detecting available RAM: `_windows_available_ram_bytes` for Windows, `_darwin_available_ram_bytes` for macOS, `_proc_available_ram_bytes` for Linux, and a fallback using `os.sysconf` when necessary. The new `_probe_available_ram` function selects the best available method and returns both the value and its source. (`[[1]](diffhunk://#diff-9bc6af1f2ebeb847e186fe5570e6ac0d76b0343bf9eb51e0fbd9f2e2c5cfa15aL462-R492)`, `[[2]](diffhunk://#diff-9bc6af1f2ebeb847e186fe5570e6ac0d76b0343bf9eb51e0fbd9f2e2c5cfa15aR502-R561)`)
* Updated `check_ram` to use the new `_probe_available_ram` function, improving reporting by including the source of the RAM measurement. (`[src/mobius/preflight.pyL486-R582](diffhunk://#diff-9bc6af1f2ebeb847e186fe5570e6ac0d76b0343bf9eb51e0fbd9f2e2c5cfa15aL486-R582)`)

**Testing and test utilities:**

* Added comprehensive tests for the new RAM detection logic, including platform-specific probes, fallback mechanisms, and parsing of macOS `vm_stat` output. Existing tests now monkeypatch `_probe_available_ram` instead of `_available_ram_bytes`. (`[[1]](diffhunk://#diff-f86b6f1c3e1afc379705d505194294a8ecc9896b48259c164b776eb3f1b34f59R199-R236)`, `[[2]](diffhunk://#diff-f86b6f1c3e1afc379705d505194294a8ecc9896b48259c164b776eb3f1b34f59L219-R257)`, `[[3]](diffhunk://#diff-f86b6f1c3e1afc379705d505194294a8ecc9896b48259c164b776eb3f1b34f59L230-R276)`, `[[4]](diffhunk://#diff-f86b6f1c3e1afc379705d505194294a8ecc9896b48259c164b776eb3f1b34f59L248-R286)`, `[[5]](diffhunk://#diff-f86b6f1c3e1afc379705d505194294a8ecc9896b48259c164b776eb3f1b34f59L272-R310)`, `[[6]](diffhunk://#diff-f86b6f1c3e1afc379705d505194294a8ecc9896b48259c164b776eb3f1b34f59L291-R329)`, `[[7]](diffhunk://#diff-f86b6f1c3e1afc379705d505194294a8ecc9896b48259c164b776eb3f1b34f59L306-R344)`, `[[8]](diffhunk://#diff-f86b6f1c3e1afc379705d505194294a8ecc9896b48259c164b776eb3f1b34f59L328-R366)`)

**General codebase improvements:**

* Added missing imports (`ctypes`, `wintypes`, `re`, `subprocess`, `sys`) to support the new platform-specific RAM detection logic. (`[src/mobius/preflight.pyR41-R52](diffhunk://#diff-9bc6af1f2ebeb847e186fe5570e6ac0d76b0343bf9eb51e0fbd9f2e2c5cfa15aR41-R52)`)
* In `_should_inline`, ensured the model graph is sorted after rewrites to maintain correct producer-consumer ordering. (`[src/mobius/_optimizations.pyR707-R709](diffhunk://#diff-0e0781be69f6ae96d51801d3a2ba76bdb7220c897d668aae0282064c2962e8a2R707-R709)`)

**Build/test validation:**

* In `tests/build_graph_test.py`, switched to using `build_from_module` for clarity and added an explicit check that ensures node producers in the vision encoder graph are ordered before their consumers. (`[[1]](diffhunk://#diff-e3747952023a0b5f01abf736f1c02d1cc314598012d2eb94b7e2dfa8405c9271L1235-R1235)`, `[[2]](diffhunk://#diff-e3747952023a0b5f01abf736f1c02d1cc314598012d2eb94b7e2dfa8405c9271R1247-R1254)`)