### PR TITLE
Harden GGUF metadata array header parsing

### DIFF
--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -20,7 +20,6 @@ __all__ = ["build_from_gguf"]
 import logging
 import math
 import re
-import struct
 from collections import Counter
 from collections.abc import Callable, Collection, Iterable, Mapping
 from pathlib import Path
@@ -49,6 +48,7 @@ from mobius.integrations.gguf._errors import (
     ShardedGGUFNotSupportedError,
     UnsupportedGGUFArchitectureError,
 )
+from mobius.integrations.gguf._header import _gguf_architecture_from_header
 from mobius.integrations.gguf._spec import Support
 
 _HUB_PREFLIGHT_TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (OSError,)
@@ -70,20 +70,6 @@ _GGUF_SHARD_FILENAME_RE = re.compile(
 )
 _NEMOTRON_H_MOE_ARCHITECTURE = "nemotron_h_moe"
 _GGUF_HEADER_RANGE_BYTES = 16 * 1024 * 1024
-_GGUF_ARCHITECTURE_KEY = b"general.architecture"
-_GGUF_SCALAR_WIDTHS = {
-    0: 1,  # UINT8
-    1: 1,  # INT8
-    2: 2,  # UINT16
-    3: 2,  # INT16
-    4: 4,  # UINT32
-    5: 4,  # INT32
-    6: 4,  # FLOAT32
-    7: 1,  # BOOL
-    10: 8,  # UINT64
-    11: 8,  # INT64
-    12: 8,  # FLOAT64
-}
 
 
 def _summarize_nemotron_h_moe_layout(
@@ -401,82 +387,9 @@ def _preflight_hf_gguf(api: HfApi, repo_id: str, filename: str) -> None:
 
 def _gguf_architecture_from_header_prefix(data: bytes, *, source: str) -> str:
     """Read ``general.architecture`` from a bounded GGUF header prefix."""
-    if len(data) < 24 or data[:4] != b"GGUF":
-        raise ValueError(f"{source!r} does not begin with a valid GGUF header.")
-    version = struct.unpack_from("<I", data, 4)[0]
-    if version not in {2, 3}:
-        raise ValueError(f"{source!r} uses unsupported GGUF version {version}.")
-
-    def read_uint32(offset: int) -> tuple[int, int]:
-        end = offset + 4
-        if end > len(data):
-            raise ValueError(f"{source!r} has a truncated GGUF metadata header.")
-        return struct.unpack_from("<I", data, offset)[0], end
-
-    def read_uint64(offset: int) -> tuple[int, int]:
-        end = offset + 8
-        if end > len(data):
-            raise ValueError(f"{source!r} has a truncated GGUF metadata header.")
-        return struct.unpack_from("<Q", data, offset)[0], end
-
-    def read_string(offset: int) -> tuple[bytes, int]:
-        length, offset = read_uint64(offset)
-        end = offset + length
-        if end > len(data):
-            raise ValueError(f"{source!r} has a truncated GGUF metadata string.")
-        return data[offset:end], end
-
-    def skip_value(value_type: int, offset: int, *, depth: int = 0) -> int:
-        width = _GGUF_SCALAR_WIDTHS.get(value_type)
-        if width is not None:
-            end = offset + width
-            if end > len(data):
-                raise ValueError(f"{source!r} has a truncated GGUF metadata value.")
-            return end
-        if value_type == 8:
-            _, offset = read_string(offset)
-            return offset
-        if value_type != 9:
-            raise ValueError(f"{source!r} uses unknown GGUF metadata type {value_type}.")
-        if depth >= 8:
-            raise ValueError(f"{source!r} has excessively nested GGUF metadata arrays.")
-        element_type, offset = read_uint32(offset)
-        count, offset = read_uint64(offset)
-        if count > len(data):
-            raise ValueError(f"{source!r} declares an impossible GGUF metadata array size.")
-        for _ in range(count):
-            offset = skip_value(element_type, offset, depth=depth + 1)
-        return offset
-
-    kv_count = struct.unpack_from("<Q", data, 16)[0]
-    if kv_count > len(data):
-        raise ValueError(f"{source!r} declares an impossible GGUF metadata entry count.")
-    offset = 24
-    architecture_values: list[bytes] = []
-    for _ in range(kv_count):
-        key, offset = read_string(offset)
-        value_type, offset = read_uint32(offset)
-        if key == _GGUF_ARCHITECTURE_KEY:
-            if value_type != 8:
-                raise ValueError(
-                    f"{source!r} encodes general.architecture with GGUF type "
-                    f"{value_type}, expected string type 8."
-                )
-            value, offset = read_string(offset)
-            architecture_values.append(value)
-        else:
-            offset = skip_value(value_type, offset)
-
-    if len(architecture_values) != 1:
-        raise ValueError(
-            f"{source!r} must contain exactly one general.architecture metadata entry, "
-            f"found {len(architecture_values)}."
-        )
-    value = architecture_values[0]
-    try:
-        return value.decode("utf-8")
-    except UnicodeDecodeError as error:
-        raise ValueError(f"{source!r} has a non-UTF-8 general.architecture value.") from error
+    architecture = _gguf_architecture_from_header(data, source=source)
+    assert architecture is not None
+    return architecture
 
 
 def _preflight_hf_gguf_file(

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -7418,6 +7418,87 @@ class TestGGUFPreflightGuards:
                 source="duplicate.gguf",
             )
 
+    def test_structural_header_parser_rejects_array_above_safety_limit(self) -> None:
+        from mobius.integrations.gguf._builder import (
+            _gguf_architecture_from_header_prefix,
+        )
+
+        count = 1_000_001
+        padding_entry = (
+            struct.pack("<Q", len(b"padding"))
+            + b"padding"
+            + struct.pack("<IIQ", 9, 0, count)
+            + bytes(count)
+        )
+        data = (
+            b"GGUF"
+            + struct.pack("<IQQ", 3, 0, 2)
+            + padding_entry
+            + _gguf_header_prefix("llama")[24:]
+        )
+        with pytest.raises(ValueError, match=r"1000001.*safety limit of 1000000"):
+            _gguf_architecture_from_header_prefix(data, source="oversized-array.gguf")
+
+    def test_structural_header_parser_rejects_truncated_fixed_width_array(self) -> None:
+        from mobius.integrations.gguf._builder import (
+            _gguf_architecture_from_header_prefix,
+        )
+
+        array_entry = (
+            struct.pack("<Q", len(b"padding"))
+            + b"padding"
+            + struct.pack("<IIQ", 9, 4, 2)
+            + b"\x00" * 7
+        )
+        data = b"GGUF" + struct.pack("<IQQ", 3, 0, 1) + array_entry
+        with pytest.raises(
+            ValueError,
+            match=r"truncated GGUF metadata array.*requiring at least 8 bytes.*7 remaining",
+        ):
+            _gguf_architecture_from_header_prefix(data, source="truncated-array.gguf")
+
+    def test_structural_header_parser_rejects_truncated_nested_array(self) -> None:
+        from mobius.integrations.gguf._builder import (
+            _gguf_architecture_from_header_prefix,
+        )
+
+        nested_array = struct.pack("<IQ", 0, 2**63)
+        array_entry = (
+            struct.pack("<Q", len(b"padding"))
+            + b"padding"
+            + struct.pack("<IIQ", 9, 9, 1)
+            + nested_array
+        )
+        data = b"GGUF" + struct.pack("<IQQ", 3, 0, 1) + array_entry
+        with pytest.raises(
+            ValueError,
+            match=r"truncated GGUF metadata array.*9223372036854775808 elements",
+        ):
+            _gguf_architecture_from_header_prefix(data, source="nested-array.gguf")
+
+    def test_structural_header_parser_accepts_array_at_safety_limit(self) -> None:
+        from mobius.integrations.gguf._builder import (
+            _gguf_architecture_from_header_prefix,
+        )
+
+        count = 1_000_000
+        padding_entry = (
+            struct.pack("<Q", len(b"padding"))
+            + b"padding"
+            + struct.pack("<IIQ", 9, 0, count)
+            + bytes(count)
+        )
+        data = (
+            b"GGUF"
+            + struct.pack("<IQQ", 3, 0, 2)
+            + padding_entry
+            + _gguf_header_prefix("llama")[24:]
+        )
+        assert (
+            _gguf_architecture_from_header_prefix(data, source="boundary-array.gguf")
+            == "llama"
+        )
+
     def test_exact_companion_preflight_rejects_unresolved_mutable_revision(self) -> None:
         from mobius.integrations.gguf._builder import (
             _preflight_hf_mmproj_companion_file,

--- a/src/mobius/integrations/gguf/_header.py
+++ b/src/mobius/integrations/gguf/_header.py
@@ -1,0 +1,165 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Bounded structural validation for GGUF metadata headers."""
+
+from __future__ import annotations
+
+import struct
+from typing import Any
+
+_GGUF_ARCHITECTURE_KEY = b"general.architecture"
+_GGUF_MAX_METADATA_ARRAY_DEPTH = 8
+_GGUF_MAX_METADATA_ARRAY_ELEMENTS = 1_000_000
+_GGUF_MAX_METADATA_ENTRIES = 1_000_000
+_GGUF_SCALAR_WIDTHS = {
+    0: 1,  # UINT8
+    1: 1,  # INT8
+    2: 2,  # UINT16
+    3: 2,  # INT16
+    4: 4,  # UINT32
+    5: 4,  # INT32
+    6: 4,  # FLOAT32
+    7: 1,  # BOOL
+    10: 8,  # UINT64
+    11: 8,  # INT64
+    12: 8,  # FLOAT64
+}
+_GGUF_STRING = 8
+_GGUF_ARRAY = 9
+
+
+def _gguf_architecture_from_header(
+    data: Any,
+    *,
+    source: str,
+    require_architecture: bool = True,
+) -> str | None:
+    """Validate a GGUF metadata table and return its architecture when present."""
+    size = len(data)
+    if size < 24 or data[0:4] != b"GGUF":
+        raise ValueError(f"{source!r} does not begin with a valid GGUF header.")
+
+    little_version = struct.unpack_from("<I", data, 4)[0]
+    if little_version in {2, 3}:
+        byte_order = "<"
+        version = little_version
+    else:
+        version = struct.unpack_from(">I", data, 4)[0]
+        if version not in {2, 3}:
+            raise ValueError(f"{source!r} uses unsupported GGUF version {little_version}.")
+        byte_order = ">"
+
+    def read_uint32(offset: int) -> tuple[int, int]:
+        end = offset + 4
+        if end > size:
+            raise ValueError(f"{source!r} has a truncated GGUF metadata header.")
+        return struct.unpack_from(f"{byte_order}I", data, offset)[0], end
+
+    def read_uint64(offset: int) -> tuple[int, int]:
+        end = offset + 8
+        if end > size:
+            raise ValueError(f"{source!r} has a truncated GGUF metadata header.")
+        return struct.unpack_from(f"{byte_order}Q", data, offset)[0], end
+
+    def read_string_span(offset: int) -> tuple[int, int, int]:
+        length, offset = read_uint64(offset)
+        end = offset + length
+        if end > size:
+            raise ValueError(
+                f"{source!r} has a truncated GGUF metadata string: "
+                f"declares {length} bytes with only {size - offset} remaining."
+            )
+        return offset, end, end
+
+    def minimum_value_width(value_type: int) -> int:
+        width = _GGUF_SCALAR_WIDTHS.get(value_type)
+        if width is not None:
+            return width
+        if value_type == _GGUF_STRING:
+            return 8
+        if value_type == _GGUF_ARRAY:
+            return 12
+        raise ValueError(f"{source!r} uses unknown GGUF metadata type {value_type}.")
+
+    def skip_value(value_type: int, offset: int, *, depth: int = 0) -> int:
+        width = _GGUF_SCALAR_WIDTHS.get(value_type)
+        if width is not None:
+            end = offset + width
+            if end > size:
+                raise ValueError(f"{source!r} has a truncated GGUF metadata value.")
+            return end
+        if value_type == _GGUF_STRING:
+            _, _, offset = read_string_span(offset)
+            return offset
+        if value_type != _GGUF_ARRAY:
+            raise ValueError(f"{source!r} uses unknown GGUF metadata type {value_type}.")
+        if depth >= _GGUF_MAX_METADATA_ARRAY_DEPTH:
+            raise ValueError(f"{source!r} has excessively nested GGUF metadata arrays.")
+
+        element_type, offset = read_uint32(offset)
+        count, offset = read_uint64(offset)
+        element_width = minimum_value_width(element_type)
+        remaining = size - offset
+        if count > remaining // element_width:
+            raise ValueError(
+                f"{source!r} has a truncated GGUF metadata array: declares {count} "
+                f"elements requiring at least {count * element_width} bytes with only "
+                f"{remaining} remaining."
+            )
+        if count > _GGUF_MAX_METADATA_ARRAY_ELEMENTS:
+            raise ValueError(
+                f"{source!r} declares {count} GGUF metadata array elements, exceeding "
+                f"the safety limit of {_GGUF_MAX_METADATA_ARRAY_ELEMENTS}."
+            )
+
+        if element_type in _GGUF_SCALAR_WIDTHS:
+            return offset + count * element_width
+        for _ in range(count):
+            offset = skip_value(element_type, offset, depth=depth + 1)
+        return offset
+
+    kv_count = struct.unpack_from(f"{byte_order}Q", data, 16)[0]
+    if kv_count > _GGUF_MAX_METADATA_ENTRIES:
+        raise ValueError(
+            f"{source!r} declares {kv_count} GGUF metadata entries, exceeding "
+            f"the safety limit of {_GGUF_MAX_METADATA_ENTRIES}."
+        )
+    # Every entry needs an 8-byte key length, a 4-byte type, and at least
+    # one value byte. Reject impossible counts before entering the loop.
+    if kv_count > (size - 24) // 13:
+        raise ValueError(
+            f"{source!r} has a truncated GGUF metadata table for {kv_count} entries."
+        )
+
+    offset = 24
+    architecture_values: list[bytes] = []
+    for _ in range(kv_count):
+        key_start, key_end, offset = read_string_span(offset)
+        value_type, offset = read_uint32(offset)
+        is_architecture = (
+            key_end - key_start == len(_GGUF_ARCHITECTURE_KEY)
+            and data[key_start:key_end] == _GGUF_ARCHITECTURE_KEY
+        )
+        if is_architecture:
+            if value_type != _GGUF_STRING:
+                raise ValueError(
+                    f"{source!r} encodes general.architecture with GGUF type "
+                    f"{value_type}, expected string type {_GGUF_STRING}."
+                )
+            value_start, value_end, offset = read_string_span(offset)
+            architecture_values.append(bytes(data[value_start:value_end]))
+        else:
+            offset = skip_value(value_type, offset)
+
+    if not architecture_values and not require_architecture:
+        return None
+    if len(architecture_values) != 1:
+        raise ValueError(
+            f"{source!r} must contain exactly one general.architecture metadata entry, "
+            f"found {len(architecture_values)}."
+        )
+    try:
+        return architecture_values[0].decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ValueError(f"{source!r} has a non-UTF-8 general.architecture value.") from error

--- a/src/mobius/integrations/gguf/_reader.py
+++ b/src/mobius/integrations/gguf/_reader.py
@@ -25,12 +25,15 @@ from __future__ import annotations
 __all__ = ["GGUFModel"]
 
 import logging
+import mmap
 from array import array
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
 import numpy as np
+
+from mobius.integrations.gguf._header import _gguf_architecture_from_header
 
 logger = logging.getLogger(__name__)
 
@@ -159,6 +162,17 @@ class GGUFModel:
             raise FileNotFoundError(f"GGUF file not found: {self._path}")
 
         source_identity = _stat_identity(self._path)
+        if source_identity[2] < 24:
+            raise ValueError(f"{str(self._path)!r} does not begin with a valid GGUF header.")
+        with (
+            self._path.open("rb") as stream,
+            mmap.mmap(stream.fileno(), length=0, access=mmap.ACCESS_READ) as mapped,
+        ):
+            _gguf_architecture_from_header(
+                mapped,
+                source=str(self._path),
+                require_architecture=False,
+            )
         self._reader = GGUFReader(str(self._path))
         if _stat_identity(self._path) != source_identity:
             raise ValueError("GGUF source changed while the reader was opening it")

--- a/src/mobius/integrations/gguf/_reader_test.py
+++ b/src/mobius/integrations/gguf/_reader_test.py
@@ -9,6 +9,7 @@ to avoid requiring model downloads.
 
 from __future__ import annotations
 
+import struct
 from pathlib import Path
 
 import numpy as np
@@ -24,6 +25,33 @@ from mobius.integrations.gguf._config_mapping import (
     gguf_to_config,
 )
 from mobius.integrations.gguf._reader import GGUFModel
+
+
+def _raw_gguf_string(value: bytes) -> bytes:
+    return struct.pack("<Q", len(value)) + value
+
+
+def _raw_gguf_header(*entries: bytes) -> bytes:
+    return b"GGUF" + struct.pack("<IQQ", 3, 0, len(entries)) + b"".join(entries)
+
+
+def _raw_gguf_architecture_entry() -> bytes:
+    return (
+        _raw_gguf_string(b"general.architecture")
+        + struct.pack("<I", 8)
+        + _raw_gguf_string(b"llama")
+    )
+
+
+def _raw_gguf_array_entry(
+    *,
+    count: int,
+    element_type: int,
+    payload: bytes = b"",
+) -> bytes:
+    return (
+        _raw_gguf_string(b"test.array") + struct.pack("<IIQ", 9, element_type, count) + payload
+    )
 
 
 def _write_test_gguf(
@@ -371,6 +399,29 @@ class TestGGUFModelReader:
     def test_file_not_found(self, tmp_path: Path):
         with pytest.raises(FileNotFoundError, match="not found"):
             GGUFModel(tmp_path / "nonexistent.gguf")
+
+    def test_rejects_huge_metadata_array_before_constructing_upstream_reader(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        import gguf
+
+        path = tmp_path / "huge-array.gguf"
+        path.write_bytes(
+            _raw_gguf_header(
+                _raw_gguf_array_entry(count=2**63, element_type=0),
+                _raw_gguf_architecture_entry(),
+            )
+        )
+
+        def fail_if_constructed(path: str):
+            pytest.fail(f"GGUFReader unexpectedly opened {path}")
+
+        monkeypatch.setattr(gguf, "GGUFReader", fail_if_constructed)
+        with pytest.raises(
+            ValueError,
+            match=r"truncated GGUF metadata array.*9223372036854775808 elements",
+        ):
+            GGUFModel(path)
 
     def test_repr(self, llama_gguf: Path):
         model = GGUFModel(llama_gguf)


### PR DESCRIPTION
## Summary
- validate GGUF metadata tables before invoking `gguf.GGUFReader`
- bound array counts by remaining encoded bytes and a 1,000,000-element safety cap
- fast-skip fixed-width arrays and safely bound nested/string arrays
- share validation with remote architecture header preflight while preserving big-endian files and continuation shards
- add adversarial coverage for huge counts, truncation, nested arrays, and the valid cap boundary

## Tests
- `python -m pytest src/mobius/integrations/gguf/_reader_test.py src/mobius/integrations/gguf/_builder_test.py -q --tb=short`
- `python -m pytest src/mobius/integrations/gguf/_reader_test.py src/mobius/integrations/gguf/_builder_test.py src/mobius/integrations/gguf/_shard_set_test.py src/mobius/integrations/gguf/_preflight_test.py -q --tb=short`
- `python -m pytest src/mobius/integrations/gguf/_docs_test.py -q --tb=short`
- `python -m pytest tests/build_graph_test.py tests/cli_test.py src/ -q -k "not phi4mm and not apply_weights_unknown" --tb=short -n auto`
- `lintrunner f --output oneline src/mobius/integrations/gguf/_header.py src/mobius/integrations/gguf/_reader.py src/mobius/integrations/gguf/_reader_test.py src/mobius/integrations/gguf/_builder.py src/mobius/integrations/gguf/_builder_test.py`

Follow-up to review comment https://github.com/onnxruntime/mobius/pull/586#discussion_r3854739700.