### PR TITLE
Fix hybrid GGUF weight transforms

### DIFF
--- a/src/mobius/integrations/gguf/_arch_registry.py
+++ b/src/mobius/integrations/gguf/_arch_registry.py
@@ -1069,7 +1069,8 @@ _SPECS: tuple[GGUFArchitectureSpec, ...] = (
         tensor_map_recipe=("nemotron_h",),
         config_key_map="nemotron_h",
         config_postprocessor="nemotron_h",
-        tensor_processor="mamba",
+        tensor_processor="nemotron_h",
+        llama_qk_permute=True,
         required_metadata=(
             "attention.layer_norm_rms_epsilon",
             "ssm.conv_kernel",
@@ -1088,7 +1089,8 @@ _SPECS: tuple[GGUFArchitectureSpec, ...] = (
         tensor_map_recipe=("nemotron_h_moe",),
         config_key_map="nemotron_h",
         config_postprocessor="nemotron_h_moe",
-        tensor_processor="mamba",
+        tensor_processor="nemotron_h",
+        llama_qk_permute=True,
         required_metadata=(
             "attention.layer_norm_rms_epsilon",
             "ssm.conv_kernel",
@@ -1121,6 +1123,7 @@ _SPECS: tuple[GGUFArchitectureSpec, ...] = (
         config_key_map="granitehybrid",
         config_postprocessor="granitehybrid",
         tensor_processor="granitehybrid",
+        llama_qk_permute=True,
         required_metadata=(
             "attention.layer_norm_rms_epsilon",
             "ssm.conv_kernel",

--- a/src/mobius/integrations/gguf/_arch_registry_test.py
+++ b/src/mobius/integrations/gguf/_arch_registry_test.py
@@ -1550,6 +1550,8 @@ class TestRejectionsAreActionable:
     def test_nemotron_h_moe_graph_is_supported_but_runtime_is_deferred(self) -> None:
         spec = get_arch_spec("nemotron_h_moe")
         assert spec.model_type == "nemotron_h"
+        assert spec.tensor_processor == "nemotron_h"
+        assert spec.llama_qk_permute is True
         assert spec.config is Support.SUPPORTED
         assert spec.tensor_map is Support.SUPPORTED
         assert spec.graph is Support.SUPPORTED
@@ -1557,6 +1559,14 @@ class TestRejectionsAreActionable:
         assert spec.quantized_import is Support.REJECTED
         assert spec.reason is not None
         assert "onnxruntime/mobius#605" in spec.reason
+
+        dense_spec = get_arch_spec("nemotron_h")
+        assert dense_spec.tensor_processor == "nemotron_h"
+        assert dense_spec.llama_qk_permute is True
+
+        granite_spec = get_arch_spec("granitehybrid")
+        assert granite_spec.tensor_processor == "granitehybrid"
+        assert granite_spec.llama_qk_permute is True
 
 
 class TestDocumentedSupportMatrix:

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -2336,6 +2336,7 @@ def _raise_for_invalid_mamba_hybrid_tensor_contract(gguf_model) -> None:
                 "or both positive"
             )
         dense_ffn = {"ffn_gate.weight", "ffn_up.weight", "ffn_down.weight"}
+        dense_ffn_biases = {"ffn_gate.bias", "ffn_up.bias", "ffn_down.bias"}
         routed_ffn = {
             "ffn_gate_inp.weight",
             "ffn_gate_exps.weight",
@@ -2378,6 +2379,9 @@ def _raise_for_invalid_mamba_hybrid_tensor_contract(gguf_model) -> None:
                 "rope_freqs.weight",
             },
         }
+        if not num_experts:
+            for optional in optional_by_type.values():
+                optional.update(dense_ffn_biases)
         forbidden_ffn = dense_ffn if num_experts else routed_ffn | shared_ffn
         present_forbidden = sorted(
             f"blk.{index}.{suffix}"

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -1113,6 +1113,7 @@ def _write_granitehybrid_moe_gguf(
     expert_used_count: int = 1,
     shared_width: int = 16,
     attention_biases: bool = True,
+    mlp_biases: bool = False,
     malformed_shape: str | None = None,
 ) -> None:
     """Write a tiny mixed GraniteHybrid GGUF with routed and shared experts."""
@@ -1205,38 +1206,47 @@ def _write_granitehybrid_moe_gguf(
         prefix = f"blk.{layer}."
         add_float(prefix + "attn_norm.weight", (hidden,))
         add_float(prefix + "ffn_norm.weight", (hidden,))
-        add_float(prefix + "ffn_gate_inp.weight", (expert_count, hidden))
         expert_projection = add_q4 if quantized else add_float
-        if quantized:
-            expert_projection(
-                prefix + "ffn_gate_exps.weight",
-                (expert_count, expert_width, hidden),
-            )
-            expert_projection(
-                prefix + "ffn_up_exps.weight",
-                (expert_count, expert_width, hidden),
-            )
-            expert_projection(
-                prefix + "ffn_down_exps.weight",
-                (expert_count, hidden, expert_width),
-            )
+        if not expert_count:
+            expert_projection(prefix + "ffn_gate.weight", (expert_width, hidden))
+            expert_projection(prefix + "ffn_up.weight", (expert_width, hidden))
+            expert_projection(prefix + "ffn_down.weight", (hidden, expert_width))
+            if mlp_biases:
+                add_float(prefix + "ffn_gate.bias", (expert_width,), fill=41.0)
+                add_float(prefix + "ffn_up.bias", (expert_width,), fill=42.0)
+                add_float(prefix + "ffn_down.bias", (hidden,), fill=43.0)
         else:
-            add_float(
-                prefix + "ffn_gate_exps.weight",
-                (expert_count, expert_width, hidden),
-                expert_base=11.0,
-            )
-            add_float(
-                prefix + "ffn_up_exps.weight",
-                (expert_count, expert_width, hidden),
-                expert_base=21.0,
-            )
-            add_float(
-                prefix + "ffn_down_exps.weight",
-                (expert_count, hidden, expert_width),
-                expert_base=31.0,
-            )
-        if shared_width:
+            add_float(prefix + "ffn_gate_inp.weight", (expert_count, hidden))
+            if quantized:
+                expert_projection(
+                    prefix + "ffn_gate_exps.weight",
+                    (expert_count, expert_width, hidden),
+                )
+                expert_projection(
+                    prefix + "ffn_up_exps.weight",
+                    (expert_count, expert_width, hidden),
+                )
+                expert_projection(
+                    prefix + "ffn_down_exps.weight",
+                    (expert_count, hidden, expert_width),
+                )
+            else:
+                add_float(
+                    prefix + "ffn_gate_exps.weight",
+                    (expert_count, expert_width, hidden),
+                    expert_base=11.0,
+                )
+                add_float(
+                    prefix + "ffn_up_exps.weight",
+                    (expert_count, expert_width, hidden),
+                    expert_base=21.0,
+                )
+                add_float(
+                    prefix + "ffn_down_exps.weight",
+                    (expert_count, hidden, expert_width),
+                    expert_base=31.0,
+                )
+        if expert_count and shared_width:
             add_float(prefix + "ffn_gate_shexp.weight", (shared_width, hidden))
             add_float(prefix + "ffn_up_shexp.weight", (shared_width, hidden))
             add_float(prefix + "ffn_down_shexp.weight", (hidden, shared_width))
@@ -1622,11 +1632,24 @@ def _write_nemotron_h_moe_gguf(
         *,
         expert_order: bool = False,
         negative: bool = False,
+        permute_heads: int | None = None,
     ) -> None:
         if name == omit:
             return
         shape = adjusted_shape(name, shape)
         values = rng.normal(0.0, 0.03, size=shape).astype(np.float32)
+        if permute_heads is not None:
+            values = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
+            values = (
+                values.reshape(
+                    permute_heads,
+                    2,
+                    shape[0] // permute_heads // 2,
+                    *shape[1:],
+                )
+                .swapaxes(1, 2)
+                .reshape(shape)
+            )
         if negative:
             values = -np.exp(values)
         if expert_order:
@@ -1700,8 +1723,20 @@ def _write_nemotron_h_moe_gguf(
         projection("blk.1.ffn_latent_down.weight", (latent_width, hidden))
         projection("blk.1.ffn_latent_up.weight", (hidden, latent_width))
 
-    projection("blk.2.attn_q.weight", (heads * head_dim, hidden))
-    projection("blk.2.attn_k.weight", (kv_heads * head_dim, hidden))
+    if quantized:
+        projection("blk.2.attn_q.weight", (heads * head_dim, hidden))
+        projection("blk.2.attn_k.weight", (kv_heads * head_dim, hidden))
+    else:
+        add_float(
+            "blk.2.attn_q.weight",
+            (heads * head_dim, hidden),
+            permute_heads=heads,
+        )
+        add_float(
+            "blk.2.attn_k.weight",
+            (kv_heads * head_dim, hidden),
+            permute_heads=kv_heads,
+        )
     projection("blk.2.attn_v.weight", (kv_heads * head_dim, hidden))
     projection("blk.2.attn_output.weight", (hidden, heads * head_dim))
 
@@ -5774,7 +5809,6 @@ class TestJambaGGUFBuild:
                     f"model.layers.1.feed_forward.experts.{expert}.{projection}.weight_t"
                 ].const_value.numpy()
                 np.testing.assert_array_equal(value, expert + 1)
-
         output_dir = tmp_path / "saved-jamba"
         package.save(output_dir, progress_bar=False)
         session = OnnxModelSession(ModelPackage.load(output_dir)["model"])
@@ -6472,6 +6506,32 @@ class TestGraniteHybridMoEGGUFBuild:
             for name in model.graph.initializers
         )
 
+    def test_dense_ffn_biases_are_fused_in_gate_then_up_order(self, tmp_path: Path) -> None:
+        from mobius.integrations.gguf import build_from_gguf
+
+        path = tmp_path / "granitehybrid-dense-biased.gguf"
+        _write_granitehybrid_moe_gguf(
+            path,
+            quantized=False,
+            expert_count=0,
+            expert_used_count=0,
+            shared_width=0,
+            mlp_biases=True,
+        )
+
+        model = build_from_gguf(path)["model"]
+        for layer in range(2):
+            prefix = f"model.layers.{layer}.shared_mlp."
+            fused_bias = model.graph.initializers[
+                prefix + "input_linear.bias"
+            ].const_value.numpy()
+            np.testing.assert_array_equal(fused_bias[:32], 41.0)
+            np.testing.assert_array_equal(fused_bias[32:], 42.0)
+            np.testing.assert_array_equal(
+                model.graph.initializers[prefix + "output_linear.bias"].const_value.numpy(),
+                43.0,
+            )
+
     def test_quantized_source_requires_explicit_dequantization(self, tmp_path: Path) -> None:
         from mobius.integrations.gguf import build_from_gguf
 
@@ -6580,6 +6640,18 @@ class TestNemotronHMoEGGUFBuild:
                     f"model.layers.1.moe.experts.{expert}.{projection}.weight_t"
                 ].const_value.numpy()
                 np.testing.assert_array_equal(value, expert + 1)
+        np.testing.assert_array_equal(
+            model.graph.initializers[
+                "model.layers.2.self_attn.q_proj.weight_t"
+            ].const_value.numpy(),
+            np.arange(32 * 32, dtype=np.float32).reshape(32, 32).T,
+        )
+        np.testing.assert_array_equal(
+            model.graph.initializers[
+                "model.layers.2.self_attn.k_proj.weight_t"
+            ].const_value.numpy(),
+            np.arange(16 * 32, dtype=np.float32).reshape(16, 32).T,
+        )
 
         output_dir = tmp_path / "saved-nemotron-h-moe"
         package.save(output_dir, progress_bar=False)
@@ -7940,6 +8012,24 @@ class TestHybridTensorContract:
                         architecture,
                         metadata,
                         [*names, partial_bias],
+                    )
+                )
+
+        if architecture == "granitehybrid":
+            dense_biases = [
+                f"blk.{layer}.ffn_{projection}.bias"
+                for layer in range(2)
+                for projection in ("gate", "up", "down")
+            ]
+            _raise_for_invalid_hybrid_tensor_contract(
+                self._FakeGGUF(architecture, metadata, [*names, *dense_biases])
+            )
+            with pytest.raises(ValueError, match=r"partial dense shared-MLP bias family"):
+                _raise_for_invalid_hybrid_tensor_contract(
+                    self._FakeGGUF(
+                        architecture,
+                        metadata,
+                        [*names, *dense_biases[:-1]],
                     )
                 )
 

--- a/src/mobius/integrations/gguf/_tensor_processors.py
+++ b/src/mobius/integrations/gguf/_tensor_processors.py
@@ -318,6 +318,15 @@ def _process_mamba(
     return state_dict
 
 
+def _process_nemotron_h(
+    state_dict: dict[str, torch.Tensor],
+    config: Any,
+) -> dict[str, torch.Tensor]:
+    """Invert both inherited GraniteHybrid attention and Mamba2 transforms."""
+    state_dict = _process_llama(state_dict, config)
+    return _process_mamba(state_dict, config)
+
+
 def _process_plamo2(
     state_dict: dict[str, torch.Tensor],
     config: Any,
@@ -433,29 +442,54 @@ def _process_granitehybrid(
     """Invert Granite transforms and reconstruct fused shared/expert gate-up weights."""
     state_dict = _process_llama(state_dict, config)
     state_dict = _process_mamba(state_dict, config)
-    for name in list(state_dict):
-        if name.endswith(".shared_mlp.gate_proj.weight"):
-            prefix = name.removesuffix("gate_proj.weight")
-            up_name = f"{prefix}up_proj.weight"
-            if up_name not in state_dict:
+
+    def fuse_pairs(
+        module_suffix: str,
+        tensor_suffix: str,
+        *,
+        rank: int,
+        dim: int,
+        label: str,
+    ) -> None:
+        gate_suffix = f"{module_suffix}gate_proj.{tensor_suffix}"
+        up_suffix = f"{module_suffix}up_proj.{tensor_suffix}"
+        prefixes = {
+            name.removesuffix(suffix)
+            for name in state_dict
+            for suffix in (gate_suffix, up_suffix)
+            if name.endswith(suffix)
+        }
+        for prefix in prefixes:
+            gate_name = f"{prefix}{gate_suffix}"
+            up_name = f"{prefix}{up_suffix}"
+            present = [name for name in (gate_name, up_name) if name in state_dict]
+            if len(present) != 2:
+                missing = up_name if gate_name in state_dict else gate_name
+                raise ValueError(f"GraniteHybrid {label} is missing paired tensor {missing!r}")
+            gate = state_dict[gate_name]
+            up = state_dict[up_name]
+            if gate.dim() != rank or up.dim() != rank or gate.shape != up.shape:
                 raise ValueError(
-                    f"GraniteHybrid shared FFN is missing paired tensor {up_name!r}"
+                    f"GraniteHybrid {label} gate/up tensors must both have the same "
+                    f"rank-{rank} shape, got {gate_name}={tuple(gate.shape)} and "
+                    f"{up_name}={tuple(up.shape)}"
                 )
-            state_dict[f"{prefix}input_linear.weight"] = torch.cat(
-                (state_dict.pop(name), state_dict.pop(up_name)), dim=0
+            state_dict[f"{prefix}{module_suffix}input_linear.{tensor_suffix}"] = torch.cat(
+                (state_dict.pop(gate_name), state_dict.pop(up_name)), dim=dim
             )
-        elif name.endswith(".block_sparse_moe.gate_proj.weight"):
-            prefix = name.removesuffix("gate_proj.weight")
-            up_name = f"{prefix}up_proj.weight"
-            if up_name not in state_dict:
-                raise ValueError(
-                    f"GraniteHybrid routed experts are missing paired tensor {up_name!r}"
-                )
-            # GGUF stores [E, F, H] gate and up tensors separately while the
-            # Transformers/Mobius module stores [E, 2F, H] in gate-then-up order.
-            state_dict[f"{prefix}input_linear.weight"] = torch.cat(
-                (state_dict.pop(name), state_dict.pop(up_name)), dim=1
-            )
+
+    # HF splits every fused input projection into gate then up along its output
+    # dimension. Reconstruct exactly that order for dense/shared weights and biases.
+    fuse_pairs(".shared_mlp.", "weight", rank=2, dim=0, label="shared FFN weights")
+    fuse_pairs(".shared_mlp.", "bias", rank=1, dim=0, label="shared FFN biases")
+    # Routed experts add a leading expert axis: [E, F, H] -> [E, 2F, H].
+    fuse_pairs(
+        ".block_sparse_moe.",
+        "weight",
+        rank=3,
+        dim=1,
+        label="routed expert weights",
+    )
     return state_dict
 
 
@@ -476,6 +510,7 @@ _PROCESSOR_IMPLS: dict[str, Any] = {
     "muse_glimmer": _process_muse_glimmer,
     "gpt2": _process_gpt2,
     "mamba": _process_mamba,
+    "nemotron_h": _process_nemotron_h,
     "plamo2": _process_plamo2,
     "granitehybrid": _process_granitehybrid,
     "kimi_linear": _process_kimi_linear,

--- a/src/mobius/integrations/gguf/_tensor_processors_test.py
+++ b/src/mobius/integrations/gguf/_tensor_processors_test.py
@@ -457,6 +457,42 @@ class TestProcessTensorsMamba:
             torch.tensor([3.0, 4.0]),
         )
 
+    def test_nemotron_h_restores_attention_and_mamba_values(self) -> None:
+        config = SimpleNamespace(
+            model_type="nemotron_h",
+            _gguf_arch="nemotron_h",
+            layer_types=["mamba2", "full_attention"],
+            num_attention_heads=2,
+            num_key_value_heads=1,
+        )
+        q = torch.arange(32, dtype=torch.float32).reshape(8, 4)
+        k = torch.arange(16, dtype=torch.float32).reshape(4, 4)
+
+        def permute(tensor: torch.Tensor, heads: int) -> torch.Tensor:
+            return (
+                tensor.reshape(heads, 2, tensor.shape[0] // heads // 2, *tensor.shape[1:])
+                .swapaxes(1, 2)
+                .reshape(tensor.shape)
+            )
+
+        state_dict = {
+            "backbone.layers.1.mixer.q_proj.weight": permute(q, 2),
+            "backbone.layers.1.mixer.k_proj.weight": permute(k, 1),
+            "backbone.layers.0.mixer.A_log": -torch.exp(torch.tensor([[0.0], [1.0]])),
+            "backbone.layers.0.mixer.D": torch.tensor([[3.0], [4.0]]),
+        }
+
+        result = process_tensors(state_dict, config)
+
+        torch.testing.assert_close(result["backbone.layers.1.mixer.q_proj.weight"], q)
+        torch.testing.assert_close(result["backbone.layers.1.mixer.k_proj.weight"], k)
+        torch.testing.assert_close(
+            result["backbone.layers.0.mixer.A_log"], torch.tensor([0.0, 1.0])
+        )
+        torch.testing.assert_close(
+            result["backbone.layers.0.mixer.D"], torch.tensor([3.0, 4.0])
+        )
+
     def test_granitehybrid_dense_gate_up_fusion_preserves_order(self) -> None:
         config = SimpleNamespace(
             model_type="granitemoehybrid",
@@ -468,10 +504,14 @@ class TestProcessTensorsMamba:
         )
         gate = torch.arange(8, dtype=torch.float32).reshape(2, 4)
         up = torch.arange(8, 16, dtype=torch.float32).reshape(2, 4)
+        gate_bias = torch.tensor([101.0, 102.0])
+        up_bias = torch.tensor([201.0, 202.0])
         a_log = torch.tensor([[-1.0], [-2.0]])
         state_dict = {
             "model.layers.0.shared_mlp.gate_proj.weight": gate,
             "model.layers.0.shared_mlp.up_proj.weight": up,
+            "model.layers.0.shared_mlp.gate_proj.bias": gate_bias,
+            "model.layers.0.shared_mlp.up_proj.bias": up_bias,
             "model.layers.0.mamba.A_log": a_log,
             "model.layers.0.mamba.D": torch.ones(2, 1),
             "model.layers.0.mamba.norm.weight": torch.ones(1, 4),
@@ -483,6 +523,12 @@ class TestProcessTensorsMamba:
             result["model.layers.0.shared_mlp.input_linear.weight"],
             torch.cat((gate, up), dim=0),
         )
+        torch.testing.assert_close(
+            result["model.layers.0.shared_mlp.input_linear.bias"],
+            torch.cat((gate_bias, up_bias), dim=0),
+        )
+        assert "model.layers.0.shared_mlp.gate_proj.bias" not in result
+        assert "model.layers.0.shared_mlp.up_proj.bias" not in result
         torch.testing.assert_close(
             result["model.layers.0.mamba.A_log"], torch.log(-a_log).flatten()
         )
@@ -511,6 +557,32 @@ class TestProcessTensorsMamba:
         assert fused.shape == (2, 4, 4)
         torch.testing.assert_close(fused[:, :2], gate)
         torch.testing.assert_close(fused[:, 2:], up)
+
+    @pytest.mark.parametrize(
+        "state_dict",
+        [
+            {
+                "model.layers.0.shared_mlp.up_proj.bias": torch.ones(2),
+            },
+            {
+                "model.layers.0.block_sparse_moe.gate_proj.weight": torch.ones(2, 3, 4),
+                "model.layers.0.block_sparse_moe.up_proj.weight": torch.ones(2, 4, 4),
+            },
+        ],
+    )
+    def test_granitehybrid_gate_up_fusion_fails_closed(
+        self, state_dict: dict[str, torch.Tensor]
+    ) -> None:
+        config = SimpleNamespace(
+            model_type="granitemoehybrid",
+            _gguf_arch="granitehybrid",
+            layer_types=[],
+            num_attention_heads=2,
+            num_key_value_heads=2,
+        )
+
+        with pytest.raises(ValueError, match=r"missing paired|same rank-3 shape"):
+            process_tensors(state_dict, config)
 
 
 class TestProcessTensorsNoop:


### PR DESCRIPTION
## Summary
- reverse llama.cpp inherited Q/K permutation for Nemotron-H and Nemotron-H-MoE while retaining Mamba2 tensor transforms
- admit complete dense GraniteHybrid FFN bias families and fuse gate/up weights and biases in authoritative gate-then-up order
- fail closed on partial or malformed pairs and preserve routed/shared expert shape and ordering contracts
- add synthetic value-based processor and graph coverage, including quantization rejection

Fixes review comments 3854971160, 3854971221, and 3854971282.

## Validation
- `python -m pytest src/mobius/integrations/gguf/_builder_test.py src/mobius/integrations/gguf/_tensor_processors_test.py src/mobius/integrations/gguf/_arch_registry_test.py src/mobius/integrations/gguf/_config_mapping_test.py src/mobius/integrations/gguf/_tensor_mapping_test.py -q --tb=short -n auto` (1770 passed)
- `python -m pytest tests/build_graph_test.py tests/cli_test.py src/ -q -k "not phi4mm and not apply_weights_unknown" --tb=short -n auto` (7769 passed, 56 skipped, 1 subtest passed)
- `python scripts/generate_gguf_support_docs.py --check`
- `lintrunner f --output oneline --all-files`
- GPT-5.6 Sol medium code review: no significant findings