### PR TITLE
Fix GGUF output head correctness

### DIFF
--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -2032,6 +2032,7 @@ def _write_moe_gguf(
     diffusion_fused_qkv: bool = False,
     fused_qkv_float: bool = False,
     quantize_tied_embedding: bool = False,
+    output_quantization: str | None = None,
     expert_scale_suffix: str | None = None,
     malformed_expert_scale: bool = False,
 ) -> None:
@@ -2116,6 +2117,11 @@ def _write_moe_gguf(
         "mxfp4": add_mxfp4,
         "q4_0": add_q4,
     }[projection_quantization]
+    add_output = {
+        "f32": add_float,
+        "mxfp4": add_mxfp4,
+        "q4_0": add_q4,
+    }[output_quantization or projection_quantization]
 
     if quantize_tied_embedding:
         assert architecture in {"qwen3moe", "granitemoe"}
@@ -2192,7 +2198,7 @@ def _write_moe_gguf(
     if architecture == "phimoe":
         add_float("output_norm.bias", (hidden_size,))
     if architecture not in {"qwen3moe", "granitemoe"}:
-        add_projection("output.weight", (vocab_size, hidden_size))
+        add_output("output.weight", (vocab_size, hidden_size))
         if architecture == "phimoe":
             add_float("output.bias", (vocab_size,))
 
@@ -3446,6 +3452,51 @@ class TestBuildQuantizedGguf:
                     repacked.zero_points[offset:end],
                 )
                 offset = end
+
+    @pytest.mark.parametrize("output_quantization", ["f32", "q4_0"])
+    def test_phimoe_output_head_honors_storage_and_values(
+        self, output_quantization: str, tmp_path: Path
+    ) -> None:
+        from mobius.integrations.gguf import build_from_gguf
+        from mobius.integrations.gguf._reader import GGUFModel
+        from mobius.integrations.gguf._repacker import repack_gguf_tensor
+
+        path = tmp_path / f"phimoe-output-{output_quantization}.gguf"
+        _write_moe_gguf(
+            path,
+            "phimoe",
+            "q4_0",
+            output_quantization=output_quantization,
+        )
+        source = GGUFModel(path)
+        package = build_from_gguf(path, keep_quantized=True)
+        model = package["model"]
+        raw, qtype, shape = next(
+            (raw, qtype, shape)
+            for name, raw, qtype, shape in source.tensor_items_raw()
+            if name == "output.weight"
+        )
+
+        if output_quantization == "q4_0":
+            assert package.config.quantization is not None
+            assert package.config.quantization.quantize_lm_head
+            repacked = repack_gguf_tensor(raw, qtype.value, shape)
+            np.testing.assert_array_equal(
+                model.graph.initializers["lm_head.weight"].const_value.numpy(),
+                repacked.weight,
+            )
+            np.testing.assert_array_equal(
+                model.graph.initializers["lm_head.scales"].const_value.numpy(),
+                repacked.scales,
+            )
+        else:
+            assert package.config.quantization is not None
+            assert not package.config.quantization.quantize_lm_head
+            assert "lm_head.scales" not in model.graph.initializers
+            np.testing.assert_array_equal(
+                model.graph.initializers["lm_head.weight_t"].const_value.numpy(),
+                source.get_tensor("output.weight").T,
+            )
 
     @pytest.mark.parametrize("architecture", ["qwen3moe", "granitemoe"])
     def test_tied_quantized_embedding_is_shared_with_output_head(

--- a/src/mobius/models/_models_test.py
+++ b/src/mobius/models/_models_test.py
@@ -16,13 +16,14 @@ import pytest
 import torch
 
 from mobius._builder import build_from_module
+from mobius._configs import QuantizationConfig
 from mobius._registry import (
     MODEL_MAP,
     ModelRegistry,
     registry,
 )
 from mobius._testing import make_config
-from mobius.components import LayerNorm, RMSNormBias
+from mobius.components import LayerNorm, Linear, QuantizedLinear, RMSNormBias
 from mobius.models.base import CausalLMModel, TextModel
 from mobius.models.moe import Phi3MoECausalLMModel, PhiMoEGGUFCausalLMModel
 from mobius.tasks import CausalLMTask
@@ -77,6 +78,33 @@ class TestCausalLMModel:
         gguf = PhiMoEGGUFCausalLMModel(config)
         assert isinstance(native.model.layers[0].input_layernorm, LayerNorm)
         assert isinstance(gguf.model.layers[0].input_layernorm, RMSNormBias)
+
+    @pytest.mark.parametrize(
+        ("quantize_lm_head", "head_type"),
+        [(False, Linear), (True, QuantizedLinear)],
+    )
+    def test_phimoe_gguf_honors_quantized_head_contract(self, quantize_lm_head, head_type):
+        config = make_config(
+            num_local_experts=4,
+            num_experts_per_tok=2,
+            partial_rotary_factor=0.5,
+            quantization=QuantizationConfig(
+                bits=4,
+                group_size=32,
+                quant_method="gguf",
+                sym=True,
+                quantize_lm_head=quantize_lm_head,
+            ),
+        )
+        module = PhiMoEGGUFCausalLMModel(config)
+
+        assert isinstance(module.model.layers[0].self_attn.q_proj, QuantizedLinear)
+        assert isinstance(module.lm_head, head_type)
+
+        model = build_from_module(module, config, task=CausalLMTask())["model"]
+        op_types = [node.op_type for node in model.graph]
+        assert "MatMulNBits" in op_types
+        assert ("lm_head.scales" in model.graph.initializers) is quantize_lm_head
 
 
 class TestBuildFromModule:

--- a/src/mobius/models/moe.py
+++ b/src/mobius/models/moe.py
@@ -329,8 +329,12 @@ class PhiMoEGGUFCausalLMModel(Phi3MoECausalLMModel):
         nn.Module.__init__(self)
         self.config = config
         self.model = MoETextModel(config, norm_class=RMSNormBias)
-        linear_class = _quantized_linear_class(config) or Linear
-        self.lm_head = linear_class(config.hidden_size, config.vocab_size, bias=True)
+        quantization = getattr(config, "quantization", None)
+        quantized_head = quantization is not None and bool(
+            getattr(quantization, "quantize_lm_head", False)
+        )
+        head_class = _quantized_linear_class(config) if quantized_head else None
+        self.lm_head = (head_class or Linear)(config.hidden_size, config.vocab_size, bias=True)
 
 
 class MoECausalLMModel(CausalLMModel):

--- a/src/mobius/models/plamo2.py
+++ b/src/mobius/models/plamo2.py
@@ -426,15 +426,31 @@ class Plamo2ForCausalLM(nn.Module):
         }
         norms_are_folded = bool(getattr(self.config, "_plamo2_norms_are_folded", False))
         tied_embeddings = effective_tie_word_embeddings(self.config)
+        tied_weight: torch.Tensor | None = None
+        if tied_embeddings:
+            embedding_weight = state_dict.get("model.embed_tokens.weight")
+            head_weight = state_dict.get("lm_head.weight")
+            if embedding_weight is not None and head_weight is not None:
+                if not torch.equal(embedding_weight, head_weight):
+                    raise ValueError(
+                        "PLaMo2 tied checkpoint contains conflicting "
+                        "model.embed_tokens.weight and lm_head.weight tensors"
+                    )
+                tied_weight = embedding_weight
+            else:
+                tied_weight = embedding_weight if embedding_weight is not None else head_weight
+
         for name, value in state_dict.items():
             name = name.replace("model.layers.layers.", "model.layers.")
-            if name == "model.embed_tokens.weight" and tied_embeddings:
-                result[name] = value
-                # onnxscript materializes the shared Parameter under both use
-                # sites, while the official checkpoint stores only the embedding.
-                result["lm_head.weight"] = value
-                continue
-            if name == "lm_head.weight" and tied_embeddings:
+            if (
+                tied_embeddings
+                and tied_weight is not None
+                and name in {"model.embed_tokens.weight", "lm_head.weight"}
+            ):
+                # Checkpoints may serialize either tied key. Keep one tensor object
+                # under both graph parameter names so weight loading deduplicates it.
+                result["model.embed_tokens.weight"] = tied_weight
+                result["lm_head.weight"] = tied_weight
                 continue
             if name == "model.norm.weight":
                 result[name] = value if norms_are_folded else value + 1.0

--- a/src/mobius/models/plamo2_test.py
+++ b/src/mobius/models/plamo2_test.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 import numpy as np
 import onnx_ir as ir
+import pytest
 import torch
 
 from mobius import build_from_module
@@ -453,7 +454,7 @@ def test_plamo2_preprocesses_offsets_and_decay_values() -> None:
         "model.layers.layers.0.post_mlp_norm.weight": torch.tensor([6.0]),
         "model.layers.layers.0.mixer.A_log": torch.tensor([0.0, 1.0]),
         "model.embed_tokens.weight": torch.tensor([8.0]),
-        "lm_head.weight": torch.tensor([9.0]),
+        "lm_head.weight": torch.tensor([8.0]),
     }
     actual = model.preprocess_weights(weights)
     torch.testing.assert_close(actual["model.norm.weight"], torch.tensor([3.0]))
@@ -480,6 +481,45 @@ def test_plamo2_preprocesses_offsets_and_decay_values() -> None:
     torch.testing.assert_close(actual["lm_head.weight"], torch.tensor([8.0]))
 
 
+@pytest.mark.parametrize("source_key", ["model.embed_tokens.weight", "lm_head.weight"])
+def test_plamo2_preprocesses_either_single_tied_weight(source_key: str) -> None:
+    model = Plamo2ForCausalLM(_config())
+    weight = torch.arange(8, dtype=torch.float32)
+
+    actual = model.preprocess_weights({source_key: weight})
+
+    assert actual["model.embed_tokens.weight"] is weight
+    assert actual["lm_head.weight"] is weight
+
+
+def test_plamo2_unifies_exact_duplicate_tied_weights() -> None:
+    model = Plamo2ForCausalLM(_config())
+    embedding_weight = torch.arange(8, dtype=torch.float32)
+    head_weight = embedding_weight.clone()
+
+    actual = model.preprocess_weights(
+        {
+            "model.embed_tokens.weight": embedding_weight,
+            "lm_head.weight": head_weight,
+        }
+    )
+
+    assert actual["model.embed_tokens.weight"] is embedding_weight
+    assert actual["lm_head.weight"] is embedding_weight
+
+
+def test_plamo2_rejects_conflicting_tied_weights() -> None:
+    model = Plamo2ForCausalLM(_config())
+
+    with pytest.raises(ValueError, match="conflicting"):
+        model.preprocess_weights(
+            {
+                "model.embed_tokens.weight": torch.tensor([8.0]),
+                "lm_head.weight": torch.tensor([9.0]),
+            }
+        )
+
+
 def test_plamo2_preprocesses_effectively_tied_quantized_embeddings() -> None:
     config = _config()
     config.tie_word_embeddings = False
@@ -489,7 +529,7 @@ def test_plamo2_preprocesses_effectively_tied_quantized_embeddings() -> None:
     actual = model.preprocess_weights(
         {
             "model.embed_tokens.weight": torch.tensor([8.0]),
-            "lm_head.weight": torch.tensor([9.0]),
+            "lm_head.weight": torch.tensor([8.0]),
         }
     )
 


### PR DESCRIPTION
## Summary
- honor `quantize_lm_head` for PhiMoE GGUF graphs while preserving exact packed output-head values
- preserve PLaMo2 tied checkpoints serialized with either embedding-only or head-only weights
- deduplicate exact tied copies and fail closed on conflicting tied tensors

Addresses review comments 3854449574 and 3855717041.

## Tests
- `python -m pytest src/mobius/models/_models_test.py src/mobius/models/plamo2_test.py src/mobius/integrations/gguf/_builder_test.py -q -k "phimoe or plamo2" --tb=short`
- `python -m pytest tests/build_graph_test.py tests/cli_test.py src/ -q -k "not phi4mm and not apply_weights_unknown" --tb=short -n auto`
- `lintrunner f --output oneline --all-files`

## Review
- GPT-5.6 Sol, medium reasoning: no significant issues found