### PR TITLE
Enforce ModelPackage persistence invariants

### DIFF
--- a/src/mobius/_model_package.py
+++ b/src/mobius/_model_package.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 __all__ = ["ModelPackage"]
 
 import inspect
+import json
 import logging
 import os
 import shutil
@@ -45,6 +46,189 @@ from mobius.generation import PolicyComponent
 from mobius.integrations._weight_loading import _assign_weight
 
 logger = logging.getLogger(__name__)
+
+_PACKAGE_MANIFEST = ".mobius-package.json"
+_PACKAGE_MANIFEST_FORMAT = "mobius.model-package.v1"
+_MTP_SIDECAR_BASENAME = ".mobius-mtp"
+
+
+def _read_mtp_sidecar_name(directory: str) -> str | None:
+    manifest_path = os.path.join(directory, _PACKAGE_MANIFEST)
+    if not os.path.lexists(manifest_path):
+        return None
+    if os.path.islink(manifest_path):
+        raise ValueError("ModelPackage manifest must not be a symlink.")
+    if not os.path.isfile(manifest_path):
+        raise ValueError(f"ModelPackage manifest is not a file: {manifest_path}.")
+    with open(manifest_path) as file:
+        manifest = json.load(file)
+    sidecar_name = manifest.get("mtp_head") if isinstance(manifest, dict) else None
+    if (
+        not isinstance(manifest, dict)
+        or manifest.get("format") != _PACKAGE_MANIFEST_FORMAT
+        or not isinstance(sidecar_name, str)
+        or not sidecar_name
+        or sidecar_name in {".", ".."}
+        or os.path.basename(sidecar_name) != sidecar_name
+    ):
+        raise ValueError(f"Invalid ModelPackage manifest: {manifest_path}.")
+    return sidecar_name
+
+
+def _write_mtp_manifest(directory: str, sidecar_name: str) -> None:
+    payload = json.dumps(
+        {"format": _PACKAGE_MANIFEST_FORMAT, "mtp_head": sidecar_name},
+        indent=2,
+        sort_keys=True,
+    )
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(os.path.join(directory, _PACKAGE_MANIFEST), flags, 0o666)
+    with os.fdopen(descriptor, "w") as file:
+        file.write(payload)
+        file.write("\n")
+
+
+def _mtp_sidecar_name(package: ModelPackage) -> str:
+    """Choose a sidecar directory that cannot hide a model component."""
+    component_keys = {name.casefold() for name in package}
+    name = _MTP_SIDECAR_BASENAME
+    suffix = 0
+    while name.casefold() in component_keys:
+        suffix += 1
+        name = f"{_MTP_SIDECAR_BASENAME}-{suffix}"
+    return name
+
+
+def _validate_mtp_chain(package: ModelPackage) -> None:
+    """Reject malformed or cyclic MTP package chains before saving any files."""
+    seen: set[int] = set()
+    current = package
+    while True:
+        identity = id(current)
+        if identity in seen:
+            raise ValueError("ModelPackage mtp_head attachments must not contain a cycle.")
+        seen.add(identity)
+        component_keys: set[str] = set()
+        for name in current:
+            if (
+                not name
+                or name in {".", ".."}
+                or "/" in name
+                or "\\" in name
+                or os.path.isabs(name)
+            ):
+                raise ValueError(
+                    f"ModelPackage component name {name!r} must be a non-empty path segment."
+                )
+            collision_key = name.casefold()
+            if collision_key in component_keys:
+                raise ValueError(
+                    "ModelPackage component names must be distinct when compared "
+                    f"case-insensitively; {name!r} collides with another component."
+                )
+            component_keys.add(collision_key)
+            if collision_key == _PACKAGE_MANIFEST.casefold():
+                raise ValueError(
+                    f"ModelPackage component name {_PACKAGE_MANIFEST!r} is reserved "
+                    "for package metadata."
+                )
+        sidecar = current.mtp_head
+        if sidecar is None:
+            return
+        if not isinstance(sidecar, ModelPackage):
+            raise TypeError("ModelPackage mtp_head must be another ModelPackage or None.")
+        current = sidecar
+
+
+def _validate_output_directory(
+    directory: str, *, kind: str, inspect_contents: bool = True
+) -> None:
+    if not os.path.lexists(directory):
+        return
+    if os.path.islink(directory) or not os.path.isdir(directory):
+        raise ValueError(f"ModelPackage {kind} output must be a real directory.")
+    if inspect_contents:
+        for root, directories, files in os.walk(directory):
+            if any(os.path.islink(os.path.join(root, entry)) for entry in directories + files):
+                raise ValueError(f"ModelPackage {kind} output must not contain symlinks.")
+
+
+def _validate_mtp_save_paths(
+    package: ModelPackage,
+    directory: str,
+    components: Callable[[str], bool] | None = None,
+    *,
+    external_data: str = "onnx",
+    include_policy_components: bool = True,
+    include_adapter_artifacts: bool = True,
+) -> None:
+    """Reject unsafe output paths throughout the package chain before any writes."""
+    _validate_output_directory(directory, kind="package", inspect_contents=False)
+    previous_sidecar_name = _read_mtp_sidecar_name(directory)
+    selected = [name for name in package if components is None or components(name)]
+    if len(selected) > 1:
+        reserved = {"policies", "adapters"}.intersection(name.casefold() for name in selected)
+        if reserved:
+            name = sorted(reserved)[0]
+            raise ValueError(
+                f"ModelPackage component name {name!r} is reserved for package artifacts."
+            )
+    if len(selected) > 1:
+        for name in selected:
+            _validate_output_directory(
+                os.path.join(directory, name),
+                kind=f"component {name!r}",
+            )
+    else:
+        for entry in os.listdir(directory) if os.path.isdir(directory) else ():
+            if (
+                entry == "model.onnx"
+                or (
+                    entry.startswith("model")
+                    and (
+                        entry.endswith(".data")
+                        or (external_data == "safetensors" and ".safetensors" in entry)
+                    )
+                )
+            ) and os.path.islink(os.path.join(directory, entry)):
+                raise ValueError("ModelPackage model output must not be a symlink.")
+    if include_policy_components and package.policy_components:
+        _validate_output_directory(
+            os.path.join(directory, "policies"),
+            kind="policy artifact",
+        )
+    if include_adapter_artifacts and package.adapter_artifacts:
+        _validate_output_directory(
+            os.path.join(directory, "adapters"),
+            kind="adapter artifact",
+        )
+    active_artifact_names = {
+        name
+        for name, active in (
+            ("policies", include_policy_components and bool(package.policy_components)),
+            ("adapters", include_adapter_artifacts and bool(package.adapter_artifacts)),
+        )
+        if active
+    }
+    if (
+        previous_sidecar_name is not None
+        and previous_sidecar_name.casefold() in active_artifact_names
+    ):
+        raise ValueError(
+            "ModelPackage manifest MTP sidecar collides with an active artifact namespace."
+        )
+    if package.mtp_head is None:
+        return
+    sidecar_directory = os.path.join(directory, _mtp_sidecar_name(package))
+    _validate_output_directory(sidecar_directory, kind="MTP sidecar")
+    _validate_mtp_save_paths(
+        package.mtp_head,
+        sidecar_directory,
+        external_data=external_data,
+        include_policy_components=include_policy_components,
+        include_adapter_artifacts=include_adapter_artifacts,
+    )
 
 
 def _adapter_dtype_name(dtype: ir.DataType) -> str:
@@ -80,8 +264,9 @@ class ModelPackage(UserDict[str, ir.Model]):
     Attributes:
         config: The architecture configuration used to build the models,
             or ``None`` if not available (e.g. after :meth:`load`).
-        mtp_head: Optional nested MTP sidecar package. :meth:`save` persists it
-            under ``mtp/`` and :meth:`load` restores it automatically.
+        mtp_head: Optional nested MTP sidecar package. :meth:`save` records its
+            collision-free directory in an explicit package manifest, and
+            :meth:`load` restores it automatically.
     """
 
     def __init__(
@@ -201,6 +386,15 @@ class ModelPackage(UserDict[str, ir.Model]):
                 *check_weights* is ``True`` and any initializer is missing its
                 ``const_value``.
         """
+        _validate_mtp_chain(self)
+        _validate_mtp_save_paths(
+            self,
+            directory,
+            components,
+            external_data=external_data,
+            include_policy_components=include_policy_components,
+            include_adapter_artifacts=include_adapter_artifacts,
+        )
         if external_data not in {"onnx", "safetensors"}:
             raise ValueError(
                 f"Unknown external_data format {external_data!r}. "
@@ -220,6 +414,7 @@ class ModelPackage(UserDict[str, ir.Model]):
                     "GGUF weight reuse writes one converted-weight sidecar and does "
                     "not support max_shard_size_bytes."
                 )
+        previous_sidecar_name = _read_mtp_sidecar_name(directory)
         os.makedirs(directory, exist_ok=True)
         selected = {
             name: model
@@ -279,8 +474,12 @@ class ModelPackage(UserDict[str, ir.Model]):
         if include_adapter_artifacts:
             self.save_adapter_artifacts(directory)
         if self.mtp_head is not None:
+            sidecar_name = _mtp_sidecar_name(self)
+            sidecar_directory = os.path.join(directory, sidecar_name)
+            if os.path.isdir(sidecar_directory):
+                shutil.rmtree(sidecar_directory)
             self.mtp_head.save(
-                os.path.join(directory, "mtp"),
+                sidecar_directory,
                 external_data=external_data,
                 max_shard_size_bytes=max_shard_size_bytes,
                 max_workers=max_workers,
@@ -289,6 +488,35 @@ class ModelPackage(UserDict[str, ir.Model]):
                 include_policy_components=include_policy_components,
                 include_adapter_artifacts=include_adapter_artifacts,
             )
+            _write_mtp_manifest(directory, sidecar_name)
+        else:
+            sidecar_name = None
+            manifest_path = os.path.join(directory, _PACKAGE_MANIFEST)
+            if os.path.isfile(manifest_path):
+                os.remove(manifest_path)
+        if previous_sidecar_name is not None and previous_sidecar_name != sidecar_name:
+            previous_sidecar = os.path.join(directory, previous_sidecar_name)
+            current_directories = (
+                [os.path.join(directory, name) for name in selected] if use_subfolders else []
+            )
+            if sidecar_name is not None:
+                current_directories.append(os.path.join(directory, sidecar_name))
+            if include_policy_components and self.policy_components:
+                current_directories.append(os.path.join(directory, "policies"))
+            if include_adapter_artifacts and self.adapter_artifacts:
+                current_directories.append(os.path.join(directory, "adapters"))
+            aliases_current_output = any(
+                os.path.exists(current)
+                and os.path.exists(previous_sidecar)
+                and os.path.samefile(previous_sidecar, current)
+                for current in current_directories
+            )
+            if (
+                not aliases_current_output
+                and os.path.isdir(previous_sidecar)
+                and not os.path.islink(previous_sidecar)
+            ):
+                shutil.rmtree(previous_sidecar)
 
     def add_policy_component(self, name: str, component: PolicyComponent) -> None:
         """Attach a reusable generation-policy graph to this package."""
@@ -597,8 +825,9 @@ class ModelPackage(UserDict[str, ir.Model]):
         - **Subfolder**: each subdirectory contains ``model.onnx`` → multi-
           component package keyed by subfolder name.
 
-        A nested ``mtp/model.onnx`` is restored as :attr:`mtp_head`, never as a
-        primary model component.
+        An MTP sidecar named by ``.mobius-package.json`` is restored as
+        :attr:`mtp_head`. Unmarked subdirectories, including ``mtp/``, remain
+        ordinary model components.
 
         Args:
             directory: Path to the directory containing models.
@@ -606,13 +835,37 @@ class ModelPackage(UserDict[str, ir.Model]):
         Returns:
             A new ``ModelPackage`` with one entry per model found.
         """
+        return cls._load(directory, frozenset())
+
+    @classmethod
+    def _load(cls, directory: str, ancestors: frozenset[str]) -> ModelPackage:
+        resolved_directory = os.path.realpath(directory)
+        if resolved_directory in ancestors:
+            raise ValueError("ModelPackage MTP sidecar manifests must not contain a cycle.")
+        ancestors = ancestors | {resolved_directory}
+        sidecar_name = _read_mtp_sidecar_name(directory)
+        mtp_dir: str | None = None
+        if sidecar_name is not None:
+            mtp_dir = os.path.join(directory, sidecar_name)
+            if not os.path.isdir(mtp_dir):
+                raise ValueError(
+                    f"ModelPackage manifest references missing MTP sidecar {sidecar_name!r}."
+                )
+            if os.path.islink(mtp_dir):
+                raise ValueError("ModelPackage MTP sidecar directory must not be a symlink.")
+            resolved_sidecar = os.path.realpath(mtp_dir)
+            if os.path.dirname(resolved_sidecar) != resolved_directory:
+                raise ValueError("ModelPackage MTP sidecar must remain inside its package.")
+
         models: dict[str, ir.Model] = {}
-        # Preserve the established multi-component precedence while excluding
-        # the nested MTP auxiliary package from the primary component scan.
         for entry in sorted(os.listdir(directory)):
-            if entry == "mtp":
-                continue
             subdir = os.path.join(directory, entry)
+            if (
+                mtp_dir is not None
+                and os.path.isdir(subdir)
+                and os.path.samefile(subdir, mtp_dir)
+            ):
+                continue
             model_path = os.path.join(subdir, "model.onnx")
             if os.path.isdir(subdir) and os.path.isfile(model_path):
                 models[entry] = ir.load(model_path)
@@ -623,9 +876,8 @@ class ModelPackage(UserDict[str, ir.Model]):
                     models[name] = ir.load(os.path.join(directory, filename))
         package = cls(models)
         package._load_policy_components(directory)
-        mtp_dir = os.path.join(directory, "mtp")
-        if os.path.isfile(os.path.join(mtp_dir, "model.onnx")):
-            package.mtp_head = cls.load(mtp_dir)
+        if mtp_dir is not None:
+            package.mtp_head = cls._load(mtp_dir, ancestors)
         return package
 
     def _load_policy_components(self, directory: str) -> None:

--- a/src/mobius/_model_package_test.py
+++ b/src/mobius/_model_package_test.py
@@ -374,7 +374,7 @@ class TestModelPackageSaveLoad:
         assert sorted(loaded) == ["model"]
         assert loaded.mtp_head is not None
         assert sorted(loaded.mtp_head) == ["model"]
-        assert (tmp_path / "mtp" / "model.onnx").exists()
+        assert (tmp_path / ".mobius-mtp" / "model.onnx").exists()
 
     def test_mtp_head_roundtrip_with_multicomponent_target(self, tmp_path):
         pkg = ModelPackage(
@@ -391,6 +391,290 @@ class TestModelPackageSaveLoad:
         assert sorted(loaded) == ["decoder", "embedding"]
         assert loaded.mtp_head is not None
         assert sorted(loaded.mtp_head) == ["model"]
+
+    def test_legitimate_mtp_component_roundtrip(self, tmp_path):
+        pkg = ModelPackage(
+            {
+                "model": _make_simple_model("target"),
+                "mtp": _make_simple_model("mtp"),
+            }
+        )
+
+        pkg.save(str(tmp_path))
+        loaded = ModelPackage.load(str(tmp_path))
+
+        assert sorted(loaded) == ["model", "mtp"]
+        assert loaded.mtp_head is None
+
+    def test_mtp_sidecar_directory_collision_is_encoded(self, tmp_path):
+        pkg = ModelPackage(
+            {
+                "model": _make_simple_model("target"),
+                ".mobius-mtp": _make_simple_model("legitimate-component"),
+                "mtp": _make_simple_model("mtp-component"),
+            }
+        )
+        pkg.mtp_head = ModelPackage(
+            {
+                "draft": _make_simple_model("draft"),
+                "auxiliary": _make_simple_model("auxiliary"),
+            }
+        )
+
+        pkg.save(str(tmp_path))
+        loaded = ModelPackage.load(str(tmp_path))
+
+        assert sorted(loaded) == [".mobius-mtp", "model", "mtp"]
+        assert loaded.mtp_head is not None
+        assert sorted(loaded.mtp_head) == ["auxiliary", "draft"]
+        assert (tmp_path / ".mobius-mtp-1" / "draft" / "model.onnx").is_file()
+
+    def test_mtp_sidecar_case_insensitive_collision_is_encoded(self, tmp_path):
+        pkg = ModelPackage(
+            {
+                "model": _make_simple_model("target"),
+                ".MOBIUS-MTP": _make_simple_model("legitimate-component"),
+            }
+        )
+        pkg.mtp_head = ModelPackage({"model": _make_simple_model("draft")})
+
+        pkg.save(str(tmp_path))
+        loaded = ModelPackage.load(str(tmp_path))
+
+        assert sorted(loaded) == [".MOBIUS-MTP", "model"]
+        assert loaded.mtp_head is not None
+        assert (tmp_path / ".mobius-mtp-1" / "model.onnx").is_file()
+
+    def test_nested_mtp_sidecars_roundtrip(self, tmp_path):
+        pkg = ModelPackage({"model": _make_simple_model("target")})
+        pkg.mtp_head = ModelPackage(
+            {
+                "draft": _make_simple_model("draft"),
+                "auxiliary": _make_simple_model("auxiliary"),
+            }
+        )
+        pkg.mtp_head.mtp_head = ModelPackage(
+            {
+                "next": _make_simple_model("next"),
+                "next_auxiliary": _make_simple_model("next-auxiliary"),
+            }
+        )
+
+        pkg.save(str(tmp_path))
+        loaded = ModelPackage.load(str(tmp_path))
+
+        assert loaded.mtp_head is not None
+        assert sorted(loaded.mtp_head) == ["auxiliary", "draft"]
+        assert loaded.mtp_head.mtp_head is not None
+        assert sorted(loaded.mtp_head.mtp_head) == ["next", "next_auxiliary"]
+
+    def test_self_referential_mtp_head_fails_before_writing(self, tmp_path):
+        pkg = ModelPackage({"model": _make_simple_model("target")})
+        pkg.mtp_head = pkg
+        output = tmp_path / "output"
+
+        with pytest.raises(ValueError, match="must not contain a cycle"):
+            pkg.save(str(output))
+
+        assert not output.exists()
+
+    def test_cyclic_nested_mtp_heads_fail_before_writing(self, tmp_path):
+        pkg = ModelPackage({"model": _make_simple_model("target")})
+        sidecar = ModelPackage({"model": _make_simple_model("draft")})
+        pkg.mtp_head = sidecar
+        sidecar.mtp_head = pkg
+        output = tmp_path / "output"
+
+        with pytest.raises(ValueError, match="must not contain a cycle"):
+            pkg.save(str(output))
+
+        assert not output.exists()
+
+    def test_reserved_manifest_component_fails_before_writing(self, tmp_path):
+        pkg = ModelPackage(
+            {
+                "model": _make_simple_model("target"),
+                ".mobius-package.json": _make_simple_model("collision"),
+            }
+        )
+        output = tmp_path / "output"
+
+        with pytest.raises(ValueError, match="reserved for package metadata"):
+            pkg.save(str(output))
+
+        assert not output.exists()
+
+    @pytest.mark.parametrize("name", ["", ".", "..", "../outside", "nested/model"])
+    def test_unsafe_component_name_fails_before_writing(self, tmp_path, name):
+        pkg = ModelPackage(
+            {
+                "model": _make_simple_model("target"),
+                name: _make_simple_model("unsafe"),
+            }
+        )
+        output = tmp_path / "output"
+
+        with pytest.raises(ValueError, match="must be a non-empty path segment"):
+            pkg.save(str(output))
+
+        assert not output.exists()
+
+    def test_removing_mtp_head_removes_stale_sidecar(self, tmp_path):
+        pkg = ModelPackage({"model": _make_simple_model("target")})
+        pkg.mtp_head = ModelPackage({"model": _make_simple_model("draft")})
+        pkg.save(str(tmp_path))
+
+        pkg.mtp_head = None
+        pkg.save(str(tmp_path))
+        loaded = ModelPackage.load(str(tmp_path))
+
+        assert sorted(loaded) == ["model"]
+        assert loaded.mtp_head is None
+        assert not (tmp_path / ".mobius-mtp").exists()
+
+    def test_manifest_artifact_collision_fails_before_writing(self, tmp_path):
+        output = tmp_path / "output"
+        output.mkdir()
+        (output / ".mobius-package.json").write_text(
+            '{"format": "mobius.model-package.v1", "mtp_head": "policies"}\n'
+        )
+        pkg = ModelPackage({"model": _make_simple_model("target")})
+        pkg.add_policy_component("sample", build_greedy_sampler())
+
+        with pytest.raises(ValueError, match="collides with an active artifact namespace"):
+            pkg.save(str(output))
+
+        assert not (output / "model.onnx").exists()
+
+    def test_resaving_mtp_head_replaces_stale_components(self, tmp_path):
+        pkg = ModelPackage({"model": _make_simple_model("target")})
+        pkg.mtp_head = ModelPackage(
+            {
+                "draft": _make_simple_model("draft"),
+                "stale": _make_simple_model("stale"),
+            }
+        )
+        pkg.save(str(tmp_path))
+
+        pkg.mtp_head = ModelPackage({"model": _make_simple_model("replacement")})
+        pkg.save(str(tmp_path))
+        loaded = ModelPackage.load(str(tmp_path))
+
+        assert loaded.mtp_head is not None
+        assert sorted(loaded.mtp_head) == ["model"]
+        assert not (tmp_path / ".mobius-mtp" / "stale").exists()
+
+    def test_sidecar_symlink_fails_before_writing(self, tmp_path):
+        output = tmp_path / "output"
+        output.mkdir()
+        external = tmp_path / "external"
+        external.mkdir()
+        (output / ".mobius-mtp").symlink_to(external, target_is_directory=True)
+        pkg = ModelPackage({"model": _make_simple_model("target")})
+        pkg.mtp_head = ModelPackage({"model": _make_simple_model("draft")})
+
+        with pytest.raises(ValueError, match="must be a real directory"):
+            pkg.save(str(output))
+
+        assert not (output / "model.onnx").exists()
+        assert not list(external.iterdir())
+
+    def test_manifest_symlink_fails_before_writing(self, tmp_path):
+        output = tmp_path / "output"
+        output.mkdir()
+        external = tmp_path / "external.json"
+        external.write_text("unchanged")
+        (output / ".mobius-package.json").symlink_to(external)
+        pkg = ModelPackage({"model": _make_simple_model("target")})
+
+        with pytest.raises(ValueError, match="manifest must not be a symlink"):
+            pkg.save(str(output))
+
+        assert not (output / "model.onnx").exists()
+        assert external.read_text() == "unchanged"
+
+    def test_component_directory_symlink_fails_before_writing(self, tmp_path):
+        output = tmp_path / "output"
+        output.mkdir()
+        external = tmp_path / "external"
+        external.mkdir()
+        (output / "decoder").symlink_to(external, target_is_directory=True)
+        pkg = ModelPackage(
+            {
+                "decoder": _make_simple_model("decoder"),
+                "embedding": _make_simple_model("embedding"),
+            }
+        )
+
+        with pytest.raises(ValueError, match=r"component 'decoder'.*real directory"):
+            pkg.save(str(output))
+
+        assert not (output / "embedding").exists()
+        assert not list(external.iterdir())
+
+    def test_flat_model_symlink_fails_before_writing(self, tmp_path):
+        output = tmp_path / "output"
+        output.mkdir()
+        external = tmp_path / "external.onnx"
+        external.write_text("unchanged")
+        (output / "model.onnx").symlink_to(external)
+        pkg = ModelPackage({"model": _make_simple_model("target")})
+
+        with pytest.raises(ValueError, match="model output must not be a symlink"):
+            pkg.save(str(output))
+
+        assert external.read_text() == "unchanged"
+
+    @pytest.mark.parametrize("name", ["policies", "adapters"])
+    def test_artifact_namespace_component_fails_before_writing(self, tmp_path, name):
+        pkg = ModelPackage(
+            {
+                "model": _make_simple_model("target"),
+                name: _make_simple_model(name),
+            }
+        )
+        output = tmp_path / "output"
+
+        with pytest.raises(ValueError, match="reserved for package artifacts"):
+            pkg.save(str(output))
+
+        assert not output.exists()
+
+    def test_case_insensitive_component_collision_fails_before_writing(self, tmp_path):
+        pkg = ModelPackage(
+            {
+                "model": _make_simple_model("lower"),
+                "MODEL": _make_simple_model("upper"),
+            }
+        )
+        output = tmp_path / "output"
+
+        with pytest.raises(ValueError, match="distinct when compared case-insensitively"):
+            pkg.save(str(output))
+
+        assert not output.exists()
+
+    def test_flat_safetensors_symlink_fails_before_writing(self, tmp_path):
+        output = tmp_path / "output"
+        output.mkdir()
+        external = tmp_path / "external.safetensors"
+        external.write_text("unchanged")
+        (output / "model.safetensors").symlink_to(external)
+        pkg = ModelPackage({"model": _make_simple_model("target")})
+
+        with pytest.raises(ValueError, match="model output must not be a symlink"):
+            pkg.save(str(output), external_data="safetensors")
+
+        assert external.read_text() == "unchanged"
+
+    @pytest.mark.parametrize("sidecar_name", [".", ".."])
+    def test_load_rejects_escaping_sidecar_name(self, tmp_path, sidecar_name):
+        (tmp_path / ".mobius-package.json").write_text(
+            f'{{"format": "mobius.model-package.v1", "mtp_head": "{sidecar_name}"}}\n'
+        )
+
+        with pytest.raises(ValueError, match="Invalid ModelPackage manifest"):
+            ModelPackage.load(str(tmp_path))
 
     def test_save_creates_directory(self, tmp_path):
         outdir = tmp_path / "nested" / "dir"

--- a/src/mobius/integrations/gguf/_reuse.py
+++ b/src/mobius/integrations/gguf/_reuse.py
@@ -194,6 +194,7 @@ def _insert_external_transform(
     uses = list(initializer.uses())
     if not uses:
         return
+    earliest_consumer = min((node for node, _ in uses), key=graph.index)
     dtype = initializer.dtype
     final_shape = initializer.shape
     assert dtype is not None and final_shape is not None
@@ -334,7 +335,7 @@ def _insert_external_transform(
     else:
         raise ValueError(f"Unknown GGUF external transform {candidate.transform!r}.")
 
-    graph.insert_before(uses[0][0], nodes)
+    graph.insert_before(earliest_consumer, nodes)
 
 
 def _validate_source(plan: GGUFReusePlan, output_directory: Path) -> None:

--- a/src/mobius/integrations/gguf/_reuse_test.py
+++ b/src/mobius/integrations/gguf/_reuse_test.py
@@ -1,0 +1,48 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Unit tests for GGUF external-data graph transforms."""
+
+from __future__ import annotations
+
+import numpy as np
+import onnx_ir as ir
+
+from mobius.integrations.gguf._reuse import (
+    GGUFReuseCandidate,
+    _insert_external_transform,
+)
+
+
+def test_external_transform_precedes_all_consumers():
+    initializer = ir.Value(
+        name="weight",
+        shape=ir.Shape([2, 2]),
+        type=ir.TensorType(ir.DataType.FLOAT),
+        const_value=ir.tensor(np.ones((2, 2), dtype=np.float32)),
+    )
+    early_output = ir.Value(name="early_output")
+    late_output = ir.Value(name="late_output")
+
+    # Construct uses in the opposite order from the graph to ensure insertion
+    # follows graph topology rather than Value.uses() registration order.
+    late = ir.Node("", "Identity", inputs=[initializer], outputs=[late_output], name="late")
+    early = ir.Node("", "Identity", inputs=[initializer], outputs=[early_output], name="early")
+    graph = ir.Graph([], [early_output, late_output], nodes=[early, late], name="test")
+    graph.initializers[initializer.name] = initializer
+    candidate = GGUFReuseCandidate(
+        source_name="weight",
+        offset=0,
+        length=initializer.const_value.nbytes,
+        qtype=0,
+        transform="transpose",
+        source_shape=(2, 2),
+    )
+
+    _insert_external_transform(graph, initializer, candidate)
+
+    transform = next(node for node in graph if node.name == "weight.gguf_reuse.Transpose")
+    assert graph.index(transform) < graph.index(early)
+    assert graph.index(transform) < graph.index(late)
+    assert early.inputs[0] is transform.outputs[0]
+    assert late.inputs[0] is transform.outputs[0]


### PR DESCRIPTION
## Summary
- insert direct GGUF external-data transforms before the earliest graph consumer
- serialize MTP sidecars through an explicit collision-safe manifest while preserving legitimate `mtp` and auxiliary components
- reject cyclic, escaping, colliding, or symlinked package layouts before writes and replace stale sidecars deterministically

Addresses review comments 3854308391, 3855174177, and 3855174238.

## Tests
- `python -m pytest src/mobius/_model_package_test.py src/mobius/integrations/gguf/_reuse_test.py src/mobius/integrations/gguf/_builder_test.py src/mobius/integrations/gguf/_reader_test.py src/mobius/integrations/gguf/_preflight_test.py -q --tb=short` (557 passed)
- `python -m pytest tests/build_graph_test.py tests/cli_test.py src/ -q -k "not phi4mm and not apply_weights_unknown" --tb=short -n auto` (7819 passed, 56 skipped)
- `lintrunner f --output oneline --all-files`

## Review
- GPT-5.6 Sol, medium reasoning; all findings addressed