### PR TITLE
Fix atomic GGUF runtime CLI publication

### DIFF
--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -12,7 +12,7 @@ import logging
 import os
 import re
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import tqdm
 
@@ -660,13 +660,13 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
             _resolve_gguf_path,
             _validate_gguf_model,
         )
-        from mobius.integrations.gguf._reader import GGUFModel
+        from mobius.integrations.gguf._shard_set import open_gguf_model
         from mobius.integrations.gguf._spec import Support
 
         # Resolve and validate the exact selected source before graph construction
         # so a deferred tokenizer cannot leave a graph-only directory behind.
         resolved_gguf_path = _resolve_gguf_path(gguf_path)
-        gguf_model = GGUFModel(resolved_gguf_path)
+        gguf_model = open_gguf_model(resolved_gguf_path)
         _validate_gguf_model(gguf_model, source=str(resolved_gguf_path))
         architecture_spec = get_arch_spec(gguf_model.architecture)
         if architecture_spec.runtime is not Support.SUPPORTED:
@@ -715,27 +715,24 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
             ),
             max_workers=args.max_workers,
         )
-    for name in pkg:
-        use_subfolders = len(pkg) > 1
-        if use_subfolders:
-            path = os.path.join(output_dir, name, "model.onnx")
-        else:
-            path = os.path.join(output_dir, "model.onnx")
-        print(f"Saved {name} to {path}")
+        _print_saved_gguf_models(pkg, output_dir)
 
-    # Save the trailing MTP / "nextn" self-speculative head sidecar (when the
-    # GGUF shipped one). ModelPackage.save() persisted it into ``mtp/``.
-    mtp_head = getattr(pkg, "mtp_head", None)
-    if mtp_head is not None:
-        mtp_dir = os.path.join(output_dir, "mtp")
-        print(f"Saved mtp head to {os.path.join(mtp_dir, 'model.onnx')}")
+        # ModelPackage.save() persisted the MTP sidecar into its manifest-selected
+        # collision-safe directory.
+        mtp_head = getattr(pkg, "mtp_head", None)
+        if mtp_head is not None:
+            from mobius._model_package import _read_mtp_sidecar_name
 
-    draft_manifest = getattr(pkg, "draft_manifest", None)
-    if draft_manifest is not None:
-        from mobius.integrations.gguf._draft import write_draft_manifest
+            mtp_dir = _read_mtp_sidecar_name(output_dir)
+            assert mtp_dir is not None
+            print(f"Saved mtp head to {os.path.join(output_dir, mtp_dir, 'model.onnx')}")
 
-        manifest_path = write_draft_manifest(draft_manifest, output_dir)
-        print(f"Saved draft pairing manifest to {manifest_path}")
+        draft_manifest = getattr(pkg, "draft_manifest", None)
+        if draft_manifest is not None:
+            from mobius.integrations.gguf._draft import write_draft_manifest
+
+            manifest_path = write_draft_manifest(draft_manifest, output_dir)
+            print(f"Saved draft pairing manifest to {manifest_path}")
 
     if runtime in ("onnx-genai", "ort-genai"):
         from mobius.integrations.gguf import write_gguf_runtime_package
@@ -755,8 +752,23 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
             ),
             max_workers=args.max_workers,
         )
+        # The writer returns only after atomically publishing the complete graph,
+        # tokenizer, and runtime configuration directory.
+        _print_saved_gguf_models(pkg, output_dir)
         for name, path in artifacts.items():
             print(f"  {name}: {path}")
+
+
+def _print_saved_gguf_models(pkg: Any, output_dir: str) -> None:
+    """Report model paths only after their containing package is durable."""
+    use_subfolders = len(pkg) > 1
+    for name in pkg:
+        path = (
+            os.path.join(output_dir, name, "model.onnx")
+            if use_subfolders
+            else os.path.join(output_dir, "model.onnx")
+        )
+        print(f"Saved {name} to {path}")
 
 
 def _cmd_convert_comfyui(args: argparse.Namespace) -> None:

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -3912,7 +3912,14 @@ def build_from_gguf(
 
     if draft_manifest is not None:
         pkg.draft_manifest = draft_manifest
-    pkg.gguf_source_path = str(Path(gguf_path).resolve())
+    canonical_source_path = (
+        gguf_model.shard_paths[0] if isinstance(gguf_model, GgufShardSet) else Path(gguf_path)
+    )
+    if isinstance(gguf_model, GgufShardSet):
+        logical_source_filename = (
+            Path(logical_source_filename).with_name(canonical_source_path.name).as_posix()
+        )
+    pkg.gguf_source_path = str(canonical_source_path.resolve())
     pkg.gguf_source_filename = logical_source_filename
     pkg.gguf_architecture = spec.gguf_arch
     pkg.gguf_execution_provider = execution_provider

--- a/src/mobius/integrations/gguf/_runtime_evidence.py
+++ b/src/mobius/integrations/gguf/_runtime_evidence.py
@@ -366,14 +366,33 @@ def gguf_artifact_identity(
     filename: str | None = None,
 ) -> GGUFArtifactIdentity:
     """Fingerprint source bytes and parsed tensor census under a canonical architecture."""
-    stat, sha256 = _hash_regular_file(source_path)
-    qtypes = Counter(tensor.tensor_type.name for tensor in gguf_model._reader.tensors)
+    shard_paths = getattr(gguf_model, "shard_paths", None)
+    if shard_paths is None:
+        stat, sha256 = _hash_regular_file(source_path)
+        size = stat.st_size
+    else:
+        paths = tuple(Path(path) for path in shard_paths)
+        if not paths:
+            raise ValueError("A GGUF shard set must contain at least one source file.")
+        digest = hashlib.sha256()
+        size = 0
+        for path in paths:
+            stat, file_sha256 = _hash_regular_file(path)
+            encoded = path.name.encode("utf-8")
+            digest.update(len(encoded).to_bytes(8, "big"))
+            digest.update(encoded)
+            digest.update(stat.st_size.to_bytes(8, "big"))
+            digest.update(bytes.fromhex(file_sha256))
+            size += stat.st_size
+        sha256 = digest.hexdigest()
+    tensors = gguf_model.reader_tensors()
+    qtypes = Counter(tensor.tensor_type.name for tensor in tensors)
     return GGUFArtifactIdentity(
         architecture=architecture,
         filename=filename or source_path.name,
-        size=stat.st_size,
+        size=size,
         sha256=sha256,
-        tensor_count=len(gguf_model._reader.tensors),
+        tensor_count=len(tensors),
         tensor_qtypes=tuple(sorted(qtypes.items())),
     )
 

--- a/src/mobius/integrations/gguf/_runtime_evidence_test.py
+++ b/src/mobius/integrations/gguf/_runtime_evidence_test.py
@@ -53,13 +53,13 @@ def _record(payload: bytes) -> GGUFRuntimeEvidence:
 
 
 def _model():
+    tensors = [
+        SimpleNamespace(tensor_type=SimpleNamespace(name="Q4_K")),
+        SimpleNamespace(tensor_type=SimpleNamespace(name="F32")),
+    ]
     return SimpleNamespace(
-        _reader=SimpleNamespace(
-            tensors=[
-                SimpleNamespace(tensor_type=SimpleNamespace(name="Q4_K")),
-                SimpleNamespace(tensor_type=SimpleNamespace(name="F32")),
-            ]
-        )
+        _reader=SimpleNamespace(tensors=tensors),
+        reader_tensors=lambda: tensors,
     )
 
 
@@ -151,6 +151,42 @@ def test_matching_evidence_rejects_source_replaced_after_build(tmp_path, monkeyp
             tokenizer_repository=record.tokenizer_repository,
             tokenizer_revision=record.tokenizer_revision,
         )
+
+
+def test_sharded_artifact_identity_frames_every_shard_and_tensor(tmp_path) -> None:
+    first = tmp_path / "model-00001-of-00002.gguf"
+    second = tmp_path / "model-00002-of-00002.gguf"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    tensors = [
+        SimpleNamespace(tensor_type=SimpleNamespace(name="F32")),
+        SimpleNamespace(tensor_type=SimpleNamespace(name="Q4_K")),
+    ]
+    model = SimpleNamespace(
+        shard_paths=[first, second],
+        reader_tensors=lambda: tensors,
+    )
+
+    identity = gguf_artifact_identity(
+        second,
+        model,
+        architecture="llama",
+        filename=first.name,
+    )
+
+    assert identity.filename == first.name
+    assert identity.size == len(b"firstsecond")
+    assert identity.tensor_count == 2
+    assert identity.tensor_qtypes == (("F32", 1), ("Q4_K", 1))
+
+    second.write_bytes(b"change")
+    changed = gguf_artifact_identity(
+        first,
+        model,
+        architecture="llama",
+        filename=first.name,
+    )
+    assert changed.sha256 != identity.sha256
 
 
 def test_evidence_id_cannot_cross_architectures(monkeypatch) -> None:

--- a/src/mobius/integrations/gguf/_runtime_package.py
+++ b/src/mobius/integrations/gguf/_runtime_package.py
@@ -25,11 +25,11 @@ from pathlib import Path
 from typing import Any, Literal
 
 from mobius.integrations.gguf._arch_registry import get_arch_spec
-from mobius.integrations.gguf._reader import GGUFModel
 from mobius.integrations.gguf._runtime_evidence import (
     gguf_graph_package_identity,
     matching_runtime_evidence,
 )
+from mobius.integrations.gguf._shard_set import open_gguf_model
 from mobius.integrations.gguf._spec import Support
 from mobius.integrations.gguf._tokenizer import (
     GGUFTokenizerAsset,
@@ -197,7 +197,12 @@ def write_gguf_runtime_package(
         )
 
     source_path = Path(getattr(pkg, "gguf_source_path", gguf_path))
-    source_model = GGUFModel(source_path)
+    source_model = open_gguf_model(source_path)
+    if not source_model.source_matches_path():
+        raise ValueError(
+            "The GGUF source changed while the canonical reader was opening it; "
+            "refusing runtime publication."
+        )
     source_architecture = get_arch_spec(source_model.architecture).gguf_arch
     if source_architecture != architecture:
         raise ValueError(
@@ -217,6 +222,11 @@ def write_gguf_runtime_package(
         tokenizer_repository=tokenizer_repository,
         tokenizer_revision=tokenizer_revision,
     )
+    if not source_model.source_matches_path():
+        raise ValueError(
+            "The GGUF source changed while runtime evidence was being matched; "
+            "refusing runtime publication."
+        )
     source_metadata = source_model.metadata
     verdict = inspect_gguf_tokenizer(
         source_metadata,

--- a/src/mobius/integrations/gguf/_runtime_package_test.py
+++ b/src/mobius/integrations/gguf/_runtime_package_test.py
@@ -129,7 +129,9 @@ class TestWriteGgufRuntimePackage:
                     reason="independent parity is missing",
                 ),
             ),
-            mock.patch("mobius.integrations.gguf._runtime_package.GGUFModel") as read_source,
+            mock.patch(
+                "mobius.integrations.gguf._runtime_package.open_gguf_model"
+            ) as read_source,
             pytest.raises(ValueError, match=r"runtime packaging.*deferred"),
         ):
             _write_runtime(pkg, tmp_path / "m.gguf", out)
@@ -141,8 +143,12 @@ class TestWriteGgufRuntimePackage:
         out = tmp_path / "out"
         with (
             mock.patch(
-                "mobius.integrations.gguf._runtime_package.GGUFModel",
-                return_value=SimpleNamespace(metadata={}, architecture="llama"),
+                "mobius.integrations.gguf._runtime_package.open_gguf_model",
+                return_value=SimpleNamespace(
+                    metadata={},
+                    architecture="llama",
+                    source_matches_path=lambda: True,
+                ),
             ),
             mock.patch(
                 "mobius.integrations.gguf._runtime_package.inspect_gguf_tokenizer",
@@ -164,11 +170,41 @@ class TestWriteGgufRuntimePackage:
         assert Path(artifacts["inference_metadata"]) == out / "inference_metadata.yaml"
         assert not list(tmp_path.glob(".out.*.tmp"))
 
+    def test_failure_after_graph_save_removes_staging_and_publishes_nothing(self, tmp_path):
+        pkg = _FakePackage()
+        out = tmp_path / "out"
+        with (
+            mock.patch(
+                "mobius.integrations.gguf._runtime_package.open_gguf_model",
+                return_value=SimpleNamespace(
+                    metadata={},
+                    architecture="llama",
+                    source_matches_path=lambda: True,
+                ),
+            ),
+            mock.patch(
+                "mobius.integrations.gguf._runtime_package.inspect_gguf_tokenizer",
+                return_value=_materialized(),
+            ),
+            mock.patch(
+                "mobius.integrations.gguf._runtime_package.materialize_gguf_tokenizer",
+                side_effect=OSError("tokenizer asset write failed"),
+            ),
+            pytest.raises(OSError, match="tokenizer asset write failed"),
+        ):
+            _write_runtime(pkg, tmp_path / "m.gguf", out)
+
+        assert pkg.saved_to is not None
+        assert not out.exists()
+        assert not list(tmp_path.glob(".out.*.tmp"))
+
     def test_missing_pinned_tokenizer_source_rejects_before_save_or_output(self, tmp_path):
         pkg = _FakePackage()
         out = tmp_path / "out"
         with (
-            mock.patch("mobius.integrations.gguf._runtime_package.GGUFModel") as read_source,
+            mock.patch(
+                "mobius.integrations.gguf._runtime_package.open_gguf_model"
+            ) as read_source,
             pytest.raises(ValueError, match="explicit tokenizer_repository"),
         ):
             write_gguf_runtime_package(pkg, tmp_path / "m.gguf", out)
@@ -181,8 +217,12 @@ class TestWriteGgufRuntimePackage:
         out = tmp_path / "out"
         with (
             mock.patch(
-                "mobius.integrations.gguf._runtime_package.GGUFModel",
-                return_value=SimpleNamespace(metadata={}, architecture="llama"),
+                "mobius.integrations.gguf._runtime_package.open_gguf_model",
+                return_value=SimpleNamespace(
+                    metadata={},
+                    architecture="llama",
+                    source_matches_path=lambda: True,
+                ),
             ),
             mock.patch(
                 "mobius.integrations.gguf._runtime_package.inspect_gguf_tokenizer",
@@ -205,7 +245,9 @@ class TestWriteGgufRuntimePackage:
         sentinel = out / "sentinel.bin"
         sentinel.write_bytes(b"unchanged")
         with (
-            mock.patch("mobius.integrations.gguf._runtime_package.GGUFModel") as read_source,
+            mock.patch(
+                "mobius.integrations.gguf._runtime_package.open_gguf_model"
+            ) as read_source,
             pytest.raises(FileExistsError, match="non-atomic directory replacement"),
         ):
             _write_runtime(pkg, tmp_path / "m.gguf", out)
@@ -246,7 +288,9 @@ class TestWriteGgufRuntimePackage:
         pkg.mtp_head = SimpleNamespace(config=object())
         out = tmp_path / "out"
         with (
-            mock.patch("mobius.integrations.gguf._runtime_package.GGUFModel") as read_source,
+            mock.patch(
+                "mobius.integrations.gguf._runtime_package.open_gguf_model"
+            ) as read_source,
             pytest.raises(ValueError, match="runtime-evidenced GGUF MTP"),
         ):
             _write_runtime(pkg, tmp_path / "m.gguf", out, runtime=runtime)
@@ -261,7 +305,9 @@ class TestWriteGgufRuntimePackage:
 
     def test_save_model_false_is_rejected_before_source_read(self, tmp_path):
         with (
-            mock.patch("mobius.integrations.gguf._runtime_package.GGUFModel") as read_source,
+            mock.patch(
+                "mobius.integrations.gguf._runtime_package.open_gguf_model"
+            ) as read_source,
             pytest.raises(ValueError, match="save_model=False is not supported"),
         ):
             write_gguf_runtime_package(

--- a/src/mobius/integrations/gguf/_shard_set.py
+++ b/src/mobius/integrations/gguf/_shard_set.py
@@ -442,6 +442,10 @@ class GgufShardSet:
     def shard_paths(self) -> list[Path]:
         return [Path(shard._path) for shard in self._shards]
 
+    def source_matches_path(self) -> bool:
+        """Return whether every shard still names the exact file that was opened."""
+        return all(shard.source_matches_path() for shard in self._shards)
+
     def _safe_architecture(self) -> str | None:
         try:
             return self._primary.architecture

--- a/tests/gguf_test.py
+++ b/tests/gguf_test.py
@@ -547,6 +547,8 @@ class TestCLIBuildGGUF:
         package = mock.MagicMock()
         package.__iter__.return_value = iter(())
         package.values.return_value = iter(())
+        package.mtp_head = None
+        package.draft_manifest = None
         with mock.patch(
             "mobius.integrations.gguf.build_from_gguf",
             return_value=package,
@@ -580,7 +582,7 @@ class TestCLIBuildGGUF:
             )
 
     def test_ort_genai_runtime_is_forwarded_to_package_writer(self, tmp_path):
-        """build-gguf forwards the selected runtime after saving the graph."""
+        """build-gguf forwards one canonically opened source to build and packaging."""
         from mobius.__main__ import main
         from mobius.integrations.gguf._spec import Support
 
@@ -588,6 +590,7 @@ class TestCLIBuildGGUF:
         package.__iter__.return_value = iter(())
         package.mtp_head = None
         package.draft_manifest = None
+        gguf_model = mock.Mock(metadata={}, architecture="llama")
         output_dir = tmp_path / "output"
         with (
             mock.patch(
@@ -595,9 +598,9 @@ class TestCLIBuildGGUF:
                 return_value=str(tmp_path / "model.gguf"),
             ),
             mock.patch(
-                "mobius.integrations.gguf._reader.GGUFModel",
-                return_value=mock.Mock(metadata={}, architecture="llama"),
-            ),
+                "mobius.integrations.gguf._shard_set.open_gguf_model",
+                return_value=gguf_model,
+            ) as open_model,
             mock.patch("mobius.integrations.gguf._builder._validate_gguf_model"),
             mock.patch(
                 "mobius.integrations.gguf._arch_registry.get_arch_spec",
@@ -610,7 +613,7 @@ class TestCLIBuildGGUF:
             mock.patch(
                 "mobius.integrations.gguf.build_from_gguf",
                 return_value=package,
-            ),
+            ) as build,
             mock.patch(
                 "mobius.integrations.gguf.write_gguf_runtime_package",
                 return_value={"genai_config": str(output_dir / "genai_config.json")},
@@ -631,6 +634,8 @@ class TestCLIBuildGGUF:
                 ]
             )
 
+        open_model.assert_called_once_with(str(tmp_path / "model.gguf"))
+        assert build.call_args.kwargs["_gguf_model"] is gguf_model
         write_runtime.assert_called_once_with(
             package,
             str(tmp_path / "model.gguf"),
@@ -656,7 +661,7 @@ class TestCLIBuildGGUF:
                 return_value=str(tmp_path / "model.gguf"),
             ),
             mock.patch(
-                "mobius.integrations.gguf._reader.GGUFModel",
+                "mobius.integrations.gguf._shard_set.open_gguf_model",
                 return_value=mock.Mock(metadata={}, architecture="llama"),
             ),
             mock.patch("mobius.integrations.gguf._builder._validate_gguf_model"),
@@ -683,3 +688,178 @@ class TestCLIBuildGGUF:
             )
         build.assert_not_called()
         assert not output.exists()
+
+    @pytest.mark.parametrize(
+        ("error", "message"),
+        [
+            (
+                FileNotFoundError(
+                    "Incomplete GGUF split set 'model': declared 2 shards but 1 missing"
+                ),
+                "1 missing",
+            ),
+            (ValueError("invalid GGUF header in continuation shard"), "invalid GGUF header"),
+        ],
+    )
+    def test_runtime_shard_preflight_fails_before_build_or_output(
+        self, tmp_path, capsys, error, message
+    ):
+        from mobius.__main__ import main
+
+        output = tmp_path / "output"
+        shard = tmp_path / "model-00001-of-00002.gguf"
+        with (
+            mock.patch(
+                "mobius.integrations.gguf._builder._resolve_gguf_path",
+                return_value=str(shard),
+            ),
+            mock.patch(
+                "mobius.integrations.gguf._shard_set.open_gguf_model",
+                side_effect=error,
+            ),
+            mock.patch("mobius.integrations.gguf.build_from_gguf") as build,
+            pytest.raises(type(error), match=message),
+        ):
+            main(
+                [
+                    "build-gguf",
+                    str(shard),
+                    "--output",
+                    str(output),
+                    "--runtime",
+                    "ort-genai",
+                    "--runtime-version",
+                    "0.15.2",
+                    "--tokenizer-repository",
+                    "owner/tokenizer",
+                    "--tokenizer-revision",
+                    "a" * 40,
+                ]
+            )
+
+        build.assert_not_called()
+        assert "Saved" not in capsys.readouterr().out
+        assert not output.exists()
+
+    def test_runtime_packaging_failure_emits_no_saved_output(self, tmp_path, capsys):
+        from mobius.__main__ import main
+        from mobius.integrations.gguf._spec import Support
+
+        output = tmp_path / "output"
+        package = mock.MagicMock()
+        package.__iter__.return_value = iter(("model",))
+        package.__len__.return_value = 1
+        gguf_model = mock.Mock(metadata={}, architecture="llama")
+        with (
+            mock.patch(
+                "mobius.integrations.gguf._builder._resolve_gguf_path",
+                return_value=str(tmp_path / "model.gguf"),
+            ),
+            mock.patch(
+                "mobius.integrations.gguf._shard_set.open_gguf_model",
+                return_value=gguf_model,
+            ),
+            mock.patch("mobius.integrations.gguf._builder._validate_gguf_model"),
+            mock.patch(
+                "mobius.integrations.gguf._arch_registry.get_arch_spec",
+                return_value=mock.Mock(
+                    gguf_arch="llama",
+                    runtime=Support.SUPPORTED,
+                    reason=None,
+                ),
+            ),
+            mock.patch(
+                "mobius.integrations.gguf.build_from_gguf",
+                return_value=package,
+            ),
+            mock.patch(
+                "mobius.integrations.gguf.write_gguf_runtime_package",
+                side_effect=ValueError("serialized package evidence mismatch"),
+            ),
+            pytest.raises(ValueError, match="evidence mismatch"),
+        ):
+            main(
+                [
+                    "build-gguf",
+                    str(tmp_path / "model.gguf"),
+                    "--output",
+                    str(output),
+                    "--runtime",
+                    "ort-genai",
+                    "--runtime-version",
+                    "0.15.2",
+                    "--tokenizer-repository",
+                    "owner/tokenizer",
+                    "--tokenizer-revision",
+                    "a" * 40,
+                ]
+            )
+
+        assert "Saved" not in capsys.readouterr().out
+        assert not output.exists()
+
+    def test_runtime_success_is_reported_only_after_publication(self, tmp_path):
+        from mobius.__main__ import main
+        from mobius.integrations.gguf._spec import Support
+
+        output = tmp_path / "output"
+        package = mock.MagicMock()
+        package.__iter__.return_value = iter(("model",))
+        package.__len__.return_value = 1
+
+        def publish(*_args, **_kwargs):
+            output.mkdir()
+            (output / "model.onnx").write_bytes(b"model")
+            return {"genai_config": str(output / "genai_config.json")}
+
+        original_print = print
+
+        def assert_published_before_print(*args, **kwargs):
+            if args and str(args[0]).startswith("Saved"):
+                assert (output / "model.onnx").is_file()
+            original_print(*args, **kwargs)
+
+        with (
+            mock.patch(
+                "mobius.integrations.gguf._builder._resolve_gguf_path",
+                return_value=str(tmp_path / "model.gguf"),
+            ),
+            mock.patch(
+                "mobius.integrations.gguf._shard_set.open_gguf_model",
+                return_value=mock.Mock(metadata={}, architecture="llama"),
+            ),
+            mock.patch("mobius.integrations.gguf._builder._validate_gguf_model"),
+            mock.patch(
+                "mobius.integrations.gguf._arch_registry.get_arch_spec",
+                return_value=mock.Mock(
+                    gguf_arch="llama",
+                    runtime=Support.SUPPORTED,
+                    reason=None,
+                ),
+            ),
+            mock.patch(
+                "mobius.integrations.gguf.build_from_gguf",
+                return_value=package,
+            ),
+            mock.patch(
+                "mobius.integrations.gguf.write_gguf_runtime_package",
+                side_effect=publish,
+            ),
+            mock.patch("builtins.print", side_effect=assert_published_before_print),
+        ):
+            main(
+                [
+                    "build-gguf",
+                    str(tmp_path / "model.gguf"),
+                    "--output",
+                    str(output),
+                    "--runtime",
+                    "ort-genai",
+                    "--runtime-version",
+                    "0.15.2",
+                    "--tokenizer-repository",
+                    "owner/tokenizer",
+                    "--tokenizer-revision",
+                    "a" * 40,
+                ]
+            )


### PR DESCRIPTION
## Summary
- route GGUF runtime CLI preflight and package publication through canonical `open_gguf_model()` shard discovery and validation
- bind runtime evidence to the complete stable shard set while preserving exact source, tokenizer, import-route, graph, runtime-version, and ORT GenAI 0.15.2 gates
- emit `Saved` output only after atomic runtime package publication succeeds, with failure cleanup that leaves no durable partial package
- preserve ModelPackage cycle, collision, sidecar, and path invariants from #629

Addresses audited Copilot comments 3855249765, 3855249840, and 3855343131.

## Tests
- `python -m pytest tests/cli_test.py tests/gguf_test.py src/mobius/_model_package_test.py src/mobius/integrations/gguf/ -q --tb=short` (3131 passed)
- `python -m pytest tests/gguf_test.py src/mobius/integrations/gguf/_builder_test.py src/mobius/integrations/gguf/_runtime_package_test.py src/mobius/integrations/gguf/_runtime_evidence_test.py src/mobius/integrations/gguf/_shard_set_test.py src/mobius/_model_package_test.py -q --tb=short` (578 passed, post-rebase)
- `python -m pytest tests/build_graph_test.py tests/cli_test.py src/ -q -k "not phi4mm and not apply_weights_unknown" --tb=short -n auto` (7822 passed, 56 skipped, 1 subtest passed)
- `lintrunner f --output oneline --all-files`

## Review
- GPT-5.6 Sol, medium reasoning; selected-shard canonical filename finding fixed; final re-review clean
