### PR TITLE
Fix accumulated model contract CI regressions

### DIFF
--- a/src/mobius/_registry.py
+++ b/src/mobius/_registry.py
@@ -88,10 +88,10 @@ from mobius.models import (
     HunYuanV1DenseCausalLMModel,
     HunYuanVLMoTModel,
     InternLM2CausalLMModel,
+    Jais2CausalLMModel,
     KimiK3CausalLMModel,
     KimiLinearCausalLMModel,
     LayerNormCausalLMModel,
-    LegacyLayerNormCausalLMModel,
     Lfm2CausalLMModel,
     Lfm2MoECausalLMModel,
     Lfm2VlForConditionalGeneration,
@@ -136,6 +136,7 @@ from mobius.models import (
     SmolLM3CausalLMModel,
     SortformerDiarizationModel,
     WhisperForConditionalGeneration,
+    XverseCausalLMModel,
 )
 from mobius.models.bamba import BambaCausalLMModel
 from mobius.models.bart import BartForConditionalGeneration
@@ -432,7 +433,7 @@ _REGISTRATIONS: dict[str, ModelRegistration] = {
     "code_llama": ModelRegistration(CausalLMModel),
     "codegen2": ModelRegistration(CausalLMModel),
     "command_r": ModelRegistration(CohereCausalLMModel),
-    "jais2": ModelRegistration(LegacyLayerNormCausalLMModel, config_class=Jais2Config),
+    "jais2": ModelRegistration(Jais2CausalLMModel, config_class=Jais2Config),
     "kclgpt": ModelRegistration(CodeShellCausalLMModel, config_class=CodeShellConfig),
     "csm": ModelRegistration(CausalLMModel),
     "dots1": ModelRegistration(DeepSeekV3CausalLMModel),
@@ -446,7 +447,7 @@ _REGISTRATIONS: dict[str, ModelRegistration] = {
     "ministral3": ModelRegistration(CausalLMModel),
     "mistral": ModelRegistration(CausalLMModel),
     "open-llama": ModelRegistration(CausalLMModel),
-    "xverse": ModelRegistration(CausalLMModel, config_class=XverseConfig),
+    "xverse": ModelRegistration(XverseCausalLMModel, config_class=XverseConfig),
     "openelm": ModelRegistration(CausalLMModel),
     "qwen2": ModelRegistration(CausalLMModel),
     "seed_oss": ModelRegistration(CausalLMModel),

--- a/src/mobius/models/__init__.py
+++ b/src/mobius/models/__init__.py
@@ -83,6 +83,7 @@ __all__ = [
     "MageVLForConditionalGeneration",
     "JambaCausalLMModel",
     "JinaBertV2GGUFModel",
+    "Jais2CausalLMModel",
     "JetMoeCausalLMModel",
     "KimiK3CausalLMModel",
     "KimiLinearCausalLMModel",
@@ -189,6 +190,7 @@ __all__ = [
     "WhisperForConditionalGeneration",
     "MLPWorldModel",
     "XLMCausalLMModel",
+    "XverseCausalLMModel",
     "Zamba2CausalLMModel",
     "mimi_default_config",
     "moshi_depformer_config",
@@ -277,7 +279,9 @@ from mobius.models.kimi_k3 import KimiK3CausalLMModel
 from mobius.models.kimi_linear import KimiLinearCausalLMModel
 from mobius.models.legacy_decoder import (
     CodeShellCausalLMModel,
+    Jais2CausalLMModel,
     LegacyLayerNormCausalLMModel,
+    XverseCausalLMModel,
 )
 from mobius.models.lfm2 import Lfm2CausalLMModel, Lfm2MoECausalLMModel
 from mobius.models.lfm2_vl import Lfm2VlForConditionalGeneration

--- a/src/mobius/models/kimi_k3.py
+++ b/src/mobius/models/kimi_k3.py
@@ -11,7 +11,7 @@ import onnx_ir as ir
 import torch
 from onnxscript import OpBuilder, nn
 
-from mobius._configs import ArchitectureConfig
+from mobius._configs import ArchitectureConfig, KimiK3Config
 from mobius.components import Linear, RMSNorm, create_attention_bias
 from mobius.models.base import (
     CausalLMModel,
@@ -570,6 +570,7 @@ class KimiK3CausalLMModel(CausalLMModel):
 
     default_task = "kimi-k3-text-generation"
     category = "Mixture of Experts"
+    config_class = KimiK3Config
 
     def __init__(self, config: ArchitectureConfig):
         if config.tie_word_embeddings:

--- a/src/mobius/models/kimi_k3_test.py
+++ b/src/mobius/models/kimi_k3_test.py
@@ -121,6 +121,10 @@ def test_config_rejects_empty_convolution_history() -> None:
         KimiK3Config.from_transformers(parent)
 
 
+def test_model_declares_config_class() -> None:
+    assert KimiK3CausalLMModel.config_class is KimiK3Config
+
+
 def test_model_has_attention_residual_latent_moe_and_untied_head() -> None:
     model = KimiK3CausalLMModel(_config())
 

--- a/src/mobius/models/legacy_decoder.py
+++ b/src/mobius/models/legacy_decoder.py
@@ -7,10 +7,16 @@ from __future__ import annotations
 
 import torch
 
-from mobius._configs import ArchitectureConfig
+from mobius._configs import (
+    ArchitectureConfig,
+    CodeShellConfig,
+    Jais2Config,
+    XverseConfig,
+)
 from mobius._weight_utils import split_fused_qkv
 from mobius.components import FCMLP
 from mobius.models.base import (
+    CausalLMModel,
     LayerNormCausalLMModel,
     linear_class_for_config,
 )
@@ -50,8 +56,16 @@ class LegacyLayerNormCausalLMModel(LayerNormCausalLMModel):
         return super().preprocess_weights(state_dict)
 
 
+class Jais2CausalLMModel(LegacyLayerNormCausalLMModel):
+    """Jais2 decoder with its published bias and normalization configuration."""
+
+    config_class = Jais2Config
+
+
 class CodeShellCausalLMModel(LegacyLayerNormCausalLMModel):
     """CodeShell decoder accepting both published HF and canonical GGUF names."""
+
+    config_class = CodeShellConfig
 
     def preprocess_weights(
         self, state_dict: dict[str, torch.Tensor]
@@ -81,3 +95,9 @@ class CodeShellCausalLMModel(LegacyLayerNormCausalLMModel):
             # Tied CodeShell graphs have one initializer owned by embed_tokens.
             normalized.pop("lm_head.weight", None)
         return normalized
+
+
+class XverseCausalLMModel(CausalLMModel):
+    """Xverse decoder with source-compatible RoPE configuration defaults."""
+
+    config_class = XverseConfig

--- a/src/mobius/models/legacy_decoder_test.py
+++ b/src/mobius/models/legacy_decoder_test.py
@@ -8,10 +8,10 @@ from types import SimpleNamespace
 import torch
 
 from mobius._configs import CodeShellConfig, Jais2Config, XverseConfig
-from mobius.models.base import CausalLMModel
 from mobius.models.legacy_decoder import (
     CodeShellCausalLMModel,
-    LegacyLayerNormCausalLMModel,
+    Jais2CausalLMModel,
+    XverseCausalLMModel,
 )
 from mobius.tasks import CausalLMTask
 
@@ -32,6 +32,12 @@ def _codeshell_hf_config() -> SimpleNamespace:
         position_embedding_type="rope",
         rope_scaling=None,
     )
+
+
+def test_specialized_model_config_classes_match_their_architectures() -> None:
+    assert Jais2CausalLMModel.config_class is Jais2Config
+    assert CodeShellCausalLMModel.config_class is CodeShellConfig
+    assert XverseCausalLMModel.config_class is XverseConfig
 
 
 def test_codeshell_real_hf_names_close_graph_and_preserve_qkv_values() -> None:
@@ -105,7 +111,7 @@ def test_xverse_hf_config_builds_rotary_embeddings() -> None:
         rms_norm_eps=1e-6,
     )
     config = XverseConfig.from_transformers(hf_config)
-    module = CausalLMModel(config)
+    module = XverseCausalLMModel(config)
     graph = CausalLMTask().build(module, config)["model"]
 
     assert module.model.rotary_emb is not None
@@ -131,7 +137,7 @@ def test_jais2_hf_config_emits_and_closes_all_bias_weights() -> None:
         tie_word_embeddings=False,
     )
     config = Jais2Config.from_transformers(hf_config)
-    module = LegacyLayerNormCausalLMModel(config)
+    module = Jais2CausalLMModel(config)
     graph = CausalLMTask().build(module, config)["model"]
     graph_weights = {
         name: value

--- a/tests/arch_validation_test.py
+++ b/tests/arch_validation_test.py
@@ -62,6 +62,8 @@ _GRAPH_ONLY_XFAILS: dict[str, str] = {
     "florence2": "Florence2 DaViT vision encoder is multi-stage (not standard ViT)",
     "got_ocr2": "VisionConfig missing without trust_remote_code",
     "janus": "VisionConfig.hidden_size missing without trust_remote_code",
+    "kimi_k3": "Selective MXFP4 compressed-tensors experts are unsupported by the "
+    "generic quantized-linear loader",
     "molmo": "VisionConfig missing without trust_remote_code",
     "ovis2": "VisionConfig missing without trust_remote_code",
 }

--- a/tests/falcon_h1_test.py
+++ b/tests/falcon_h1_test.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 import numpy as np
 import onnx_ir as ir
 import pytest
@@ -26,6 +28,28 @@ def _tiny_overrides() -> dict:
         for model_type, overrides, _representative in CAUSAL_LM_CONFIGS
         if model_type == "falcon_h1"
     )
+
+
+def _linear_attention_state(
+    states: torch.Tensor | Mapping[int, torch.Tensor | None], state_name: str
+) -> torch.Tensor:
+    if isinstance(states, torch.Tensor):
+        return states
+    elif isinstance(states, Mapping):
+        assert set(states) == {0}, (
+            f"Falcon-H1 expected one {state_name} tensor at state index 0, "
+            f"got indices {sorted(states)}"
+        )
+        state = states[0]
+        assert state is not None, (
+            f"Falcon-H1 expected {state_name} at state index 0 to be a tensor, got None"
+        )
+        return state
+    else:
+        raise AssertionError(  # noqa: TRY004 - unexpected test data is an assertion failure
+            f"Falcon-H1 received unexpected {state_name} container type: "
+            f"{type(states).__name__}"
+        )
 
 
 def test_falcon_h1_rejects_invalid_attention_and_ssm_geometry() -> None:
@@ -188,6 +212,10 @@ def test_falcon_h1_prefill_decode_logits_and_four_states_match_transformers() ->
             atol=1e-3,
         )
         for layer, hf_state in enumerate(hf_prefill.past_key_values.layers):
+            hf_conv_state = _linear_attention_state(hf_state.conv_states, "convolution state")
+            hf_recurrent_state = _linear_attention_state(
+                hf_state.recurrent_states, "recurrent state"
+            )
             np.testing.assert_allclose(
                 ort_prefill[f"present.{layer}.key"],
                 hf_state.keys.numpy(),
@@ -202,13 +230,13 @@ def test_falcon_h1_prefill_decode_logits_and_four_states_match_transformers() ->
             )
             np.testing.assert_allclose(
                 ort_prefill[f"present.{layer}.conv_state"],
-                hf_state.conv_states[:, :, -(config.mamba_d_conv - 1) :].numpy(),
+                hf_conv_state[:, :, -(config.mamba_d_conv - 1) :].numpy(),
                 rtol=1e-4,
                 atol=1e-4,
             )
             np.testing.assert_allclose(
                 ort_prefill[f"present.{layer}.ssm_state"],
-                hf_state.recurrent_states.transpose(2, 3).numpy(),
+                hf_recurrent_state.transpose(2, 3).numpy(),
                 rtol=1e-3,
                 atol=1e-3,
             )

--- a/tests/generate_dashboard_test.py
+++ b/tests/generate_dashboard_test.py
@@ -968,8 +968,7 @@ def test_meta_no_skipped_or_xfailed_model_is_counted_as_passing(gd):
             f"{mt!r} is in an L2 xfail dict yet l2_passes is True; status={info.l2_status!r}"
         )
         assert info.confidence_level != 2, (
-            f"{mt!r} L2 xfail must not determine confidence_level; "
-            f"got {info.confidence_level}"
+            f"{mt!r} L2 xfail must not determine confidence_level; got {info.confidence_level}"
         )
 
 

--- a/tests/generate_dashboard_test.py
+++ b/tests/generate_dashboard_test.py
@@ -967,8 +967,8 @@ def test_meta_no_skipped_or_xfailed_model_is_counted_as_passing(gd):
         assert info.l2_passes is False, (
             f"{mt!r} is in an L2 xfail dict yet l2_passes is True; status={info.l2_status!r}"
         )
-        assert info.confidence_level < 2, (
-            f"{mt!r} L2 xfail must not be counted toward confidence_level; "
+        assert info.confidence_level != 2, (
+            f"{mt!r} L2 xfail must not determine confidence_level; "
             f"got {info.confidence_level}"
         )
 

--- a/tests/model_coverage_test.py
+++ b/tests/model_coverage_test.py
@@ -161,6 +161,9 @@ _COVERAGE_SKIP: dict[str, str] = {
     "kimi_linear": "Kimi Linear is a 48B remote-code hybrid with a heterogeneous "
     "KDA/MLA state ABI; L1-L2 and synthetic GGUF execution are covered, while "
     "real-weight L4/L5 parity remains pending.",
+    "kimi_k3": "Registered tiny checkpoint uses selective MXFP4 compressed-tensors "
+    "unsupported by the generic loader; dedicated model/GGUF tests exist, and "
+    "real-weight L4/L5 awaits an unquantized or supported checkpoint.",
     "t5encoder": "Encoder-only T5 task — covered by src/mobius/models/t5_test.py "
     "and GGUF integration tests; generic encoder tests require token_type_ids",
     # --- Internal / duplicate aliases ---
@@ -254,6 +257,9 @@ _COVERAGE_SKIP: dict[str, str] = {
     "kclgpt": "CodeShell's public checkpoint is 7B; L1 graph, config, "
     "weight-alignment, and synthetic weight-path coverage are present, but no "
     "small public artifact exists for bounded L4/L5 golden generation.",
+    "lfm2_moe": "LFM2-MoE is an 8B hybrid recurrent/MoE model with no small public "
+    "checkpoint; dedicated unit and synthetic parity tests cover its graph and "
+    "weight paths.",
     "llama4_text": "Very large MoE (109B) — no small public checkpoint",
     "orion": "Orion's public checkpoint is 14B; L1 graph/config/tensor closure is "
     "covered, but no small public artifact exists for bounded L4/L5 validation.",

--- a/tests/parity/gated_deltanet_integration_test.py
+++ b/tests/parity/gated_deltanet_integration_test.py
@@ -14,6 +14,8 @@ Run with::
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 import numpy as np
 import onnx_ir as ir
 import pytest
@@ -56,6 +58,29 @@ _HF_CONFIG = Qwen3_5TextConfig(
     linear_value_head_dim=16,
     linear_conv_kernel_dim=4,
 )
+
+
+def _recurrent_state_tensor(
+    states: torch.Tensor | Mapping[int, torch.Tensor | None],
+) -> torch.Tensor:
+    """Extract the single recurrent-state tensor across Transformers cache ABIs."""
+    if isinstance(states, torch.Tensor):
+        return states
+    elif isinstance(states, Mapping):
+        assert set(states) == {0}, (
+            "Qwen3.5 expected one recurrent-state tensor at state index 0, "
+            f"got indices {sorted(states)}"
+        )
+        state = states[0]
+        assert state is not None, (
+            "Qwen3.5 expected recurrent state at state index 0 to be a tensor, got None"
+        )
+        return state
+    else:
+        raise AssertionError(  # noqa: TRY004 - unexpected test data is an assertion failure
+            "Qwen3.5 received unexpected recurrent-state container type: "
+            f"{type(states).__name__}"
+        )
 
 
 def _build_cache_feeds(
@@ -128,9 +153,9 @@ def parity_outputs():
             position_ids=torch.from_numpy(position_ids),
         )
     hf_logits = hf_out.logits.numpy()
-    # transformers >=5.x stores recurrent state per cache layer
-    # (``cache.layers[idx].recurrent_states``) instead of a top-level list.
-    hf_rec = hf_out.past_key_values.layers[0].recurrent_states.numpy()
+    # transformers >=5.14 stores recurrent state in a mapping keyed by state
+    # index; earlier releases expose the tensor directly.
+    hf_rec = _recurrent_state_tensor(hf_out.past_key_values.layers[0].recurrent_states).numpy()
 
     # ONNX forward — build zero-valued cache feeds from graph inputs.
     base_feeds: dict[str, np.ndarray] = {


### PR DESCRIPTION
## Summary

- align Jais2, CodeShell, Xverse, and Kimi-K3 model `config_class` declarations with registry dispatch
- record Kimi-K3 and LFM2-MoE coverage limitations without fabricating golden data
- support both tensor and mapping Transformers linear-attention cache ABIs in Falcon-H1 and GatedDeltaNet parity tests
- mark the selective-MXFP4 Kimi-K3 checkpoint as a strict graph-only L2 xfail
- preserve independent dashboard confidence levels when L2 xfails but L3 passes

## Root causes

- #635 introduced the Jais2, CodeShell, and Xverse registry/model contract mismatches
- #621 introduced the Kimi-K3 contract and coverage gaps
- #606 introduced LFM2-MoE without an L4/L5 coverage disposition
- #610 assumed the older tensor cache representation in Falcon-H1 parity coverage
- #327 added a dashboard meta-assertion that incorrectly required every L2 xfail to have confidence below L2, contradicting the independent-level truth table

## Validation

- dashboard plus original CI regression gates: 90 passed
- affected graph and weight-alignment gates: 25 passed
- Kimi-K3 L2: 1 passed, 2 strict xfailed
