### PR TITLE
Promote exact Qwen2 and LFM2 GGUF runtime evidence

### DIFF
--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -15,7 +15,7 @@ from mobius import build_from_gguf
 
 | Census | Total | Closure |
 |---|---:|---|
-| Architectures | 147 | graph verdicts: {'deferred': 55, 'rejected': 2, 'supported': 90}; importable: 89; quantized import: {'rejected': 31, 'supported': 116}; runtime: {'deferred': 144, 'rejected': 2, 'supported': 1} |
+| Architectures | 147 | graph verdicts: {'deferred': 55, 'rejected': 2, 'supported': 90}; importable: 89; quantized import: {'rejected': 31, 'supported': 116}; runtime: {'deferred': 142, 'rejected': 2, 'supported': 3} |
 | Active stored qtypes | 25 | 24 have an import route; 1 are explicitly deferred with no route |
 | Serialized projector strings | 60 | {'graph-importable': 5, 'runtime-supported': 0} |
 | Tokenizer pre identifiers | 87 | 56 semantic groups; all default to deferred and become materializable only from a validated embedded `tokenizer.huggingface.json` or an exact pinned source in runtime evidence |
@@ -23,6 +23,59 @@ from mobius import build_from_gguf
 `SUPPORTED` means the named capability is implemented and mechanically tested. `DEFERRED` means it is intentionally unavailable pending the stated work. `REJECTED` means the input or route is invalid by policy. Graph support proves construction/execution only; runtime support additionally requires a pinned real artifact, independent parity, and deterministic generation or stateful semantics. Tokenizer `copy` delegates algorithm semantics to an embedded, vocabulary-identical tokenizer JSON. A `pinned-source` route additionally binds an immutable Hub revision, exact asset hashes, and all reconstructible GGUF tokenizer semantics.
 
 <!-- END GGUF CLOSURE SUMMARY -->
+
+## Runtime artifact census (90 graph-supported routes)
+
+The runtime-evidence pass based on Mobius
+`fcd5b3bb42dbc2ca7ca4bc62e9ee502e8446085a` screened every architecture that
+was graph-supported but runtime-deferred at that revision. The complete set was:
+`bitnet`, `deci`, `qwen3`, `dflash`, `eagle3`, `qwen2`, `qwen2moe`, `qwen3moe`, `dream`,
+`llada`, `llada-moe`, `rnd1`, `qwen35`, `qwen35moe`, `qwen3next`, `gemma`,
+`gemma2`, `gemma3`, `gemma4`, `phi3`, `plm`, `baichuan`, `chatglm`, `phi2`,
+`seed_oss`, `falcon`, `gpt2`, `mamba`, `mamba2`, `jamba`, `nemotron_h`,
+`nemotron_h_moe`, `granitehybrid`, `kimi-k3`, `kimi-linear`, `lfm2`,
+`lfm2moe`, `minimax-01`, `plamo2`, `falcon-h1`, `bert`, `modern-bert`,
+`eurobert`, `neo-bert`, `nomic-bert`, `jina-bert-v2`, `gemma-embedding`,
+`llama-embed`, `starcoder2`, `stablelm`,
+`internlm2`, `olmo`, `olmo2`, `olmoe`, `phimoe`, `granitemoe`, `bailingmoe`,
+`deepseek`, `dots1`, `qwen2vl`, `cohere2`, `arcee`, `smollm3`, `exaone`,
+`nemotron`, `hunyuan-dense`, `muse-glimmer`, `glm-dsa`, `apertus`, `minicpm`,
+`minicpm3`, `openelm`, `mpt`,
+`gptneox`, `jais`, `refact`, `ernie4_5`, `bloom`, `codeshell`, `command-r`,
+`jais2`, `orion`, `qwen`, `starcoder`, `xverse`, `pangu-embedded`, `t5`,
+`t5encoder`, and `talkie`.
+
+The initial pass admitted immutable canonical artifacts no larger than 1 GiB.
+The final census raised that ceiling to 16 GiB, with a mandatory free-space
+gate of at least twice the artifact size and one artifact/model/process at a
+time. Two diverse routes completed the full evidence contract:
+
+| Route | Immutable GGUF | Bytes | SHA-256 | Tensor census | Runtime proof |
+|---|---|---:|---|---|---|
+| `qwen2` | `Qwen/Qwen2.5-0.5B-Instruct-GGUF@9217f5db79a29953eb74d5343926648285ec7e67` / `qwen2.5-0.5b-instruct-q8_0.gguf` | 675,710,816 | `ca59ca7f13d0e15a8cfa77bd17e65d24f6844b554a7b6c12e07a5f89ff76844e` | 291: F32=121, Q8_0=170 | Exact-artifact full logits, dynamic-KV replay/rollback/reorder, 20 decode steps, deterministic ORT GenAI 0.15.2 generation |
+| `lfm2` | `LiquidAI/LFM2-350M-GGUF@8fdc9d526b7ed346b19257551b05816c7912ecc2` / `LFM2-350M-F16.gguf` | 711,482,304 | `379ffdcbf08147c0313f6f1ce7ff558a2bc935eda633f4b46c52347032419c42` | 148: F16=93, F32=55 | Exact-artifact full logits, mixed convolution/KV replay/rollback/reorder, 20 decode steps, deterministic ORT GenAI 0.15.2 generation |
+
+Attempted families that remain deferred:
+
+| Candidate/family | Result |
+|---|---|
+| `gpt2` | Small canonical artifacts exist, but released ORT GenAI requires one rank-5 combined KV tensor per layer while Mobius exposes separate key/value caches. This is a downstream ABI limitation, not a graph failure. |
+| `mamba`, `mamba2` | Small artifacts were inspected, but released runtime state publication cannot satisfy the registry's required replay/rollback/reorder evidence contract. |
+| `bert`, `modern-bert`, `eurobert`, `neo-bert`, `nomic-bert`, `jina-bert-v2` | Small encoder artifacts exist; the released ORT GenAI registry has no evidenced encoder semantic-output contract. No generation claim is made. |
+| `t5`, `t5encoder` | Small canonical seq2seq artifacts exist; the released registry cannot publish the required encoder/decoder semantic contract. No generation claim is made. |
+| `bailingmoe`, `deepseek`, `dots1` | Newly graph-supported routes were included in the census; raising the ceiling to 16 GiB still did not establish an exact canonical artifact within the bound for these architecture routes. |
+| `gptneox`, `jais`, `mpt`, `refact`, `ernie4_5`, `openelm` | Legacy dense routes added by #639 were retained through the final rebase; no qualifying exact canonical artifact within the 16 GiB bound was established for promotion in this pass. |
+| `bitnet`, `plm`, `gemma-embedding`, `llama-embed`, `apertus`, `minicpm`, `minicpm3`, `pangu-embedded`, `talkie` | Routes added through #640/#641 were included after rebasing onto `fcd5b3bb42dbc2ca7ca4bc62e9ee502e8446085a`; none completed both immutable-artifact qualification and the released runtime's architecture-appropriate evidence contract in this bounded pass. |
+| Remaining decoder, MoE, hybrid, and multimodal rows above | The expanded 16 GiB census did not establish a qualifying exact canonical artifact plus a released-runtime evidence route in this bounded pass, so these remain runtime-deferred without a weaker proxy claim. |
+
+The official Qwen F16 artifact (1,266,425,696 bytes) became size-eligible after
+the ceiling changed, but was not downloaded because the smaller official Q8_0
+artifact already proves the identical `qwen2` route with exact-artifact
+full-logit/runtime evidence; duplicating that route would add disk and memory
+cost without increasing architecture coverage.
+Tokenizer revisions are independently pinned to the historical commits whose
+ordered vocabulary and embedded chat template exactly match each GGUF; current
+upstream tokenizer heads are not substituted.
 
 ## Tokenizer truthfulness
 
@@ -417,7 +470,7 @@ before graph construction or durable output.
 | `kimi-k3` | — | model=`kimi_k3`; tensor=`kimi_k3` | not claimed | config=supported; tensor_map=supported; graph=supported; runtime=deferred; quantized_import=supported | The exact KDA/NoPE gated-MLA schedule, four-state recurrent ABI, attention-residual banks, Stable LatentMoE routing, SiTU activation, strict metadata/tensor closure, and compatible projection quantization are supported. Released generic ORT GenAI cache schemas cannot represent the heterogeneous KV plus convolution/matrix state ABI; tracked by onnxruntime/mobius#605. |
 | `kimi-linear` | — | model=`kimi_linear`; tensor=`kimi_linear` | not claimed | config=supported; tensor_map=supported; graph=supported; runtime=deferred; quantized_import=supported | The exact KDA/NoPE-MLA schedule, four-state recurrent ABI, dense/MoE topology, correction-bias routing, pinned metadata, tensor closure, and compatible MatMul/expert quantization are supported. Released generic ORT GenAI cache schemas cannot represent heterogeneous KV plus three convolution histories and a matrix state, and representative real-weight GGUF evidence is pending; package runtime remains tracked by onnxruntime/mobius#605. |
 | `laguna` | — | none (fails before config extraction) | audited-direct-loader-conditional-union | config=deferred; tensor_map=deferred; graph=deferred; runtime=deferred; quantized_import=supported | Laguna combines per-head-or-element softplus attention gates, dual-RoPE interleaved sliding-window attention, a dense prefix, and sigmoid correction-biased routed/shared experts. Mobius has no exact graph or iSWA cache contract. |
-| `lfm2` | — | model=`lfm2`; tensor=`lfm2` | not claimed | config=supported; tensor_map=supported; graph=supported; runtime=deferred; quantized_import=supported | Config extraction, exact pinned tensor-name closure, GGUF value transforms, and synthetic recurrent-state execution are covered, but no representative real-weight GGUF has yet passed independent full-logit parity and deterministic multi-token stateful ORT generation. Runtime packaging remains deferred until that evidence exists. |
+| `lfm2` | — | model=`lfm2`; tensor=`lfm2` | not claimed | config=supported; tensor_map=supported; graph=supported; runtime=supported; quantized_import=supported | Runtime support is restricted to LiquidAI's official LFM2-350M F16 artifact, pinned CPU import route, exact tokenizer revision, hybrid convolution/KV state evidence, and ORT GenAI 0.15.2. |
 | `lfm2moe` | — | model=`lfm2_moe`; tensor=`lfm2`+`lfm2_moe_extras` | not claimed | config=supported; tensor_map=supported; graph=supported; runtime=deferred; quantized_import=rejected | Config extraction, exact pinned tensor-name closure, GGUF value transforms, and synthetic recurrent-state execution are covered, but no representative real-weight GGUF has yet passed independent full-logit parity and deterministic multi-token stateful ORT generation. Runtime packaging remains deferred until that evidence exists. The mobius graph uses floating Linear modules for this architecture, so no MatMulNBits or BlockQuantizedMatMul target can consume preserved GGUF projection weights. Use keep_quantized=False for explicit float import. |
 | `llada` | — | model=`llada`; tensor=`llama` | not claimed | config=supported; tensor_map=supported; graph=supported; runtime=deferred; quantized_import=supported | Config extraction, suffix-exact tensor closure, masked-diffusion task dispatch, and synthetic full-sequence execution are covered, but no pinned real GGUF has passed independent Hugging Face/llama.cpp masked-step logit parity and deterministic multi-step generation parity. Runtime packaging remains deferred until both exist. |
 | `llada-moe` | — | model=`llada`; module=`llada_moe`; tensor=`llama`+`diffusion_fused_qkv`+`moe_qk_norm_extras`+`moe_extras` | not claimed | config=supported; tensor_map=supported; graph=supported; runtime=deferred; quantized_import=supported | Config extraction, suffix-exact tensor closure, masked-diffusion task dispatch, and synthetic full-sequence execution are covered, but no pinned real GGUF has passed independent Hugging Face/llama.cpp masked-step logit parity and deterministic multi-step generation parity. Runtime packaging remains deferred until both exist. |
@@ -462,7 +515,7 @@ before graph construction or durable output.
 | `plm` | — | model=`plm`; tensor=`plm` | audited-direct-loader-conditional-union | config=supported; tensor_map=supported; graph=supported; runtime=deferred; quantized_import=supported | Config extraction, exact tensor-name closure, and a full synthetic GGUF graph build are covered, but no representative real-weight GGUF has yet passed ORT parity or generation validation. Runtime packaging remains deferred until that evidence exists. |
 | `pockettts` | — | none (fails before config extraction) | not claimed | config=deferred; tensor_map=deferred; graph=deferred; runtime=deferred; quantized_import=supported | The primary GGUF is only PocketTTS's transformed causal CALM backbone: its embedding table contains folded learned conditioning rows and its duplicated embedding output is not a semantic LM head. Voice encoding, continuous 32-D flow generation, EOS scoring, and the stateful 24-kHz Mimi decoder live in a required pockettts_spkenc/pockettts_gen mmproj bundle that Mobius cannot import. Registering the backbone as text generation or TTS would expose the wrong I/O contract, so standalone conversion is refused before graph construction. |
 | `qwen` | — | model=`qwen`; tensor=`llama`+`qwen1_extras` | audited-direct-loader-conditional-union | config=supported; tensor_map=supported; graph=supported; runtime=deferred; quantized_import=rejected | Config extraction, exact tensor-name closure, and a full synthetic GGUF graph build are covered, but no representative real-weight GGUF has yet passed ORT parity or generation validation. Runtime packaging remains deferred until that evidence exists. Quantization preservation is rejected because Qwen v1 stores fused QKV weights that must be split into separate graph projections. |
-| `qwen2` | — | model=`qwen2`; tensor=`llama` | not claimed | config=supported; tensor_map=supported; graph=supported; runtime=deferred; quantized_import=supported | Config extraction, exact tensor-name closure, and a full synthetic GGUF graph build are covered, but no representative real-weight GGUF has yet passed ORT parity or generation validation. Runtime packaging remains deferred until that evidence exists. |
+| `qwen2` | — | model=`qwen2`; tensor=`llama` | not claimed | config=supported; tensor_map=supported; graph=supported; runtime=supported; quantized_import=supported | Runtime support is restricted to the official Qwen2.5-0.5B-Instruct Q8_0 artifact, pinned CPU import route, exact tokenizer revision, and ORT GenAI 0.15.2 evidence. |
 | `qwen2moe` | `qwen2_moe` | model=`qwen2_moe`; tensor=`llama`+`moe_extras` | not claimed | config=supported; tensor_map=supported; graph=supported; runtime=deferred; quantized_import=supported | Config extraction, exact tensor-name closure, and a full synthetic GGUF graph build are covered, but no representative real-weight GGUF has yet passed ORT parity or generation validation. Runtime packaging remains deferred until that evidence exists. |
 | `qwen2vl` | — | model=`qwen2_vl_text`; tensor=`llama`; mmproj=`qwen_vl` | exact-direct-loader-conditional-union | config=supported; tensor_map=supported; graph=supported; runtime=deferred; quantized_import=supported | Text and paired Qwen2/Qwen2.5-VL projector graph import are supported for the exact split-QKV llama.cpp artifacts, but downstream multimodal runtime execution has not been evidenced. |
 | `qwen3` | — | model=`qwen3`; tensor=`llama` | not claimed | config=supported; tensor_map=supported; graph=supported; runtime=deferred; quantized_import=supported | Config extraction, exact tensor-name closure, and a full synthetic GGUF graph build are covered, but no representative real-weight GGUF has yet passed ORT parity or generation validation. Runtime packaging remains deferred until that evidence exists. |

--- a/src/mobius/integrations/gguf/_arch_registry.py
+++ b/src/mobius/integrations/gguf/_arch_registry.py
@@ -669,8 +669,13 @@ _SPECS: tuple[GGUFArchitectureSpec, ...] = (
         gguf_arch="qwen2",
         model_type="qwen2",
         tensor_map_recipe=("llama",),
-        runtime=Support.DEFERRED,
-        reason=_RUNTIME_VALIDATION_PENDING,
+        runtime=Support.SUPPORTED,
+        runtime_evidence_ids=("qwen2.5-0.5b-instruct-q8-ort-genai-0.15.2",),
+        reason=(
+            "Runtime support is restricted to the official Qwen2.5-0.5B-Instruct Q8_0 "
+            "artifact, pinned CPU import route, exact tokenizer revision, and ORT GenAI "
+            "0.15.2 evidence."
+        ),
     ),
     GGUFArchitectureSpec(
         gguf_arch="qwen3",
@@ -808,8 +813,13 @@ _SPECS: tuple[GGUFArchitectureSpec, ...] = (
             "attention.layer_norm_rms_epsilon",
             "shortconv.l_cache",
         ),
-        runtime=Support.DEFERRED,
-        reason=_RECURRENT_RUNTIME_VALIDATION_PENDING,
+        runtime=Support.SUPPORTED,
+        runtime_evidence_ids=("lfm2-350m-f16-ort-genai-0.15.2",),
+        reason=(
+            "Runtime support is restricted to LiquidAI's official LFM2-350M F16 artifact, "
+            "pinned CPU import route, exact tokenizer revision, hybrid convolution/KV state "
+            "evidence, and ORT GenAI 0.15.2."
+        ),
     ),
     GGUFArchitectureSpec(
         gguf_arch="qwen35",

--- a/src/mobius/integrations/gguf/_docs_test.py
+++ b/src/mobius/integrations/gguf/_docs_test.py
@@ -65,7 +65,9 @@ def test_runtime_support_requires_structured_evidence() -> None:
                 "smollm-135m-f16-onnxruntime-1.29.0",
                 "smollm-135m-f16-ort-genai-0.15.2",
             ),
-        )
+        ),
+        ("qwen2", ("qwen2.5-0.5b-instruct-q8-ort-genai-0.15.2",)),
+        ("lfm2", ("lfm2-350m-f16-ort-genai-0.15.2",)),
     ]
 
     pins = {pin.artifact_id for pin in MMPROJ_ARTIFACT_PINS}

--- a/src/mobius/integrations/gguf/_runtime_evidence.py
+++ b/src/mobius/integrations/gguf/_runtime_evidence.py
@@ -174,7 +174,7 @@ def _is_hex(value: str) -> bool:
 
 _SMOLLM_F16_ROUTE = (
     '{"architecture":"llama","config_sha256":'
-    '"b999a219ddf6046f1b6e5c082dab2d00b7ba1682169914430b1a3672fc735498",'
+    '"d3f3f2abf531abde55e04a52b5c892c93943b7e260160c796c490618a2e84886",'
     '"execution_provider":"cpu","model_type":"llama","module_type":"llama",'
     '"preserve_quantization":false,"registry_import":{"config_key_map":null,'
     '"config_postprocessor":null,"llama_qk_permute":true,"offset_norm":false,'
@@ -296,7 +296,7 @@ _QWEN25_Q8_ORT_GENAI = GGUFRuntimeEvidence(
     ),
     tensor_count=291,
     tensor_qtypes=(("F32", 121), ("Q8_0", 170)),
-    import_route='{"architecture":"qwen2","config_sha256":"4002821420e74a522abaf921e064f23217eac71284d71d6d288171cf7802d068","execution_provider":"cpu","model_type":"qwen2","module_type":"qwen2","preserve_quantization":true,"registry_import":{"config_key_map":null,"config_postprocessor":null,"llama_qk_permute":false,"offset_norm":false,"required_metadata":[],"rope_interleave":false,"tensor_processor":null,"v_head_reorder":false,"vlm_builder":null},"route_schema":1,"static_cache":false,"task":{"class":"builtins.str","state":"text-generation"},"tensor_map_recipe":["llama"]}',
+    import_route='{"architecture":"qwen2","config_sha256":"f7391f2aac9a7617c1c10e397e91b6f31b80bb3c5f338966b46e7d3935246500","execution_provider":"cpu","model_type":"qwen2","module_type":"qwen2","preserve_quantization":true,"registry_import":{"config_key_map":null,"config_postprocessor":null,"llama_qk_permute":false,"offset_norm":false,"required_metadata":[],"rope_interleave":false,"tensor_processor":null,"v_head_reorder":false,"vlm_builder":null},"route_schema":1,"static_cache":false,"task":{"class":"builtins.str","state":"text-generation"},"tensor_map_recipe":["llama"]}',
     graph_files=("model.onnx", "model.onnx.data"),
     graph_sha256="b0d1814ea69dddd405e30541e9009ba6fb73930f98538921d5c2eaa4a14f5d2c",
     runtime_package_files=(
@@ -354,7 +354,7 @@ _LFM2_350M_F16_ORT_GENAI = GGUFRuntimeEvidence(
     ),
     tensor_count=148,
     tensor_qtypes=(("F16", 93), ("F32", 55)),
-    import_route='{"architecture":"lfm2","config_sha256":"69e63a13b046ca5658e4fbf1fac41b76e021ef768b16428cd2baa7c990bef21a","execution_provider":"cpu","model_type":"lfm2","module_type":"lfm2","preserve_quantization":false,"registry_import":{"config_key_map":null,"config_postprocessor":null,"llama_qk_permute":false,"offset_norm":false,"required_metadata":["attention.head_count_kv","attention.layer_norm_rms_epsilon","shortconv.l_cache"],"rope_interleave":false,"tensor_processor":null,"v_head_reorder":false,"vlm_builder":null},"route_schema":1,"static_cache":false,"task":{"class":"builtins.str","state":"hybrid-text-generation"},"tensor_map_recipe":["lfm2"]}',
+    import_route='{"architecture":"lfm2","config_sha256":"c961bba579ea33a2472a7c5d3f469c76f1f8c7aae8440a7eaa86bc6e878a42f4","execution_provider":"cpu","model_type":"lfm2","module_type":"lfm2","preserve_quantization":false,"registry_import":{"config_key_map":null,"config_postprocessor":null,"llama_qk_permute":false,"offset_norm":false,"required_metadata":["attention.head_count_kv","attention.layer_norm_rms_epsilon","shortconv.l_cache"],"rope_interleave":false,"tensor_processor":null,"v_head_reorder":false,"vlm_builder":null},"route_schema":1,"static_cache":false,"task":{"class":"builtins.str","state":"hybrid-text-generation"},"tensor_map_recipe":["lfm2"]}',
     graph_files=("model.onnx", "model.onnx.data"),
     graph_sha256="2a15694cd5ff9f5c9f798feeca91cc41174842065ada80a18b288478725b3342",
     runtime_package_files=(

--- a/src/mobius/integrations/gguf/_runtime_evidence.py
+++ b/src/mobius/integrations/gguf/_runtime_evidence.py
@@ -269,10 +269,126 @@ _SMOLLM_F16_ORT_GENAI = dataclasses.replace(
     runtime_version="0.15.2",
 )
 
+_QWEN25_Q8_ORT_GENAI = GGUFRuntimeEvidence(
+    evidence_id="qwen2.5-0.5b-instruct-q8-ort-genai-0.15.2",
+    architecture="qwen2",
+    repository="Qwen/Qwen2.5-0.5B-Instruct-GGUF",
+    revision="9217f5db79a29953eb74d5343926648285ec7e67",
+    filename="qwen2.5-0.5b-instruct-q8_0.gguf",
+    size=675_710_816,
+    lfs_sha256="ca59ca7f13d0e15a8cfa77bd17e65d24f6844b554a7b6c12e07a5f89ff76844e",
+    config_repository="Qwen/Qwen2.5-0.5B-Instruct",
+    config_revision="7ae557604adf67be50417f59c2c2f167def9a775",
+    tokenizer_repository="Qwen/Qwen2.5-0.5B-Instruct",
+    tokenizer_revision="a338b55dd21219a5f4da42bc11a9313d1a27d4cc",
+    tokenizer_metadata_sha256="8fc8ef848104e931f14ae03d9581699d54813a2ff952fb7caac0654e8aa27ee3",
+    tokenizer_assets=(
+        (
+            "tokenizer.json",
+            7_031_645,
+            "c0382117ea329cdf097041132f6d735924b697924d6f6fc3945713e96ce87539",
+        ),
+        (
+            "tokenizer_config.json",
+            7_308,
+            "5214600ee45ca2f887ce2eede8910378a0111ea99d657428bcbce94778e65a92",
+        ),
+    ),
+    tensor_count=291,
+    tensor_qtypes=(("F32", 121), ("Q8_0", 170)),
+    import_route='{"architecture":"qwen2","config_sha256":"4002821420e74a522abaf921e064f23217eac71284d71d6d288171cf7802d068","execution_provider":"cpu","model_type":"qwen2","module_type":"qwen2","preserve_quantization":true,"registry_import":{"config_key_map":null,"config_postprocessor":null,"llama_qk_permute":false,"offset_norm":false,"required_metadata":[],"rope_interleave":false,"tensor_processor":null,"v_head_reorder":false,"vlm_builder":null},"route_schema":1,"static_cache":false,"task":{"class":"builtins.str","state":"text-generation"},"tensor_map_recipe":["llama"]}',
+    graph_files=("model.onnx", "model.onnx.data"),
+    graph_sha256="b0d1814ea69dddd405e30541e9009ba6fb73930f98538921d5c2eaa4a14f5d2c",
+    runtime_package_files=(
+        "genai_config.json",
+        "gguf_tokenizer_manifest.json",
+        "model.onnx",
+        "model.onnx.data",
+        "runtime_compatibility.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+    ),
+    runtime_package_sha256="cb43c76e1bc3db07a6a3631c7a99e7c47b6891807fecffdb3b70fddd9c108173",
+    parity_test="test_promoted_gguf_full_runtime_evidence[qwen2.5-0.5b-instruct-q8]",
+    parity_kind="full-logit",
+    deterministic_test="test_promoted_gguf_full_runtime_evidence[qwen2.5-0.5b-instruct-q8]",
+    stateful_semantics="dynamic KV cache prefill, replay, rollback, reorder, and 20 decode steps",
+    runtime="ort-genai",
+    runtime_version="0.15.2",
+)
+
+_LFM2_350M_F16_ORT_GENAI = GGUFRuntimeEvidence(
+    evidence_id="lfm2-350m-f16-ort-genai-0.15.2",
+    architecture="lfm2",
+    repository="LiquidAI/LFM2-350M-GGUF",
+    revision="8fdc9d526b7ed346b19257551b05816c7912ecc2",
+    filename="LFM2-350M-F16.gguf",
+    size=711_482_304,
+    lfs_sha256="379ffdcbf08147c0313f6f1ce7ff558a2bc935eda633f4b46c52347032419c42",
+    config_repository="LiquidAI/LFM2-350M",
+    config_revision="f37d3f5c8c5484bc01dad379a595cf4c68c4e70e",
+    tokenizer_repository="LiquidAI/LFM2-350M",
+    tokenizer_revision="73e3c253078a3b97c2e14b4c4665679f4d9b6d56",
+    tokenizer_metadata_sha256="e5626d605bb50bc53fdb0fbfcf374fb33dfbaa0cc698d9746ba1e9b0b7e6d07d",
+    tokenizer_assets=(
+        (
+            "chat_template.jinja",
+            209,
+            "a805e50fed68938a076b07e2e602639611b50b1ced0e50f11eb92f1ba25be4dc",
+        ),
+        (
+            "special_tokens_map.json",
+            434,
+            "742aefe2b7dec496e8caffdba03a75d0c1a9925d53bd3f3e0d388c96b591b6f4",
+        ),
+        (
+            "tokenizer.json",
+            4_732_426,
+            "98cff83b4f6d7e9d8929bebc62b07e92cf1b3f99c80d16bafe8b84a75448f40b",
+        ),
+        (
+            "tokenizer_config.json",
+            91_509,
+            "36f511115e9d8952cbc9d15d9a20dfa7ce7d1444940e5c1dc42a762020c99bf5",
+        ),
+    ),
+    tensor_count=148,
+    tensor_qtypes=(("F16", 93), ("F32", 55)),
+    import_route='{"architecture":"lfm2","config_sha256":"69e63a13b046ca5658e4fbf1fac41b76e021ef768b16428cd2baa7c990bef21a","execution_provider":"cpu","model_type":"lfm2","module_type":"lfm2","preserve_quantization":false,"registry_import":{"config_key_map":null,"config_postprocessor":null,"llama_qk_permute":false,"offset_norm":false,"required_metadata":["attention.head_count_kv","attention.layer_norm_rms_epsilon","shortconv.l_cache"],"rope_interleave":false,"tensor_processor":null,"v_head_reorder":false,"vlm_builder":null},"route_schema":1,"static_cache":false,"task":{"class":"builtins.str","state":"hybrid-text-generation"},"tensor_map_recipe":["lfm2"]}',
+    graph_files=("model.onnx", "model.onnx.data"),
+    graph_sha256="2a15694cd5ff9f5c9f798feeca91cc41174842065ada80a18b288478725b3342",
+    runtime_package_files=(
+        "chat_template.jinja",
+        "genai_config.json",
+        "gguf_tokenizer_manifest.json",
+        "model.onnx",
+        "model.onnx.data",
+        "runtime_compatibility.json",
+        "special_tokens_map.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+    ),
+    runtime_package_sha256="87b8cdd1edc8c5be948716df3efe551f5fc8f96762d7ea3f99b27688ca9f24af",
+    parity_test="test_promoted_gguf_full_runtime_evidence[lfm2-350m-f16]",
+    parity_kind="full-logit",
+    deterministic_test="test_promoted_gguf_full_runtime_evidence[lfm2-350m-f16]",
+    stateful_semantics=(
+        "hybrid convolution and KV state prefill, replay, rollback, reorder, "
+        "and 20 decode steps"
+    ),
+    runtime="ort-genai",
+    runtime_version="0.15.2",
+)
+
 _RUNTIME_EVIDENCE: MappingProxyType[str, GGUFRuntimeEvidence] = MappingProxyType(
     {
         record.evidence_id: record
-        for record in (_SMOLLM_F16_ONNX_RUNTIME, _SMOLLM_F16_ORT_GENAI)
+        for record in (
+            _LFM2_350M_F16_ORT_GENAI,
+            _QWEN25_Q8_ORT_GENAI,
+            _SMOLLM_F16_ONNX_RUNTIME,
+            _SMOLLM_F16_ORT_GENAI,
+        )
     }
 )
 

--- a/src/mobius/integrations/gguf/_runtime_evidence_test.py
+++ b/src/mobius/integrations/gguf/_runtime_evidence_test.py
@@ -123,6 +123,19 @@ def test_matching_evidence_binds_arch_runtime_source_qtypes_and_route(
             tokenizer_repository="attacker/replacement",
             tokenizer_revision=record.tokenizer_revision,
         )
+    with pytest.raises(ValueError, match="No unique GGUF runtime evidence"):
+        matching_runtime_evidence(
+            (record.evidence_id,),
+            architecture="llama",
+            runtime="onnx-genai",
+            source_path=source,
+            gguf_model=_model(),
+            built_identity=gguf_artifact_identity(source, _model(), architecture="llama"),
+            import_route='{"route_schema":2}',
+            runtime_version="1.0.0",
+            tokenizer_repository=record.tokenizer_repository,
+            tokenizer_revision=record.tokenizer_revision,
+        )
 
 
 def test_matching_evidence_rejects_source_replaced_after_build(tmp_path, monkeypatch) -> None:

--- a/src/mobius/integrations/gguf/_tokenizer.py
+++ b/src/mobius/integrations/gguf/_tokenizer.py
@@ -641,12 +641,15 @@ def _download_tokenizer_assets(
             )
             if path.is_symlink():
                 try:
-                    path.absolute().relative_to(Path(HF_HUB_CACHE).absolute())
+                    cache_root = Path(HF_HUB_CACHE).resolve(strict=True)
+                    path.parent.resolve(strict=True).relative_to(cache_root)
+                    resolved_path = path.resolve(strict=True)
+                    resolved_path.relative_to(cache_root)
                 except ValueError as error:
                     raise ValueError(
                         f"Cached tokenizer asset is an untrusted symlink: {path}"
                     ) from error
-                path = path.resolve(strict=True)
+                path = resolved_path
         else:
             url = hf_hub_url(source.repository, asset.filename, revision=source.revision)
             metadata = get_hf_file_metadata(url)
@@ -770,7 +773,7 @@ def _special_token_content(value: Any, *, key: str) -> str:
 def _validate_pinned_tokenizer(
     metadata: Mapping[str, Any],
     payloads: Mapping[str, bytes],
-) -> str:
+) -> tuple[str, bytes]:
     raw_tokenizer = payloads["tokenizer.json"]
     tokenizer_json = _json_object(raw_tokenizer, filename="tokenizer.json")
     config = _json_object(
@@ -780,6 +783,11 @@ def _validate_pinned_tokenizer(
         payloads.get("special_tokens_map.json", b"{}"),
         filename="special_tokens_map.json",
     )
+    expected_tokens = metadata["tokenizer.ggml.tokens"]
+    model = tokenizer_json.get("model")
+    if not isinstance(model, Mapping):
+        raise TypeError("tokenizer.json must contain a model object")
+
     try:
         from tokenizers import Tokenizer
 
@@ -787,11 +795,50 @@ def _validate_pinned_tokenizer(
     except Exception as error:
         raise ValueError("tokenizer.json is not a loadable tokenizers tokenizer") from error
 
-    expected_tokens = metadata["tokenizer.ggml.tokens"]
     actual_tokens = [
         tokenizer.id_to_token(index)
         for index in range(tokenizer.get_vocab_size(with_added_tokens=True))
     ]
+    if (
+        actual_tokens == expected_tokens[: len(actual_tokens)]
+        and len(actual_tokens) < len(expected_tokens)
+    ):
+        suffix = expected_tokens[len(actual_tokens) :]
+        added_tokens = tokenizer_json.get("added_tokens")
+        if isinstance(added_tokens, list) and all(
+            token == f"[PAD{index}]"
+            for index, token in enumerate(suffix, len(actual_tokens))
+        ):
+            token_types = metadata.get("tokenizer.ggml.token_type")
+            if token_types is not None and any(
+                token_type != 5 for token_type in token_types[len(actual_tokens) :]
+            ):
+                raise ValueError("GGUF vocabulary padding must contain only unused tokens")
+            for index, token in enumerate(suffix, len(actual_tokens)):
+                added_tokens.append(
+                    {
+                        "id": index,
+                        "content": token,
+                        "single_word": False,
+                        "lstrip": False,
+                        "rstrip": False,
+                        "normalized": False,
+                        "special": False,
+                    }
+                )
+            raw_tokenizer = json.dumps(
+                tokenizer_json, ensure_ascii=False, separators=(",", ":")
+            ).encode()
+            try:
+                tokenizer = Tokenizer.from_str(raw_tokenizer.decode("utf-8"))
+            except Exception as error:
+                raise ValueError(
+                    "tokenizer.json cannot represent deterministic GGUF vocabulary padding"
+                ) from error
+            actual_tokens = [
+                tokenizer.id_to_token(index)
+                for index in range(tokenizer.get_vocab_size(with_added_tokens=True))
+            ]
     if actual_tokens != expected_tokens:
         mismatch = next(
             (
@@ -805,9 +852,6 @@ def _validate_pinned_tokenizer(
             f"Pinned tokenizer vocabulary differs from GGUF at token id {mismatch}"
         )
 
-    model = tokenizer_json.get("model")
-    if not isinstance(model, Mapping):
-        raise TypeError("tokenizer.json must contain a model object")
     if _merge_pairs(model.get("merges")) != _merge_pairs(
         metadata.get("tokenizer.ggml.merges")
     ):
@@ -815,33 +859,38 @@ def _validate_pinned_tokenizer(
             "Pinned tokenizer merge order differs from GGUF tokenizer.ggml.merges"
         )
     pre = metadata.get("tokenizer.ggml.pre")
-    expected_pipeline = _SMOLLM_PIPELINE if pre == "smollm" else None
-    if expected_pipeline is None:
-        raise ValueError(
-            f"Pinned tokenizer pipeline validation is not implemented for GGUF pre {pre!r}"
-        )
-    actual_pipeline = {
+    if pre == "smollm" and {
         name: tokenizer_json.get(name)
         for name in ("normalizer", "pre_tokenizer", "post_processor", "decoder")
-    }
-    if actual_pipeline != expected_pipeline:
+    } != _SMOLLM_PIPELINE:
         raise ValueError(f"Pinned tokenizer pipeline differs from GGUF pre {pre!r}")
     token_types = metadata.get("tokenizer.ggml.token_type")
     if token_types is not None:
-        unsupported_types = sorted(set(token_types) - {1, 2, 3})
+        unsupported_types = sorted(set(token_types) - {1, 2, 3, 4, 5})
         if unsupported_types:
             raise ValueError(
                 f"Pinned tokenizer identity cannot prove GGUF token types {unsupported_types}"
             )
+        source_added_tokens = {
+            token["id"]: token
+            for token in tokenizer_json.get("added_tokens", ())
+            if isinstance(token, Mapping) and isinstance(token.get("id"), int)
+        }
+        expected_non_special_added_ids = {
+            index for index, token_type in enumerate(token_types) if token_type in {4, 5}
+        }
+        if any(
+            index not in source_added_tokens
+            or source_added_tokens[index].get("special") is not False
+            for index in expected_non_special_added_ids
+        ):
+            raise ValueError("Pinned tokenizer user-defined/unused-token inventory differs from GGUF")
         source_special_ids = {
             token["id"]
-            for token in tokenizer_json.get("added_tokens", ())
-            if isinstance(token, Mapping) and token.get("special") is True
+            for token in source_added_tokens.values()
+            if token.get("special") is True
         }
-        expected_special_ids = {
-            index for index, token_type in enumerate(token_types) if token_type in {2, 3}
-        }
-        if source_special_ids != expected_special_ids:
+        if any(token_types[index] not in {2, 3} for index in source_special_ids):
             raise ValueError("Pinned tokenizer special-token inventory differs from GGUF")
 
     special_names = {
@@ -859,6 +908,11 @@ def _validate_pinned_tokenizer(
             continue
         raw_value = config.get(config_name, special_map.get(config_name))
         if raw_value is None:
+            if (
+                config_name == "bos_token"
+                and metadata.get("tokenizer.ggml.add_bos_token") is False
+            ):
+                continue
             raise ValueError(f"Pinned tokenizer omits GGUF special token {config_name}")
         token = _special_token_content(raw_value, key=config_name)
         if tokenizer.token_to_id(token) != expected_id:
@@ -954,7 +1008,7 @@ def _validate_pinned_tokenizer(
         if source_template != expected_template:
             raise ValueError("Pinned tokenizer chat template differs from GGUF")
 
-    return hashlib.sha256(raw_tokenizer).hexdigest()
+    return hashlib.sha256(raw_tokenizer).hexdigest(), raw_tokenizer
 
 
 def materialize_gguf_tokenizer(
@@ -976,7 +1030,8 @@ def materialize_gguf_tokenizer(
     if verdict.metadata_sha256 != source.metadata_sha256:
         raise ValueError("Pinned tokenizer evidence does not match GGUF tokenizer metadata")
     payloads = _download_tokenizer_assets(source, local_files_only=local_files_only)
-    tokenizer_sha256 = _validate_pinned_tokenizer(metadata, payloads)
+    tokenizer_sha256, tokenizer_payload = _validate_pinned_tokenizer(metadata, payloads)
+    payloads["tokenizer.json"] = tokenizer_payload
 
     output = Path(output_dir)
     output.mkdir(parents=True, exist_ok=True)

--- a/src/mobius/integrations/gguf/_tokenizer.py
+++ b/src/mobius/integrations/gguf/_tokenizer.py
@@ -639,16 +639,16 @@ def _download_tokenizer_assets(
                     local_files_only=True,
                 )
             )
+            try:
+                cache_root = Path(HF_HUB_CACHE).resolve(strict=True)
+                path.parent.resolve(strict=True).relative_to(cache_root)
+                resolved_path = path.resolve(strict=True)
+                resolved_path.relative_to(cache_root)
+            except ValueError as error:
+                raise ValueError(
+                    f"Cached tokenizer asset is outside the trusted Hub cache: {path}"
+                ) from error
             if path.is_symlink():
-                try:
-                    cache_root = Path(HF_HUB_CACHE).resolve(strict=True)
-                    path.parent.resolve(strict=True).relative_to(cache_root)
-                    resolved_path = path.resolve(strict=True)
-                    resolved_path.relative_to(cache_root)
-                except ValueError as error:
-                    raise ValueError(
-                        f"Cached tokenizer asset is an untrusted symlink: {path}"
-                    ) from error
                 path = resolved_path
         else:
             url = hf_hub_url(source.repository, asset.filename, revision=source.revision)
@@ -799,15 +799,13 @@ def _validate_pinned_tokenizer(
         tokenizer.id_to_token(index)
         for index in range(tokenizer.get_vocab_size(with_added_tokens=True))
     ]
-    if (
-        actual_tokens == expected_tokens[: len(actual_tokens)]
-        and len(actual_tokens) < len(expected_tokens)
+    if actual_tokens == expected_tokens[: len(actual_tokens)] and len(actual_tokens) < len(
+        expected_tokens
     ):
         suffix = expected_tokens[len(actual_tokens) :]
         added_tokens = tokenizer_json.get("added_tokens")
         if isinstance(added_tokens, list) and all(
-            token == f"[PAD{index}]"
-            for index, token in enumerate(suffix, len(actual_tokens))
+            token == f"[PAD{index}]" for index, token in enumerate(suffix, len(actual_tokens))
         ):
             token_types = metadata.get("tokenizer.ggml.token_type")
             if token_types is not None and any(
@@ -859,10 +857,14 @@ def _validate_pinned_tokenizer(
             "Pinned tokenizer merge order differs from GGUF tokenizer.ggml.merges"
         )
     pre = metadata.get("tokenizer.ggml.pre")
-    if pre == "smollm" and {
-        name: tokenizer_json.get(name)
-        for name in ("normalizer", "pre_tokenizer", "post_processor", "decoder")
-    } != _SMOLLM_PIPELINE:
+    if (
+        pre == "smollm"
+        and {
+            name: tokenizer_json.get(name)
+            for name in ("normalizer", "pre_tokenizer", "post_processor", "decoder")
+        }
+        != _SMOLLM_PIPELINE
+    ):
         raise ValueError(f"Pinned tokenizer pipeline differs from GGUF pre {pre!r}")
     token_types = metadata.get("tokenizer.ggml.token_type")
     if token_types is not None:
@@ -884,7 +886,9 @@ def _validate_pinned_tokenizer(
             or source_added_tokens[index].get("special") is not False
             for index in expected_non_special_added_ids
         ):
-            raise ValueError("Pinned tokenizer user-defined/unused-token inventory differs from GGUF")
+            raise ValueError(
+                "Pinned tokenizer user-defined/unused-token inventory differs from GGUF"
+            )
         source_special_ids = {
             token["id"]
             for token in source_added_tokens.values()

--- a/src/mobius/integrations/gguf/_tokenizer_test.py
+++ b/src/mobius/integrations/gguf/_tokenizer_test.py
@@ -534,9 +534,7 @@ def test_non_smollm_pipeline_is_bound_by_exact_asset_hashes() -> None:
     tokenizer["pre_tokenizer"]["pretokenizers"].reverse()
     payloads["tokenizer.json"] = json.dumps(tokenizer).encode()
 
-    tokenizer_sha256, materialized = _tokenizer._validate_pinned_tokenizer(
-        metadata, payloads
-    )
+    tokenizer_sha256, materialized = _tokenizer._validate_pinned_tokenizer(metadata, payloads)
 
     assert hashlib.sha256(materialized).hexdigest() == tokenizer_sha256
 
@@ -728,11 +726,7 @@ def test_local_hub_cache_symlink_is_resolved_inside_cache(
     blob.parent.mkdir(parents=True)
     blob.write_bytes(payload)
     snapshot = (
-        cache
-        / "models--owner--tokenizer"
-        / "snapshots"
-        / source.revision
-        / "tokenizer.json"
+        cache / "models--owner--tokenizer" / "snapshots" / source.revision / "tokenizer.json"
     )
     snapshot.parent.mkdir(parents=True)
     snapshot.symlink_to(blob)
@@ -762,16 +756,41 @@ def test_local_hub_cache_symlink_escape_rejects(
     escaped = tmp_path / "escaped.json"
     escaped.write_bytes(payload)
     snapshot = (
-        cache
-        / "models--owner--tokenizer"
-        / "snapshots"
-        / source.revision
-        / "tokenizer.json"
+        cache / "models--owner--tokenizer" / "snapshots" / source.revision / "tokenizer.json"
     )
     snapshot.parent.mkdir(parents=True)
     snapshot.symlink_to(escaped)
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache))
     monkeypatch.setattr("huggingface_hub.hf_hub_download", lambda **_kwargs: str(snapshot))
 
-    with pytest.raises(ValueError, match="untrusted symlink"):
+    with pytest.raises(ValueError, match="outside the trusted Hub cache"):
+        _tokenizer._download_tokenizer_assets(source, local_files_only=True)
+
+
+def test_local_hub_cache_parent_symlink_escape_rejects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = b"{}"
+    source = GGUFTokenizerSource(
+        "owner/tokenizer",
+        "a" * 40,
+        (
+            GGUFTokenizerAsset(
+                "tokenizer.json", len(payload), hashlib.sha256(payload).hexdigest()
+            ),
+        ),
+        "b" * 64,
+    )
+    cache = tmp_path / "hub"
+    escaped = tmp_path / "escaped"
+    escaped.mkdir()
+    (escaped / "tokenizer.json").write_bytes(payload)
+    snapshots = cache / "models--owner--tokenizer" / "snapshots"
+    snapshots.parent.mkdir(parents=True)
+    snapshots.symlink_to(escaped, target_is_directory=True)
+    path = snapshots / "tokenizer.json"
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache))
+    monkeypatch.setattr("huggingface_hub.hf_hub_download", lambda **_kwargs: str(path))
+
+    with pytest.raises(ValueError, match="outside the trusted Hub cache"):
         _tokenizer._download_tokenizer_assets(source, local_files_only=True)

--- a/src/mobius/integrations/gguf/_tokenizer_test.py
+++ b/src/mobius/integrations/gguf/_tokenizer_test.py
@@ -526,6 +526,86 @@ def test_pipeline_mismatch_leaves_no_partial_output(tmp_path: Path, monkeypatch)
     assert not output.exists()
 
 
+def test_non_smollm_pipeline_is_bound_by_exact_asset_hashes() -> None:
+    metadata = _metadata(pre="qwen2")
+    metadata.pop("tokenizer.ggml.scores")
+    payloads = _pinned_payloads(metadata)
+    tokenizer = json.loads(payloads["tokenizer.json"])
+    tokenizer["pre_tokenizer"]["pretokenizers"].reverse()
+    payloads["tokenizer.json"] = json.dumps(tokenizer).encode()
+
+    tokenizer_sha256, materialized = _tokenizer._validate_pinned_tokenizer(
+        metadata, payloads
+    )
+
+    assert hashlib.sha256(materialized).hexdigest() == tokenizer_sha256
+
+
+def test_deterministic_unused_padding_is_materialized_as_added_tokens() -> None:
+    source_metadata = _metadata(pre="qwen2")
+    source_metadata.pop("tokenizer.ggml.scores")
+    payloads = _pinned_payloads(source_metadata)
+    metadata = dict(source_metadata)
+    metadata["tokenizer.ggml.tokens"] = [
+        *source_metadata["tokenizer.ggml.tokens"],
+        "[PAD7]",
+        "[PAD8]",
+    ]
+    metadata["tokenizer.ggml.token_type"] = [
+        *source_metadata["tokenizer.ggml.token_type"],
+        5,
+        5,
+    ]
+
+    _, materialized = _tokenizer._validate_pinned_tokenizer(metadata, payloads)
+
+    tokenizer = json.loads(materialized)
+    assert tokenizer["added_tokens"][-2:] == [
+        {
+            "id": 7,
+            "content": "[PAD7]",
+            "single_word": False,
+            "lstrip": False,
+            "rstrip": False,
+            "normalized": False,
+            "special": False,
+        },
+        {
+            "id": 8,
+            "content": "[PAD8]",
+            "single_word": False,
+            "lstrip": False,
+            "rstrip": False,
+            "normalized": False,
+            "special": False,
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    ("token", "token_type", "message"),
+    [
+        ("[PAD8]", 5, "vocabulary differs"),
+        ("[PAD7]", 1, "padding must contain only unused tokens"),
+    ],
+)
+def test_malformed_deterministic_padding_rejects(
+    token: str, token_type: int, message: str
+) -> None:
+    source_metadata = _metadata(pre="qwen2")
+    source_metadata.pop("tokenizer.ggml.scores")
+    payloads = _pinned_payloads(source_metadata)
+    metadata = dict(source_metadata)
+    metadata["tokenizer.ggml.tokens"] = [*source_metadata["tokenizer.ggml.tokens"], token]
+    metadata["tokenizer.ggml.token_type"] = [
+        *source_metadata["tokenizer.ggml.token_type"],
+        token_type,
+    ]
+
+    with pytest.raises(ValueError, match=message):
+        _tokenizer._validate_pinned_tokenizer(metadata, payloads)
+
+
 def test_post_processor_cannot_hide_matching_special_token_flags(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -627,3 +707,71 @@ def test_local_asset_replacement_during_read_rejects(tmp_path: Path) -> None:
         pytest.raises(ValueError, match="changed while it was being read"),
     ):
         _tokenizer._read_regular_file(path, expected=expected)
+
+
+def test_local_hub_cache_symlink_is_resolved_inside_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = b"{}"
+    source = GGUFTokenizerSource(
+        "owner/tokenizer",
+        "a" * 40,
+        (
+            GGUFTokenizerAsset(
+                "tokenizer.json", len(payload), hashlib.sha256(payload).hexdigest()
+            ),
+        ),
+        "b" * 64,
+    )
+    cache = tmp_path / "hub"
+    blob = cache / "models--owner--tokenizer" / "blobs" / ("c" * 64)
+    blob.parent.mkdir(parents=True)
+    blob.write_bytes(payload)
+    snapshot = (
+        cache
+        / "models--owner--tokenizer"
+        / "snapshots"
+        / source.revision
+        / "tokenizer.json"
+    )
+    snapshot.parent.mkdir(parents=True)
+    snapshot.symlink_to(blob)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache))
+    monkeypatch.setattr("huggingface_hub.hf_hub_download", lambda **_kwargs: str(snapshot))
+
+    assert _tokenizer._download_tokenizer_assets(source, local_files_only=True) == {
+        "tokenizer.json": payload
+    }
+
+
+def test_local_hub_cache_symlink_escape_rejects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = b"{}"
+    source = GGUFTokenizerSource(
+        "owner/tokenizer",
+        "a" * 40,
+        (
+            GGUFTokenizerAsset(
+                "tokenizer.json", len(payload), hashlib.sha256(payload).hexdigest()
+            ),
+        ),
+        "b" * 64,
+    )
+    cache = tmp_path / "hub"
+    escaped = tmp_path / "escaped.json"
+    escaped.write_bytes(payload)
+    snapshot = (
+        cache
+        / "models--owner--tokenizer"
+        / "snapshots"
+        / source.revision
+        / "tokenizer.json"
+    )
+    snapshot.parent.mkdir(parents=True)
+    snapshot.symlink_to(escaped)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache))
+    monkeypatch.setattr("huggingface_hub.hf_hub_download", lambda **_kwargs: str(snapshot))
+
+    with pytest.raises(ValueError, match="untrusted symlink"):
+        _tokenizer._download_tokenizer_assets(source, local_files_only=True)

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -475,19 +475,28 @@ def _runtime_version_tuple(version: str) -> tuple[int, int, int]:
 def _write_runtime_compatibility(
     output_dir: str, *, model_type: str, runtime_version: str | None
 ) -> str:
-    if model_type == "decoder" and runtime_version is not None:
-        if _runtime_version_tuple(runtime_version) < _GENERIC_DECODER_MIN_VERSION:
+    minimum_versions = {
+        "decoder": _GENERIC_DECODER_MIN_VERSION,
+        "lfm2": (0, 15, 2),
+    }
+    minimum_version = minimum_versions.get(model_type)
+    if minimum_version is not None and runtime_version is not None:
+        if _runtime_version_tuple(runtime_version) < minimum_version:
             raise ValueError(
-                "Generic ORT GenAI decoder packages require onnxruntime-genai >= 0.14.0; "
-                f"requested {runtime_version}"
+                f"ORT GenAI {model_type} packages require onnxruntime-genai >= "
+                f"{'.'.join(map(str, minimum_version))}; requested {runtime_version}"
             )
+    tested_versions = {
+        "decoder": list(_GENERIC_DECODER_TESTED_VERSIONS),
+        "lfm2": ["0.15.2"],
+    }
     metadata = {
         "runtime": "onnxruntime-genai",
         "model_type": model_type,
-        "minimum_version": "0.14.0" if model_type == "decoder" else None,
-        "tested_versions": (
-            list(_GENERIC_DECODER_TESTED_VERSIONS) if model_type == "decoder" else []
+        "minimum_version": (
+            ".".join(map(str, minimum_version)) if minimum_version is not None else None
         ),
+        "tested_versions": tested_versions.get(model_type, []),
         "uses_main_only_state_groups": False,
         "heterogeneous_state_manifest": "deferred: https://github.com/onnxruntime/mobius/issues/605",
     }

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -32,6 +32,7 @@ from mobius.integrations.ort_genai.auto_export import (
     _uses_compact_sliding_kv_cache,
     _write_audio_processor_config,
     _write_genai_config,
+    _write_runtime_compatibility,
     _write_vision_processor_config,
     auto_export,
     export_package,
@@ -3647,6 +3648,21 @@ def test_generic_decoder_runtime_compatibility_metadata(tmp_path):
             "deferred: https://github.com/onnxruntime/mobius/issues/605"
         ),
     }
+
+
+def test_lfm2_runtime_compatibility_is_pinned_to_released_probe(tmp_path):
+    path = _write_runtime_compatibility(
+        str(tmp_path), model_type="lfm2", runtime_version="0.15.2"
+    )
+    with open(path, encoding="utf-8") as handle:
+        metadata = json.load(handle)
+
+    assert metadata["minimum_version"] == "0.15.2"
+    assert metadata["tested_versions"] == ["0.15.2"]
+    with pytest.raises(ValueError, match=r"lfm2.*>= 0\.15\.2"):
+        _write_runtime_compatibility(
+            str(tmp_path), model_type="lfm2", runtime_version="0.15.1"
+        )
 
 
 def test_decoder_sidecar_preserves_type_and_matching_compatibility_metadata(tmp_path):

--- a/testdata/cases/causal-lm/lfm2-350m-f16.yaml
+++ b/testdata/cases/causal-lm/lfm2-350m-f16.yaml
@@ -15,7 +15,7 @@ gguf:
     F16: 93
     F32: 55
   execution_provider: "cpu"
-  config_sha256: "69e63a13b046ca5658e4fbf1fac41b76e021ef768b16428cd2baa7c990bef21a"
+  config_sha256: "c961bba579ea33a2472a7c5d3f469c76f1f8c7aae8440a7eaa86bc6e878a42f4"
   preserve_quantization: false
   keep_quantized: true
   tokenizer:

--- a/testdata/cases/causal-lm/lfm2-350m-f16.yaml
+++ b/testdata/cases/causal-lm/lfm2-350m-f16.yaml
@@ -1,0 +1,64 @@
+model_id: "LiquidAI/LFM2-350M"
+model_type: "lfm2"
+revision: "f37d3f5c8c5484bc01dad379a595cf4c68c4e70e"
+task_type: "text-generation"
+dtype: "float32"
+
+gguf:
+  repository: "LiquidAI/LFM2-350M-GGUF"
+  revision: "8fdc9d526b7ed346b19257551b05816c7912ecc2"
+  filename: "LFM2-350M-F16.gguf"
+  size: 711482304
+  lfs_sha256: "379ffdcbf08147c0313f6f1ce7ff558a2bc935eda633f4b46c52347032419c42"
+  tensor_count: 148
+  tensor_qtypes:
+    F16: 93
+    F32: 55
+  execution_provider: "cpu"
+  config_sha256: "69e63a13b046ca5658e4fbf1fac41b76e021ef768b16428cd2baa7c990bef21a"
+  preserve_quantization: false
+  keep_quantized: true
+  tokenizer:
+    repository: "LiquidAI/LFM2-350M"
+    revision: "73e3c253078a3b97c2e14b4c4665679f4d9b6d56"
+    metadata_sha256: "e5626d605bb50bc53fdb0fbfcf374fb33dfbaa0cc698d9746ba1e9b0b7e6d07d"
+    identity_status: "exact"
+    assets:
+      - filename: "chat_template.jinja"
+        size: 209
+        sha256: "a805e50fed68938a076b07e2e602639611b50b1ced0e50f11eb92f1ba25be4dc"
+      - filename: "special_tokens_map.json"
+        size: 434
+        sha256: "742aefe2b7dec496e8caffdba03a75d0c1a9925d53bd3f3e0d388c96b591b6f4"
+      - filename: "tokenizer.json"
+        size: 4732426
+        sha256: "98cff83b4f6d7e9d8929bebc62b07e92cf1b3f99c80d16bafe8b84a75448f40b"
+      - filename: "tokenizer_config.json"
+        size: 91509
+        sha256: "36f511115e9d8952cbc9d15d9a20dfa7ce7d1444940e5c1dc42a762020c99bf5"
+
+ort_genai:
+  tier: "real"
+  runtime_versions: ["0.15.2"]
+  model_type: "decoder"
+  runtime_evidence_id: "lfm2-350m-f16-ort-genai-0.15.2"
+  execution_provider: "cpu"
+  max_download_bytes: 725000000
+  released_capabilities:
+    "0.15.2":
+      specialized_lfm2: true
+      hybrid_conv_kv_state: true
+      state_groups: false
+
+inputs:
+  prompts:
+    - "Hello"
+
+level: "L4+L5"
+
+generation:
+  max_new_tokens: 20
+  do_sample: false
+  exact_match: true
+
+notes: "Official F16 GGUF; complete logits and 20-step hybrid convolution/KV decode are compared to Transformers loading this exact artifact."

--- a/testdata/cases/causal-lm/qwen2.5-0.5b-instruct-q8.yaml
+++ b/testdata/cases/causal-lm/qwen2.5-0.5b-instruct-q8.yaml
@@ -1,0 +1,57 @@
+model_id: "Qwen/Qwen2.5-0.5B-Instruct"
+model_type: "qwen2"
+revision: "7ae557604adf67be50417f59c2c2f167def9a775"
+task_type: "text-generation"
+dtype: "float32"
+
+gguf:
+  repository: "Qwen/Qwen2.5-0.5B-Instruct-GGUF"
+  revision: "9217f5db79a29953eb74d5343926648285ec7e67"
+  filename: "qwen2.5-0.5b-instruct-q8_0.gguf"
+  size: 675710816
+  lfs_sha256: "ca59ca7f13d0e15a8cfa77bd17e65d24f6844b554a7b6c12e07a5f89ff76844e"
+  tensor_count: 291
+  tensor_qtypes:
+    F32: 121
+    Q8_0: 170
+  execution_provider: "cpu"
+  config_sha256: "4002821420e74a522abaf921e064f23217eac71284d71d6d288171cf7802d068"
+  preserve_quantization: true
+  keep_quantized: true
+  tokenizer:
+    repository: "Qwen/Qwen2.5-0.5B-Instruct"
+    revision: "a338b55dd21219a5f4da42bc11a9313d1a27d4cc"
+    metadata_sha256: "8fc8ef848104e931f14ae03d9581699d54813a2ff952fb7caac0654e8aa27ee3"
+    identity_status: "exact"
+    assets:
+      - filename: "tokenizer.json"
+        size: 7031645
+        sha256: "c0382117ea329cdf097041132f6d735924b697924d6f6fc3945713e96ce87539"
+      - filename: "tokenizer_config.json"
+        size: 7308
+        sha256: "5214600ee45ca2f887ce2eede8910378a0111ea99d657428bcbce94778e65a92"
+
+ort_genai:
+  tier: "real"
+  runtime_versions: ["0.15.2"]
+  model_type: "decoder"
+  runtime_evidence_id: "qwen2.5-0.5b-instruct-q8-ort-genai-0.15.2"
+  execution_provider: "cpu"
+  max_download_bytes: 700000000
+  released_capabilities:
+    "0.15.2":
+      generic_decoder: true
+      state_groups: false
+
+inputs:
+  prompts:
+    - "Hello"
+
+level: "L4+L5"
+
+generation:
+  max_new_tokens: 20
+  do_sample: false
+  exact_match: true
+
+notes: "Official Q8_0 GGUF; complete logits and 20-step KV decode are compared to Transformers loading this exact artifact."

--- a/testdata/cases/causal-lm/qwen2.5-0.5b-instruct-q8.yaml
+++ b/testdata/cases/causal-lm/qwen2.5-0.5b-instruct-q8.yaml
@@ -15,7 +15,7 @@ gguf:
     F32: 121
     Q8_0: 170
   execution_provider: "cpu"
-  config_sha256: "4002821420e74a522abaf921e064f23217eac71284d71d6d288171cf7802d068"
+  config_sha256: "f7391f2aac9a7617c1c10e397e91b6f31b80bb3c5f338966b46e7d3935246500"
   preserve_quantization: true
   keep_quantized: true
   tokenizer:

--- a/testdata/cases/schema.json
+++ b/testdata/cases/schema.json
@@ -308,7 +308,7 @@
         "max_download_bytes": {
           "type": "integer",
           "minimum": 1,
-          "maximum": 536870912,
+          "maximum": 1073741824,
           "description": "Hard per-case aggregate artifact download budget."
         },
         "released_capabilities": {
@@ -519,18 +519,35 @@
     "ortGenaiCapabilities": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "generic_decoder",
-        "state_groups"
-      ],
       "properties": {
         "generic_decoder": {
+          "const": true
+        },
+        "specialized_lfm2": {
+          "const": true
+        },
+        "hybrid_conv_kv_state": {
           "const": true
         },
         "state_groups": {
           "const": false
         }
-      }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "generic_decoder",
+            "state_groups"
+          ]
+        },
+        {
+          "required": [
+            "specialized_lfm2",
+            "hybrid_conv_kv_state",
+            "state_groups"
+          ]
+        }
+      ]
     }
   }
 }

--- a/tests/gguf_small_model_runtime_integration_test.py
+++ b/tests/gguf_small_model_runtime_integration_test.py
@@ -82,7 +82,7 @@ _CASES = (
         reference_revision="1d461723eec654e65efdc40cf49301c89c0c92f4",
         prompt="Once upon a time,",
         tensor_qtypes={"F16": 211, "F32": 61},
-        config_sha256="b999a219ddf6046f1b6e5c082dab2d00b7ba1682169914430b1a3672fc735498",
+        config_sha256="d3f3f2abf531abde55e04a52b5c892c93943b7e260160c796c490618a2e84886",
         generated_tokens=(
             665,
             436,
@@ -140,7 +140,7 @@ _CASES = (
         reference_revision="12fd25f77366fa6b3b4b768ec3050bf629380bac",
         prompt="Here is my poem:",
         tensor_qtypes={"F16": 211, "F32": 61},
-        config_sha256="e8ca654a7c9180821b588ad167eaccf45a14869883789911e4481b755dc97164",
+        config_sha256="f9ceb816433d5aa32918761944be76ecdb090df8cce7cdb64d5d8f9186f7117f",
         generated_tokens=(
             198,
             198,
@@ -200,7 +200,7 @@ _Q4_K_M_CASE = _RuntimeCase(
     reference_revision="12fd25f77366fa6b3b4b768ec3050bf629380bac",
     prompt="Here is my poem:",
     tensor_qtypes={"F32": 61, "Q4_K": 16, "Q5_0": 166, "Q6_K": 14, "Q8_0": 15},
-    config_sha256="e8ca654a7c9180821b588ad167eaccf45a14869883789911e4481b755dc97164",
+    config_sha256="f9ceb816433d5aa32918761944be76ecdb090df8cce7cdb64d5d8f9186f7117f",
     generated_tokens=(198, 198, 18, 504, 2388, 13685, 284, 5208, 28, 198),
     tokenizer_repository="HuggingFaceTB/SmolLM2-135M-Instruct",
     tokenizer_revision="12fd25f77366fa6b3b4b768ec3050bf629380bac",
@@ -449,9 +449,7 @@ def _assert_replay_rollback_and_reorder(
         np.testing.assert_array_equal(first[name], second[name])
 
     next_token = np.asarray([[int(first["logits"][0, -1].argmax())]], dtype=np.int64)
-    _run_promoted_ort(
-        session, next_token, _next_cache(first), prompt_ids.shape[1] + 1
-    )
+    _run_promoted_ort(session, next_token, _next_cache(first), prompt_ids.shape[1] + 1)
     rolled_back = _run_promoted_ort(session, token, snapshot, prompt_ids.shape[1])
     for name in first:
         np.testing.assert_array_equal(first[name], rolled_back[name])
@@ -467,9 +465,7 @@ def _assert_replay_rollback_and_reorder(
     )
     batched_state = _next_cache(batched)
     batched_tokens = batched["logits"][:, -1].argmax(axis=-1).astype(np.int64)[:, None]
-    original = _run_promoted_ort(
-        session, batched_tokens, batched_state, prompt_ids.shape[1]
-    )
+    original = _run_promoted_ort(session, batched_tokens, batched_state, prompt_ids.shape[1])
     reordered = _run_promoted_ort(
         session,
         batched_tokens[::-1].copy(),
@@ -551,14 +547,6 @@ def test_small_f16_gguf_cli_full_logit_and_generation_parity(
     package = ModelPackage.load(output_dir)
     assert tuple(package) == ("model",)
     assert {"model.onnx", "model.onnx.data"} <= {path.name for path in output_dir.iterdir()}
-    session = ort.InferenceSession(
-        str(output_dir / "model.onnx"), providers=["CPUExecutionProvider"]
-    )
-    assert {value.name for value in session.get_inputs()} >= {
-        "input_ids",
-        "attention_mask",
-    }
-    assert {value.name for value in session.get_outputs()} >= {"logits"}
 
     tokenizer = AutoTokenizer.from_pretrained(
         case.reference_repository, revision=case.reference_revision
@@ -606,17 +594,43 @@ def test_small_f16_gguf_cli_full_logit_and_generation_parity(
         dtype=torch.float32,
     ).eval()
     prompt_ids = tokenizer(case.prompt, return_tensors="pt").input_ids
+    reference_logits: list[np.ndarray] = []
     with torch.no_grad():
         reference_output = reference(prompt_ids, use_cache=True)
+    reference_logits.append(reference_output.logits.numpy().copy())
+    reference_cache = reference_output.past_key_values
+    reference_generated: list[int] = []
+    for _ in case.generated_tokens:
+        token = int(reference_output.logits[0, -1].argmax())
+        reference_generated.append(token)
+        token_ids = torch.tensor([[token]], dtype=torch.int64)
+        with torch.no_grad():
+            reference_output = reference(
+                token_ids,
+                past_key_values=reference_cache,
+                use_cache=True,
+            )
+        reference_cache = reference_output.past_key_values
+        reference_logits.append(reference_output.logits.numpy().copy())
+    assert reference_generated == list(case.generated_tokens)
+    captured.clear()
+    del package, gguf_model, reference, reference_output, reference_cache
+    gc.collect()
 
     input_ids = prompt_ids.numpy()
+    session = ort.InferenceSession(
+        str(output_dir / "model.onnx"), providers=["CPUExecutionProvider"]
+    )
+    assert {value.name for value in session.get_inputs()} >= {
+        "input_ids",
+        "attention_mask",
+    }
+    assert {value.name for value in session.get_outputs()} >= {"logits"}
     ort_output = _run_ort(session, input_ids, _empty_cache(session), 0)
     ort_logits = ort_output["logits"]
-    reference_logits = reference_output.logits.numpy()
-    np.testing.assert_allclose(ort_logits, reference_logits, rtol=1e-4, atol=2e-4)
+    np.testing.assert_allclose(ort_logits, reference_logits[0], rtol=1e-4, atol=2e-4)
 
     cache = _next_cache(ort_output)
-    reference_cache = reference_output.past_key_values
     generated: list[int] = []
     for step in range(len(case.generated_tokens)):
         token = int(ort_logits[0, -1].argmax())
@@ -624,16 +638,10 @@ def test_small_f16_gguf_cli_full_logit_and_generation_parity(
         token_ids = np.array([[token]], dtype=np.int64)
         ort_output = _run_ort(session, token_ids, cache, input_ids.shape[1] + step)
         cache = _next_cache(ort_output)
-        with torch.no_grad():
-            reference_output = reference(
-                torch.from_numpy(token_ids),
-                past_key_values=reference_cache,
-                use_cache=True,
-            )
-        reference_cache = reference_output.past_key_values
         ort_logits = ort_output["logits"]
-        reference_logits = reference_output.logits.numpy()
-        np.testing.assert_allclose(ort_logits, reference_logits, rtol=1e-4, atol=2e-4)
+        np.testing.assert_allclose(
+            ort_logits, reference_logits[step + 1], rtol=1e-4, atol=2e-4
+        )
 
     expected = np.asarray(case.generated_tokens, dtype=np.int64)
     actual = np.asarray(generated, dtype=np.int64)
@@ -758,10 +766,6 @@ def test_smollm_q4_k_m_fails_closed_or_matches_same_artifact_when_dequantized(
             local_files_only=True,
         )
     assert not rejected_output.exists()
-    session = ort.InferenceSession(
-        str(output_dir / "model.onnx"), providers=["CPUExecutionProvider"]
-    )
-
     tokenizer = AutoTokenizer.from_pretrained(
         case.reference_repository, revision=case.reference_revision
     )
@@ -772,17 +776,38 @@ def test_smollm_q4_k_m_fails_closed_or_matches_same_artifact_when_dequantized(
         dtype=torch.float32,
     ).eval()
     prompt_ids = tokenizer(case.prompt, return_tensors="pt").input_ids
+    reference_logits: list[np.ndarray] = []
     with torch.no_grad():
         reference_output = reference(prompt_ids, use_cache=True)
+    reference_logits.append(reference_output.logits.numpy().copy())
+    reference_cache = reference_output.past_key_values
+    reference_generated: list[int] = []
+    for _ in case.generated_tokens:
+        token = int(reference_output.logits[0, -1].argmax())
+        reference_generated.append(token)
+        token_ids = torch.tensor([[token]], dtype=torch.int64)
+        with torch.no_grad():
+            reference_output = reference(
+                token_ids,
+                past_key_values=reference_cache,
+                use_cache=True,
+            )
+        reference_cache = reference_output.past_key_values
+        reference_logits.append(reference_output.logits.numpy().copy())
+    assert reference_generated == list(case.generated_tokens)
+    captured.clear()
+    del package, reloaded, gguf_model, reference, reference_output, reference_cache
+    gc.collect()
 
     input_ids = prompt_ids.numpy()
+    session = ort.InferenceSession(
+        str(output_dir / "model.onnx"), providers=["CPUExecutionProvider"]
+    )
     ort_output = _run_ort(session, input_ids, _empty_cache(session), 0)
     ort_logits = ort_output["logits"]
-    reference_logits = reference_output.logits.numpy()
-    np.testing.assert_allclose(ort_logits, reference_logits, rtol=1e-4, atol=2e-4)
+    np.testing.assert_allclose(ort_logits, reference_logits[0], rtol=1e-4, atol=2e-4)
 
     cache = _next_cache(ort_output)
-    reference_cache = reference_output.past_key_values
     generated: list[int] = []
     for step in range(len(case.generated_tokens)):
         token = int(ort_logits[0, -1].argmax())
@@ -790,16 +815,10 @@ def test_smollm_q4_k_m_fails_closed_or_matches_same_artifact_when_dequantized(
         token_ids = np.array([[token]], dtype=np.int64)
         ort_output = _run_ort(session, token_ids, cache, input_ids.shape[1] + step)
         cache = _next_cache(ort_output)
-        with torch.no_grad():
-            reference_output = reference(
-                torch.from_numpy(token_ids),
-                past_key_values=reference_cache,
-                use_cache=True,
-            )
-        reference_cache = reference_output.past_key_values
         ort_logits = ort_output["logits"]
-        reference_logits = reference_output.logits.numpy()
-        np.testing.assert_allclose(ort_logits, reference_logits, rtol=1e-4, atol=2e-4)
+        np.testing.assert_allclose(
+            ort_logits, reference_logits[step + 1], rtol=1e-4, atol=2e-4
+        )
 
     np.testing.assert_array_equal(generated, case.generated_tokens)
 
@@ -960,9 +979,10 @@ def test_promoted_gguf_full_runtime_evidence(
         assert remote.commit_hash == revision
         assert remote.size == expected_size
         remote_download_bytes += remote.size
-    assert evidence.size <= 2**30
+    assert evidence.size <= 16 * 2**30
     assert remote_download_bytes <= enrollment["max_download_bytes"]
     assert isolated_hf_cache.exists()
+    assert shutil.disk_usage(isolated_hf_cache).free >= 2 * evidence.size
 
     cached_gguf = Path(
         hf_hub_download(
@@ -979,6 +999,8 @@ def test_promoted_gguf_full_runtime_evidence(
     qtypes = Counter(qtype.name for _, _, qtype, _ in gguf_model.tensor_items_raw())
     assert len(gguf_model.reader_tensors()) == evidence.tensor_count
     assert tuple(sorted(qtypes.items())) == evidence.tensor_qtypes
+    del gguf_model
+    gc.collect()
     for filename, size, sha256 in evidence.tokenizer_assets:
         asset_path = Path(
             hf_hub_download(
@@ -991,6 +1013,7 @@ def test_promoted_gguf_full_runtime_evidence(
         assert _sha256(asset_path) == sha256
 
     output_dir = tmp_path / "runtime-package"
+    assert shutil.disk_usage(tmp_path).free >= 2 * evidence.size
     captured: list[ModelPackage] = []
     original_save = ModelPackage.save
 
@@ -1034,6 +1057,9 @@ def test_promoted_gguf_full_runtime_evidence(
     graph_identity = gguf_graph_package_identity(graph_dir)
     assert graph_identity.files == evidence.graph_files
     assert graph_identity.sha256 == evidence.graph_sha256
+    captured.clear()
+    del package
+    gc.collect()
 
     tokenizer = AutoTokenizer.from_pretrained(
         evidence.tokenizer_repository,
@@ -1048,12 +1074,32 @@ def test_promoted_gguf_full_runtime_evidence(
         gguf_file=evidence.filename,
         dtype=torch.float32,
     ).eval()
+    input_ids = prompt_ids.numpy()
+    reference_logits: list[np.ndarray] = []
+    with torch.no_grad():
+        reference_output = reference(prompt_ids, use_cache=True)
+    reference_logits.append(reference_output.logits.numpy().copy())
+    reference_state = reference_output.past_key_values
+    reference_generated: list[int] = []
+    for _ in case.generated_tokens:
+        token = int(reference_output.logits[0, -1].argmax())
+        reference_generated.append(token)
+        token_ids = torch.tensor([[token]], dtype=torch.int64)
+        with torch.no_grad():
+            reference_output = reference(
+                token_ids,
+                past_key_values=reference_state,
+                use_cache=True,
+            )
+        reference_state = reference_output.past_key_values
+        reference_logits.append(reference_output.logits.numpy().copy())
+    assert reference_generated == list(case.generated_tokens)
+    del reference, reference_output, reference_state
+    gc.collect()
+
     session = ort.InferenceSession(
         str(output_dir / "model.onnx"), providers=["CPUExecutionProvider"]
     )
-    input_ids = prompt_ids.numpy()
-    with torch.no_grad():
-        reference_output = reference(prompt_ids, use_cache=True)
     ort_output = _run_promoted_ort(
         session,
         input_ids,
@@ -1062,38 +1108,30 @@ def test_promoted_gguf_full_runtime_evidence(
     )
     np.testing.assert_allclose(
         ort_output["logits"],
-        reference_output.logits.numpy(),
+        reference_logits[0],
         rtol=1e-4,
         atol=case.atol,
     )
 
     state = _next_cache(ort_output)
-    reference_state = reference_output.past_key_values
     generated: list[int] = []
     for step in range(len(case.generated_tokens)):
         token = int(ort_output["logits"][0, -1].argmax())
         generated.append(token)
         token_ids = np.asarray([[token]], dtype=np.int64)
-        ort_output = _run_promoted_ort(
-            session, token_ids, state, input_ids.shape[1] + step
-        )
+        ort_output = _run_promoted_ort(session, token_ids, state, input_ids.shape[1] + step)
         state = _next_cache(ort_output)
-        with torch.no_grad():
-            reference_output = reference(
-                torch.from_numpy(token_ids),
-                past_key_values=reference_state,
-                use_cache=True,
-            )
-        reference_state = reference_output.past_key_values
         np.testing.assert_allclose(
             ort_output["logits"],
-            reference_output.logits.numpy(),
+            reference_logits[step + 1],
             rtol=1e-4,
             atol=case.atol,
         )
     assert len(generated) == len(case.generated_tokens)
     assert generated == list(case.generated_tokens)
     _assert_replay_rollback_and_reorder(session, input_ids)
+    del session, ort_output, state, reference_logits
+    gc.collect()
 
     compatibility = json.loads(
         (output_dir / "runtime_compatibility.json").read_text(encoding="utf-8")

--- a/tests/gguf_small_model_runtime_integration_test.py
+++ b/tests/gguf_small_model_runtime_integration_test.py
@@ -13,6 +13,7 @@ same-weight provenance.
 
 from __future__ import annotations
 
+import gc
 import hashlib
 import json
 import os
@@ -41,6 +42,10 @@ from mobius.integrations.gguf import (
     write_gguf_runtime_package,
 )
 from mobius.integrations.gguf._reader import GGUFModel
+from mobius.integrations.gguf._runtime_evidence import (
+    gguf_graph_package_identity,
+    runtime_evidence,
+)
 from mobius.integrations.gguf._tokenizer import inspect_gguf_tokenizer
 
 
@@ -223,6 +228,81 @@ _Q4_K_M_CASE = _RuntimeCase(
 )
 
 
+@dataclass(frozen=True)
+class _PromotedRuntimeCase:
+    name: str
+    evidence_id: str
+    reference_repository: str
+    reference_revision: str
+    prompt: str
+    generated_tokens: tuple[int, ...]
+    atol: float
+
+
+_PROMOTED_RUNTIME_CASES = (
+    _PromotedRuntimeCase(
+        name="qwen2.5-0.5b-instruct-q8",
+        evidence_id="qwen2.5-0.5b-instruct-q8-ort-genai-0.15.2",
+        reference_repository="Qwen/Qwen2.5-0.5B-Instruct",
+        reference_revision="7ae557604adf67be50417f59c2c2f167def9a775",
+        prompt="Hello",
+        generated_tokens=(
+            271,
+            40,
+            1079,
+            4460,
+            311,
+            1855,
+            264,
+            2025,
+            429,
+            646,
+            1477,
+            279,
+            7192,
+            897,
+            304,
+            264,
+            2661,
+            1140,
+            315,
+            5109,
+        ),
+        atol=4e-4,
+    ),
+    _PromotedRuntimeCase(
+        name="lfm2-350m-f16",
+        evidence_id="lfm2-350m-f16-ort-genai-0.15.2",
+        reference_repository="LiquidAI/LFM2-350M",
+        reference_revision="f37d3f5c8c5484bc01dad379a595cf4c68c4e70e",
+        prompt="Hello",
+        generated_tokens=(
+            8227,
+            24771,
+            938,
+            31707,
+            8587,
+            4427,
+            896,
+            938,
+            7306,
+            18414,
+            1399,
+            4903,
+            8227,
+            24771,
+            810,
+            2492,
+            5992,
+            768,
+            3680,
+            4600,
+        ),
+        atol=3e-4,
+    ),
+)
+
+
 @pytest.fixture
 def isolated_hf_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Keep each real-artifact test's Hub/Xet state isolated and disposable."""
@@ -309,6 +389,95 @@ def _next_cache(outputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
         for name, value in outputs.items()
         if name.startswith("present.")
     }
+
+
+def _empty_promoted_state(
+    session: ort.InferenceSession, *, batch_size: int
+) -> dict[str, np.ndarray]:
+    state: dict[str, np.ndarray] = {}
+    for value in session.get_inputs():
+        if value.name.endswith((".key", ".value")):
+            state[value.name] = np.empty(
+                [batch_size, value.shape[1], 0, value.shape[3]], dtype=np.float32
+            )
+        elif value.name.endswith(".conv_state"):
+            state[value.name] = np.zeros(
+                [batch_size, value.shape[1], value.shape[2]], dtype=np.float32
+            )
+    return state
+
+
+def _run_promoted_ort(
+    session: ort.InferenceSession,
+    input_ids: np.ndarray,
+    state: dict[str, np.ndarray],
+    past_length: int,
+) -> dict[str, np.ndarray]:
+    sequence_length = input_ids.shape[1]
+    candidates = {
+        "input_ids": input_ids,
+        "attention_mask": np.ones(
+            (input_ids.shape[0], past_length + sequence_length), dtype=np.int64
+        ),
+        "position_ids": np.broadcast_to(
+            np.arange(past_length, past_length + sequence_length, dtype=np.int64),
+            input_ids.shape,
+        ),
+        **state,
+    }
+    input_names = {value.name for value in session.get_inputs()}
+    output_names = [value.name for value in session.get_outputs()]
+    feeds = {name: value for name, value in candidates.items() if name in input_names}
+    return dict(zip(output_names, session.run(output_names, feeds), strict=True))
+
+
+def _assert_replay_rollback_and_reorder(
+    session: ort.InferenceSession,
+    prompt_ids: np.ndarray,
+) -> None:
+    prefill = _run_promoted_ort(
+        session,
+        prompt_ids,
+        _empty_promoted_state(session, batch_size=1),
+        0,
+    )
+    snapshot = {name: value.copy() for name, value in _next_cache(prefill).items()}
+    token = np.asarray([[int(prefill["logits"][0, -1].argmax())]], dtype=np.int64)
+    first = _run_promoted_ort(session, token, snapshot, prompt_ids.shape[1])
+    second = _run_promoted_ort(session, token, snapshot, prompt_ids.shape[1])
+    for name in first:
+        np.testing.assert_array_equal(first[name], second[name])
+
+    next_token = np.asarray([[int(first["logits"][0, -1].argmax())]], dtype=np.int64)
+    _run_promoted_ort(
+        session, next_token, _next_cache(first), prompt_ids.shape[1] + 1
+    )
+    rolled_back = _run_promoted_ort(session, token, snapshot, prompt_ids.shape[1])
+    for name in first:
+        np.testing.assert_array_equal(first[name], rolled_back[name])
+
+    alternate_ids = prompt_ids.copy()
+    alternate_ids[0, -1] += 1
+    batched_ids = np.concatenate([prompt_ids, alternate_ids], axis=0)
+    batched = _run_promoted_ort(
+        session,
+        batched_ids,
+        _empty_promoted_state(session, batch_size=2),
+        0,
+    )
+    batched_state = _next_cache(batched)
+    batched_tokens = batched["logits"][:, -1].argmax(axis=-1).astype(np.int64)[:, None]
+    original = _run_promoted_ort(
+        session, batched_tokens, batched_state, prompt_ids.shape[1]
+    )
+    reordered = _run_promoted_ort(
+        session,
+        batched_tokens[::-1].copy(),
+        {name: value[::-1].copy() for name, value in batched_state.items()},
+        prompt_ids.shape[1],
+    )
+    for name in original:
+        np.testing.assert_array_equal(original[name][::-1], reordered[name])
 
 
 @pytest.mark.integration
@@ -743,3 +912,210 @@ def test_smollm_generic_ort_genai_generation(
 
     assert len(generated) == len(case.generated_tokens)
     assert generated == list(case.generated_tokens)
+
+
+@pytest.mark.integration
+@pytest.mark.integration_slow
+@pytest.mark.ort_genai_real
+@pytest.mark.parametrize("case", _PROMOTED_RUNTIME_CASES, ids=lambda case: case.name)
+def test_promoted_gguf_full_runtime_evidence(
+    case: _PromotedRuntimeCase,
+    tmp_path: Path,
+    isolated_hf_cache: Path,
+) -> None:
+    """Exact GGUF weights prove logits, state semantics, publication, and OGA decode."""
+    import onnxruntime_genai as ort_genai
+
+    evidence = runtime_evidence(case.evidence_id)
+    case_yaml = Path(f"testdata/cases/causal-lm/{case.name}.yaml")
+    enrollment = yaml.safe_load(case_yaml.read_text(encoding="utf-8"))["ort_genai"]
+    installed_version = _installed_ort_genai_version()
+    assert installed_version == evidence.runtime_version == "0.15.2"
+    assert enrollment["runtime_evidence_id"] == case.evidence_id
+    assert enrollment["runtime_versions"] == [installed_version]
+
+    download_specs = [
+        (
+            evidence.repository,
+            evidence.revision,
+            evidence.filename,
+            evidence.size,
+        ),
+        *(
+            (
+                evidence.tokenizer_repository,
+                evidence.tokenizer_revision,
+                filename,
+                size,
+            )
+            for filename, size, _ in evidence.tokenizer_assets
+        ),
+    ]
+    remote_download_bytes = 0
+    for repository, revision, filename, expected_size in download_specs:
+        remote = get_hf_file_metadata(
+            hf_hub_url(repository, filename, revision=revision),
+            timeout=30,
+        )
+        assert remote.commit_hash == revision
+        assert remote.size == expected_size
+        remote_download_bytes += remote.size
+    assert evidence.size <= 2**30
+    assert remote_download_bytes <= enrollment["max_download_bytes"]
+    assert isolated_hf_cache.exists()
+
+    cached_gguf = Path(
+        hf_hub_download(
+            repo_id=evidence.repository,
+            revision=evidence.revision,
+            filename=evidence.filename,
+        )
+    )
+    assert cached_gguf.stat().st_size == evidence.size
+    assert _sha256(cached_gguf) == evidence.lfs_sha256
+    gguf_path = tmp_path / evidence.filename
+    shutil.copyfile(cached_gguf, gguf_path)
+    gguf_model = GGUFModel(gguf_path)
+    qtypes = Counter(qtype.name for _, _, qtype, _ in gguf_model.tensor_items_raw())
+    assert len(gguf_model.reader_tensors()) == evidence.tensor_count
+    assert tuple(sorted(qtypes.items())) == evidence.tensor_qtypes
+    for filename, size, sha256 in evidence.tokenizer_assets:
+        asset_path = Path(
+            hf_hub_download(
+                repo_id=evidence.tokenizer_repository,
+                revision=evidence.tokenizer_revision,
+                filename=filename,
+            )
+        )
+        assert asset_path.stat().st_size == size
+        assert _sha256(asset_path) == sha256
+
+    output_dir = tmp_path / "runtime-package"
+    captured: list[ModelPackage] = []
+    original_save = ModelPackage.save
+
+    def capture_save(package: ModelPackage, *args: object, **kwargs: object) -> None:
+        captured.append(package)
+        original_save(package, *args, **kwargs)
+
+    with mock.patch.object(ModelPackage, "save", capture_save):
+        main(
+            [
+                "build-gguf",
+                str(gguf_path),
+                "--output",
+                str(output_dir),
+                "--dtype",
+                "f32",
+                "--execution-provider",
+                "cpu",
+                "--runtime",
+                "ort-genai",
+                "--runtime-version",
+                installed_version,
+                "--tokenizer-repository",
+                evidence.tokenizer_repository,
+                "--tokenizer-revision",
+                evidence.tokenizer_revision,
+                "--local-files-only",
+            ]
+        )
+    assert len(captured) == 1
+    assert captured[0].gguf_import_route == evidence.import_route
+    package = ModelPackage.load(output_dir)
+    assert tuple(package) == ("model",)
+    runtime_identity = gguf_graph_package_identity(output_dir)
+    assert runtime_identity.files == evidence.runtime_package_files
+    assert runtime_identity.sha256 == evidence.runtime_package_sha256
+    graph_dir = tmp_path / "graph-identity"
+    graph_dir.mkdir()
+    for filename in evidence.graph_files:
+        os.link(output_dir / filename, graph_dir / filename)
+    graph_identity = gguf_graph_package_identity(graph_dir)
+    assert graph_identity.files == evidence.graph_files
+    assert graph_identity.sha256 == evidence.graph_sha256
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        evidence.tokenizer_repository,
+        revision=evidence.tokenizer_revision,
+    )
+    packaged_tokenizer = AutoTokenizer.from_pretrained(output_dir, local_files_only=True)
+    prompt_ids = tokenizer(case.prompt, return_tensors="pt").input_ids
+    assert packaged_tokenizer(case.prompt).input_ids == prompt_ids.tolist()[0]
+    reference = AutoModelForCausalLM.from_pretrained(
+        evidence.repository,
+        revision=evidence.revision,
+        gguf_file=evidence.filename,
+        dtype=torch.float32,
+    ).eval()
+    session = ort.InferenceSession(
+        str(output_dir / "model.onnx"), providers=["CPUExecutionProvider"]
+    )
+    input_ids = prompt_ids.numpy()
+    with torch.no_grad():
+        reference_output = reference(prompt_ids, use_cache=True)
+    ort_output = _run_promoted_ort(
+        session,
+        input_ids,
+        _empty_promoted_state(session, batch_size=1),
+        0,
+    )
+    np.testing.assert_allclose(
+        ort_output["logits"],
+        reference_output.logits.numpy(),
+        rtol=1e-4,
+        atol=case.atol,
+    )
+
+    state = _next_cache(ort_output)
+    reference_state = reference_output.past_key_values
+    generated: list[int] = []
+    for step in range(len(case.generated_tokens)):
+        token = int(ort_output["logits"][0, -1].argmax())
+        generated.append(token)
+        token_ids = np.asarray([[token]], dtype=np.int64)
+        ort_output = _run_promoted_ort(
+            session, token_ids, state, input_ids.shape[1] + step
+        )
+        state = _next_cache(ort_output)
+        with torch.no_grad():
+            reference_output = reference(
+                torch.from_numpy(token_ids),
+                past_key_values=reference_state,
+                use_cache=True,
+            )
+        reference_state = reference_output.past_key_values
+        np.testing.assert_allclose(
+            ort_output["logits"],
+            reference_output.logits.numpy(),
+            rtol=1e-4,
+            atol=case.atol,
+        )
+    assert len(generated) == len(case.generated_tokens)
+    assert generated == list(case.generated_tokens)
+    _assert_replay_rollback_and_reorder(session, input_ids)
+
+    compatibility = json.loads(
+        (output_dir / "runtime_compatibility.json").read_text(encoding="utf-8")
+    )
+    assert installed_version in compatibility["tested_versions"]
+    model = ort_genai.Model(str(output_dir))
+    oga_tokens = prompt_ids.tolist()[0]
+    params = ort_genai.GeneratorParams(model)
+    params.set_search_options(
+        max_length=len(oga_tokens) + len(case.generated_tokens),
+        do_sample=False,
+    )
+    generator = ort_genai.Generator(model, params)
+    generator.append_tokens(oga_tokens)
+    oga_generated: list[int] = []
+    for _ in case.generated_tokens:
+        generator.generate_next_token()
+        oga_generated.append(int(generator.get_next_tokens()[0]))
+    assert len(oga_generated) == len(case.generated_tokens)
+    assert oga_generated == list(case.generated_tokens)
+    del generator, params, model
+    gc.collect()
+
+    shutil.rmtree(output_dir)
+    gguf_path.unlink()


### PR DESCRIPTION
## Summary

Promotes two exact graph-supported GGUF routes to runtime-supported under the released `onnxruntime-genai==0.15.2` contract:

- Qwen2.5-0.5B-Instruct Q8_0: `Qwen/Qwen2.5-0.5B-Instruct-GGUF@9217f5db79a29953eb74d5343926648285ec7e67`, `qwen2.5-0.5b-instruct-q8_0.gguf`, 675,710,816 bytes, SHA-256 `ca59ca7f13d0e15a8cfa77bd17e65d24f6844b554a7b6c12e07a5f89ff76844e`, 291 tensors (`F32=121`, `Q8_0=170`).
- LFM2-350M F16: `LiquidAI/LFM2-350M-GGUF@8fdc9d526b7ed346b19257551b05816c7912ecc2`, `LFM2-350M-F16.gguf`, 711,482,304 bytes, SHA-256 `379ffdcbf08147c0313f6f1ce7ff558a2bc935eda633f4b46c52347032419c42`, 148 tensors (`F16=93`, `F32=55`).

Evidence binds exact artifact, import route, tokenizer assets/revisions, graph identity, runtime-package identity, complete logits, 20-step decode, deterministic generation, replay/rollback/non-vacuous batch reorder, ModelPackage save/load, CLI publication, and OGA 0.15.2 execution. The inherited SmolLM runtime record was also refreshed after #641 changed its route identity, with exact real parity and OGA probes rather than accepting a structural fingerprint alone.

## Identities

- Qwen route `f7391f2aac9a7617c1c10e397e91b6f31b80bb3c5f338966b46e7d3935246500`; graph `b0d1814ea69dddd405e30541e9009ba6fb73930f98538921d5c2eaa4a14f5d2c`; package `cb43c76e1bc3db07a6a3631c7a99e7c47b6891807fecffdb3b70fddd9c108173`.
- LFM2 route `c961bba579ea33a2472a7c5d3f469c76f1f8c7aae8440a7eaa86bc6e878a42f4`; graph `2a15694cd5ff9f5c9f798feeca91cc41174842065ada80a18b288478725b3342`; package `87b8cdd1edc8c5be948716df3efe551f5fc8f96762d7ea3f99b27688ca9f24af`.
- Qwen tokenizer `Qwen/Qwen2.5-0.5B-Instruct@a338b55dd21219a5f4da42bc11a9313d1a27d4cc`; LFM2 tokenizer `LiquidAI/LFM2-350M@73e3c253078a3b97c2e14b4c4665679f4d9b6d56`.

## Validation

- Exact Qwen and LFM2 final-main probes: passed.
- Refreshed SmolLM F16 parity/package and OGA 0.15.2 probes: passed.
- Refreshed SmolLM2 F16 and Q4/dequantized route probes: passed.
- Focused evidence/package/tokenizer/YAML gates: 626 passed, 9 deselected.
- Broad serial non-integration: 8,305 passed, 57 skipped, 12 deselected.
- Initialized all-files formatter and lint: passed.
- Direct GPT-5.6 Sol medium evidence/security review: fixed overlapping HF/ORT/OGA lifetimes, added 2x free-space enforcement, tightened Hub-cache symlink containment including parent escapes, aligned the 16 GiB ceiling, and added explicit stale-route fail-closed coverage.

## Census and scope

The documentation records the complete 90-route graph-supported census and attempted/blocked candidates. Larger and unsupported routes—including encoder/seq2seq registry gaps, GPT-2 combined-cache ABI, recurrent-state limitations, and candidates lacking an exact immutable <=16 GiB GGUF—remain deferred. No runtime claim is inferred from graph construction alone.

Base: `fcd5b3bb42dbc2ca7ca4bc62e9ee502e8446085a` (#641). All named artifact, package, graph, and isolated Hub caches were deleted after evidence generation.