### PR TITLE
Audit all GGUF tokenizer routes

### DIFF
--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -12,7 +12,7 @@ Support is capability-specific: graph import does not imply runtime packaging.
 | Architectures | 147 | graph verdicts: {'deferred': 55, 'rejected': 2, 'supported': 90}; importable: 89; quantized import: {'rejected': 31, 'supported': 116}; runtime: {'deferred': 142, 'rejected': 2, 'supported': 3} |
 | Active stored qtypes | 25 | 24 have an import route; 1 are explicitly deferred with no route |
 | Serialized projector strings | 60 | {'graph-importable': 5, 'runtime-supported': 0} |
-| Tokenizer pre identifiers | 87 | 56 semantic groups; all default to deferred and become materializable only from a validated embedded `tokenizer.huggingface.json` or exact artifact-scoped tokenizer evidence |
+| Tokenizer pre identifiers | 87 | 56 semantic groups; route dispositions: {'deferred-compiled-semantics': 83, 'validated-pinned-source': 4} |
 
 `SUPPORTED` means the named capability is implemented and mechanically tested. `DEFERRED` means it is intentionally unavailable pending the stated work. `REJECTED` means the input or route is invalid by policy. Graph support proves construction/execution only; runtime support additionally requires a pinned real artifact, independent parity, and deterministic generation or stateful semantics. Tokenizer `copy` requires embedded ordered-vocabulary identity; `pinned-source` also binds the complete GGUF artifact, immutable Hub assets, reconstruction policy, semantic hashes, and representative token-ID vectors.
 
@@ -64,13 +64,16 @@ evidence match.
 | `smollm-135m-f16-onnxruntime-1.29.0` | `neopolita/smollm-135m-gguf@22cca988936eafe92908e7558907c3964e10bba7`<br>`ggml-model-f16.gguf`<br>270,885,504 B<br>`ec8c775c16944a7e4b5251f97b3f848500dcc3e701b0d492ce9055cea42138a2` | `HuggingFaceTB/SmolLM-135M@1d461723eec654e65efdc40cf49301c89c0c92f4` | `HuggingFaceTB/SmolLM-135M@1d461723eec654e65efdc40cf49301c89c0c92f4`<br>`special_tokens_map.json` 831 B `e786b595b9a23148bf1630df78d9037a048ea671e48bfd3549a1e3c233742bb3`, `tokenizer.json` 2,104,556 B `9ca9acddb6525a194ec8ac7a87f24fbba7232a9a15ffa1af0c1224fcd888e47c`, `tokenizer_config.json` 3,685 B `238ad6b60d48e471624ea70bc79e92f2611844d5016471fee8c167854bcb98e8`<br>metadata `46646ba36ecae43de6f9f649d217774b889e0fd405af92205319b882927493fc` | onnx-genai 1.29.0; full-logit; dynamic KV cache prefill plus 20 cache-threaded decode steps |
 | `smollm-135m-f16-ort-genai-0.15.2` | `neopolita/smollm-135m-gguf@22cca988936eafe92908e7558907c3964e10bba7`<br>`ggml-model-f16.gguf`<br>270,885,504 B<br>`ec8c775c16944a7e4b5251f97b3f848500dcc3e701b0d492ce9055cea42138a2` | `HuggingFaceTB/SmolLM-135M@1d461723eec654e65efdc40cf49301c89c0c92f4` | `HuggingFaceTB/SmolLM-135M@1d461723eec654e65efdc40cf49301c89c0c92f4`<br>`special_tokens_map.json` 831 B `e786b595b9a23148bf1630df78d9037a048ea671e48bfd3549a1e3c233742bb3`, `tokenizer.json` 2,104,556 B `9ca9acddb6525a194ec8ac7a87f24fbba7232a9a15ffa1af0c1224fcd888e47c`, `tokenizer_config.json` 3,685 B `238ad6b60d48e471624ea70bc79e92f2611844d5016471fee8c167854bcb98e8`<br>metadata `46646ba36ecae43de6f9f649d217774b889e0fd405af92205319b882927493fc` | ort-genai 0.15.2; full-logit; ORT GenAI prefill plus 20 cache-threaded decode steps |
 
-Qwen2.5 remains covered only by its existing runtime evidence record above.
+Runtime support above is independent from tokenizer materialization support below.
 
 ## Tokenizer evidence
 
 | Evidence ID | GGUF identity | Official source | Exact tokenizer proof |
 |---|---|---|---|
-| `qwen3.5-0.8b-q4-tokenizer` | `ggml-org/Qwen3.5-0.8B-GGUF@8fea620810c4afa23dd6443f999a48574c1611a3`<br>`Qwen3.5-0.8B-Q4_0.gguf`<br>563,036,064 B<br>`57d1997790d1744fba5b40a7317df71ea5e2acee28c47e78f0cce39c0703f8cf`<br>320 tensors: F32=133, Q4_0=186, Q8_0=1 | `Qwen/Qwen3.5-0.8B@2fc06364715b967f1860aea9cf38778875588b17`<br>`config.json` 2,907 B `b90b86f35c8e6925ef74ee04d0e758f0a845c83a42089ad82bbaa948de9b4204`<br>`chat_template.jinja` 7,755 B `273d8e0e683b885071fb17e08d71e5f2a5ddfb5309756181681de4f5a1822d80`, `tokenizer.json` 12,807,982 B `5f9e4d4901a92b997e463c1f46055088b6cca5ca61a6522d1b9f64c4bb81cb42`, `tokenizer_config.json` 16,709 B `49e2b6e395f959f077f1e992b338919c0d4a9732fc6e613995e06557f843500c` | GGUF metadata `45302b58b2086a666a874652d0e9e1d5b4b26e786ffbaf9362a4f902eba0b10d`<br>248,320 ordered tokens `5ee0f927bcaa4b9fe85c244776ae9487468e427f83e053fc81f2a186f14936a3`<br>247,587 ordered merges `7e299304d9ad9dc312acdbcb1f6ccf0dce1256bf1aa986d651f13814dfd27e7b`<br>official source IDs `0..248076`; deterministic unused `[PAD{id}]` IDs `248077..248319`; embedding rows=248,320<br>materialized `a78b900eb4cd335bba249158066db523ce221f744e2b6144692bb81673d551af`<br>`Hello, world! 12345` → `[9419, 11, 1814, 0, 220, 16, 17, 18, 19, 20]`<br>`  spaced  text\n` → `[220, 61674, 220, 1414, 198]`<br>`\u4f60\u597d\uff0c\u4e16\u754c\uff01` → `[109266, 3709, 96748, 6115]`<br>`Caf\xe9 \u2014 \u03ba\u03cc\u03c3\u03bc\u03bf\u03c2 \U0001f680` → `[34, 2492, 933, 1892, 166265, 203260, 10838, 248, 222]`<br>`<\|im_start\|>user\nHello<\|im_end\|>\n<\|im_start\|>assistant\n` → `[248045, 846, 198, 9419, 248046, 198, 248045, 74455, 198]`<br>`<\|audio_start\|><\|audio_pad\|><\|audio_end\|>` → `[248070, 248076, 248071]` |
+| `lfm2-350m-f16-tokenizer` | `LiquidAI/LFM2-350M-GGUF@8fdc9d526b7ed346b19257551b05816c7912ecc2`<br>`LFM2-350M-F16.gguf`<br>711,482,304 B<br>`379ffdcbf08147c0313f6f1ce7ff558a2bc935eda633f4b46c52347032419c42` | `LiquidAI/LFM2-350M@73e3c253078a3b97c2e14b4c4665679f4d9b6d56`<br>`config.json` 999 B `fd3b3fba4e50e7b9a22bd41cbab59e9b28e319b2de19668d7fd9777c8d1a9ba1`<br>`chat_template.jinja` 209 B `a805e50fed68938a076b07e2e602639611b50b1ced0e50f11eb92f1ba25be4dc`, `special_tokens_map.json` 434 B `742aefe2b7dec496e8caffdba03a75d0c1a9925d53bd3f3e0d388c96b591b6f4`, `tokenizer.json` 4,732,426 B `98cff83b4f6d7e9d8929bebc62b07e92cf1b3f99c80d16bafe8b84a75448f40b`, `tokenizer_config.json` 91,509 B `36f511115e9d8952cbc9d15d9a20dfa7ce7d1444940e5c1dc42a762020c99bf5` | metadata `e5626d605bb50bc53fdb0fbfcf374fb33dfbaa0cc698d9746ba1e9b0b7e6d07d`<br>tokens 65,536 `c004fd0578dbfbff394335a7d5f95e78a8cdbbff6abc8c389ba2290637be58b6`<br>merges 63,683 `c70042d0b5969460432a218556522dedee908735a3e4cf70f27936353c5b3f65`<br>types `ffe1ea561257dc6e1f2c257b99b4913d63e9d6b896cf2f9da1a3d2cac316d4b4`; scores=0<br>source IDs `0..65535`; no GGUF-only padding extension; rows=65,536<br>materialized `e7b7960966e2ed43a22b00431246cf820d5e2751bec58c44f0184cbe9b8d18c9`<br>`Hello, world! 12345` → `[36309, 521, 2031, 510, 730, 10293, 2637]`<br>`  spaced  text\n` → `[730, 56551, 730, 3304, 708]`<br>`\u4f60\u597d\uff0c\u4e16\u754c\uff01` → `[11754, 6400, 1198, 11370, 8668]`<br>`Caf\xe9 \u2014 \u03ba\u03cc\u03c3\u03bc\u03bf\u03c2 \U0001f680` → `[544, 2305, 860, 2180, 59955, 49122, 27443, 16883, 51332, 23805, 758, 732]`<br>`<\|startoftext\|><\|im_start\|>user\nHello<\|im_end\|>` → `[1, 6, 6423, 708, 36309, 7]` |
+| `qwen2.5-0.5b-instruct-q8-tokenizer` | `Qwen/Qwen2.5-0.5B-Instruct-GGUF@9217f5db79a29953eb74d5343926648285ec7e67`<br>`qwen2.5-0.5b-instruct-q8_0.gguf`<br>675,710,816 B<br>`ca59ca7f13d0e15a8cfa77bd17e65d24f6844b554a7b6c12e07a5f89ff76844e` | `Qwen/Qwen2.5-0.5B-Instruct@a338b55dd21219a5f4da42bc11a9313d1a27d4cc`<br>`config.json` 659 B `18e18afcaccafade98daf13a54092927904649e1dd4eba8299ab717d5d94ff45`<br>`tokenizer.json` 7,031,645 B `c0382117ea329cdf097041132f6d735924b697924d6f6fc3945713e96ce87539`, `tokenizer_config.json` 7,308 B `5214600ee45ca2f887ce2eede8910378a0111ea99d657428bcbce94778e65a92` | metadata `8fc8ef848104e931f14ae03d9581699d54813a2ff952fb7caac0654e8aa27ee3`<br>tokens 151,936 `e2fadeac783c911f535d21f858f43127672a1d261af510d3f895e34bd2f6fb10`<br>merges 151,387 `24fa2ae2a398e50784a1fff678482094af4f63e6783d35686726abacda8dc371`<br>types `17ccfa7767a8721474dc0fd21ca1308fdfd04e0f64036efbfa97f3e16e5f18f1`; scores=0<br>source IDs `0..151935`; no GGUF-only padding extension; rows=151,936<br>materialized `be55f66f0643df9d3c1b5dc55ae552b0e334f219a3a5f8338e6864f8eb3a8ac5`<br>`Hello, world! 12345` → `[9707, 11, 1879, 0, 220, 16, 17, 18, 19, 20]`<br>`  spaced  text\n` → `[220, 63828, 220, 1467, 198]`<br>`\u4f60\u597d\uff0c\u4e16\u754c\uff01` → `[108386, 3837, 99489, 6313]`<br>`Caf\xe9 \u2014 \u03ba\u03cc\u03c3\u03bc\u03bf\u03c2 \U0001f680` → `[34, 2577, 963, 1959, 71638, 75195, 43928, 43123, 27554, 45642, 11162, 248, 222]`<br>`<\|im_start\|>user\nHello<\|im_end\|>\n` → `[151644, 872, 198, 9707, 151645, 198]` |
+| `qwen3.5-0.8b-q4-tokenizer` | `ggml-org/Qwen3.5-0.8B-GGUF@8fea620810c4afa23dd6443f999a48574c1611a3`<br>`Qwen3.5-0.8B-Q4_0.gguf`<br>563,036,064 B<br>`57d1997790d1744fba5b40a7317df71ea5e2acee28c47e78f0cce39c0703f8cf` | `Qwen/Qwen3.5-0.8B@2fc06364715b967f1860aea9cf38778875588b17`<br>`config.json` 2,907 B `b90b86f35c8e6925ef74ee04d0e758f0a845c83a42089ad82bbaa948de9b4204`<br>`chat_template.jinja` 7,755 B `273d8e0e683b885071fb17e08d71e5f2a5ddfb5309756181681de4f5a1822d80`, `tokenizer.json` 12,807,982 B `5f9e4d4901a92b997e463c1f46055088b6cca5ca61a6522d1b9f64c4bb81cb42`, `tokenizer_config.json` 16,709 B `49e2b6e395f959f077f1e992b338919c0d4a9732fc6e613995e06557f843500c` | metadata `45302b58b2086a666a874652d0e9e1d5b4b26e786ffbaf9362a4f902eba0b10d`<br>tokens 248,320 `5ee0f927bcaa4b9fe85c244776ae9487468e427f83e053fc81f2a186f14936a3`<br>merges 247,587 `7e299304d9ad9dc312acdbcb1f6ccf0dce1256bf1aa986d651f13814dfd27e7b`<br>types `f6fdca1063d1ae1cc77ba1f5087d259f044c2634e64b65e31bc844ec00e9acab`; scores=0<br>source IDs `0..248076`; unused `[PAD{id}]` IDs `248077..248319`; rows=248,320<br>materialized `a78b900eb4cd335bba249158066db523ce221f744e2b6144692bb81673d551af`<br>`Hello, world! 12345` → `[9419, 11, 1814, 0, 220, 16, 17, 18, 19, 20]`<br>`  spaced  text\n` → `[220, 61674, 220, 1414, 198]`<br>`\u4f60\u597d\uff0c\u4e16\u754c\uff01` → `[109266, 3709, 96748, 6115]`<br>`Caf\xe9 \u2014 \u03ba\u03cc\u03c3\u03bc\u03bf\u03c2 \U0001f680` → `[34, 2492, 933, 1892, 166265, 203260, 10838, 248, 222]`<br>`<\|im_start\|>user\nHello<\|im_end\|>\n<\|im_start\|>assistant\n` → `[248045, 846, 198, 9419, 248046, 198, 248045, 74455, 198]`<br>`<\|audio_start\|><\|audio_pad\|><\|audio_end\|>` → `[248070, 248076, 248071]` |
+| `smollm-135m-f16-tokenizer` | `neopolita/smollm-135m-gguf@22cca988936eafe92908e7558907c3964e10bba7`<br>`ggml-model-f16.gguf`<br>270,885,504 B<br>`ec8c775c16944a7e4b5251f97b3f848500dcc3e701b0d492ce9055cea42138a2` | `HuggingFaceTB/SmolLM-135M@1d461723eec654e65efdc40cf49301c89c0c92f4`<br>`config.json` 724 B `a1fe6f43e20f7a6c6dbc6380222af9526b5cef262446391a281c038249e3e3b7`<br>`special_tokens_map.json` 831 B `e786b595b9a23148bf1630df78d9037a048ea671e48bfd3549a1e3c233742bb3`, `tokenizer.json` 2,104,556 B `9ca9acddb6525a194ec8ac7a87f24fbba7232a9a15ffa1af0c1224fcd888e47c`, `tokenizer_config.json` 3,685 B `238ad6b60d48e471624ea70bc79e92f2611844d5016471fee8c167854bcb98e8` | metadata `46646ba36ecae43de6f9f649d217774b889e0fd405af92205319b882927493fc`<br>tokens 49,152 `ecc2f33f7cdf683196646ea97b005f82398e5ddbb0e143fbe95a402277eb1788`<br>merges 48,900 `3d6f4016bc9b70ea16f0f01b1dadb4504ad99c5eaa8584b81997dc65168e136b`<br>types `3a92d63c9763834e17f2d93490d5a9643fa07057f2799168d67d7812d08e31aa`; scores=0<br>source IDs `0..49151`; no GGUF-only padding extension; rows=49,152<br>materialized `9ca9acddb6525a194ec8ac7a87f24fbba7232a9a15ffa1af0c1224fcd888e47c`<br>`Hello, world! 12345` → `[19556, 28, 905, 17, 216, 33, 34, 35, 36, 37]`<br>`  spaced  text\n` → `[216, 23861, 216, 1694, 198]`<br>`\u4f60\u597d\uff0c\u4e16\u754c\uff01` → `[18645, 250, 48392, 138, 12831, 7906, 240, 178, 239, 230, 8083, 219]`<br>`Caf\xe9 \u2014 \u03ba\u03cc\u03c3\u03bc\u03bf\u03c2 \U0001f680` → `[51, 1939, 2756, 1841, 31953, 36180, 18751, 16674, 39346, 15107, 244, 218]`<br>`<\|endoftext\|>` → `[0]` |
 
 ```python
 from mobius.integrations.gguf import materialize_evidenced_gguf_tokenizer
@@ -78,12 +81,10 @@ from mobius.integrations.gguf import materialize_evidenced_gguf_tokenizer
 materialize_evidenced_gguf_tokenizer("Qwen3.5-0.8B-Q4_0.gguf", "tokenizer")
 ```
 
-Qwen3.5 tokenizer materialization uses `pinned-source`, not embedded `copy`: official
-`tokenizer.json` covers IDs 0-248069, official `tokenizer_config.json` adds IDs
-248070-248076, and only the GGUF embedding-alignment suffix 248077-248319 is reconstructed
-as non-special unused `[PAD{id}]` tokens. Every ordered token, merge, special ID, source
-asset, chat template, representative encoding, and the final materialized hash is checked
-before output. Qwen3.5 full model runtime remains **deferred**.
+Each row is independently artifact-scoped. Evidence proves ordered tokens, merges or scores,
+token types, special IDs, source pipeline/config assets, representative encodings, embedding
+alignment, any non-matchable padding extension, and the final materialized hash. It does not
+claim graph or runtime support.
 
 ## Supported GGUF architectures
 
@@ -357,100 +358,100 @@ Reason codes are concise user-facing categories; detailed architecture audits re
 
 ## Tokenizer pre-types
 
-The pre-type is never sufficient evidence by itself. Each row defaults to deferred; only an
-embedded exact JSON or a complete artifact-scoped evidence record can materialize a tokenizer.
+The pre-type is never sufficient evidence by itself. The generated census preserves all aliases
+and gives every route an exact evidence ID or concrete compiled-semantics blocker.
 
 <!-- BEGIN GGUF TOKENIZER PRE SUPPORT MATRIX -->
 
-| Exact identifier | Canonical semantic group | Pinned pre-type | Default route | Exactness/restriction |
+| Exact identifier | Semantic group / pre-type | Default policy | Current status | Evidence / blocker |
 |---|---|---|---|---|
-| `a.x-4.0` | `gpt-2` | `GPT2` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `afmoe` | `afmoe` | `AFMOE` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `bailingmoe` | `bailingmoe` | `BAILINGMOE` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `bailingmoe2` | `bailingmoe` | `BAILINGMOE` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `bloom` | `bloom` | `BLOOM` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `chameleon` | `chameleon` | `CHAMELEON` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `chatglm-bpe` | `glm4` | `CHATGLM4` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `codeshell` | `codeshell` | `CODESHELL` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `cohere2moe` | `tiny_aya` | `TINY_AYA` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `command-r` | `command-r` | `COMMAND_R` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `dbrx` | `dbrx` | `DBRX` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `deepseek-coder` | `deepseek-coder` | `DEEPSEEK_CODER` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `deepseek-llm` | `deepseek-llm` | `DEEPSEEK_LLM` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `deepseek-r1-qwen` | `qwen2` | `QWEN2` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `deepseek-v3` | `deepseek-v3` | `DEEPSEEK3_LLM` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `default` | `default` | `DEFAULT` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `exaone` | `exaone` | `EXAONE` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `exaone-moe` | `exaone-moe` | `EXAONE_MOE` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `exaone4` | `gpt-2` | `GPT2` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `f2llmv2` | `qwen2` | `QWEN2` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `falcon` | `falcon` | `FALCON` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `falcon-h1` | `llama3` | `LLAMA3` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `falcon3` | `llama3` | `LLAMA3` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `gemma4` | `gemma4` | `GEMMA4` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `gigachat` | `gpt-2` | `GPT2` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `glm4` | `glm4` | `CHATGLM4` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `gpt-2` | `gpt-2` | `GPT2` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `gpt-4o` | `gpt-4o` | `GPT4O` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `gpt3-finnish` | `gpt3-finnish` | `GPT3_FINNISH` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `granite-docling` | `granite-docling` | `GRANITE_DOCLING` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `granite-embed-multi-311m` | `gemma4` | `GEMMA4` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `granite-embed-multi-97m` | `granite-embed-multi-97m` | `GRANITE_EMB_MULTI` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `grok-2` | `grok-2` | `GROK_2` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `hunyuan` | `hunyuan` | `HUNYUAN` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `hunyuan-dense` | `hunyuan-dense` | `HUNYUAN_DENSE` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `jais` | `jais` | `JAIS` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `jais-2` | `jais-2` | `JAIS2` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `jina-de` | `gpt-2` | `GPT2` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `jina-es` | `gpt-2` | `GPT2` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `jina-v1-en` | `jina-v1-en` | `GPT2_ADD_SEP` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `jina-v2-code` | `jina-v1-en` | `GPT2_ADD_SEP` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `jina-v2-de` | `gpt-2` | `GPT2` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `jina-v2-es` | `gpt-2` | `GPT2` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `jina-v5-nano` | `llama3` | `LLAMA3` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `joyai-llm` | `joyai-llm` | `JOYAI_LLM` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `kanana2` | `gpt-4o` | `GPT4O` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `kimi-k2` | `kimi-k2` | `KIMI_K2` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `kormo` | `qwen2` | `QWEN2` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `laguna` | `laguna` | `LAGUNA` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `lfm2` | `llama3` | `LLAMA3` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `llada-moe` | `bailingmoe` | `BAILINGMOE` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `llama-bpe` | `llama3` | `LLAMA3` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `llama-v3` | `llama3` | `LLAMA3` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `llama3` | `llama3` | `LLAMA3` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `llama4` | `gpt-4o` | `GPT4O` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `megrez` | `megrez` | `QWEN2_CLEAN_SPACES` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `mellum` | `gpt-2` | `GPT2` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `mellum2` | `mellum2` | `MELLUM2` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `midm-2.0` | `llama3` | `LLAMA3` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `minerva-7b` | `minerva-7b` | `MINERVA` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `minicpm5` | `minicpm5` | `MINICPM5` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `minimax-m2` | `minimax-m2` | `MINIMAX_M2` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `modern-bert` | `gpt-2` | `GPT2` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `mpt` | `mpt` | `MPT` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `olmo` | `olmo` | `OLMO` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `phi-2` | `gpt-2` | `GPT2` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `pixtral` | `llama3` | `LLAMA3` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `poro-chat` | `poro-chat` | `PORO` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `qwen2` | `qwen2` | `QWEN2` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `qwen35` | `qwen35` | `QWEN35` | `deferred` | ARTIFACT_PINNED — Exact pinned-source materialization is available only for `qwen3.5-0.8b-q4-tokenizer`; every other artifact remains deferred. |
-| `refact` | `refact` | `REFACT` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `roberta-bpe` | `jina-v1-en` | `GPT2_ADD_SEP` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `sarvam-moe` | `sarvam-moe` | `SARVAM_MOE` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `seed-coder` | `seed-coder` | `SEED_CODER` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `smaug-bpe` | `smaug-bpe` | `SMAUG` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `smollm` | `smollm` | `SMOLLM` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `solar-open` | `solar-open` | `SOLAR_OPEN` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `stablelm2` | `stablelm2` | `STABLELM2` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `starcoder` | `starcoder` | `STARCODER` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `superbpe` | `superbpe` | `SUPERBPE` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `talkie` | `gpt-4o` | `GPT4O` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `tekken` | `tekken` | `TEKKEN` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `tiny_aya` | `tiny_aya` | `TINY_AYA` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `trillion` | `trillion` | `TRILLION` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `viking` | `viking` | `VIKING` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `whitespace` | `whitespace` | `WHITESPACE` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
-| `youtu` | `youtu` | `YOUTU` | `deferred` | TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or artifact-scoped pinned-source evidence. |
+| `a.x-4.0` | `gpt-2` / `GPT2` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `afmoe` | `afmoe` / `AFMOE` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `bailingmoe` | `bailingmoe` / `BAILINGMOE` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `bailingmoe2` | `bailingmoe` / `BAILINGMOE` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `bloom` | `bloom` / `BLOOM` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `chameleon` | `chameleon` / `CHAMELEON` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `chatglm-bpe` | `glm4` / `CHATGLM4` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `codeshell` | `codeshell` / `CODESHELL` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `cohere2moe` | `tiny_aya` / `TINY_AYA` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `command-r` | `command-r` / `COMMAND_R` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `dbrx` | `dbrx` / `DBRX` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `deepseek-coder` | `deepseek-coder` / `DEEPSEEK_CODER` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `deepseek-llm` | `deepseek-llm` / `DEEPSEEK_LLM` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `deepseek-r1-qwen` | `qwen2` / `QWEN2` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `deepseek-v3` | `deepseek-v3` / `DEEPSEEK3_LLM` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `default` | `default` / `DEFAULT` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `exaone` | `exaone` / `EXAONE` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `exaone-moe` | `exaone-moe` / `EXAONE_MOE` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `exaone4` | `gpt-2` / `GPT2` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `f2llmv2` | `qwen2` / `QWEN2` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `falcon` | `falcon` / `FALCON` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `falcon-h1` | `llama3` / `LLAMA3` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `falcon3` | `llama3` / `LLAMA3` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `gemma4` | `gemma4` / `GEMMA4` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `gigachat` | `gpt-2` / `GPT2` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `glm4` | `glm4` / `CHATGLM4` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `gpt-2` | `gpt-2` / `GPT2` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `gpt-4o` | `gpt-4o` / `GPT4O` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `gpt3-finnish` | `gpt3-finnish` / `GPT3_FINNISH` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `granite-docling` | `granite-docling` / `GRANITE_DOCLING` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `granite-embed-multi-311m` | `gemma4` / `GEMMA4` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `granite-embed-multi-97m` | `granite-embed-multi-97m` / `GRANITE_EMB_MULTI` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `grok-2` | `grok-2` / `GROK_2` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `hunyuan` | `hunyuan` / `HUNYUAN` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `hunyuan-dense` | `hunyuan-dense` / `HUNYUAN_DENSE` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `jais` | `jais` / `JAIS` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `jais-2` | `jais-2` / `JAIS2` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `jina-de` | `gpt-2` / `GPT2` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `jina-es` | `gpt-2` / `GPT2` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `jina-v1-en` | `jina-v1-en` / `GPT2_ADD_SEP` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `jina-v2-code` | `jina-v1-en` / `GPT2_ADD_SEP` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `jina-v2-de` | `gpt-2` / `GPT2` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `jina-v2-es` | `gpt-2` / `GPT2` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `jina-v5-nano` | `llama3` / `LLAMA3` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `joyai-llm` | `joyai-llm` / `JOYAI_LLM` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `kanana2` | `gpt-4o` / `GPT4O` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `kimi-k2` | `kimi-k2` / `KIMI_K2` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `kormo` | `qwen2` / `QWEN2` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `laguna` | `laguna` / `LAGUNA` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `lfm2` | `llama3` / `LLAMA3` | `deferred` | `validated-pinned-source` | `lfm2-350m-f16-tokenizer` |
+| `llada-moe` | `bailingmoe` / `BAILINGMOE` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `llama-bpe` | `llama3` / `LLAMA3` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `llama-v3` | `llama3` / `LLAMA3` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `llama3` | `llama3` / `LLAMA3` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `llama4` | `gpt-4o` / `GPT4O` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `megrez` | `megrez` / `QWEN2_CLEAN_SPACES` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `mellum` | `gpt-2` / `GPT2` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `mellum2` | `mellum2` / `MELLUM2` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `midm-2.0` | `llama3` / `LLAMA3` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `minerva-7b` | `minerva-7b` / `MINERVA` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `minicpm5` | `minicpm5` / `MINICPM5` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `minimax-m2` | `minimax-m2` / `MINIMAX_M2` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `modern-bert` | `gpt-2` / `GPT2` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `mpt` | `mpt` / `MPT` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `olmo` | `olmo` / `OLMO` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `phi-2` | `gpt-2` / `GPT2` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `pixtral` | `llama3` / `LLAMA3` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `poro-chat` | `poro-chat` / `PORO` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `qwen2` | `qwen2` / `QWEN2` | `deferred` | `validated-pinned-source` | `qwen2.5-0.5b-instruct-q8-tokenizer` |
+| `qwen35` | `qwen35` / `QWEN35` | `deferred` | `validated-pinned-source` | `qwen3.5-0.8b-q4-tokenizer` |
+| `refact` | `refact` / `REFACT` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `roberta-bpe` | `jina-v1-en` / `GPT2_ADD_SEP` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `sarvam-moe` | `sarvam-moe` / `SARVAM_MOE` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `seed-coder` | `seed-coder` / `SEED_CODER` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `smaug-bpe` | `smaug-bpe` / `SMAUG` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `smollm` | `smollm` / `SMOLLM` | `deferred` | `validated-pinned-source` | `smollm-135m-f16-tokenizer` |
+| `solar-open` | `solar-open` / `SOLAR_OPEN` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `stablelm2` | `stablelm2` / `STABLELM2` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `starcoder` | `starcoder` / `STARCODER` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `superbpe` | `superbpe` / `SUPERBPE` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `talkie` | `gpt-4o` / `GPT4O` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `tekken` | `tekken` / `TEKKEN` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `tiny_aya` | `tiny_aya` / `TINY_AYA` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `trillion` | `trillion` / `TRILLION` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `viking` | `viking` / `VIKING` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `whitespace` | `whitespace` / `WHITESPACE` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
+| `youtu` | `youtu` / `YOUTU` | `deferred` | `deferred-compiled-semantics` | `compiled-llama.cpp-semantic-dependency` |
 
 <!-- END GGUF TOKENIZER PRE SUPPORT MATRIX -->
 

--- a/src/mobius/integrations/gguf/__init__.py
+++ b/src/mobius/integrations/gguf/__init__.py
@@ -63,6 +63,10 @@ from mobius.integrations.gguf._tokenizer import (
     materialize_gguf_tokenizer,
     write_gguf_tokenizer_json,
 )
+from mobius.integrations.gguf._tokenizer_census import (
+    GGUFTokenizerRouteAudit,
+    tokenizer_route_census,
+)
 
 __all__ = [
     "build_from_gguf",
@@ -70,9 +74,11 @@ __all__ = [
     "build_gemma4_vlm_from_gguf",
     "build_qwen_vlm_from_gguf",
     "GGUFTokenizerAsset",
+    "GGUFTokenizerRouteAudit",
     "GGUFTokenizerSource",
     "materialize_evidenced_gguf_tokenizer",
     "materialize_gguf_tokenizer",
+    "tokenizer_route_census",
     "write_gguf_runtime_package",
     "write_gguf_tokenizer_json",
     "verify_gguf_reuse_manifest",

--- a/src/mobius/integrations/gguf/_docs.py
+++ b/src/mobius/integrations/gguf/_docs.py
@@ -31,7 +31,8 @@ from mobius.integrations.gguf._quant_registry import (
 )
 from mobius.integrations.gguf._runtime_evidence import runtime_evidence
 from mobius.integrations.gguf._spec import GGUFArchitectureSpec, StorageRole, Support
-from mobius.integrations.gguf._tokenizer_evidence import tokenizer_evidence
+from mobius.integrations.gguf._tokenizer_census import tokenizer_route_census
+from mobius.integrations.gguf._tokenizer_evidence import iter_tokenizer_evidence
 from mobius.integrations.gguf._tokenizer_registry import tokenizer_pre_policies
 from mobius.integrations.gguf._upstream import (
     UPSTREAM_COMMIT,
@@ -55,6 +56,7 @@ def _summary() -> str:
     qtypes = iter_quant_specs()
     projectors = iter_projector_specs()
     tokenizers = tokenizer_pre_policies()
+    tokenizer_statuses = Counter(record.current_status for record in tokenizer_route_census())
     stored = [spec for spec in qtypes if spec.readable and spec.role is StorageRole.QUANTIZED]
     routed = [
         spec
@@ -94,8 +96,7 @@ def _summary() -> str:
             (
                 f"| Tokenizer pre identifiers | {len(tokenizers)} | "
                 f"{len({policy.canonical for policy in tokenizers.values()})} semantic groups; "
-                "all default to deferred and become materializable only from a validated embedded "
-                "`tokenizer.huggingface.json` or exact artifact-scoped tokenizer evidence |"
+                f"route dispositions: {dict(sorted(tokenizer_statuses.items()))} |"
             ),
             "",
             (
@@ -233,24 +234,21 @@ def _projectors() -> str:
 def _tokenizers() -> str:
     rows = [
         (
-            "| Exact identifier | Canonical semantic group | Pinned pre-type | Default route | "
-            "Exactness/restriction |"
+            "| Exact identifier | Semantic group / pre-type | Default policy | Current status | "
+            "Evidence / blocker |"
         ),
         "|---|---|---|---|---|",
     ]
-    for identifier, policy in sorted(tokenizer_pre_policies().items()):
-        restriction = (
-            "ARTIFACT_PINNED — Exact pinned-source materialization is available only for "
-            "`qwen3.5-0.8b-q4-tokenizer`; every other artifact remains deferred."
-            if identifier == "qwen35"
-            else "TOKENIZER_EVIDENCE_REQUIRED — Requires embedded exact JSON or "
-            "artifact-scoped pinned-source evidence."
+    for record in tokenizer_route_census():
+        disposition = (
+            f"`{record.evidence_id}`"
+            if record.evidence_id is not None
+            else f"`{record.blocker_category}`"
         )
-        row = (
-            f"| `{identifier}` | `{policy.canonical}` | `{policy.pre_type}` | "
-            f"`{policy.default_route}` | {restriction} |"
+        rows.append(
+            f"| `{record.identifier}` | `{record.semantic_group}` / `{record.pre_type}` | "
+            f"`{record.default_policy}` | `{record.current_status}` | {disposition} |"
         )
-        rows.append(row)
     return "\n".join(rows)
 
 
@@ -299,51 +297,52 @@ def _runtime_evidence_table() -> str:
 
 
 def _tokenizer_evidence_table() -> str:
-    evidence = tokenizer_evidence("qwen3.5-0.8b-q4-tokenizer")
-    if evidence is None:
-        raise ValueError("Missing qwen3.5-0.8b-q4-tokenizer evidence")
-    assets = ", ".join(
-        f"`{name}` {size:,} B `{sha256}`" for name, size, sha256 in evidence.tokenizer_assets
-    )
-    encodings = "<br>".join(
-        f"`{text.encode('unicode_escape').decode()}` → `{list(token_ids)}`"
-        for text, token_ids in evidence.representative_encodings
-    )
-    padding_start, padding_end = evidence.deterministic_padding_range
-    identity = (
-        f"`{evidence.repository}@{evidence.revision}`<br>"
-        f"`{evidence.filename}`<br>{evidence.size:,} B<br>`{evidence.lfs_sha256}`<br>"
-        f"{evidence.tensor_count} tensors: "
-        f"{', '.join(f'{name}={count}' for name, count in evidence.tensor_qtypes)}"
-    )
-    source = (
-        f"`{evidence.tokenizer_repository}@{evidence.tokenizer_revision}`<br>"
-        f"`{evidence.source_config_asset[0]}` {evidence.source_config_asset[1]:,} B "
-        f"`{evidence.source_config_asset[2]}`<br>{assets}"
-    )
-    proof = (
-        f"GGUF metadata `{evidence.tokenizer_metadata_sha256}`<br>"
-        f"{evidence.token_count:,} ordered tokens "
-        f"`{evidence.ordered_vocabulary_sha256}`<br>"
-        f"{evidence.merge_count:,} ordered merges "
-        f"`{evidence.ordered_merges_sha256}`<br>"
-        f"official source IDs `0..{evidence.source_token_count - 1}`; deterministic "
-        f"unused `[PAD{{id}}]` IDs `{padding_start}..{padding_end}`; "
-        f"embedding rows={evidence.embedding_vocabulary_size:,}<br>"
-        f"materialized `{evidence.materialized_tokenizer_sha256}`<br>{encodings}"
-    )
-    return "\n".join(
-        (
-            "| Evidence ID | GGUF identity | Official source | Exact tokenizer proof |",
-            "|---|---|---|---|",
+    rows = [
+        "| Evidence ID | GGUF identity | Official source | Exact tokenizer proof |",
+        "|---|---|---|---|",
+    ]
+    for evidence in iter_tokenizer_evidence():
+        assets = ", ".join(
+            f"`{name}` {size:,} B `{sha256}`"
+            for name, size, sha256 in evidence.tokenizer_assets
+        )
+        encodings = "<br>".join(
+            f"`{text.encode('unicode_escape').decode()}` → `{list(token_ids)}`"
+            for text, token_ids in evidence.representative_encodings
+        )
+        padding_start, padding_end = evidence.deterministic_padding_range
+        padding = (
+            f"unused `[PAD{{id}}]` IDs `{padding_start}..{padding_end}`"
+            if padding_start <= padding_end
+            else "no GGUF-only padding extension"
+        )
+        identity = (
+            f"`{evidence.repository}@{evidence.revision}`<br>"
+            f"`{evidence.filename}`<br>{evidence.size:,} B<br>`{evidence.lfs_sha256}`"
+        )
+        source = (
+            f"`{evidence.tokenizer_repository}@{evidence.tokenizer_revision}`<br>"
+            f"`{evidence.source_config_asset[0]}` {evidence.source_config_asset[1]:,} B "
+            f"`{evidence.source_config_asset[2]}`<br>{assets}"
+        )
+        proof = (
+            f"metadata `{evidence.tokenizer_metadata_sha256}`<br>"
+            f"tokens {evidence.token_count:,} `{evidence.ordered_vocabulary_sha256}`<br>"
+            f"merges {evidence.merge_count:,} `{evidence.ordered_merges_sha256}`<br>"
+            f"types `{evidence.ordered_token_types_sha256}`; scores={evidence.score_count}<br>"
+            f"source IDs `0..{evidence.source_token_count - 1}`; {padding}; "
+            f"rows={evidence.embedding_vocabulary_size:,}<br>"
+            f"materialized `{evidence.materialized_tokenizer_sha256}`<br>{encodings}"
+        )
+        rows.append(
             "| "
             + " | ".join(
                 _cell(value)
                 for value in (f"`{evidence.evidence_id}`", identity, source, proof)
             )
-            + " |",
+            + " |"
         )
-    )
+    return "\n".join(rows)
 
 
 def _projector_evidence_table() -> str:
@@ -415,7 +414,7 @@ evidence match.
 
 {_runtime_evidence_table()}
 
-Qwen2.5 remains covered only by its existing runtime evidence record above.
+Runtime support above is independent from tokenizer materialization support below.
 
 ## Tokenizer evidence
 
@@ -427,12 +426,10 @@ from mobius.integrations.gguf import materialize_evidenced_gguf_tokenizer
 materialize_evidenced_gguf_tokenizer("Qwen3.5-0.8B-Q4_0.gguf", "tokenizer")
 ```
 
-Qwen3.5 tokenizer materialization uses `pinned-source`, not embedded `copy`: official
-`tokenizer.json` covers IDs 0-248069, official `tokenizer_config.json` adds IDs
-248070-248076, and only the GGUF embedding-alignment suffix 248077-248319 is reconstructed
-as non-special unused `[PAD{{id}}]` tokens. Every ordered token, merge, special ID, source
-asset, chat template, representative encoding, and the final materialized hash is checked
-before output. Qwen3.5 full model runtime remains **deferred**.
+Each row is independently artifact-scoped. Evidence proves ordered tokens, merges or scores,
+token types, special IDs, source pipeline/config assets, representative encodings, embedding
+alignment, any non-matchable padding extension, and the final materialized hash. It does not
+claim graph or runtime support.
 
 ## Supported GGUF architectures
 
@@ -465,8 +462,8 @@ Reason codes are concise user-facing categories; detailed architecture audits re
 
 ## Tokenizer pre-types
 
-The pre-type is never sufficient evidence by itself. Each row defaults to deferred; only an
-embedded exact JSON or a complete artifact-scoped evidence record can materialize a tokenizer.
+The pre-type is never sufficient evidence by itself. The generated census preserves all aliases
+and gives every route an exact evidence ID or concrete compiled-semantics blocker.
 
 <!-- BEGIN GGUF TOKENIZER PRE SUPPORT MATRIX -->
 

--- a/src/mobius/integrations/gguf/_docs_test.py
+++ b/src/mobius/integrations/gguf/_docs_test.py
@@ -37,22 +37,28 @@ def test_document_is_concise_and_reason_coded() -> None:
     assert len(document.splitlines()) < 500
     assert "RUNTIME_EVIDENCE_PENDING" in document
     assert "qwen3.5-0.8b-q4-tokenizer" in document
-    assert "IDs 0-248069" in document
-    assert "Qwen3.5 full model runtime remains **deferred**" in document
+    assert "qwen2.5-0.5b-instruct-q8-tokenizer" in document
+    assert "deferred-compiled-semantics" in document
+    assert "does not claim graph or runtime support." in " ".join(document.split())
 
 
-def test_tokenizer_evidence_row_has_exactly_four_markdown_columns() -> None:
-    row = next(
+def test_tokenizer_evidence_rows_have_exactly_four_markdown_columns() -> None:
+    evidence_ids = {
+        "lfm2-350m-f16-tokenizer",
+        "qwen2.5-0.5b-instruct-q8-tokenizer",
+        "qwen3.5-0.8b-q4-tokenizer",
+        "smollm-135m-f16-tokenizer",
+    }
+    rows = [
         line
         for line in render_document().splitlines()
-        if line.startswith("| `qwen3.5-0.8b-q4-tokenizer`")
-    )
-    parts = re.split(r"(?<!\\)\|", row)
-    assert parts[0] == parts[-1] == ""
-    cells = [part.strip() for part in parts[1:-1]]
-    assert len(cells) == 4
-    assert r"<\|im_start\|>" in cells[3]
-    assert r"<\|audio_start\|>" in cells[3]
+        if line.startswith("| `") and line.split("`", 2)[1] in evidence_ids
+    ]
+    assert len(rows) == 4
+    for row in rows:
+        parts = re.split(r"(?<!\\)\|", row)
+        assert parts[0] == parts[-1] == ""
+        assert len([part.strip() for part in parts[1:-1]]) == 4
 
 
 def test_architecture_restrictions_are_concise_and_fully_registry_derived() -> None:

--- a/src/mobius/integrations/gguf/_tokenizer_census.py
+++ b/src/mobius/integrations/gguf/_tokenizer_census.py
@@ -1,0 +1,100 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Registry-derived, machine-readable disposition of every GGUF tokenizer route."""
+
+from __future__ import annotations
+
+__all__ = ["GGUFTokenizerRouteAudit", "tokenizer_route_census"]
+
+import dataclasses
+import functools
+from typing import Literal
+
+from mobius.integrations.gguf._tokenizer_evidence import (
+    GGUFTokenizerEvidence,
+    iter_tokenizer_evidence,
+)
+from mobius.integrations.gguf._tokenizer_registry import tokenizer_pre_policies
+
+TokenizerAuditStatus = Literal["validated-pinned-source", "deferred-compiled-semantics"]
+TokenizerBlocker = Literal["compiled-llama.cpp-semantic-dependency"]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class GGUFTokenizerRouteAudit:
+    """Exact policy, evidence identity, and disposition for one pre identifier."""
+
+    identifier: str
+    semantic_group: str
+    pre_type: str
+    default_policy: str
+    current_status: TokenizerAuditStatus
+    evidence_id: str | None
+    artifact_repository: str | None
+    artifact_revision: str | None
+    artifact_filename: str | None
+    artifact_size: int | None
+    artifact_sha256: str | None
+    tokenizer_repository: str | None
+    tokenizer_revision: str | None
+    tokenizer_assets: tuple[tuple[str, int, str], ...]
+    blocker_category: TokenizerBlocker | None
+
+
+def _evidenced_route(evidence: GGUFTokenizerEvidence) -> GGUFTokenizerRouteAudit:
+    policy = tokenizer_pre_policies()[evidence.pre_identifier]
+    return GGUFTokenizerRouteAudit(
+        identifier=policy.identifier,
+        semantic_group=policy.canonical,
+        pre_type=policy.pre_type,
+        default_policy=policy.default_route,
+        current_status="validated-pinned-source",
+        evidence_id=evidence.evidence_id,
+        artifact_repository=evidence.repository,
+        artifact_revision=evidence.revision,
+        artifact_filename=evidence.filename,
+        artifact_size=evidence.size,
+        artifact_sha256=evidence.lfs_sha256,
+        tokenizer_repository=evidence.tokenizer_repository,
+        tokenizer_revision=evidence.tokenizer_revision,
+        tokenizer_assets=tuple(
+            sorted((evidence.source_config_asset, *evidence.tokenizer_assets))
+        ),
+        blocker_category=None,
+    )
+
+
+@functools.lru_cache(maxsize=1)
+def tokenizer_route_census() -> tuple[GGUFTokenizerRouteAudit, ...]:
+    """Return all exact routes, including aliases, in identifier order."""
+    evidenced = {
+        evidence.pre_identifier: _evidenced_route(evidence)
+        for evidence in iter_tokenizer_evidence()
+    }
+    if len(evidenced) != len(iter_tokenizer_evidence()):
+        raise RuntimeError("Tokenizer evidence contains duplicate exact pre identifiers")
+
+    records = []
+    for identifier, policy in sorted(tokenizer_pre_policies().items()):
+        record = evidenced.get(identifier)
+        if record is None:
+            record = GGUFTokenizerRouteAudit(
+                identifier=identifier,
+                semantic_group=policy.canonical,
+                pre_type=policy.pre_type,
+                default_policy=policy.default_route,
+                current_status="deferred-compiled-semantics",
+                evidence_id=None,
+                artifact_repository=None,
+                artifact_revision=None,
+                artifact_filename=None,
+                artifact_size=None,
+                artifact_sha256=None,
+                tokenizer_repository=None,
+                tokenizer_revision=None,
+                tokenizer_assets=(),
+                blocker_category="compiled-llama.cpp-semantic-dependency",
+            )
+        records.append(record)
+    return tuple(records)

--- a/src/mobius/integrations/gguf/_tokenizer_evidence.py
+++ b/src/mobius/integrations/gguf/_tokenizer_evidence.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 __all__ = [
     "GGUFTokenizerEvidence",
+    "iter_tokenizer_evidence",
     "matching_tokenizer_evidence",
     "tokenizer_evidence",
 ]
@@ -29,6 +30,7 @@ class GGUFTokenizerEvidence:
 
     evidence_id: str
     architecture: str
+    pre_identifier: str
     repository: str
     revision: str
     filename: str
@@ -47,7 +49,10 @@ class GGUFTokenizerEvidence:
     deterministic_padding_range: tuple[int, int]
     ordered_vocabulary_sha256: str
     merge_count: int
-    ordered_merges_sha256: str
+    ordered_merges_sha256: str | None
+    score_count: int
+    ordered_scores_sha256: str | None
+    ordered_token_types_sha256: str
     materialized_tokenizer_sha256: str
     special_token_ids: tuple[tuple[str, int], ...]
     representative_encodings: tuple[tuple[str, tuple[int, ...]], ...]
@@ -58,7 +63,7 @@ class GGUFTokenizerEvidence:
             self.lfs_sha256,
             self.tokenizer_metadata_sha256,
             self.ordered_vocabulary_sha256,
-            self.ordered_merges_sha256,
+            self.ordered_token_types_sha256,
             self.materialized_tokenizer_sha256,
         )
         if any(re.fullmatch(r"[0-9a-f]{40}", value) is None for value in revisions):
@@ -72,7 +77,6 @@ class GGUFTokenizerEvidence:
                 self.token_count,
                 self.source_token_count,
                 self.embedding_vocabulary_size,
-                self.merge_count,
             )
             <= 0
         ):
@@ -104,6 +108,26 @@ class GGUFTokenizerEvidence:
         )
         if tuple(sorted(self.special_token_ids)) != self.special_token_ids:
             raise ValueError("Tokenizer evidence special token IDs must be sorted by token")
+        if self.merge_count < 0 or (
+            (self.merge_count == 0) != (self.ordered_merges_sha256 is None)
+        ):
+            raise ValueError("Tokenizer evidence merge count and digest disagree")
+        if (
+            self.ordered_merges_sha256 is not None
+            and re.fullmatch(r"[0-9a-f]{64}", self.ordered_merges_sha256) is None
+        ):
+            raise ValueError("Tokenizer evidence merge digest must be lowercase SHA-256")
+        if self.score_count < 0 or (
+            (self.score_count == 0) != (self.ordered_scores_sha256 is None)
+        ):
+            raise ValueError("Tokenizer evidence score count and digest disagree")
+        if (
+            self.ordered_scores_sha256 is not None
+            and re.fullmatch(r"[0-9a-f]{64}", self.ordered_scores_sha256) is None
+        ):
+            raise ValueError("Tokenizer evidence score digest must be lowercase SHA-256")
+        if self.merge_count == 0 and self.score_count == 0:
+            raise ValueError("Tokenizer evidence requires ordered merges or ordered scores")
         if not self.representative_encodings or any(
             not text or not token_ids for text, token_ids in self.representative_encodings
         ):
@@ -125,6 +149,7 @@ class GGUFTokenizerEvidence:
 _QWEN35_08B_Q4_TOKENIZER = GGUFTokenizerEvidence(
     evidence_id="qwen3.5-0.8b-q4-tokenizer",
     architecture="qwen35",
+    pre_identifier="qwen35",
     repository="ggml-org/Qwen3.5-0.8B-GGUF",
     revision="8fea620810c4afa23dd6443f999a48574c1611a3",
     filename="Qwen3.5-0.8B-Q4_0.gguf",
@@ -164,6 +189,11 @@ _QWEN35_08B_Q4_TOKENIZER = GGUFTokenizerEvidence(
     ordered_vocabulary_sha256="5ee0f927bcaa4b9fe85c244776ae9487468e427f83e053fc81f2a186f14936a3",
     merge_count=247_587,
     ordered_merges_sha256="7e299304d9ad9dc312acdbcb1f6ccf0dce1256bf1aa986d651f13814dfd27e7b",
+    score_count=0,
+    ordered_scores_sha256=None,
+    ordered_token_types_sha256=(
+        "f6fdca1063d1ae1cc77ba1f5087d259f044c2634e64b65e31bc844ec00e9acab"
+    ),
     materialized_tokenizer_sha256=(
         "a78b900eb4cd335bba249158066db523ce221f744e2b6144692bb81673d551af"
     ),
@@ -203,14 +233,219 @@ _QWEN35_08B_Q4_TOKENIZER = GGUFTokenizerEvidence(
     ),
 )
 
+_SMOLLM_135M_F16_TOKENIZER = GGUFTokenizerEvidence(
+    evidence_id="smollm-135m-f16-tokenizer",
+    architecture="llama",
+    pre_identifier="smollm",
+    repository="neopolita/smollm-135m-gguf",
+    revision="22cca988936eafe92908e7558907c3964e10bba7",
+    filename="ggml-model-f16.gguf",
+    size=270_885_504,
+    lfs_sha256="ec8c775c16944a7e4b5251f97b3f848500dcc3e701b0d492ce9055cea42138a2",
+    tensor_count=272,
+    tensor_qtypes=(("F16", 211), ("F32", 61)),
+    tokenizer_repository="HuggingFaceTB/SmolLM-135M",
+    tokenizer_revision="1d461723eec654e65efdc40cf49301c89c0c92f4",
+    source_config_asset=(
+        "config.json",
+        724,
+        "a1fe6f43e20f7a6c6dbc6380222af9526b5cef262446391a281c038249e3e3b7",
+    ),
+    tokenizer_metadata_sha256="46646ba36ecae43de6f9f649d217774b889e0fd405af92205319b882927493fc",
+    tokenizer_assets=(
+        (
+            "special_tokens_map.json",
+            831,
+            "e786b595b9a23148bf1630df78d9037a048ea671e48bfd3549a1e3c233742bb3",
+        ),
+        (
+            "tokenizer.json",
+            2_104_556,
+            "9ca9acddb6525a194ec8ac7a87f24fbba7232a9a15ffa1af0c1224fcd888e47c",
+        ),
+        (
+            "tokenizer_config.json",
+            3_685,
+            "238ad6b60d48e471624ea70bc79e92f2611844d5016471fee8c167854bcb98e8",
+        ),
+    ),
+    token_count=49_152,
+    source_token_count=49_152,
+    embedding_vocabulary_size=49_152,
+    deterministic_padding_range=(49_152, 49_151),
+    ordered_vocabulary_sha256="ecc2f33f7cdf683196646ea97b005f82398e5ddbb0e143fbe95a402277eb1788",
+    merge_count=48_900,
+    ordered_merges_sha256="3d6f4016bc9b70ea16f0f01b1dadb4504ad99c5eaa8584b81997dc65168e136b",
+    score_count=0,
+    ordered_scores_sha256=None,
+    ordered_token_types_sha256=(
+        "3a92d63c9763834e17f2d93490d5a9643fa07057f2799168d67d7812d08e31aa"
+    ),
+    materialized_tokenizer_sha256=(
+        "9ca9acddb6525a194ec8ac7a87f24fbba7232a9a15ffa1af0c1224fcd888e47c"
+    ),
+    special_token_ids=(("<|endoftext|>", 0),),
+    representative_encodings=(
+        ("Hello, world! 12345", (19556, 28, 905, 17, 216, 33, 34, 35, 36, 37)),
+        ("  spaced  text\n", (216, 23861, 216, 1694, 198)),
+        ("你好，世界！", (18645, 250, 48392, 138, 12831, 7906, 240, 178, 239, 230, 8083, 219)),  # noqa: RUF001
+        (
+            "Café — κόσμος 🚀",
+            (51, 1939, 2756, 1841, 31953, 36180, 18751, 16674, 39346, 15107, 244, 218),
+        ),
+        ("<|endoftext|>", (0,)),
+    ),
+)
+
+_QWEN25_05B_Q8_TOKENIZER = GGUFTokenizerEvidence(
+    evidence_id="qwen2.5-0.5b-instruct-q8-tokenizer",
+    architecture="qwen2",
+    pre_identifier="qwen2",
+    repository="Qwen/Qwen2.5-0.5B-Instruct-GGUF",
+    revision="9217f5db79a29953eb74d5343926648285ec7e67",
+    filename="qwen2.5-0.5b-instruct-q8_0.gguf",
+    size=675_710_816,
+    lfs_sha256="ca59ca7f13d0e15a8cfa77bd17e65d24f6844b554a7b6c12e07a5f89ff76844e",
+    tensor_count=291,
+    tensor_qtypes=(("F32", 121), ("Q8_0", 170)),
+    tokenizer_repository="Qwen/Qwen2.5-0.5B-Instruct",
+    tokenizer_revision="a338b55dd21219a5f4da42bc11a9313d1a27d4cc",
+    source_config_asset=(
+        "config.json",
+        659,
+        "18e18afcaccafade98daf13a54092927904649e1dd4eba8299ab717d5d94ff45",
+    ),
+    tokenizer_metadata_sha256="8fc8ef848104e931f14ae03d9581699d54813a2ff952fb7caac0654e8aa27ee3",
+    tokenizer_assets=(
+        (
+            "tokenizer.json",
+            7_031_645,
+            "c0382117ea329cdf097041132f6d735924b697924d6f6fc3945713e96ce87539",
+        ),
+        (
+            "tokenizer_config.json",
+            7_308,
+            "5214600ee45ca2f887ce2eede8910378a0111ea99d657428bcbce94778e65a92",
+        ),
+    ),
+    token_count=151_936,
+    source_token_count=151_936,
+    embedding_vocabulary_size=151_936,
+    deterministic_padding_range=(151_936, 151_935),
+    ordered_vocabulary_sha256="e2fadeac783c911f535d21f858f43127672a1d261af510d3f895e34bd2f6fb10",
+    merge_count=151_387,
+    ordered_merges_sha256="24fa2ae2a398e50784a1fff678482094af4f63e6783d35686726abacda8dc371",
+    score_count=0,
+    ordered_scores_sha256=None,
+    ordered_token_types_sha256=(
+        "17ccfa7767a8721474dc0fd21ca1308fdfd04e0f64036efbfa97f3e16e5f18f1"
+    ),
+    materialized_tokenizer_sha256=(
+        "be55f66f0643df9d3c1b5dc55ae552b0e334f219a3a5f8338e6864f8eb3a8ac5"
+    ),
+    special_token_ids=(("<|endoftext|>", 151643), ("<|im_end|>", 151645)),
+    representative_encodings=(
+        ("Hello, world! 12345", (9707, 11, 1879, 0, 220, 16, 17, 18, 19, 20)),
+        ("  spaced  text\n", (220, 63828, 220, 1467, 198)),
+        ("你好，世界！", (108386, 3837, 99489, 6313)),  # noqa: RUF001
+        (
+            "Café — κόσμος 🚀",
+            (34, 2577, 963, 1959, 71638, 75195, 43928, 43123, 27554, 45642, 11162, 248, 222),
+        ),
+        ("<|im_start|>user\nHello<|im_end|>\n", (151644, 872, 198, 9707, 151645, 198)),
+    ),
+)
+
+_LFM2_350M_F16_TOKENIZER = GGUFTokenizerEvidence(
+    evidence_id="lfm2-350m-f16-tokenizer",
+    architecture="lfm2",
+    pre_identifier="lfm2",
+    repository="LiquidAI/LFM2-350M-GGUF",
+    revision="8fdc9d526b7ed346b19257551b05816c7912ecc2",
+    filename="LFM2-350M-F16.gguf",
+    size=711_482_304,
+    lfs_sha256="379ffdcbf08147c0313f6f1ce7ff558a2bc935eda633f4b46c52347032419c42",
+    tensor_count=148,
+    tensor_qtypes=(("F16", 93), ("F32", 55)),
+    tokenizer_repository="LiquidAI/LFM2-350M",
+    tokenizer_revision="73e3c253078a3b97c2e14b4c4665679f4d9b6d56",
+    source_config_asset=(
+        "config.json",
+        999,
+        "fd3b3fba4e50e7b9a22bd41cbab59e9b28e319b2de19668d7fd9777c8d1a9ba1",
+    ),
+    tokenizer_metadata_sha256="e5626d605bb50bc53fdb0fbfcf374fb33dfbaa0cc698d9746ba1e9b0b7e6d07d",
+    tokenizer_assets=(
+        (
+            "chat_template.jinja",
+            209,
+            "a805e50fed68938a076b07e2e602639611b50b1ced0e50f11eb92f1ba25be4dc",
+        ),
+        (
+            "special_tokens_map.json",
+            434,
+            "742aefe2b7dec496e8caffdba03a75d0c1a9925d53bd3f3e0d388c96b591b6f4",
+        ),
+        (
+            "tokenizer.json",
+            4_732_426,
+            "98cff83b4f6d7e9d8929bebc62b07e92cf1b3f99c80d16bafe8b84a75448f40b",
+        ),
+        (
+            "tokenizer_config.json",
+            91_509,
+            "36f511115e9d8952cbc9d15d9a20dfa7ce7d1444940e5c1dc42a762020c99bf5",
+        ),
+    ),
+    token_count=65_536,
+    source_token_count=65_536,
+    embedding_vocabulary_size=65_536,
+    deterministic_padding_range=(65_536, 65_535),
+    ordered_vocabulary_sha256="c004fd0578dbfbff394335a7d5f95e78a8cdbbff6abc8c389ba2290637be58b6",
+    merge_count=63_683,
+    ordered_merges_sha256="c70042d0b5969460432a218556522dedee908735a3e4cf70f27936353c5b3f65",
+    score_count=0,
+    ordered_scores_sha256=None,
+    ordered_token_types_sha256=(
+        "ffe1ea561257dc6e1f2c257b99b4913d63e9d6b896cf2f9da1a3d2cac316d4b4"
+    ),
+    materialized_tokenizer_sha256=(
+        "e7b7960966e2ed43a22b00431246cf820d5e2751bec58c44f0184cbe9b8d18c9"
+    ),
+    special_token_ids=(("<|im_end|>", 7), ("<|pad|>", 0), ("<|startoftext|>", 1)),
+    representative_encodings=(
+        ("Hello, world! 12345", (36309, 521, 2031, 510, 730, 10293, 2637)),
+        ("  spaced  text\n", (730, 56551, 730, 3304, 708)),
+        ("你好，世界！", (11754, 6400, 1198, 11370, 8668)),  # noqa: RUF001
+        (
+            "Café — κόσμος 🚀",
+            (544, 2305, 860, 2180, 59955, 49122, 27443, 16883, 51332, 23805, 758, 732),
+        ),
+        ("<|startoftext|><|im_start|>user\nHello<|im_end|>", (1, 6, 6423, 708, 36309, 7)),
+    ),
+)
+
 _TOKENIZER_EVIDENCE = MappingProxyType(
-    {_QWEN35_08B_Q4_TOKENIZER.evidence_id: _QWEN35_08B_Q4_TOKENIZER}
+    {
+        record.evidence_id: record
+        for record in (
+            _LFM2_350M_F16_TOKENIZER,
+            _QWEN25_05B_Q8_TOKENIZER,
+            _QWEN35_08B_Q4_TOKENIZER,
+            _SMOLLM_135M_F16_TOKENIZER,
+        )
+    }
 )
 
 
 def tokenizer_evidence(evidence_id: str) -> GGUFTokenizerEvidence | None:
     """Return exact tokenizer evidence by stable ID."""
     return _TOKENIZER_EVIDENCE.get(evidence_id)
+
+
+def iter_tokenizer_evidence() -> tuple[GGUFTokenizerEvidence, ...]:
+    """Return every tokenizer evidence record in stable evidence-ID order."""
+    return tuple(_TOKENIZER_EVIDENCE[key] for key in sorted(_TOKENIZER_EVIDENCE))
 
 
 def matching_tokenizer_evidence(
@@ -237,11 +472,14 @@ def matching_tokenizer_evidence(
 
     token_count, vocabulary_sha256 = sequence_digest("tokenizer.ggml.tokens")
     merge_count, merges_sha256 = sequence_digest("tokenizer.ggml.merges")
+    score_count, scores_sha256 = sequence_digest("tokenizer.ggml.scores")
+    token_type_count, token_types_sha256 = sequence_digest("tokenizer.ggml.token_type")
     token_types = metadata.get("tokenizer.ggml.token_type")
     matches = [
         evidence
         for evidence in _TOKENIZER_EVIDENCE.values()
         if evidence.architecture == architecture
+        and evidence.pre_identifier == metadata.get("tokenizer.ggml.pre")
         and evidence.filename == identity.filename
         and evidence.size == identity.size
         and evidence.lfs_sha256 == identity.sha256
@@ -251,7 +489,11 @@ def matching_tokenizer_evidence(
         and evidence.token_count == token_count
         and evidence.ordered_vocabulary_sha256 == vocabulary_sha256
         and evidence.merge_count == merge_count
-        and evidence.ordered_merges_sha256 == merges_sha256
+        and evidence.ordered_merges_sha256 == (merges_sha256 or None)
+        and evidence.score_count == score_count
+        and evidence.ordered_scores_sha256 == (scores_sha256 or None)
+        and evidence.token_count == token_type_count
+        and evidence.ordered_token_types_sha256 == token_types_sha256
         and gguf_model.get_tensor_shape("token_embd.weight")[0]
         == evidence.embedding_vocabulary_size
         and all(

--- a/src/mobius/integrations/gguf/_tokenizer_evidence_test.py
+++ b/src/mobius/integrations/gguf/_tokenizer_evidence_test.py
@@ -14,7 +14,9 @@ import pytest
 
 from mobius.integrations.gguf import _tokenizer_evidence
 from mobius.integrations.gguf._runtime_evidence import GGUFArtifactIdentity, runtime_evidence
+from mobius.integrations.gguf._tokenizer_census import tokenizer_route_census
 from mobius.integrations.gguf._tokenizer_evidence import (
+    iter_tokenizer_evidence,
     matching_tokenizer_evidence,
     tokenizer_evidence,
 )
@@ -34,10 +36,69 @@ def test_qwen35_tokenizer_evidence_is_exact_and_runtime_independent() -> None:
     assert evidence.deterministic_padding_range == (248_077, 248_319)
     assert evidence.embedding_vocabulary_size == 248_320
     assert evidence.merge_count == 247_587
+    assert evidence.ordered_token_types_sha256 == (
+        "f6fdca1063d1ae1cc77ba1f5087d259f044c2634e64b65e31bc844ec00e9acab"
+    )
     assert evidence.materialized_tokenizer_sha256 == (
         "a78b900eb4cd335bba249158066db523ce221f744e2b6144692bb81673d551af"
     )
     assert runtime_evidence("qwen3.5-0.8b-q4-tokenizer") is None
+
+
+def test_first_tokenizer_evidence_batch_is_complete_and_artifact_scoped() -> None:
+    records = iter_tokenizer_evidence()
+    assert [(record.pre_identifier, record.architecture) for record in records] == [
+        ("lfm2", "lfm2"),
+        ("qwen2", "qwen2"),
+        ("qwen35", "qwen35"),
+        ("smollm", "llama"),
+    ]
+    assert all(record.token_count > 0 for record in records)
+    assert all(record.ordered_token_types_sha256 for record in records)
+    assert all(record.representative_encodings for record in records)
+    assert all(record.source_config_asset[0] == "config.json" for record in records)
+
+
+def test_evidence_schema_accepts_scores_instead_of_bpe_merges() -> None:
+    evidence = tokenizer_evidence("qwen3.5-0.8b-q4-tokenizer")
+    assert evidence is not None
+    scores_only = dataclasses.replace(
+        evidence,
+        merge_count=0,
+        ordered_merges_sha256=None,
+        score_count=evidence.token_count,
+        ordered_scores_sha256="a" * 64,
+    )
+    assert scores_only.ordered_merges_sha256 is None
+    with pytest.raises(ValueError, match="ordered merges or ordered scores"):
+        dataclasses.replace(
+            evidence,
+            merge_count=0,
+            ordered_merges_sha256=None,
+        )
+
+
+def test_registry_derived_census_has_a_concrete_disposition_for_every_alias() -> None:
+    census = tokenizer_route_census()
+    assert len(census) == 87
+    assert len({record.identifier for record in census}) == 87
+    statuses = {
+        status: sum(record.current_status == status for record in census)
+        for status in {record.current_status for record in census}
+    }
+    assert statuses == {
+        "deferred-compiled-semantics": 83,
+        "validated-pinned-source": 4,
+    }
+    for record in census:
+        assert (record.evidence_id is None) == (record.blocker_category is not None)
+        if record.evidence_id is None:
+            assert record.artifact_repository is None
+            assert record.tokenizer_repository is None
+        else:
+            assert record.artifact_revision is not None
+            assert record.tokenizer_revision is not None
+            assert record.tokenizer_assets
 
 
 def test_existing_qwen25_runtime_tokenizer_evidence_remains_pinned() -> None:
@@ -50,7 +111,7 @@ def test_existing_qwen25_runtime_tokenizer_evidence_remains_pinned() -> None:
     )
 
 
-def _digest(values: list[str]) -> str:
+def _digest(values: list[object]) -> str:
     payload = json.dumps(values, ensure_ascii=False, separators=(",", ":")).encode()
     return hashlib.sha256(payload).hexdigest()
 
@@ -72,6 +133,7 @@ def _small_evidence():
         ordered_vocabulary_sha256=_digest(["a", "<special>"]),
         merge_count=1,
         ordered_merges_sha256=_digest(["a <special>"]),
+        ordered_token_types_sha256=_digest([1, 3]),
         special_token_ids=(("<special>", 1),),
     )
 
@@ -80,6 +142,7 @@ def _small_model():
     return SimpleNamespace(
         architecture="qwen35",
         metadata={
+            "tokenizer.ggml.pre": "qwen35",
             "tokenizer.ggml.tokens": ["a", "<special>"],
             "tokenizer.ggml.merges": ["a <special>"],
             "tokenizer.ggml.token_type": [1, 3],
@@ -120,7 +183,10 @@ def test_matching_evidence_binds_ordered_semantics_and_embedding_rows(
     )
 
 
-@pytest.mark.parametrize("mismatch", ["metadata", "vocabulary", "merges", "special", "rows"])
+@pytest.mark.parametrize(
+    "mismatch",
+    ["metadata", "pre", "vocabulary", "merges", "scores", "token_types", "special", "rows"],
+)
 def test_matching_evidence_fails_closed_on_compact_identity_mismatch(
     tmp_path, monkeypatch, mismatch
 ) -> None:
@@ -129,10 +195,16 @@ def test_matching_evidence_fails_closed_on_compact_identity_mismatch(
     metadata_sha256 = evidence.tokenizer_metadata_sha256
     if mismatch == "metadata":
         metadata_sha256 = "b" * 64
+    elif mismatch == "pre":
+        model.metadata["tokenizer.ggml.pre"] = "qwen2"
     elif mismatch == "vocabulary":
         model.metadata["tokenizer.ggml.tokens"][0] = "changed"
     elif mismatch == "merges":
         model.metadata["tokenizer.ggml.merges"][0] = "<special> a"
+    elif mismatch == "scores":
+        model.metadata["tokenizer.ggml.scores"] = [0.0, 0.0]
+    elif mismatch == "token_types":
+        model.metadata["tokenizer.ggml.token_type"][0] = 2
     elif mismatch == "special":
         model.metadata["tokenizer.ggml.tokens"][1] = "<changed>"
     else:

--- a/src/mobius/models/talkie_test.py
+++ b/src/mobius/models/talkie_test.py
@@ -160,9 +160,7 @@ def test_talkie_weight_mapping_owns_every_and_only_graph_parameter() -> None:
     source = _FakeTalkieGGUF()
     config = gguf_to_config(source)
     graph = CausalLMTask().build(TalkieForCausalLM(config), config)["model"].graph
-    mapped = {
-        map_gguf_to_hf_names(name, "talkie") for name in source.tensor_names
-    }
+    mapped = {map_gguf_to_hf_names(name, "talkie") for name in source.tensor_names}
     graph_weights = {
         name.removesuffix("_t")
         for name in graph.initializers
@@ -254,9 +252,7 @@ def test_talkie_nonzero_prefill_decode_and_logit_scale() -> None:
             past_value=reference_value,
             start_position=3,
         )
-        np.testing.assert_allclose(
-            decode["logits"], expected_decode, rtol=2e-4, atol=2e-4
-        )
+        np.testing.assert_allclose(decode["logits"], expected_decode, rtol=2e-4, atol=2e-4)
         assert decode["present.0.key"].shape == (1, 1, 4, 4)
         np.testing.assert_allclose(
             decode["present.0.key"][:, 0],


### PR DESCRIPTION
## Summary
- add a public, machine-readable census for all 87 pinned `tokenizer.ggml.pre` identifiers and aliases across 56 semantic groups
- promote exact artifact-scoped tokenizer evidence for Qwen3.5, Qwen2.5, LFM2, and SmolLM, including ordered token/merge/type hashes, source assets, special IDs, representative encodings, padding constraints, and final materialized hashes
- generate concise drift-checked docs with 4 validated pinned-source routes and 83 concrete compiled-llama.cpp semantic blockers; tokenizer evidence remains independent from graph/runtime support

## Validation
- initialized all-files lint; all checks pass
- focused tokenizer/docs suite: 71 passed
- broad non-integration serial suite: 8331 passed, 57 skipped, 12 deselected
- direct GPT-5.6 Sol medium review completed; scores-only tokenizer evidence support was added from review

## Serialized remaining batches
1. Alias cohorts (38): `a.x-4.0`, `bailingmoe`, `bailingmoe2`, `chatglm-bpe`, `cohere2moe`, `deepseek-r1-qwen`, `exaone4`, `f2llmv2`, `falcon-h1`, `falcon3`, `gemma4`, `gigachat`, `glm4`, `gpt-2`, `gpt-4o`, `granite-embed-multi-311m`, `jina-de`, `jina-es`, `jina-v1-en`, `jina-v2-code`, `jina-v2-de`, `jina-v2-es`, `jina-v5-nano`, `kanana2`, `kormo`, `llada-moe`, `llama-bpe`, `llama-v3`, `llama3`, `llama4`, `mellum`, `midm-2.0`, `modern-bert`, `phi-2`, `pixtral`, `roberta-bpe`, `talkie`, `tiny_aya`.
2. Singleton cohort A (23): `afmoe`, `bloom`, `chameleon`, `codeshell`, `command-r`, `dbrx`, `deepseek-coder`, `deepseek-llm`, `deepseek-v3`, `default`, `exaone`, `exaone-moe`, `falcon`, `gpt3-finnish`, `granite-docling`, `granite-embed-multi-97m`, `grok-2`, `hunyuan`, `hunyuan-dense`, `jais`, `jais-2`, `joyai-llm`, `kimi-k2`.
3. Singleton cohort B (22): `laguna`, `megrez`, `mellum2`, `minerva-7b`, `minicpm5`, `minimax-m2`, `mpt`, `olmo`, `poro-chat`, `refact`, `sarvam-moe`, `seed-coder`, `smaug-bpe`, `solar-open`, `stablelm2`, `starcoder`, `superbpe`, `tekken`, `trillion`, `viking`, `whitespace`, `youtu`.