### PR TITLE
Support complete sharded GGUF imports

### DIFF
--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -30,6 +30,14 @@ package.save("output")
 Use `keep_quantized=False` for explicit float import. Pass `mmproj=` only for an
 evidenced multimodal sidecar. The CLI equivalent is `mobius build model.gguf -o output`.
 
+Split GGUF models are accepted by pointing at any local
+`model-00001-of-000NN.gguf` shard. Mobius discovers the exact sibling set in the same
+directory, validates all split metadata and tensor ownership, and reads tensors lazily from
+their owning shard without concatenating payloads. Hub references such as
+`owner/repo@revision:path/model-00002-of-00003.gguf` resolve the complete set at one immutable
+commit, preflight its total download size against free cache space, and never build from a
+partial download.
+
 ## API
 
 ```python

--- a/src/mobius/integrations/gguf/__init__.py
+++ b/src/mobius/integrations/gguf/__init__.py
@@ -12,6 +12,10 @@ Usage::
 
     # Text-only model
     pkg = build_from_gguf("path/to/model.gguf")
+    # Any local shard discovers and validates its exact sibling set.
+    pkg = build_from_gguf("path/to/model-00002-of-00003.gguf")
+    # Hub shard references resolve and pin the complete immutable set.
+    pkg = build_from_gguf("owner/repo@commit:model-00002-of-00003.gguf")
     # Supported quantization is preserved by default; pass
     # keep_quantized=False for a fully float model.
 

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -20,9 +20,10 @@ __all__ = ["build_from_gguf"]
 import logging
 import math
 import re
+import shutil
 from collections import Counter
 from collections.abc import Callable, Collection, Iterable, Mapping
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
@@ -34,6 +35,7 @@ from huggingface_hub import (
     get_session,
     hf_hub_download,
     hf_hub_url,
+    try_to_load_from_cache,
 )
 from huggingface_hub.utils import build_hf_headers
 
@@ -351,7 +353,6 @@ def _assert_sparse_moe_graph(pkg, *, source: str, allow_dense: bool) -> None:
 def _preflight_hf_gguf(api: HfApi, repo_id: str, filename: str) -> None:
     """Use Hub metadata to reject known-bad inputs before a multi-GB download."""
     source = f"{repo_id}:{filename}"
-    _raise_for_sharded_gguf(source=source, filename=filename)
     try:
         info = api.model_info(repo_id, expand=["gguf"])
     except TypeError as error:
@@ -402,7 +403,6 @@ def _preflight_hf_gguf_file(
 ) -> str:
     """Validate the exact selected Hub file header and return its immutable revision."""
     source = f"{repo_id}@{revision}:{filename}"
-    _raise_for_sharded_gguf(source=source, filename=filename)
     url = hf_hub_url(repo_id, filename, revision=revision)
     try:
         metadata = get_hf_file_metadata(url)
@@ -4653,6 +4653,185 @@ def _looks_like_hf_repo_id(value: str) -> bool:
     return len(parts) == 2 and all(p and not p.endswith(".gguf") for p in parts)
 
 
+def _select_complete_hf_gguf_set(
+    repo_files: Collection[str],
+    filename: str | None,
+) -> tuple[str, list[str]]:
+    """Select one immutable logical GGUF and enumerate its complete shard set."""
+    gguf_files = sorted(name for name in repo_files if name.lower().endswith(".gguf"))
+    if not gguf_files:
+        raise FileNotFoundError("The Hugging Face repository contains no *.gguf files.")
+
+    if filename is None:
+        plain_files = [
+            name
+            for name in gguf_files
+            if _GGUF_SHARD_FILENAME_RE.search(PurePosixPath(name).name) is None
+        ]
+        shard_groups: dict[tuple[str, str, int], list[str]] = {}
+        for name in gguf_files:
+            path = PurePosixPath(name)
+            match = _GGUF_SHARD_FILENAME_RE.search(path.name)
+            if match is None:
+                continue
+            prefix = path.name[: match.start()]
+            key = (path.parent.as_posix(), prefix, int(match.group("count")))
+            shard_groups.setdefault(key, []).append(name)
+        if len(plain_files) == 1 and not shard_groups:
+            return plain_files[0], plain_files
+        if len(shard_groups) == 1 and not plain_files:
+            group = next(iter(shard_groups.values()))
+            filename = sorted(group)[0]
+        else:
+            raise ValueError(
+                "The Hugging Face repository contains multiple logical GGUF models: "
+                f"{gguf_files}. Specify one via 'owner/repo:<filename.gguf>'."
+            )
+
+    if filename not in gguf_files:
+        raise FileNotFoundError(
+            f"GGUF file {filename!r} is not present in the selected Hugging Face revision."
+        )
+    selected_path = PurePosixPath(filename)
+    selected_match = _GGUF_SHARD_FILENAME_RE.search(selected_path.name)
+    if selected_match is None:
+        return filename, [filename]
+
+    prefix = selected_path.name[: selected_match.start()]
+    count = int(selected_match.group("count"))
+    by_index: dict[int, str] = {}
+    for candidate in gguf_files:
+        candidate_path = PurePosixPath(candidate)
+        if candidate_path.parent != selected_path.parent:
+            continue
+        match = _GGUF_SHARD_FILENAME_RE.search(candidate_path.name)
+        if match is None:
+            continue
+        if (
+            candidate_path.name[: match.start()] != prefix
+            or int(match.group("count")) != count
+        ):
+            continue
+        index = int(match.group("index"))
+        if index in by_index:
+            raise ValueError(
+                f"Duplicate Hugging Face GGUF shard index {index:05d}: "
+                f"{by_index[index]!r} and {candidate!r}."
+            )
+        by_index[index] = candidate
+
+    missing = [index for index in range(1, count + 1) if index not in by_index]
+    if missing:
+        raise ValueError(
+            f"Incomplete Hugging Face GGUF split set for {filename!r}: declared "
+            f"{count} shards but missing indices {[f'{index:05d}' for index in missing]}. "
+            "No payload was downloaded."
+        )
+    extra = sorted(index for index in by_index if index < 1 or index > count)
+    if extra:
+        raise ValueError(
+            f"GGUF split set for {filename!r} has out-of-range shard indices {extra}."
+        )
+    return filename, [by_index[index] for index in range(1, count + 1)]
+
+
+def _existing_disk_usage_path(path: Path) -> Path:
+    """Return the nearest existing ancestor accepted by ``disk_usage``."""
+    candidate = path.expanduser().absolute()
+    while not candidate.exists() and candidate != candidate.parent:
+        candidate = candidate.parent
+    return candidate
+
+
+def _preflight_hf_download_space(total_bytes: int, *, cache_path: Path) -> None:
+    """Fail before download when the Hub cache cannot hold the complete set."""
+    if total_bytes < 0:
+        raise ValueError(f"GGUF download size cannot be negative, got {total_bytes} bytes.")
+    if total_bytes == 0:
+        return
+    usage = shutil.disk_usage(_existing_disk_usage_path(cache_path))
+    if usage.free < total_bytes:
+        raise OSError(
+            "Insufficient free space for the complete GGUF split set: "
+            f"requires {total_bytes:,} bytes ({total_bytes / (1 << 30):.2f} GiB), "
+            f"but only {usage.free:,} bytes ({usage.free / (1 << 30):.2f} GiB) "
+            f"are available for the Hugging Face cache at {cache_path}. "
+            "Free space or set HF_HOME/HF_HUB_CACHE to a larger volume; no shard "
+            "download was started."
+        )
+
+
+def _download_hf_gguf_shards(
+    api: HfApi,
+    *,
+    repo_id: str,
+    selected_filename: str,
+    shard_filenames: list[str],
+    revision: str,
+) -> str:
+    """Preflight and download one complete shard set at an immutable revision."""
+    from huggingface_hub.constants import HF_HUB_CACHE
+
+    paths_info = api.get_paths_info(
+        repo_id,
+        shard_filenames,
+        revision=revision,
+        expand=True,
+    )
+    info_by_path = {getattr(info, "path", None): info for info in paths_info}
+    sizes: dict[str, int] = {}
+    required_bytes = 0
+    for name in shard_filenames:
+        info = info_by_path.get(name)
+        size = int(getattr(info, "size", 0) or 0)
+        if info is None or size <= 0:
+            raise ValueError(
+                f"Hugging Face metadata omitted a positive size for GGUF shard "
+                f"{name!r} at {repo_id}@{revision}; no payload was downloaded."
+            )
+        sizes[name] = size
+        cached = try_to_load_from_cache(
+            repo_id,
+            name,
+            cache_dir=HF_HUB_CACHE,
+            revision=revision,
+        )
+        if not (
+            isinstance(cached, str)
+            and Path(cached).is_file()
+            and Path(cached).stat().st_size == size
+        ):
+            required_bytes += size
+
+    total_bytes = sum(sizes.values())
+    _preflight_hf_download_space(required_bytes, cache_path=Path(HF_HUB_CACHE))
+    logger.info(
+        "Downloading complete GGUF split set: %d shards, %.3f GiB total, "
+        "%.3f GiB not cached from %s@%s",
+        len(shard_filenames),
+        total_bytes / float(1 << 30),
+        required_bytes / float(1 << 30),
+        repo_id,
+        revision,
+    )
+
+    downloaded: dict[str, str] = {}
+    for name in shard_filenames:
+        local_path = hf_hub_download(
+            repo_id=repo_id,
+            filename=name,
+            revision=revision,
+        )
+        actual_size = Path(local_path).stat().st_size
+        if actual_size != sizes[name]:
+            raise OSError(
+                f"Downloaded GGUF shard {name!r} has {actual_size:,} bytes, "
+                f"expected {sizes[name]:,}; remove the corrupt cache entry and retry."
+            )
+        downloaded[name] = local_path
+    return downloaded[selected_filename]
+
+
 def _resolve_gguf_path_impl(gguf_path: str | Path, *, allow_mmproj_companion: bool) -> str:
     """Resolve a GGUF reference with an internal primary/companion context.
 
@@ -4680,37 +4859,44 @@ def _resolve_gguf_path_impl(gguf_path: str | Path, *, allow_mmproj_companion: bo
         return raw
 
     api = HfApi()
-    if not filename:
-        files = [
-            f for f in api.list_repo_files(repo_id, revision=revision) if f.endswith(".gguf")
-        ]
-        if not files:
-            raise FileNotFoundError(f"No *.gguf files found in HF repo {repo_id!r}")
-        if len(files) > 1:
-            raise ValueError(
-                f"HF repo {repo_id!r} contains multiple .gguf files: {files}. "
-                f"Specify one via '{repo_id}:<filename.gguf>'."
-            )
-        filename = files[0]
+    if filename and _GGUF_SHARD_FILENAME_RE.search(PurePosixPath(filename).name) is None:
+        selected_files = [filename]
+    else:
+        repo_files = api.list_repo_files(repo_id, revision=revision)
+        filename, selected_files = _select_complete_hf_gguf_set(repo_files, filename or None)
+    primary_filename = selected_files[0]
 
     resolved_revision: str | None
     if allow_mmproj_companion:
+        if len(selected_files) != 1:
+            raise ValueError("Sharded mmproj companion GGUF files are not supported.")
         resolved_revision = _preflight_hf_mmproj_companion_file(
             repo_id,
-            filename,
+            primary_filename,
             revision=revision,
         )
     else:
         resolved_revision = _preflight_hf_gguf_file(
             repo_id,
-            filename,
+            primary_filename,
             revision=revision,
         )
-    logger.info("Downloading %s from %s", filename, repo_id)
     if resolved_revision is None:
         raise RuntimeError(
             f"Hub did not resolve an immutable revision for {repo_id}:{filename}"
         )
+    if len(selected_files) > 1:
+        pinned_files = api.list_repo_files(repo_id, revision=resolved_revision)
+        filename, selected_files = _select_complete_hf_gguf_set(pinned_files, filename)
+        return _download_hf_gguf_shards(
+            api,
+            repo_id=repo_id,
+            selected_filename=filename,
+            shard_filenames=selected_files,
+            revision=resolved_revision,
+        )
+
+    logger.info("Downloading %s from %s", filename, repo_id)
     return hf_hub_download(
         repo_id=repo_id,
         filename=filename,
@@ -4726,6 +4912,29 @@ def _resolve_gguf_path(gguf_path: str | Path) -> str:
 def _resolve_mmproj_companion_path(gguf_path: str | Path) -> str:
     """Resolve an internal mmproj companion, allowing only ``clip`` Hub metadata."""
     return _resolve_gguf_path_impl(gguf_path, allow_mmproj_companion=True)
+
+
+def _hub_cache_identity_paths(paths: Collection[Path]) -> list[Path] | None:
+    """Resolve trusted Hub snapshot links to regular blob paths for hashing."""
+    from huggingface_hub.constants import HF_HUB_CACHE
+
+    cache_root = Path(HF_HUB_CACHE).expanduser().absolute()
+    resolved_paths: list[Path] = []
+    for path in paths:
+        absolute = path.expanduser().absolute()
+        try:
+            absolute.relative_to(cache_root)
+        except ValueError:
+            return None
+        resolved = absolute.resolve(strict=True)
+        try:
+            resolved.relative_to(cache_root)
+        except ValueError:
+            return None
+        if not resolved.is_file() or resolved.is_symlink():
+            return None
+        resolved_paths.append(resolved)
+    return resolved_paths
 
 
 def _logical_source_filename(reference: str | Path, resolved_path: str | Path) -> str:
@@ -4780,12 +4989,14 @@ def build_from_gguf(
     error instead of silently falling back to a float model.
 
     Args:
-        gguf_path: Path to the ``.gguf`` file, *or* a HuggingFace Hub
+        gguf_path: Path to a ``.gguf`` file or any member of a complete local
+            split set, *or* a HuggingFace Hub
             reference of the form ``"owner/repo"`` (the repo must
             contain exactly one ``*.gguf`` file) or
             ``"owner/repo:filename.gguf"`` to pick a specific file. HF
             references are downloaded via ``huggingface_hub`` into the
-            standard local cache.
+            standard local cache. A selected Hub shard resolves every sibling
+            at one immutable commit after a total-size/free-space preflight.
         task: Override the model task (e.g. ``"text-generation"``).
             When ``None``, the task is auto-detected from the
             model type.
@@ -4905,7 +5116,7 @@ def build_from_gguf(
     gguf_path = _resolve_gguf_path(gguf_path)
     logical_source_filename = _logical_source_filename(source_reference, gguf_path)
     source_path = Path(gguf_path)
-    if source_path.is_symlink():
+    if source_path.is_symlink() and _GGUF_SHARD_FILENAME_RE.search(source_path.name) is None:
         from huggingface_hub.constants import HF_HUB_CACHE
 
         try:
@@ -4917,6 +5128,10 @@ def build_from_gguf(
             source_path = source_path.resolve(strict=True)
             gguf_path = str(source_path)
     gguf_model = _gguf_model if _gguf_model is not None else open_gguf_model(gguf_path)
+    if isinstance(gguf_model, GgufShardSet):
+        identity_paths = _hub_cache_identity_paths(gguf_model.shard_paths)
+        if identity_paths is not None:
+            gguf_model._set_identity_paths(identity_paths)
     _validate_gguf_model(gguf_model, source=str(gguf_path))
     if reuse_gguf_weights and isinstance(gguf_model, GgufShardSet):
         raise ValueError(
@@ -6795,9 +7010,6 @@ def _load_quantized_state_dict(
     # per-tensor file offset (mainline byte sizes are wrong).
     tencent_q1_0 = is_tencent_q1_0_layout(gguf_model)
     if tencent_q1_0:
-        gguf_path = str(gguf_model._path)
-        data_section_offset = gguf_model._reader.data_offset
-        tensors_by_name = {t.name: t for t in gguf_model._reader.tensors}
         logger.info(
             "Detected Tencent Q1_0 layout (block_size=512, 2-bit SEQ); "
             "using custom per-tensor parser"
@@ -7235,10 +7447,13 @@ def _load_quantized_state_dict(
             n_repacked += num_experts
         elif should_repack:
             if is_tencent_q1_0_tensor:
+                gguf_path, data_section_offset, reader_tensor = gguf_model._tensor_source(
+                    gguf_name
+                )
                 repacked = parse_tencent_q1_0_tensor(
-                    gguf_path,
+                    str(gguf_path),
                     data_section_offset,
-                    tensors_by_name[gguf_name],
+                    reader_tensor,
                 )
             elif is_kimi_reshaped_projection:
                 values = gguf_model.dequantize_raw_tensor(raw, qtype, np_shape)

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -127,6 +127,8 @@ def _write_quantized_gguf(
     float_type: str = "f32",
     fused_qkv: bool = False,
     fused_qkv_float: bool = False,
+    split_max_tensors: int = 0,
+    small_first_shard: bool = False,
 ) -> None:
     """Write a GGUF file with quantized projection weights.
 
@@ -136,7 +138,13 @@ def _write_quantized_gguf(
     """
     from gguf import GGMLQuantizationType, GGUFWriter
 
-    writer = GGUFWriter(str(path), architecture)
+    writer_path = path.with_suffix("") if split_max_tensors else path
+    writer = GGUFWriter(
+        str(writer_path),
+        architecture,
+        split_max_tensors=split_max_tensors,
+        small_first_shard=small_first_shard,
+    )
     writer.add_context_length(512)
     writer.add_embedding_length(hidden_size)
     writer.add_feed_forward_length(intermediate_size)
@@ -3061,6 +3069,24 @@ class TestBuildQuantizedGguf:
         assert "MatMulNBits" in op_types, (
             f"Expected MatMulNBits in ops, got: {sorted(op_types)}"
         )
+
+    def test_sharded_quantized_build_preserves_matmulnbits(self, tmp_path: Path):
+        """A metadata-only primary and split Q4 payloads use the normal packed path."""
+        from mobius.integrations.gguf import build_from_gguf
+        from mobius.integrations.gguf._reader import GGUFModel
+
+        stem = tmp_path / "split-q4.gguf"
+        _write_quantized_gguf(
+            stem,
+            split_max_tensors=4,
+            small_first_shard=True,
+        )
+        shards = sorted(tmp_path.glob("split-q4-*.gguf"))
+        assert len(shards) > 1
+        assert GGUFModel(shards[0]).num_tensors == 0
+
+        model = build_from_gguf(shards[-1], keep_quantized=True)["model"]
+        assert any(node.op_type == "MatMulNBits" for node in model.graph)
 
     def test_default_quantized_package_save_reload(self, q4_0_gguf: Path, tmp_path: Path):
         """Default quantized ops and weights survive ModelPackage persistence."""
@@ -8041,18 +8067,22 @@ class TestGGUFPreflightGuards:
 
         download.assert_not_called()
 
-    def test_remote_shard_fails_before_hub_calls(self):
+    def test_remote_incomplete_shard_fails_before_preflight_or_download(self):
         from mobius.integrations.gguf._builder import _resolve_gguf_path
 
         filename = "BF16/model-00001-of-00002.gguf"
         with (
             mock.patch("mobius.integrations.gguf._builder.HfApi") as api_type,
             mock.patch("mobius.integrations.gguf._builder.hf_hub_download") as download,
-            pytest.raises(NotImplementedError, match="shard 1 of 2"),
+            mock.patch(
+                "mobius.integrations.gguf._builder._preflight_hf_gguf_file"
+            ) as preflight,
+            pytest.raises(ValueError, match=r"Incomplete.*00002"),
         ):
+            api_type.return_value.list_repo_files.return_value = [filename]
             _resolve_gguf_path(f"owner/repo:{filename}")
 
-        api_type.return_value.model_info.assert_not_called()
+        preflight.assert_not_called()
         download.assert_not_called()
 
     def test_local_split_metadata_is_rejected(self):

--- a/src/mobius/integrations/gguf/_docs.py
+++ b/src/mobius/integrations/gguf/_docs.py
@@ -417,6 +417,14 @@ package.save("output")
 Use `keep_quantized=False` for explicit float import. Pass `mmproj=` only for an
 evidenced multimodal sidecar. The CLI equivalent is `mobius build model.gguf -o output`.
 
+Split GGUF models are accepted by pointing at any local
+`model-00001-of-000NN.gguf` shard. Mobius discovers the exact sibling set in the same
+directory, validates all split metadata and tensor ownership, and reads tensors lazily from
+their owning shard without concatenating payloads. Hub references such as
+`owner/repo@revision:path/model-00002-of-00003.gguf` resolve the complete set at one immutable
+commit, preflight its total download size against free cache space, and never build from a
+partial download.
+
 ## API
 
 ```python

--- a/src/mobius/integrations/gguf/_reader.py
+++ b/src/mobius/integrations/gguf/_reader.py
@@ -274,6 +274,16 @@ class GGUFModel:
         """
         return list(self._reader.tensors)
 
+    def _tensor_source(self, name: str) -> tuple[Path, int, Any]:
+        """Return the owning path, data-section offset, and reader record."""
+        if name not in self._tensor_index:
+            raise KeyError(f"Tensor '{name}' not found in GGUF file.")
+        return (
+            self._path,
+            int(self._reader.data_offset),
+            self._reader.get_tensor(self._tensor_index[name]),
+        )
+
     @property
     def is_little_endian(self) -> bool:
         """Whether raw tensor payloads use ONNX-compatible little-endian bytes."""

--- a/src/mobius/integrations/gguf/_runtime_evidence.py
+++ b/src/mobius/integrations/gguf/_runtime_evidence.py
@@ -488,12 +488,17 @@ def gguf_artifact_identity(
         size = stat.st_size
     else:
         paths = tuple(Path(path) for path in shard_paths)
+        identity_paths = tuple(
+            Path(path) for path in getattr(gguf_model, "identity_paths", paths)
+        )
         if not paths:
             raise ValueError("A GGUF shard set must contain at least one source file.")
+        if len(identity_paths) != len(paths):
+            raise ValueError("GGUF shard identity paths must match the shard set length.")
         digest = hashlib.sha256()
         size = 0
-        for path in paths:
-            stat, file_sha256 = _hash_regular_file(path)
+        for path, identity_path in zip(paths, identity_paths):
+            stat, file_sha256 = _hash_regular_file(identity_path)
             encoded = path.name.encode("utf-8")
             digest.update(len(encoded).to_bytes(8, "big"))
             digest.update(encoded)

--- a/src/mobius/integrations/gguf/_runtime_evidence_test.py
+++ b/src/mobius/integrations/gguf/_runtime_evidence_test.py
@@ -202,6 +202,39 @@ def test_sharded_artifact_identity_frames_every_shard_and_tensor(tmp_path) -> No
     assert changed.sha256 != identity.sha256
 
 
+def test_sharded_artifact_identity_hashes_regular_aliases_for_snapshot_links(
+    tmp_path,
+) -> None:
+    blobs = tmp_path / "blobs"
+    snapshot = tmp_path / "snapshots" / ("a" * 40)
+    blobs.mkdir()
+    snapshot.mkdir(parents=True)
+    first_blob = blobs / "first-blob"
+    second_blob = blobs / "second-blob"
+    first_blob.write_bytes(b"first")
+    second_blob.write_bytes(b"second")
+    first = snapshot / "model-00001-of-00002.gguf"
+    second = snapshot / "model-00002-of-00002.gguf"
+    first.symlink_to(first_blob)
+    second.symlink_to(second_blob)
+    tensors = [SimpleNamespace(tensor_type=SimpleNamespace(name="F32"))]
+    model = SimpleNamespace(
+        shard_paths=[first, second],
+        identity_paths=[first_blob, second_blob],
+        reader_tensors=lambda: tensors,
+    )
+
+    identity = gguf_artifact_identity(
+        second,
+        model,
+        architecture="llama",
+        filename=first.name,
+    )
+
+    assert identity.filename == first.name
+    assert identity.size == len(b"firstsecond")
+
+
 def test_evidence_id_cannot_cross_architectures(monkeypatch) -> None:
     record = _record(b"pinned-gguf")
     monkeypatch.setattr(

--- a/src/mobius/integrations/gguf/_shard_set.py
+++ b/src/mobius/integrations/gguf/_shard_set.py
@@ -340,6 +340,8 @@ class GgufShardSet:
         self._shards = [shards[i] for i in order]
         self._infos = [self._infos[i] for i in order]
         self._primary = self._shards[0]
+        self._identity_paths = [Path(shard._path) for shard in self._shards]
+        self._metadata: dict[str, Any] | None = None
 
         # Combined, order-preserving tensor index: name -> owning shard.
         self._owner: dict[str, GGUFModel] = {}
@@ -380,11 +382,23 @@ class GgufShardSet:
 
     @property
     def metadata(self) -> dict[str, Any]:
-        """Model key-value metadata (from the primary shard)."""
-        return self._primary.metadata
+        """Deterministically merged metadata from every shard.
+
+        Split bookkeeping is canonicalized to the logical set: ``split.no``
+        remains zero while ``split.count`` and ``split.tensors.count`` describe
+        the complete model. All other repeated keys must have identical values.
+        """
+        if self._metadata is None:
+            self._metadata = _merge_metadata(self._infos, self._shards)
+        return self._metadata
 
     def get_metadata(self, key: str, default: Any = None) -> Any:
-        return self._primary.get_metadata(key, default)
+        return self.metadata.get(key, default)
+
+    @property
+    def format_version(self) -> int:
+        """GGUF container version shared by all shards."""
+        return self._primary.format_version
 
     @property
     def tensor_names(self) -> list[str]:
@@ -400,6 +414,11 @@ class GgufShardSet:
         for shard in self._shards:
             records.extend(shard.reader_tensors())
         return records
+
+    @property
+    def is_little_endian(self) -> bool:
+        """Whether every shard stores tensor payloads in little-endian order."""
+        return all(shard.is_little_endian for shard in self._shards)
 
     def tensor_items(self) -> Iterator[tuple[str, np.ndarray]]:
         for shard in self._shards:
@@ -423,6 +442,27 @@ class GgufShardSet:
             raise KeyError(f"Tensor {name!r} not found in split set.")
         return shard.get_tensor_type(name)
 
+    def get_tensor_shape(self, name: str) -> tuple[int, ...]:
+        """Get a tensor's logical numpy shape from its owning shard."""
+        shard = self._owner.get(name)
+        if shard is None:
+            raise KeyError(f"Tensor {name!r} not found in split set.")
+        return shard.get_tensor_shape(name)
+
+    def tensor_storage_range(self, name: str) -> tuple[int, int, str]:
+        """Get a tensor's byte range within its owning shard."""
+        shard = self._owner.get(name)
+        if shard is None:
+            raise KeyError(f"Tensor {name!r} not found in split set.")
+        return shard.tensor_storage_range(name)
+
+    def _tensor_source(self, name: str) -> tuple[Path, int, Any]:
+        """Return the owning path, data-section offset, and reader record."""
+        shard = self._owner.get(name)
+        if shard is None:
+            raise KeyError(f"Tensor {name!r} not found in split set.")
+        return shard._tensor_source(name)
+
     def dequantize_raw_tensor(
         self,
         raw_data: np.ndarray,
@@ -441,6 +481,27 @@ class GgufShardSet:
     @property
     def shard_paths(self) -> list[Path]:
         return [Path(shard._path) for shard in self._shards]
+
+    @property
+    def identity_paths(self) -> list[Path]:
+        """Regular files used for immutable identity hashing, in shard order."""
+        return list(self._identity_paths)
+
+    def _set_identity_paths(self, paths: list[Path]) -> None:
+        """Bind trusted regular-file aliases of the opened shard sources."""
+        if len(paths) != len(self._paths):
+            raise ValueError(
+                f"Expected {len(self._paths)} shard identity paths, got {len(paths)}."
+            )
+        ordered: list[Path] = []
+        for shard, candidate in zip(self._shards, paths):
+            original = Path(shard._path)
+            if not original.samefile(candidate):
+                raise ValueError(
+                    f"Identity path does not name the opened shard {original.name!r}."
+                )
+            ordered.append(candidate)
+        self._identity_paths = ordered
 
     def source_matches_path(self) -> bool:
         """Return whether every shard still names the exact file that was opened."""
@@ -533,6 +594,16 @@ def _validate_shard_set(infos: list[ShardInfo], shards: list[GGUFModel]) -> None
     """Fail closed on any structural inconsistency in the split set."""
     n = len(infos)
     filename_count = infos[0].filename_count
+    prefixes = {
+        parsed[0]
+        for info in infos
+        if (parsed := parse_shard_filename(info.path.name)) is not None
+    }
+    if len(prefixes) != 1:
+        raise GgufShardError(
+            f"Shard filenames have inconsistent basenames {sorted(prefixes)}; "
+            "the files belong to different split sets."
+        )
     if any(info.filename_count != filename_count for info in infos):
         counts = sorted({info.filename_count for info in infos})
         raise GgufShardError(
@@ -545,35 +616,49 @@ def _validate_shard_set(infos: list[ShardInfo], shards: list[GGUFModel]) -> None
         )
 
     # Authoritative split.count metadata must agree with the filename count.
-    declared_counts = {info.split_count for info in infos if info.split_count is not None}
-    if declared_counts and declared_counts != {filename_count}:
+    missing_counts = [info.path.name for info in infos if info.split_count is None]
+    if missing_counts:
+        raise GgufShardError(
+            f"Every shard must declare split.count; missing from {missing_counts}."
+        )
+    declared_counts = {info.split_count for info in infos}
+    if declared_counts != {filename_count}:
         raise GgufShardError(
             f"GGUF split.count metadata {sorted(declared_counts)} disagrees with the "
             f"{filename_count}-shard filenames; mixed or corrupt split set."
         )
 
     # split.no must be a contiguous 0..count-1 permutation when present.
+    missing_nos = [info.path.name for info in infos if info.split_no is None]
+    if missing_nos:
+        raise GgufShardError(f"Every shard must declare split.no; missing from {missing_nos}.")
     split_nos = [info.split_no for info in infos]
-    if all(s is not None for s in split_nos):
-        if sorted(split_nos) != list(range(n)):
-            raise GgufShardError(
-                f"GGUF split.no values {sorted(split_nos)} are not the contiguous "
-                f"set 0..{n - 1} (missing, duplicate, or mixed shards)."
-            )
-    else:
-        # Fall back to filename indices, which must be the contiguous 1..count.
-        indices = sorted(info.filename_index for info in infos)
-        if indices != list(range(1, n + 1)):
-            raise GgufShardError(
-                f"Shard filename indices {indices} are not the contiguous set "
-                f"1..{n} and no split.no metadata is present to recover order."
-            )
+    if sorted(split_nos) != list(range(n)):
+        raise GgufShardError(
+            f"GGUF split.no values {sorted(split_nos)} are not the contiguous "
+            f"set 0..{n - 1} (missing, duplicate, or mixed shards)."
+        )
+    mismatched_nos = [
+        (info.path.name, info.filename_index, info.split_no)
+        for info in infos
+        if info.split_no != info.filename_index - 1
+    ]
+    if mismatched_nos:
+        raise GgufShardError(
+            f"Shard filename indices do not match their split.no metadata: {mismatched_nos}."
+        )
 
     # split.tensors.count (total across the set) must agree everywhere and equal
     # the observed tensor total.
-    declared_tensor_totals = {
-        info.split_tensors_count for info in infos if info.split_tensors_count is not None
-    }
+    missing_tensor_totals = [
+        info.path.name for info in infos if info.split_tensors_count is None
+    ]
+    if missing_tensor_totals:
+        raise GgufShardError(
+            "Every shard must declare split.tensors.count; missing from "
+            f"{missing_tensor_totals}."
+        )
+    declared_tensor_totals = {info.split_tensors_count for info in infos}
     observed_total = sum(info.tensor_count for info in infos)
     if len(declared_tensor_totals) > 1:
         raise GgufShardError(
@@ -588,7 +673,21 @@ def _validate_shard_set(infos: list[ShardInfo], shards: list[GGUFModel]) -> None
         )
 
     _validate_identity(infos, shards)
+    _validate_container_compatibility(infos, shards)
     _validate_offsets(infos, shards)
+
+
+def _validate_container_compatibility(infos: list[ShardInfo], shards: list[GGUFModel]) -> None:
+    """Require one GGUF version and byte order across the complete set."""
+    versions = {shard.format_version for shard in shards}
+    if len(versions) != 1:
+        raise GgufShardError(
+            f"Shards use incompatible GGUF container versions {sorted(versions)}."
+        )
+    endian_values = {shard.is_little_endian for shard in shards}
+    if len(endian_values) != 1:
+        names = [info.path.name for info in infos]
+        raise GgufShardError(f"Shards use mixed byte order across {names}.")
 
 
 def _validate_identity(infos: list[ShardInfo], shards: list[GGUFModel]) -> None:
@@ -617,6 +716,45 @@ def _validate_identity(infos: list[ShardInfo], shards: list[GGUFModel]) -> None:
                     f"Shards disagree on {key!r} ({where}); this is a mixed-revision "
                     "or mixed-quant split set and cannot be stitched together."
                 )
+
+
+def _merge_metadata(infos: list[ShardInfo], shards: list[GGUFModel]) -> dict[str, Any]:
+    """Merge shard metadata in split order and reject incompatible repeats."""
+    merged: dict[str, Any] = {}
+    owners: dict[str, str] = {}
+    for info, shard in zip(infos, shards):
+        for key, value in shard.metadata.items():
+            if key == _SPLIT_NO:
+                continue
+            # gguf-py exposes container-local pseudo fields alongside serialized
+            # metadata. Keep the primary values, then canonicalize tensor_count
+            # below for the logical model.
+            if key.startswith("GGUF."):
+                if key not in merged:
+                    merged[key] = value
+                    owners[key] = info.path.name
+                continue
+            if key in merged and not _metadata_values_equal(merged[key], value):
+                raise GgufShardError(
+                    f"Shards disagree on metadata key {key!r}: "
+                    f"{merged[key]!r} in {owners[key]} versus {value!r} "
+                    f"in {info.path.name}."
+                )
+            if key not in merged:
+                merged[key] = value
+                owners[key] = info.path.name
+    merged[_SPLIT_NO] = 0
+    merged[_SPLIT_COUNT] = len(shards)
+    merged[_SPLIT_TENSORS_COUNT] = sum(info.tensor_count for info in infos)
+    merged["GGUF.tensor_count"] = sum(info.tensor_count for info in infos)
+    return merged
+
+
+def _metadata_values_equal(left: Any, right: Any) -> bool:
+    """Compare parsed metadata values, including numpy-backed unknown fields."""
+    if isinstance(left, np.ndarray) or isinstance(right, np.ndarray):
+        return bool(np.array_equal(left, right))
+    return bool(left == right)
 
 
 def _validate_offsets(infos: list[ShardInfo], shards: list[GGUFModel]) -> None:

--- a/src/mobius/integrations/gguf/_shard_set_test.py
+++ b/src/mobius/integrations/gguf/_shard_set_test.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import tracemalloc
 from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
 
 import numpy as np
 import pytest
@@ -48,6 +50,7 @@ def _write_sharded_gguf(
     cols: int = 16,
     name_override: str | None = None,
     seed: int = 0,
+    small_first_shard: bool = False,
 ) -> list[Path]:
     """Write a synthetic split GGUF set and return its shard paths in order.
 
@@ -58,7 +61,10 @@ def _write_sharded_gguf(
 
     directory.mkdir(parents=True, exist_ok=True)
     writer = GGUFWriter(
-        str(directory / stem), architecture, split_max_tensors=split_max_tensors
+        str(directory / stem),
+        architecture,
+        split_max_tensors=split_max_tensors,
+        small_first_shard=small_first_shard,
     )
     writer.add_context_length(128)
     writer.add_embedding_length(cols)
@@ -156,6 +162,26 @@ def test_happy_path_reads_all_tensors(tmp_path, split_max_tensors):
             single_reads[name] = gm.get_tensor(name)
     for name in model.tensor_names:
         np.testing.assert_array_equal(model.get_tensor(name), single_reads[name])
+    assert [name for name, _ in model.tensor_items()] == model.tensor_names
+
+
+def test_metadata_only_first_shard_is_assembled(tmp_path):
+    shards = _write_sharded_gguf(
+        tmp_path,
+        split_max_tensors=3,
+        small_first_shard=True,
+    )
+    assert GGUFModel(shards[0]).num_tensors == 0
+
+    model = open_gguf_model(shards[0])
+    assert isinstance(model, GgufShardSet)
+    assert model.num_tensors == len(_tensor_names(3))
+    assert model.metadata["split.no"] == 0
+    assert model.metadata["split.count"] == len(shards)
+    assert model.metadata["split.tensors.count"] == len(_tensor_names(3))
+    assert model.format_version == 3
+    assert model.is_little_endian
+    assert model.get_tensor_shape("token_embd.weight") == (8, 16)
 
 
 def test_tensors_split_across_files(tmp_path):
@@ -250,6 +276,45 @@ def test_duplicate_tensor_across_shards_rejected(tmp_path):
     shards[2].write_bytes(shards[1].read_bytes())
     with pytest.raises(GgufShardError):
         open_gguf_model(shards[0])
+
+
+def _write_manual_split(
+    directory: Path,
+    *,
+    split_counts: tuple[int, int] = (2, 2),
+    tensor_names: tuple[str, str] = ("left", "right"),
+) -> list[Path]:
+    from gguf import GGUFWriter
+
+    paths: list[Path] = []
+    for split_no in range(2):
+        path = directory / f"manual-{split_no + 1:05d}-of-00002.gguf"
+        writer = GGUFWriter(str(path), "llama")
+        writer.add_uint16("split.no", split_no)
+        writer.add_uint16("split.count", split_counts[split_no])
+        writer.add_uint64("split.tensors.count", 2)
+        writer.add_tensor(
+            tensor_names[split_no],
+            np.full((2, 2), split_no + 1, dtype=np.float32),
+        )
+        writer.write_header_to_file()
+        writer.write_kv_data_to_file()
+        writer.write_tensors_to_file()
+        writer.close()
+        paths.append(path)
+    return paths
+
+
+def test_split_count_metadata_mismatch_rejected(tmp_path):
+    paths = _write_manual_split(tmp_path, split_counts=(2, 3))
+    with pytest.raises(GgufShardError, match=r"split\.count"):
+        open_gguf_model(paths[0])
+
+
+def test_actual_duplicate_tensor_names_rejected(tmp_path):
+    paths = _write_manual_split(tmp_path, tensor_names=("duplicate", "duplicate"))
+    with pytest.raises(GgufShardError, match="Duplicate tensor"):
+        open_gguf_model(paths[0])
 
 
 def test_corrupt_truncated_shard_rejected(tmp_path):
@@ -506,6 +571,165 @@ def test_iq1_type_matches_single_file(tmp_path):
     from gguf import GGMLQuantizationType
 
     assert int(model.get_tensor_type("blk.0.attn_q.weight")) == int(GGMLQuantizationType.IQ1_M)
+
+
+# --------------------------------------------------------------------------- #
+# Hugging Face resolution (metadata/download boundary only)
+# --------------------------------------------------------------------------- #
+
+
+def test_hub_shard_resolution_pins_and_downloads_complete_set(tmp_path):
+    from mobius.integrations.gguf import _builder as builder
+
+    shards = _write_sharded_gguf(
+        tmp_path,
+        split_max_tensors=3,
+        small_first_shard=True,
+    )
+    remote_files = [f"weights/{path.name}" for path in shards]
+    local_by_remote = dict(zip(remote_files, shards))
+    api = mock.Mock()
+    api.list_repo_files.side_effect = [remote_files, remote_files]
+    api.get_paths_info.return_value = [
+        SimpleNamespace(path=name, size=local_by_remote[name].stat().st_size)
+        for name in remote_files
+    ]
+    commit = "d3bc75ee6ccef3efc1e228ec00a6cc2cdb1e2249"
+    events: list[str] = []
+
+    def disk_usage(_path):
+        events.append("space")
+        return SimpleNamespace(free=1 << 40)
+
+    def download(*, repo_id, filename, revision):
+        assert repo_id == "unsloth/tiny-sharded"
+        assert revision == commit
+        assert events == ["space"] or events[-1] == "download"
+        events.append("download")
+        return str(local_by_remote[filename])
+
+    with (
+        mock.patch.object(builder, "HfApi", return_value=api),
+        mock.patch.object(
+            builder,
+            "_preflight_hf_gguf_file",
+            return_value=commit,
+        ) as preflight,
+        mock.patch.object(builder.shutil, "disk_usage", side_effect=disk_usage),
+        mock.patch.object(builder, "hf_hub_download", side_effect=download) as hub_download,
+    ):
+        resolved = builder._resolve_gguf_path(f"unsloth/tiny-sharded:{remote_files[1]}")
+
+    assert resolved == str(shards[1])
+    preflight.assert_called_once_with(
+        "unsloth/tiny-sharded",
+        remote_files[0],
+        revision="main",
+    )
+    assert api.list_repo_files.call_args_list == [
+        mock.call("unsloth/tiny-sharded", revision="main"),
+        mock.call("unsloth/tiny-sharded", revision=commit),
+    ]
+    api.get_paths_info.assert_called_once_with(
+        "unsloth/tiny-sharded",
+        remote_files,
+        revision=commit,
+        expand=True,
+    )
+    assert hub_download.call_count == len(shards)
+    assert open_gguf_model(resolved).num_tensors == len(_tensor_names(3))
+
+
+def test_hub_incomplete_shard_set_rejected_before_preflight_or_download():
+    from mobius.integrations.gguf import _builder as builder
+
+    filename = "weights/model-00002-of-00003.gguf"
+    api = mock.Mock()
+    api.list_repo_files.return_value = [
+        "weights/model-00001-of-00003.gguf",
+        filename,
+    ]
+    with (
+        mock.patch.object(builder, "HfApi", return_value=api),
+        mock.patch.object(builder, "_preflight_hf_gguf_file") as preflight,
+        mock.patch.object(builder, "hf_hub_download") as download,
+        pytest.raises(ValueError, match=r"Incomplete.*missing indices.*00003"),
+    ):
+        builder._resolve_gguf_path(f"owner/repo:{filename}")
+
+    preflight.assert_not_called()
+    download.assert_not_called()
+
+
+def test_hub_free_space_preflight_is_actionable(tmp_path):
+    from mobius.integrations.gguf import _builder as builder
+
+    with (
+        mock.patch.object(
+            builder.shutil,
+            "disk_usage",
+            return_value=SimpleNamespace(free=100),
+        ),
+        pytest.raises(OSError, match=r"requires 1,000 bytes.*only 100 bytes.*HF_HOME"),
+    ):
+        builder._preflight_hf_download_space(1000, cache_path=tmp_path)
+
+
+def test_hub_download_space_counts_only_uncached_shards(tmp_path):
+    from mobius.integrations.gguf import _builder as builder
+
+    cached = tmp_path / "cached.gguf"
+    missing = tmp_path / "missing.gguf"
+    cached.write_bytes(b"cached")
+    missing.write_bytes(b"new")
+    names = ["model-00001-of-00002.gguf", "model-00002-of-00002.gguf"]
+    api = mock.Mock()
+    api.get_paths_info.return_value = [
+        SimpleNamespace(path=names[0], size=cached.stat().st_size),
+        SimpleNamespace(path=names[1], size=missing.stat().st_size),
+    ]
+    with (
+        mock.patch.object(
+            builder,
+            "try_to_load_from_cache",
+            side_effect=[str(cached), None],
+        ),
+        mock.patch.object(builder, "_preflight_hf_download_space") as preflight,
+        mock.patch.object(
+            builder,
+            "hf_hub_download",
+            side_effect=[str(cached), str(missing)],
+        ),
+    ):
+        resolved = builder._download_hf_gguf_shards(
+            api,
+            repo_id="owner/repo",
+            selected_filename=names[0],
+            shard_filenames=names,
+            revision="a" * 40,
+        )
+
+    assert resolved == str(cached)
+    preflight.assert_called_once()
+    assert preflight.call_args.args == (missing.stat().st_size,)
+
+
+def test_hub_cache_identity_paths_resolve_only_inside_cache(tmp_path):
+    from mobius.integrations.gguf import _builder as builder
+
+    cache = tmp_path / "hub"
+    blobs = cache / "blobs"
+    snapshot = cache / "snapshots" / ("a" * 40)
+    blobs.mkdir(parents=True)
+    snapshot.mkdir(parents=True)
+    blob = blobs / "abc"
+    blob.write_bytes(b"GGUF")
+    shard = snapshot / "model-00001-of-00002.gguf"
+    shard.symlink_to(blob)
+
+    with mock.patch("huggingface_hub.constants.HF_HUB_CACHE", str(cache)):
+        assert builder._hub_cache_identity_paths([shard]) == [blob]
+        assert builder._hub_cache_identity_paths([tmp_path / "outside.gguf"]) is None
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- assemble a complete local GGUF shard set as one lazy logical model while retaining every reader/memmap
- validate filename identity, contiguous `split.no`, matching `split.count` and `split.tensors.count`, compatible metadata/container properties, tensor extents, and unique tensor names
- resolve Hugging Face shard references as an exact complete set pinned to one immutable commit, with cache-aware total-size/free-space preflight before downloads
- preserve single-file behavior, quantized tensor import, and runtime artifact identity hashing across Hub snapshot symlinks
- document generated user-facing shard behavior

## Tests
- `python -m pytest src/mobius/integrations/gguf/_reader_test.py src/mobius/integrations/gguf/_shard_set_test.py src/mobius/integrations/gguf/_preflight_test.py src/mobius/integrations/gguf/_runtime_evidence_test.py src/mobius/integrations/gguf/_builder_test.py -q --tb=short` (538 passed)
- `python -m pytest tests/build_graph_test.py tests/cli_test.py src/ -q -k 'not phi4mm and not apply_weights_unknown' --tb=short` (8,362 passed, 57 skipped, 12 deselected)
- `lintrunner f --output oneline --all-files`
- `lintrunner -a`

All shard coverage uses tiny generated GGUF files and mocked Hub metadata/download boundaries. The motivating multi-gigabyte artifact was not downloaded.