### PR TITLE
Support block-scaled FP8 weights

### DIFF
--- a/src/mobius/integrations/_weight_loading.py
+++ b/src/mobius/integrations/_weight_loading.py
@@ -266,7 +266,9 @@ def _dequantize_fp8_weights(state_dict: dict[str, torch.Tensor]) -> dict[str, to
 
     Some HuggingFace checkpoints (e.g. Ministral-3-3B) store linear layer
     weights as float8_e4m3fn with a scalar ``weight_scale_inv`` tensor.
-    The real weight value is ``fp8_weight.to(bfloat16) * weight_scale_inv``.
+    Others use a two-dimensional grid of inverse scales, with each element
+    applying to a 128-by-128 weight block. The real weight value is
+    ``fp8_weight.to(bfloat16) * weight_scale_inv``.
 
     Dequantization targets bfloat16 because that is the native training
     dtype for FP8-quantized checkpoints — the FP8 values represent
@@ -303,7 +305,42 @@ def _dequantize_fp8_weights(state_dict: dict[str, torch.Tensor]) -> dict[str, to
             # Cast scale to bfloat16 to guarantee the output dtype is bfloat16,
             # even when weight_scale_inv is stored as FP32 in the checkpoint.
             scale = result[scale_key].to(torch.bfloat16)
-            result[key] = result[key].to(torch.bfloat16) * scale
+            if scale.ndim == 0:
+                result[key] = result[key].to(torch.bfloat16) * scale
+            elif scale.ndim == 2:
+                weight = result[key]
+                if weight.ndim != 2:
+                    raise ValueError(
+                        f"FP8 weight '{key}' has a 2-D scale grid but is "
+                        f"{weight.ndim}-D; block scaling requires a 2-D weight"
+                    )
+
+                rows, cols = weight.shape
+                expected_grid_shape = ((rows + 127) // 128, (cols + 127) // 128)
+                if tuple(scale.shape) != expected_grid_shape:
+                    raise ValueError(
+                        f"FP8 weight '{key}' has scale grid shape {tuple(scale.shape)}; "
+                        f"expected {expected_grid_shape} for weight shape {tuple(weight.shape)}"
+                    )
+
+                # Scale each 128-by-128 tile in the BF16 output. This avoids
+                # allocating a full expanded scale tensor for large expert weights.
+                dequantized = weight.to(torch.bfloat16)
+                for block_row in range(expected_grid_shape[0]):
+                    row_start = block_row * 128
+                    row_end = min(row_start + 128, rows)
+                    for block_col in range(expected_grid_shape[1]):
+                        col_start = block_col * 128
+                        col_end = min(col_start + 128, cols)
+                        dequantized[row_start:row_end, col_start:col_end].mul_(
+                            scale[block_row, block_col]
+                        )
+                result[key] = dequantized
+            else:
+                raise ValueError(
+                    f"FP8 weight '{key}' has scale with shape {tuple(scale.shape)}; "
+                    "expected a scalar or 2-D block scale grid"
+                )
         else:
             logger.warning("FP8 weight '%s' has no scale_inv — casting without scaling", key)
             result[key] = result[key].to(torch.bfloat16)

--- a/src/mobius/integrations/_weight_loading_test.py
+++ b/src/mobius/integrations/_weight_loading_test.py
@@ -925,6 +925,90 @@ class TestDequantizeFP8Weights:
             f"Expected bfloat16, got {result['proj.weight'].dtype}"
         )
 
+    def test_2d_scale_grid_dequantizes_128_by_128_blocks(self):
+        """A 2-D inverse-scale grid maps to 128-by-128 FP8 weight tiles."""
+        from mobius.integrations._weight_loading import _dequantize_fp8_weights
+
+        fp8_weight = torch.full((129, 130), 2.0, dtype=torch.float32).to(torch.float8_e4m3fn)
+        scale_grid = torch.tensor([[0.5, 1.0], [1.5, 2.0]], dtype=torch.bfloat16)
+        state_dict = {
+            "expert.down_proj.weight": fp8_weight,
+            "expert.down_proj.weight_scale_inv": scale_grid,
+            "expert.down_proj.activation_scale": torch.tensor(1.0, dtype=torch.bfloat16),
+        }
+
+        result = _dequantize_fp8_weights(state_dict)
+
+        expected = torch.empty((129, 130), dtype=torch.bfloat16)
+        expected[:128, :128] = 1.0
+        expected[:128, 128:] = 2.0
+        expected[128:, :128] = 3.0
+        expected[128:, 128:] = 4.0
+        assert torch.equal(result["expert.down_proj.weight"], expected)
+        assert result["expert.down_proj.weight"].dtype == torch.bfloat16
+        assert "expert.down_proj.weight_scale_inv" not in result
+        assert "expert.down_proj.activation_scale" not in result
+        assert torch.equal(
+            state_dict["expert.down_proj.weight"].to(torch.float32),
+            fp8_weight.to(torch.float32),
+        )
+        assert torch.equal(state_dict["expert.down_proj.weight_scale_inv"], scale_grid)
+        assert "expert.down_proj.activation_scale" in state_dict
+
+    @pytest.mark.parametrize(
+        ("weight_shape", "grid_shape"),
+        [
+            ((128, 128), (1, 2)),
+            ((129, 128), (1, 1)),
+        ],
+    )
+    def test_2d_scale_grid_requires_exact_block_shape(self, weight_shape, grid_shape):
+        """Block-scale grids must cover every full or partial 128-by-128 tile."""
+        from mobius.integrations._weight_loading import _dequantize_fp8_weights
+
+        state_dict = {
+            "proj.weight": torch.ones(weight_shape, dtype=torch.float32).to(
+                torch.float8_e4m3fn
+            ),
+            "proj.weight_scale_inv": torch.ones(grid_shape, dtype=torch.bfloat16),
+        }
+
+        with pytest.raises(ValueError, match="scale grid shape"):
+            _dequantize_fp8_weights(state_dict)
+
+    @pytest.mark.parametrize(
+        "scale",
+        [
+            torch.ones(2, dtype=torch.bfloat16),
+            torch.ones((1, 1, 1), dtype=torch.bfloat16),
+        ],
+    )
+    def test_scale_must_be_scalar_or_2d_grid(self, scale):
+        """Non-scalar, non-grid inverse scales fail closed."""
+        from mobius.integrations._weight_loading import _dequantize_fp8_weights
+
+        state_dict = {
+            "proj.weight": torch.ones((128, 128), dtype=torch.float32).to(torch.float8_e4m3fn),
+            "proj.weight_scale_inv": scale,
+        }
+
+        with pytest.raises(ValueError, match="scalar or 2-D block scale grid"):
+            _dequantize_fp8_weights(state_dict)
+
+    def test_2d_scale_grid_requires_2d_weight(self):
+        """Block-scale grids cannot silently broadcast over non-matrix FP8 weights."""
+        from mobius.integrations._weight_loading import _dequantize_fp8_weights
+
+        state_dict = {
+            "proj.weight": torch.ones((1, 128, 128), dtype=torch.float32).to(
+                torch.float8_e4m3fn
+            ),
+            "proj.weight_scale_inv": torch.ones((1, 1), dtype=torch.bfloat16),
+        }
+
+        with pytest.raises(ValueError, match="block scaling requires a 2-D weight"):
+            _dequantize_fp8_weights(state_dict)
+
     def test_does_not_mutate_input(self):
         """_dequantize_fp8_weights should not mutate the input dict."""
         from mobius.integrations._weight_loading import _dequantize_fp8_weights


### PR DESCRIPTION
## Summary
- dequantize FP8 matrix weights using strict 128-by-128 inverse-scale grids
- retain scalar-scale behavior and fail closed for malformed block metadata
- cover block boundaries, partial edge blocks, invalid grids, unsupported dimensions, auxiliary removal, and input immutability

## Validation
- `python -m pytest src/mobius/integrations/_weight_loading_test.py -q --tb=short`
- `python -m pytest tests/build_graph_test.py tests/cli_test.py src/ -q -k "not phi4mm and not apply_weights_unknown" --tb=short`
- `lintrunner f --output oneline --all-files`