### PR TITLE
Report GGUF quantization fidelity truthfully

### DIFF
--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -27,8 +27,18 @@ package = build_from_gguf("model.gguf")
 package.save("output")
 ```
 
-Use `keep_quantized=False` for explicit float import. Pass `mmproj=` only for an
-evidenced multimodal sidecar. The CLI equivalent is `mobius build model.gguf -o output`.
+`keep_quantized=True` requests quantized target storage where supported; it does
+not guarantee source byte or numerical fidelity. Mobius classifies qtypes before
+payload conversion, emits one aggregate warning for lossy requantization, and
+saves the typed result as `quantization_report.json`. Use
+`keep_quantized=False` for explicit float import.
+
+Storage and compute are separate: packed MatMulNBits initializers may use a
+native custom op or a portable inline fallback with nibble unpack,
+`DequantizeLinear`, and float `MatMul`. The fallback does not replace packed
+initializers with dense float storage or promise a particular ORT kernel. Pass
+`mmproj=` only for an evidenced multimodal sidecar. The CLI equivalent is
+`mobius build model.gguf -o output`.
 
 ## API
 

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -364,10 +364,11 @@ mobius build --model Qwen/Qwen2.5-0.5B --output output_dir/ \
 
 Build an ONNX model from a GGUF file (e.g. from llama.cpp). This is an explicit
 opt-in import path; `mobius build` does not auto-discover or select GGUF files.
-Supported GGUF quantization is preserved by default through byte-preserving
-native blocks or value-preserving affine repacking. Mixed source qtypes that
-would require lossy dequantization/requantization, including Q4_K_M presets,
-fail closed and require `--dequantize`.
+Quantized target storage is used by default where supported. Native blocks may
+remain byte-identical and affine repacks may be numerically exact, but mixed
+source qtypes can be lossily dequantized/requantized to a common packed target.
+Mobius emits one aggregate warning and writes `quantization_report.json`; this
+mode does not guarantee source-preset fidelity.
 
 > **Note**: Requires the optional `gguf` package: `pip install mobius-onnx[gguf]`
 
@@ -389,7 +390,7 @@ mobius build-gguf GGUF_PATH --output OUTPUT_DIR [options]
 |--------|-------------|
 | `--output OUTPUT_DIR`, `-o OUTPUT_DIR` | Required output directory for the ONNX model. |
 | `--max-shard-size SIZE` | Maximum external-data shard size (e.g. `5GB`). |
-| `--dequantize` | Explicitly dequantize all GGUF weights to float. |
+| `--dequantize` | Explicitly dequantize all mapped GGUF weights to float storage and report no quantized-storage claim. |
 | `--dtype DTYPE` | Target dtype for model weights: `f16`, `bf16`, `f32`. |
 | `--external-data FORMAT` | External data format: `onnx` (default) or `safetensors`. |
 | `--ep EP` | Target execution provider for EP-aware optimization. |
@@ -404,7 +405,7 @@ mobius build-gguf GGUF_PATH --output OUTPUT_DIR [options]
 ### Examples
 
 ```bash
-# Basic GGUF conversion (preserves supported quantization)
+# Basic GGUF conversion (quantized target storage where supported)
 mobius build-gguf model.gguf --output output/
 
 # Explicitly dequantize all weights
@@ -415,12 +416,16 @@ mobius build-gguf model.gguf --output output/ --dtype f16
 ```
 
 F32-, F16-, and BF16-only files build normally as float models because they
-contain no quantization to preserve.
-Quantized files containing only qtypes with no supported preservation target
-(for example, pure Q5_K weights) fail instead of silently becoming
-float. Re-run with `--dequantize` to request explicit float conversion.
-The same rule applies when only some projection tensors are incompatible with
-the selected affine target; Mobius does not silently requantize those tensors.
+contain no quantization to convert. Supported decoder-backed qtypes such as
+Q5_K are explicitly dequantized and requantized to a packed target such as INT4
+affine block-32, with their lossy disposition recorded in the report. Unknown
+qtypes, missing dequantizers, and mapped tensors whose disposition cannot be
+determined still fail closed before payload conversion.
+
+Storage and compute are separate report fields. Packed MatMulNBits initializers
+may use a native custom op or the portable inline fallback
+(`BitShift`/`BitwiseAnd`, `DequantizeLinear`, float `MatMul`). The fallback does
+not convert packed initializers to dense float storage or promise an ORT kernel.
 
 Encoder-only BERT and ModernBERT GGUF backbones auto-select
 `feature-extraction` and output `last_hidden_state`; they do not produce logits

--- a/docs/design/gguf-support-proposal.md
+++ b/docs/design/gguf-support-proposal.md
@@ -858,11 +858,11 @@ Neither QDQ nor MatMulNBits can natively represent:
 
 ### 8.7 Implemented Direct-Import Policy
 
-Direct GGUF import preserves supported quantization by default, with an
-explicit fully float path:
+Direct GGUF import uses quantized target storage by default, with an explicit
+fully float path and a persistent fidelity report:
 
 ```python
-# Default: preserve supported quantization
+# Default: quantized target storage where supported
 pkg = build_from_gguf("model.gguf")
 
 # Explicitly dequantize all weights
@@ -872,9 +872,11 @@ pkg = build_from_gguf("model.gguf", keep_quantized=False)
 The quantized path is classified per tensor: supported affine blocks are
 repacked for `MatMulNBits`; in text-only builds, supported native IQ/MXFP4
 projection blocks retain their bytes for `BlockQuantizedMatMul`; and multimodal
-or mixed source qtypes may require dequantization/requantization or produce a
-clear unsupported-layout error. F32-, F16-, and BF16-only files use the float
-path automatically because there is no quantization to preserve.
+or mixed source qtypes may require lossy dequantization/requantization or produce
+a clear unsupported-layout error. One deterministic warning summarizes lossy
+qtypes, counts, and bytes, while `quantization_report.json` records storage and
+compute semantics separately. F32-, F16-, and BF16-only files use the float path
+automatically because there is no quantized storage to convert.
 
 ### 8.8 Historical Alternative: QDQLinear (Not Implemented)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,8 +96,8 @@ pkg = build("facebook/wav2vec2-base")
 
 ### Build from a GGUF file
 
-Convert a GGUF model (e.g. from llama.cpp) to ONNX. Supported quantization is
-preserved by default:
+Convert a GGUF model (e.g. from llama.cpp) to ONNX. Quantized target storage is
+used by default where the selected graph supports it:
 
 ```python
 from mobius import build_from_gguf
@@ -115,6 +115,20 @@ mobius build-gguf path/to/model.gguf --output output/model/
 Pass `--dequantize` on the CLI, or `keep_quantized=False` to
 `build_from_gguf()`, when a fully float ONNX model is required. F32-, F16-, and
 BF16-only GGUFs automatically use the float path.
+
+`keep_quantized=True` does **not** promise source byte or numerical fidelity.
+Some qtypes are byte-preserved or losslessly repacked, while others are
+dequantized and lossily requantized to a target such as INT4 affine block-32.
+Mobius emits one aggregate warning for lossy conversion and saves the complete
+classification as `quantization_report.json`; do not label normalized output as
+the source GGUF preset (for example, Q4_K_M). The report lists source qtype
+counts/bytes, explicit float tensors, storage fidelity, and compute capability.
+
+Packed storage and runtime compute are separate. A runtime may execute a native
+`MatMulNBits` custom op, or Mobius may inline its portable standard-ONNX
+fallback (nibble `BitShift`/`BitwiseAnd`, `DequantizeLinear`, then float
+`MatMul`). Inlining the fallback does not replace packed weight initializers
+with dense float initializers and does not promise a particular ORT kernel.
 
 > **Note**: GGUF support requires the optional `gguf` package:
 > `pip install mobius-onnx[gguf]`

--- a/docs/model-catalog.md
+++ b/docs/model-catalog.md
@@ -267,10 +267,12 @@ All decoder-only LLMs and MoE models support quantized weight loading:
 | **AWQ** | HuggingFace (e.g. `-AWQ` suffix models) | `build("TheBloke/Llama-2-7B-AWQ")` |
 | **GGUF** | Local `.gguf` files | `build_from_gguf("model.gguf")` |
 
-GGUF import preserves supported quantization by default using value-preserving
-affine repacking or, for supported text-only inputs, native quantized ops.
-Projection tensors that would require lossy dequantization/requantization fail
-closed. Use `--dequantize` for an explicitly float model.
+GGUF import uses quantized target storage by default where the selected graph
+supports it. Source blocks may be byte-preserved, losslessly repacked, or
+lossily dequantized/requantized to a target such as INT4 affine block-32.
+Lossy conversion emits one aggregate warning, and every saved package records
+source fidelity, storage, and compute semantics in `quantization_report.json`.
+Use `--dequantize` for an explicitly reported float model.
 
 Encoder GGUF imports for `bert` and `modern-bert` select
 `feature-extraction` and expose token-level `last_hidden_state` only. Pooling,

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -620,9 +620,14 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
         )
 
     if keep_quantized:
-        print("Preserving supported GGUF quantization (float-only inputs stay float)...")
+        print(
+            "Quantized-target mode: classifying GGUF qtypes before conversion; "
+            "lossy requantization will be reported..."
+        )
     else:
-        print("Dequantized mode: converting GGUF weights to float...")
+        print(
+            "Dequantized mode: converting GGUF weights to explicitly reported float storage..."
+        )
 
     gguf_path = args.gguf_path
     gguf_reference = gguf_path
@@ -1264,7 +1269,11 @@ def build_parser() -> argparse.ArgumentParser:
     gguf_parser.add_argument(
         "--dequantize",
         action="store_true",
-        help="Dequantize all GGUF weights to float instead of preserving quantization.",
+        help=(
+            "Dequantize all mapped GGUF weights to float. Without this flag, Mobius "
+            "keeps quantized target storage where supported, but may lossily normalize "
+            "source qtypes and emits a quantization_report.json fidelity report."
+        ),
     )
     gguf_parser.add_argument(
         "--reuse-gguf-weights",

--- a/src/mobius/_model_package.py
+++ b/src/mobius/_model_package.py
@@ -29,7 +29,7 @@ import threading
 from collections import UserDict
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import onnx_ir as ir
 import rfc8785
@@ -45,11 +45,15 @@ from mobius.adapters import (
 from mobius.generation import PolicyComponent
 from mobius.integrations._weight_loading import _assign_weight
 
+if TYPE_CHECKING:
+    from mobius.integrations.gguf._quantization_report import GGUFQuantizationReport
+
 logger = logging.getLogger(__name__)
 
 _PACKAGE_MANIFEST = ".mobius-package.json"
 _PACKAGE_MANIFEST_FORMAT = "mobius.model-package.v1"
 _MTP_SIDECAR_BASENAME = ".mobius-mtp"
+_QUANTIZATION_REPORT = "quantization_report.json"
 
 
 def _read_mtp_sidecar_name(directory: str) -> str | None:
@@ -128,10 +132,12 @@ def _validate_mtp_chain(package: ModelPackage) -> None:
                     f"case-insensitively; {name!r} collides with another component."
                 )
             component_keys.add(collision_key)
-            if collision_key == _PACKAGE_MANIFEST.casefold():
+            if collision_key in {
+                _PACKAGE_MANIFEST.casefold(),
+                _QUANTIZATION_REPORT.casefold(),
+            }:
                 raise ValueError(
-                    f"ModelPackage component name {_PACKAGE_MANIFEST!r} is reserved "
-                    "for package metadata."
+                    f"ModelPackage component name {name!r} is reserved for package metadata."
                 )
         sidecar = current.mtp_head
         if sidecar is None:
@@ -165,6 +171,11 @@ def _validate_mtp_save_paths(
 ) -> None:
     """Reject unsafe output paths throughout the package chain before any writes."""
     _validate_output_directory(directory, kind="package", inspect_contents=False)
+    report_path = os.path.join(directory, _QUANTIZATION_REPORT)
+    if os.path.lexists(report_path) and (
+        os.path.islink(report_path) or not os.path.isfile(report_path)
+    ):
+        raise ValueError("ModelPackage quantization report output must be a real file.")
     previous_sidecar_name = _read_mtp_sidecar_name(directory)
     selected = [name for name in package if components is None or components(name)]
     if len(selected) > 1:
@@ -280,6 +291,7 @@ class ModelPackage(UserDict[str, ir.Model]):
     ) -> None:
         super().__init__(models or {})
         self.config = config
+        self.gguf_quantization_report: GGUFQuantizationReport | None = None
         # Optional persistence policy attached by the GGUF importer.
         self.gguf_reuse_plan: Any = None
         self.mtp_head: ModelPackage | None = None
@@ -416,6 +428,11 @@ class ModelPackage(UserDict[str, ir.Model]):
                 )
         previous_sidecar_name = _read_mtp_sidecar_name(directory)
         os.makedirs(directory, exist_ok=True)
+        quantization_report_path = os.path.join(directory, _QUANTIZATION_REPORT)
+        if self.gguf_quantization_report is not None:
+            self.gguf_quantization_report.write_json(quantization_report_path)
+        elif os.path.isfile(quantization_report_path):
+            os.remove(quantization_report_path)
         selected = {
             name: model
             for name, model in self.data.items()
@@ -875,6 +892,17 @@ class ModelPackage(UserDict[str, ir.Model]):
                     name = filename.removesuffix(".onnx")
                     models[name] = ir.load(os.path.join(directory, filename))
         package = cls(models)
+        quantization_report_path = os.path.join(directory, _QUANTIZATION_REPORT)
+        if os.path.lexists(quantization_report_path):
+            if os.path.islink(quantization_report_path) or not os.path.isfile(
+                quantization_report_path
+            ):
+                raise ValueError("ModelPackage quantization report must be a real file.")
+            from mobius.integrations.gguf._quantization_report import GGUFQuantizationReport
+
+            package.gguf_quantization_report = GGUFQuantizationReport.read_json(
+                quantization_report_path
+            )
         package._load_policy_components(directory)
         if mtp_dir is not None:
             package.mtp_head = cls._load(mtp_dir, ancestors)

--- a/src/mobius/_model_package.py
+++ b/src/mobius/_model_package.py
@@ -176,6 +176,12 @@ def _validate_mtp_save_paths(
         os.path.islink(report_path) or not os.path.isfile(report_path)
     ):
         raise ValueError("ModelPackage quantization report output must be a real file.")
+    if package.gguf_quantization_report is None and os.path.isfile(report_path):
+        raise ValueError(
+            "ModelPackage output contains a stale quantization_report.json, but the "
+            "package being saved has no GGUF quantization report. Remove or clean the "
+            "output directory before saving."
+        )
     previous_sidecar_name = _read_mtp_sidecar_name(directory)
     selected = [name for name in package if components is None or components(name)]
     if len(selected) > 1:
@@ -431,8 +437,6 @@ class ModelPackage(UserDict[str, ir.Model]):
         quantization_report_path = os.path.join(directory, _QUANTIZATION_REPORT)
         if self.gguf_quantization_report is not None:
             self.gguf_quantization_report.write_json(quantization_report_path)
-        elif os.path.isfile(quantization_report_path):
-            os.remove(quantization_report_path)
         selected = {
             name: model
             for name, model in self.data.items()

--- a/src/mobius/_model_package_test.py
+++ b/src/mobius/_model_package_test.py
@@ -353,6 +353,17 @@ class TestModelPackageSaveLoad:
         assert pkg["model"].graph is not None
         assert loaded["model"].graph.num_nodes() == pkg["model"].graph.num_nodes()
 
+    def test_save_without_report_rejects_stale_report(self, tmp_path):
+        report_path = tmp_path / "quantization_report.json"
+        report_path.write_text('{"user": "owned"}\n', encoding="utf-8")
+        pkg = ModelPackage({"model": _make_simple_model("model")})
+
+        with pytest.raises(ValueError, match=r"stale quantization_report.json"):
+            pkg.save(str(tmp_path))
+
+        assert report_path.read_text(encoding="utf-8") == '{"user": "owned"}\n'
+        assert not (tmp_path / "model.onnx").exists()
+
     def test_load_multiple(self, tmp_path):
         pkg = ModelPackage(
             {

--- a/src/mobius/functions/matmul_nbits_test.py
+++ b/src/mobius/functions/matmul_nbits_test.py
@@ -114,12 +114,15 @@ class TestMatMulNBitsInlineParity:
         model, feeds, *_ = _build_matmulnbits_model(n_out=8, k_in=64, block=32)
         reference = _run(model, feeds)
 
-        inlined, feeds2, *_ = _build_matmulnbits_model(n_out=8, k_in=64, block=32)
+        inlined, feeds2, packed, *_ = _build_matmulnbits_model(n_out=8, k_in=64, block=32)
         self._inline(inlined)
         # Op is expanded: no MatMulNBits left, DequantizeLinear present.
         ops = [n.op_type for n in inlined.graph]
         assert "MatMulNBits" not in ops
         assert "DequantizeLinear" in ops
+        packed_initializer = inlined.graph.initializers["B"]
+        assert packed_initializer.dtype == ir.DataType.UINT8
+        np.testing.assert_array_equal(np.asarray(packed_initializer.const_value), packed)
         got = _run(inlined, feeds2)
 
         np.testing.assert_allclose(got, reference, rtol=0, atol=0)

--- a/src/mobius/integrations/gguf/__init__.py
+++ b/src/mobius/integrations/gguf/__init__.py
@@ -12,8 +12,8 @@ Usage::
 
     # Text-only model
     pkg = build_from_gguf("path/to/model.gguf")
-    # Supported quantization is preserved by default; pass
-    # keep_quantized=False for a fully float model.
+    # Quantized target storage is used by default with a fidelity report;
+    # pass keep_quantized=False for explicitly reported float storage.
 
     # Multimodal (text + companion mmproj vision/audio encoder)
     pkg = build_from_gguf("path/to/model.gguf", mmproj="path/to/mmproj.gguf")
@@ -46,6 +46,13 @@ from mobius.integrations.gguf._preflight import (
     preflight_gguf,
     preflight_hf_gguf,
     preflight_local_gguf,
+)
+from mobius.integrations.gguf._quantization_report import (
+    GGUFQuantizationReport,
+    QuantizationDisposition,
+    QuantizationDispositionStat,
+    QuantizationTensorRecord,
+    QuantizationTypeStat,
 )
 from mobius.integrations.gguf._reuse import verify_gguf_reuse_manifest
 from mobius.integrations.gguf._runtime_package import write_gguf_runtime_package
@@ -99,4 +106,9 @@ __all__ = [
     "preflight_hf_gguf",
     "GgufPreflightReport",
     "GgufTypeStat",
+    "GGUFQuantizationReport",
+    "QuantizationDisposition",
+    "QuantizationDispositionStat",
+    "QuantizationTensorRecord",
+    "QuantizationTypeStat",
 ]

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -4,12 +4,12 @@
 """GGUF → ONNX build pipeline.
 
 Converts ``.gguf`` model files to ONNX using the standard build
-pipeline. Quantized preservation is the default: affine linear-layer weights
+pipeline. Quantized target storage is the default: affine linear-layer weights
 are repacked into MatMulNBits format and compatible token embeddings into
 GatherBlockQuantized format. For text-only builds, runtime-supported native
-IQ/MXFP4 projection blocks are preserved for BlockQuantizedMatMul. A requested
-preservation route fails closed when a projection would need lossy
-dequantization/requantization, including mixed Q4_K_M presets. Set
+IQ/MXFP4 projection blocks are preserved for BlockQuantizedMatMul. Lossy
+normalization to a common packed target is allowed only with a deterministic
+warning and persistent fidelity report. Set
 ``keep_quantized=False`` to request a fully float import explicitly.
 """
 
@@ -4770,10 +4770,10 @@ def build_from_gguf(
     7. Run ``preprocess_weights()`` (HF → ONNX name mapping)
     8. Apply weights to the ONNX model
 
-    By default, supported affine tensors are repacked into MatMulNBits format.
+    By default, supported tensors use quantized target storage.
     For text-only builds, operator-native IQ/MXFP4 projection blocks
     are retained byte-for-byte for BlockQuantizedMatMul. Multimodal text
-    backbones require a lossless route for every quantized projection. GGUFs
+    backbones normalize quantized projections to their common affine target. GGUFs
     containing only F32, F16, or BF16 weights use the float path because there
     is no quantization to preserve.
     Quantized files with no supported preservation target raise an actionable
@@ -4791,12 +4791,13 @@ def build_from_gguf(
             model type.
         dtype: Override model dtype (e.g. ``"f16"``). When ``None``,
             defaults to float32.
-        keep_quantized: Preserve quantization when quantized tensors are
-            present. This is the default. Supported affine blocks are repacked,
+        keep_quantized: Keep quantized target storage when supported. This is
+            the default. Supported affine blocks are repacked,
             text-only runtime-supported native IQ/MXFP4 projection blocks
-            retain their bytes, and any projection requiring lossy
-            requantization is rejected. Set to ``False`` to dequantize all
-            weights.
+            retain their bytes, and incompatible source qtypes are explicitly
+            classified as lossy dequantize/requantize conversions. This does not
+            guarantee source-byte or source-value fidelity. Set to ``False`` to
+            dequantize all weights to float.
         execution_provider: Target execution provider for EP-aware
             optimisations (e.g. ``"cpu"`` to apply the
             GroupQueryAttention rewrite). Defaults to ``"default"``
@@ -5283,9 +5284,64 @@ def build_from_gguf(
         # then the gate fails closed if any per-expert dense storm survives.
         # Enforcing here (pre-export, module level) would reject the very layers
         # the fusion can now collapse, so the authority moved to the graph.
+    quantization_report = _preflight_quantization_report(
+        gguf_model,
+        gguf_arch,
+        module,
+        config,
+        preserve_quantization=preserve_quantization,
+        target_bits=(config.quantization.bits if preserve_quantization else None),
+        target_block_size=(config.quantization.group_size if preserve_quantization else None),
+        execution_provider=execution_provider,
+        dequantize_float_linear_types=float_linear_dequantization_types,
+        emit_warning=not emit_mtp_head,
+        include_tensor=(
+            (
+                lambda name: (
+                    not any(
+                        name.startswith(f"blk.{block_index}.")
+                        for block_index in mtp_block_indices
+                    )
+                )
+            )
+            if emit_mtp_head
+            else None
+        ),
+    )
+    mtp_pkg = None
+    if emit_mtp_head:
+        mtp_preflight_received = False
+
+        def combine_mtp_report(mtp_report) -> None:
+            nonlocal quantization_report, mtp_preflight_received
+            from mobius.integrations.gguf._quantization_report import (
+                GGUFQuantizationReport,
+            )
+
+            quantization_report = GGUFQuantizationReport.combine(
+                quantization_report,
+                mtp_report,
+            )
+            mtp_preflight_received = True
+            warning = quantization_report.warning_message()
+            if warning is not None:
+                logger.warning("%s", warning)
+
+        mtp_pkg = build_mtp_head_from_gguf(
+            gguf_model,
+            config,
+            preserve_quantization=preserve_quantization,
+            execution_provider=execution_provider,
+            on_preflight=combine_mtp_report,
+        )
+        if not mtp_preflight_received:
+            warning = quantization_report.warning_message()
+            if warning is not None:
+                logger.warning("%s", warning)
     pkg = build_from_module(
         module, config, resolved_task, execution_provider=execution_provider
     )
+    pkg.gguf_quantization_report = quantization_report
     logger.info(
         "Built ONNX graph for %s (%d components)",
         model_type,
@@ -5398,15 +5454,8 @@ def build_from_gguf(
     # the GGUF's ``blk.<nextn>.*`` tensors (dropped by the backbone build) and
     # attach it to the package so the CLI can save it into a ``mtp/`` subdir.
     # Auto-detected from source-tensor presence (see step 4b).
-    if emit_mtp_head:
-        mtp_pkg = build_mtp_head_from_gguf(
-            gguf_model,
-            config,
-            preserve_quantization=preserve_quantization,
-            execution_provider=execution_provider,
-        )
-        if mtp_pkg is not None:
-            pkg.mtp_head = mtp_pkg
+    if mtp_pkg is not None:
+        pkg.mtp_head = mtp_pkg
 
     if draft_manifest is not None:
         pkg.draft_manifest = draft_manifest
@@ -6114,6 +6163,277 @@ def _has_quantized_weights(gguf_model, gguf_arch: str) -> bool:
     return False
 
 
+def _preflight_quantization_report(
+    gguf_model,
+    gguf_arch: str,
+    module,
+    config,
+    *,
+    preserve_quantization: bool,
+    target_bits: int | None,
+    target_block_size: int | None,
+    execution_provider: str,
+    name_mapper: Callable[[str, str], str | None] | None = None,
+    target_name_mapper: Callable[[str], str] | None = None,
+    dequantize_float_linear_types: Mapping[str, Collection[str]] | None = None,
+    emit_warning: bool = True,
+    include_tensor: Callable[[str], bool] | None = None,
+):
+    """Classify every mapped weight from header metadata before payload conversion."""
+    from mobius.components import (
+        BlockQuantizedLinear,
+        Embedding,
+        Linear,
+        QuantizedEmbedding,
+        QuantizedLinear,
+    )
+    from mobius.integrations.gguf._quant_registry import (
+        float_storage_type_ids,
+        get_quant_spec,
+        quant_import_decision,
+    )
+    from mobius.integrations.gguf._quantization_report import (
+        GGUFQuantizationReport,
+        QuantizationDisposition,
+        QuantizationTensorRecord,
+        disposition_for_import_route,
+    )
+    from mobius.integrations.gguf._spec import (
+        QuantImportRoute,
+        RepackExactness,
+        Support,
+        TensorRole,
+    )
+    from mobius.integrations.gguf._tensor_mapping import map_gguf_to_hf_names
+
+    if name_mapper is None:
+        name_mapper = map_gguf_to_hf_names
+
+    quantized_stems: set[str] = set()
+    native_stems: set[str] = set()
+    quantized_embedding_stems: set[str] = set()
+    float_stems: set[str] = set()
+    embedding_stems: set[str] = set()
+    parameter_names = {name for name, _ in module.named_parameters()}
+    for module_name, child in module.named_modules():
+        if isinstance(child, QuantizedLinear) or getattr(
+            child, "_gguf_quantized_linear", False
+        ):
+            quantized_stems.add(module_name)
+        elif isinstance(child, BlockQuantizedLinear):
+            native_stems.add(module_name)
+        elif isinstance(child, QuantizedEmbedding):
+            quantized_embedding_stems.add(module_name)
+            embedding_stems.add(module_name)
+        elif isinstance(child, Linear):
+            float_stems.add(module_name)
+        elif isinstance(child, Embedding):
+            embedding_stems.add(module_name)
+
+    float_type_ids = float_storage_type_ids()
+    source_qtypes: list[tuple[str, int]] = []
+    records: list[QuantizationTensorRecord] = []
+    rejected: list[QuantizationTensorRecord] = []
+    for tensor in gguf_model.reader_tensors():
+        qtype = tensor.tensor_type
+        qtype_id = getattr(qtype, "value", qtype)
+        quant_spec = get_quant_spec(qtype)
+        qtype_name = (
+            quant_spec.name if quant_spec is not None else str(getattr(qtype, "name", qtype))
+        )
+        source_bytes = int(tensor.n_bytes)
+        source_qtypes.append((qtype_name, source_bytes))
+        if include_tensor is not None and not include_tensor(tensor.name):
+            continue
+        hf_name = name_mapper(tensor.name, gguf_arch)
+        if hf_name is None or not hf_name.endswith(".weight"):
+            continue
+        shape = tuple(int(dim) for dim in reversed(tensor.shape))
+        module_hf_name = target_name_mapper(hf_name) if target_name_mapper else hf_name
+        if gguf_arch == "bert" and module_hf_name.startswith("bert."):
+            module_hf_name = module_hf_name[len("bert.") :]
+        elif gguf_arch == "modern-bert" and module_hf_name.startswith("model."):
+            module_hf_name = module_hf_name[len("model.") :]
+        elif gguf_arch in {"t5", "t5encoder"}:
+            from mobius.models.t5 import _rename_t5_weight
+
+            renamed = _rename_t5_weight(
+                module_hf_name,
+                is_gated_act=bool(getattr(config, "is_gated_act", False)),
+            )
+            if renamed is not None:
+                module_hf_name = renamed
+
+        module_stem = module_hf_name.removesuffix(".weight")
+        native_targets = _native_block_target_stems(hf_name, shape, native_stems)
+        affine_targets = _native_block_target_stems(module_hf_name, shape, quantized_stems)
+        fused_targets = _fused_projection_target_stems(module_hf_name, quantized_stems)
+        is_kimi_fused_kv_projection = gguf_arch == "kimi-k3" and module_hf_name.endswith(
+            ".kv_b_proj.weight"
+        )
+        is_quantized_embedding = module_stem in quantized_embedding_stems
+        target_is_quantized = bool(
+            native_targets
+            or affine_targets
+            or fused_targets
+            or module_stem in quantized_stems
+            or is_quantized_embedding
+            or is_kimi_fused_kv_projection
+        )
+        if qtype_id in float_type_ids:
+            disposition = (
+                QuantizationDisposition.REJECTED
+                if preserve_quantization and target_is_quantized
+                else QuantizationDisposition.SOURCE_FLOAT
+            )
+            target = "rejected" if disposition is QuantizationDisposition.REJECTED else "float"
+            reason = (
+                "The selected quantized graph would quantize a source-float tensor."
+                if disposition is QuantizationDisposition.REJECTED
+                else "The GGUF tensor is already stored as float."
+            )
+        elif quant_spec is None:
+            disposition = QuantizationDisposition.REJECTED
+            target = "rejected"
+            reason = "The qtype is outside the pinned llama.cpp census."
+        elif not preserve_quantization:
+            disposition = QuantizationDisposition.DEQUANTIZED_FLOAT
+            target = "float"
+            reason = "Explicit float import dequantizes every mapped quantized tensor."
+        else:
+            explicitly_dequantized = (
+                dequantize_float_linear_types is not None
+                and module_stem in dequantize_float_linear_types
+                and quant_spec.name in dequantize_float_linear_types[module_stem]
+            )
+            known_float_route = explicitly_dequantized or _uses_explicit_float_route(
+                gguf_arch, tensor.name
+            )
+            if known_float_route:
+                role = TensorRole.NON_MATMUL
+            elif is_quantized_embedding:
+                role = TensorRole.EMBEDDING
+            elif native_targets:
+                role = TensorRole.PROJECTION
+            elif target_is_quantized:
+                role = TensorRole.AFFINE_PROJECTION
+            elif (
+                module_stem in float_stems
+                or module_stem in embedding_stems
+                or module_hf_name in parameter_names
+                or len(shape) < 2
+            ):
+                role = TensorRole.NON_MATMUL
+            else:
+                role = TensorRole.NON_MATMUL
+                route = QuantImportRoute.REJECTED
+                exactness = None
+                reason = "The mapped tensor has no corresponding graph parameter target."
+            if (
+                module_hf_name in parameter_names
+                or module_stem in float_stems
+                or module_stem in embedding_stems
+                or target_is_quantized
+                or known_float_route
+                or len(shape) < 2
+            ):
+                route, exactness, reason = quant_import_decision(
+                    qtype,
+                    role,
+                    target_bits=target_bits,
+                    target_block_size=target_block_size,
+                )
+            is_kimi_reshaped_projection = gguf_arch in {
+                "kimi-linear",
+                "kimi-k3",
+            } and module_hf_name.endswith((".k_b_proj.weight", ".v_b_proj.weight"))
+            if is_kimi_reshaped_projection and route is not QuantImportRoute.REJECTED:
+                if quant_spec.dequantize is not Support.SUPPORTED:
+                    route = QuantImportRoute.REJECTED
+                    exactness = None
+                    reason = "The reshaped projection has no trusted dequantizer."
+                else:
+                    route = QuantImportRoute.DEQUANTIZE_REQUANTIZE
+                    exactness = RepackExactness.LOSSY
+                    reason = (
+                        "The Kimi MLA layout transform changes affine block groups and "
+                        "requires lossy dequantization/requantization."
+                    )
+            disposition = disposition_for_import_route(route, exactness)
+            target = (
+                "native GGUF block storage"
+                if route is QuantImportRoute.NATIVE_BYTES
+                else "float"
+                if route is QuantImportRoute.DEQUANTIZE_FLOAT
+                else "rejected"
+                if route is QuantImportRoute.REJECTED
+                else f"INT{target_bits} affine block-{target_block_size}"
+            )
+        record = QuantizationTensorRecord(
+            name=tensor.name,
+            qtype=qtype_name,
+            source_bytes=source_bytes,
+            disposition=disposition,
+            target_storage=target,
+            reason=reason,
+        )
+        records.append(record)
+        if disposition is QuantizationDisposition.REJECTED:
+            rejected.append(record)
+
+    quantized_records = [
+        record
+        for record in records
+        if record.disposition
+        in {
+            QuantizationDisposition.NATIVE_BYTES,
+            QuantizationDisposition.LOSSLESS_REPACK,
+            QuantizationDisposition.LOSSY_REQUANTIZE,
+        }
+    ]
+    if quantized_records:
+        targets = {record.target_storage for record in quantized_records}
+        target_storage_format = " + ".join(sorted(targets))
+    else:
+        target_storage_format = "float"
+    compute_mode = (
+        "float operators"
+        if not quantized_records
+        else "runtime-dependent native custom op or inline standard-ONNX fallback"
+    )
+    compute_capability = (
+        "Storage is float and executes through float operators."
+        if not quantized_records
+        else (
+            "Packed storage may be consumed by native MatMulNBits/"
+            "GatherBlockQuantized/BlockQuantizedMatMul implementations. "
+            "MatMulNBits may instead be inlined as nibble BitShift/BitwiseAnd, "
+            "DequantizeLinear, and float MatMul; this does not change packed storage "
+            f"and makes no promise about the {execution_provider!r} runtime kernel."
+        )
+    )
+    report = GGUFQuantizationReport.create(
+        source_qtypes=source_qtypes,
+        tensor_records=records,
+        target_storage_format=target_storage_format,
+        compute_mode=compute_mode,
+        compute_capability=compute_capability,
+    )
+    if rejected:
+        details = "; ".join(
+            f"{record.name} ({record.qtype}): {record.reason}" for record in rejected[:5]
+        )
+        suffix = "" if len(rejected) <= 5 else f"; and {len(rejected) - 5} more"
+        raise ValueError(
+            "GGUF quantization preflight could not determine a safe disposition for "
+            f"{len(rejected)} mapped tensor(s): {details}{suffix}"
+        )
+    warning = report.warning_message()
+    if warning is not None and emit_warning:
+        logger.warning("%s", warning)
+    return report
+
+
 def _uses_explicit_float_route(
     gguf_arch: str,
     tensor_name: str,
@@ -6124,6 +6444,11 @@ def _uses_explicit_float_route(
         "token_embd_norm.weight",
         "token_types.weight",
         "position_embd.weight",
+    }:
+        return True
+    if gguf_arch in {"t5", "t5encoder"} and tensor_name in {
+        "token_embd.weight",
+        "shared.weight",
     }:
         return True
     if tensor_name.endswith(("_norm.weight", ".norm.weight")):
@@ -6180,13 +6505,10 @@ def _reject_unsupported_quantization_preservation(
     from mobius.integrations.gguf._quant_registry import (
         float_storage_type_ids,
         get_quant_spec,
-        lossless_preservation_type_names,
     )
     from mobius.integrations.gguf._tensor_mapping import map_gguf_to_hf_names
 
     float_type_ids = float_storage_type_ids()
-    lossless_types = lossless_preservation_type_names()
-    affine_targets: dict[tuple[int, int], tuple[str, str]] = {}
     metadata = getattr(gguf_model, "metadata", {})
     block_count = int(metadata.get(f"{gguf_arch}.block_count", 0))
     mtp_count = int(metadata.get(f"{gguf_arch}.nextn_predict_layers", 0))
@@ -6234,15 +6556,6 @@ def _reject_unsupported_quantization_preservation(
                 f"{tensor_name} ({type_name}) in this graph. Use keep_quantized=False "
                 "(API) or --dequantize (CLI) for explicit float import."
             )
-        if type_name not in lossless_types:
-            raise ValueError(
-                "Quantization-preserving GGUF import would change the dequantized "
-                f"values of {tensor_name} ({type_name}). The current ORT "
-                "MatMulNBits route cannot represent this source block format "
-                "losslessly; mixed presets such as Q4_K_M must not be normalized "
-                "to a common 4-bit affine layout. Use keep_quantized=False (API) "
-                "or --dequantize (CLI) for explicit float import."
-            )
         spec = get_quant_spec(qtype)
         block_match = re.match(r"blk\.(\d+)\.", tensor_name)
         is_mtp_block = block_match is not None and int(block_match.group(1)) in mtp_blocks
@@ -6250,42 +6563,12 @@ def _reject_unsupported_quantization_preservation(
             spec is not None
             and spec.native_preserve is not None
             and (not allow_native_blocks or ".nextn." in tensor_name or is_mtp_block)
+            and spec.dequantize is not Support.SUPPORTED
         ):
             raise ValueError(
-                "Quantization-preserving GGUF import cannot retain native block "
-                f"format {type_name} for {tensor_name} in this graph. Use "
-                "keep_quantized=False (API) or --dequantize (CLI) for explicit "
-                "float import."
+                "Quantization-preserving GGUF import cannot normalize native block "
+                f"format {type_name} for {tensor_name}: no trusted dequantizer is available."
             )
-        if (
-            spec is not None
-            and spec.native_preserve is not None
-            and tensor_name
-            in {
-                "token_embd.weight",
-                "shared.weight",
-            }
-        ):
-            raise ValueError(
-                "Quantization-preserving GGUF import cannot retain native block "
-                f"format {type_name} for embedding tensor {tensor_name}; "
-                "GatherBlockQuantized does not consume that layout. Use "
-                "keep_quantized=False (API) or --dequantize (CLI) for explicit "
-                "float import."
-            )
-        if spec is not None and spec.affine_repack is not None:
-            affine_targets.setdefault(spec.affine_repack.as_params(), (tensor_name, type_name))
-
-    if len(affine_targets) > 1:
-        details = ", ".join(
-            f"{name} ({qtype}: {bits}-bit/block-{block_size})"
-            for (bits, block_size), (name, qtype) in sorted(affine_targets.items())
-        )
-        raise ValueError(
-            "Quantization-preserving GGUF import requires one affine MatMulNBits "
-            f"contract across projection modules, but found incompatible targets: {details}. "
-            "Use keep_quantized=False (API) or --dequantize (CLI) for explicit float import."
-        )
 
     if gguf_arch not in {"dream", "llada-moe", "rnd1"}:
         return
@@ -6373,18 +6656,21 @@ def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, int, bool]:
         {qtype: count for qtype, count in counts.items() if _native_block_format(qtype)}
     )
     if native_counts:
+        requires_normalization = any(
+            qtype not in native_counts
+            and spec is not None
+            and spec.import_route is QuantImportRoute.DEQUANTIZE_REQUANTIZE
+            for qtype, spec in quant_specs.items()
+        )
         affine_specs = {
             spec.affine_repack
             for qtype in counts
             if qtype not in native_counts
             if (spec := get_quant_spec(qtype)) is not None and spec.affine_repack is not None
         }
-        if len(affine_specs) > 1:
-            raise ValueError(
-                "Native-block GGUF contains incompatible affine projection targets; "
-                "use keep_quantized=False for explicit float import."
-            )
-        if affine_specs:
+        if requires_normalization or len(affine_specs) > 1:
+            bits, block_size, can_omit_zero_points = 4, 32, False
+        elif affine_specs:
             target = next(iter(affine_specs))
             bits, block_size = target.as_params()
             can_omit_zero_points = target.omit_zero_points
@@ -6398,7 +6684,12 @@ def _detect_quant_params(gguf_model, gguf_arch: str) -> tuple[int, int, bool]:
         )
         return bits, block_size, can_omit_zero_points
 
-    if any(
+    affine_specs = {
+        spec.affine_repack
+        for spec in quant_specs.values()
+        if spec is not None and spec.affine_repack is not None
+    }
+    if len(affine_specs) > 1 or any(
         spec is not None and spec.import_route is QuantImportRoute.DEQUANTIZE_REQUANTIZE
         for spec in quant_specs.values()
     ):
@@ -6749,7 +7040,7 @@ def _load_quantized_state_dict(
         repack_dequantized_tensor,
         repack_gguf_tensor,
     )
-    from mobius.integrations.gguf._spec import QuantImportRoute, RepackExactness, TensorRole
+    from mobius.integrations.gguf._spec import QuantImportRoute, TensorRole
     from mobius.integrations.gguf._tencent_q1_0 import (
         is_tencent_q1_0_layout,
         parse_tencent_q1_0_tensor,
@@ -6846,17 +7137,16 @@ def _load_quantized_state_dict(
             # K3 may serialize MLA K/V-B as one head-major matrix, while the
             # graph has distinct quantized projections. Preserve each source
             # row exactly while splitting and reordering the head-major blocks.
-            route, exactness, _reason = quant_import_decision(
+            route, _exactness, _reason = quant_import_decision(
                 qtype,
                 TensorRole.PROJECTION,
                 target_bits=target_bits,
                 target_block_size=target_block_size,
             )
-            if (
-                route is not QuantImportRoute.AFFINE_REPACK
-                or exactness is not RepackExactness.EXACT
-                or not can_repack(qtype_val)
-            ):
+            if route not in {
+                QuantImportRoute.AFFINE_REPACK,
+                QuantImportRoute.DEQUANTIZE_REQUANTIZE,
+            }:
                 quant_name = get_quant_spec(qtype)
                 quant_name = quant_name.name if quant_name is not None else str(qtype)
                 raise ValueError(
@@ -6864,10 +7154,16 @@ def _load_quantized_state_dict(
                     f"values of {gguf_name} ({quant_name}). Use keep_quantized=False "
                     "(API) or --dequantize (CLI) for explicit float import."
                 )
-            repacked = repack_gguf_tensor(
-                raw.ravel().view(np.uint8),
-                qtype_val,
-                (int(np_shape[0]), int(np_shape[1])),
+            repacked = repack_gguf_weight_to_target(
+                gguf_model,
+                raw,
+                qtype,
+                np_shape,
+                target_bits=target_bits,
+                target_block_size=target_block_size,
+                target_symmetric=target_symmetric,
+                tensor_name=hf_name,
+                tensor_role=TensorRole.AFFINE_PROJECTION,
             )
             if repacked.bits != target_bits or repacked.block_size != target_block_size:
                 raise ValueError(
@@ -7003,16 +7299,6 @@ def _load_quantized_state_dict(
                     f"Cannot import GGUF tensor {gguf_name} mapped to {hf_name} "
                     f"({quant_spec.name}, role={tensor_role.value}): {reason}"
                 )
-            if route is QuantImportRoute.DEQUANTIZE_REQUANTIZE or (
-                _exactness is RepackExactness.LOSSY
-                and route is not QuantImportRoute.DEQUANTIZE_FLOAT
-            ):
-                raise ValueError(
-                    "Quantization-preserving GGUF import would change the dequantized "
-                    f"values of {gguf_name} ({quant_spec.name}). Use "
-                    "keep_quantized=False (API) or --dequantize (CLI) for explicit "
-                    "float import."
-                )
             if route is QuantImportRoute.NATIVE_BYTES and not native_targets:
                 raise ValueError(
                     f"Cannot preserve native {quant_spec.name} bytes for {hf_name}: "
@@ -7061,14 +7347,26 @@ def _load_quantized_state_dict(
                 "explicit float import."
             )
         if fused_projection_targets:
-            if route is not QuantImportRoute.AFFINE_REPACK or not can_repack(qtype_val):
+            if route not in {
+                QuantImportRoute.AFFINE_REPACK,
+                QuantImportRoute.DEQUANTIZE_REQUANTIZE,
+            }:
                 raise ValueError(
                     "Quantization-preserving GGUF import cannot split fused projection "
-                    f"{gguf_name} ({getattr(qtype, 'name', qtype)}) without changing "
-                    "its dequantized values. Use keep_quantized=False (API) or "
-                    "--dequantize (CLI) for explicit float import."
+                    f"{gguf_name} ({getattr(qtype, 'name', qtype)}): no packed target "
+                    "conversion route is available."
                 )
-            repacked = repack_gguf_tensor(raw, qtype_val, tuple(int(dim) for dim in np_shape))
+            repacked = repack_gguf_weight_to_target(
+                gguf_model,
+                raw,
+                qtype,
+                np_shape,
+                target_bits=target_bits,
+                target_block_size=target_block_size,
+                target_symmetric=target_symmetric,
+                tensor_name=hf_name,
+                tensor_role=TensorRole.AFFINE_PROJECTION,
+            )
             offset = 0
             for target_stem in fused_projection_targets:
                 n_out = quantized_output_sizes[target_stem]

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -6179,7 +6179,7 @@ def _preflight_quantization_report(
     emit_warning: bool = True,
     include_tensor: Callable[[str], bool] | None = None,
 ):
-    """Classify every mapped weight from header metadata before payload conversion."""
+    """Classify every mapped tensor from header metadata before payload conversion."""
     from mobius.components import (
         BlockQuantizedLinear,
         Embedding,
@@ -6203,6 +6203,11 @@ def _preflight_quantization_report(
         RepackExactness,
         Support,
         TensorRole,
+    )
+    from mobius.integrations.gguf._tencent_q1_0 import (
+        is_tencent_q1_0_layout,
+        tencent_q1_0_source_nbytes,
+        tencent_q1_0_target_bits,
     )
     from mobius.integrations.gguf._tensor_mapping import map_gguf_to_hf_names
 
@@ -6231,6 +6236,7 @@ def _preflight_quantization_report(
             embedding_stems.add(module_name)
 
     float_type_ids = float_storage_type_ids()
+    tencent_q1_0 = is_tencent_q1_0_layout(gguf_model)
     source_qtypes: list[tuple[str, int]] = []
     records: list[QuantizationTensorRecord] = []
     rejected: list[QuantizationTensorRecord] = []
@@ -6241,12 +6247,17 @@ def _preflight_quantization_report(
         qtype_name = (
             quant_spec.name if quant_spec is not None else str(getattr(qtype, "name", qtype))
         )
-        source_bytes = int(tensor.n_bytes)
+        is_tencent_q1_0_tensor = tencent_q1_0 and qtype_name == "Q1_0"
+        source_bytes = (
+            tencent_q1_0_source_nbytes(tensor)
+            if is_tencent_q1_0_tensor
+            else int(tensor.n_bytes)
+        )
         source_qtypes.append((qtype_name, source_bytes))
         if include_tensor is not None and not include_tensor(tensor.name):
             continue
         hf_name = name_mapper(tensor.name, gguf_arch)
-        if hf_name is None or not hf_name.endswith(".weight"):
+        if hf_name is None:
             continue
         shape = tuple(int(dim) for dim in reversed(tensor.shape))
         module_hf_name = target_name_mapper(hf_name) if target_name_mapper else hf_name
@@ -6321,7 +6332,6 @@ def _preflight_quantization_report(
                 module_stem in float_stems
                 or module_stem in embedding_stems
                 or module_hf_name in parameter_names
-                or len(shape) < 2
             ):
                 role = TensorRole.NON_MATMUL
             else:
@@ -6335,14 +6345,30 @@ def _preflight_quantization_report(
                 or module_stem in embedding_stems
                 or target_is_quantized
                 or known_float_route
-                or len(shape) < 2
             ):
-                route, exactness, reason = quant_import_decision(
-                    qtype,
-                    role,
-                    target_bits=target_bits,
-                    target_block_size=target_block_size,
-                )
+                if is_tencent_q1_0_tensor and role is not TensorRole.NON_MATMUL:
+                    selected_bits = tencent_q1_0_target_bits()
+                    if (target_bits, target_block_size) == (selected_bits, 128):
+                        route = QuantImportRoute.AFFINE_REPACK
+                        exactness = RepackExactness.EXACT
+                        reason = (
+                            "Tencent Q1_0 2-bit/512 blocks are exactly represented as "
+                            f"INT{selected_bits} affine block-128."
+                        )
+                    else:
+                        route = QuantImportRoute.REJECTED
+                        exactness = None
+                        reason = (
+                            "Tencent Q1_0 requires the selected exact "
+                            f"INT{selected_bits} affine block-128 target."
+                        )
+                else:
+                    route, exactness, reason = quant_import_decision(
+                        qtype,
+                        role,
+                        target_bits=target_bits,
+                        target_block_size=target_block_size,
+                    )
             is_kimi_reshaped_projection = gguf_arch in {
                 "kimi-linear",
                 "kimi-k3",
@@ -7025,7 +7051,6 @@ def _load_quantized_state_dict(
     from mobius.components import (
         BlockQuantizedLinear,
         Embedding,
-        Linear,
         QuantizedEmbedding,
         QuantizedLinear,
     )
@@ -7061,7 +7086,6 @@ def _load_quantized_state_dict(
     quantized_output_sizes: dict[str, int] = {}
     native_block_stems: dict[str, str] = {}
     quantized_embedding_stems = set()
-    float_linear_stems = set()
     embedding_stems = set()
     for mod_name, mod in module.named_modules():
         if isinstance(mod, QuantizedLinear) or getattr(mod, "_gguf_quantized_linear", False):
@@ -7072,8 +7096,6 @@ def _load_quantized_state_dict(
         elif isinstance(mod, QuantizedEmbedding):
             quantized_embedding_stems.add(mod_name)
             embedding_stems.add(mod_name)
-        elif isinstance(mod, Linear):
-            float_linear_stems.add(mod_name)
         elif isinstance(mod, Embedding):
             embedding_stems.add(mod_name)
 
@@ -7214,7 +7236,7 @@ def _load_quantized_state_dict(
         module_stem = (
             module_hf_name[: -len(".weight")] if module_hf_name.endswith(".weight") else None
         )
-        is_tencent_q1_0_tensor = tencent_q1_0 and qtype == GGMLQuantizationType.Q1_0
+        is_tencent_q1_0_tensor = tencent_q1_0 and qtype_val == GGMLQuantizationType.Q1_0.value
         is_quantized_embedding = (
             module_stem is not None and module_stem in quantized_embedding_stems
         )
@@ -7232,6 +7254,11 @@ def _load_quantized_state_dict(
             np_shape,
             quantized_stems,
         )
+        if is_tencent_q1_0_tensor:
+            # Tencent tensors are ordinary rank-2 projections. Route them
+            # through the custom 130-byte-block parser below rather than the
+            # generic target-splitting path, which assumes mainline Q1_0 bytes.
+            affine_targets = []
         is_kimi_reshaped_projection = gguf_arch in {
             "kimi-linear",
             "kimi-k3",
@@ -7251,22 +7278,22 @@ def _load_quantized_state_dict(
             "bert",
             "modern-bert",
         }
+        is_float_embedding = is_embedding_tensor and not is_quantized_embedding
+        output_targets_quantized = module_stem is not None and (
+            module_stem in quantized_stems or module_stem in native_block_stems
+        )
         tensor_role = (
             TensorRole.EMBEDDING
             if is_embedding_tensor
             else TensorRole.EXPERT
             if len(np_shape) == 3 and ".experts." in hf_name
             else TensorRole.OUTPUT
-            if hf_name == "lm_head.weight"
+            if hf_name == "lm_head.weight" and output_targets_quantized
             else TensorRole.PROJECTION
             if fused_projection_targets
             or (
                 module_stem is not None
-                and (
-                    module_stem in quantized_stems
-                    or module_stem in native_block_stems
-                    or module_stem in float_linear_stems
-                )
+                and (module_stem in quantized_stems or module_stem in native_block_stems)
             )
             else TensorRole.NON_MATMUL
         )
@@ -7278,6 +7305,12 @@ def _load_quantized_state_dict(
                 target_bits=target_bits,
                 target_block_size=target_block_size,
             )
+            if is_tencent_q1_0_tensor and tensor_role is not TensorRole.NON_MATMUL:
+                route = QuantImportRoute.AFFINE_REPACK
+                reason = (
+                    "Tencent Q1_0 uses the selected exact "
+                    f"INT{target_bits} affine block-{target_block_size} representation."
+                )
             explicitly_dequantized = (
                 dequantize_float_linear_types is not None
                 and module_stem in dequantize_float_linear_types
@@ -7292,7 +7325,9 @@ def _load_quantized_state_dict(
                         "the stored format has no supported dequantization route."
                     )
                 route = QuantImportRoute.DEQUANTIZE_REQUANTIZE
-            if is_encoder_embedding and quant_spec.dequantize is Support.SUPPORTED:
+            if (
+                is_encoder_embedding or is_float_embedding
+            ) and quant_spec.dequantize is Support.SUPPORTED:
                 route = QuantImportRoute.DEQUANTIZE_FLOAT
             if route is QuantImportRoute.REJECTED:
                 raise ValueError(
@@ -7538,6 +7573,15 @@ def _load_quantized_state_dict(
                     data_section_offset,
                     tensors_by_name[gguf_name],
                 )
+                if (repacked.bits, repacked.block_size) != (
+                    target_bits,
+                    target_block_size,
+                ):
+                    raise ValueError(
+                        f"Tencent Q1_0 parser produced INT{repacked.bits} "
+                        f"block-{repacked.block_size} for {hf_name}, but the graph "
+                        f"expects INT{target_bits} block-{target_block_size}."
+                    )
             elif is_kimi_reshaped_projection:
                 values = gguf_model.dequantize_raw_tensor(raw, qtype, np_shape)
                 if hf_name.endswith(".k_b_proj.weight"):

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -258,6 +258,18 @@ def _write_quantized_gguf(
         )
         writer.add_tensor(name, raw, raw_dtype=qtype)
 
+    def _add_k_quant(name: str, n_out: int, k_in: int, format_name: str) -> None:
+        """Write finite K-quant blocks over the flattened logical tensor."""
+        qtype, block_bytes = {
+            "q4_k": (GGMLQuantizationType.Q4_K, 144),
+            "q5_k": (GGMLQuantizationType.Q5_K, 176),
+            "q6_k": (GGMLQuantizationType.Q6_K, 210),
+        }[format_name]
+        if k_in % 256:
+            raise ValueError(f"{format_name} test tensors require K divisible by 256")
+        raw = np.zeros((n_out, (k_in // 256) * block_bytes), dtype=np.uint8)
+        writer.add_tensor(name, raw, raw_dtype=qtype)
+
     if quantize_embedding:
         _add_q4_0("token_embd.weight", vocab_size, hidden_size)
     elif embedding_quantization == "q8_0":
@@ -277,6 +289,13 @@ def _write_quantized_gguf(
             raw,
             raw_dtype=GGMLQuantizationType.IQ4_NL,
         )
+    elif embedding_quantization in {"q4_k", "q5_k", "q6_k"}:
+        _add_k_quant(
+            "token_embd.weight",
+            vocab_size,
+            hidden_size,
+            embedding_quantization,
+        )
     elif embedding_quantization is not None:
         _add_native("token_embd.weight", vocab_size, hidden_size, embedding_quantization)
     else:
@@ -288,6 +307,11 @@ def _write_quantized_gguf(
             "q5_1": _add_q5_1,
             "q8_0": _add_q8_0,
         }[projection_quantization]
+    elif projection_quantization in {"q4_k", "q5_k", "q6_k"}:
+
+        def add_projection(name: str, n_out: int, k_in: int) -> None:
+            _add_k_quant(name, n_out, k_in, projection_quantization)
+
     elif projection_quantization in {"f32", "f16", "bf16"}:
 
         def add_projection(name: str, n_out: int, k_in: int) -> None:
@@ -298,9 +322,16 @@ def _write_quantized_gguf(
         def add_projection(name: str, n_out: int, k_in: int) -> None:
             _add_native(name, n_out, k_in, projection_quantization)
 
-    add_value_projection = (
-        _add_q5_1 if value_projection_quantization == "q5_1" else add_projection
-    )
+    if value_projection_quantization == "q5_1":
+        add_value_projection = _add_q5_1
+    elif value_projection_quantization in {"q4_k", "q5_k", "q6_k"}:
+
+        def add_value_projection(name: str, n_out: int, k_in: int) -> None:
+            assert value_projection_quantization is not None
+            _add_k_quant(name, n_out, k_in, value_projection_quantization)
+
+    else:
+        add_value_projection = add_projection
 
     for i in range(num_layers):
         if fused_qkv:
@@ -3080,24 +3111,84 @@ class TestBuildQuantizedGguf:
             is not None
         )
 
-    def test_decoder_backed_qtype_requires_explicit_dequantization(
-        self, q5_1_gguf: Path, tmp_path: Path
+    def test_decoder_backed_qtype_warns_and_persists_lossy_report(
+        self, q5_1_gguf: Path, tmp_path: Path, caplog
     ) -> None:
-        """A pure Q5_1 file fails closed, while explicit float import round-trips."""
+        """A Q5_1 source stays packed but is reported as lossy target quantization."""
         from mobius._model_package import ModelPackage
-        from mobius.integrations.gguf import build_from_gguf
-
-        with pytest.raises(
-            ValueError, match="cannot represent this source block format losslessly"
-        ):
-            build_from_gguf(q5_1_gguf)
+        from mobius.integrations.gguf import QuantizationDisposition, build_from_gguf
 
         output_dir = tmp_path / "saved_q5_1"
-        package = build_from_gguf(q5_1_gguf, keep_quantized=False)
+        with caplog.at_level("WARNING"):
+            package = build_from_gguf(q5_1_gguf)
+        assert caplog.text.count("GGUF QUANTIZATION FIDELITY WARNING") == 1
+        assert "Q5_1: 7 tensor(s)" in caplog.text
+        assert "Losslessly preserved/repacked qtypes in this artifact: none" in caplog.text
+        report = package.gguf_quantization_report
+        assert report.target_storage_format == "INT4 affine block-32"
+        assert report.storage_quantized is True
+        assert report.source_fidelity is False
+        assert {
+            record.disposition for record in report.tensor_records if record.qtype == "Q5_1"
+        } == {QuantizationDisposition.LOSSY_REQUANTIZE}
+        assert any(node.op_type == "MatMulNBits" for node in package["model"].graph)
         package.save(str(output_dir), progress_bar=False)
-        model = ModelPackage.load(str(output_dir))["model"]
+        reloaded = ModelPackage.load(str(output_dir))
+        assert (output_dir / "quantization_report.json").is_file()
+        assert reloaded.gguf_quantization_report == report
+        assert any(node.op_type == "MatMulNBits" for node in reloaded["model"].graph)
 
-        assert all(node.op_type != "MatMulNBits" for node in model.graph)
+    def test_dequantize_reports_float_without_quantized_claim(self, q5_1_gguf: Path) -> None:
+        from mobius.integrations.gguf import QuantizationDisposition, build_from_gguf
+
+        package = build_from_gguf(q5_1_gguf, keep_quantized=False)
+        report = package.gguf_quantization_report
+        assert report.target_storage_format == "float"
+        assert report.storage_quantized is False
+        assert report.source_fidelity is False
+        assert {
+            record.disposition for record in report.tensor_records if record.qtype == "Q5_1"
+        } == {QuantizationDisposition.DEQUANTIZED_FLOAT}
+        assert all(node.op_type != "MatMulNBits" for node in package["model"].graph)
+
+    def test_mixed_k_quant_census_warns_once_and_remains_packed(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        from mobius.integrations.gguf import QuantizationDisposition, build_from_gguf
+
+        path = tmp_path / "mixed.gguf"
+        _write_quantized_gguf(
+            path,
+            hidden_size=256,
+            intermediate_size=256,
+            vocab_size=256,
+            num_heads=8,
+            num_kv_heads=2,
+            projection_quantization="q4_k",
+            value_projection_quantization="q6_k",
+            embedding_quantization="q5_k",
+            output_quantization="q4_0",
+        )
+        with caplog.at_level("WARNING"):
+            package = build_from_gguf(path)
+        report = package.gguf_quantization_report
+        assert caplog.text.count("GGUF QUANTIZATION FIDELITY WARNING") == 1
+        assert all(name in caplog.text for name in ("Q4_K:", "Q5_K:", "Q6_K:"))
+        assert "Losslessly preserved/repacked qtypes in this artifact: Q4_0:" in caplog.text
+        assert report.converted_from == "Q4_K_M-like mixed GGUF"
+        assert {
+            record.qtype
+            for record in report.tensor_records
+            if record.disposition is QuantizationDisposition.LOSSY_REQUANTIZE
+        } == {"Q4_K", "Q5_K", "Q6_K"}
+        assert report.storage_quantized is True
+        packed = [
+            initializer
+            for model in package.values()
+            for initializer in model.graph.initializers.values()
+            if initializer.dtype == ir.DataType.UINT8
+        ]
+        assert packed
 
     def test_float_only_default_uses_float_path(self, float_only_gguf: Path):
         """F32/BF16-only GGUFs do not fail when preservation is the default."""
@@ -3880,14 +3971,22 @@ class TestBuildQuantizedGguf:
         imports = {opset.domain: opset.version for opset in proto.opset_import}
         assert imports["pkg.nxrt"] == 1
 
-    def test_mixed_native_quantization_rejects_lossy_q5_fallback(
-        self, mixed_native_q5_q8_gguf: Path
+    def test_mixed_native_quantization_reports_lossy_affine_normalization(
+        self, mixed_native_q5_q8_gguf: Path, caplog
     ):
-        """Native IQ blocks do not make lossy Q5_1-to-Q4 conversion acceptable."""
-        from mobius.integrations.gguf import build_from_gguf
+        """Native IQ bytes coexist with explicitly reported Q5/Q8 normalization."""
+        from mobius.integrations.gguf import QuantizationDisposition, build_from_gguf
 
-        with pytest.raises(ValueError, match=r"attn_v\.weight \(Q5_1\)"):
-            build_from_gguf(mixed_native_q5_q8_gguf, keep_quantized=True)
+        with caplog.at_level("WARNING"):
+            package = build_from_gguf(mixed_native_q5_q8_gguf, keep_quantized=True)
+        report = package.gguf_quantization_report
+        assert caplog.text.count("GGUF QUANTIZATION FIDELITY WARNING") == 1
+        assert {
+            record.qtype
+            for record in report.tensor_records
+            if record.disposition is QuantizationDisposition.LOSSY_REQUANTIZE
+        } == {"Q5_1", "Q8_0"}
+        assert "native GGUF block storage" in report.target_storage_format
 
     def test_quantized_embedding_uses_gatherblockquantized(self, q4_0_embedding_gguf: Path):
         """A quantized GGUF embedding remains packed in the ONNX graph."""
@@ -3927,13 +4026,21 @@ class TestBuildQuantizedGguf:
         wrong = _run_gather_block_quantized(tmp_path, zero_point=0x00).astype(np.float32)
         assert not np.allclose(wrong, expected)
 
-    def test_native_projection_abi_embedding_requires_explicit_dequantization(
-        self, iq4_nl_embedding_gguf: Path
+    def test_native_projection_abi_embedding_is_lossily_normalized(
+        self, iq4_nl_embedding_gguf: Path, caplog
     ) -> None:
-        from mobius.integrations.gguf import build_from_gguf
+        from mobius.integrations.gguf import QuantizationDisposition, build_from_gguf
 
-        with pytest.raises(ValueError, match="cannot retain native block format IQ4_NL"):
-            build_from_gguf(iq4_nl_embedding_gguf)
+        with caplog.at_level("WARNING"):
+            package = build_from_gguf(iq4_nl_embedding_gguf)
+        report = package.gguf_quantization_report
+        assert "IQ4_NL:" in caplog.text
+        assert any(
+            record.qtype == "IQ4_NL"
+            and record.disposition is QuantizationDisposition.LOSSY_REQUANTIZE
+            for record in report.tensor_records
+        )
+        assert any(node.op_type == "GatherBlockQuantized" for node in package["model"].graph)
 
         model = build_from_gguf(iq4_nl_embedding_gguf, keep_quantized=False)["model"]
         assert all(node.op_type != "GatherBlockQuantized" for node in model.graph)
@@ -3953,32 +4060,33 @@ class TestBuildQuantizedGguf:
         assert "model.embed_tokens.zero_points" in model.graph.initializers
         assert not any(name.startswith("lm_head.") for name in model.graph.initializers)
 
-    def test_untied_head_with_incompatible_affine_target_fails_closed(
-        self, q4_0_embedding_q8_head_gguf: Path
+    def test_untied_head_with_incompatible_affine_target_is_reported(
+        self, q4_0_embedding_q8_head_gguf: Path, caplog
     ):
-        """An untied Q8 head is not silently requantized to the graph's Q4 layout."""
+        """An untied Q8 head is visibly requantized to the graph's Q4 layout."""
+        from mobius.integrations.gguf import QuantizationDisposition, build_from_gguf
+
+        with caplog.at_level("WARNING"):
+            package = build_from_gguf(q4_0_embedding_q8_head_gguf, keep_quantized=True)
+        assert "Q8_0: 1 tensor(s)" in caplog.text
+        assert any(
+            record.name == "output.weight"
+            and record.disposition is QuantizationDisposition.LOSSY_REQUANTIZE
+            for record in package.gguf_quantization_report.tensor_records
+        )
+
+    def test_mixed_affine_targets_select_supported_int4_normalization(
+        self, q8_0_projection_q4_head_gguf: Path, caplog
+    ):
+        """Mixed affine targets normalize to the supported INT4 target."""
         from mobius.integrations.gguf import build_from_gguf
 
-        with pytest.raises(
-            ValueError, match=r"token_embd\.weight \(Q4_0.*output\.weight \(Q8_0"
-        ):
-            build_from_gguf(q4_0_embedding_q8_head_gguf, keep_quantized=True)
-
-    def test_unsupported_requantization_target_has_clear_error(
-        self, q8_0_projection_q4_head_gguf: Path
-    ):
-        """Mixed affine targets fail before any head requantization."""
-        from mobius.integrations.gguf import build_from_gguf
-
-        with pytest.raises(
-            ValueError,
-            match=(
-                r"incompatible targets: output\.weight "
-                r"\(Q4_0: 4-bit/block-32\), blk\.0\.attn_q\.weight "
-                r"\(Q8_0: 8-bit/block-32\)"
-            ),
-        ):
-            build_from_gguf(q8_0_projection_q4_head_gguf, keep_quantized=True)
+        with caplog.at_level("WARNING"):
+            package = build_from_gguf(q8_0_projection_q4_head_gguf, keep_quantized=True)
+        assert package.gguf_quantization_report.target_storage_format == (
+            "INT4 affine block-32"
+        )
+        assert "Q8_0:" in caplog.text
 
     def test_norms_are_float(self, q4_0_gguf: Path):
         """Norm weights remain float, not quantized."""
@@ -4087,8 +4195,8 @@ class TestBuildQuantizedGguf:
 
         assert not _can_quantize_lm_head(_OutputModel(), "llama")
 
-    def test_q4_k_m_mixed_profile_fails_closed(self):
-        """Mixed Q4_K_M projections cannot be losslessly normalized to INT4."""
+    def test_q4_k_m_mixed_profile_is_allowed_for_reported_normalization(self):
+        """Mixed Q4_K_M-like projections may use the declared lossy INT4 route."""
         from gguf import GGMLQuantizationType
 
         from mobius.integrations.gguf._builder import (
@@ -4111,16 +4219,9 @@ class TestBuildQuantizedGguf:
                     (64, 128),
                 )
 
-        with pytest.raises(
-            ValueError,
-            match=(
-                r"blk\.0\.attn_q\.weight \(Q5_0\).*cannot represent this "
-                r"source block format losslessly"
-            ),
-        ):
-            _reject_unsupported_quantization_preservation(
-                _MixedModel(), "llama", preserve_quantization=True
-            )
+        _reject_unsupported_quantization_preservation(
+            _MixedModel(), "llama", preserve_quantization=True
+        )
 
     def test_decoder_backed_qtype_selects_explicit_requantization_target(self):
         """A decoder-backed qtype takes the declared 4-bit requantization route."""
@@ -4196,8 +4297,8 @@ class TestBuildQuantizedGguf:
         ):
             build_from_gguf(path)
 
-    def test_q6_k_projection_fails_closed(self):
-        """A stacked 6-bit expert projection must not be silently requantized."""
+    def test_q6_k_projection_is_allowed_for_reported_requantization(self):
+        """A stacked 6-bit expert projection may use the declared lossy route."""
         from gguf import GGMLQuantizationType
 
         from mobius.integrations.gguf._builder import (
@@ -4213,13 +4314,12 @@ class TestBuildQuantizedGguf:
                     (4, 64, 128),
                 )
 
-        with pytest.raises(ValueError, match=r"ffn_down\.weight \(Q6_K\)"):
-            _reject_unsupported_quantization_preservation(
-                _Q6KModel(), "llama", preserve_quantization=True
-            )
+        _reject_unsupported_quantization_preservation(
+            _Q6KModel(), "llama", preserve_quantization=True
+        )
 
-    def test_native_blocks_fail_closed_when_builder_cannot_install_native_modules(self):
-        """A builder without native module replacement must not requantize native blocks."""
+    def test_native_blocks_may_normalize_when_builder_cannot_install_native_modules(self):
+        """A builder without native modules may use a declared lossy affine route."""
         from gguf import GGMLQuantizationType
 
         from mobius.integrations.gguf._builder import (
@@ -4235,16 +4335,15 @@ class TestBuildQuantizedGguf:
                     (64, 64),
                 )
 
-        with pytest.raises(ValueError, match=r"native block format MXFP4"):
-            _reject_unsupported_quantization_preservation(
-                _NativeModel(),
-                "gemma4",
-                preserve_quantization=True,
-                allow_native_blocks=False,
-            )
+        _reject_unsupported_quantization_preservation(
+            _NativeModel(),
+            "gemma4",
+            preserve_quantization=True,
+            allow_native_blocks=False,
+        )
 
-    def test_native_mtp_blocks_fail_closed_without_sidecar_module_replacement(self):
-        """Native MTP blocks must not fall through to affine requantization."""
+    def test_native_mtp_blocks_may_use_affine_requantization(self):
+        """Native MTP blocks with a decoder may use a declared lossy affine route."""
         from gguf import GGMLQuantizationType
 
         from mobius.integrations.gguf._builder import (
@@ -4265,10 +4364,9 @@ class TestBuildQuantizedGguf:
                     (64, 128),
                 )
 
-        with pytest.raises(ValueError, match=r"native block format MXFP4.*blk\.24"):
-            _reject_unsupported_quantization_preservation(
-                _NativeMtpModel(), "qwen35", preserve_quantization=True
-            )
+        _reject_unsupported_quantization_preservation(
+            _NativeMtpModel(), "qwen35", preserve_quantization=True
+        )
 
     @pytest.mark.parametrize(
         ("tensor_name", "options", "message"),
@@ -4334,8 +4432,8 @@ class TestBuildQuantizedGguf:
                 _FusedExpertModel(), "qwen35moe", preserve_quantization=True
             )
 
-    def test_unmapped_mtp_projection_fails_closed(self):
-        """Sidecar-specific mappings cannot bypass value-preservation policy."""
+    def test_mtp_projection_is_allowed_for_reported_requantization(self):
+        """Sidecar-specific mappings may use the declared lossy conversion route."""
         from gguf import GGMLQuantizationType
 
         from mobius.integrations.gguf._builder import (
@@ -4354,13 +4452,12 @@ class TestBuildQuantizedGguf:
 
         model = _MTPModel()
         assert _has_quantized_weights(model, "qwen3")
-        with pytest.raises(ValueError, match=r"nextn\.ffn_down\.weight \(Q4_K\)"):
-            _reject_unsupported_quantization_preservation(
-                model, "qwen3", preserve_quantization=True
-            )
+        _reject_unsupported_quantization_preservation(
+            model, "qwen3", preserve_quantization=True
+        )
 
-    def test_lossy_tied_embedding_source_fails_closed(self):
-        """A tied Q4_K table cannot silently dequantize for Gather and the head."""
+    def test_lossy_tied_embedding_source_is_allowed_for_reported_conversion(self):
+        """A tied Q4_K table may use the declared affine conversion route."""
         from gguf import GGMLQuantizationType
 
         from mobius.integrations.gguf._builder import (
@@ -4376,13 +4473,12 @@ class TestBuildQuantizedGguf:
                     (256, 128),
                 )
 
-        with pytest.raises(ValueError, match=r"token_embd\.weight \(Q4_K\)"):
-            _reject_unsupported_quantization_preservation(
-                _EmbeddingModel(), "llama", preserve_quantization=True
-            )
+        _reject_unsupported_quantization_preservation(
+            _EmbeddingModel(), "llama", preserve_quantization=True
+        )
 
-    def test_mixed_lossless_affine_targets_still_fail_closed(self):
-        """Q4_0 and Q8_0 are exact alone but cannot share one graph contract."""
+    def test_mixed_lossless_affine_targets_may_normalize_to_one_contract(self):
+        """Q4_0 and Q8_0 may share one contract through reported normalization."""
         from gguf import GGMLQuantizationType
 
         from mobius.integrations.gguf._builder import (
@@ -4404,10 +4500,9 @@ class TestBuildQuantizedGguf:
                     (64, 64),
                 )
 
-        with pytest.raises(ValueError, match=r"incompatible targets:.*Q4_0.*Q8_0"):
-            _reject_unsupported_quantization_preservation(
-                _MixedExactModel(), "llama", preserve_quantization=True
-            )
+        _reject_unsupported_quantization_preservation(
+            _MixedExactModel(), "llama", preserve_quantization=True
+        )
 
     def test_encoder_float_embedding_does_not_constrain_projection_target(self):
         """An encoder embedding's float route is independent of packed projections."""
@@ -4802,7 +4897,7 @@ class TestEncoderGGUFBuild:
             fused_qkv=True,
             fused_qkv_float=True,
         )
-        with pytest.raises(ValueError, match=r"would quantize float projection"):
+        with pytest.raises(ValueError, match=r"would quantize a source-float tensor"):
             build_from_gguf(path, keep_quantized=True)
 
         explicit_float = build_from_gguf(path, keep_quantized=False)["model"]
@@ -6568,11 +6663,12 @@ class TestKimiLinearGGUFBuild:
         ("native_quantized", "qtype_name"),
         [(False, "Q4_0"), (True, "IQ4_NL")],
     )
-    def test_quantized_mla_reshape_requires_explicit_dequantization(
+    def test_quantized_mla_reshape_is_reported_as_lossy(
         self,
         tmp_path: Path,
         native_quantized: bool,
         qtype_name: str,
+        caplog,
     ) -> None:
         from mobius.integrations.gguf import build_from_gguf
 
@@ -6582,11 +6678,11 @@ class TestKimiLinearGGUFBuild:
             quantized=True,
             native_quantized=native_quantized,
         )
-        with pytest.raises(
-            ValueError,
-            match=rf"change the dequantized values.*attn_k_b\.weight \({qtype_name}\)",
-        ):
-            build_from_gguf(path, keep_quantized=True)
+        with caplog.at_level("WARNING"):
+            package = build_from_gguf(path, keep_quantized=True)
+        assert caplog.text.count("GGUF QUANTIZATION FIDELITY WARNING") == 1
+        assert f"{qtype_name}:" in caplog.text
+        assert package.gguf_quantization_report.source_fidelity is False
 
         model = build_from_gguf(path, keep_quantized=False)["model"]
         assert all(node.op_type != "MatMulNBits" for node in model.graph)

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -387,12 +387,74 @@ def _write_quantized_gguf(
             _add_q4_0("output.weight", vocab_size, hidden_size)
         elif output_quantization == "q8_0":
             _add_q8_0("output.weight", vocab_size, hidden_size)
+        elif output_quantization in {"q4_k", "q5_k", "q6_k"}:
+            _add_k_quant(
+                "output.weight",
+                vocab_size,
+                hidden_size,
+                output_quantization,
+            )
         else:
             add_float("output.weight", (vocab_size, hidden_size))
 
     writer.write_header_to_file()
     writer.write_kv_data_to_file()
     writer.write_tensors_to_file()
+    writer.close()
+
+
+def _write_tencent_q1_0_gguf(path: Path) -> None:
+    """Write a tiny Llama file using Tencent's 130-byte Q1_0 blocks."""
+    from gguf import GGMLQuantizationType, GGUFWriter
+
+    hidden = intermediate = 512
+    vocab = 32
+    writer = GGUFWriter(str(path), "llama")
+    writer.add_context_length(32)
+    writer.add_embedding_length(hidden)
+    writer.add_feed_forward_length(intermediate)
+    writer.add_block_count(1)
+    writer.add_head_count(8)
+    writer.add_head_count_kv(2)
+    writer.add_rope_freq_base(10000.0)
+    writer.add_layer_norm_rms_eps(1e-5)
+    writer.add_vocab_size(vocab)
+
+    def add_float(name: str, shape: tuple[int, ...]) -> None:
+        writer.add_tensor(name, np.ones(shape, dtype=np.float32))
+
+    def add_tencent_q1(name: str, n_out: int, k_in: int) -> None:
+        assert k_in % 512 == 0
+        blocks_per_row = k_in // 512
+        raw = np.zeros((n_out, blocks_per_row * 130), dtype=np.uint8)
+        raw.reshape(n_out, blocks_per_row, 130)[:, :, :2] = np.array(
+            [1.0], dtype=np.float16
+        ).view(np.uint8)
+        writer.add_tensor_info(
+            name,
+            (n_out, (k_in // 128) * 18),
+            raw.dtype,
+            raw.nbytes,
+            raw_dtype=GGMLQuantizationType.Q1_0,
+        )
+        writer.tensors[-1][name].tensor = raw
+
+    add_float("token_embd.weight", (vocab, hidden))
+    add_tencent_q1("blk.0.attn_q.weight", hidden, hidden)
+    add_tencent_q1("blk.0.attn_k.weight", hidden // 4, hidden)
+    add_tencent_q1("blk.0.attn_v.weight", hidden // 4, hidden)
+    add_tencent_q1("blk.0.attn_output.weight", hidden, hidden)
+    add_tencent_q1("blk.0.ffn_gate.weight", intermediate, hidden)
+    add_tencent_q1("blk.0.ffn_up.weight", intermediate, hidden)
+    add_tencent_q1("blk.0.ffn_down.weight", hidden, intermediate)
+    add_float("blk.0.attn_norm.weight", (hidden,))
+    add_float("blk.0.ffn_norm.weight", (hidden,))
+    add_float("output_norm.weight", (hidden,))
+    add_float("output.weight", (vocab, hidden))
+
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_tensors_to_file(progress=False)
     writer.close()
 
 
@@ -4088,6 +4150,121 @@ class TestBuildQuantizedGguf:
         )
         assert "Q8_0:" in caplog.text
 
+    def test_quantized_source_float_output_head_dequantizes_consistently(
+        self, tmp_path: Path
+    ) -> None:
+        from mobius.integrations.gguf import QuantizationDisposition, build_from_gguf
+
+        path = tmp_path / "olmo2-q6-output.gguf"
+        _write_quantized_gguf(
+            path,
+            architecture="olmo2",
+            hidden_size=256,
+            intermediate_size=256,
+            vocab_size=256,
+            num_heads=8,
+            num_kv_heads=2,
+            projection_quantization="q4_k",
+            output_quantization="q6_k",
+        )
+
+        package = build_from_gguf(path, keep_quantized=True)
+        report_record = next(
+            record
+            for record in package.gguf_quantization_report.tensor_records
+            if record.name == "output.weight"
+        )
+        assert report_record.disposition is QuantizationDisposition.DEQUANTIZED_FLOAT
+        assert report_record.target_storage == "float"
+        head_initializers = [
+            value
+            for name, value in package["model"].graph.initializers.items()
+            if name.startswith("lm_head.weight")
+        ]
+        assert len(head_initializers) == 1
+        assert head_initializers[0].dtype == ir.DataType.FLOAT
+
+    @pytest.mark.parametrize(
+        ("native_2bit", "expected_bits"),
+        [(False, 4), (True, 2)],
+    )
+    def test_tencent_q1_0_preflight_uses_layout_and_exact_payload_bytes(
+        self,
+        tmp_path: Path,
+        native_2bit: bool,
+        expected_bits: int,
+    ) -> None:
+        from mobius._flags import override_flags
+        from mobius.integrations.gguf import QuantizationDisposition, build_from_gguf
+
+        path = tmp_path / f"tencent-q1-{expected_bits}.gguf"
+        _write_tencent_q1_0_gguf(path)
+        with override_flags(tencent_q1_0_use_native_2bit=native_2bit):
+            package = build_from_gguf(path, keep_quantized=True)
+
+        report = package.gguf_quantization_report
+        q1_records = [record for record in report.tensor_records if record.qtype == "Q1_0"]
+        assert len(q1_records) == 7
+        assert sum(record.source_bytes for record in q1_records) == 2_816 * 130
+        assert {record.disposition for record in q1_records} == {
+            QuantizationDisposition.LOSSLESS_REPACK
+        }
+        assert {record.target_storage for record in q1_records} == {
+            f"INT{expected_bits} affine block-128"
+        }
+        assert any(node.op_type == "MatMulNBits" for node in package["model"].graph)
+
+    def test_preflight_records_mapped_bias_and_scale_parameters(self) -> None:
+        from gguf import GGMLQuantizationType
+        from onnxscript import nn
+
+        from mobius.integrations.gguf import QuantizationDisposition
+        from mobius.integrations.gguf._builder import _preflight_quantization_report
+
+        module = nn.Module()
+        module.bias = nn.Parameter([2])
+        module.scale = nn.Parameter([1])
+        tensors = [
+            SimpleNamespace(
+                name="source.bias",
+                tensor_type=GGMLQuantizationType.F32,
+                shape=(2,),
+                n_bytes=8,
+            ),
+            SimpleNamespace(
+                name="source.scale",
+                tensor_type=GGMLQuantizationType.F32,
+                shape=(1,),
+                n_bytes=4,
+            ),
+        ]
+        source = SimpleNamespace(
+            reader_tensors=lambda: iter(tensors),
+            _reader=None,
+        )
+        report = _preflight_quantization_report(
+            source,
+            "test",
+            module,
+            SimpleNamespace(),
+            preserve_quantization=True,
+            target_bits=4,
+            target_block_size=32,
+            execution_provider="default",
+            name_mapper=lambda name, _architecture: name.removeprefix("source."),
+        )
+
+        assert {record.name for record in report.tensor_records} == {
+            "source.bias",
+            "source.scale",
+        }
+        assert {record.disposition for record in report.tensor_records} == {
+            QuantizationDisposition.SOURCE_FLOAT
+        }
+        assert sum(record.source_bytes for record in report.tensor_records) == sum(
+            stat.source_bytes for stat in report.source_qtype_census
+        )
+
     def test_norms_are_float(self, q4_0_gguf: Path):
         """Norm weights remain float, not quantized."""
         import onnx_ir as ir
@@ -4845,6 +5022,26 @@ class TestEncoderGGUFBuild:
         expected = self._run(explicit_float, 5, masked=True)
         np.testing.assert_allclose(actual, expected, rtol=0, atol=1e-2)
 
+    def test_report_includes_mapped_biases_and_reconciles_source_bytes(
+        self, tmp_path: Path
+    ) -> None:
+        from mobius.integrations.gguf import QuantizationDisposition, build_from_gguf
+
+        path = tmp_path / "bert-records.gguf"
+        _write_encoder_gguf(path, "bert", quantized=True)
+        report = build_from_gguf(path).gguf_quantization_report
+
+        bias_records = [
+            record for record in report.tensor_records if record.name.endswith(".bias")
+        ]
+        assert bias_records
+        assert {record.disposition for record in bias_records} == {
+            QuantizationDisposition.SOURCE_FLOAT
+        }
+        assert sum(record.source_bytes for record in report.tensor_records) == sum(
+            stat.source_bytes for stat in report.source_qtype_census
+        )
+
     def test_float_fused_bert_qkv_splits_losslessly_and_runs(self, tmp_path: Path) -> None:
         import torch
 
@@ -5501,18 +5698,25 @@ class TestHybridGGUFBuild:
         assert outputs[1]["present.1.key"].shape == (1, 2, 4, 8)
         assert all(np.isfinite(output["logits"]).all() for output in outputs)
 
-    def test_lfm2_quantized_preservation_fails_closed_and_float_import_executes(
+    def test_lfm2_quantized_preservation_dequantizes_float_targets_and_executes(
         self, tmp_path: Path
     ) -> None:
-        from mobius.integrations.gguf import build_from_gguf
+        from mobius.integrations.gguf import QuantizationDisposition, build_from_gguf
 
         path = tmp_path / "lfm2-q4.gguf"
         _write_lfm2_gguf(path, quantized=True)
-        with pytest.raises(
-            ValueError,
-            match=r"Cannot keep Q4_0 projection .*MatMulNBits",
-        ):
-            build_from_gguf(path, keep_quantized=True)
+        preserved_package = build_from_gguf(path, keep_quantized=True)
+        preserved = preserved_package["model"]
+        assert "MatMulNBits" not in {node.op_type for node in preserved.graph}
+        assert preserved_package.gguf_quantization_report.storage_quantized is False
+        assert any(
+            record.disposition is QuantizationDisposition.DEQUANTIZED_FLOAT
+            for record in preserved_package.gguf_quantization_report.tensor_records
+        )
+        preserved_outputs = self._run_lfm2(preserved)
+        assert preserved_outputs[0]["present.0.conv_state"].shape == (1, 32, 2)
+        assert preserved_outputs[1]["present.1.key"].shape == (1, 2, 4, 8)
+        assert all(np.isfinite(output["logits"]).all() for output in preserved_outputs)
 
         explicit_float = build_from_gguf(path, keep_quantized=False)["model"]
 

--- a/src/mobius/integrations/gguf/_docs.py
+++ b/src/mobius/integrations/gguf/_docs.py
@@ -414,8 +414,18 @@ package = build_from_gguf("model.gguf")
 package.save("output")
 ```
 
-Use `keep_quantized=False` for explicit float import. Pass `mmproj=` only for an
-evidenced multimodal sidecar. The CLI equivalent is `mobius build model.gguf -o output`.
+`keep_quantized=True` requests quantized target storage where supported; it does
+not guarantee source byte or numerical fidelity. Mobius classifies qtypes before
+payload conversion, emits one aggregate warning for lossy requantization, and
+saves the typed result as `quantization_report.json`. Use
+`keep_quantized=False` for explicit float import.
+
+Storage and compute are separate: packed MatMulNBits initializers may use a
+native custom op or a portable inline fallback with nibble unpack,
+`DequantizeLinear`, and float `MatMul`. The fallback does not replace packed
+initializers with dense float storage or promise a particular ORT kernel. Pass
+`mmproj=` only for an evidenced multimodal sidecar. The CLI equivalent is
+`mobius build model.gguf -o output`.
 
 ## API
 

--- a/src/mobius/integrations/gguf/_kimi_k3_test.py
+++ b/src/mobius/integrations/gguf/_kimi_k3_test.py
@@ -542,15 +542,19 @@ class TestKimiK3GGUFBuild:
         finally:
             session.close()
 
-    def test_separate_quantized_mla_requires_explicit_dequantization(
-        self, tmp_path: Path
-    ) -> None:
-        from mobius.integrations.gguf import build_from_gguf
+    def test_separate_quantized_mla_is_reported_as_lossy(self, tmp_path: Path, caplog) -> None:
+        from mobius.integrations.gguf import QuantizationDisposition, build_from_gguf
 
         path = tmp_path / "kimi-k3-q4.gguf"
         _write_kimi_k3_gguf(path, quantized=True)
-        with pytest.raises(ValueError, match=r"attn_k_b\.weight \(Q4_0\)"):
-            build_from_gguf(path, keep_quantized=True)
+        with caplog.at_level("WARNING"):
+            package = build_from_gguf(path, keep_quantized=True)
+        assert caplog.text.count("GGUF QUANTIZATION FIDELITY WARNING") == 1
+        assert any(
+            record.name.endswith(("attn_k_b.weight", "attn_v_b.weight"))
+            and record.disposition is QuantizationDisposition.LOSSY_REQUANTIZE
+            for record in package.gguf_quantization_report.tensor_records
+        )
 
         model = build_from_gguf(path, keep_quantized=False)["model"]
         assert all(node.op_type != "MatMulNBits" for node in model.graph)

--- a/src/mobius/integrations/gguf/_mmproj.py
+++ b/src/mobius/integrations/gguf/_mmproj.py
@@ -1718,12 +1718,13 @@ def build_gemma4_vlm_from_gguf(
         include_audio: When ``True``, also build the (experimental) audio
             encoder. Off by default — see the module docstring.
         keep_quantized: Preserve the text backbone's GGUF quantization when
-            present. This is the default: decoder projections become
+            present as quantized target storage. This is the default: decoder projections become
             MatMulNBits and compatible token-embedding tables become
             GatherBlockQuantized. Incompatible embedding qtypes or shapes stay
             float. Quantized projection source types, including native
             IQ/MXFP4 blocks, are normalized to the common affine layout rather
-            than retained byte-for-byte. Set to ``False`` to dequantize all
+            than retained byte-for-byte. Lossy normalization emits one warning
+            and is recorded in ``quantization_report.json``. Set to ``False`` to dequantize all
             text weights. The vision (and audio) encoder always stays float
             because its weights come from the mmproj as F16 — see the "Mixed
             precision" note below.
@@ -1746,6 +1747,7 @@ def build_gemma4_vlm_from_gguf(
     from mobius._builder import resolve_dtype
     from mobius.integrations.gguf._builder import (
         _has_quantized_weights,
+        _preflight_quantization_report,
         _reject_unsupported_quantization_preservation,
         _validate_gguf_model,
     )
@@ -1883,9 +1885,32 @@ def build_gemma4_vlm_from_gguf(
     from mobius._builder import build_from_module
 
     module = Gemma4Model(config)
+
+    def target_name(hf_name: str) -> str:
+        if hf_name.startswith("language_model.lm_head."):
+            return "decoder.lm_head." + hf_name.removeprefix("language_model.lm_head.")
+        if hf_name.startswith("language_model.embed_tokens"):
+            return "embedding." + hf_name.removeprefix("language_model.")
+        if hf_name.startswith("language_model."):
+            return "decoder.model." + hf_name.removeprefix("language_model.")
+        return hf_name
+
+    quantization_report = _preflight_quantization_report(
+        text_gguf,
+        "gemma4",
+        module,
+        config,
+        preserve_quantization=preserve_quantization,
+        target_bits=(config.quantization.bits if preserve_quantization else None),
+        target_block_size=(config.quantization.group_size if preserve_quantization else None),
+        execution_provider=execution_provider,
+        name_mapper=lambda name, _architecture: _text_gguf_name_to_hf_multimodal(name),
+        target_name_mapper=target_name,
+    )
     pkg = build_from_module(
         module, config, task=Gemma4Task(), execution_provider=execution_provider
     )
+    pkg.gguf_quantization_report = quantization_report
     logger.info("Built Gemma4 VLM graph (%d components: %s)", len(pkg), list(pkg))
 
     # 3. Assemble the combined HF-multimodal state dict from both GGUFs. The

--- a/src/mobius/integrations/gguf/_mmproj.py
+++ b/src/mobius/integrations/gguf/_mmproj.py
@@ -49,7 +49,7 @@ import logging
 import math
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit, urlunsplit
 
 import numpy as np
@@ -64,6 +64,12 @@ from mobius.integrations.gguf._mmproj_registry import (
     projector_type_for_modality,
 )
 from mobius.integrations.gguf._spec import Support
+
+if TYPE_CHECKING:
+    from mobius.integrations.gguf._quantization_report import (
+        GGUFQuantizationReport,
+        QuantizationTensorRecord,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -1693,6 +1699,174 @@ def build_gemma3_vlm_from_gguf(
     return pkg
 
 
+def _preflight_mmproj_quantization_report(
+    mmproj_gguf: Any,
+    *,
+    include_audio: bool,
+) -> GGUFQuantizationReport:
+    """Classify every mapped mmproj vision/(audio) tensor before conversion.
+
+    The Gemma4 vision (and optional audio) encoder always builds float
+    parameters regardless of the mmproj source qtype -- see
+    ``build_gemma4_vlm_from_gguf``'s "Mixed precision" note -- so every mapped
+    tensor here lands on an explicit float disposition: a tensor already
+    stored as float (F32/F16/BF16) is ``SOURCE_FLOAT``; anything else is
+    unconditionally dequantized on load (:meth:`GGUFModel.get_tensor` always
+    dequantizes) and is ``DEQUANTIZED_FLOAT``. There is no lossy-requantize
+    path for mmproj tensors, so this never contributes to the fidelity
+    warning.
+
+    Record names are qualified with an ``"mmproj:"`` prefix so they cannot
+    collide with the text GGUF's own tensor names when the two component
+    reports are merged (see :func:`_merge_component_quantization_reports`)
+    into the package-level report.
+    """
+    from mobius.integrations.gguf._mmproj_mapping import (
+        map_mmproj_audio_to_hf,
+        map_mmproj_vision_to_hf,
+    )
+    from mobius.integrations.gguf._quant_registry import (
+        float_storage_type_ids,
+        get_quant_spec,
+    )
+    from mobius.integrations.gguf._quantization_report import (
+        GGUFQuantizationReport,
+        QuantizationDisposition,
+        QuantizationTensorRecord,
+    )
+    from mobius.integrations.gguf._spec import Support
+
+    float_type_ids = float_storage_type_ids()
+    source_qtypes: list[tuple[str, int]] = []
+    records: list[QuantizationTensorRecord] = []
+    rejected: list[QuantizationTensorRecord] = []
+    for tensor in mmproj_gguf.reader_tensors():
+        qtype = tensor.tensor_type
+        qtype_id = getattr(qtype, "value", qtype)
+        quant_spec = get_quant_spec(qtype)
+        qtype_name = (
+            quant_spec.name if quant_spec is not None else str(getattr(qtype, "name", qtype))
+        )
+        source_bytes = int(tensor.n_bytes)
+        source_qtypes.append((qtype_name, source_bytes))
+
+        hf_name = None
+        if tensor.name.startswith("v.") or tensor.name == "mm.input_projection.weight":
+            hf_name = map_mmproj_vision_to_hf(tensor.name)
+        elif include_audio and (
+            tensor.name.startswith("a.") or tensor.name == "mm.a.input_projection.weight"
+        ):
+            hf_name = map_mmproj_audio_to_hf(tensor.name)
+        if hf_name is None:
+            # Unmapped tensor (e.g. a different modality, or an unused
+            # metadata tensor): still counted in the source qtype census
+            # above, but not a mapped-weight record.
+            continue
+
+        if qtype_id in float_type_ids:
+            disposition = QuantizationDisposition.SOURCE_FLOAT
+            reason = (
+                "The mmproj vision/audio tensor is already stored as float and "
+                "the encoder always builds float parameters."
+            )
+        elif quant_spec is None:
+            disposition = QuantizationDisposition.REJECTED
+            reason = "The qtype is outside the pinned llama.cpp census."
+        elif quant_spec.dequantize is not Support.SUPPORTED:
+            disposition = QuantizationDisposition.REJECTED
+            reason = "The mapped mmproj tensor has no trusted float dequantizer."
+        else:
+            disposition = QuantizationDisposition.DEQUANTIZED_FLOAT
+            reason = (
+                "The mmproj vision/audio encoder always builds float parameters; "
+                "the quantized source tensor is unconditionally dequantized on load."
+            )
+        record = QuantizationTensorRecord(
+            name=f"mmproj:{tensor.name}",
+            qtype=qtype_name,
+            source_bytes=source_bytes,
+            disposition=disposition,
+            target_storage=(
+                "rejected" if disposition is QuantizationDisposition.REJECTED else "float"
+            ),
+            reason=reason,
+        )
+        records.append(record)
+        if disposition is QuantizationDisposition.REJECTED:
+            rejected.append(record)
+
+    if rejected:
+        details = "; ".join(
+            f"{record.name} ({record.qtype}): {record.reason}" for record in rejected[:5]
+        )
+        suffix = "" if len(rejected) <= 5 else f"; and {len(rejected) - 5} more"
+        raise ValueError(
+            "GGUF quantization preflight could not determine a safe disposition for "
+            f"{len(rejected)} mapped mmproj tensor(s): {details}{suffix}"
+        )
+
+    return GGUFQuantizationReport.create(
+        source_qtypes=source_qtypes,
+        tensor_records=records,
+        target_storage_format="float",
+        compute_mode="float operators",
+        compute_capability="Storage is float and executes through float operators.",
+    )
+
+
+def _merge_component_quantization_reports(
+    *reports: GGUFQuantizationReport,
+) -> GGUFQuantizationReport:
+    """Merge independently-preflighted reports from *different* GGUF sources.
+
+    :meth:`GGUFQuantizationReport.combine` requires every component to share
+    one GGUF source qtype census -- it's designed to reassemble one file's
+    main graph plus its MTP-head sidecar. The Gemma4 multimodal package
+    instead draws from two independent files (the text backbone GGUF and the
+    companion mmproj GGUF), each with its own census, so this recomputes the
+    merged census/dispositions directly from every component's raw per-tensor
+    statistics via :meth:`GGUFQuantizationReport.create` rather than asserting
+    the censuses match.
+
+    Tensor records must already use source-qualified names where collisions
+    are possible (see :func:`_preflight_mmproj_quantization_report`'s
+    ``"mmproj:"`` prefix); a name collision with conflicting dispositions
+    raises, mirroring :meth:`GGUFQuantizationReport.combine`.
+    """
+    from mobius.integrations.gguf._quantization_report import (
+        GGUFQuantizationReport,
+    )
+
+    if not reports:
+        raise ValueError("At least one GGUF quantization report is required")
+    records_by_name: dict[str, QuantizationTensorRecord] = {}
+    for report in reports:
+        for record in report.tensor_records:
+            previous = records_by_name.setdefault(record.name, record)
+            if previous != record:
+                raise ValueError(
+                    f"Conflicting GGUF quantization dispositions for {record.name!r}"
+                )
+    source_qtypes = [
+        (stat.qtype, stat.source_bytes if index == 0 else 0)
+        for report in reports
+        for stat in report.source_qtype_census
+        for index in range(stat.tensor_count)
+    ]
+    target_formats = {
+        target for report in reports for target in report.target_storage_format.split(" + ")
+    }
+    compute_modes = {report.compute_mode for report in reports}
+    compute_capabilities = {report.compute_capability for report in reports}
+    return GGUFQuantizationReport.create(
+        source_qtypes=source_qtypes,
+        tensor_records=records_by_name.values(),
+        target_storage_format=" + ".join(sorted(target_formats)),
+        compute_mode=" + ".join(sorted(compute_modes)),
+        compute_capability=" ".join(sorted(compute_capabilities)),
+    )
+
+
 def build_gemma4_vlm_from_gguf(
     text_gguf_path: str | Path,
     mmproj_gguf_path: str | Path,
@@ -1727,7 +1901,10 @@ def build_gemma4_vlm_from_gguf(
             and is recorded in ``quantization_report.json``. Set to ``False`` to dequantize all
             text weights. The vision (and audio) encoder always stays float
             because its weights come from the mmproj as F16 — see the "Mixed
-            precision" note below.
+            precision" note below. ``quantization_report.json`` also censuses
+            the mmproj vision/(audio) source tensors and records their
+            (always-float) dispositions alongside the text backbone's, under
+            source-qualified ``"mmproj:"``-prefixed tensor names.
 
     Returns:
         A :class:`ModelPackage` with ``decoder`` + ``vision_encoder`` +
@@ -1895,6 +2072,12 @@ def build_gemma4_vlm_from_gguf(
             return "decoder.model." + hf_name.removeprefix("language_model.")
         return hf_name
 
+    # The text-only preflight below already emits the single deterministic
+    # fidelity warning (via its default emit_warning=True) when the text
+    # backbone has lossy tensors. The mmproj vision/(audio) report merged in
+    # afterwards can never introduce a lossy-requantize tensor (mmproj
+    # weights always stay float — see _preflight_mmproj_quantization_report),
+    # so it cannot change that warning; the merge below must not re-emit it.
     quantization_report = _preflight_quantization_report(
         text_gguf,
         "gemma4",
@@ -1906,6 +2089,12 @@ def build_gemma4_vlm_from_gguf(
         execution_provider=execution_provider,
         name_mapper=lambda name, _architecture: _text_gguf_name_to_hf_multimodal(name),
         target_name_mapper=target_name,
+    )
+    mmproj_quantization_report = _preflight_mmproj_quantization_report(
+        mmproj_gguf, include_audio=include_audio
+    )
+    quantization_report = _merge_component_quantization_reports(
+        quantization_report, mmproj_quantization_report
     )
     pkg = build_from_module(
         module, config, task=Gemma4Task(), execution_provider=execution_provider

--- a/src/mobius/integrations/gguf/_mmproj_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_test.py
@@ -1507,8 +1507,11 @@ class TestKeepQuantizedMixedPrecision:
         assert float_embedding.const_value is not None
         assert list(float_embedding.shape) == [64, 32]
         assert package.gguf_quantization_report.storage_quantized is True
+        # The float mmproj vision encoder is merged into the package-level
+        # report alongside the quantized text backbone (issue 4): the target
+        # storage format spans both.
         assert package.gguf_quantization_report.target_storage_format == (
-            "INT4 affine block-32"
+            "INT4 affine block-32 + float"
         )
 
         missing = [
@@ -1667,6 +1670,373 @@ class TestKeepQuantizedMixedPrecision:
         session = ort.InferenceSession(str(decoder_path), providers=["CPUExecutionProvider"])
         input_names = {graph_input.name for graph_input in session.get_inputs()}
         assert "inputs_embeds" in input_names
+
+
+class TestMmprojQuantizationReportPreflight:
+    """Unit tests for the mmproj vision/(audio) preflight (follow-up issue 4).
+
+    ``build_gemma4_vlm_from_gguf`` previously computed
+    ``pkg.gguf_quantization_report`` from the text GGUF alone, silently
+    excluding every mmproj vision/(audio) source tensor from the census and
+    tensor records. These tests exercise
+    ``_preflight_mmproj_quantization_report`` directly against a synthetic
+    ``clip`` mmproj GGUF.
+    """
+
+    def test_vision_only_census_covers_whole_file_and_records_are_mapped_vision(
+        self, tmp_path: Path
+    ):
+        from mobius.integrations.gguf._mmproj import (
+            _preflight_mmproj_quantization_report,
+        )
+        from mobius.integrations.gguf._mmproj_mapping import map_mmproj_vision_to_hf
+        from mobius.integrations.gguf._quantization_report import QuantizationDisposition
+        from mobius.integrations.gguf._reader import GGUFModel
+
+        path = tmp_path / "mmproj.gguf"
+        _write_clip_mmproj_gguf(path, with_audio=True)
+        mmproj_gguf = GGUFModel(str(path))
+
+        report = _preflight_mmproj_quantization_report(mmproj_gguf, include_audio=False)
+
+        # The source qtype census covers *every* tensor in the file (vision +
+        # audio + projector), independent of whether audio is mapped below.
+        assert sum(stat.tensor_count for stat in report.source_qtype_census) == (
+            mmproj_gguf.num_tensors
+        )
+        assert sum(stat.source_bytes for stat in report.source_qtype_census) == sum(
+            int(tensor.n_bytes) for tensor in mmproj_gguf.reader_tensors()
+        )
+        # This fixture is entirely float32.
+        assert [stat.qtype for stat in report.source_qtype_census] == ["F32"]
+
+        # Only vision (+ shared projector) tensors are *mapped* into records
+        # when include_audio=False, even though audio tensors are present in
+        # the file and already counted in the census above.
+        expected_names = {
+            f"mmproj:{name}"
+            for name in mmproj_gguf.tensor_names
+            if (name.startswith("v.") or name == "mm.input_projection.weight")
+            and map_mmproj_vision_to_hf(name) is not None
+        }
+        assert expected_names  # sanity: the fixture does map some tensors
+        assert {record.name for record in report.tensor_records} == expected_names
+        assert not any(record.name.startswith("mmproj:a.") for record in report.tensor_records)
+        assert all(
+            record.disposition is QuantizationDisposition.SOURCE_FLOAT
+            for record in report.tensor_records
+        )
+        assert report.explicit_float_tensors == report.tensor_records
+        assert report.source_fidelity is True
+        assert report.storage_quantized is False
+        assert report.target_storage_format == "float"
+
+    def test_include_audio_adds_audio_records_without_changing_the_file_census(
+        self, tmp_path: Path
+    ):
+        from mobius.integrations.gguf._mmproj import (
+            _preflight_mmproj_quantization_report,
+        )
+        from mobius.integrations.gguf._mmproj_mapping import (
+            map_mmproj_audio_to_hf,
+        )
+        from mobius.integrations.gguf._reader import GGUFModel
+
+        path = tmp_path / "mmproj.gguf"
+        _write_clip_mmproj_gguf(path, with_audio=True)
+        mmproj_gguf = GGUFModel(str(path))
+
+        vision_only = _preflight_mmproj_quantization_report(mmproj_gguf, include_audio=False)
+        vision_and_audio = _preflight_mmproj_quantization_report(
+            mmproj_gguf, include_audio=True
+        )
+
+        # Enabling audio only adds mapped records; the raw file census (every
+        # tensor's qtype/bytes) is a property of the file, not of what gets
+        # mapped, so it must be unaffected by include_audio.
+        assert vision_and_audio.source_qtype_census == vision_only.source_qtype_census
+        assert len(vision_and_audio.tensor_records) > len(vision_only.tensor_records)
+
+        expected_audio_names = {
+            f"mmproj:{name}"
+            for name in mmproj_gguf.tensor_names
+            if (name.startswith("a.") or name == "mm.a.input_projection.weight")
+            and map_mmproj_audio_to_hf(name) is not None
+        }
+        assert expected_audio_names  # the with_audio fixture maps audio tensors
+        record_names = {record.name for record in vision_and_audio.tensor_records}
+        assert expected_audio_names <= record_names
+        vision_names = {record.name for record in vision_only.tensor_records}
+        assert expected_audio_names.isdisjoint(vision_names)
+        assert vision_names <= record_names
+
+    def test_quantized_mmproj_tensor_dequantizes_to_float_and_breaks_fidelity(
+        self, tmp_path: Path
+    ):
+        """Report atypical quantized mmproj tensors as dequantized float.
+
+        The encoder always builds a float parameter, so the report must show
+        dequantization rather than silently claiming perfect source fidelity.
+        """
+        from gguf import GGMLQuantizationType, GGUFWriter
+
+        from mobius.integrations.gguf._mmproj import (
+            _preflight_mmproj_quantization_report,
+        )
+        from mobius.integrations.gguf._quantization_report import QuantizationDisposition
+        from mobius.integrations.gguf._reader import GGUFModel
+
+        path = tmp_path / "mmproj-quantized-patch.gguf"
+        writer = GGUFWriter(str(path), "clip")
+        writer.add_string("clip.vision.projector_type", "gemma4v")
+        writer.add_bool("clip.has_vision_encoder", True)
+        # A Q8_0 block is 32 elements: a 2-byte f16 scale + 32 int8 values.
+        out_features, in_features = 8, 32
+        block_bytes = 34
+        raw = np.zeros((out_features, in_features // 32 * block_bytes), dtype=np.uint8)
+        writer.add_tensor("v.patch_embd.weight", raw, raw_dtype=GGMLQuantizationType.Q8_0)
+        writer.write_header_to_file()
+        writer.write_kv_data_to_file()
+        writer.write_tensors_to_file()
+        writer.close()
+
+        mmproj_gguf = GGUFModel(str(path))
+        report = _preflight_mmproj_quantization_report(mmproj_gguf, include_audio=False)
+
+        assert len(report.tensor_records) == 1
+        record = report.tensor_records[0]
+        assert record.name == "mmproj:v.patch_embd.weight"
+        assert record.qtype == "Q8_0"
+        assert record.disposition is QuantizationDisposition.DEQUANTIZED_FLOAT
+        assert record.target_storage == "float"
+        assert report.source_fidelity is False
+        assert report.storage_quantized is False
+
+    def test_unknown_mapped_mmproj_qtype_fails_preflight(self) -> None:
+        from mobius.integrations.gguf._mmproj import (
+            _preflight_mmproj_quantization_report,
+        )
+
+        tensor = SimpleNamespace(
+            name="v.patch_embd.weight",
+            tensor_type=SimpleNamespace(name="UNKNOWN", value=99_999),
+            shape=(8, 32),
+            n_bytes=256,
+        )
+        source = SimpleNamespace(reader_tensors=lambda: iter([tensor]))
+
+        with pytest.raises(ValueError, match=r"no safe disposition|pinned llama.cpp census"):
+            _preflight_mmproj_quantization_report(source, include_audio=False)
+
+
+class TestGemma4MultimodalQuantizationReportMerge:
+    """The package-level report must combine text + mmproj without collisions.
+
+    Covers the follow-up (issue 4): the Gemma4 multimodal builder previously
+    preflighted only the text GGUF, so the persisted
+    ``quantization_report.json`` silently excluded every mmproj vision/audio
+    source tensor. These synthetic text+vision and text+vision/audio tests
+    assert the merged package-level report's counts/bytes, tensor records,
+    and JSON persistence.
+    """
+
+    def test_text_plus_vision_report_counts_bytes_records_and_persists(self, tmp_path: Path):
+        from mobius._model_package import ModelPackage
+        from mobius.integrations.gguf import build_gemma4_vlm_from_gguf
+        from mobius.integrations.gguf._quantization_report import QuantizationDisposition
+        from mobius.integrations.gguf._reader import GGUFModel
+
+        mmproj_path = tmp_path / "mmproj.gguf"
+        _write_clip_mmproj_gguf(mmproj_path, with_audio=True)
+        text_path = tmp_path / "gemma4-q4.gguf"
+        _write_quantized_gemma4_text_gguf(text_path)
+
+        text_gguf = GGUFModel(str(text_path))
+        mmproj_gguf = GGUFModel(str(mmproj_path))
+
+        package = build_gemma4_vlm_from_gguf(text_path, mmproj_path, image_token_id=63)
+        report = package.gguf_quantization_report
+
+        # The census covers every tensor from BOTH source files (including
+        # the mmproj's audio tensors, which are present but unmapped since
+        # include_audio defaults to False).
+        assert sum(stat.tensor_count for stat in report.source_qtype_census) == (
+            text_gguf.num_tensors + mmproj_gguf.num_tensors
+        )
+        expected_bytes = sum(
+            int(tensor.n_bytes) for tensor in text_gguf.reader_tensors()
+        ) + sum(int(tensor.n_bytes) for tensor in mmproj_gguf.reader_tensors())
+        assert sum(stat.source_bytes for stat in report.source_qtype_census) == expected_bytes
+
+        # Mapped tensor records include both the text decoder's mapped
+        # weights and the mmproj vision tower's, disambiguated by the
+        # "mmproj:" prefix so the two components cannot collide.
+        mmproj_records = [
+            record for record in report.tensor_records if record.name.startswith("mmproj:")
+        ]
+        text_records = [
+            record for record in report.tensor_records if not record.name.startswith("mmproj:")
+        ]
+        assert mmproj_records and text_records
+        assert not any(record.name.startswith("mmproj:a.") for record in mmproj_records)
+        assert all(
+            record.disposition is QuantizationDisposition.SOURCE_FLOAT
+            for record in mmproj_records
+        )
+        assert report.storage_quantized is True
+        assert report.target_storage_format == "INT4 affine block-32 + float"
+
+        # Persistence: the merged report round-trips through the package
+        # save/load path exactly like the pre-existing single-source case.
+        output_dir = tmp_path / "saved"
+        package.save(str(output_dir), progress_bar=False)
+        reloaded = ModelPackage.load(str(output_dir))
+        assert reloaded.gguf_quantization_report == report
+
+    def test_text_plus_vision_and_audio_reports_merge_counts_bytes_and_persist(
+        self, tmp_path: Path
+    ):
+        """Exercises the include_audio=True mmproj preflight + merge.
+
+        ``build_gemma4_vlm_from_gguf(..., include_audio=True)`` currently
+        fails closed before reaching the quantization preflight step (the
+        ``gemma4a`` audio projector is deferred/rejected -- see
+        ``_preflight_mmproj_pair`` and the module docstring's audio caveat),
+        so this drives the same mmproj preflight + merge helpers the builder
+        itself uses at the level below that guard, covering the combined
+        vision+audio report shape end to end. The "text" side is a minimal
+        synthetic stand-in report (this test targets the mmproj preflight and
+        the merge, which is the code changed for issue 4).
+        """
+        from mobius.integrations.gguf._mmproj import (
+            _merge_component_quantization_reports,
+            _preflight_mmproj_quantization_report,
+        )
+        from mobius.integrations.gguf._quantization_report import (
+            GGUFQuantizationReport,
+            QuantizationDisposition,
+            QuantizationTensorRecord,
+            disposition_for_import_route,
+        )
+        from mobius.integrations.gguf._reader import GGUFModel
+        from mobius.integrations.gguf._spec import QuantImportRoute, RepackExactness
+
+        mmproj_path = tmp_path / "mmproj.gguf"
+        _write_clip_mmproj_gguf(mmproj_path, with_audio=True)
+        mmproj_gguf = GGUFModel(str(mmproj_path))
+        mmproj_report = _preflight_mmproj_quantization_report(mmproj_gguf, include_audio=True)
+
+        # A minimal stand-in text-backbone component report (one lossless
+        # native tensor, one float tensor) shaped like what
+        # _builder._preflight_quantization_report produces for a real text
+        # GGUF, so the merge is exercised against a genuinely quantized
+        # component without needing to build a full Gemma4Model here.
+        text_report = GGUFQuantizationReport.create(
+            source_qtypes=[("Q4_0", 4608), ("F32", 256)],
+            tensor_records=[
+                QuantizationTensorRecord(
+                    name="blk.0.attn_q.weight",
+                    qtype="Q4_0",
+                    source_bytes=4608,
+                    disposition=disposition_for_import_route(
+                        QuantImportRoute.NATIVE_BYTES, RepackExactness.EXACT
+                    ),
+                    target_storage="native GGUF block storage",
+                    reason="synthetic stand-in for the text component",
+                ),
+                QuantizationTensorRecord(
+                    name="token_embd.weight",
+                    qtype="F32",
+                    source_bytes=256,
+                    disposition=QuantizationDisposition.SOURCE_FLOAT,
+                    target_storage="float",
+                    reason="synthetic stand-in for the text component",
+                ),
+            ],
+            target_storage_format="native GGUF block storage",
+            compute_mode="runtime-dependent native custom op or inline standard-ONNX fallback",
+            compute_capability="synthetic stand-in capability",
+        )
+
+        merged = _merge_component_quantization_reports(text_report, mmproj_report)
+
+        assert sum(stat.tensor_count for stat in merged.source_qtype_census) == sum(
+            stat.tensor_count for stat in text_report.source_qtype_census
+        ) + sum(stat.tensor_count for stat in mmproj_report.source_qtype_census)
+        assert sum(stat.source_bytes for stat in merged.source_qtype_census) == sum(
+            stat.source_bytes for stat in text_report.source_qtype_census
+        ) + sum(stat.source_bytes for stat in mmproj_report.source_qtype_census)
+        assert len(merged.tensor_records) == len(text_report.tensor_records) + len(
+            mmproj_report.tensor_records
+        )
+
+        audio_records = [
+            record
+            for record in merged.tensor_records
+            if record.name.startswith("mmproj:a.")
+            or record.name == "mmproj:mm.a.input_projection.weight"
+        ]
+        vision_records = [
+            record
+            for record in merged.tensor_records
+            if record.name.startswith("mmproj:v.")
+            or record.name == "mmproj:mm.input_projection.weight"
+        ]
+        assert audio_records and vision_records
+        assert {"blk.0.attn_q.weight", "token_embd.weight"} <= {
+            record.name for record in merged.tensor_records
+        }
+        assert all(
+            record.disposition is QuantizationDisposition.SOURCE_FLOAT
+            for record in audio_records + vision_records
+        )
+        assert merged.storage_quantized is True
+        assert merged.target_storage_format == "float + native GGUF block storage"
+
+        # Persistence: the merged report round-trips through JSON exactly
+        # like the package-level report does via ModelPackage.save/load.
+        report_path = tmp_path / "quantization_report.json"
+        merged.write_json(report_path)
+        reloaded = GGUFQuantizationReport.read_json(report_path)
+        assert reloaded == merged
+
+    def test_merge_rejects_conflicting_duplicate_tensor_names(self):
+        """Guard the source-name collision contract.
+
+        If two component reports disagree about the same unqualified tensor
+        name, the merge must fail loudly rather than silently pick one.
+        """
+        from mobius.integrations.gguf._mmproj import (
+            _merge_component_quantization_reports,
+        )
+        from mobius.integrations.gguf._quantization_report import (
+            GGUFQuantizationReport,
+            QuantizationDisposition,
+            QuantizationTensorRecord,
+        )
+
+        def make_report(disposition: QuantizationDisposition) -> GGUFQuantizationReport:
+            return GGUFQuantizationReport.create(
+                source_qtypes=[("F32", 4)],
+                tensor_records=[
+                    QuantizationTensorRecord(
+                        name="shared.weight",
+                        qtype="F32",
+                        source_bytes=4,
+                        disposition=disposition,
+                        target_storage="float",
+                        reason="conflict fixture",
+                    )
+                ],
+                target_storage_format="float",
+                compute_mode="float operators",
+                compute_capability="test",
+            )
+
+        first = make_report(QuantizationDisposition.SOURCE_FLOAT)
+        second = make_report(QuantizationDisposition.DEQUANTIZED_FLOAT)
+        with pytest.raises(ValueError, match="Conflicting GGUF quantization dispositions"):
+            _merge_component_quantization_reports(first, second)
 
 
 # Small synthetic Muse Glimmer vision tower dimensions.

--- a/src/mobius/integrations/gguf/_mmproj_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_test.py
@@ -1506,6 +1506,10 @@ class TestKeepQuantizedMixedPrecision:
         ]
         assert float_embedding.const_value is not None
         assert list(float_embedding.shape) == [64, 32]
+        assert package.gguf_quantization_report.storage_quantized is True
+        assert package.gguf_quantization_report.target_storage_format == (
+            "INT4 affine block-32"
+        )
 
         missing = [
             f"{component}:{name}"
@@ -1518,6 +1522,7 @@ class TestKeepQuantizedMixedPrecision:
         output_dir = tmp_path / "saved"
         package.save(str(output_dir), progress_bar=False)
         reloaded = ModelPackage.load(str(output_dir))
+        assert reloaded.gguf_quantization_report == package.gguf_quantization_report
         assert set(reloaded) == {"decoder", "vision_encoder", "embedding"}
         assert all(
             initializer.const_value is not None
@@ -1533,7 +1538,7 @@ class TestKeepQuantizedMixedPrecision:
         text_gguf = tmp_path / "gemma4-q4-f32-projection.gguf"
         _write_quantized_gemma4_text_gguf(text_gguf, float_projection=True)
 
-        with pytest.raises(ValueError, match=r"would quantize float projection"):
+        with pytest.raises(ValueError, match=r"would quantize a source-float tensor"):
             build_gemma4_vlm_from_gguf(text_gguf, clip_mmproj_gguf, image_token_id=63)
 
         package = build_gemma4_vlm_from_gguf(

--- a/src/mobius/integrations/gguf/_mtp.py
+++ b/src/mobius/integrations/gguf/_mtp.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 import re
+from collections.abc import Callable
 from types import MappingProxyType
 from typing import TYPE_CHECKING
 
@@ -43,6 +44,7 @@ from mobius.integrations.gguf._spec import Support
 
 if TYPE_CHECKING:
     from mobius._model_package import ModelPackage
+    from mobius.integrations.gguf._quantization_report import GGUFQuantizationReport
 
 logger = logging.getLogger(__name__)
 
@@ -552,6 +554,7 @@ def build_mtp_head_from_gguf(
     *,
     preserve_quantization: bool,
     execution_provider: str = "default",
+    on_preflight: Callable[[GGUFQuantizationReport], None] | None = None,
 ) -> ModelPackage | None:
     """Build the Qwen3.5/3.8 MTP head sidecar :class:`ModelPackage` from GGUF.
 
@@ -566,6 +569,7 @@ def build_mtp_head_from_gguf(
         _load_dequantized_state_dict,
         _load_quantized_state_dict,
         _normalize_gguf_weights,
+        _preflight_quantization_report,
         _replace_native_block_linears,
     )
     from mobius.integrations.gguf._tensor_processors import process_tensors
@@ -609,9 +613,27 @@ def build_mtp_head_from_gguf(
             gguf_arch,
             name_mapper=_mapper,
         )
+    quantization_report = _preflight_quantization_report(
+        gguf_model,
+        gguf_arch,
+        module,
+        mtp_config,
+        preserve_quantization=preserve_quantization,
+        target_bits=(mtp_config.quantization.bits if preserve_quantization else None),
+        target_block_size=(
+            mtp_config.quantization.group_size if preserve_quantization else None
+        ),
+        execution_provider=execution_provider,
+        name_mapper=_mapper,
+        dequantize_float_linear_types={"lm_head": {"Q4_1"}},
+        emit_warning=False,
+    )
+    if on_preflight is not None:
+        on_preflight(quantization_report)
     pkg = build_from_module(
         module, mtp_config, Qwen35MtpTask(), execution_provider=execution_provider
     )
+    pkg.gguf_quantization_report = quantization_report
 
     if preserve_quantization:
         state_dict = _load_quantized_state_dict(

--- a/src/mobius/integrations/gguf/_mtp_test.py
+++ b/src/mobius/integrations/gguf/_mtp_test.py
@@ -475,7 +475,7 @@ class TestBuildMtpHead:
         tied_output: bool,
         quantized: bool,
     ) -> None:
-        from mobius.integrations.gguf import build_from_gguf
+        from mobius.integrations.gguf import QuantizationDisposition, build_from_gguf
         from mobius.integrations.gguf._reader import GGUFModel
 
         path = tmp_path / "mtp-tables.gguf"
@@ -487,14 +487,23 @@ class TestBuildMtpHead:
             dedicated_head=dedicated_head,
             tied_output=tied_output,
         )
-        preserve_quantization = quantized and not (dedicated_embedding or dedicated_head)
-        if quantized and not preserve_quantization:
-            with pytest.raises(
-                ValueError,
-                match=r"Cannot keep Q4_0 (?:embedding|output) .* quantized",
-            ):
-                build_from_gguf(path, keep_quantized=True)
+        preserve_quantization = quantized
         package = build_from_gguf(path, keep_quantized=preserve_quantization)
+        if quantized:
+            records = {
+                record.name: record
+                for record in package.gguf_quantization_report.tensor_records
+            }
+            if dedicated_embedding:
+                assert (
+                    records["blk.1.nextn.embed_tokens.weight"].disposition
+                    is QuantizationDisposition.DEQUANTIZED_FLOAT
+                )
+            if dedicated_head:
+                assert (
+                    records["blk.1.nextn.shared_head_head.weight"].disposition
+                    is QuantizationDisposition.DEQUANTIZED_FLOAT
+                )
         head = package.mtp_head
         assert head is not None
         target_initializers = package["model"].graph.initializers

--- a/src/mobius/integrations/gguf/_mtp_test.py
+++ b/src/mobius/integrations/gguf/_mtp_test.py
@@ -594,7 +594,7 @@ class TestBuildMtpHead:
         assert "embed_tokens.weight" not in sidecar.graph.initializers
         assert not any("nextn" in name for name in target.graph.initializers)
 
-    def test_asymmetric_dedicated_head_requires_explicit_dequantization(self, tmp_path: Path):
+    def test_asymmetric_dedicated_head_is_reported_as_float(self, tmp_path: Path):
         import onnxruntime as ort
 
         from mobius.integrations.gguf import build_from_gguf
@@ -612,12 +612,13 @@ class TestBuildMtpHead:
             asymmetric_dedicated_head=True,
         )
         shared = build_from_gguf(shared_path, keep_quantized=True).mtp_head
-        with pytest.raises(
-            ValueError,
-            match=r"nextn\.shared_head_head\.weight \(Q4_1\).*cannot represent",
-        ):
-            build_from_gguf(dedicated_path, keep_quantized=True)
-        dedicated = build_from_gguf(dedicated_path, keep_quantized=False).mtp_head
+        dedicated_package = build_from_gguf(dedicated_path, keep_quantized=True)
+        dedicated = dedicated_package.mtp_head
+        assert dedicated_package.gguf_quantization_report.source_fidelity is False
+        assert any(
+            record.name == "blk.1.nextn.shared_head_head.weight"
+            for record in dedicated_package.gguf_quantization_report.explicit_float_tensors
+        )
         shared_dir = tmp_path / "shared"
         dedicated_dir = tmp_path / "dedicated"
         shared.save(shared_dir, progress_bar=False, check_weights=True)

--- a/src/mobius/integrations/gguf/_quant_registry.py
+++ b/src/mobius/integrations/gguf/_quant_registry.py
@@ -161,8 +161,8 @@ _REQUIRES_EXPLICIT_ZERO_POINT: frozenset[str] = frozenset(
     }
 )
 
-#: Value-preserving types in which an untied ``lm_head`` may stay quantized.
-#: Lossy dequantize/requantize routes fail closed.
+#: Direct/value-preserving types in which an untied ``lm_head`` may use the
+#: quantized graph target without builder-specific normalization.
 _LM_HEAD_PRESERVE: frozenset[str] = frozenset(
     {
         "Q1_0",
@@ -354,6 +354,11 @@ def quant_import_decision(
                 "Re-quantize to a supported qtype."
             ),
         )
+    target = (
+        None
+        if target_bits is None or target_block_size is None
+        else (target_bits, target_block_size)
+    )
     if (
         tensor_role
         in {
@@ -363,9 +368,18 @@ def quant_import_decision(
         and spec.native_preserve is not None
     ):
         if spec.dequantize is Support.SUPPORTED:
+            if target is not None and target != (4, 32):
+                return (
+                    QuantImportRoute.REJECTED,
+                    None,
+                    (
+                        "Conversion from the native GGUF block ABI currently supports "
+                        f"only the affine (4, 32) target, not {target}."
+                    ),
+                )
             return (
                 QuantImportRoute.DEQUANTIZE_REQUANTIZE,
-                None,
+                RepackExactness.LOSSY,
                 (
                     "GatherBlockQuantized does not consume BlockQuantizedMatMul's "
                     "native GGUF byte ABI; the embedding must use the affine Gather ABI."
@@ -409,23 +423,40 @@ def quant_import_decision(
         # then splits the packed rows across those complete expert targets.
         # Non-native qtypes therefore use the same declared affine/decode
         # policy as ordinary projections below.
-    target = (
-        None
-        if target_bits is None or target_block_size is None
-        else (target_bits, target_block_size)
-    )
     if (
         target is not None
         and spec.affine_repack is not None
         and spec.affine_repack.as_params() != target
     ):
         if spec.dequantize is Support.SUPPORTED:
+            if target != (4, 32):
+                return (
+                    QuantImportRoute.REJECTED,
+                    None,
+                    (
+                        "Lossy dequantize/requantize conversion currently supports only "
+                        f"the affine (4, 32) target, not {target}."
+                    ),
+                )
             return (
                 QuantImportRoute.DEQUANTIZE_REQUANTIZE,
                 RepackExactness.LOSSY,
                 (
                     f"The exact {spec.repack_params} affine layout does not match target "
                     f"{target}; conversion through float is lossy."
+                ),
+            )
+        if (
+            target is not None
+            and spec.import_route is QuantImportRoute.DEQUANTIZE_REQUANTIZE
+            and target != (4, 32)
+        ):
+            return (
+                QuantImportRoute.REJECTED,
+                None,
+                (
+                    "Lossy dequantize/requantize conversion currently supports only "
+                    f"the affine (4, 32) target, not {target}."
                 ),
             )
         return (

--- a/src/mobius/integrations/gguf/_quant_registry_test.py
+++ b/src/mobius/integrations/gguf/_quant_registry_test.py
@@ -372,6 +372,27 @@ class TestStorageInvariants:
         assert route is QuantImportRoute.REJECTED
         assert "no trusted decoder" in reason
 
+    def test_requantization_rejects_an_unsupported_affine_target(self) -> None:
+        route, exactness, reason = quant_import_decision(
+            2,
+            TensorRole.PROJECTION,
+            target_bits=8,
+            target_block_size=32,
+        )
+        assert route is QuantImportRoute.REJECTED
+        assert exactness is None
+        assert "only the affine (4, 32) target" in reason
+
+    def test_native_to_affine_conversion_is_explicitly_lossy(self) -> None:
+        route, exactness, _ = quant_import_decision(
+            20,
+            TensorRole.EMBEDDING,
+            target_bits=4,
+            target_block_size=32,
+        )
+        assert route is QuantImportRoute.DEQUANTIZE_REQUANTIZE
+        assert exactness is RepackExactness.LOSSY
+
     @pytest.mark.parametrize("name", ["Q4_0", "Q8_0", "Q1_0"])
     def test_exact_affine_routes_are_declared(self, name: str) -> None:
         spec = quant_spec_by_name(name)

--- a/src/mobius/integrations/gguf/_quantization_report.py
+++ b/src/mobius/integrations/gguf/_quantization_report.py
@@ -1,0 +1,461 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Typed, persistent fidelity reporting for GGUF quantization conversion."""
+
+from __future__ import annotations
+
+__all__ = [
+    "GGUFQuantizationReport",
+    "QuantizationDisposition",
+    "QuantizationDispositionStat",
+    "QuantizationTensorRecord",
+    "QuantizationTypeStat",
+    "disposition_for_import_route",
+]
+
+import dataclasses
+import enum
+import json
+import os
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+
+from mobius.integrations.gguf._spec import QuantImportRoute, RepackExactness
+
+
+class QuantizationDisposition(enum.Enum):
+    """How one mapped GGUF tensor is represented in the resulting package."""
+
+    NATIVE_BYTES = "byte-preserved native"
+    LOSSLESS_REPACK = "numerically lossless repack"
+    LOSSY_REQUANTIZE = "lossy dequantize+requantize"
+    DEQUANTIZED_FLOAT = "dequantized-to-float"
+    SOURCE_FLOAT = "source float"
+    REJECTED = "rejected"
+
+
+def disposition_for_import_route(
+    route: QuantImportRoute,
+    exactness: RepackExactness | None,
+) -> QuantizationDisposition:
+    """Map the authoritative qtype route onto its report disposition."""
+    if route is QuantImportRoute.NATIVE_BYTES:
+        return QuantizationDisposition.NATIVE_BYTES
+    if route is QuantImportRoute.AFFINE_REPACK:
+        return (
+            QuantizationDisposition.LOSSLESS_REPACK
+            if exactness is RepackExactness.EXACT
+            else QuantizationDisposition.LOSSY_REQUANTIZE
+        )
+    if route is QuantImportRoute.DEQUANTIZE_REQUANTIZE:
+        return QuantizationDisposition.LOSSY_REQUANTIZE
+    if route is QuantImportRoute.DEQUANTIZE_FLOAT:
+        return QuantizationDisposition.DEQUANTIZED_FLOAT
+    return QuantizationDisposition.REJECTED
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class QuantizationTypeStat:
+    """Tensor count and source payload bytes for one GGUF qtype."""
+
+    qtype: str
+    tensor_count: int
+    source_bytes: int
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class QuantizationDispositionStat:
+    """Aggregate mapped-tensor statistics for one conversion disposition."""
+
+    disposition: QuantizationDisposition
+    tensor_count: int
+    source_bytes: int
+    qtypes: tuple[str, ...]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class QuantizationTensorRecord:
+    """Fidelity decision for one mapped GGUF tensor."""
+
+    name: str
+    qtype: str
+    source_bytes: int
+    disposition: QuantizationDisposition
+    target_storage: str
+    reason: str
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class GGUFQuantizationReport:
+    """Machine-readable source/target quantization fidelity statement."""
+
+    source_qtype_census: tuple[QuantizationTypeStat, ...]
+    target_storage_format: str
+    dispositions: tuple[QuantizationDispositionStat, ...]
+    source_fidelity: bool
+    storage_quantized: bool
+    compute_mode: str
+    compute_capability: str
+    explicit_float_tensors: tuple[QuantizationTensorRecord, ...]
+    tensor_records: tuple[QuantizationTensorRecord, ...]
+    converted_from: str | None = None
+    schema_version: int = 1
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        source_qtypes: Iterable[tuple[str, int]],
+        tensor_records: Iterable[QuantizationTensorRecord],
+        target_storage_format: str,
+        compute_mode: str,
+        compute_capability: str,
+    ) -> GGUFQuantizationReport:
+        """Create a deterministic report from header census and mapped decisions."""
+        census_counts: Counter[str] = Counter()
+        census_bytes: Counter[str] = Counter()
+        for qtype, source_bytes in source_qtypes:
+            if source_bytes < 0:
+                raise ValueError(f"GGUF tensor source bytes must be non-negative, got {source_bytes}")
+            census_counts[qtype] += 1
+            census_bytes[qtype] += source_bytes
+        census = tuple(
+            QuantizationTypeStat(name, census_counts[name], census_bytes[name])
+            for name in sorted(census_counts)
+        )
+
+        records = tuple(sorted(tensor_records, key=lambda record: record.name))
+        grouped: dict[QuantizationDisposition, list[QuantizationTensorRecord]] = defaultdict(list)
+        for record in records:
+            grouped[record.disposition].append(record)
+        dispositions = tuple(
+            QuantizationDispositionStat(
+                disposition,
+                len(grouped[disposition]),
+                sum(record.source_bytes for record in grouped[disposition]),
+                tuple(sorted({record.qtype for record in grouped[disposition]})),
+            )
+            for disposition in QuantizationDisposition
+            if grouped[disposition]
+        )
+        quantized_dispositions = {
+            QuantizationDisposition.NATIVE_BYTES,
+            QuantizationDisposition.LOSSLESS_REPACK,
+            QuantizationDisposition.LOSSY_REQUANTIZE,
+        }
+        fidelity_breaks = {
+            QuantizationDisposition.LOSSY_REQUANTIZE,
+            QuantizationDisposition.DEQUANTIZED_FLOAT,
+            QuantizationDisposition.REJECTED,
+        }
+        census_names = {stat.qtype for stat in census}
+        converted_from = (
+            "Q4_K_M-like mixed GGUF"
+            if "Q4_K" in census_names and census_names.intersection({"Q5_K", "Q6_K"})
+            else None
+        )
+        return cls(
+            source_qtype_census=census,
+            target_storage_format=target_storage_format,
+            dispositions=dispositions,
+            source_fidelity=not any(record.disposition in fidelity_breaks for record in records),
+            storage_quantized=any(
+                record.disposition in quantized_dispositions for record in records
+            ),
+            compute_mode=compute_mode,
+            compute_capability=compute_capability,
+            explicit_float_tensors=tuple(
+                record
+                for record in records
+                if record.disposition
+                in {
+                    QuantizationDisposition.DEQUANTIZED_FLOAT,
+                    QuantizationDisposition.SOURCE_FLOAT,
+                }
+            ),
+            tensor_records=records,
+            converted_from=converted_from,
+        )
+
+    def warning_message(self) -> str | None:
+        """Return the single deterministic warning for lossy quantized conversion."""
+        lossy = [
+            record
+            for record in self.tensor_records
+            if record.disposition is QuantizationDisposition.LOSSY_REQUANTIZE
+        ]
+        if not lossy:
+            return None
+
+        def summarize(records: Iterable[QuantizationTensorRecord]) -> str:
+            counts: Counter[str] = Counter()
+            source_bytes: Counter[str] = Counter()
+            for record in records:
+                counts[record.qtype] += 1
+                source_bytes[record.qtype] += record.source_bytes
+            return ", ".join(
+                f"{qtype}: {counts[qtype]} tensor(s) / {source_bytes[qtype]} source bytes"
+                for qtype in sorted(counts)
+            )
+
+        lossless = [
+            record
+            for record in self.tensor_records
+            if record.disposition
+            in {
+                QuantizationDisposition.NATIVE_BYTES,
+                QuantizationDisposition.LOSSLESS_REPACK,
+            }
+        ]
+        lossless_summary = summarize(lossless) if lossless else "none"
+        return (
+            "GGUF QUANTIZATION FIDELITY WARNING: output target is "
+            f"{self.target_storage_format}; lossy requantization will change represented "
+            f"source values ({summarize(lossy)}). Losslessly preserved/repacked qtypes "
+            f"in this artifact: {lossless_summary}. The output is quantized target storage "
+            "but is NOT source-faithful and must not be labeled as the original GGUF preset."
+        )
+
+    @classmethod
+    def combine(
+        cls,
+        *reports: GGUFQuantizationReport,
+    ) -> GGUFQuantizationReport:
+        """Combine component reports for one GGUF artifact into a root report."""
+        if not reports:
+            raise ValueError("At least one GGUF quantization report is required")
+        census = reports[0].source_qtype_census
+        if any(report.source_qtype_census != census for report in reports[1:]):
+            raise ValueError("Cannot combine reports from different GGUF qtype censuses")
+        records_by_name: dict[str, QuantizationTensorRecord] = {}
+        for report in reports:
+            for record in report.tensor_records:
+                previous = records_by_name.setdefault(record.name, record)
+                if previous != record:
+                    raise ValueError(
+                        f"Conflicting GGUF quantization dispositions for {record.name!r}"
+                    )
+        source_qtypes = [
+            (stat.qtype, stat.source_bytes if index == 0 else 0)
+            for stat in census
+            for index in range(stat.tensor_count)
+        ]
+        target_formats = {
+            target
+            for report in reports
+            for target in report.target_storage_format.split(" + ")
+        }
+        compute_modes = {report.compute_mode for report in reports}
+        compute_capabilities = {report.compute_capability for report in reports}
+        return cls.create(
+            source_qtypes=source_qtypes,
+            tensor_records=records_by_name.values(),
+            target_storage_format=" + ".join(sorted(target_formats)),
+            compute_mode=" + ".join(sorted(compute_modes)),
+            compute_capability=" ".join(sorted(compute_capabilities)),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the stable JSON-compatible representation."""
+        return {
+            "schema_version": self.schema_version,
+            "converted_from": self.converted_from,
+            "source_qtype_census": [dataclasses.asdict(stat) for stat in self.source_qtype_census],
+            "target_storage_format": self.target_storage_format,
+            "dispositions": [
+                {
+                    **dataclasses.asdict(stat),
+                    "disposition": stat.disposition.value,
+                }
+                for stat in self.dispositions
+            ],
+            "source_fidelity": self.source_fidelity,
+            "storage_quantized": self.storage_quantized,
+            "compute_mode": self.compute_mode,
+            "compute_capability": self.compute_capability,
+            "explicit_float_tensors": [
+                self._record_to_dict(record) for record in self.explicit_float_tensors
+            ],
+            "tensor_records": [self._record_to_dict(record) for record in self.tensor_records],
+        }
+
+    @staticmethod
+    def _record_to_dict(record: QuantizationTensorRecord) -> dict[str, object]:
+        payload = dataclasses.asdict(record)
+        payload["disposition"] = record.disposition.value
+        return payload
+
+    def write_json(self, path: str | Path) -> None:
+        """Persist the stable report artifact."""
+        payload = json.dumps(self.to_dict(), indent=2, sort_keys=True) + "\n"
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(path, flags, 0o666)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as file:
+            file.write(payload)
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> GGUFQuantizationReport:
+        """Validate and restore a report from its JSON representation."""
+        schema_version = payload.get("schema_version")
+        if schema_version != 1:
+            raise ValueError(f"Unsupported GGUF quantization report schema: {schema_version!r}")
+
+        def required_string(key: str) -> str:
+            value = payload.get(key)
+            if not isinstance(value, str):
+                raise ValueError(f"GGUF quantization report {key!r} must be a string")
+            return value
+
+        def required_bool(key: str) -> bool:
+            value = payload.get(key)
+            if not isinstance(value, bool):
+                raise ValueError(f"GGUF quantization report {key!r} must be a boolean")
+            return value
+
+        def nonnegative_int(value: object, *, field: str) -> int:
+            if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                raise ValueError(
+                    f"GGUF quantization report {field!r} must be a non-negative integer"
+                )
+            return value
+
+        def mapping_string(record: Mapping[str, object], key: str, *, field: str) -> str:
+            value = record.get(key)
+            if not isinstance(value, str):
+                raise ValueError(f"GGUF quantization report {field!r} must be a string")
+            return value
+
+        def records(key: str) -> tuple[QuantizationTensorRecord, ...]:
+            raw_records = payload.get(key)
+            if not isinstance(raw_records, list):
+                raise ValueError(f"GGUF quantization report {key!r} must be a list")
+            if not all(isinstance(record, Mapping) for record in raw_records):
+                raise ValueError(
+                    f"GGUF quantization report {key!r} entries must be objects"
+                )
+            return tuple(
+                QuantizationTensorRecord(
+                    name=mapping_string(record, "name", field=f"{key}.name"),
+                    qtype=mapping_string(record, "qtype", field=f"{key}.qtype"),
+                    source_bytes=nonnegative_int(
+                        record.get("source_bytes"), field=f"{key}.source_bytes"
+                    ),
+                    disposition=QuantizationDisposition(
+                        mapping_string(
+                            record,
+                            "disposition",
+                            field=f"{key}.disposition",
+                        )
+                    ),
+                    target_storage=mapping_string(
+                        record,
+                        "target_storage",
+                        field=f"{key}.target_storage",
+                    ),
+                    reason=mapping_string(record, "reason", field=f"{key}.reason"),
+                )
+                for record in raw_records
+            )
+
+        raw_census = payload.get("source_qtype_census")
+        raw_dispositions = payload.get("dispositions")
+        if not isinstance(raw_census, list) or not isinstance(raw_dispositions, list):
+            raise ValueError("GGUF quantization report census/dispositions must be lists")
+        if not all(isinstance(stat, Mapping) for stat in raw_census):
+            raise ValueError("GGUF quantization report census entries must be objects")
+        if not all(isinstance(stat, Mapping) for stat in raw_dispositions):
+            raise ValueError("GGUF quantization report disposition entries must be objects")
+        census = tuple(
+            QuantizationTypeStat(
+                qtype=mapping_string(
+                    stat,
+                    "qtype",
+                    field="source_qtype_census.qtype",
+                ),
+                tensor_count=nonnegative_int(
+                    stat.get("tensor_count"),
+                    field="source_qtype_census.tensor_count",
+                ),
+                source_bytes=nonnegative_int(
+                    stat.get("source_bytes"),
+                    field="source_qtype_census.source_bytes",
+                ),
+            )
+            for stat in raw_census
+        )
+        dispositions: list[QuantizationDispositionStat] = []
+        for stat in raw_dispositions:
+            raw_qtypes = stat.get("qtypes")
+            if not isinstance(raw_qtypes, list) or not all(
+                isinstance(item, str) for item in raw_qtypes
+            ):
+                raise ValueError(
+                    "GGUF quantization report 'dispositions.qtypes' must be a list "
+                    "of strings"
+                )
+            dispositions.append(
+                QuantizationDispositionStat(
+                    disposition=QuantizationDisposition(
+                        mapping_string(
+                            stat,
+                            "disposition",
+                            field="dispositions.disposition",
+                        )
+                    ),
+                    tensor_count=nonnegative_int(
+                        stat.get("tensor_count"),
+                        field="dispositions.tensor_count",
+                    ),
+                    source_bytes=nonnegative_int(
+                        stat.get("source_bytes"),
+                        field="dispositions.source_bytes",
+                    ),
+                    qtypes=tuple(raw_qtypes),
+                )
+            )
+        converted_from = payload.get("converted_from")
+        if converted_from is not None and not isinstance(converted_from, str):
+            raise ValueError(
+                "GGUF quantization report 'converted_from' must be a string or null"
+            )
+        report = cls(
+            source_qtype_census=census,
+            target_storage_format=required_string("target_storage_format"),
+            dispositions=tuple(dispositions),
+            source_fidelity=required_bool("source_fidelity"),
+            storage_quantized=required_bool("storage_quantized"),
+            compute_mode=required_string("compute_mode"),
+            compute_capability=required_string("compute_capability"),
+            explicit_float_tensors=records("explicit_float_tensors"),
+            tensor_records=records("tensor_records"),
+            converted_from=converted_from,
+            schema_version=1,
+        )
+        source_qtypes = [
+            (stat.qtype, stat.source_bytes if index == 0 else 0)
+            for stat in census
+            for index in range(stat.tensor_count)
+        ]
+        canonical = cls.create(
+            source_qtypes=source_qtypes,
+            tensor_records=report.tensor_records,
+            target_storage_format=report.target_storage_format,
+            compute_mode=report.compute_mode,
+            compute_capability=report.compute_capability,
+        )
+        if report != canonical:
+            raise ValueError(
+                "GGUF quantization report summaries are inconsistent with tensor records"
+            )
+        return report
+
+    @classmethod
+    def read_json(cls, path: str | Path) -> GGUFQuantizationReport:
+        """Load and validate a persisted report artifact."""
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+        if not isinstance(payload, Mapping):
+            raise ValueError("GGUF quantization report root must be an object")
+        return cls.from_dict(payload)

--- a/src/mobius/integrations/gguf/_quantization_report.py
+++ b/src/mobius/integrations/gguf/_quantization_report.py
@@ -118,7 +118,9 @@ class GGUFQuantizationReport:
         census_bytes: Counter[str] = Counter()
         for qtype, source_bytes in source_qtypes:
             if source_bytes < 0:
-                raise ValueError(f"GGUF tensor source bytes must be non-negative, got {source_bytes}")
+                raise ValueError(
+                    f"GGUF tensor source bytes must be non-negative, got {source_bytes}"
+                )
             census_counts[qtype] += 1
             census_bytes[qtype] += source_bytes
         census = tuple(
@@ -127,7 +129,9 @@ class GGUFQuantizationReport:
         )
 
         records = tuple(sorted(tensor_records, key=lambda record: record.name))
-        grouped: dict[QuantizationDisposition, list[QuantizationTensorRecord]] = defaultdict(list)
+        grouped: dict[QuantizationDisposition, list[QuantizationTensorRecord]] = defaultdict(
+            list
+        )
         for record in records:
             grouped[record.disposition].append(record)
         dispositions = tuple(
@@ -160,7 +164,9 @@ class GGUFQuantizationReport:
             source_qtype_census=census,
             target_storage_format=target_storage_format,
             dispositions=dispositions,
-            source_fidelity=not any(record.disposition in fidelity_breaks for record in records),
+            source_fidelity=not any(
+                record.disposition in fidelity_breaks for record in records
+            ),
             storage_quantized=any(
                 record.disposition in quantized_dispositions for record in records
             ),
@@ -262,7 +268,9 @@ class GGUFQuantizationReport:
         return {
             "schema_version": self.schema_version,
             "converted_from": self.converted_from,
-            "source_qtype_census": [dataclasses.asdict(stat) for stat in self.source_qtype_census],
+            "source_qtype_census": [
+                dataclasses.asdict(stat) for stat in self.source_qtype_census
+            ],
             "target_storage_format": self.target_storage_format,
             "dispositions": [
                 {
@@ -301,22 +309,26 @@ class GGUFQuantizationReport:
         """Validate and restore a report from its JSON representation."""
         schema_version = payload.get("schema_version")
         if schema_version != 1:
-            raise ValueError(f"Unsupported GGUF quantization report schema: {schema_version!r}")
+            raise ValueError(
+                f"Unsupported GGUF quantization report schema: {schema_version!r}"
+            )
 
         def required_string(key: str) -> str:
             value = payload.get(key)
             if not isinstance(value, str):
-                raise ValueError(f"GGUF quantization report {key!r} must be a string")
+                raise TypeError(f"GGUF quantization report {key!r} must be a string")
             return value
 
         def required_bool(key: str) -> bool:
             value = payload.get(key)
             if not isinstance(value, bool):
-                raise ValueError(f"GGUF quantization report {key!r} must be a boolean")
+                raise TypeError(f"GGUF quantization report {key!r} must be a boolean")
             return value
 
         def nonnegative_int(value: object, *, field: str) -> int:
-            if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise TypeError(f"GGUF quantization report {field!r} must be an integer")
+            if value < 0:
                 raise ValueError(
                     f"GGUF quantization report {field!r} must be a non-negative integer"
                 )
@@ -325,17 +337,15 @@ class GGUFQuantizationReport:
         def mapping_string(record: Mapping[str, object], key: str, *, field: str) -> str:
             value = record.get(key)
             if not isinstance(value, str):
-                raise ValueError(f"GGUF quantization report {field!r} must be a string")
+                raise TypeError(f"GGUF quantization report {field!r} must be a string")
             return value
 
         def records(key: str) -> tuple[QuantizationTensorRecord, ...]:
             raw_records = payload.get(key)
             if not isinstance(raw_records, list):
-                raise ValueError(f"GGUF quantization report {key!r} must be a list")
+                raise TypeError(f"GGUF quantization report {key!r} must be a list")
             if not all(isinstance(record, Mapping) for record in raw_records):
-                raise ValueError(
-                    f"GGUF quantization report {key!r} entries must be objects"
-                )
+                raise TypeError(f"GGUF quantization report {key!r} entries must be objects")
             return tuple(
                 QuantizationTensorRecord(
                     name=mapping_string(record, "name", field=f"{key}.name"),
@@ -363,11 +373,11 @@ class GGUFQuantizationReport:
         raw_census = payload.get("source_qtype_census")
         raw_dispositions = payload.get("dispositions")
         if not isinstance(raw_census, list) or not isinstance(raw_dispositions, list):
-            raise ValueError("GGUF quantization report census/dispositions must be lists")
+            raise TypeError("GGUF quantization report census/dispositions must be lists")
         if not all(isinstance(stat, Mapping) for stat in raw_census):
-            raise ValueError("GGUF quantization report census entries must be objects")
+            raise TypeError("GGUF quantization report census entries must be objects")
         if not all(isinstance(stat, Mapping) for stat in raw_dispositions):
-            raise ValueError("GGUF quantization report disposition entries must be objects")
+            raise TypeError("GGUF quantization report disposition entries must be objects")
         census = tuple(
             QuantizationTypeStat(
                 qtype=mapping_string(
@@ -392,9 +402,8 @@ class GGUFQuantizationReport:
             if not isinstance(raw_qtypes, list) or not all(
                 isinstance(item, str) for item in raw_qtypes
             ):
-                raise ValueError(
-                    "GGUF quantization report 'dispositions.qtypes' must be a list "
-                    "of strings"
+                raise TypeError(
+                    "GGUF quantization report 'dispositions.qtypes' must be a list of strings"
                 )
             dispositions.append(
                 QuantizationDispositionStat(
@@ -418,7 +427,7 @@ class GGUFQuantizationReport:
             )
         converted_from = payload.get("converted_from")
         if converted_from is not None and not isinstance(converted_from, str):
-            raise ValueError(
+            raise TypeError(
                 "GGUF quantization report 'converted_from' must be a string or null"
             )
         report = cls(
@@ -457,5 +466,5 @@ class GGUFQuantizationReport:
         """Load and validate a persisted report artifact."""
         payload = json.loads(Path(path).read_text(encoding="utf-8"))
         if not isinstance(payload, Mapping):
-            raise ValueError("GGUF quantization report root must be an object")
+            raise TypeError("GGUF quantization report root must be an object")
         return cls.from_dict(payload)

--- a/src/mobius/integrations/gguf/_quantization_report_test.py
+++ b/src/mobius/integrations/gguf/_quantization_report_test.py
@@ -130,7 +130,7 @@ def test_malformed_record_fails_closed(tmp_path) -> None:
         encoding="utf-8",
     )
 
-    with pytest.raises(ValueError, match="entries must be objects"):
+    with pytest.raises(TypeError, match="entries must be objects"):
         GGUFQuantizationReport.read_json(path)
 
 

--- a/src/mobius/integrations/gguf/_quantization_report_test.py
+++ b/src/mobius/integrations/gguf/_quantization_report_test.py
@@ -1,0 +1,200 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mobius.integrations.gguf._quantization_report import (
+    GGUFQuantizationReport,
+    QuantizationDisposition,
+    QuantizationTensorRecord,
+)
+
+
+def _record(
+    name: str,
+    qtype: str,
+    source_bytes: int,
+    disposition: QuantizationDisposition,
+    target: str,
+) -> QuantizationTensorRecord:
+    return QuantizationTensorRecord(
+        name=name,
+        qtype=qtype,
+        source_bytes=source_bytes,
+        disposition=disposition,
+        target_storage=target,
+        reason="tested route",
+    )
+
+
+def test_report_is_deterministic_and_round_trips(tmp_path) -> None:
+    report = GGUFQuantizationReport.create(
+        source_qtypes=[
+            ("Q6_K", 210),
+            ("F32", 128),
+            ("Q4_K", 144),
+            ("Q5_K", 176),
+        ],
+        tensor_records=[
+            _record(
+                "blk.0.attn_v.weight",
+                "Q6_K",
+                210,
+                QuantizationDisposition.LOSSY_REQUANTIZE,
+                "INT4 affine block-32",
+            ),
+            _record(
+                "blk.0.attn_q.weight",
+                "Q4_K",
+                144,
+                QuantizationDisposition.LOSSY_REQUANTIZE,
+                "INT4 affine block-32",
+            ),
+            _record(
+                "token_embd.weight",
+                "Q5_K",
+                176,
+                QuantizationDisposition.LOSSY_REQUANTIZE,
+                "INT4 affine block-32",
+            ),
+            _record(
+                "output_norm.weight",
+                "F32",
+                128,
+                QuantizationDisposition.SOURCE_FLOAT,
+                "float",
+            ),
+        ],
+        target_storage_format="INT4 affine block-32",
+        compute_mode="runtime-dependent native custom op or inline standard-ONNX fallback",
+        compute_capability="no kernel promise",
+    )
+    path = tmp_path / "quantization_report.json"
+    report.write_json(path)
+
+    assert GGUFQuantizationReport.read_json(path) == report
+    assert report.converted_from == "Q4_K_M-like mixed GGUF"
+    assert report.storage_quantized is True
+    assert report.source_fidelity is False
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert [stat["qtype"] for stat in payload["source_qtype_census"]] == [
+        "F32",
+        "Q4_K",
+        "Q5_K",
+        "Q6_K",
+    ]
+
+
+def test_converted_from_is_census_based_not_filename() -> None:
+    report = GGUFQuantizationReport.create(
+        source_qtypes=[("Q4_K", 144)],
+        tensor_records=[
+            _record(
+                "a-Q4_K_M.gguf.weight",
+                "Q4_K",
+                144,
+                QuantizationDisposition.LOSSY_REQUANTIZE,
+                "INT4 affine block-32",
+            )
+        ],
+        target_storage_format="INT4 affine block-32",
+        compute_mode="custom op",
+        compute_capability="no kernel promise",
+    )
+
+    assert report.converted_from is None
+
+
+def test_malformed_record_fails_closed(tmp_path) -> None:
+    path = tmp_path / "quantization_report.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "converted_from": None,
+                "source_qtype_census": [],
+                "target_storage_format": "float",
+                "dispositions": [],
+                "source_fidelity": True,
+                "storage_quantized": False,
+                "compute_mode": "float",
+                "compute_capability": "float",
+                "explicit_float_tensors": [],
+                "tensor_records": ["not an object"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="entries must be objects"):
+        GGUFQuantizationReport.read_json(path)
+
+
+def test_inconsistent_fidelity_claim_fails_closed(tmp_path) -> None:
+    report = GGUFQuantizationReport.create(
+        source_qtypes=[("Q5_K", 176)],
+        tensor_records=[
+            _record(
+                "token_embd.weight",
+                "Q5_K",
+                176,
+                QuantizationDisposition.LOSSY_REQUANTIZE,
+                "INT4 affine block-32",
+            )
+        ],
+        target_storage_format="INT4 affine block-32",
+        compute_mode="custom op or fallback",
+        compute_capability="no kernel promise",
+    )
+    payload = report.to_dict()
+    payload["source_fidelity"] = True
+    path = tmp_path / "quantization_report.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="inconsistent with tensor records"):
+        GGUFQuantizationReport.read_json(path)
+
+
+def test_component_reports_combine_without_losing_float_records() -> None:
+    common = {
+        "source_qtypes": [("Q4_0", 144), ("Q4_1", 160)],
+        "target_storage_format": "INT4 affine block-32",
+        "compute_mode": "custom op or fallback",
+        "compute_capability": "no kernel promise",
+    }
+    backbone = GGUFQuantizationReport.create(
+        **common,
+        tensor_records=[
+            _record(
+                "blk.0.attn_q.weight",
+                "Q4_0",
+                144,
+                QuantizationDisposition.LOSSLESS_REPACK,
+                "INT4 affine block-32",
+            )
+        ],
+    )
+    sidecar = GGUFQuantizationReport.create(
+        **common,
+        tensor_records=[
+            _record(
+                "blk.1.nextn.shared_head_head.weight",
+                "Q4_1",
+                160,
+                QuantizationDisposition.DEQUANTIZED_FLOAT,
+                "float",
+            )
+        ],
+    )
+
+    combined = GGUFQuantizationReport.combine(backbone, sidecar)
+
+    assert combined.source_fidelity is False
+    assert combined.storage_quantized is True
+    assert [record.name for record in combined.explicit_float_tensors] == [
+        "blk.1.nextn.shared_head_head.weight"
+    ]

--- a/src/mobius/integrations/gguf/_repacker_test.py
+++ b/src/mobius/integrations/gguf/_repacker_test.py
@@ -656,6 +656,7 @@ class TestRepackQ4K:
         ort_deq = _dequantize_repacked_q4(result, 256).ravel()
         max_abs_diff = float(np.max(np.abs(ort_deq - gguf_deq)))
         tolerance = float(result.scales.max()) * 0.51 + 1e-6
+        assert max_abs_diff > 0
         assert max_abs_diff <= tolerance
 
     def test_super_blocks_may_cross_logical_rows(self):
@@ -783,7 +784,9 @@ class TestRepackQ6K:
 
         assert result.weight.shape[0] == n_out
         max_scale = float(result.scales.max())
-        assert np.max(np.abs(got - reference)) <= max_scale * 0.51 + 1e-6
+        error = np.abs(got - reference)
+        assert np.any(error > 0)
+        assert np.max(error) <= max_scale * 0.51 + 1e-6
 
     def test_super_block_byte_and_element_counts(self):
         """Q6_K is 210 bytes per 256 elements; a wrong size mis-slices silently."""

--- a/src/mobius/integrations/gguf/_tencent_q1_0.py
+++ b/src/mobius/integrations/gguf/_tencent_q1_0.py
@@ -62,6 +62,8 @@ __all__ = [
     "TENCENT_Q1_0_NATIVE_ZERO_POINT",
     "is_tencent_q1_0_layout",
     "parse_tencent_q1_0_tensor",
+    "tencent_q1_0_source_nbytes",
+    "tencent_q1_0_target_bits",
 ]
 
 import math
@@ -134,6 +136,25 @@ def _tensor_data_offset(tensor) -> int:
     # Each tensor's metadata ends with the data offset (relative to the
     # data section start). It is the last part in the field record.
     return int(tensor.field.parts[tensor.field.data[-1]][0])
+
+
+def tencent_q1_0_source_nbytes(tensor) -> int:
+    """Return the exact payload bytes for one Tencent-layout Q1_0 tensor."""
+    if len(tensor.shape) != 2:
+        raise ValueError(f"Tensor {tensor.name!r} must be rank 2 for Tencent Q1_0")
+    ne0 = int(tensor.shape[0])
+    ne1 = int(tensor.shape[1])
+    if ne0 % TENCENT_Q1_0_NATIVE_BLOCK_SIZE != 0:
+        raise ValueError(
+            f"Tensor {tensor.name!r} has K={ne0} not divisible by "
+            f"Tencent Q1_0 native block size {TENCENT_Q1_0_NATIVE_BLOCK_SIZE}"
+        )
+    return ne1 * (ne0 // TENCENT_Q1_0_NATIVE_BLOCK_SIZE) * _TENCENT_Q1_0_BLOCK_BYTES
+
+
+def tencent_q1_0_target_bits() -> int:
+    """Return the selected exact MatMulNBits representation width."""
+    return 2 if flags.tencent_q1_0_use_native_2bit else 4
 
 
 def parse_tencent_q1_0_tensor(

--- a/src/mobius/models/gguf_embeddings_test.py
+++ b/src/mobius/models/gguf_embeddings_test.py
@@ -73,6 +73,15 @@ class _FakeEmbeddingGGUF:
         for name, value in self.tensors.items():
             yield name, None, SimpleNamespace(value=0, name="F32"), value.shape
 
+    def reader_tensors(self):
+        for name, value in self.tensors.items():
+            yield SimpleNamespace(
+                name=name,
+                tensor_type=SimpleNamespace(value=0, name="F32"),
+                shape=tuple(reversed(value.shape)),
+                n_bytes=value.nbytes,
+            )
+
     def tensor_items(self):
         return self.tensors.items()
 

--- a/src/mobius/models/talkie_test.py
+++ b/src/mobius/models/talkie_test.py
@@ -53,6 +53,15 @@ class _FakeTalkieGGUF:
         for name, value in self.tensors.items():
             yield name, None, SimpleNamespace(value=0, name="F32"), value.shape
 
+    def reader_tensors(self):
+        for name, value in self.tensors.items():
+            yield SimpleNamespace(
+                name=name,
+                tensor_type=SimpleNamespace(value=0, name="F32"),
+                shape=tuple(reversed(value.shape)),
+                n_bytes=value.nbytes,
+            )
+
     def tensor_items(self):
         return self.tensors.items()
 

--- a/tests/gguf_dense_cohort_integration_test.py
+++ b/tests/gguf_dense_cohort_integration_test.py
@@ -67,8 +67,10 @@ def _sha256(path: Path) -> str:
 
 @pytest.mark.integration
 @pytest.mark.parametrize("artifact", _ARTIFACTS, ids=lambda artifact: artifact.architecture)
-def test_real_dense_gguf_artifact_fails_closed(artifact: _Artifact) -> None:
-    """Pinned Q4_K_M artifacts do not silently requantize incompatible projections."""
+def test_real_dense_gguf_artifact_reports_lossy_requantization(
+    artifact: _Artifact, caplog
+) -> None:
+    """Pinned Q4_K_M artifacts remain packed without a source-fidelity claim."""
     path = Path(
         hf_hub_download(
             repo_id=artifact.repo_id,
@@ -83,8 +85,11 @@ def test_real_dense_gguf_artifact_fails_closed(artifact: _Artifact) -> None:
     qtypes = Counter(qtype.name for _, _, qtype, _ in gguf_model.tensor_items_raw())
     assert dict(sorted(qtypes.items())) == artifact.qtypes
 
-    with pytest.raises(
-        ValueError,
-        match=r"Quantization-preserving GGUF import would change the dequantized values",
-    ):
-        build_from_gguf(path)
+    with caplog.at_level("WARNING"):
+        package = build_from_gguf(path)
+    report = package.gguf_quantization_report
+    assert caplog.text.count("GGUF QUANTIZATION FIDELITY WARNING") == 1
+    assert report.storage_quantized is True
+    assert report.source_fidelity is False
+    assert report.converted_from == "Q4_K_M-like mixed GGUF"
+    assert {stat.qtype for stat in report.source_qtype_census} == set(artifact.qtypes)

--- a/tests/gguf_test.py
+++ b/tests/gguf_test.py
@@ -511,7 +511,7 @@ class TestCLIBuildGGUF:
         ],
     )
     def test_quantization_flag_parsing(self, tmp_path, extra_args, expected):
-        """Quantization is preserved by default; ``--dequantize`` opts out.
+        """Quantized target storage is default; ``--dequantize`` requests float.
 
         The ``--keep-quantized`` alias that used to be covered here was removed:
         it was never read (``keep_quantized = not args.dequantize``), so the case


### PR DESCRIPTION
## Summary

- classify mapped GGUF tensors before payload conversion using the authoritative qtype registry
- allow lossy quantized-to-quantized normalization with one deterministic warning and a typed `quantization_report.json`
- separate source fidelity, target storage, explicit float tensors, and runtime compute capability across text, Gemma4 multimodal, and MTP packages
- keep unknown qtypes, unsupported targets, and unclassified mapped tensors fail-closed
- document that MatMulNBits fallback compute does not change packed initializer storage

## Validation

- `python -m pytest tests/build_graph_test.py tests/cli_test.py src/ -q -k "not phi4mm and not apply_weights_unknown" --tb=short` — 8,362 passed, 56 skipped, 12 deselected
- focused GGUF policy suite — 811 passed
- `lintrunner f --output oneline --all-files`
- `python scripts/generate_gguf_support_docs.py --check`
- independent code review — no significant findings

The pinned multi-gigabyte motivating artifact was not downloaded; coverage uses synthetic mixed-qtype GGUF fixtures and the pinned integration-test metadata.