### PR TITLE
Make MiniCPM oracle hashes portable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/data/gguf_minicpm_tokenizer_oracle.json text eol=lf

--- a/scripts/generate_minicpm_tokenizer_oracle.py
+++ b/scripts/generate_minicpm_tokenizer_oracle.py
@@ -96,6 +96,28 @@ def _sha256(value: bytes) -> str:
     return hashlib.sha256(value).hexdigest()
 
 
+def _canonical_utf8_source_bytes(path: Path) -> bytes:
+    """Read source text as UTF-8 and canonicalize checkout line endings to LF."""
+    text = path.read_text(encoding="utf-8")
+    return text.replace("\r\n", "\n").replace("\r", "\n").encode("utf-8")
+
+
+def _generator_sha256(path: Path) -> str:
+    return _sha256(_canonical_utf8_source_bytes(path))
+
+
+def _render_fixture(payload: object) -> bytes:
+    return (json.dumps(payload, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+
+
+def _write_or_check_fixture(path: Path, rendered: bytes, *, check: bool) -> None:
+    if check:
+        if path.read_bytes() != rendered:
+            raise SystemExit(f"{path} is stale; regenerate without --check")
+    else:
+        path.write_bytes(rendered)
+
+
 def build_corpus() -> tuple[str, ...]:
     """Return the exact fixed-plus-seeded corpus in oracle execution order."""
     generator = random.Random(SEED)
@@ -489,7 +511,7 @@ def main() -> None:
 
     payload = {
         "generator": "scripts/generate_minicpm_tokenizer_oracle.py",
-        "generator_sha256": _sha256(Path(__file__).read_bytes()),
+        "generator_sha256": _generator_sha256(Path(__file__)),
         "serialization": "UTF-8 compact JSON arrays (ensure_ascii=false; separators=(',',':'))",
         "llamacpp_commit": UPSTREAM_COMMIT,
         "seed": SEED,
@@ -504,12 +526,7 @@ def main() -> None:
         "case_count_per_route": len(MODES) * len(corpus),
         "routes": routes,
     }
-    rendered = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
-    if args.check:
-        if args.output.read_text(encoding="utf-8") != rendered:
-            raise SystemExit(f"{args.output} is stale; regenerate without --check")
-    else:
-        args.output.write_text(rendered, encoding="utf-8")
+    _write_or_check_fixture(args.output, _render_fixture(payload), check=args.check)
 
 
 if __name__ == "__main__":

--- a/tests/data/gguf_minicpm_tokenizer_oracle.json
+++ b/tests/data/gguf_minicpm_tokenizer_oracle.json
@@ -1,6 +1,6 @@
 {
   "generator": "scripts/generate_minicpm_tokenizer_oracle.py",
-  "generator_sha256": "d5beab3d8012b9370fac72904fa948b0f43c5d190986710eef3c91030f71dde2",
+  "generator_sha256": "0aad8a9d152f8899b0af0bb82e28fd0e63d58b8657c7f33cc5051bcd66674d02",
   "serialization": "UTF-8 compact JSON arrays (ensure_ascii=false; separators=(',',':'))",
   "llamacpp_commit": "8d9af256337d1a501250f9bbf4c0859a654bddd6",
   "seed": 648,

--- a/tests/generate_minicpm_tokenizer_oracle_test.py
+++ b/tests/generate_minicpm_tokenizer_oracle_test.py
@@ -22,7 +22,10 @@ from generate_minicpm_tokenizer_oracle import (  # noqa: E402
     RANDOM_COUNT,
     RANDOM_LENGTH_STOP,
     SEED,
+    _generator_sha256,
     _json_bytes,
+    _render_fixture,
+    _write_or_check_fixture,
     build_corpus,
     summarize_results,
 )
@@ -37,7 +40,7 @@ def test_committed_fixture_binds_exact_generator_and_corpus() -> None:
     corpus = build_corpus()
 
     assert fixture["generator"] == "scripts/generate_minicpm_tokenizer_oracle.py"
-    assert fixture["generator_sha256"] == hashlib.sha256(_GENERATOR.read_bytes()).hexdigest()
+    assert fixture["generator_sha256"] == _generator_sha256(_GENERATOR)
     assert fixture["serialization"] == (
         "UTF-8 compact JSON arrays (ensure_ascii=false; separators=(',',':'))"
     )
@@ -54,6 +57,39 @@ def test_committed_fixture_binds_exact_generator_and_corpus() -> None:
     assert fixture["corpus_sha256"] == hashlib.sha256(_json_bytes(corpus)).hexdigest()
     assert fixture["modes"] == [list(mode) for mode in MODES]
     assert fixture["case_count_per_route"] == len(MODES) * len(corpus)
+
+
+def test_generator_and_fixture_bytes_are_deterministic_across_line_endings(
+    tmp_path: Path,
+) -> None:
+    lf_source = tmp_path / "generator-lf.py"
+    crlf_source = tmp_path / "generator-crlf.py"
+    source = bytes("# UTF-8: café\nprint('MiniCPM')\n", encoding="utf-8")
+    lf_source.write_bytes(source)
+    crlf_source.write_bytes(source.replace(b"\n", b"\r\n"))
+
+    lf_rendered = _render_fixture({"generator_sha256": _generator_sha256(lf_source)})
+    crlf_rendered = _render_fixture({"generator_sha256": _generator_sha256(crlf_source)})
+    lf_output = tmp_path / "oracle-lf.json"
+    crlf_output = tmp_path / "oracle-crlf.json"
+    _write_or_check_fixture(lf_output, lf_rendered, check=False)
+    _write_or_check_fixture(crlf_output, crlf_rendered, check=False)
+
+    assert _generator_sha256(lf_source) == hashlib.sha256(source).hexdigest()
+    assert lf_output.read_bytes() == crlf_output.read_bytes() == lf_rendered
+    assert b"\r\n" not in lf_rendered
+
+
+def test_fixture_check_requires_exact_utf8_lf_bytes(tmp_path: Path) -> None:
+    output = tmp_path / "oracle.json"
+    rendered = _render_fixture({"text": "café", "lines": ["first", "second"]})
+    output.write_bytes(rendered)
+
+    _write_or_check_fixture(output, rendered, check=True)
+
+    output.write_bytes(rendered.replace(b"\n", b"\r\n"))
+    with pytest.raises(SystemExit, match="is stale; regenerate without --check"):
+        _write_or_check_fixture(output, rendered, check=True)
 
 
 def test_result_summary_recomputes_hashes_counts_and_first_witness() -> None:


### PR DESCRIPTION
## Summary

- canonicalize only the MiniCPM oracle generator source as explicit UTF-8 with LF line endings before computing `generator_sha256`
- render, write, and `--check` the oracle fixture as exact UTF-8/LF bytes
- pin the committed MiniCPM oracle fixture to LF in Git so Windows clean checkouts remain byte-canonical
- add network-free LF/CRLF regression coverage without changing tokenizer semantics, pinned evidence, or expected result hashes

## Root cause

PR #660 hashed `Path(__file__).read_bytes()`, so Git CRLF conversion changed the generator identity on Windows. Its text-mode fixture write/check boundary also allowed platform newline translation and universal-newline comparisons rather than enforcing one canonical artifact.

## Validation

- `python -m pytest tests/generate_minicpm_tokenizer_oracle_test.py src/mobius/integrations/gguf/_tokenizer_evidence_test.py -q --tb=short` — 32 passed
- `python -m pytest tests/build_graph_test.py tests/cli_test.py src/ -q -k "not phi4mm and not apply_weights_unknown" --tb=short` — 8,616 passed, 63 skipped, 12 deselected, 1 subtest passed
- `lintrunner f --output oneline --all-files` — passed
- independent GPT-5.6 Sol medium review — one Windows checkout finding fixed by pinning the fixture `eol=lf`; affected gates rerun successfully