### PR TITLE
Remove production checkpoint revision gates

### DIFF
--- a/docs/design/qwen4-exp-text-core.md
+++ b/docs/design/qwen4-exp-text-core.md
@@ -6,14 +6,14 @@ Mobius implements both the `qwen4_exp_text` decoder and the
 `decoder`, `vision_encoder`, and `embedding`. `text_only=True` selects the same
 decoder without the vision stages.
 
-The implementation is pinned to:
+The implementation evidence was collected from:
 
 - `Qwen/Qwen3.8-Flash-Next@f5d08274bafd880402bd16f5e3e6c514136ec06c`
 - `unsloth/Qwen3.8-Flash-Next-FP8@41cc25fe32cc20053a59c89716196897580cddf6`
 - `unsloth/Qwen3.8-Flash-Next-GGUF@d3bc75ee6ccef3efc1e228ec00a6cc2cdb1e2249`
 - `huggingface/transformers@598d8ba8baaec7fec5a22da0e2844c7bf4ea20e1`
 
-Exported models record that pin as `mobius.semantic_reference_revision` and
+Exported models record the semantic reference as `mobius.semantic_reference_revision` and
 record the caller's requested checkpoint revision separately as
 `mobius.source_revision` (`unpinned` when no revision was supplied).
 
@@ -24,7 +24,7 @@ schedule, full-kernel Gated-DeltaNet convolution state, recurrent delta-rule
 state, four-stream gated residual hyper-connections, exact softmax-first
 top-k routed MoE plus the sigmoid-gated shared expert, QSA block pooling and
 token selection, and PLE hashed n-gram embeddings with their dilated
-convolution and token-context states. The pinned BF16 checkpoint keeps
+convolution and token-context states. The evidenced BF16 checkpoint keeps
 DeltaNet recurrent math and recurrent cache state in float32, while convolution
 state, projections, sparse-attention caches, and logits remain in model dtype.
 Official safetensors are loaded through a bounded-memory package transaction:
@@ -59,7 +59,7 @@ embeddings. Mobius reuses the Qwen3 vision implementation with DeepStack
 disabled and the merger projected to the decoder width of 2560.
 
 The embedding graph scatters `image_features` at token 248056 while preserving
-the original token IDs for PLE. The processor contract is the pinned Qwen3
+the original token IDs for PLE. The processor contract follows the evidenced Qwen3
 image processor with vision start/end tokens 248053/248054. This package is
 explicitly image-only: config extraction validates the checkpoint's video token
 but removes it from runtime metadata, the embedding graph exposes no video
@@ -78,7 +78,7 @@ of a dedicated sparse-attention runtime kernel.
 
 ## Guarded features
 
-The pinned ordinary Transformers forward preserves MTP metadata but does not
+The evidenced ordinary Transformers forward preserves MTP metadata but does not
 execute its `mtp.*` sidecar. Mobius mirrors that next-token route and does not
 publish an MTP task. Dedicated MTP embeddings fail closed because no flattened
 NextN cache ABI exists. Alternative vision geometries and nonempty DeepStack
@@ -86,7 +86,7 @@ configurations also fail closed.
 
 ## GGUF header support and payload guard
 
-The pinned GGUF is a text-only `general.architecture=qwen4exp` split set:
+The GGUF evidence artifact is a text-only `general.architecture=qwen4exp` split set:
 
 | Shard | Tensors | Bytes | LFS SHA-256 |
 |---|---:|---:|---|
@@ -94,12 +94,13 @@ The pinned GGUF is a text-only `general.architecture=qwen4exp` split set:
 | `UD-IQ1_S/Qwen3.8-Flash-Next-UD-IQ1_S-00002-of-00003.gguf` | 595 | 49,990,818,368 | `3a62e35bbf9add4733bd1438ebd3a67649d5edd6cb0e72bb78e33c913992b2b6` |
 | `UD-IQ1_S/Qwen3.8-Flash-Next-UD-IQ1_S-00003-of-00003.gguf` | 629 | 22,544,696,352 | `0e25ceaeb89b8a80aa973c6c0c7448943682f7408c2855b2ebd016b7643a861a` |
 
-Shard 0 owns all model/tokenizer metadata and no tensors. The importer
-inherits that metadata across the complete set and requires the exact
-`0 + 595 + 629 = 1224` closure. Header validation covers every
-hyper-connection, PLE, QSA/indexer, DeltaNet, routed/shared expert, and final
-output mixer tensor. GGUF's split indexer query/key matrices are concatenated
-row-wise into Hugging Face's fused `index_qk_proj`; they are not Q/K-permuted.
+Shard 0 owns all model/tokenizer metadata and no tensors in that evidence set.
+Production routing is not bound to its repository, revision, filenames, byte
+sizes, hashes, or shard distribution. Bounded header inspection identifies
+`general.architecture=qwen4exp`, while validation uses the model metadata and
+complete 1,224-name tensor shape/qtype contract. GGUF's split indexer query/key
+matrices are concatenated row-wise into Hugging Face's fused `index_qk_proj`;
+they are not Q/K-permuted.
 
 Payload conversion deliberately fails before Hub download. The combined PLE
 table is an enormous IQ4_NL embedding for which the graph has no compatible
@@ -120,13 +121,15 @@ lossy `%d` cache templates. The decoder graph carries a separate
 `mobius.state_manifest` metadata document with explicit role-to-layer
 membership for direct ONNX Runtime orchestration.
 
-## Pinned FP8 checkpoint
+## FP8 checkpoint evidence
 
-`unsloth/Qwen3.8-Flash-Next-FP8` is accepted only at immutable revision
-`41cc25fe32cc20053a59c89716196897580cddf6`. Its 131 safetensors headers were
-range-read without downloading the 185.5 GB tensor payload. The committed
-schema evidence records the config/index hashes, complete tensor census, and
-canonical header-schema hash.
+The committed evidence for `unsloth/Qwen3.8-Flash-Next-FP8` was collected at
+immutable revision `41cc25fe32cc20053a59c89716196897580cddf6`. Library builds do
+not lock to that revision: omitting `revision` follows the Hugging Face default,
+and an explicit branch, tag, or SHA is forwarded unchanged to config and weight
+loading. Its 131 safetensors headers were range-read without downloading the
+185.5 GB tensor payload. The schema evidence records the config/index hashes,
+complete tensor census, and canonical header-schema hash.
 
 The checkpoint uses three text-weight paths:
 
@@ -134,14 +137,14 @@ The checkpoint uses three text-weight paths:
   grids. Every grid is validated as exactly
   `[ceil(rows / 128), ceil(cols / 128)]`.
 - 128 PLE embedding shards use `F8_E4M3` storage and one shared BF16
-  `ngram_embedding.weight_scale` scalar. Its pinned payload is BF16 bits
+  `ngram_embedding.weight_scale` scalar. The evidenced payload is BF16 bits
   `0x3951` (`0.00019931793212890625` as float32). Mobius requires that exact
   scalar and reconstructs each shard lazily as
   `shard.astype(target_dtype) * weight_scale`. The shards remain separate in
   the ONNX graph instead of concatenating a roughly 95 GiB dense table during
   export.
 - Remaining text weights are ordinary BF16 tensors. The 943-entry
-  `modules_to_not_convert` list resolves completely against the pinned header.
+  `modules_to_not_convert` list resolves completely against the evidenced header.
 
 By default Mobius preserves every FP8 code tensor and BF16 scale tensor as an
 external-data initializer. Standard ONNX QDQ reconstructs the logical weights:

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -483,13 +483,6 @@ def _gguf_header_info_from_header_prefix(
     )
 
 
-def _requires_strict_hub_header_preflight(repo_id: str) -> bool:
-    """Return whether this route must never fall back to payload download."""
-    from mobius.integrations.gguf._qwen4_exp import QWEN4EXP_GGUF_REPO
-
-    return repo_id == QWEN4EXP_GGUF_REPO
-
-
 def _validate_preflight_split_header(info: GGUFHeaderInfo, *, source: str) -> None:
     """Require complete, internally consistent split bookkeeping when present."""
     split_values = (info.split_no, info.split_count, info.split_tensors_count)
@@ -585,12 +578,6 @@ def _preflight_hf_gguf_file(
             with session.get(metadata.location, headers=headers, stream=True) as response:
                 chunks = read_response(response)
     except _HUB_PREFLIGHT_TRANSPORT_ERRORS as error:
-        if _requires_strict_hub_header_preflight(repo_id):
-            raise RuntimeError(
-                f"Cannot read the bounded GGUF header for {source!r}; refusing payload "
-                "download because Qwen4Exp route policy cannot be established. "
-                "No payload was downloaded."
-            ) from error
         logger.warning(
             "Bounded GGUF header range read failed for %s (%s); downloading the "
             "same immutable revision and validating its local header before dispatch.",
@@ -603,13 +590,7 @@ def _preflight_hf_gguf_file(
             b"".join(chunks),
             source=source,
         )
-    except GGUFHeaderTruncatedError as error:
-        if _requires_strict_hub_header_preflight(repo_id):
-            raise RuntimeError(
-                f"The selected GGUF metadata header for {source!r} exceeds the bounded "
-                "range; refusing payload download because Qwen4Exp route policy cannot "
-                "be established. No payload was downloaded."
-            ) from error
+    except GGUFHeaderTruncatedError:
         logger.warning(
             "The selected GGUF metadata header for %s exceeds the bounded range; "
             "downloading the same immutable revision for full local validation.",
@@ -646,9 +627,9 @@ def _preflight_hf_gguf_file(
             allow_preflight_only=True,
         )
     if architecture == "qwen4exp" and dispatch_architecture:
-        from mobius.integrations.gguf._qwen4_exp import validate_qwen4exp_hub_source
+        from mobius.integrations.gguf._qwen4_exp import reject_qwen4exp_payload
 
-        validate_qwen4exp_hub_source(repo_id=repo_id, revision=commit_hash)
+        reject_qwen4exp_payload()
     return _GGUFPreflightRevision(commit_hash, header_info)
 
 
@@ -5018,9 +4999,9 @@ def _select_hf_gguf_set_from_split_headers(
         allow_preflight_only=True,
     )
     if primary_architecture == "qwen4exp":
-        from mobius.integrations.gguf._qwen4_exp import validate_qwen4exp_hub_source
+        from mobius.integrations.gguf._qwen4_exp import reject_qwen4exp_payload
 
-        validate_qwen4exp_hub_source(repo_id=repo_id, revision=revision)
+        reject_qwen4exp_payload()
     mismatched_architectures = {
         name: architecture
         for name, architecture in declared_architectures.items()
@@ -5258,19 +5239,6 @@ def _resolve_gguf_path_impl(
         filename, selected_files = _select_complete_hf_gguf_set(pinned_files, filename)
 
     if len(selected_files) > 1:
-        from mobius.integrations.gguf._qwen4_exp import (
-            QWEN4EXP_GGUF_REPO,
-            validate_qwen4exp_hub_artifact,
-        )
-
-        if repo_id == QWEN4EXP_GGUF_REPO:
-            validate_qwen4exp_hub_artifact(
-                api,
-                repo_id=repo_id,
-                revision=resolved_revision,
-                shard_filenames=selected_files,
-                keep_quantized=keep_quantized,
-            )
         return _download_hf_gguf_shards(
             api,
             repo_id=repo_id,

--- a/src/mobius/integrations/gguf/_qwen4_exp.py
+++ b/src/mobius/integrations/gguf/_qwen4_exp.py
@@ -5,80 +5,28 @@
 
 from __future__ import annotations
 
-import hashlib
 import math
-from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
 
 __all__ = [
-    "QWEN4EXP_GGUF_REPO",
-    "QWEN4EXP_GGUF_REVISION",
-    "QWEN4EXP_GGUF_SHARDS",
     "Qwen4ExpGGUFImportError",
-    "validate_qwen4exp_hub_artifact",
-    "validate_qwen4exp_hub_source",
+    "reject_qwen4exp_payload",
     "validate_qwen4exp_tensor_contract",
 ]
 
-QWEN4EXP_GGUF_REPO = "unsloth/Qwen3.8-Flash-Next-GGUF"
-QWEN4EXP_GGUF_REVISION = "d3bc75ee6ccef3efc1e228ec00a6cc2cdb1e2249"
-
-
-@dataclass(frozen=True, slots=True)
-class _PinnedShard:
-    filename: str
-    size: int
-    lfs_sha256: str
-    tensor_count: int
-
-
-QWEN4EXP_GGUF_SHARDS = (
-    _PinnedShard(
-        "UD-IQ1_S/Qwen3.8-Flash-Next-UD-IQ1_S-00001-of-00003.gguf",
-        10_946_624,
-        "88a1420825a9304063e882ada29d438263617f51ac8923d438d927496693bafd",
-        0,
-    ),
-    _PinnedShard(
-        "UD-IQ1_S/Qwen3.8-Flash-Next-UD-IQ1_S-00002-of-00003.gguf",
-        49_990_818_368,
-        "3a62e35bbf9add4733bd1438ebd3a67649d5edd6cb0e72bb78e33c913992b2b6",
-        595,
-    ),
-    _PinnedShard(
-        "UD-IQ1_S/Qwen3.8-Flash-Next-UD-IQ1_S-00003-of-00003.gguf",
-        22_544_696_352,
-        "0e25ceaeb89b8a80aa973c6c0c7448943682f7408c2855b2ebd016b7643a861a",
-        629,
-    ),
-)
 _EXPECTED_TENSOR_COUNT = 1224
-_PINNED_TENSOR_MANIFEST_SHA256 = (
-    "25a1e6a2073caf19d3a3835dd23702a19fa09cc651506e11a13de7b48076359d"
-)
 _MAX_DEQUANTIZED_SINGLE_TENSOR_BYTES = 8 << 30
 _IQ2_EXPERT_LAYERS = frozenset({1, 2, 4, 14, 16, 25, 30, 32, 37, 39, 42, 45, 46, 47})
 
 
 class Qwen4ExpGGUFImportError(NotImplementedError):
-    """The pinned Qwen4Exp payload has no truthful executable import route."""
+    """A Qwen4Exp payload has no truthful executable import route."""
 
 
-def _lfs_sha256(info: Any) -> str | None:
-    lfs = getattr(info, "lfs", None)
-    if isinstance(lfs, dict):
-        value = lfs.get("sha256") or lfs.get("oid")
-    else:
-        value = getattr(lfs, "sha256", None) or getattr(lfs, "oid", None)
-    if isinstance(value, str) and value.startswith("sha256:"):
-        value = value.removeprefix("sha256:")
-    return value if isinstance(value, str) else None
-
-
-def _payload_blocker(*, keep_quantized: bool) -> Qwen4ExpGGUFImportError:
-    if keep_quantized:
+def _payload_blocker(*, keep_quantized: bool | None) -> Qwen4ExpGGUFImportError:
+    if keep_quantized is True:
         detail = (
             "per_layer_token_embd.weight is an IQ4_NL embedding with no matching "
             "GatherBlockQuantized ABI, and the rank-3 routed experts mix IQ1_S "
@@ -86,7 +34,7 @@ def _payload_blocker(*, keep_quantized: bool) -> Qwen4ExpGGUFImportError:
             "rank-2 projection ABI, while the released BlockQuantizedMoE path has "
             "no mixed-format expert-bank ABI or real-weight runtime evidence."
         )
-    else:
+    elif keep_quantized is False:
         detail = (
             "per_layer_token_embd.weight expands to roughly 191 GiB as float32 "
             "(about 95 GiB at its source BF16 logical width) by itself, "
@@ -94,6 +42,12 @@ def _payload_blocker(*, keep_quantized: bool) -> Qwen4ExpGGUFImportError:
             "single-tensor materialization limit before the expert banks are "
             "included. The current importer materializes a complete torch tensor, "
             "so dequantization is not a bounded-memory route."
+        )
+    else:
+        detail = (
+            "The quantized tensors require unsupported embedding and mixed-format "
+            "expert-bank ABIs, while dense materialization exceeds the bounded-memory "
+            "import route."
         )
     return Qwen4ExpGGUFImportError(
         "Qwen3.8 Flash-Next GGUF payload import is intentionally fail-closed. "
@@ -103,70 +57,13 @@ def _payload_blocker(*, keep_quantized: bool) -> Qwen4ExpGGUFImportError:
     )
 
 
-def validate_qwen4exp_hub_artifact(
-    api: Any,
-    *,
-    repo_id: str,
-    revision: str,
-    shard_filenames: list[str],
-    keep_quantized: bool,
-) -> None:
-    """Verify the only published artifact identity, then reject before download."""
-    validate_qwen4exp_hub_source(repo_id=repo_id, revision=revision)
-    expected_names = [shard.filename for shard in QWEN4EXP_GGUF_SHARDS]
-    if shard_filenames != expected_names:
-        raise Qwen4ExpGGUFImportError(
-            "Qwen4Exp GGUF shard set does not match the pinned three-file route: "
-            f"expected {expected_names}, got {shard_filenames}. No payload was downloaded."
-        )
-
-    infos = api.get_paths_info(
-        repo_id,
-        shard_filenames,
-        revision=revision,
-        expand=True,
-    )
-    by_path = {getattr(info, "path", None): info for info in infos}
-    for shard in QWEN4EXP_GGUF_SHARDS:
-        info = by_path.get(shard.filename)
-        actual_size = int(getattr(info, "size", 0) or 0)
-        actual_sha256 = _lfs_sha256(info)
-        if actual_size != shard.size or actual_sha256 != shard.lfs_sha256:
-            raise Qwen4ExpGGUFImportError(
-                f"Pinned Qwen4Exp shard identity mismatch for {shard.filename!r}: "
-                f"expected size/SHA-256 {shard.size}/{shard.lfs_sha256}, got "
-                f"{actual_size}/{actual_sha256}. No payload was downloaded."
-            )
+def reject_qwen4exp_payload(*, keep_quantized: bool | None = None) -> None:
+    """Reject a header-identified Qwen4Exp payload before materializing tensors."""
     raise _payload_blocker(keep_quantized=keep_quantized)
-
-
-def validate_qwen4exp_hub_source(*, repo_id: str, revision: str) -> None:
-    """Reject unpinned Qwen4Exp repositories and revisions before payload access."""
-    if repo_id != QWEN4EXP_GGUF_REPO:
-        raise Qwen4ExpGGUFImportError(
-            f"Qwen4Exp Hub GGUF source {repo_id!r} is not the pinned repository "
-            f"{QWEN4EXP_GGUF_REPO!r}; refusing an unverified payload before download."
-        )
-    if revision != QWEN4EXP_GGUF_REVISION:
-        raise Qwen4ExpGGUFImportError(
-            f"Qwen4Exp Hub GGUF revision {revision!r} is not the pinned revision "
-            f"{QWEN4EXP_GGUF_REVISION}; refusing mutable or unverified payloads."
-        )
 
 
 def _qtype_name(qtype: Any) -> str:
     return str(getattr(qtype, "name", qtype)).upper()
-
-
-def _tensor_manifest_sha256(
-    entries: list[tuple[str, tuple[int, ...], str]],
-) -> str:
-    """Hash all header-owned names, logical shapes, and GGML qtypes."""
-    lines = [
-        f"{name}|{','.join(str(dim) for dim in shape)}|{qtype}"
-        for name, shape, qtype in sorted(entries)
-    ]
-    return hashlib.sha256("\n".join(lines).encode()).hexdigest()
 
 
 def _expected_shapes(metadata: dict[str, Any]) -> dict[str, tuple[int, ...]]:
@@ -290,7 +187,7 @@ def _expected_shapes(metadata: dict[str, Any]) -> dict[str, tuple[int, ...]]:
 
 
 def _expected_qtypes(metadata: dict[str, Any]) -> dict[str, str]:
-    """Return the complete dynamic-quantization assignment from pinned headers."""
+    """Return the supported dynamic-quantization assignment."""
     layers = int(metadata["qwen4exp.block_count"])
     ratios = [int(value) for value in metadata["qwen4exp.attention.compress_ratios"]]
     ple_layers = {int(value) for value in metadata["qwen4exp.ple.layers"]}
@@ -377,7 +274,7 @@ def validate_qwen4exp_tensor_contract(
     source: str,
     keep_quantized: bool | None = None,
 ) -> None:
-    """Validate the exact 1,224-tensor pinned header without touching payloads."""
+    """Validate the supported Qwen4Exp metadata and tensor layout without payloads."""
     if model.architecture != "qwen4exp":
         return
     metadata = model.metadata
@@ -470,11 +367,11 @@ def validate_qwen4exp_tensor_contract(
     if "qwen4exp.feed_forward_length" in metadata:
         mismatches["qwen4exp.feed_forward_length"] = (
             metadata["qwen4exp.feed_forward_length"],
-            "absent in the pinned MoE-only header",
+            "absent in the supported MoE-only layout",
         )
     if mismatches:
         raise ValueError(
-            f"Qwen4Exp GGUF metadata does not match the pinned source contract: {mismatches}"
+            f"Qwen4Exp GGUF metadata does not match the supported contract: {mismatches}"
         )
 
     expected_shapes = _expected_shapes(metadata)
@@ -493,7 +390,6 @@ def validate_qwen4exp_tensor_contract(
         )
 
     qtypes: dict[str, str] = {}
-    manifest_entries: list[tuple[str, tuple[int, ...], str]] = []
     shape_errors: dict[str, tuple[tuple[int, ...], tuple[int, ...]]] = {}
     for name, _raw, qtype, shape in model.tensor_items_raw():
         actual_shape = tuple(int(dim) for dim in shape)
@@ -501,16 +397,8 @@ def validate_qwen4exp_tensor_contract(
         if actual_shape != expected_shape:
             shape_errors[name] = (actual_shape, expected_shape)
         qtypes[name] = _qtype_name(qtype)
-        manifest_entries.append((name, actual_shape, qtypes[name]))
     if shape_errors:
         raise ValueError(f"Qwen4Exp GGUF tensor shape mismatch: {shape_errors}")
-    manifest_sha256 = _tensor_manifest_sha256(manifest_entries)
-    if manifest_sha256 != _PINNED_TENSOR_MANIFEST_SHA256:
-        raise ValueError(
-            "Qwen4Exp GGUF complete tensor manifest mismatch: expected SHA-256 "
-            f"{_PINNED_TENSOR_MANIFEST_SHA256}, got {manifest_sha256}. The digest "
-            "covers all 1,224 names, logical shapes, and GGML qtypes."
-        )
 
     expected_qtypes = _expected_qtypes(metadata)
     qtype_errors = {
@@ -519,17 +407,6 @@ def validate_qwen4exp_tensor_contract(
         if qtypes.get(name) != expected
     }
     if qtype_errors:
-        raise ValueError(f"Qwen4Exp GGUF pinned qtype mismatch: {qtype_errors}")
-
-    manifest = getattr(model, "manifest", None)
-    if manifest is None:
-        raise ValueError("Qwen4Exp GGUF requires the pinned complete three-shard set")
-    shard_counts = [int(shard.tensor_count) for shard in manifest.shards]
-    if manifest.split_count != 3 or shard_counts != [0, 595, 629]:
-        raise ValueError(
-            "Qwen4Exp GGUF shard closure must be metadata-only shard 0 plus "
-            f"0+595+629=1224 tensors, got split_count={manifest.split_count}, "
-            f"counts={shard_counts}"
-        )
+        raise ValueError(f"Qwen4Exp GGUF qtype mismatch: {qtype_errors}")
     if keep_quantized is not None:
         raise _payload_blocker(keep_quantized=keep_quantized)

--- a/src/mobius/integrations/gguf/_qwen4_exp_test.py
+++ b/src/mobius/integrations/gguf/_qwen4_exp_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from types import SimpleNamespace
 from unittest import mock
 
@@ -10,21 +11,32 @@ import numpy as np
 import pytest
 
 from mobius._configs import Qwen4ExpConfig
-from mobius.integrations.gguf import _qwen4_exp as qwen4exp_gguf
 from mobius.integrations.gguf._config_mapping import gguf_to_config
 from mobius.integrations.gguf._qwen4_exp import (
-    QWEN4EXP_GGUF_REPO,
-    QWEN4EXP_GGUF_REVISION,
-    QWEN4EXP_GGUF_SHARDS,
     Qwen4ExpGGUFImportError,
     _expected_qtypes,
     _expected_shapes,
-    validate_qwen4exp_hub_artifact,
-    validate_qwen4exp_hub_source,
     validate_qwen4exp_tensor_contract,
 )
 from mobius.integrations.gguf._tensor_mapping import map_gguf_to_hf_names
 from mobius.models.qwen4_exp import _build_layer_multipliers, _find_nth_prime_after
+
+_EVIDENCE_REPO = "unsloth/Qwen3.8-Flash-Next-GGUF"
+_EVIDENCE_REVISION = "d3bc75ee6ccef3efc1e228ec00a6cc2cdb1e2249"
+_EVIDENCE_SHARDS = (
+    SimpleNamespace(
+        filename="UD-IQ1_S/Qwen3.8-Flash-Next-UD-IQ1_S-00001-of-00003.gguf",
+        tensor_count=0,
+    ),
+    SimpleNamespace(
+        filename="UD-IQ1_S/Qwen3.8-Flash-Next-UD-IQ1_S-00002-of-00003.gguf",
+        tensor_count=595,
+    ),
+    SimpleNamespace(
+        filename="UD-IQ1_S/Qwen3.8-Flash-Next-UD-IQ1_S-00003-of-00003.gguf",
+        tensor_count=629,
+    ),
+)
 
 
 def _metadata() -> dict[str, object]:
@@ -104,8 +116,7 @@ class _HeaderFixture:
         self.manifest = SimpleNamespace(
             split_count=3,
             shards=[
-                SimpleNamespace(tensor_count=shard.tensor_count)
-                for shard in QWEN4EXP_GGUF_SHARDS
+                SimpleNamespace(tensor_count=shard.tensor_count) for shard in _EVIDENCE_SHARDS
             ],
         )
         self.qtype_overrides = qtype_overrides or {}
@@ -205,7 +216,7 @@ def test_qwen4exp_exact_tensor_mapping(gguf_name: str, hf_name: str):
     assert map_gguf_to_hf_names(gguf_name, "qwen4exp") == hf_name
 
 
-def test_qwen4exp_header_fixture_proves_exact_three_shard_closure():
+def test_qwen4exp_header_fixture_matches_pinned_evidence():
     fixture = _HeaderFixture()
 
     _validate_fixture(fixture)
@@ -221,7 +232,11 @@ def test_qwen4exp_header_fixture_proves_exact_three_shard_closure():
         (name, tuple(shape), qtype.name)
         for name, _raw, qtype, shape in fixture.tensor_items_raw()
     ]
-    assert qwen4exp_gguf._tensor_manifest_sha256(entries) == (
+    lines = [
+        f"{name}|{','.join(str(dim) for dim in shape)}|{qtype}"
+        for name, shape, qtype in sorted(entries)
+    ]
+    assert hashlib.sha256("\n".join(lines).encode()).hexdigest() == (
         "25a1e6a2073caf19d3a3835dd23702a19fa09cc651506e11a13de7b48076359d"
     )
 
@@ -241,112 +256,57 @@ def test_qwen4exp_payload_modes_fail_closed_before_raw_payload_access(
         _validate_fixture(_HeaderFixture(), keep_quantized=keep_quantized)
 
 
-def test_qwen4exp_complete_manifest_digest_rejects_any_unpinned_qtype():
+def test_qwen4exp_content_contract_rejects_unsupported_qtype():
     changed = _HeaderFixture({"blk.0.hc_attn_down.weight": "Q5_K"})
 
-    with pytest.raises(ValueError, match="complete tensor manifest mismatch"):
+    with pytest.raises(ValueError, match="qtype mismatch"):
         validate_qwen4exp_tensor_contract(changed, source="changed-header")
 
 
-def _path_infos():
-    return [
-        SimpleNamespace(
-            path=shard.filename,
-            size=shard.size,
-            lfs={"sha256": shard.lfs_sha256},
-        )
-        for shard in QWEN4EXP_GGUF_SHARDS
-    ]
-
-
-def test_qwen4exp_hub_identity_is_pinned_before_payload_download():
-    api = mock.MagicMock()
-    api.get_paths_info.return_value = _path_infos()
-
-    with pytest.raises(Qwen4ExpGGUFImportError, match="intentionally fail-closed"):
-        validate_qwen4exp_hub_artifact(
-            api,
-            repo_id=QWEN4EXP_GGUF_REPO,
-            revision=QWEN4EXP_GGUF_REVISION,
-            shard_filenames=[shard.filename for shard in QWEN4EXP_GGUF_SHARDS],
-            keep_quantized=True,
-        )
-
-    api.get_paths_info.assert_called_once_with(
-        QWEN4EXP_GGUF_REPO,
-        [shard.filename for shard in QWEN4EXP_GGUF_SHARDS],
-        revision=QWEN4EXP_GGUF_REVISION,
-        expand=True,
-    )
-
-
-@pytest.mark.parametrize(
-    ("repo_id", "revision", "message"),
-    [
-        ("other/Qwen4Exp-GGUF", QWEN4EXP_GGUF_REVISION, "not the pinned repository"),
-        (QWEN4EXP_GGUF_REPO, "a" * 40, "not the pinned revision"),
-    ],
-)
-def test_qwen4exp_unpinned_hub_source_fails_before_payload(
-    repo_id: str,
-    revision: str,
-    message: str,
-):
-    with pytest.raises(Qwen4ExpGGUFImportError, match=message):
-        validate_qwen4exp_hub_source(repo_id=repo_id, revision=revision)
-
-
-def test_hub_preflight_range_failure_never_falls_through_to_payload(monkeypatch):
+def test_qwen4exp_hub_preflight_is_source_independent_and_forwards_revision(monkeypatch):
     from mobius.integrations.gguf import _builder
 
+    hub_url = mock.Mock(return_value="https://huggingface.co/exact-file")
     monkeypatch.setattr(
         _builder,
         "hf_hub_url",
-        lambda *_args, **_kwargs: "https://huggingface.co/exact-file",
+        hub_url,
     )
     monkeypatch.setattr(
         _builder,
         "get_hf_file_metadata",
         lambda _url: SimpleNamespace(
-            commit_hash=QWEN4EXP_GGUF_REVISION,
+            commit_hash="a" * 40,
             location="https://cdn.example/model.gguf",
         ),
     )
+    response = mock.MagicMock()
+    response.iter_bytes.return_value = [b"header"]
+    response_context = mock.MagicMock()
+    response_context.__enter__.return_value = response
     session = mock.MagicMock()
-    session.stream.side_effect = OSError("range unavailable")
+    session.stream.return_value = response_context
     monkeypatch.setattr(_builder, "get_session", lambda: session)
-
-    with pytest.raises(RuntimeError, match=r"bounded GGUF header.*No payload"):
-        _builder._preflight_hf_gguf_file(
-            QWEN4EXP_GGUF_REPO,
-            QWEN4EXP_GGUF_SHARDS[0].filename,
-            revision=QWEN4EXP_GGUF_REVISION,
-        )
-
-
-def test_qwen4exp_resolver_never_starts_hub_payload_download(monkeypatch):
-    from mobius.integrations.gguf import _builder
-
-    api = mock.MagicMock()
-    filenames = [shard.filename for shard in QWEN4EXP_GGUF_SHARDS]
-    api.list_repo_files.return_value = filenames
-    api.get_paths_info.return_value = _path_infos()
-    monkeypatch.setattr(_builder, "HfApi", lambda: api)
     monkeypatch.setattr(
         _builder,
-        "_preflight_hf_gguf_file",
-        lambda *_args, **_kwargs: QWEN4EXP_GGUF_REVISION,
+        "_gguf_header_info_from_header_prefix",
+        lambda *_args, **_kwargs: _builder.GGUFHeaderInfo(
+            architecture="qwen4exp",
+            tensor_count=0,
+            split_no=0,
+            split_count=3,
+            split_tensors_count=1224,
+        ),
     )
-    download = mock.MagicMock(side_effect=AssertionError("payload download attempted"))
-    monkeypatch.setattr(_builder, "hf_hub_download", download)
 
-    source = (
-        f"{QWEN4EXP_GGUF_REPO}@{QWEN4EXP_GGUF_REVISION}:{QWEN4EXP_GGUF_SHARDS[0].filename}"
+    with pytest.raises(Qwen4ExpGGUFImportError, match="intentionally fail-closed"):
+        _builder._preflight_hf_gguf_file(
+            "other/Qwen4Exp-GGUF",
+            "renamed-00001-of-00003.gguf",
+            revision="feature/revision",
+        )
+    hub_url.assert_called_once_with(
+        "other/Qwen4Exp-GGUF",
+        "renamed-00001-of-00003.gguf",
+        revision="feature/revision",
     )
-    with pytest.raises(
-        Qwen4ExpGGUFImportError,
-        match="No GGUF tensor payload was downloaded",
-    ):
-        _builder._resolve_gguf_path(source)
-
-    download.assert_not_called()

--- a/src/mobius/integrations/transformers/_builder.py
+++ b/src/mobius/integrations/transformers/_builder.py
@@ -28,10 +28,6 @@ from mobius.tasks import ModelTask
 
 logger = logging.getLogger(__name__)
 
-_PINNED_CHECKPOINT_REVISIONS = {
-    "unsloth/Qwen3.8-Flash-Next-FP8": "41cc25fe32cc20053a59c89716196897580cddf6",
-}
-
 
 def _is_qwen4_exp_composite(config) -> bool:
     """Return whether *config* describes the multimodal Qwen4-Exp wrapper."""
@@ -203,16 +199,6 @@ def build_transformers_model(
     their native block-weight representation. Set it to ``False`` only to
     request explicit dense reconstruction.
     """
-    pinned_revision = _PINNED_CHECKPOINT_REVISIONS.get(model_id)
-    if pinned_revision is not None:
-        if revision is None:
-            revision = pinned_revision
-        elif revision != pinned_revision:
-            raise ValueError(
-                f"{model_id} is integrated only at immutable revision "
-                f"{pinned_revision}; got {revision}."
-            )
-
     from mobius.integrations.diffusers import build_diffusers_pipeline
     from mobius.integrations.transformers._config_resolver import (
         _config_from_hf,
@@ -293,7 +279,7 @@ def build_transformers_model(
             missing = sorted(expected_scale_layers - provided_scale_layers)
             extra = sorted(provided_scale_layers - expected_scale_layers)
             raise ValueError(
-                "fp8_kv_cache=True requires the pinned checkpoint's complete per-layer "
+                "fp8_kv_cache=True requires the checkpoint's complete per-layer "
                 "k_scale/v_scale map; partial maps would silently use unit scales. "
                 f"Missing layers: {missing}; unexpected layers: {extra}."
             )

--- a/src/mobius/integrations/transformers/_builder_test.py
+++ b/src/mobius/integrations/transformers/_builder_test.py
@@ -58,13 +58,18 @@ def test_qwen38_fp8_selects_storage_or_dense_loader(
     )
     model = ir.Model(ir.Graph([], [], nodes=[], name="model"), ir_version=11)
     package = ModelPackage({"model": model})
-    calls = []
+    config_calls = []
+    loader_calls = []
     built_configs = []
+
+    def load_config(model_id, **kwargs):
+        config_calls.append((model_id, kwargs))
+        return expected_parent, False
 
     monkeypatch.setattr(
         transformers_builder,
         "_load_transformers_config",
-        lambda *args, **kwargs: (expected_parent, False),
+        load_config,
     )
     monkeypatch.setattr(
         transformers_builder,
@@ -103,11 +108,11 @@ def test_qwen38_fp8_selects_storage_or_dense_loader(
     monkeypatch.setattr(transformers_builder, "build_from_module", build_module)
 
     def qdq(*args, **kwargs):
-        calls.append("qdq")
+        loader_calls.append(("qdq", args, kwargs))
         return {"format": "mobius.weight-loading-report.v1"}
 
     def dense(*args, **kwargs):
-        calls.append("dense")
+        loader_calls.append(("dense", args, kwargs))
         return {"format": "mobius.weight-loading-report.v1"}
 
     monkeypatch.setattr(transformers_builder, "stream_qdq_safetensors_to_model", qdq)
@@ -119,12 +124,23 @@ def test_qwen38_fp8_selects_storage_or_dense_loader(
 
     result = transformers_builder.build_transformers_model(
         "unsloth/Qwen3.8-Flash-Next-FP8",
+        revision="feature/revision",
         keep_quantized=keep_quantized,
         text_only=True,
     )
 
     assert result is package
-    assert calls == [expected_loader]
+    assert config_calls == [
+        (
+            "unsloth/Qwen3.8-Flash-Next-FP8",
+            {"revision": "feature/revision", "trust_remote_code": False},
+        )
+    ]
+    assert len(loader_calls) == 1
+    loader_name, loader_args, loader_kwargs = loader_calls[0]
+    assert loader_name == expected_loader
+    assert loader_args[1] == "unsloth/Qwen3.8-Flash-Next-FP8"
+    assert loader_kwargs["revision"] == "feature/revision"
     assert built_configs[0].block_quant_scheme is not None
     assert built_configs[0].model_type == "qwen4_exp_text"
     assert built_configs[0].vision is None
@@ -193,7 +209,7 @@ def test_qwen38_multimodal_config_keeps_parent_fields(monkeypatch) -> None:
     assert built_configs[0].image_token_id == 248056
 
 
-def test_qwen38_fp8_defaults_to_immutable_integrated_revision(monkeypatch) -> None:
+def test_qwen38_fp8_none_revision_uses_hugging_face_default(monkeypatch) -> None:
     calls = []
 
     def stop_after_config(model_id, **kwargs):
@@ -216,20 +232,37 @@ def test_qwen38_fp8_defaults_to_immutable_integrated_revision(monkeypatch) -> No
         (
             "unsloth/Qwen3.8-Flash-Next-FP8",
             {
-                "revision": "41cc25fe32cc20053a59c89716196897580cddf6",
+                "revision": None,
                 "trust_remote_code": False,
             },
         )
     ]
 
 
-def test_qwen38_fp8_rejects_other_revision() -> None:
-    with pytest.raises(ValueError, match="integrated only at immutable revision"):
-        transformers_builder.build_transformers_model(
-            "unsloth/Qwen3.8-Flash-Next-FP8",
-            revision="main",
-            load_weights=False,
-        )
+@pytest.mark.parametrize("revision", [None, "feature/revision"])
+def test_transformers_config_forwards_only_explicit_revision(monkeypatch, revision) -> None:
+    import transformers
+
+    calls = []
+    config = SimpleNamespace(model_type="qwen2")
+
+    def from_pretrained(model_id, **kwargs):
+        calls.append((model_id, kwargs))
+        return config
+
+    monkeypatch.setattr(transformers.AutoConfig, "from_pretrained", from_pretrained)
+
+    result = transformers_builder._load_transformers_config(
+        "unsloth/Qwen3.8-Flash-Next-FP8",
+        revision=revision,
+        trust_remote_code=False,
+    )
+
+    assert result == (config, False)
+    expected_kwargs = {"trust_remote_code": False}
+    if revision is not None:
+        expected_kwargs["revision"] = revision
+    assert calls == [("unsloth/Qwen3.8-Flash-Next-FP8", expected_kwargs)]
 
 
 def test_transformers_build_uses_canonical_weight_loader(monkeypatch) -> None:

--- a/src/mobius/models/qwen4_exp.py
+++ b/src/mobius/models/qwen4_exp.py
@@ -83,7 +83,7 @@ def validate_qwen4_exp_fp8_header_contract(
         if weight_dtype != "F8_E4M3":
             raise ValueError(
                 f"Qwen4-Exp FP8 source '{weight_name}' has dtype {weight_dtype}; "
-                "the pinned checkpoint requires F8_E4M3"
+                "the supported checkpoint layout requires F8_E4M3"
             )
         if ".ple.ple_embedding.ngram_embedding.shard_" in weight_name:
             if len(weight_shape) != 2:
@@ -94,7 +94,7 @@ def validate_qwen4_exp_fp8_header_contract(
             if per_shard_scale in key_index:
                 raise ValueError(
                     f"Qwen4-Exp PLE source '{weight_name}' has forbidden per-shard "
-                    f"scale '{per_shard_scale}'; the pinned layout uses one shared scalar"
+                    f"scale '{per_shard_scale}'; the supported layout uses one shared scalar"
                 )
             ple_scale_name = _qwen4_exp_ple_scale_name(weight_name)
             ple_scale = key_index.get(ple_scale_name)
@@ -136,7 +136,7 @@ def validate_qwen4_exp_fp8_header_contract(
         if scale_dtype != "BF16":
             raise ValueError(
                 f"Qwen4-Exp FP8 source '{weight_name}' has scale dtype {scale_dtype}; "
-                "the pinned checkpoint requires BF16 inverse scales"
+                "the supported checkpoint layout requires BF16 inverse scales"
             )
         consumed_scales.add(scale_name)
         scaled += 1
@@ -1477,7 +1477,7 @@ class Qwen4ExpCausalLMModel(nn.Module):
             constants=constants,
             report={
                 "checkpoint_family": "Qwen3.8-Flash-Next-FP8",
-                "dense_dtype": "graph-declared (BF16 for the pinned checkpoint)",
+                "dense_dtype": "graph-declared (BF16 for the supported checkpoint layout)",
                 "native_fp8_reason": (
                     "No available ONNX Runtime MatMul/MoE ABI consumes F8_E4M3 "
                     "weights with BF16 128x128 inverse-scale grids exactly."

--- a/src/mobius/models/qwen4_exp_test.py
+++ b/src/mobius/models/qwen4_exp_test.py
@@ -2070,7 +2070,7 @@ def test_fp8_streaming_plan_rejects_e5m2_ple_storage():
     path, shape, _dtype = index[weight_name]
     index[weight_name] = (path, shape, "F8_E5M2")
 
-    with pytest.raises(ValueError, match="pinned checkpoint requires F8_E4M3"):
+    with pytest.raises(ValueError, match="supported checkpoint layout requires F8_E4M3"):
         module.build_fp8_streaming_plan(index, model.graph.initializers)
 
 

--- a/testdata/cases/causal-lm/qwen3.8-flash-next-fp8.yaml
+++ b/testdata/cases/causal-lm/qwen3.8-flash-next-fp8.yaml
@@ -15,7 +15,7 @@ generation:
   do_sample: false
 
 skip_reason: >
-  The pinned checkpoint payload is 185.5 GB and includes a roughly 95 GiB PLE
+  The evidenced checkpoint payload is 185.5 GB and includes a roughly 95 GiB PLE
   table, so full-checkpoint L4/L5 generation exceeds CI resources. Immutable
   all-header validation, independent reduced FP8 ORT parity, and pinned
   Transformers reduced-model full-logit parity provide the committed evidence.


### PR DESCRIPTION
## Summary
- restore standard Hugging Face revision behavior for Transformers builds: omitted revisions remain omitted and explicit refs pass through unchanged
- remove Qwen4Exp GGUF repository, revision, filename, size, and LFS identity gates
- keep GGUF payload handling fail-closed based on detected architecture and metadata/tensor layout, with immutable source pins retained only as evidence
- add regressions for default and arbitrary explicit revision forwarding across config and FP8 weight loaders

## Validation
- `python -m pytest src/mobius/integrations/transformers/_builder_test.py src/mobius/integrations/gguf/_qwen4_exp_test.py src/mobius/models/qwen4_exp_test.py -q --tb=short`
- `python -m pytest tests/cli_test.py src/mobius/integrations/_weight_loading_test.py src/mobius/integrations/compressed_tensors/_loader_test.py src/mobius/integrations/transformers/_builder_test.py src/mobius/integrations/gguf/_qwen4_exp_test.py -q --tb=short`
- `python -m pytest tests/build_graph_test.py tests/cli_test.py src/ -q -k "not phi4mm and not apply_weights_unknown" --tb=short`
- `lintrunner f --output oneline --all-files`
- independent code review: no findings