### PR TITLE
Add seven Qwen and GLM GGUF projector routes

### DIFF
--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -11,7 +11,7 @@ Support is capability-specific: graph import does not imply runtime packaging.
 |---|---:|---|
 | Architectures | 148 | graph verdicts: {'deferred': 41, 'rejected': 2, 'supported': 105}; importable: 105; quantized import: {'rejected': 47, 'supported': 101}; runtime: {'deferred': 136, 'rejected': 2, 'supported': 10} |
 | Active stored qtypes | 25 | 24 have an import route; 1 are explicitly deferred with no route |
-| Serialized projector strings | 60 | {'graph-importable': 18, 'runtime-evidenced': 0} |
+| Serialized projector strings | 60 | {'graph-importable': 25, 'runtime-evidenced': 0} |
 | Tokenizer pre identifiers | 87 | 56 semantic groups; route dispositions: {'deferred-compiled-semantics': 45, 'deferred-pinned-artifact-evidence': 4, 'deferred-pinned-artifact-mismatch': 7, 'validated-pinned-source': 31} |
 
 `SUPPORTED` means the named capability is implemented and mechanically tested. `DEFERRED` means it is intentionally unavailable pending the stated work. `REJECTED` means the input or route is invalid by policy. Graph support controls export. The separate runtime verdict records pinned real-artifact validation, independent parity, and deterministic generation or stateful semantics; it never gates export of a faithfully represented graph and package contract. Tokenizer `copy` requires embedded ordered-vocabulary identity; `pinned-source` also binds the complete GGUF artifact, immutable Hub assets, reconstruction policy, semantic hashes, and representative token-ID vectors.
@@ -65,6 +65,11 @@ artifact, graph, tokenizer, runtime version, parity proof, and deterministic sta
 evidence match.
 Processor-owned `image_token_id` overrides are forwarded unchanged for `mmproj=` packages.
 
+Use `build_mmproj_from_gguf("mmproj.gguf", projector_type=..., target_architecture=...)`
+to export a registry-evidenced standalone `vision_encoder`, `audio_encoder`, or
+`speaker_encoder`. It never invents decoder, media-mixing, or generated-audio roles and
+warns while downstream runtime orchestration remains unvalidated.
+
 ## Runtime evidence
 
 The first low-cost architecture batch promotes GPT-2, GPT-NeoX/Pythia, MPT, OLMo,
@@ -115,8 +120,8 @@ remain machine-readable in `_route_census.py`; this table groups only shared nex
 | `evidence-only` | `architecture-runtime-evidence` | `architecture:apertus`, `architecture:arcee`, `architecture:arctic`, `architecture:baichuan`, `architecture:bailingmoe`, `architecture:bert`, `architecture:bitnet`, `architecture:bloom`, `architecture:chatglm`, `architecture:codeshell`, `architecture:cohere2`, `architecture:command-r`, `architecture:dbrx`, `architecture:deci`, `architecture:deepseek`, `architecture:dflash`, `architecture:dots1`, `architecture:dream`, `architecture:eagle3`, `architecture:ernie4_5`, `architecture:ernie4_5-moe`, `architecture:eurobert`, `architecture:exaone`, `architecture:falcon`, `architecture:falcon-h1`, `architecture:gemma`, `architecture:gemma-embedding`, `architecture:gemma2`, `architecture:gemma3`, `architecture:gemma4`, `architecture:glm-dsa`, `architecture:granite`, `architecture:granitehybrid`, `architecture:granitemoe`, `architecture:grok`, `architecture:grovemoe`, `architecture:hunyuan-dense`, `architecture:hunyuan-moe`, `architecture:hy_v3`, `architecture:internlm2`, `architecture:jais`, `architecture:jais2`, `architecture:jamba`, `architecture:jina-bert-v2`, `architecture:jina-bert-v3`, `architecture:kimi-k3`, `architecture:kimi-linear`, `architecture:lfm2moe`, `architecture:llada`, `architecture:llada-moe`, `architecture:llama-embed`, `architecture:maincoder`, `architecture:mamba`, `architecture:mamba2`, `architecture:minicpm`, `architecture:minicpm3`, `architecture:minimax-01`, `architecture:minimax-m2`, `architecture:mistral4`, `architecture:modern-bert`, `architecture:muse-glimmer`, `architecture:nemotron`, `architecture:nemotron_h`, `architecture:nemotron_h_moe`, `architecture:neo-bert`, `architecture:nomic-bert`, `architecture:nomic-bert-moe`, `architecture:olmo2`, `architecture:olmoe`, `architecture:openelm`, `architecture:orion`, `architecture:pangu-embedded`, `architecture:phi2`, `architecture:phi3`, `architecture:phimoe`, `architecture:plamo`, `architecture:plamo2`, `architecture:plm`, `architecture:qwen`, `architecture:qwen2moe`, `architecture:qwen2vl`, `architecture:qwen3`, `architecture:qwen35`, `architecture:qwen3moe`, `architecture:qwen3next`, `architecture:refact`, `architecture:rnd1`, `architecture:seed_oss`, `architecture:smallthinker`, `architecture:smollm3`, `architecture:stablelm`, `architecture:t5`, `architecture:t5encoder`, `architecture:talkie`, `architecture:xverse` | immutable representative GGUF; full-logit prefill and cached-decode parity; deterministic generation/state evidence |
 | `evidence-only` | `draft-runtime-evidence` | `draft:dflash`, `draft:eagle3` | target acceptance loop; draft cache orchestration; deterministic speedup parity |
 | `evidence-only` | `mtp-runtime-evidence` | `mtp:hy_v3`, `mtp:qwen35` | target acceptance loop; cache-threaded draft/target parity |
-| `evidence-only` | `projector-runtime-evidence` | `projector:adapter`, `projector:gemma3`, `projector:gemma3na`, `projector:gemma3nv`, `projector:gemma4a`, `projector:gemma4ua`, `projector:gemma4uv`, `projector:gemma4v`, `projector:idefics3`, `projector:internvl`, `projector:ldp`, `projector:ldpv2`, `projector:llama4`, `projector:mlp`, `projector:muse-glimmer`, `projector:pixtral`, `projector:qwen2.5vl_merger`, `projector:qwen2vl_merger` | paired text target; processor boundary; deterministic multimodal package execution |
-| `immediately-implementable` | `projector-implementation` | `projector:cogvlm`, `projector:deepseekocr`, `projector:deepseekocr2`, `projector:dots3note_a`, `projector:dots3note_v`, `projector:dots_ocr`, `projector:exaone4_5`, `projector:glm4v`, `projector:glma`, `projector:granite4_vision`, `projector:granite_speech`, `projector:hunyuanvl`, `projector:janus_pro`, `projector:kimik25`, `projector:kimivl`, `projector:lfm2`, `projector:lfm2a`, `projector:lightonocr`, `projector:meralion`, `projector:mimo_audio`, `projector:mimovl`, `projector:minicpmv4_6`, `projector:minimax_m3`, `projector:musicflamingo`, `projector:nemotron_v2_vl`, `projector:paddleocr`, `projector:parakeet`, `projector:pockettts_spkenc`, `projector:qwen2.5o`, `projector:qwen2a`, `projector:qwen3a`, `projector:qwen3tts_spkenc`, `projector:qwen3vl_merger`, `projector:step3vl`, `projector:ultravox`, `projector:voxtral`, `projector:yasa2`, `projector:youtuvl` | metadata schema; tensor closure; component graph parity |
+| `evidence-only` | `projector-runtime-evidence` | `projector:adapter`, `projector:gemma3`, `projector:gemma3na`, `projector:gemma3nv`, `projector:gemma4a`, `projector:gemma4ua`, `projector:gemma4uv`, `projector:gemma4v`, `projector:glm4v`, `projector:glma`, `projector:idefics3`, `projector:internvl`, `projector:ldp`, `projector:ldpv2`, `projector:llama4`, `projector:mlp`, `projector:muse-glimmer`, `projector:pixtral`, `projector:qwen2.5o`, `projector:qwen2.5vl_merger`, `projector:qwen2a`, `projector:qwen2vl_merger`, `projector:qwen3a`, `projector:qwen3tts_spkenc`, `projector:qwen3vl_merger` | paired text target; processor boundary; deterministic multimodal package execution |
+| `immediately-implementable` | `projector-implementation` | `projector:cogvlm`, `projector:deepseekocr`, `projector:deepseekocr2`, `projector:dots3note_a`, `projector:dots3note_v`, `projector:dots_ocr`, `projector:exaone4_5`, `projector:granite4_vision`, `projector:granite_speech`, `projector:hunyuanvl`, `projector:janus_pro`, `projector:kimik25`, `projector:kimivl`, `projector:lfm2`, `projector:lfm2a`, `projector:lightonocr`, `projector:meralion`, `projector:mimo_audio`, `projector:mimovl`, `projector:minicpmv4_6`, `projector:minimax_m3`, `projector:musicflamingo`, `projector:nemotron_v2_vl`, `projector:paddleocr`, `projector:parakeet`, `projector:pockettts_spkenc`, `projector:step3vl`, `projector:ultravox`, `projector:voxtral`, `projector:yasa2`, `projector:youtuvl` | metadata schema; tensor closure; component graph parity |
 | `intentionally-rejected` | `policy-rejections` | `architecture:bailingmoe2`, `architecture:clip`, `architecture:dots3note`, `architecture:exaone-moe`, `architecture:exaone4`, `architecture:glm4`, `architecture:glm4moe`, `architecture:gptj` | policy change plus independent correctness proof |
 | `intentionally-rejected` | `policy-rejections` | `projector:pockettts_gen`, `projector:qwen3tts_gen` | sidecar role must become a valid projector contract |
 | `intentionally-rejected` | `policy-rejections` | `mtp:bailingmoe2`, `mtp:dots3note`, `mtp:exaone-moe`, `mtp:exaone4`, `mtp:gemma4-assistant`, `mtp:glm4`, `mtp:glm4moe`, `mtp:graniteswitch`, `mtp:nemotron_h` | upstream executable ownership change |
@@ -376,6 +381,11 @@ operator ABI for every tensor role, and treats dequantize/requantize as non-pres
 | `gemma3-4b-f16` | `ggml-org/gemma-3-4b-it-GGUF@ab31416aceb30cd095cb34cc27eea120940964e4`<br>`mmproj-model-f16.gguf` | 851,251,104 | `8c0fb064b019a6972856aaae2c7e4792858af3ca4561be2dbf649123ba6c40cb` | `gemma3` | `gemma-3-4b-it-Q4_K_M.gguf` | `google/gemma-3-4b-it@093f9f388b31de276ce2de164bdc2081324b9767` |
 | `gemma4-e2b-f16` | `unsloth/gemma-4-E2B-it-GGUF@0314792d7f1f7e229411f620751375812bb9faf2`<br>`mmproj-F16.gguf` | 985,654,080 | `337ee849e80b6169ce9d1d573d424fc1653bcafa5f0cb0cbb901beba54f4b41c` | `gemma4v`, `gemma4a` | `unsloth/gemma-4-E2B-it-GGUF@0314792d7f1f7e229411f620751375812bb9faf2`<br>`gemma-4-E2B-it-Q4_K_M.gguf`<br>3,106,738,272 bytes | `google/gemma-4-E2B-it@3e22461f65e89153144f8adb70e3b8c2cc9845a7` |
 | `muse-glimmer-30b-bf16` | `unsloth/Muse-Glimmer-30B-GGUF@faa5b025c584459c13febfa5c59883516710ae39`<br>`mmproj-Muse-Glimmer-30B-BF16.gguf` | 3,849,173,728 | `7aa788cfe25ae5e4bf4837511f64df22cabe595e58223708274a67b3136f53ab` | `muse-glimmer` | `Muse-Glimmer-30B-UD-Q4_K_XL.gguf` | — |
+| `qwen3-vl-projector-f16` | `bartowski/Qwen_Qwen3-VL-2B-Instruct-GGUF@e84f8ae7ffee8b04793a4ed771609e2b61d3f3cf`<br>`mmproj-Qwen_Qwen3-VL-2B-Instruct-f16.gguf` | 819,394,848 | `8c3f6a56979a1ce7056b9a20be6cf6b6f6ad4837aa3da532b5afcfcfd1faa38b` | `qwen3vl_merger` | `Qwen_Qwen3-VL-2B-Instruct-Q4_K_M.gguf` | `Qwen/Qwen3-VL-2B-Instruct@89644892e4d85e24eaac8bacfd4f463576704203` |
+| `qwen3-audio-projector-bf16` | `ggml-org/Qwen3-ASR-0.6B-GGUF@928ab958557df9aa2ef1c93e0e83c7ad0933fae2`<br>`mmproj-Qwen3-ASR-0.6B-bf16.gguf` | 378,575,520 | `dae36c855f9a82a8916bea2238b24bda69a39d8da8b2f46dee7c103775656039` | `qwen3a` | `Qwen3-ASR-0.6B-bf16.gguf` | `Qwen/Qwen3-ASR-0.6B@5eb144179a02acc5e5ba31e748d22b0cf3e303b0` |
+| `qwen2-audio-projector-f16` | `mradermacher/Qwen2-Audio-7B-Instruct-GGUF@e1e68850ba33e38eafbc3817919c318d9c7e757b`<br>`Qwen2-Audio-7B-Instruct.mmproj-f16.gguf` | 1,289,301,536 | `b52435dead2956f1fc113818c3b5ceb42a940cb487e59163cb1ffc69cae69347` | `qwen2a` | `Qwen2-Audio-7B-Instruct.Q4_K_M.gguf` | `Qwen/Qwen2-Audio-7B-Instruct@0a095220c30b7b31434169c3086508ef3ea5bf0a` |
+| `qwen25-omni-projector-f16` | `ggml-org/Qwen2.5-Omni-3B-GGUF@75f1b73b657a50f5092502799457ccb4a4a1f9df`<br>`mmproj-Qwen2.5-Omni-3B-f16.gguf` | 2,623,983,328 | `f6d9276e9fa4f060c7abdbe886786cf31a8911b62770f8a54b7581b7b99fa27e` | `qwen2.5o`, `qwen2.5vl_merger`, `qwen2a` | `Qwen2.5-Omni-3B-Q4_K_M.gguf` | `Qwen/Qwen2.5-Omni-3B@f75b40e3da2003cdd6e1829b1f420ca70797c34e` |
+| `glm4v-projector-f16` | `mradermacher/GLM-OCR-GGUF@3c1e642c0fa5df64831f0b04f3c674b57ce341af`<br>`GLM-OCR.mmproj-f16.gguf` | 869,018,080 | `fe5805b3b70f3174d25a912b8d197569eaa8e1e3e6d9777a385b8cc4c622af6c` | `glm4v` | `GLM-OCR.Q4_K_M.gguf` | `zai-org/GLM-OCR@ca5d8b3e287e52589e37c28385d9655ee4372f9d` |
 
 The five generic projector evidence pairs total **10,672,691,328 bytes** (sidecars plus paired text GGUFs), below the 16 GiB evidence budget. Runtime remains deferred; four routes have independent nonzero-weight graph parity, while MiniCPM resampler remains component-only and graph-deferred.
 
@@ -390,68 +400,68 @@ implementation work until tensor mapping and component parity are independently 
 
 <!-- BEGIN GGUF MMPROJ SUPPORT MATRIX (generated; see _mmproj_registry.py) -->
 
-| Projector string | Modality | Paired text architecture | Metadata/tensor/graph/runtime | Exactness/evidence |
-|---|---|---|---|---|
-| `adapter` | vision | `chatglm` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`glm-edge-v-2b-adapter-f16` |
-| `cogvlm` | vision | `cogvlm` | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `deepseekocr` | vision | `deepseek2-ocr` | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `deepseekocr2` | vision | `deepseek2-ocr` | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `dots3note_a` | audio | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `dots3note_v` | vision | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `dots_ocr` | vision | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `exaone4_5` | vision | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `gemma3` | vision | `gemma3` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`gemma3-4b-f16` |
-| `gemma3na` | audio | `gemma3n` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`gemma3n-e4b-f16` |
-| `gemma3nv` | vision | `gemma3n` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`gemma3n-e4b-f16` |
-| `gemma4a` | audio | `gemma4` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`gemma4-e2b-f16` |
-| `gemma4ua` | audio | `gemma4` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`gemma4-unified-12b-f16` |
-| `gemma4uv` | vision | `gemma4` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`gemma4-unified-12b-f16` |
-| `gemma4v` | vision | `gemma4` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`gemma4-e2b-f16` |
-| `glm4v` | vision | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `glma` | audio | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `granite4_vision` | vision | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `granite_speech` | audio | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `hunyuanvl` | vision | `hunyuan_vl` | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `idefics3` | vision | `llama` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`smolvlm-256m-idefics3-f16` |
-| `internvl` | vision | `qwen2` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`internvl25-1b-f16` |
-| `janus_pro` | vision | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `kimik25` | vision | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `kimivl` | vision | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `ldp` | vision | `llama` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`mobilevlm-1.7b-ldp-f16` |
-| `ldpv2` | vision | `llama` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`mobilevlm-v2-1.7b-ldpv2-f16` |
-| `lfm2` | vision | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `lfm2a` | audio | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `lightonocr` | vision | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `llama4` | vision | `llama4` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`llama4-scout-f16` |
-| `meralion` | audio | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `mimo_audio` | audio | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `mimovl` | vision | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `minicpmv4_6` | vision | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `minimax_m3` | vision | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `mlp` | vision | `llama` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`llava-llama3-8b-mlp-f16` |
-| `muse-glimmer` | vision | `muse-glimmer` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`muse-glimmer-30b-bf16` |
-| `musicflamingo` | audio | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `nemotron_v2_vl` | vision | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `paddleocr` | vision | `paddleocr` | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `parakeet` | audio | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `phi4` | vision | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `pixtral` | vision | `llama` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`pixtral-12b-f16` |
-| `pockettts_gen` | gen.audio | — | metadata=rejected; tensor_map=rejected; graph=rejected; runtime=rejected | CONFIG_REJECTED — The serialized architecture contract is deliberately refused. |
-| `pockettts_spkenc` | audio | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `qwen2.5o` | audio, vision | `qwen2vl` | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `qwen2.5vl_merger` | vision | `qwen2vl` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`qwen25-vl-3b-f16` |
-| `qwen2a` | audio | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `qwen2vl_merger` | vision | `qwen2vl` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`qwen2-vl-2b-f16` |
-| `qwen3a` | audio | `qwen3vl`, `qwen3vlmoe` | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `qwen3tts_gen` | gen.audio | — | metadata=rejected; tensor_map=rejected; graph=rejected; runtime=rejected | CONFIG_REJECTED — The serialized architecture contract is deliberately refused. |
-| `qwen3tts_spkenc` | audio | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `qwen3vl_merger` | vision | `qwen35`, `qwen35moe`, `qwen3vl`, `qwen3vlmoe` | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `resampler` | vision | `minicpm` | metadata=supported; tensor_map=supported; graph=deferred; runtime=deferred | artifact pins=`minicpm-v2-resampler-f16` |
-| `step3vl` | vision | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `ultravox` | audio | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `voxtral` | audio | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `yasa2` | vision | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
-| `youtuvl` | vision | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| Projector string | Modality | Graph role / route | Paired text architecture | Metadata/tensor/graph/runtime | Exactness/evidence |
+|---|---|---|---|---|---|
+| `adapter` | vision | paired package via `generic_projector` | `chatglm` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`glm-edge-v-2b-adapter-f16` |
+| `cogvlm` | vision | — | `cogvlm` | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `deepseekocr` | vision | — | `deepseek2-ocr` | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `deepseekocr2` | vision | — | `deepseek2-ocr` | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `dots3note_a` | audio | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `dots3note_v` | vision | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `dots_ocr` | vision | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `exaone4_5` | vision | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `gemma3` | vision | paired package via `gemma3` | `gemma3` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`gemma3-4b-f16` |
+| `gemma3na` | audio | audio_encoder via `core_vlm_projector` | `gemma3n` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`gemma3n-e4b-f16` |
+| `gemma3nv` | vision | vision_encoder via `core_vlm_projector` | `gemma3n` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`gemma3n-e4b-f16` |
+| `gemma4a` | audio | audio_encoder via `core_vlm_projector` | `gemma4` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`gemma4-e2b-f16` |
+| `gemma4ua` | audio | audio_encoder via `core_vlm_projector` | `gemma4` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`gemma4-unified-12b-f16` |
+| `gemma4uv` | vision | vision_encoder via `core_vlm_projector` | `gemma4` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`gemma4-unified-12b-f16` |
+| `gemma4v` | vision | paired package via `gemma4` | `gemma4` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`gemma4-e2b-f16` |
+| `glm4v` | vision | vision_encoder via `qwen_glm_projector` | `glm4`, `glm4moe` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`glm4v-projector-f16` |
+| `glma` | audio | audio_encoder via `qwen_glm_projector` | `llama` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | source evidence=`glma-converter-checkpoint-drift` |
+| `granite4_vision` | vision | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `granite_speech` | audio | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `hunyuanvl` | vision | — | `hunyuan_vl` | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `idefics3` | vision | vision_encoder via `core_vlm_projector` | `llama` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`smolvlm-256m-idefics3-f16` |
+| `internvl` | vision | vision_encoder via `core_vlm_projector` | `qwen2` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`internvl25-1b-f16` |
+| `janus_pro` | vision | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `kimik25` | vision | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `kimivl` | vision | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `ldp` | vision | paired package via `generic_projector` | `llama` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`mobilevlm-1.7b-ldp-f16` |
+| `ldpv2` | vision | paired package via `generic_projector` | `llama` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`mobilevlm-v2-1.7b-ldpv2-f16` |
+| `lfm2` | vision | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `lfm2a` | audio | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `lightonocr` | vision | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `llama4` | vision | vision_encoder via `core_vlm_projector` | `llama4` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`llama4-scout-f16` |
+| `meralion` | audio | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `mimo_audio` | audio | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `mimovl` | vision | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `minicpmv4_6` | vision | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `minimax_m3` | vision | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `mlp` | vision | paired package via `generic_projector` | `llama` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`llava-llama3-8b-mlp-f16` |
+| `muse-glimmer` | vision | paired package via `muse_glimmer` | `muse-glimmer` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`muse-glimmer-30b-bf16` |
+| `musicflamingo` | audio | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `nemotron_v2_vl` | vision | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `paddleocr` | vision | — | `paddleocr` | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `parakeet` | audio | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `phi4` | vision | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `pixtral` | vision | vision_encoder via `core_vlm_projector` | `llama` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`pixtral-12b-f16` |
+| `pockettts_gen` | gen.audio | — | — | metadata=rejected; tensor_map=rejected; graph=rejected; runtime=rejected | CONFIG_REJECTED — The serialized architecture contract is deliberately refused. |
+| `pockettts_spkenc` | audio | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `qwen2.5o` | audio, vision | vision_encoder, audio_encoder via `qwen_glm_projector` | `qwen2vl` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`qwen25-omni-projector-f16` |
+| `qwen2.5vl_merger` | vision | paired package via `qwen_vl` | `qwen2vl` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`qwen25-vl-3b-f16` |
+| `qwen2a` | audio | audio_encoder via `qwen_glm_projector` | `qwen2` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`qwen2-audio-projector-f16` |
+| `qwen2vl_merger` | vision | paired package via `qwen_vl` | `qwen2vl` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`qwen2-vl-2b-f16` |
+| `qwen3a` | audio | audio_encoder via `qwen_glm_projector` | `qwen3vl`, `qwen3vlmoe` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`qwen3-audio-projector-bf16` |
+| `qwen3tts_gen` | gen.audio | — | — | metadata=rejected; tensor_map=rejected; graph=rejected; runtime=rejected | CONFIG_REJECTED — The serialized architecture contract is deliberately refused. |
+| `qwen3tts_spkenc` | audio | speaker_encoder via `qwen_glm_projector` | `qwen3tts` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | source evidence=`qwen3tts-speaker-runtime-boundary` |
+| `qwen3vl_merger` | vision | vision_encoder via `qwen_glm_projector` | `qwen35`, `qwen35moe`, `qwen3vl`, `qwen3vlmoe` | metadata=supported; tensor_map=supported; graph=supported; runtime=deferred | artifact pins=`qwen3-vl-projector-f16` |
+| `resampler` | vision | paired package via `generic_projector` | `minicpm` | metadata=supported; tensor_map=supported; graph=deferred; runtime=deferred | artifact pins=`minicpm-v2-resampler-f16` |
+| `step3vl` | vision | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `ultravox` | audio | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `voxtral` | audio | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `yasa2` | vision | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
+| `youtuvl` | vision | — | — | metadata=deferred; tensor_map=deferred; graph=deferred; runtime=deferred | CONFIG_DEFERRED — Exact configuration ownership is not implemented. |
 
 <!-- END GGUF MMPROJ SUPPORT MATRIX -->
 

--- a/src/mobius/components/__init__.py
+++ b/src/mobius/components/__init__.py
@@ -39,6 +39,7 @@ __all__ = [
     "Gemma3nAudioEncoder",
     "Gemma3nMultimodalEmbedder",
     "GlmOcrVisionModel",
+    "Glm4VVisionModel",
     "GatedShortConv",
     "ClippableLinear",
     "GroupNorm",
@@ -57,6 +58,9 @@ __all__ = [
     "Llama4Projector",
     "Llama4VisionTower",
     "GGUFMLPProjector",
+    "GGUFLegacyGlmAudioProjector",
+    "GGUFQwen2AudioProjector",
+    "GGUFWhisperAudioTower",
     "GLMEdgeAdapterProjector",
     "LoRALinear",
     "MLP",
@@ -203,6 +207,12 @@ from mobius.components._gemma3n_audio import Gemma3nAudioEncoder
 from mobius.components._gemma3n_embedder import Gemma3nMultimodalEmbedder
 from mobius.components._gemma4_audio import ClippableLinear
 from mobius.components._gemma4_audio import Gemma4AudioEncoder as Gemma4AudioEncoder
+from mobius.components._gguf_audio_projectors import (
+    GGUFLegacyGlmAudioProjector,
+    GGUFQwen2AudioProjector,
+    GGUFWhisperAudioTower,
+)
+from mobius.components._glm4v_vision import Glm4VVisionModel
 from mobius.components._glm_ocr_vision import GlmOcrVisionModel
 from mobius.components._kimi_linear import KimiDeltaAttention, KimiMLAAttention
 from mobius.components._lightning_attention import (

--- a/src/mobius/components/_gguf_audio_projectors.py
+++ b/src/mobius/components/_gguf_audio_projectors.py
@@ -1,0 +1,214 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Reusable audio encoder/projectors used by GGUF ``clip`` sidecars."""
+
+from __future__ import annotations
+
+import onnx_ir as ir
+from onnxscript import OpBuilder, nn
+
+from mobius.components._activations import get_activation
+from mobius.components._common import LayerNorm, Linear
+from mobius.components._whisper import Conv1d, WhisperEncoderLayer
+
+
+class GGUFWhisperAudioTower(nn.Module):
+    """Whisper encoder stored by llama.cpp audio-projector sidecars.
+
+    The processor boundary is a log-mel tensor ``[B, n_mels, frames]``.
+    Qwen2-Audio enables the final two-frame average pool; legacy GLM-ASR
+    leaves the post-convolution sequence unpooled before its own frame stack.
+    """
+
+    def __init__(
+        self,
+        *,
+        num_mel_bins: int,
+        hidden_size: int,
+        intermediate_size: int,
+        num_hidden_layers: int,
+        num_attention_heads: int,
+        max_source_positions: int,
+        norm_eps: float,
+        average_pool: bool,
+    ) -> None:
+        super().__init__()
+        self.conv1 = Conv1d(num_mel_bins, hidden_size, kernel_size=3, padding=1)
+        self.conv2 = Conv1d(hidden_size, hidden_size, kernel_size=3, stride=2, padding=1)
+        self.position_embeddings = nn.Parameter([max_source_positions, hidden_size])
+        self.layers = nn.ModuleList(
+            [
+                WhisperEncoderLayer(
+                    hidden_size,
+                    num_attention_heads,
+                    intermediate_size,
+                    activation="gelu",
+                    eps=norm_eps,
+                )
+                for _ in range(num_hidden_layers)
+            ]
+        )
+        self.post_layernorm = LayerNorm(hidden_size, eps=norm_eps)
+        self._average_pool = average_pool
+
+    def forward(self, op: OpBuilder, input_features: ir.Value) -> ir.Value:
+        input_features = op.CastLike(input_features, self.conv1.weight)
+        hidden_states = op.Gelu(self.conv1(op, input_features), approximate="none")
+        hidden_states = op.Gelu(self.conv2(op, hidden_states), approximate="none")
+        hidden_states = op.Transpose(hidden_states, perm=[0, 2, 1])
+        # [B, ceil(frames / 2), hidden]
+
+        sequence_length = op.Shape(hidden_states, start=1, end=2)
+        positions = op.Slice(
+            self.position_embeddings,
+            op.Constant(value_ints=[0]),
+            sequence_length,
+            op.Constant(value_ints=[0]),
+        )
+        hidden_states = op.Add(hidden_states, op.CastLike(positions, hidden_states))
+        for layer in self.layers:
+            hidden_states = layer(op, hidden_states)
+
+        if self._average_pool:
+            hidden_states = op.Transpose(hidden_states, perm=[0, 2, 1])
+            hidden_states = op.AveragePool(
+                hidden_states,
+                kernel_shape=[2],
+                strides=[2],
+            )
+            hidden_states = op.Transpose(hidden_states, perm=[0, 2, 1])
+            # [B, floor(ceil(frames / 2) / 2), hidden]
+        return self.post_layernorm(op, hidden_states)
+
+
+class GGUFQwen2AudioProjector(nn.Module):
+    """Qwen2-Audio Whisper tower followed by one text-width affine projection."""
+
+    def __init__(
+        self,
+        *,
+        num_mel_bins: int,
+        hidden_size: int,
+        intermediate_size: int,
+        num_hidden_layers: int,
+        num_attention_heads: int,
+        max_source_positions: int,
+        output_size: int,
+        norm_eps: float = 1e-5,
+    ) -> None:
+        super().__init__()
+        self.audio_tower = GGUFWhisperAudioTower(
+            num_mel_bins=num_mel_bins,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_hidden_layers=num_hidden_layers,
+            num_attention_heads=num_attention_heads,
+            max_source_positions=max_source_positions,
+            norm_eps=norm_eps,
+            average_pool=True,
+        )
+        self.projection = Linear(hidden_size, output_size, bias=True)
+        self.input_schema = (
+            (
+                "input_features",
+                ir.DataType.FLOAT,
+                (1, num_mel_bins, 2 * max_source_positions),
+            ),
+        )
+
+    def forward(self, op: OpBuilder, input_features: ir.Value) -> ir.Value:
+        projected = self.projection(op, self.audio_tower(op, input_features))
+        return op.Squeeze(projected, [0])
+
+
+class GGUFLegacyGlmAudioProjector(nn.Module):
+    """Legacy llama.cpp GLMA Whisper tower and boundary-token projector.
+
+    This component documents and tests the serialized graph. The current
+    GLM-ASR checkpoint instead uses partial RoPE and cannot be converted into
+    this legacy topology, so registry dispatch remains fail-closed.
+    """
+
+    def __init__(
+        self,
+        *,
+        num_mel_bins: int,
+        hidden_size: int,
+        intermediate_size: int,
+        num_hidden_layers: int,
+        num_attention_heads: int,
+        max_source_positions: int,
+        stack_factor: int,
+        projector_intermediate_size: int,
+        output_size: int,
+        norm_eps: float = 1e-5,
+        activation: str = "gelu",
+    ) -> None:
+        super().__init__()
+        if stack_factor <= 0:
+            raise ValueError("GLMA stack factor must be positive")
+        self.audio_tower = GGUFWhisperAudioTower(
+            num_mel_bins=num_mel_bins,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_hidden_layers=num_hidden_layers,
+            num_attention_heads=num_attention_heads,
+            max_source_positions=max_source_positions,
+            norm_eps=norm_eps,
+            average_pool=False,
+        )
+        self.pre_projector_norm = LayerNorm(hidden_size, eps=norm_eps)
+        self.linear_1 = Linear(
+            hidden_size * stack_factor,
+            projector_intermediate_size,
+            bias=True,
+        )
+        self.linear_2 = Linear(projector_intermediate_size, output_size, bias=True)
+        self.boi = nn.Parameter([output_size])
+        self.eoi = nn.Parameter([output_size])
+        self._activation = get_activation(activation)
+        self._stack_factor = stack_factor
+        self._hidden_size = hidden_size
+        self._output_size = output_size
+        self.input_schema = (
+            (
+                "input_features",
+                ir.DataType.FLOAT,
+                (1, num_mel_bins, 2 * max_source_positions),
+            ),
+        )
+
+    def _stack_frames(self, op: OpBuilder, hidden_states: ir.Value) -> ir.Value:
+        sequence_length = op.Squeeze(op.Shape(hidden_states, start=1, end=2), [0])
+        factor = op.Constant(value_int=self._stack_factor)
+        remainder = op.Mod(sequence_length, factor)
+        pad_length = op.Mod(op.Sub(factor, remainder), factor)
+        pads = op.Concat(
+            op.Constant(value_ints=[0, 0, 0, 0]),
+            op.Reshape(pad_length, [1]),
+            op.Constant(value_ints=[0]),
+            axis=0,
+        )
+        hidden_states = op.Pad(hidden_states, pads)
+        return op.Reshape(
+            hidden_states,
+            [0, -1, self._hidden_size * self._stack_factor],
+        )
+
+    def forward(self, op: OpBuilder, input_features: ir.Value) -> ir.Value:
+        hidden_states = self.pre_projector_norm(
+            op,
+            self.audio_tower(op, input_features),
+        )
+        hidden_states = self._stack_frames(op, hidden_states)
+        hidden_states = self.linear_2(
+            op,
+            self._activation(op, self.linear_1(op, hidden_states)),
+        )
+
+        batch = op.Shape(hidden_states, start=0, end=1)
+        boundary_shape = op.Concat(batch, [1, self._output_size], axis=0)
+        boi = op.Expand(op.Reshape(self.boi, [1, 1, self._output_size]), boundary_shape)
+        eoi = op.Expand(op.Reshape(self.eoi, [1, 1, self._output_size]), boundary_shape)
+        return op.Squeeze(op.Concat(boi, hidden_states, eoi, axis=1), [0])

--- a/src/mobius/components/_glm4v_vision.py
+++ b/src/mobius/components/_glm4v_vision.py
@@ -1,0 +1,377 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""GLM4V packed vision encoder and gated projector."""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any
+
+import onnx_ir as ir
+from onnxscript import OpBuilder, nn
+
+from mobius.components._common import LayerNorm, Linear
+from mobius.components._conv import Conv2d
+from mobius.components._glm_ocr_vision import (
+    GlmOcrVisionModel,
+    GlmOcrVisionPatchEmbed,
+    GlmOcrVisionRotaryEmbedding,
+)
+from mobius.components._mlp import GatedMLP
+from mobius.components._qwen25_vl_vision import Qwen25VLVisionAttention
+from mobius.components._rms_norm import RMSNorm
+from mobius.components._scan_utils import (
+    compact_scan_output,
+    create_body_graph,
+    rename_subgraph_values,
+)
+
+if TYPE_CHECKING:
+    pass
+
+
+class Glm4VVisionAttention(Qwen25VLVisionAttention):
+    """GLM4V packed attention with bias-free QKV and output projections."""
+
+    def __init__(self, hidden_size: int, num_heads: int) -> None:
+        nn.Module.__init__(self)
+        self.num_heads = num_heads
+        self.head_dim = hidden_size // num_heads
+        self.qkv = Linear(hidden_size, hidden_size * 3, bias=False)
+        self.proj = Linear(hidden_size, hidden_size, bias=False)
+
+
+class Glm4VVisionBlock(nn.Module):
+    """RMS-pre-norm GLM4V vision transformer block."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        num_heads: int,
+        norm_eps: float,
+        hidden_act: str,
+    ) -> None:
+        super().__init__()
+        self.norm1 = RMSNorm(hidden_size, eps=norm_eps)
+        self.norm2 = RMSNorm(hidden_size, eps=norm_eps)
+        self.attn = Glm4VVisionAttention(hidden_size, num_heads)
+        self.mlp = GatedMLP(
+            hidden_size,
+            intermediate_size,
+            activation=hidden_act,
+            bias=False,
+        )
+
+    def forward(
+        self,
+        op: OpBuilder,
+        hidden_states: ir.Value,
+        cu_seqlens: ir.Value,
+        cos: ir.Value,
+        sin: ir.Value,
+    ) -> ir.Value:
+        residual = hidden_states
+        hidden_states = self.attn(
+            op,
+            self.norm1(op, hidden_states),
+            cu_seqlens=cu_seqlens,
+            cos=cos,
+            sin=sin,
+        )
+        hidden_states = op.Add(residual, hidden_states)
+
+        residual = hidden_states
+        hidden_states = self.mlp(op, self.norm2(op, hidden_states))
+        return op.Add(residual, hidden_states)
+
+
+class Glm4VVisionPatchMerger(nn.Module):
+    """GLM4V post-downsample projection, norm, GELU, and gated MLP."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        *,
+        hidden_act: str,
+    ) -> None:
+        super().__init__()
+        self.proj = Linear(hidden_size, hidden_size, bias=False)
+        self.post_projection_norm = LayerNorm(hidden_size, eps=1e-5)
+        self.gate_proj = Linear(hidden_size, intermediate_size, bias=False)
+        self.up_proj = Linear(hidden_size, intermediate_size, bias=False)
+        self.down_proj = Linear(intermediate_size, hidden_size, bias=False)
+        self._hidden_act = hidden_act
+
+    def forward(self, op: OpBuilder, hidden_states: ir.Value) -> ir.Value:
+        hidden_states = self.proj(op, hidden_states)
+        hidden_states = op.Gelu(
+            self.post_projection_norm(op, hidden_states),
+            approximate="none",
+        )
+        gate = self.gate_proj(op, hidden_states)
+        gate = (
+            op.Mul(gate, op.Sigmoid(gate))
+            if self._hidden_act == "silu"
+            else op.Gelu(gate, approximate="none")
+        )
+        return self.down_proj(op, op.Mul(gate, self.up_proj(op, hidden_states)))
+
+
+class Glm4VVisionModel(GlmOcrVisionModel):
+    """Dynamic-resolution GLM4V ViT, 2x2 downsampler, and gated projector."""
+
+    def __init__(
+        self,
+        *,
+        depth: int,
+        hidden_size: int,
+        intermediate_size: int,
+        num_heads: int,
+        patch_size: int,
+        temporal_patch_size: int,
+        in_channels: int,
+        out_hidden_size: int,
+        spatial_merge_size: int,
+        norm_eps: float,
+        hidden_act: str = "silu",
+        num_position_embeddings: int | None = None,
+        projector_intermediate_size: int | None = None,
+    ) -> None:
+        nn.Module.__init__(self)
+        if spatial_merge_size != 2:
+            raise ValueError("GLM4V requires a 2x2 spatial merge")
+        if hidden_size % num_heads:
+            raise ValueError("GLM4V hidden size must be divisible by its head count")
+        self._spatial_merge_size = spatial_merge_size
+        self._spatial_merge_unit = spatial_merge_size**2
+        self._hidden_size = hidden_size
+        self._out_hidden_size = out_hidden_size
+
+        self.patch_embed: Any = GlmOcrVisionPatchEmbed(
+            patch_size=patch_size,
+            temporal_patch_size=temporal_patch_size,
+            in_channels=in_channels,
+            hidden_size=hidden_size,
+        )
+        self.post_conv_layernorm = RMSNorm(hidden_size, eps=norm_eps)
+        self.position_embeddings: nn.Parameter | None
+        if num_position_embeddings is None:
+            self.position_embeddings = None
+            self._position_grid_size = None
+        else:
+            position_grid = math.isqrt(num_position_embeddings)
+            if position_grid * position_grid != num_position_embeddings:
+                raise ValueError("GLM4V learned position rows must form a square grid")
+            self.position_embeddings = nn.Parameter([num_position_embeddings, hidden_size])
+            self._position_grid_size = position_grid
+
+        head_dim = hidden_size // num_heads
+        self.rotary_pos_emb: Any = GlmOcrVisionRotaryEmbedding(head_dim // 2)
+        self.blocks = nn.ModuleList(
+            [
+                Glm4VVisionBlock(
+                    hidden_size,
+                    intermediate_size,
+                    num_heads,
+                    norm_eps,
+                    hidden_act,
+                )
+                for _ in range(depth)
+            ]
+        )
+        self.post_layernorm = RMSNorm(hidden_size, eps=norm_eps)
+        self.downsample = Conv2d(
+            hidden_size,
+            out_hidden_size,
+            kernel_size=spatial_merge_size,
+            stride=spatial_merge_size,
+        )
+        self.merger: Any = Glm4VVisionPatchMerger(
+            out_hidden_size,
+            projector_intermediate_size or intermediate_size,
+            hidden_act=hidden_act,
+        )
+
+    def _guard_grid_contract(
+        self,
+        op: OpBuilder,
+        pixel_values: ir.Value,
+        grid_thw: ir.Value,
+    ) -> ir.Value:
+        temporal = op.Slice(grid_thw, [0], [1], [1], [1])
+        height = op.Slice(grid_thw, [1], [2], [1], [1])
+        width = op.Slice(grid_thw, [2], [3], [1], [1])
+        merge = op.Constant(value_int=self._spatial_merge_size)
+        invalid = op.Or(
+            op.LessOrEqual(grid_thw, op.Constant(value_int=0)),
+            op.Concat(
+                op.Equal(temporal, op.Constant(value_int=-1)),
+                op.Not(op.Equal(op.Mod(height, merge), op.Constant(value_int=0))),
+                op.Not(op.Equal(op.Mod(width, merge), op.Constant(value_int=0))),
+                axis=1,
+            ),
+        )
+        invalid_count = op.ReduceSum(op.Cast(invalid, to=ir.DataType.INT64), keepdims=False)
+        expected_patches = op.ReduceSum(
+            op.Mul(temporal, op.Mul(height, width)),
+            keepdims=False,
+        )
+        actual_patches = op.Squeeze(op.Shape(pixel_values, start=0, end=1), [0])
+        invalid_count = op.Add(
+            invalid_count,
+            op.Cast(op.Not(op.Equal(expected_patches, actual_patches)), to=ir.DataType.INT64),
+        )
+        guard = op.Gather(
+            op.Constant(value_ints=[0]),
+            invalid_count,
+            axis=0,
+        )
+        return op.Add(pixel_values, op.CastLike(guard, pixel_values))
+
+    def _interpolate_position_embeddings(
+        self,
+        op: OpBuilder,
+        image_grid_thw: ir.Value,
+    ) -> ir.Value | None:
+        if self.position_embeddings is None or self._position_grid_size is None:
+            return None
+
+        hidden_size = self._hidden_size
+        merge = self._spatial_merge_size
+        source_grid = self._position_grid_size
+        temporal = op.Squeeze(
+            op.Slice(image_grid_thw, [0], [1], [1], [1]),
+            [1],
+        )
+        height = op.Squeeze(
+            op.Slice(image_grid_thw, [1], [2], [1], [1]),
+            [1],
+        )
+        width = op.Squeeze(
+            op.Slice(image_grid_thw, [2], [3], [1], [1]),
+            [1],
+        )
+        patch_counts = op.Mul(temporal, op.Mul(height, width))
+        max_patches = op.ReduceMax(patch_counts, keepdims=False)
+
+        body_thw = ir.Value(
+            name="body_thw",
+            shape=ir.Shape([3]),
+            type=ir.TensorType(ir.DataType.INT64),
+        )
+        body_graph, body_builder = create_body_graph([], [body_thw])
+        body_op = body_builder.op
+        body_t = body_op.Squeeze(body_op.Gather(body_thw, 0))
+        body_h = body_op.Squeeze(body_op.Gather(body_thw, 1))
+        body_w = body_op.Squeeze(body_op.Gather(body_thw, 2))
+
+        position_grid = body_op.Reshape(
+            self.position_embeddings,
+            [1, source_grid, source_grid, hidden_size],
+        )
+        position_grid = body_op.Transpose(position_grid, perm=[0, 3, 1, 2])
+        resize_shape = body_op.Concat(
+            body_op.Constant(value_ints=[1, hidden_size]),
+            body_op.Reshape(body_h, [1]),
+            body_op.Reshape(body_w, [1]),
+            axis=0,
+        )
+        resized = body_op.Resize(
+            position_grid,
+            None,
+            None,
+            resize_shape,
+            mode="cubic",
+            coordinate_transformation_mode="half_pixel",
+            cubic_coeff_a=-0.75,
+        )
+        resized = body_op.Reshape(
+            body_op.Transpose(resized, perm=[0, 2, 3, 1]),
+            [-1, hidden_size],
+        )
+        resized = body_op.Tile(
+            resized,
+            body_op.Concat(
+                body_op.Reshape(body_t, [1]),
+                body_op.Constant(value_ints=[1]),
+                axis=0,
+            ),
+        )
+
+        body_hm = body_op.Div(body_h, body_op.Constant(value_int=merge))
+        body_wm = body_op.Div(body_w, body_op.Constant(value_int=merge))
+        merged_shape = body_op.Concat(
+            body_op.Reshape(body_t, [1]),
+            body_op.Reshape(body_hm, [1]),
+            body_op.Constant(value_ints=[merge]),
+            body_op.Reshape(body_wm, [1]),
+            body_op.Constant(value_ints=[merge, hidden_size]),
+            axis=0,
+        )
+        resized = body_op.Reshape(resized, merged_shape)
+        resized = body_op.Transpose(resized, perm=[0, 1, 3, 2, 4, 5])
+        resized = body_op.Reshape(resized, [-1, hidden_size])
+
+        body_count = body_op.Mul(body_t, body_op.Mul(body_h, body_w))
+        pad_length = body_op.Reshape(body_op.Sub(max_patches, body_count), [1])
+        pads = body_op.Concat(
+            body_op.Constant(value_ints=[0, 0]),
+            pad_length,
+            body_op.Constant(value_ints=[0]),
+            axis=0,
+        )
+        padded = body_op.Pad(resized, pads, 0.0)
+        padded.name = "padded_glm4v_positions"
+        body_graph.outputs.append(padded)
+        rename_subgraph_values(body_graph, "glm4v_position_body_")
+
+        scanned = op.Scan(
+            image_grid_thw,
+            body=body_graph,
+            num_scan_inputs=1,
+            _outputs=1,
+        )
+        return compact_scan_output(op, scanned, patch_counts)
+
+    def forward(
+        self,
+        op: OpBuilder,
+        pixel_values: ir.Value,
+        image_grid_thw: ir.Value,
+    ) -> ir.Value:
+        pixel_values = self._guard_grid_contract(op, pixel_values, image_grid_thw)
+        hidden_states = self.patch_embed(op, pixel_values)
+        hidden_states = self.post_conv_layernorm(op, hidden_states)
+
+        position_ids = self._compute_rotary_pos_ids(op, image_grid_thw)
+        cu_seqlens = self._compute_cu_seqlens(op, image_grid_thw)
+        cos, sin = self.rotary_pos_emb(op, position_ids)
+        learned_positions = self._interpolate_position_embeddings(op, image_grid_thw)
+        if learned_positions is not None:
+            hidden_states = op.Add(
+                hidden_states,
+                op.CastLike(learned_positions, hidden_states),
+            )
+
+        for block in self.blocks:
+            hidden_states = block(
+                op,
+                hidden_states,
+                cu_seqlens=cu_seqlens,
+                cos=cos,
+                sin=sin,
+            )
+        hidden_states = self.post_layernorm(op, hidden_states)
+
+        merge = self._spatial_merge_size
+        hidden_states = op.Reshape(
+            hidden_states,
+            [-1, merge, merge, self._hidden_size],
+        )
+        hidden_states = op.Transpose(hidden_states, perm=[0, 3, 1, 2])
+        hidden_states = self.downsample(op, hidden_states)
+        hidden_states = op.Reshape(hidden_states, [-1, self._out_hidden_size])
+        return self.merger(op, hidden_states)

--- a/src/mobius/components/_qwen3_vl_vision.py
+++ b/src/mobius/components/_qwen3_vl_vision.py
@@ -95,7 +95,7 @@ class Qwen3VLVisionRotaryEmbedding(nn.Module):
         dim = head_dim // 2
         inv_freq = 1.0 / (10000.0 ** (np.arange(0, dim, 2, dtype=np.float32) / dim))
 
-        pos = np.arange(0, max_grid_size, dtype=np.float32)
+        pos: np.ndarray = np.arange(0, max_grid_size, dtype=np.float32)
         angles = np.outer(pos, inv_freq)
         cos_table = np.cos(angles).astype(np.float32)
         sin_table = np.sin(angles).astype(np.float32)
@@ -378,10 +378,12 @@ class Qwen3VLPatchMerger(nn.Module):
         out_hidden_size: int,
         spatial_merge_size: int = 2,
         use_postshuffle_norm: bool = False,
+        gelu_approximate: str = "none",
     ):
         super().__init__()
         self.merged_size = hidden_size * (spatial_merge_size**2)
         self.use_postshuffle_norm = use_postshuffle_norm
+        self.gelu_approximate = gelu_approximate
 
         norm_dim = self.merged_size if use_postshuffle_norm else hidden_size
         self.norm = LayerNorm(norm_dim, eps=1e-6)
@@ -399,7 +401,7 @@ class Qwen3VLPatchMerger(nn.Module):
             x = op.Reshape(x, [-1, self.merged_size])
 
         x = self.linear_fc1(op, x)
-        x = op.Gelu(x, approximate="none")
+        x = op.Gelu(x, approximate=self.gelu_approximate)
         return self.linear_fc2(op, x)
 
 
@@ -500,6 +502,7 @@ class Qwen3VLVisionModel(nn.Module):
         spatial_merge_size: int = 2,
         num_position_embeddings: int = 2304,
         deepstack_visual_indexes: list[int] | None = None,
+        merger_gelu_approximate: str = "none",
     ):
         super().__init__()
         if out_hidden_size is None:
@@ -544,6 +547,7 @@ class Qwen3VLVisionModel(nn.Module):
             out_hidden_size=out_hidden_size,
             spatial_merge_size=spatial_merge_size,
             use_postshuffle_norm=False,
+            gelu_approximate=merger_gelu_approximate,
         )
 
         self.deepstack_merger_list = nn.ModuleList(
@@ -553,6 +557,7 @@ class Qwen3VLVisionModel(nn.Module):
                     out_hidden_size=out_hidden_size,
                     spatial_merge_size=spatial_merge_size,
                     use_postshuffle_norm=True,
+                    gelu_approximate=merger_gelu_approximate,
                 )
                 for _ in range(len(deepstack_visual_indexes))
             ]

--- a/src/mobius/components/_qwen3_vl_vision.py
+++ b/src/mobius/components/_qwen3_vl_vision.py
@@ -337,13 +337,19 @@ class Qwen3VLVisionBlock(nn.Module):
     Structure: LayerNorm → Attention → Residual → LayerNorm → MLP → Residual.
     """
 
-    def __init__(self, hidden_size: int, intermediate_size: int, num_heads: int):
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        num_heads: int,
+        *,
+        activation: str = "gelu_new",
+    ):
         super().__init__()
         self.norm1 = LayerNorm(hidden_size, eps=1e-6)
         self.attn = Qwen3VLVisionAttention(hidden_size, num_heads)
         self.norm2 = LayerNorm(hidden_size, eps=1e-6)
-        # GELU (tanh approx) MLP with bias (HF linear_fc1/linear_fc2 → up_proj/down_proj)
-        self.mlp = FCMLP(hidden_size, intermediate_size, activation="gelu_new", bias=True)
+        self.mlp = FCMLP(hidden_size, intermediate_size, activation=activation, bias=True)
 
     def forward(
         self,
@@ -502,6 +508,7 @@ class Qwen3VLVisionModel(nn.Module):
         spatial_merge_size: int = 2,
         num_position_embeddings: int = 2304,
         deepstack_visual_indexes: list[int] | None = None,
+        block_activation: str = "gelu_new",
         merger_gelu_approximate: str = "none",
     ):
         super().__init__()
@@ -537,7 +544,12 @@ class Qwen3VLVisionModel(nn.Module):
 
         self.blocks = nn.ModuleList(
             [
-                Qwen3VLVisionBlock(hidden_size, intermediate_size, num_heads)
+                Qwen3VLVisionBlock(
+                    hidden_size,
+                    intermediate_size,
+                    num_heads,
+                    activation=block_activation,
+                )
                 for _ in range(depth)
             ]
         )

--- a/src/mobius/integrations/gguf/_docs.py
+++ b/src/mobius/integrations/gguf/_docs.py
@@ -225,10 +225,10 @@ def _qtypes() -> str:
 def _projectors() -> str:
     rows = [
         (
-            "| Projector string | Modality | Paired text architecture | "
+            "| Projector string | Modality | Graph role / route | Paired text architecture | "
             "Metadata/tensor/graph/runtime | Exactness/evidence |"
         ),
-        "|---|---|---|---|---|",
+        "|---|---|---|---|---|---|",
     ]
     for spec in sorted(iter_projector_specs(), key=lambda item: item.projector_type):
         modalities = ", ".join(
@@ -237,13 +237,25 @@ def _projectors() -> str:
         targets = (
             ", ".join(f"`{target}`" for target in sorted(spec.target_architectures)) or "—"
         )
-        evidence = (
-            "artifact pins=" + ", ".join(f"`{item}`" for item in spec.real_artifact_ids)
-            if spec.real_artifact_ids
-            else _reason_code(dict(spec.verdicts))
+        roles = ", ".join(role.value for role in spec.model_roles)
+        route = (
+            f"{roles or 'paired package'} via `{spec.sidecar_builder or spec.builder}`"
+            if spec.sidecar_builder or spec.builder
+            else "—"
         )
+        evidence_parts = []
+        if spec.real_artifact_ids:
+            evidence_parts.append(
+                "artifact pins=" + ", ".join(f"`{item}`" for item in spec.real_artifact_ids)
+            )
+        if spec.source_evidence_ids:
+            evidence_parts.append(
+                "source evidence="
+                + ", ".join(f"`{item}`" for item in spec.source_evidence_ids)
+            )
+        evidence = "; ".join(evidence_parts) or _reason_code(dict(spec.verdicts))
         rows.append(
-            f"| `{spec.projector_type}` | {modalities} | {targets} | "
+            f"| `{spec.projector_type}` | {modalities} | {_cell(route)} | {targets} | "
             f"{_cell(_status(dict(spec.verdicts)))} | {_cell(evidence or 'none')} |"
         )
     return "\n".join(rows)
@@ -688,6 +700,11 @@ the original immutable GGUF at runtime. Runtime packages additionally require an
 artifact, graph, tokenizer, runtime version, parity proof, and deterministic state/generation
 evidence match.
 Processor-owned `image_token_id` overrides are forwarded unchanged for `mmproj=` packages.
+
+Use `build_mmproj_from_gguf("mmproj.gguf", projector_type=..., target_architecture=...)`
+to export a registry-evidenced standalone `vision_encoder`, `audio_encoder`, or
+`speaker_encoder`. It never invents decoder, media-mixing, or generated-audio roles and
+warns while downstream runtime orchestration remains unvalidated.
 
 ## Runtime evidence
 

--- a/src/mobius/integrations/gguf/_docs_test.py
+++ b/src/mobius/integrations/gguf/_docs_test.py
@@ -39,7 +39,7 @@ def test_document_is_exact_generator_output() -> None:
 
 def test_document_is_concise_and_reason_coded() -> None:
     document = Path("docs/api/build_from_gguf.md").read_text(encoding="utf-8")
-    assert len(document.splitlines()) < 585
+    assert len(document.splitlines()) < 600
     assert "RUNTIME_EVIDENCE_PENDING" in document
     assert "qwen3.5-0.8b-q4-tokenizer" in document
     assert "qwen2.5-0.5b-instruct-q8-tokenizer" in document

--- a/src/mobius/integrations/gguf/_mmproj.py
+++ b/src/mobius/integrations/gguf/_mmproj.py
@@ -34,6 +34,7 @@ __all__ = [
     "build_gemma3_vlm_from_gguf",
     "build_gemma4_vlm_from_gguf",
     "build_mmproj_from_gguf",
+    "build_qwen_glm_projector_from_gguf",
     "build_qwen_vlm_from_gguf",
     "build_vlm_from_gguf",
     "build_muse_glimmer_vlm_from_gguf",
@@ -516,6 +517,7 @@ def _validate_block_tensor_set(
     blocks: dict[int, set[str]],
     block_count: int,
     required_suffixes: tuple[str, ...],
+    suffix_variants: tuple[tuple[str, ...], ...] = (),
 ) -> None:
     expected_layers = set(range(block_count))
     if set(blocks) != expected_layers:
@@ -523,6 +525,20 @@ def _validate_block_tensor_set(
             f"{projector_type} {modality.value} block indices are "
             f"{sorted(blocks)}, expected {sorted(expected_layers)}."
         )
+    if suffix_variants:
+        variants = tuple(set(variant) for variant in suffix_variants)
+        mismatched = {
+            layer: sorted(blocks[layer])
+            for layer in sorted(blocks)
+            if not any(blocks[layer] == variant for variant in variants)
+        }
+        if mismatched:
+            raise ValueError(
+                f"{projector_type} mmproj has unsupported {modality.value} block "
+                f"suffix variants: {mismatched}"
+            )
+        return
+
     required = set(required_suffixes)
     missing = {
         layer: sorted(required - blocks[layer])
@@ -573,10 +589,19 @@ def _validate_mmproj_tensor_closure(mmproj_gguf: Any, spec: ProjectorSpec) -> No
         block_names: dict[int, set[str]] = {}
         matched: set[str] = set()
     else:
+        allowed_suffixes = (
+            tuple(
+                sorted(
+                    {suffix for variant in spec.block_suffix_variants for suffix in variant}
+                )
+            )
+            if spec.block_suffix_variants
+            else spec.block_suffixes
+        )
         block_names, matched = _collect_block_tensors(
             names,
             prefix=spec.block_prefix,
-            suffixes=spec.block_suffixes,
+            suffixes=allowed_suffixes,
         )
     for pattern in spec.auxiliary_tensor_patterns:
         expression = re.compile(pattern)
@@ -675,6 +700,7 @@ def _validate_mmproj_tensor_closure(mmproj_gguf: Any, spec: ProjectorSpec) -> No
             blocks=block_names,
             block_count=layers,
             required_suffixes=spec.block_suffixes,
+            suffix_variants=spec.block_suffix_variants,
         )
 
     for name in sorted(names):
@@ -1216,6 +1242,15 @@ def build_mmproj_from_gguf(
         raise RuntimeError(
             f"{projector_type} standalone builder produced components "
             f"{sorted(package)}, expected {sorted(expected_roles)}."
+        )
+    if spec.runtime is not Support.SUPPORTED:
+        logger.warning(
+            "Built standalone %s graph component(s) for clip projector %r; "
+            "downstream runtime orchestration is %s: %s",
+            ", ".join(sorted(expected_roles)),
+            projector_type,
+            spec.runtime.value,
+            spec.reason,
         )
     return package
 
@@ -3078,6 +3113,45 @@ def build_muse_glimmer_vlm_from_gguf(
     return pkg
 
 
+def build_qwen_glm_projector_from_gguf(
+    mmproj_gguf_path: str | Path,
+    *,
+    projector_type: str,
+    target_architecture: str,
+    dtype: str | None = None,
+    execution_provider: str = "default",
+    _mmproj_gguf_model: Any | None = None,
+) -> ModelPackage:
+    """Build the exact standalone Qwen/GLM vision, audio, or speaker roles."""
+    from mobius.integrations.gguf._builder import _validate_gguf_model
+    from mobius.integrations.gguf._qwen_glm_projector import (
+        build_qwen_glm_projector_package,
+    )
+    from mobius.integrations.gguf._reader import GGUFModel
+
+    resolved_path = _resolve_mmproj_companion_path(mmproj_gguf_path)
+    mmproj_gguf = (
+        _mmproj_gguf_model if _mmproj_gguf_model is not None else GGUFModel(resolved_path)
+    )
+    _validate_gguf_model(
+        mmproj_gguf,
+        source=str(mmproj_gguf_path),
+        allow_mmproj_companion=True,
+    )
+    _preflight_standalone_mmproj(
+        mmproj_gguf,
+        projector_type=projector_type,
+        target_architecture=target_architecture,
+    )
+    return build_qwen_glm_projector_package(
+        mmproj_gguf,
+        resolved_path=resolved_path,
+        projector_type=projector_type,
+        dtype=dtype,
+        execution_provider=execution_provider,
+    )
+
+
 def build_vlm_from_gguf(
     text_gguf_path: str | Path,
     mmproj_gguf_path: str | Path,
@@ -3154,7 +3228,8 @@ def _build_core_vlm_projector_mmproj(*args, **kwargs) -> ModelPackage:
 
 
 _MMPROJ_BUILDERS: dict[str, str] = {
-    "core_vlm_projector": "_build_core_vlm_projector_mmproj",
+   "core_vlm_projector": "_build_core_vlm_projector_mmproj",
+   "qwen_glm_projector": "build_qwen_glm_projector_from_gguf",
 }
 
 

--- a/src/mobius/integrations/gguf/_mmproj.py
+++ b/src/mobius/integrations/gguf/_mmproj.py
@@ -3134,26 +3134,28 @@ def build_qwen_glm_projector_from_gguf(
     _mmproj_gguf_model: Any | None = None,
 ) -> ModelPackage:
     """Build the exact standalone Qwen/GLM vision, audio, or speaker roles."""
-    from mobius.integrations.gguf._builder import _validate_gguf_model
     from mobius.integrations.gguf._qwen_glm_projector import (
         build_qwen_glm_projector_package,
     )
-    from mobius.integrations.gguf._reader import GGUFModel
 
-    resolved_path = _resolve_mmproj_companion_path(mmproj_gguf_path)
-    mmproj_gguf = (
-        _mmproj_gguf_model if _mmproj_gguf_model is not None else GGUFModel(resolved_path)
-    )
-    _validate_gguf_model(
-        mmproj_gguf,
-        source=str(mmproj_gguf_path),
-        allow_mmproj_companion=True,
-    )
-    _preflight_standalone_mmproj(
-        mmproj_gguf,
-        projector_type=projector_type,
-        target_architecture=target_architecture,
-    )
+    resolved_path = Path(mmproj_gguf_path)
+    mmproj_gguf = _mmproj_gguf_model
+    if mmproj_gguf is None:
+        from mobius.integrations.gguf._builder import _validate_gguf_model
+        from mobius.integrations.gguf._reader import GGUFModel
+
+        resolved_path = _resolve_mmproj_companion_path(mmproj_gguf_path)
+        mmproj_gguf = GGUFModel(resolved_path)
+        _validate_gguf_model(
+            mmproj_gguf,
+            source=str(mmproj_gguf_path),
+            allow_mmproj_companion=True,
+        )
+        _preflight_standalone_mmproj(
+            mmproj_gguf,
+            projector_type=projector_type,
+            target_architecture=target_architecture,
+        )
     return build_qwen_glm_projector_package(
         mmproj_gguf,
         resolved_path=resolved_path,
@@ -3227,6 +3229,7 @@ _VLM_BUILDERS: dict[str, str] = {
     "qwen_vl": "build_qwen_vlm_from_gguf",
 }
 
+
 #: Standalone sidecar graph entry points selected by
 #: :attr:`ProjectorSpec.sidecar_builder`. Unlike ``_VLM_BUILDERS``, these
 #: functions never create or silently omit a paired text decoder.
@@ -3239,8 +3242,8 @@ def _build_core_vlm_projector_mmproj(*args, **kwargs) -> ModelPackage:
 
 
 _MMPROJ_BUILDERS: dict[str, str] = {
-   "core_vlm_projector": "_build_core_vlm_projector_mmproj",
-   "qwen_glm_projector": "build_qwen_glm_projector_from_gguf",
+    "core_vlm_projector": "_build_core_vlm_projector_mmproj",
+    "qwen_glm_projector": "build_qwen_glm_projector_from_gguf",
 }
 
 

--- a/src/mobius/integrations/gguf/_mmproj.py
+++ b/src/mobius/integrations/gguf/_mmproj.py
@@ -1069,6 +1069,15 @@ def _validate_supported_mmproj_shapes(mmproj_gguf: Any, spec: ProjectorSpec) -> 
         _generic_projector_dimensions(mmproj_gguf, spec.projector_type, vision)
 
 
+def _validate_supported_mmproj_metadata(mmproj_gguf: Any, spec: ProjectorSpec) -> None:
+    if spec.sidecar_builder == "qwen_glm_projector":
+        from mobius.integrations.gguf._qwen_glm_projector import (
+            validate_qwen_glm_projector_metadata,
+        )
+
+        validate_qwen_glm_projector_metadata(mmproj_gguf, spec.projector_type)
+
+
 def _preflight_mmproj_pair(
     text_gguf: Any,
     mmproj_gguf: Any,
@@ -1109,6 +1118,7 @@ def _preflight_mmproj_pair(
             raise ValueError(
                 f"{projector_type} mmproj is missing required metadata: {missing_metadata}"
             )
+        _validate_supported_mmproj_metadata(mmproj_gguf, spec)
         _validate_mmproj_tensor_closure(mmproj_gguf, spec)
         if not spec.is_importable:
             blocked = ", ".join(
@@ -1167,6 +1177,7 @@ def _preflight_standalone_mmproj(
         raise ValueError(
             f"{projector_type} mmproj is missing required metadata: {missing_metadata}"
         )
+    _validate_supported_mmproj_metadata(mmproj_gguf, spec)
     _validate_mmproj_tensor_closure(mmproj_gguf, spec)
     if not spec.is_importable or spec.sidecar_builder is None:
         blocked = ", ".join(

--- a/src/mobius/integrations/gguf/_mmproj.py
+++ b/src/mobius/integrations/gguf/_mmproj.py
@@ -3142,7 +3142,6 @@ _VLM_BUILDERS: dict[str, str] = {
     "qwen_vl": "build_qwen_vlm_from_gguf",
 }
 
-
 #: Standalone sidecar graph entry points selected by
 #: :attr:`ProjectorSpec.sidecar_builder`. Unlike ``_VLM_BUILDERS``, these
 #: functions never create or silently omit a paired text decoder.

--- a/src/mobius/integrations/gguf/_mmproj_mapping.py
+++ b/src/mobius/integrations/gguf/_mmproj_mapping.py
@@ -36,10 +36,16 @@ __all__ = [
     "is_mmproj_stat_tensor",
     "map_generic_projector_to_onnx",
     "map_generic_vision_to_onnx",
+    "map_mmproj_glma_audio_to_onnx",
     "map_mmproj_gemma3_vision_to_hf",
     "map_mmproj_qwen_vision_to_hf",
     "map_mmproj_audio_to_hf",
+    "map_mmproj_glm4v_vision_to_onnx",
     "map_mmproj_muse_glimmer_vision_to_hf",
+    "map_mmproj_qwen2_audio_to_onnx",
+    "map_mmproj_qwen3_audio_to_onnx",
+    "map_mmproj_qwen3_speaker_to_onnx",
+    "map_mmproj_qwen3_vision_to_onnx",
     "map_mmproj_vision_to_hf",
 ]
 
@@ -385,6 +391,227 @@ def map_mmproj_qwen_vision_to_hf(name: str) -> str | None:
         "mm.2.bias": "visual.merger.mlp.2.bias",
     }
     return top.get(name)
+
+
+_QWEN_GLM_BLOCK = re.compile(r"^[av]\.blk\.(\d+)\.(.+)$")
+
+
+def _map_standard_encoder_block(name: str, *, prefix: str) -> str | None:
+    """Map llama.cpp's common ViT/Whisper block stems to module paths."""
+    match = _QWEN_GLM_BLOCK.match(name)
+    if match is None:
+        return None
+    index, stem = match.groups()
+    mapped = {
+        "ln1.weight": "norm1.weight",
+        "ln1.bias": "norm1.bias",
+        "ln2.weight": "norm2.weight",
+        "ln2.bias": "norm2.bias",
+        "attn_qkv.weight": "attn.qkv.weight",
+        "attn_qkv.bias": "attn.qkv.bias",
+        "attn_out.weight": "attn.proj.weight",
+        "attn_out.bias": "attn.proj.bias",
+        "ffn_up.weight": "mlp.up_proj.weight",
+        "ffn_up.bias": "mlp.up_proj.bias",
+        "ffn_gate.weight": "mlp.gate_proj.weight",
+        "ffn_gate.bias": "mlp.gate_proj.bias",
+        "ffn_down.weight": "mlp.down_proj.weight",
+        "ffn_down.bias": "mlp.down_proj.bias",
+    }.get(stem)
+    return None if mapped is None else f"{prefix}.{index}.{mapped}"
+
+
+def map_mmproj_qwen3_vision_to_onnx(
+    name: str,
+    *,
+    deepstack_layers: tuple[int, ...],
+) -> str | None:
+    """Map Qwen3-VL sidecar names to the standalone vision component."""
+    mapped = _map_standard_encoder_block(name, prefix="visual.blocks")
+    if mapped is not None:
+        return mapped
+
+    deepstack = re.match(r"^v\.deepstack\.(\d+)\.(norm|fc1|fc2)\.(weight|bias)$", name)
+    if deepstack is not None:
+        layer, stem, kind = deepstack.groups()
+        layer_index = int(layer)
+        if layer_index not in deepstack_layers:
+            return None
+        merger_index = deepstack_layers.index(layer_index)
+        target = {
+            "norm": "norm",
+            "fc1": "linear_fc1",
+            "fc2": "linear_fc2",
+        }[stem]
+        return f"visual.deepstack_merger_list.{merger_index}.{target}.{kind}"
+
+    return {
+        "v.patch_embd.bias": "visual.patch_embed.proj.bias",
+        "v.position_embd.weight": "visual.pos_embed.weight",
+        "v.post_ln.weight": "visual.merger.norm.weight",
+        "v.post_ln.bias": "visual.merger.norm.bias",
+        "mm.0.weight": "visual.merger.linear_fc1.weight",
+        "mm.0.bias": "visual.merger.linear_fc1.bias",
+        "mm.2.weight": "visual.merger.linear_fc2.weight",
+        "mm.2.bias": "visual.merger.linear_fc2.bias",
+    }.get(name)
+
+
+def map_mmproj_glm4v_vision_to_onnx(name: str) -> str | None:
+    """Map GLM4V sidecar names to the standalone vision component."""
+    mapped = _map_standard_encoder_block(name, prefix="visual.blocks")
+    if mapped is not None:
+        return mapped
+    qk_norm = re.match(r"^v\.blk\.(\d+)\.attn_([qk])_norm\.weight$", name)
+    if qk_norm is not None:
+        layer, kind = qk_norm.groups()
+        return f"visual.blocks.{layer}.attn.{kind}_norm.weight"
+    return {
+        "v.patch_embd.bias": "visual.patch_embed.proj.bias",
+        "v.norm_embd.weight": "visual.post_conv_layernorm.weight",
+        "v.position_embd.weight": "visual.position_embeddings",
+        "v.post_ln.weight": "visual.post_layernorm.weight",
+        "mm.model.fc.weight": "visual.merger.proj.weight",
+        "mm.post_norm.weight": "visual.merger.post_projection_norm.weight",
+        "mm.post_norm.bias": "visual.merger.post_projection_norm.bias",
+        "mm.patch_merger.weight": "visual.downsample.weight",
+        "mm.patch_merger.bias": "visual.downsample.bias",
+        "mm.up.weight": "visual.merger.up_proj.weight",
+        "mm.gate.weight": "visual.merger.gate_proj.weight",
+        "mm.down.weight": "visual.merger.down_proj.weight",
+    }.get(name)
+
+
+def _map_whisper_audio_block(name: str, *, prefix: str) -> str | None:
+    match = _QWEN_GLM_BLOCK.match(name)
+    if match is None or not name.startswith("a."):
+        return None
+    index, stem = match.groups()
+    mapped = {
+        "ln1.weight": "self_attn_layer_norm.weight",
+        "ln1.bias": "self_attn_layer_norm.bias",
+        "ln2.weight": "final_layer_norm.weight",
+        "ln2.bias": "final_layer_norm.bias",
+        "attn_q.weight": "self_attn.q_proj.weight",
+        "attn_q.bias": "self_attn.q_proj.bias",
+        "attn_k.weight": "self_attn.k_proj.weight",
+        "attn_v.weight": "self_attn.v_proj.weight",
+        "attn_v.bias": "self_attn.v_proj.bias",
+        "attn_out.weight": "self_attn.out_proj.weight",
+        "attn_out.bias": "self_attn.out_proj.bias",
+        "ffn_up.weight": "fc1.weight",
+        "ffn_up.bias": "fc1.bias",
+        "ffn_down.weight": "fc2.weight",
+        "ffn_down.bias": "fc2.bias",
+    }.get(stem)
+    return None if mapped is None else f"{prefix}.{index}.{mapped}"
+
+
+def map_mmproj_qwen2_audio_to_onnx(name: str) -> str | None:
+    """Map Qwen2-Audio's Whisper tower and linear projector."""
+    mapped = _map_whisper_audio_block(name, prefix="audio_tower.layers")
+    if mapped is not None:
+        return mapped
+    return {
+        "a.conv1d.1.weight": "audio_tower.conv1.weight",
+        "a.conv1d.1.bias": "audio_tower.conv1.bias",
+        "a.conv1d.2.weight": "audio_tower.conv2.weight",
+        "a.conv1d.2.bias": "audio_tower.conv2.bias",
+        "a.position_embd.weight": "audio_tower.position_embeddings",
+        "a.post_ln.weight": "audio_tower.post_layernorm.weight",
+        "a.post_ln.bias": "audio_tower.post_layernorm.bias",
+        "mm.a.fc.weight": "projection.weight",
+        "mm.a.fc.bias": "projection.bias",
+    }.get(name)
+
+
+def map_mmproj_glma_audio_to_onnx(name: str) -> str | None:
+    """Map the legacy GLMA Whisper tower, stacked MLP, and boundary rows."""
+    mapped = _map_whisper_audio_block(name, prefix="audio_tower.layers")
+    if mapped is not None:
+        return mapped
+    return {
+        "a.conv1d.1.weight": "audio_tower.conv1.weight",
+        "a.conv1d.1.bias": "audio_tower.conv1.bias",
+        "a.conv1d.2.weight": "audio_tower.conv2.weight",
+        "a.conv1d.2.bias": "audio_tower.conv2.bias",
+        "a.position_embd.weight": "audio_tower.position_embeddings",
+        "a.post_ln.weight": "audio_tower.post_layernorm.weight",
+        "a.post_ln.bias": "audio_tower.post_layernorm.bias",
+        "mm.a.norm_pre.weight": "pre_projector_norm.weight",
+        "mm.a.norm_pre.bias": "pre_projector_norm.bias",
+        "mm.a.mlp.1.weight": "linear_1.weight",
+        "mm.a.mlp.1.bias": "linear_1.bias",
+        "mm.a.mlp.2.weight": "linear_2.weight",
+        "mm.a.mlp.2.bias": "linear_2.bias",
+        "v.boi": "boi",
+        "v.eoi": "eoi",
+    }.get(name)
+
+
+def map_mmproj_qwen3_audio_to_onnx(name: str) -> str | None:
+    """Map Qwen3 audio sidecar tensors onto ``Qwen3ASRAudioEncoder``."""
+    mapped = _map_whisper_audio_block(name, prefix="audio_tower.layers")
+    if mapped is not None:
+        return mapped
+    key_bias = re.match(r"^a\.blk\.(\d+)\.attn_k\.bias$", name)
+    if key_bias is not None:
+        return f"audio_tower.layers.{key_bias.group(1)}.self_attn.k_proj.bias"
+    return {
+        "a.conv2d.1.weight": "audio_tower.conv2d1.weight",
+        "a.conv2d.1.bias": "audio_tower.conv2d1.bias",
+        "a.conv2d.2.weight": "audio_tower.conv2d2.weight",
+        "a.conv2d.2.bias": "audio_tower.conv2d2.bias",
+        "a.conv2d.3.weight": "audio_tower.conv2d3.weight",
+        "a.conv2d.3.bias": "audio_tower.conv2d3.bias",
+        "a.conv_out.weight": "audio_tower.conv_out.weight",
+        "a.position_embd.weight": "audio_tower.positional_embedding",
+        "a.post_ln.weight": "audio_tower.ln_post.weight",
+        "a.post_ln.bias": "audio_tower.ln_post.bias",
+        "mm.a.mlp.1.weight": "audio_tower.proj1.weight",
+        "mm.a.mlp.1.bias": "audio_tower.proj1.bias",
+        "mm.a.mlp.2.weight": "audio_tower.proj2.weight",
+        "mm.a.mlp.2.bias": "audio_tower.proj2.bias",
+    }.get(name)
+
+
+def map_mmproj_qwen3_speaker_to_onnx(name: str) -> str | None:
+    """Map the Qwen3-TTS ECAPA speaker subset to ``SpeakerEncoder``."""
+    top = {
+        "a.conv1d.0.weight": "encoder.blocks.0.conv.weight",
+        "a.conv1d.0.bias": "encoder.blocks.0.conv.bias",
+        "a.conv_out.weight": "encoder.mfa.conv.weight",
+        "a.conv_out.bias": "encoder.mfa.conv.bias",
+        "a.asp_attn.weight": "encoder.asp.conv.weight",
+        "a.asp_attn.bias": "encoder.asp.conv.bias",
+        "a.asp_tdnn.weight": "encoder.asp.tdnn.conv.weight",
+        "a.asp_tdnn.bias": "encoder.asp.tdnn.conv.bias",
+        "mm.a.fc.weight": "encoder.fc.weight",
+        "mm.a.fc.bias": "encoder.fc.bias",
+    }
+    if name in top:
+        return top[name]
+
+    match = re.match(
+        r"^a\.blk\.([1-3])\."
+        r"(conv_pw1|conv_pw2|se_conv1|se_conv2)\.(weight|bias)$",
+        name,
+    )
+    if match is not None:
+        block, stem, kind = match.groups()
+        target = {
+            "conv_pw1": "tdnn1.conv",
+            "conv_pw2": "tdnn2.conv",
+            "se_conv1": "se_block.conv1",
+            "se_conv2": "se_block.conv2",
+        }[stem]
+        return f"encoder.blocks.{block}.{target}.{kind}"
+
+    res2 = re.match(r"^a\.blk\.([1-3])\.res2\.([0-6])\.(weight|bias)$", name)
+    if res2 is None:
+        return None
+    block, branch, kind = res2.groups()
+    return f"encoder.blocks.{block}.res2net_block.blocks.{branch}.conv.{kind}"
 
 
 # ---------------------------------------------------------------------------

--- a/src/mobius/integrations/gguf/_mmproj_mapping_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_mapping_test.py
@@ -13,6 +13,12 @@ from mobius.integrations.gguf._mmproj_mapping import (
     map_generic_vision_to_onnx,
     map_mmproj_audio_to_hf,
     map_mmproj_gemma3_vision_to_hf,
+    map_mmproj_glm4v_vision_to_onnx,
+    map_mmproj_glma_audio_to_onnx,
+    map_mmproj_qwen2_audio_to_onnx,
+    map_mmproj_qwen3_audio_to_onnx,
+    map_mmproj_qwen3_speaker_to_onnx,
+    map_mmproj_qwen3_vision_to_onnx,
     map_mmproj_vision_to_hf,
 )
 
@@ -330,3 +336,72 @@ class TestMuseGlimmerVisionMapping:
         assert convert("v.blk.0.ffn_gate.weight") is None
         assert convert("v.blk.0.attn_q_norm.weight") is None
         assert convert("a.blk.0.attn_q.weight") is None
+
+
+class TestQwenGlmProjectorMapping:
+    def test_qwen3vl_deepstack_layer_maps_to_dense_merger_index(self) -> None:
+        assert (
+            map_mmproj_qwen3_vision_to_onnx(
+                "v.deepstack.11.fc2.weight",
+                deepstack_layers=(5, 11, 17),
+            )
+            == "visual.deepstack_merger_list.1.linear_fc2.weight"
+        )
+        assert (
+            map_mmproj_qwen3_vision_to_onnx(
+                "v.deepstack.7.fc2.weight",
+                deepstack_layers=(5, 11, 17),
+            )
+            is None
+        )
+
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [
+            (
+                "v.blk.2.attn_qkv.weight",
+                "visual.blocks.2.attn.qkv.weight",
+            ),
+            ("v.post_ln.bias", "visual.merger.norm.bias"),
+            ("mm.2.weight", "visual.merger.linear_fc2.weight"),
+        ],
+    )
+    def test_qwen3vl_names(self, source: str, expected: str) -> None:
+        assert (
+            map_mmproj_qwen3_vision_to_onnx(
+                source,
+                deepstack_layers=(5, 11, 17),
+            )
+            == expected
+        )
+
+    def test_glm4v_qk_norm_variant(self) -> None:
+        assert (
+            map_mmproj_glm4v_vision_to_onnx("v.blk.3.attn_q_norm.weight")
+            == "visual.blocks.3.attn.q_norm.weight"
+        )
+        assert (
+            map_mmproj_glm4v_vision_to_onnx("mm.patch_merger.weight")
+            == "visual.downsample.weight"
+        )
+
+    def test_qwen2_and_qwen3_audio_names_remain_distinct(self) -> None:
+        assert map_mmproj_qwen2_audio_to_onnx("mm.a.fc.weight") == "projection.weight"
+        assert (
+            map_mmproj_qwen3_audio_to_onnx("a.blk.4.attn_k.bias")
+            == "audio_tower.layers.4.self_attn.k_proj.bias"
+        )
+        assert (
+            map_mmproj_qwen3_audio_to_onnx("mm.a.mlp.2.weight") == "audio_tower.proj2.weight"
+        )
+
+    def test_glma_boundary_rows_and_stack_projector(self) -> None:
+        assert map_mmproj_glma_audio_to_onnx("v.boi") == "boi"
+        assert map_mmproj_glma_audio_to_onnx("mm.a.mlp.1.weight") == "linear_1.weight"
+
+    def test_qwen3tts_speaker_res2_branch(self) -> None:
+        assert (
+            map_mmproj_qwen3_speaker_to_onnx("a.blk.2.res2.6.weight")
+            == "encoder.blocks.2.res2net_block.blocks.6.conv.weight"
+        )
+        assert map_mmproj_qwen3_speaker_to_onnx("a.gen.code.proj_in.weight") is None

--- a/src/mobius/integrations/gguf/_mmproj_registry.py
+++ b/src/mobius/integrations/gguf/_mmproj_registry.py
@@ -21,6 +21,7 @@ __all__ = [
     "LLAMA_CPP_MMPROJ_SHA",
     "MMPROJ_ARTIFACT_AVAILABILITY_PINS",
     "MMPROJ_ARTIFACT_PINS",
+    "MMPROJ_SOURCE_EVIDENCE",
     "ClipMetadataField",
     "CompanionTensorSpec",
     "DeferredCompanionSpec",
@@ -45,7 +46,7 @@ from typing import Any
 
 from mobius.integrations.gguf._spec import Support
 
-LLAMA_CPP_MMPROJ_SHA = "8d9af256337d1a501250f9bbf4c0859a654bddd6"
+LLAMA_CPP_MMPROJ_SHA = "86632248188c106d749fad34a1dcd237c95863d4"
 
 
 class MMProjModality(enum.Enum):
@@ -129,6 +130,7 @@ class ProjectorSpec:
     optional_top_tensors: tuple[str, ...] = ()
     block_prefix: str | None = None
     block_suffixes: tuple[str, ...] = ()
+    block_suffix_variants: tuple[tuple[str, ...], ...] = ()
     auxiliary_tensor_patterns: tuple[str, ...] = ()
     companion_tensors: tuple[CompanionTensorSpec, ...] = ()
     deferred_companions: tuple[DeferredCompanionSpec, ...] = ()
@@ -150,6 +152,7 @@ class ProjectorSpec:
                 self.optional_top_tensors,
                 self.block_prefix,
                 self.block_suffixes,
+                self.block_suffix_variants,
                 self.auxiliary_tensor_patterns,
                 self.companion_tensors,
                 self.deferred_companions,
@@ -362,6 +365,7 @@ CLIP_METADATA_SCHEMA: tuple[ClipMetadataField, ...] = (
     ClipMetadataField("clip.vision.image_grid_pinpoints", default=()),
     ClipMetadataField("clip.vision.n_wa_pattern"),
     ClipMetadataField("clip.vision.wa_layer_indexes"),
+    ClipMetadataField("clip.vision.is_deepstack_layers"),
     ClipMetadataField("clip.vision.wa_pattern_mode"),
     ClipMetadataField("clip.vision.window_size"),
     ClipMetadataField("clip.minicpmv_version"),
@@ -638,6 +642,152 @@ _QWEN25VL_BLOCK_SUFFIXES = (
         for kind in ("weight", "bias")
     ),
 )
+
+_QWEN3VL_BLOCK_SUFFIXES = tuple(
+    f"{stem}.{kind}"
+    for stem in (
+        "ln1",
+        "ln2",
+        "attn_qkv",
+        "attn_out",
+        "ffn_up",
+        "ffn_down",
+    )
+    for kind in ("weight", "bias")
+)
+
+_GLM4V_BLOCK_SUFFIXES = (
+    "ln1.weight",
+    "ln2.weight",
+    "attn_qkv.weight",
+    "attn_out.weight",
+    "ffn_gate.weight",
+    "ffn_up.weight",
+    "ffn_down.weight",
+)
+
+_GLMOCR_BLOCK_SUFFIXES = (
+    "ln1.weight",
+    "ln2.weight",
+    "attn_qkv.weight",
+    "attn_qkv.bias",
+    "attn_q_norm.weight",
+    "attn_k_norm.weight",
+    "attn_out.weight",
+    "attn_out.bias",
+    "ffn_gate.weight",
+    "ffn_gate.bias",
+    "ffn_up.weight",
+    "ffn_up.bias",
+    "ffn_down.weight",
+    "ffn_down.bias",
+)
+
+_WHISPER_AUDIO_BLOCK_SUFFIXES = (
+    "ln1.weight",
+    "ln1.bias",
+    "ln2.weight",
+    "ln2.bias",
+    "attn_q.weight",
+    "attn_q.bias",
+    "attn_k.weight",
+    "attn_v.weight",
+    "attn_v.bias",
+    "attn_out.weight",
+    "attn_out.bias",
+    "ffn_up.weight",
+    "ffn_up.bias",
+    "ffn_down.weight",
+    "ffn_down.bias",
+)
+
+_QWEN3A_BLOCK_SUFFIXES = (
+    *_WHISPER_AUDIO_BLOCK_SUFFIXES,
+    "attn_k.bias",
+)
+
+_COMMON_AUDIO_BODY_METADATA = (
+    "clip.has_audio_encoder",
+    "clip.audio.embedding_length",
+    "clip.audio.feed_forward_length",
+    "clip.audio.block_count",
+    "clip.audio.projection_dim",
+    "clip.audio.attention.head_count",
+    "clip.audio.attention.layer_norm_epsilon",
+    "clip.audio.num_mel_bins",
+)
+
+_QWEN2A_TOP_TENSORS = (
+    "a.conv1d.1.weight",
+    "a.conv1d.1.bias",
+    "a.conv1d.2.weight",
+    "a.conv1d.2.bias",
+    "a.position_embd.weight",
+    "a.post_ln.weight",
+    "a.post_ln.bias",
+    "mm.a.fc.weight",
+    "mm.a.fc.bias",
+)
+
+_QWEN3A_TOP_TENSORS = (
+    "a.conv2d.1.weight",
+    "a.conv2d.1.bias",
+    "a.conv2d.2.weight",
+    "a.conv2d.2.bias",
+    "a.conv2d.3.weight",
+    "a.conv2d.3.bias",
+    "a.conv_out.weight",
+    "a.position_embd.weight",
+    "a.post_ln.weight",
+    "a.post_ln.bias",
+    "mm.a.mlp.1.weight",
+    "mm.a.mlp.1.bias",
+    "mm.a.mlp.2.weight",
+    "mm.a.mlp.2.bias",
+)
+
+_GLMA_TOP_TENSORS = (
+    "a.conv1d.1.weight",
+    "a.conv1d.1.bias",
+    "a.conv1d.2.weight",
+    "a.conv1d.2.bias",
+    "a.position_embd.weight",
+    "a.post_ln.weight",
+    "a.post_ln.bias",
+    "mm.a.mlp.1.weight",
+    "mm.a.mlp.1.bias",
+    "mm.a.mlp.2.weight",
+    "mm.a.mlp.2.bias",
+    "mm.a.norm_pre.weight",
+    "mm.a.norm_pre.bias",
+    "v.boi",
+    "v.eoi",
+)
+
+_QWEN3TTS_SPEAKER_TOP_TENSOR_LIST = [
+    "a.conv1d.0.weight",
+    "a.conv1d.0.bias",
+    "a.conv_out.weight",
+    "a.conv_out.bias",
+    "a.asp_attn.weight",
+    "a.asp_attn.bias",
+    "a.asp_tdnn.weight",
+    "a.asp_tdnn.bias",
+    "mm.a.fc.weight",
+    "mm.a.fc.bias",
+]
+for _speaker_block in range(1, 4):
+    for _speaker_stem in ("conv_pw1", "conv_pw2", "se_conv1", "se_conv2"):
+        for _speaker_kind in ("weight", "bias"):
+            _QWEN3TTS_SPEAKER_TOP_TENSOR_LIST.append(
+                f"a.blk.{_speaker_block}.{_speaker_stem}.{_speaker_kind}"
+            )
+    for _speaker_branch in range(7):
+        for _speaker_kind in ("weight", "bias"):
+            _QWEN3TTS_SPEAKER_TOP_TENSOR_LIST.append(
+                f"a.blk.{_speaker_block}.res2.{_speaker_branch}.{_speaker_kind}"
+            )
+_QWEN3TTS_SPEAKER_TOP_TENSORS = tuple(_QWEN3TTS_SPEAKER_TOP_TENSOR_LIST)
 
 _COMMON_REQUIRED_VISION_METADATA = (
     "clip.has_vision_encoder",
@@ -975,12 +1125,49 @@ _SPECS: tuple[ProjectorSpec, ...] = (
         ),
         real_artifact_ids=("qwen25-vl-3b-f16",),
     ),
-    _deferred(
-        "qwen3vl_merger",
-        "PROJECTOR_TYPE_QWEN3VL",
-        _VISION_BASE,
-        "The Qwen3-VL merger/window ordering has no GGUF tensor-closure parity test.",
+    ProjectorSpec(
+        projector_type="qwen3vl_merger",
+        enum_name="PROJECTOR_TYPE_QWEN3VL",
+        modalities=_VISION_BASE,
         target_architectures=frozenset({"qwen3vl", "qwen3vlmoe", "qwen35", "qwen35moe"}),
+        metadata=Support.SUPPORTED,
+        tensor_map=Support.SUPPORTED,
+        graph=Support.SUPPORTED,
+        runtime=Support.DEFERRED,
+        reason=(
+            "Standalone vision and DeepStack merger graphs are exact. Paired runtime "
+            "execution remains unvalidated because the decoder must consume four-section "
+            "MRoPE positions and hidden_size * (1 + deepstack_layers) embeddings."
+        ),
+        sidecar_builder="qwen_glm_projector",
+        model_roles=(MMProjModelRole.VISION_ENCODER,),
+        required_metadata=(
+            *_COMMON_REQUIRED_VISION_METADATA,
+            "clip.projector_type",
+            "clip.vision.spatial_merge_size",
+            "clip.vision.is_deepstack_layers",
+        ),
+        required_top_tensors=(
+            "v.patch_embd.weight",
+            "v.patch_embd.weight.1",
+            "v.patch_embd.bias",
+            "v.position_embd.weight",
+            "v.post_ln.weight",
+            "v.post_ln.bias",
+            "mm.0.weight",
+            "mm.0.bias",
+            "mm.2.weight",
+            "mm.2.bias",
+        ),
+        block_prefix="v.blk.",
+        block_suffixes=_QWEN3VL_BLOCK_SUFFIXES,
+        auxiliary_tensor_patterns=(r"v\.deepstack\.\d+\.(?:norm|fc1|fc2)\.(?:weight|bias)",),
+        tensor_roles=(
+            ("v.deepstack.", MMProjTensorRole.PROJECTOR),
+            ("v.", MMProjTensorRole.ENCODER),
+            ("mm.", MMProjTensorRole.PROJECTOR),
+        ),
+        real_artifact_ids=("qwen3-vl-projector-f16",),
     ),
     _deferred(
         "step3vl",
@@ -1411,31 +1598,149 @@ _SPECS: tuple[ProjectorSpec, ...] = (
         ),
         real_artifact_ids=("llama4-scout-f16",),
     ),
-    _deferred(
-        "qwen2a",
-        "PROJECTOR_TYPE_QWEN2A",
-        _AUDIO_BASE,
-        "Qwen2 audio encoder/projector is not implemented.",
+    ProjectorSpec(
+        projector_type="qwen2a",
+        enum_name="PROJECTOR_TYPE_QWEN2A",
+        modalities=_AUDIO_BASE,
+        target_architectures=frozenset({"qwen2"}),
+        primary_modality=MMProjModality.AUDIO,
+        metadata=Support.SUPPORTED,
+        tensor_map=Support.SUPPORTED,
+        graph=Support.SUPPORTED,
+        runtime=Support.DEFERRED,
+        reason=(
+            "The standalone Whisper encoder, two-frame average pool, and affine audio "
+            "projector are exact; paired audio-token runtime execution remains unvalidated."
+        ),
+        sidecar_builder="qwen_glm_projector",
+        model_roles=(MMProjModelRole.AUDIO_ENCODER,),
+        required_metadata=(*_COMMON_AUDIO_BODY_METADATA, "clip.projector_type"),
+        required_top_tensors=_QWEN2A_TOP_TENSORS,
+        block_prefix="a.blk.",
+        block_suffixes=_WHISPER_AUDIO_BLOCK_SUFFIXES,
+        tensor_roles=(
+            ("a.", MMProjTensorRole.ENCODER),
+            ("mm.a.", MMProjTensorRole.PROJECTOR),
+        ),
+        real_artifact_ids=("qwen2-audio-projector-f16",),
     ),
-    _deferred(
-        "qwen3a",
-        "PROJECTOR_TYPE_QWEN3A",
-        _AUDIO_BASE,
-        "Qwen3 audio encoder/projector is not implemented.",
+    ProjectorSpec(
+        projector_type="qwen3a",
+        enum_name="PROJECTOR_TYPE_QWEN3A",
+        modalities=_AUDIO_BASE,
         target_architectures=frozenset({"qwen3vl", "qwen3vlmoe"}),
+        primary_modality=MMProjModality.AUDIO,
+        metadata=Support.SUPPORTED,
+        tensor_map=Support.SUPPORTED,
+        graph=Support.SUPPORTED,
+        runtime=Support.DEFERRED,
+        reason=(
+            "The standalone 100-frame chunked Conv2D encoder and two-layer audio "
+            "projector are exact; paired MRoPE audio-token runtime execution remains "
+            "unvalidated."
+        ),
+        sidecar_builder="qwen_glm_projector",
+        model_roles=(MMProjModelRole.AUDIO_ENCODER,),
+        required_metadata=(
+            *_COMMON_AUDIO_BODY_METADATA,
+            "clip.audio.projector_type",
+        ),
+        required_top_tensors=_QWEN3A_TOP_TENSORS,
+        block_prefix="a.blk.",
+        block_suffixes=_QWEN3A_BLOCK_SUFFIXES,
+        tensor_roles=(
+            ("a.", MMProjTensorRole.ENCODER),
+            ("mm.a.", MMProjTensorRole.PROJECTOR),
+        ),
+        real_artifact_ids=("qwen3-audio-projector-bf16",),
     ),
-    _deferred(
-        "glma",
-        "PROJECTOR_TYPE_GLMA",
-        _AUDIO_BASE,
-        "GLM audio encoder/projector is not implemented.",
+    ProjectorSpec(
+        projector_type="glma",
+        enum_name="PROJECTOR_TYPE_GLMA",
+        modalities=_AUDIO_BASE,
+        target_architectures=frozenset({"llama"}),
+        primary_modality=MMProjModality.AUDIO,
+        metadata=Support.SUPPORTED,
+        tensor_map=Support.SUPPORTED,
+        graph=Support.SUPPORTED,
+        runtime=Support.DEFERRED,
+        reason=(
+            "The serialized legacy Whisper, frame-stack, MLP, and BOI/EOI graph is "
+            "implemented. Current GLM-ASR cannot provide evidence: its converter misses "
+            "the checkpoint architecture and merge_factor and its encoder uses partial "
+            "RoPE instead of this additive-position topology."
+        ),
+        sidecar_builder="qwen_glm_projector",
+        model_roles=(MMProjModelRole.AUDIO_ENCODER,),
+        required_metadata=(
+            *_COMMON_AUDIO_BODY_METADATA,
+            "clip.projector_type",
+            "clip.audio.projector.stack_factor",
+        ),
+        required_top_tensors=_GLMA_TOP_TENSORS,
+        block_prefix="a.blk.",
+        block_suffixes=_WHISPER_AUDIO_BLOCK_SUFFIXES,
+        tensor_roles=(
+            ("a.", MMProjTensorRole.ENCODER),
+            ("mm.a.", MMProjTensorRole.PROJECTOR),
+            ("v.boi", MMProjTensorRole.PROJECTOR),
+            ("v.eoi", MMProjTensorRole.PROJECTOR),
+        ),
+        source_evidence_ids=("glma-converter-checkpoint-drift",),
     ),
-    _deferred(
-        "qwen2.5o",
-        "PROJECTOR_TYPE_QWEN25O",
-        _VISION_BASE | _AUDIO_BASE,
-        "This legacy string changes meaning by modality; accepting it would create a false alias.",
+    ProjectorSpec(
+        projector_type="qwen2.5o",
+        enum_name="PROJECTOR_TYPE_QWEN25O",
+        modalities=_VISION_BASE | _AUDIO_BASE,
         target_architectures=frozenset({"qwen2vl"}),
+        metadata=Support.SUPPORTED,
+        tensor_map=Support.SUPPORTED,
+        graph=Support.SUPPORTED,
+        runtime=Support.DEFERRED,
+        reason=(
+            "The legacy selector is resolved per modality into separate "
+            "qwen2.5vl_merger and qwen2a components; no generic qwen2.5o graph exists. "
+            "Paired multimodal runtime orchestration remains unvalidated."
+        ),
+        sidecar_builder="qwen_glm_projector",
+        model_roles=(
+            MMProjModelRole.VISION_ENCODER,
+            MMProjModelRole.AUDIO_ENCODER,
+        ),
+        required_metadata=(
+            *_COMMON_REQUIRED_VISION_METADATA,
+            *_COMMON_AUDIO_BODY_METADATA,
+            "clip.projector_type",
+            "clip.vision.n_wa_pattern",
+        ),
+        required_top_tensors=(
+            "v.patch_embd.weight",
+            "v.patch_embd.weight.1",
+            "v.post_ln.weight",
+            "mm.0.weight",
+            "mm.0.bias",
+            "mm.2.weight",
+            "mm.2.bias",
+        ),
+        block_prefix="v.blk.",
+        block_suffixes=_QWEN25VL_BLOCK_SUFFIXES,
+        companion_tensors=(
+            CompanionTensorSpec(
+                modality=MMProjModality.AUDIO,
+                projector_type="qwen2.5o",
+                required_metadata=_COMMON_AUDIO_BODY_METADATA,
+                required_top_tensors=_QWEN2A_TOP_TENSORS,
+                block_prefix="a.blk.",
+                block_suffixes=_WHISPER_AUDIO_BLOCK_SUFFIXES,
+            ),
+        ),
+        tensor_roles=(
+            ("v.", MMProjTensorRole.ENCODER),
+            ("a.", MMProjTensorRole.ENCODER),
+            ("mm.a.", MMProjTensorRole.PROJECTOR),
+            ("mm.", MMProjTensorRole.PROJECTOR),
+        ),
+        real_artifact_ids=("qwen25-omni-projector-f16",),
     ),
     _deferred(
         "voxtral",
@@ -1531,11 +1836,54 @@ _SPECS: tuple[ProjectorSpec, ...] = (
         _AUDIO_BASE,
         "LFM2 conformer audio graph has no GGUF tensor mapping.",
     ),
-    _deferred(
-        "glm4v",
-        "PROJECTOR_TYPE_GLM4V",
-        _VISION_BASE,
-        "GLM4V downsampler and projector are not implemented.",
+    ProjectorSpec(
+        projector_type="glm4v",
+        enum_name="PROJECTOR_TYPE_GLM4V",
+        modalities=_VISION_BASE,
+        target_architectures=frozenset({"glm4", "glm4moe"}),
+        metadata=Support.SUPPORTED,
+        tensor_map=Support.SUPPORTED,
+        graph=Support.SUPPORTED,
+        runtime=Support.DEFERRED,
+        reason=(
+            "The standalone RMS-normalized ViT, learned 2x2 downsampler, and gated "
+            "projector are exact; paired four-section MRoPE runtime execution remains "
+            "unvalidated."
+        ),
+        sidecar_builder="qwen_glm_projector",
+        model_roles=(MMProjModelRole.VISION_ENCODER,),
+        required_metadata=(
+            *_COMMON_REQUIRED_VISION_METADATA,
+            "clip.projector_type",
+        ),
+        required_top_tensors=(
+            "v.patch_embd.weight",
+            "v.patch_embd.weight.1",
+            "v.patch_embd.bias",
+            "v.post_ln.weight",
+            "mm.model.fc.weight",
+            "mm.up.weight",
+            "mm.gate.weight",
+            "mm.down.weight",
+            "mm.post_norm.weight",
+            "mm.post_norm.bias",
+            "mm.patch_merger.weight",
+            "mm.patch_merger.bias",
+        ),
+        optional_top_tensors=(
+            "v.norm_embd.weight",
+            "v.position_embd.weight",
+        ),
+        block_prefix="v.blk.",
+        block_suffix_variants=(
+            _GLM4V_BLOCK_SUFFIXES,
+            _GLMOCR_BLOCK_SUFFIXES,
+        ),
+        tensor_roles=(
+            ("v.", MMProjTensorRole.ENCODER),
+            ("mm.", MMProjTensorRole.PROJECTOR),
+        ),
+        real_artifact_ids=("glm4v-projector-f16",),
     ),
     _deferred(
         "youtuvl",
@@ -1616,11 +1964,46 @@ _SPECS: tuple[ProjectorSpec, ...] = (
         _AUDIO_BASE,
         "Parakeet audio encoder graph is not implemented.",
     ),
-    _deferred(
-        "qwen3tts_spkenc",
-        "PROJECTOR_TYPE_QWEN3TTS_SPKENC",
-        _AUDIO_BASE,
-        "Qwen3-TTS speaker encoder graph is not implemented.",
+    ProjectorSpec(
+        projector_type="qwen3tts_spkenc",
+        enum_name="PROJECTOR_TYPE_QWEN3TTS_SPKENC",
+        modalities=_AUDIO_BASE,
+        target_architectures=frozenset({"qwen3tts"}),
+        primary_modality=MMProjModality.AUDIO,
+        metadata=Support.SUPPORTED,
+        tensor_map=Support.SUPPORTED,
+        graph=Support.SUPPORTED,
+        runtime=Support.DEFERRED,
+        reason=(
+            "The standalone ECAPA-TDNN speaker encoder is exact. Runtime use remains "
+            "unvalidated because its one-row output must be added to the tts_pad "
+            "embedding inside the architecture-specific four-section MRoPE prompt, and "
+            "current converters co-package an unowned stateful qwen3tts_gen runtime."
+        ),
+        sidecar_builder="qwen_glm_projector",
+        model_roles=(MMProjModelRole.SPEAKER_ENCODER,),
+        required_metadata=(
+            *_COMMON_AUDIO_BODY_METADATA,
+            "clip.audio.projector_type",
+        ),
+        required_top_tensors=_QWEN3TTS_SPEAKER_TOP_TENSORS,
+        deferred_companions=(
+            DeferredCompanionSpec(
+                modality=MMProjModality.GENERATED_AUDIO,
+                projector_type="qwen3tts_gen",
+                tensor_prefixes=("a.gen.",),
+                reason=(
+                    "qwen3tts_gen owns autoregressive sampling and streaming codec "
+                    "state, not speaker embedding projection."
+                ),
+            ),
+        ),
+        tensor_roles=(
+            ("a.gen.", MMProjTensorRole.GENERATED_AUDIO),
+            ("a.", MMProjTensorRole.ENCODER),
+            ("mm.a.", MMProjTensorRole.PROJECTOR),
+        ),
+        source_evidence_ids=("qwen3tts-speaker-runtime-boundary",),
     ),
     _rejected(
         "qwen3tts_gen",
@@ -1683,6 +2066,64 @@ _SPECS: tuple[ProjectorSpec, ...] = (
 
 _INDEX: Mapping[str, ProjectorSpec] = MappingProxyType(
     {spec.projector_type: spec for spec in _SPECS}
+)
+
+MMPROJ_SOURCE_EVIDENCE: tuple[MMProjSourceEvidence, ...] = (
+    MMProjSourceEvidence(
+        evidence_id="glma-converter-checkpoint-drift",
+        sources=(
+            (
+                "ggml-org/llama.cpp",
+                LLAMA_CPP_MMPROJ_SHA,
+                "tools/mtmd/models/whisper-enc.cpp",
+            ),
+            (
+                "ggml-org/llama.cpp",
+                LLAMA_CPP_MMPROJ_SHA,
+                "conversion/ultravox.py",
+            ),
+            (
+                "zai-org/GLM-ASR-Nano-2512",
+                "61ba4e0b3309b6656edea3e93e419f7bd5c61957",
+                "config.json",
+            ),
+        ),
+        finding=(
+            "llama.cpp defines the legacy additive-position GLMA graph, but its converter "
+            "registers GlmasrModel and requires a top-level merge_factor. The immutable "
+            "current checkpoint declares GlmAsrForConditionalGeneration, omits "
+            "merge_factor, and configures a partial-RoPE encoder. Mobius can import a "
+            "structurally valid legacy sidecar without claiming that this checkpoint can "
+            "produce one."
+        ),
+    ),
+    MMProjSourceEvidence(
+        evidence_id="qwen3tts-speaker-runtime-boundary",
+        sources=(
+            (
+                "ggml-org/llama.cpp",
+                LLAMA_CPP_MMPROJ_SHA,
+                "tools/mtmd/models/qwen3tts-spkenc.cpp",
+            ),
+            (
+                "ggml-org/llama.cpp",
+                LLAMA_CPP_MMPROJ_SHA,
+                "conversion/qwen3tts.py",
+            ),
+            (
+                "ggml-org/llama.cpp",
+                LLAMA_CPP_MMPROJ_SHA,
+                "tools/mtmd/mtmd-helper-gen.cpp",
+            ),
+        ),
+        finding=(
+            "The speaker graph deterministically emits one text-width ECAPA embedding. "
+            "The downstream helper adds it to the tts_pad embedding inside a hand-built "
+            "four-section MRoPE prompt, while the converter co-emits a separate stateful "
+            "qwen3tts_gen namespace. Mobius exports only the exact speaker_encoder role "
+            "and makes no generated-audio runtime claim."
+        ),
+    ),
 )
 
 MMPROJ_ARTIFACT_AVAILABILITY_PINS: tuple[MMProjArtifactAvailabilityPin, ...] = (
@@ -2255,6 +2696,195 @@ MMPROJ_ARTIFACT_PINS: tuple[MMProjArtifactPin, ...] = (
         tensor_qtypes=(("F32", 506), ("BF16", 303)),
         tensor_count=809,
         parity_test="TestMuseGlimmerVisionEncoder.test_matches_independent_numpy_reference",
+    ),
+    MMProjArtifactPin(
+        artifact_id="qwen3-vl-projector-f16",
+        repository="bartowski/Qwen_Qwen3-VL-2B-Instruct-GGUF",
+        revision="e84f8ae7ffee8b04793a4ed771609e2b61d3f3cf",
+        filename="mmproj-Qwen_Qwen3-VL-2B-Instruct-f16.gguf",
+        size=819_394_848,
+        lfs_sha256="8c3f6a56979a1ce7056b9a20be6cf6b6f6ad4837aa3da532b5afcfcfd1faa38b",
+        projector_types=("qwen3vl_merger",),
+        paired_text_architecture="qwen3vl",
+        paired_text_target="Qwen_Qwen3-VL-2B-Instruct-Q4_K_M.gguf",
+        metadata=(
+            ("clip.vision.embedding_length", 1024),
+            ("clip.vision.projection_dim", 2048),
+            ("clip.vision.block_count", 24),
+            ("clip.vision.patch_size", 16),
+            ("clip.vision.spatial_merge_size", 2),
+            ("clip.vision.is_deepstack_layers", (5, 11, 17)),
+        ),
+        tensor_qtypes=(("F32", 210), ("F16", 106)),
+        tensor_count=316,
+        parity_test="test_qwen3vl_projector_matches_transformers",
+        processor_repository="Qwen/Qwen3-VL-2B-Instruct",
+        processor_revision="89644892e4d85e24eaac8bacfd4f463576704203",
+        processor_files=(
+            "chat_template.json",
+            "config.json",
+            "preprocessor_config.json",
+            "tokenizer_config.json",
+        ),
+        processor_class="Qwen3VLProcessor",
+        processor_contract=(
+            ("pixel_values", "float32[total_image_patches,1536]"),
+            ("image_grid_thw", "int64[num_images,3]"),
+            ("pixel_values_videos", "float32[total_video_patches,1536]"),
+            ("video_grid_thw", "int64[num_videos,3]"),
+            ("output_rows", "sum(T*H*W/4) in merge-block-major order"),
+            ("output_width", "2048 final + 3x2048 DeepStack features"),
+            ("decoder_positions", "int64[4,batch,sequence] MRoPE; y/x section order"),
+            ("empty_media", "omit pixel and grid keys; do not invoke vision graph"),
+        ),
+    ),
+    MMProjArtifactPin(
+        artifact_id="qwen3-audio-projector-bf16",
+        repository="ggml-org/Qwen3-ASR-0.6B-GGUF",
+        revision="928ab958557df9aa2ef1c93e0e83c7ad0933fae2",
+        filename="mmproj-Qwen3-ASR-0.6B-bf16.gguf",
+        size=378_575_520,
+        lfs_sha256="dae36c855f9a82a8916bea2238b24bda69a39d8da8b2f46dee7c103775656039",
+        projector_types=("qwen3a",),
+        paired_text_architecture="qwen3vl",
+        paired_text_target="Qwen3-ASR-0.6B-bf16.gguf",
+        metadata=(
+            ("clip.audio.embedding_length", 896),
+            ("clip.audio.projection_dim", 1024),
+            ("clip.audio.block_count", 18),
+            ("clip.audio.num_mel_bins", 128),
+        ),
+        tensor_qtypes=(("F32", 188), ("BF16", 110), ("F16", 4)),
+        tensor_count=302,
+        parity_test="test_qwen3a_projector_matches_transformers",
+        processor_repository="Qwen/Qwen3-ASR-0.6B",
+        processor_revision="5eb144179a02acc5e5ba31e748d22b0cf3e303b0",
+        processor_files=(
+            "chat_template.json",
+            "config.json",
+            "preprocessor_config.json",
+            "tokenizer_config.json",
+        ),
+        processor_class="Qwen3ASRProcessor",
+        processor_contract=(
+            ("input_features", "float32[1,128,frames_multiple_of_100]"),
+            ("input_features_mask", "int32[1,frames_multiple_of_100]"),
+            ("windowing", "at most 800 mel frames, right-pad to a multiple of 100"),
+            ("output_rows", "13 * (padded_frames / 100)"),
+            ("ordering", "window-major, then chunk-major"),
+            ("empty_media", "do not invoke audio graph"),
+        ),
+    ),
+    MMProjArtifactPin(
+        artifact_id="qwen2-audio-projector-f16",
+        repository="mradermacher/Qwen2-Audio-7B-Instruct-GGUF",
+        revision="e1e68850ba33e38eafbc3817919c318d9c7e757b",
+        filename="Qwen2-Audio-7B-Instruct.mmproj-f16.gguf",
+        size=1_289_301_536,
+        lfs_sha256="b52435dead2956f1fc113818c3b5ceb42a940cb487e59163cb1ffc69cae69347",
+        projector_types=("qwen2a",),
+        paired_text_architecture="qwen2",
+        paired_text_target="Qwen2-Audio-7B-Instruct.Q4_K_M.gguf",
+        metadata=(
+            ("clip.audio.embedding_length", 1280),
+            ("clip.audio.projection_dim", 4096),
+            ("clip.audio.block_count", 32),
+            ("clip.audio.num_mel_bins", 128),
+        ),
+        tensor_qtypes=(("F32", 294), ("F16", 195)),
+        tensor_count=489,
+        parity_test="test_qwen2a_projector_matches_transformers",
+        processor_repository="Qwen/Qwen2-Audio-7B-Instruct",
+        processor_revision="0a095220c30b7b31434169c3086508ef3ea5bf0a",
+        processor_files=(
+            "config.json",
+            "preprocessor_config.json",
+            "tokenizer_config.json",
+        ),
+        processor_class="Qwen2AudioProcessor",
+        processor_contract=(
+            ("input_features", "float32[1,128,3000]"),
+            ("feature_attention_mask", "int32[1,3000]; graph consumes padded chunk"),
+            ("output_rows", "750 per 30-second chunk"),
+            ("ordering", "audio-major fixed chunks"),
+            ("empty_media", "omit input_features; do not invoke audio graph"),
+        ),
+    ),
+    MMProjArtifactPin(
+        artifact_id="qwen25-omni-projector-f16",
+        repository="ggml-org/Qwen2.5-Omni-3B-GGUF",
+        revision="75f1b73b657a50f5092502799457ccb4a4a1f9df",
+        filename="mmproj-Qwen2.5-Omni-3B-f16.gguf",
+        size=2_623_983_328,
+        lfs_sha256="f6d9276e9fa4f060c7abdbe886786cf31a8911b62770f8a54b7581b7b99fa27e",
+        projector_types=("qwen2.5o", "qwen2.5vl_merger", "qwen2a"),
+        paired_text_architecture="qwen2vl",
+        paired_text_target="Qwen2.5-Omni-3B-Q4_K_M.gguf",
+        metadata=(
+            ("clip.projector_type", "qwen2.5o"),
+            ("clip.vision.embedding_length", 1280),
+            ("clip.vision.projection_dim", 2048),
+            ("clip.vision.block_count", 32),
+            ("clip.vision.n_wa_pattern", 8),
+            ("clip.audio.embedding_length", 1280),
+            ("clip.audio.projection_dim", 2048),
+            ("clip.audio.block_count", 32),
+        ),
+        tensor_qtypes=(("F32", 586), ("F16", 422)),
+        tensor_count=1008,
+        parity_test="test_qwen25o_alias_builds_distinct_vision_and_audio_graphs",
+        processor_repository="Qwen/Qwen2.5-Omni-3B",
+        processor_revision="f75b40e3da2003cdd6e1829b1f420ca70797c34e",
+        processor_files=(
+            "chat_template.json",
+            "config.json",
+            "preprocessor_config.json",
+            "tokenizer_config.json",
+        ),
+        processor_class="Qwen2_5OmniProcessor",
+        processor_contract=(
+            ("vision", "Qwen2.5-VL packed image/video patch ABI"),
+            ("audio_processor", "float32[1,128,30000] plus int32 feature mask"),
+            ("audio_graph", "split processor rows into 3000-frame qwen2a chunks"),
+            ("roles", "separate vision_encoder and audio_encoder graphs"),
+            ("empty_media", "invoke only the component for each present modality"),
+        ),
+    ),
+    MMProjArtifactPin(
+        artifact_id="glm4v-projector-f16",
+        repository="mradermacher/GLM-OCR-GGUF",
+        revision="3c1e642c0fa5df64831f0b04f3c674b57ce341af",
+        filename="GLM-OCR.mmproj-f16.gguf",
+        size=869_018_080,
+        lfs_sha256="fe5805b3b70f3174d25a912b8d197569eaa8e1e3e6d9777a385b8cc4c622af6c",
+        projector_types=("glm4v",),
+        paired_text_architecture="glm4",
+        paired_text_target="GLM-OCR.Q4_K_M.gguf",
+        metadata=(
+            ("clip.projector_type", "glm4v"),
+            ("clip.vision.embedding_length", 1024),
+            ("clip.vision.projection_dim", 1536),
+            ("clip.vision.block_count", 24),
+            ("clip.vision.patch_size", 14),
+        ),
+        tensor_qtypes=(("F32", 221), ("F16", 127)),
+        tensor_count=348,
+        parity_test="test_glm4v_projector_matches_transformers",
+        processor_repository="zai-org/GLM-OCR",
+        processor_revision="ca5d8b3e287e52589e37c28385d9655ee4372f9d",
+        processor_files=(
+            "config.json",
+            "preprocessor_config.json",
+            "tokenizer_config.json",
+        ),
+        processor_class="Glm46VProcessor",
+        processor_contract=(
+            ("pixel_values", "float32[total_patches,1176]"),
+            ("image_grid_thw", "int64[num_images,3]"),
+            ("output_rows", "sum(T*H*W/4)"),
+            ("ordering", "batch-major images, merge-block-major 2x2 patches"),
+            ("empty_media", "omit pixel and grid keys; do not invoke vision graph"),
+        ),
     ),
 )
 

--- a/src/mobius/integrations/gguf/_mmproj_registry_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_registry_test.py
@@ -15,7 +15,9 @@ from mobius.integrations.gguf._mmproj_registry import (
     LLAMA_CPP_MMPROJ_SHA,
     MMPROJ_ARTIFACT_AVAILABILITY_PINS,
     MMPROJ_ARTIFACT_PINS,
+    MMPROJ_SOURCE_EVIDENCE,
     MMProjModality,
+    MMProjModelRole,
     get_projector_spec,
     iter_projector_specs,
     projector_type_for_modality,
@@ -89,7 +91,7 @@ _PINNED_PROJECTOR_STRINGS = (
 
 def test_registry_is_the_exact_pinned_60_string_census() -> None:
     specs = iter_projector_specs()
-    assert LLAMA_CPP_MMPROJ_SHA == "8d9af256337d1a501250f9bbf4c0859a654bddd6"
+    assert LLAMA_CPP_MMPROJ_SHA == "86632248188c106d749fad34a1dcd237c95863d4"
     assert tuple(spec.projector_type for spec in specs) == _PINNED_PROJECTOR_STRINGS
     assert len({spec.enum_name for spec in specs}) == 60
 
@@ -111,6 +113,7 @@ def test_graph_import_is_conservative_and_artifact_backed() -> None:
         "adapter",
         "qwen2vl_merger",
         "qwen2.5vl_merger",
+        "qwen3vl_merger",
         "gemma3",
         "gemma3nv",
         "gemma3na",
@@ -122,6 +125,12 @@ def test_graph_import_is_conservative_and_artifact_backed() -> None:
         "pixtral",
         "internvl",
         "llama4",
+        "qwen2a",
+        "qwen3a",
+        "glma",
+        "qwen2.5o",
+        "glm4v",
+        "qwen3tts_spkenc",
         "muse-glimmer",
     )
     pins = {pin.artifact_id: pin for pin in MMPROJ_ARTIFACT_PINS}
@@ -142,13 +151,18 @@ def test_graph_import_is_conservative_and_artifact_backed() -> None:
         "pixtral-12b-f16",
         "qwen2-vl-2b-f16",
         "qwen25-vl-3b-f16",
+        "qwen3-vl-projector-f16",
+        "qwen3-audio-projector-bf16",
+        "qwen2-audio-projector-f16",
+        "qwen25-omni-projector-f16",
+        "glm4v-projector-f16",
     }
     for projector_type in supported_projector_types():
         spec = get_projector_spec(projector_type)
         assert spec.is_importable
         assert spec.runtime is Support.DEFERRED
         assert not spec.is_supported
-        assert spec.real_artifact_ids
+        assert spec.real_artifact_ids or spec.source_evidence_ids
         assert all(artifact_id in pins for artifact_id in spec.real_artifact_ids)
         assert all(pins[artifact_id].parity_test for artifact_id in spec.real_artifact_ids)
 
@@ -172,6 +186,19 @@ def test_graph_import_is_conservative_and_artifact_backed() -> None:
         "resampler": None,
     }
     assert sum(pin.size + (pin.paired_text_size or 0) for pin in cohort) <= 16 * 1024**3
+
+    qwen_glm = [
+        pins[artifact_id]
+        for artifact_id in (
+            "qwen3-vl-projector-f16",
+            "qwen3-audio-projector-bf16",
+            "qwen2-audio-projector-f16",
+            "qwen25-omni-projector-f16",
+            "glm4v-projector-f16",
+        )
+    ]
+    assert sum(pin.size for pin in qwen_glm) == 5_980_273_312
+    assert sum(pin.size for pin in qwen_glm) <= 16 * 1024**3
 
 
 def test_deferred_and_packed_projector_artifacts_are_immutably_available() -> None:
@@ -283,9 +310,6 @@ def test_gemma3_processor_assets_and_real_contract_are_exactly_pinned() -> None:
 
 def test_vlm_text_cohort_records_exact_companion_identity_without_support_claims() -> None:
     expected_targets = {
-        "qwen3vl_merger": {"qwen3vl", "qwen3vlmoe", "qwen35", "qwen35moe"},
-        "qwen3a": {"qwen3vl", "qwen3vlmoe"},
-        "qwen2.5o": {"qwen2vl"},
         "paddleocr": {"paddleocr"},
         "cogvlm": {"cogvlm"},
         "deepseekocr": {"deepseek2-ocr"},
@@ -301,6 +325,57 @@ def test_vlm_text_cohort_records_exact_companion_identity_without_support_claims
         assert spec.required_top_tensors == ()
 
 
+def test_qwen_glm_routes_have_exact_standalone_roles_and_pairing() -> None:
+    expected = {
+        "glm4v": ({"glm4", "glm4moe"}, (MMProjModelRole.VISION_ENCODER,)),
+        "glma": ({"llama"}, (MMProjModelRole.AUDIO_ENCODER,)),
+        "qwen2.5o": (
+            {"qwen2vl"},
+            (MMProjModelRole.VISION_ENCODER, MMProjModelRole.AUDIO_ENCODER),
+        ),
+        "qwen2a": ({"qwen2"}, (MMProjModelRole.AUDIO_ENCODER,)),
+        "qwen3a": ({"qwen3vl", "qwen3vlmoe"}, (MMProjModelRole.AUDIO_ENCODER,)),
+        "qwen3vl_merger": (
+            {"qwen3vl", "qwen3vlmoe", "qwen35", "qwen35moe"},
+            (MMProjModelRole.VISION_ENCODER,),
+        ),
+        "qwen3tts_spkenc": (
+            {"qwen3tts"},
+            (MMProjModelRole.SPEAKER_ENCODER,),
+        ),
+    }
+    for projector_type, (targets, roles) in expected.items():
+        spec = get_projector_spec(projector_type)
+        assert spec.target_architectures == frozenset(targets)
+        assert spec.sidecar_builder == "qwen_glm_projector"
+        assert spec.builder is None
+        assert spec.model_roles == roles
+        assert spec.is_importable
+        assert spec.runtime is Support.DEFERRED
+
+    alias = get_projector_spec("qwen2.5o")
+    assert alias.primary_modality is MMProjModality.VISION
+    assert alias.companion_tensors[0].modality is MMProjModality.AUDIO
+    speaker = get_projector_spec("qwen3tts_spkenc")
+    assert speaker.deferred_companions[0].projector_type == "qwen3tts_gen"
+    assert speaker.deferred_companions[0].tensor_prefixes == ("a.gen.",)
+
+
+def test_qwen_glm_source_blockers_are_immutable_and_not_model_gates() -> None:
+    evidence = {record.evidence_id: record for record in MMPROJ_SOURCE_EVIDENCE}
+    assert set(evidence) == {
+        "glma-converter-checkpoint-drift",
+        "qwen3tts-speaker-runtime-boundary",
+    }
+    assert all(
+        len(revision) == 40
+        for record in evidence.values()
+        for _, revision, _ in record.sources
+    )
+    assert "partial-RoPE" in evidence["glma-converter-checkpoint-drift"].finding
+    assert "tts_pad" in evidence["qwen3tts-speaker-runtime-boundary"].finding
+
+
 def test_every_non_supported_verdict_has_an_actionable_reason() -> None:
     for spec in iter_projector_specs():
         if spec.is_supported:
@@ -310,7 +385,7 @@ def test_every_non_supported_verdict_has_an_actionable_reason() -> None:
 
 
 def test_metadata_schema_captures_the_pinned_absence_of_a_text_encoder() -> None:
-    assert len(CLIP_METADATA_SCHEMA) == 61
+    assert len(CLIP_METADATA_SCHEMA) == 62
     fields = {field.key: field for field in CLIP_METADATA_SCHEMA}
     assert fields["clip.has_vision_encoder"].default is False
     assert fields["clip.has_audio_encoder"].default is False
@@ -332,7 +407,7 @@ def test_missing_modality_and_global_projector_fails_closed() -> None:
         projector_type_for_modality({}, MMProjModality.GENERATED_AUDIO)
 
 
-@pytest.mark.parametrize("projector_type", ["qwen2.5o"])
+@pytest.mark.parametrize("projector_type", ["voxtral"])
 def test_deferred_projector_has_no_dispatch_or_loader_closure(projector_type: str) -> None:
     spec = get_projector_spec(projector_type)
     assert not spec.is_supported

--- a/src/mobius/integrations/gguf/_qwen_glm_projector.py
+++ b/src/mobius/integrations/gguf/_qwen_glm_projector.py
@@ -1,0 +1,951 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Exact Qwen/GLM ``clip`` sidecar configuration, mapping, and graph helpers."""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+import re
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import onnx_ir as ir
+import torch
+from onnxscript import nn
+
+from mobius._configs import (
+    ArchitectureConfig,
+    AudioConfig,
+    SpeakerEncoderConfig,
+    TTSConfig,
+    VisionConfig,
+)
+from mobius._model_package import ModelPackage
+from mobius.components import (
+    GGUFLegacyGlmAudioProjector,
+    GGUFQwen2AudioProjector,
+)
+from mobius.integrations.gguf._mmproj_mapping import (
+    map_mmproj_glm4v_vision_to_onnx,
+    map_mmproj_glma_audio_to_onnx,
+    map_mmproj_qwen2_audio_to_onnx,
+    map_mmproj_qwen3_audio_to_onnx,
+    map_mmproj_qwen3_speaker_to_onnx,
+    map_mmproj_qwen3_vision_to_onnx,
+)
+from mobius.models.gguf_qwen_glm_projector import (
+    GGUFGlm4VVisionProjector,
+    GGUFGlmOcrVisionProjector,
+    GGUFQwen3AudioProjector,
+    GGUFQwen3TTSSpeakerProjector,
+    GGUFQwen3VLProjector,
+    GGUFQwen25OmniVisionProjector,
+)
+
+_FLOAT_DTYPES = {
+    ir.DataType.FLOAT,
+    ir.DataType.FLOAT16,
+    ir.DataType.BFLOAT16,
+}
+
+QWEN_GLM_PROCESSOR_ABIS: dict[str, dict[str, str | int]] = {
+    "qwen2a": {
+        "sample_rate": 16_000,
+        "input_features": "float32[1,128,3000]",
+        "output": "750 audio rows per 30-second chunk",
+        "preprocessing": "Whisper log10 mel; fixed 3000-frame chunks",
+        "empty_media": "do not invoke the audio graph",
+    },
+    "qwen3a": {
+        "sample_rate": 16_000,
+        "input_features": "float32[1,128,frames_multiple_of_100]",
+        "output": "13 * (frames / 100) audio rows",
+        "preprocessing": "Qwen3 Whisper mel; <=800-frame windows padded to 100",
+        "empty_media": "do not invoke the audio graph",
+    },
+    "glma": {
+        "sample_rate": 16_000,
+        "input_features": "float32[1,num_mel_bins,3000]",
+        "output": "frames / (2 * stack_factor) + BOI/EOI rows",
+        "preprocessing": "legacy Whisper log10 mel; fixed 3000-frame chunks",
+        "empty_media": "do not invoke the audio graph",
+    },
+    "qwen3tts_spkenc": {
+        "sample_rate": 24_000,
+        "mel_features": "float32[frames,128]",
+        "output": "one speaker-conditioning row",
+        "preprocessing": "natural-log magnitude mel; n_fft=1024, hop=256",
+        "empty_media": "speaker conditioning omitted; do not invoke graph",
+    },
+    "qwen3vl_merger": {
+        "pixel_values": "float32[total_patches,3*2*16*16]",
+        "image_grid_thw": "int64[num_media,3]",
+        "output": "sum(T*H*W/4) rows, width=(1+deepstack_layers)*text_hidden",
+        "ordering": "batch-major media; merge-block-major 2x2 patches",
+        "empty_media": "do not invoke the vision graph",
+    },
+    "glm4v": {
+        "pixel_values": "float32[total_patches,3*2*patch_size*patch_size]",
+        "image_grid_thw": "int64[num_media,3]",
+        "output": "sum(T*H*W/4) text-width rows",
+        "ordering": "batch-major media; merge-block-major 2x2 patches",
+        "empty_media": "do not invoke the vision graph",
+    },
+    "qwen2.5o": {
+        "vision": "qwen2.5vl_merger component ABI",
+        "audio": "qwen2a component ABI",
+        "output": "separate vision_encoder and audio_encoder components",
+        "empty_media": "invoke only components for present modalities",
+    },
+}
+
+
+def qwen3vl_decoder_mrope_positions(
+    *,
+    merged_height: int,
+    merged_width: int,
+    start_position: int,
+) -> tuple[np.ndarray, int]:
+    """Return llama.cpp's four decoder-position sections for one image grid.
+
+    Section order is ``t, y, x, z``. Unlike the vision tower's internal
+    merge-block rotary coordinates, these positions index the *merged* image
+    rows inserted into the text sequence. The next text position advances by
+    ``max(merged_height, merged_width)`` rather than by the image token count.
+    """
+    if merged_height <= 0 or merged_width <= 0 or start_position < 0:
+        raise ValueError("Qwen3-VL merged dimensions must be positive")
+    token_count = merged_height * merged_width
+    indices: np.ndarray = np.arange(token_count, dtype=np.int64)
+    positions = np.stack(
+        (
+            np.full(token_count, start_position, dtype=np.int64),
+            start_position + indices // merged_width,
+            start_position + indices % merged_width,
+            np.zeros(token_count, dtype=np.int64),
+        ),
+        axis=0,
+    )
+    return positions, start_position + max(merged_height, merged_width)
+
+
+def _base_config(
+    *,
+    model_type: str,
+    hidden_size: int,
+    dtype: ir.DataType,
+    vision: VisionConfig | None = None,
+    audio: AudioConfig | None = None,
+    tts: TTSConfig | None = None,
+) -> ArchitectureConfig:
+    if dtype not in _FLOAT_DTYPES:
+        raise ValueError(f"{model_type} sidecar dtype must be floating point")
+    return ArchitectureConfig(
+        model_type=model_type,
+        vocab_size=1,
+        hidden_size=hidden_size,
+        intermediate_size=hidden_size,
+        num_hidden_layers=1,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        head_dim=hidden_size,
+        max_position_embeddings=1,
+        hidden_act="silu",
+        dtype=dtype,
+        vision=vision,
+        audio=audio,
+        tts=tts,
+    )
+
+
+def _shape(model: Any, name: str) -> tuple[int, ...]:
+    return tuple(int(dim) for dim in model.get_tensor_shape(name))
+
+
+def _expect_shape(model: Any, name: str, expected: tuple[int, ...]) -> None:
+    actual = _shape(model, name)
+    if actual != expected:
+        raise ValueError(f"mmproj tensor {name!r} has shape {actual}, expected {expected}.")
+
+
+def read_qwen3vl_sidecar_config(model: Any, *, dtype: ir.DataType) -> ArchitectureConfig:
+    """Read the Qwen3-VL tower and DeepStack merger configuration."""
+    metadata = model.metadata
+    hidden = int(metadata["clip.vision.embedding_length"])
+    projection = int(metadata["clip.vision.projection_dim"])
+    patch_size = int(metadata["clip.vision.patch_size"])
+    merge = int(metadata.get("clip.vision.spatial_merge_size", 2))
+    if merge != 2:
+        raise ValueError(
+            "qwen3vl_merger requires clip.vision.spatial_merge_size=2 because "
+            "the final GGUF merger hardcodes four patches per output token."
+        )
+    position_rows = _shape(model, "v.position_embd.weight")[0]
+    position_grid = math.isqrt(position_rows)
+    if position_grid * position_grid != position_rows:
+        raise ValueError("Qwen3-VL position embeddings must form a square grid")
+
+    deepstack_layers = sorted(
+        {
+            int(match.group(1))
+            for name in model.tensor_names
+            if (
+                match := re.match(
+                    r"^v\.deepstack\.(\d+)\.(?:norm|fc1|fc2)\.(?:weight|bias)$",
+                    name,
+                )
+            )
+        }
+    )
+    declared = metadata.get("clip.vision.is_deepstack_layers")
+    if declared is not None:
+        if not isinstance(declared, list) or len(declared) != int(
+            metadata["clip.vision.block_count"]
+        ):
+            raise ValueError(
+                "clip.vision.is_deepstack_layers must be one bool per vision block"
+            )
+        declared_layers = [index for index, enabled in enumerate(declared) if bool(enabled)]
+        if declared_layers != deepstack_layers:
+            raise ValueError(
+                "Qwen3-VL DeepStack metadata and tensor layer indices disagree: "
+                f"{declared_layers} != {deepstack_layers}."
+            )
+
+    vision = VisionConfig(
+        hidden_size=hidden,
+        intermediate_size=int(metadata["clip.vision.feed_forward_length"]),
+        num_hidden_layers=int(metadata["clip.vision.block_count"]),
+        num_attention_heads=int(metadata["clip.vision.attention.head_count"]),
+        image_size=int(metadata["clip.vision.image_size"]),
+        patch_size=patch_size,
+        norm_eps=float(metadata["clip.vision.attention.layer_norm_epsilon"]),
+        in_channels=_shape(model, "v.patch_embd.weight")[1],
+        out_hidden_size=projection,
+        spatial_merge_size=merge,
+        temporal_patch_size=2,
+        num_position_embeddings=position_rows,
+        deepstack_visual_indexes=deepstack_layers,
+        hidden_act=(
+            "silu" if bool(metadata.get("clip.use_silu", False)) else "gelu_pytorch_tanh"
+        ),
+    )
+    return _base_config(
+        model_type="gguf_qwen3vl_merger",
+        hidden_size=projection,
+        dtype=dtype,
+        vision=vision,
+    )
+
+
+def read_glm4v_sidecar_config(model: Any, *, dtype: ir.DataType) -> ArchitectureConfig:
+    """Read GLM4V's packed ViT, learned downsampler, and gated projector."""
+    metadata = model.metadata
+    hidden = int(metadata["clip.vision.embedding_length"])
+    projection = int(metadata["clip.vision.projection_dim"])
+    merge = int(metadata.get("clip.vision.spatial_merge_size", 2))
+    if merge != 2:
+        raise ValueError("glm4v requires clip.vision.spatial_merge_size=2")
+    position_rows = (
+        _shape(model, "v.position_embd.weight")[0]
+        if "v.position_embd.weight" in model.tensor_names
+        else None
+    )
+    projector_intermediate = _shape(model, "mm.up.weight")[0]
+    block_intermediate = _shape(model, "v.blk.0.ffn_up.weight")[0]
+    vision = VisionConfig(
+        hidden_size=hidden,
+        intermediate_size=block_intermediate,
+        num_hidden_layers=int(metadata["clip.vision.block_count"]),
+        num_attention_heads=int(metadata["clip.vision.attention.head_count"]),
+        image_size=int(metadata["clip.vision.image_size"]),
+        patch_size=int(metadata["clip.vision.patch_size"]),
+        norm_eps=float(metadata["clip.vision.attention.layer_norm_epsilon"]),
+        in_channels=_shape(model, "v.patch_embd.weight")[1],
+        out_hidden_size=projection,
+        spatial_merge_size=merge,
+        temporal_patch_size=2,
+        num_position_embeddings=position_rows,
+        projector_intermediate_size=projector_intermediate,
+        hidden_act="silu" if bool(metadata.get("clip.use_silu", False)) else "gelu",
+    )
+    return _base_config(
+        model_type="gguf_glm4v",
+        hidden_size=projection,
+        dtype=dtype,
+        vision=vision,
+    )
+
+
+def read_qwen25o_vision_config(
+    model: Any,
+    *,
+    dtype: ir.DataType,
+) -> ArchitectureConfig:
+    """Resolve qwen2.5o's vision context as an exact Qwen2.5-VL merger."""
+    metadata = model.metadata
+    hidden = int(metadata["clip.vision.embedding_length"])
+    layers = int(metadata["clip.vision.block_count"])
+    intermediate = _shape(model, "v.blk.0.ffn_up.weight")[0]
+    pattern = int(metadata["clip.vision.n_wa_pattern"])
+    if pattern <= 0:
+        raise ValueError("clip.vision.n_wa_pattern must be positive")
+    vision = VisionConfig(
+        hidden_size=hidden,
+        intermediate_size=intermediate,
+        num_hidden_layers=layers,
+        num_attention_heads=int(metadata["clip.vision.attention.head_count"]),
+        image_size=int(metadata["clip.vision.image_size"]),
+        patch_size=int(metadata["clip.vision.patch_size"]),
+        norm_eps=float(metadata["clip.vision.attention.layer_norm_epsilon"]),
+        in_channels=_shape(model, "v.patch_embd.weight")[1],
+        out_hidden_size=int(metadata["clip.vision.projection_dim"]),
+        spatial_merge_size=2,
+        temporal_patch_size=2,
+        fullatt_block_indexes=list(range(pattern - 1, layers, pattern)),
+        window_size=112,
+        hidden_act="silu",
+    )
+    return _base_config(
+        model_type="gguf_qwen25o_vision",
+        hidden_size=int(vision.out_hidden_size or 0),
+        dtype=dtype,
+        vision=vision,
+    )
+
+
+def _audio_config(model: Any) -> AudioConfig:
+    metadata = model.metadata
+    return AudioConfig(
+        d_model=int(metadata["clip.audio.embedding_length"]),
+        encoder_layers=int(metadata["clip.audio.block_count"]),
+        encoder_attention_heads=int(metadata["clip.audio.attention.head_count"]),
+        encoder_ffn_dim=int(metadata["clip.audio.feed_forward_length"]),
+        encoder_layer_norm_eps=float(metadata["clip.audio.attention.layer_norm_epsilon"]),
+        num_mel_bins=int(metadata["clip.audio.num_mel_bins"]),
+        max_source_positions=_shape(model, "a.position_embd.weight")[0],
+        output_dim=int(metadata["clip.audio.projection_dim"]),
+        activation_function="gelu",
+    )
+
+
+def read_qwen2a_sidecar_config(model: Any, *, dtype: ir.DataType) -> ArchitectureConfig:
+    audio = _audio_config(model)
+    return _base_config(
+        model_type="gguf_qwen2a",
+        hidden_size=int(audio.output_dim or 0),
+        dtype=dtype,
+        audio=audio,
+    )
+
+
+def read_qwen3a_sidecar_config(model: Any, *, dtype: ir.DataType) -> ArchitectureConfig:
+    audio = dataclasses.replace(
+        _audio_config(model),
+        downsample_hidden_size=_shape(model, "a.conv2d.1.weight")[0],
+        n_window=50,
+        n_window_infer=int(model.metadata.get("clip.audio.projector.window_size", 800)),
+    )
+    return _base_config(
+        model_type="gguf_qwen3a",
+        hidden_size=int(audio.output_dim or 0),
+        dtype=dtype,
+        audio=audio,
+    )
+
+
+def read_glma_sidecar_config(model: Any, *, dtype: ir.DataType) -> ArchitectureConfig:
+    audio = _audio_config(model)
+    return _base_config(
+        model_type="gguf_glma",
+        hidden_size=int(audio.output_dim or 0),
+        dtype=dtype,
+        audio=audio,
+    )
+
+
+def read_qwen3tts_speaker_config(
+    model: Any,
+    *,
+    dtype: ir.DataType,
+) -> ArchitectureConfig:
+    """Infer the non-metadata ECAPA dimensions from the exact tensor closure."""
+    stem = _shape(model, "a.conv1d.0.weight")
+    mfa = _shape(model, "a.conv_out.weight")
+    asp_tdnn = _shape(model, "a.asp_tdnn.weight")
+    se = _shape(model, "a.blk.1.se_conv1.weight")
+    final = _shape(model, "mm.a.fc.weight")
+    speaker = SpeakerEncoderConfig(
+        mel_dim=stem[1],
+        enc_dim=final[0],
+        enc_channels=[stem[0], stem[0], stem[0], stem[0], mfa[0]],
+        enc_kernel_sizes=[stem[2], 3, 3, 3, mfa[2]],
+        enc_dilations=[1, 2, 3, 4, 1],
+        enc_attention_channels=asp_tdnn[0],
+        enc_res2net_scale=8,
+        enc_se_channels=se[0],
+    )
+    return _base_config(
+        model_type="gguf_qwen3tts_spkenc",
+        hidden_size=speaker.enc_dim,
+        # llama.cpp forces speaker TDNN matrix products to float32.
+        dtype=ir.DataType.FLOAT,
+        tts=TTSConfig(speaker_encoder=speaker),
+    )
+
+
+def create_qwen_glm_projector(
+    projector_type: str,
+    model: Any,
+    *,
+    dtype: ir.DataType,
+) -> tuple[nn.Module, ArchitectureConfig]:
+    """Create one exact standalone component and its graph-only config."""
+    component: nn.Module
+    if projector_type == "glm4v":
+        config = read_glm4v_sidecar_config(model, dtype=dtype)
+        if "v.blk.0.attn_q_norm.weight" in model.tensor_names:
+            return GGUFGlmOcrVisionProjector(config), config
+        return GGUFGlm4VVisionProjector(config), config
+    if projector_type == "qwen3vl_merger":
+        config = read_qwen3vl_sidecar_config(model, dtype=dtype)
+        return GGUFQwen3VLProjector(config), config
+    if projector_type == "qwen2a":
+        config = read_qwen2a_sidecar_config(model, dtype=dtype)
+        audio = config.audio
+        assert audio is not None
+        component = GGUFQwen2AudioProjector(
+            num_mel_bins=int(audio.num_mel_bins or 0),
+            hidden_size=int(audio.d_model or 0),
+            intermediate_size=int(audio.encoder_ffn_dim or 0),
+            num_hidden_layers=int(audio.encoder_layers or 0),
+            num_attention_heads=int(audio.encoder_attention_heads or 0),
+            max_source_positions=int(audio.max_source_positions or 0),
+            output_size=int(audio.output_dim or 0),
+            norm_eps=float(audio.encoder_layer_norm_eps or 1e-5),
+        )
+        return component, config
+    if projector_type == "qwen3a":
+        config = read_qwen3a_sidecar_config(model, dtype=dtype)
+        return GGUFQwen3AudioProjector(config), config
+    if projector_type == "glma":
+        config = read_glma_sidecar_config(model, dtype=dtype)
+        audio = config.audio
+        assert audio is not None
+        stack_factor = int(model.metadata["clip.audio.projector.stack_factor"])
+        component = GGUFLegacyGlmAudioProjector(
+            num_mel_bins=int(audio.num_mel_bins or 0),
+            hidden_size=int(audio.d_model or 0),
+            intermediate_size=int(audio.encoder_ffn_dim or 0),
+            num_hidden_layers=int(audio.encoder_layers or 0),
+            num_attention_heads=int(audio.encoder_attention_heads or 0),
+            max_source_positions=int(audio.max_source_positions or 0),
+            stack_factor=stack_factor,
+            projector_intermediate_size=_shape(model, "mm.a.mlp.1.weight")[0],
+            output_size=int(audio.output_dim or 0),
+            norm_eps=float(audio.encoder_layer_norm_eps or 1e-5),
+            activation="silu" if bool(model.metadata.get("clip.use_silu")) else "gelu",
+        )
+        return component, config
+    if projector_type == "qwen3tts_spkenc":
+        config = read_qwen3tts_speaker_config(model, dtype=dtype)
+        return GGUFQwen3TTSSpeakerProjector(config), config
+    raise ValueError(f"Unsupported Qwen/GLM projector type {projector_type!r}")
+
+
+def _mapped_state(
+    model: Any,
+    projector_type: str,
+    *,
+    component_prefix: str,
+    deepstack_layers: tuple[int, ...] = (),
+) -> dict[str, torch.Tensor]:
+    mappers = {
+        "glm4v": map_mmproj_glm4v_vision_to_onnx,
+        "qwen2a": map_mmproj_qwen2_audio_to_onnx,
+        "qwen3a": map_mmproj_qwen3_audio_to_onnx,
+        "glma": map_mmproj_glma_audio_to_onnx,
+        "qwen3tts_spkenc": map_mmproj_qwen3_speaker_to_onnx,
+    }
+    mapper = mappers.get(projector_type)
+    state: dict[str, torch.Tensor] = {}
+    fused_sources: set[str] = set()
+
+    if projector_type in {"glm4v", "qwen3vl_merger"}:
+        patch_names = ("v.patch_embd.weight", "v.patch_embd.weight.1")
+        patch_halves = [
+            np.asarray(model.get_tensor(name), dtype=np.float32) for name in patch_names
+        ]
+        state[f"{component_prefix}.visual.patch_embed.proj.weight"] = torch.from_numpy(
+            np.stack(patch_halves, axis=2).copy()
+        )
+        fused_sources.update(patch_names)
+
+    if projector_type == "qwen3vl_merger":
+        mapper = lambda name: map_mmproj_qwen3_vision_to_onnx(  # noqa: E731
+            name,
+            deepstack_layers=deepstack_layers,
+        )
+
+    for name in model.tensor_names:
+        if name in fused_sources or name.startswith("a.gen."):
+            continue
+        if mapper is None:
+            continue
+        mapped = mapper(name)
+        if mapped is None:
+            continue
+        values = np.asarray(model.get_tensor(name), dtype=np.float32)
+        target = f"{component_prefix}.{mapped}"
+        initializer_shape = values.shape
+        if name.endswith(".bias") and values.ndim > 1:
+            values = values.reshape(-1)
+        if (
+            projector_type == "qwen3tts_spkenc"
+            and name.endswith(".weight")
+            and values.ndim == 2
+            and name.startswith(("a.conv", "a.asp", "mm.a.fc"))
+        ):
+            values = values[:, :, None]
+        if not values.flags.c_contiguous:
+            values = values.copy()
+        state[target] = torch.from_numpy(values)
+        del initializer_shape
+    return state
+
+
+def qwen_glm_projector_state(
+    model: Any,
+    projector_type: str,
+    *,
+    component_prefix: str,
+) -> dict[str, torch.Tensor]:
+    """Load and transform the selected sidecar component into ONNX names."""
+    deepstack_layers: tuple[int, ...] = ()
+    if projector_type == "qwen3vl_merger":
+        vision = read_qwen3vl_sidecar_config(
+            model,
+            dtype=ir.DataType.FLOAT,
+        ).vision
+        assert vision is not None
+        deepstack_layers = tuple(vision.deepstack_visual_indexes or ())
+    return _mapped_state(
+        model,
+        projector_type,
+        component_prefix=component_prefix,
+        deepstack_layers=deepstack_layers,
+    )
+
+
+def qwen25o_vision_state(
+    model: Any,
+    *,
+    component_prefix: str,
+) -> dict[str, torch.Tensor]:
+    """Transform the legacy alias's vision tensors through Qwen2.5-VL rules."""
+    from mobius.integrations.gguf._mmproj import _mmproj_qwen_vision_to_hf
+
+    transformed = _mmproj_qwen_vision_to_hf(model, "qwen2.5vl_merger")
+    state = {}
+    for name, value in transformed.items():
+        name = name.replace(".merger.mlp.0.", ".merger.mlp_0.")
+        name = name.replace(".merger.mlp.2.", ".merger.mlp_2.")
+        state[f"{component_prefix}.{name}"] = value
+    return state
+
+
+def validate_qwen_glm_projector_shapes(model: Any, projector_type: str) -> None:
+    """Reject any shape contract that the exact route graph cannot consume."""
+    metadata = model.metadata
+    if projector_type == "qwen2.5o":
+        # The legacy selector has no graph of its own. Its audio context is
+        # exactly qwen2a, while its vision context is qwen2.5vl_merger.
+        validate_qwen_glm_projector_shapes(model, "qwen2a")
+        hidden = int(metadata["clip.vision.embedding_length"])
+        intermediate = _shape(model, "v.blk.0.ffn_up.weight")[0]
+        projection = int(metadata["clip.vision.projection_dim"])
+        patch = int(metadata["clip.vision.patch_size"])
+        layers = int(metadata["clip.vision.block_count"])
+        heads = int(metadata["clip.vision.attention.head_count"])
+        if hidden <= 0 or heads <= 0 or hidden % heads:
+            raise ValueError("Qwen2.5-Omni vision hidden size must divide by heads")
+        for name in ("v.patch_embd.weight", "v.patch_embd.weight.1"):
+            _expect_shape(model, name, (hidden, 3, patch, patch))
+        merged = hidden * 4
+        _expect_shape(model, "v.post_ln.weight", (hidden,))
+        _expect_shape(model, "mm.0.weight", (merged, merged))
+        _expect_shape(model, "mm.0.bias", (merged,))
+        _expect_shape(model, "mm.2.weight", (projection, merged))
+        _expect_shape(model, "mm.2.bias", (projection,))
+        for layer in range(layers):
+            prefix = f"v.blk.{layer}."
+            for norm in ("ln1", "ln2"):
+                _expect_shape(model, prefix + norm + ".weight", (hidden,))
+            for stem in ("attn_q", "attn_k", "attn_v", "attn_out"):
+                _expect_shape(model, prefix + stem + ".weight", (hidden, hidden))
+                _expect_shape(model, prefix + stem + ".bias", (hidden,))
+            for stem in ("ffn_gate", "ffn_up"):
+                _expect_shape(model, prefix + stem + ".weight", (intermediate, hidden))
+                _expect_shape(model, prefix + stem + ".bias", (intermediate,))
+            _expect_shape(model, prefix + "ffn_down.weight", (hidden, intermediate))
+            _expect_shape(model, prefix + "ffn_down.bias", (hidden,))
+        return
+
+    if projector_type in {"glm4v", "qwen3vl_merger"}:
+        hidden = int(metadata["clip.vision.embedding_length"])
+        intermediate = int(metadata["clip.vision.feed_forward_length"])
+        projection = int(metadata["clip.vision.projection_dim"])
+        patch = int(metadata["clip.vision.patch_size"])
+        layers = int(metadata["clip.vision.block_count"])
+        heads = int(metadata["clip.vision.attention.head_count"])
+        if hidden <= 0 or heads <= 0 or hidden % heads:
+            raise ValueError("vision hidden size must be divisible by its head count")
+        if projector_type == "glm4v":
+            intermediate = _shape(model, "v.blk.0.ffn_up.weight")[0]
+        for name in ("v.patch_embd.weight", "v.patch_embd.weight.1"):
+            _expect_shape(model, name, (hidden, 3, patch, patch))
+        _expect_shape(model, "v.patch_embd.bias", (hidden,))
+
+        if projector_type == "qwen3vl_merger":
+            position = _shape(model, "v.position_embd.weight")
+            if len(position) != 2 or position[1] != hidden:
+                raise ValueError("Qwen3-VL position embeddings must be [positions, hidden]")
+            merged = hidden * 4
+            _expect_shape(model, "v.post_ln.weight", (hidden,))
+            _expect_shape(model, "v.post_ln.bias", (hidden,))
+            _expect_shape(model, "mm.0.weight", (merged, merged))
+            _expect_shape(model, "mm.0.bias", (merged,))
+            _expect_shape(model, "mm.2.weight", (projection, merged))
+            _expect_shape(model, "mm.2.bias", (projection,))
+            for layer in range(layers):
+                prefix = f"v.blk.{layer}."
+                for norm in ("ln1", "ln2"):
+                    _expect_shape(model, prefix + norm + ".weight", (hidden,))
+                    _expect_shape(model, prefix + norm + ".bias", (hidden,))
+                _expect_shape(model, prefix + "attn_qkv.weight", (3 * hidden, hidden))
+                _expect_shape(model, prefix + "attn_qkv.bias", (3 * hidden,))
+                _expect_shape(model, prefix + "attn_out.weight", (hidden, hidden))
+                _expect_shape(model, prefix + "attn_out.bias", (hidden,))
+                _expect_shape(model, prefix + "ffn_up.weight", (intermediate, hidden))
+                _expect_shape(model, prefix + "ffn_up.bias", (intermediate,))
+                _expect_shape(model, prefix + "ffn_down.weight", (hidden, intermediate))
+                _expect_shape(model, prefix + "ffn_down.bias", (hidden,))
+            config = read_qwen3vl_sidecar_config(model, dtype=ir.DataType.FLOAT)
+            deepstack = config.vision.deepstack_visual_indexes if config.vision else []
+            for layer in deepstack or []:
+                prefix = f"v.deepstack.{layer}."
+                _expect_shape(model, prefix + "norm.weight", (merged,))
+                _expect_shape(model, prefix + "norm.bias", (merged,))
+                _expect_shape(model, prefix + "fc1.weight", (merged, merged))
+                _expect_shape(model, prefix + "fc1.bias", (merged,))
+                _expect_shape(model, prefix + "fc2.weight", (projection, merged))
+                _expect_shape(model, prefix + "fc2.bias", (projection,))
+            return
+
+        is_glm_ocr = "v.blk.0.attn_q_norm.weight" in model.tensor_names
+        if is_glm_ocr and (
+            "v.norm_embd.weight" in model.tensor_names
+            or "v.position_embd.weight" in model.tensor_names
+        ):
+            raise ValueError(
+                "The GLM-OCR qk-norm variant cannot carry GLM4V post-conv or "
+                "learned-position tensors."
+            )
+        if not is_glm_ocr and "v.norm_embd.weight" not in model.tensor_names:
+            raise ValueError("The GLM4V variant requires v.norm_embd.weight")
+        if "v.norm_embd.weight" in model.tensor_names:
+            _expect_shape(model, "v.norm_embd.weight", (hidden,))
+        if "v.position_embd.weight" in model.tensor_names:
+            position = _shape(model, "v.position_embd.weight")
+            if len(position) != 2 or position[1] != hidden:
+                raise ValueError("GLM4V position embeddings must be [positions, hidden]")
+        _expect_shape(model, "v.post_ln.weight", (hidden,))
+        _expect_shape(model, "mm.patch_merger.weight", (projection, hidden, 2, 2))
+        _expect_shape(model, "mm.patch_merger.bias", (projection,))
+        _expect_shape(model, "mm.model.fc.weight", (projection, projection))
+        _expect_shape(model, "mm.post_norm.weight", (projection,))
+        _expect_shape(model, "mm.post_norm.bias", (projection,))
+        projector_intermediate = _shape(model, "mm.up.weight")[0]
+        _expect_shape(model, "mm.up.weight", (projector_intermediate, projection))
+        _expect_shape(model, "mm.gate.weight", (projector_intermediate, projection))
+        _expect_shape(model, "mm.down.weight", (projection, projector_intermediate))
+        for layer in range(layers):
+            prefix = f"v.blk.{layer}."
+            for norm in ("ln1", "ln2"):
+                _expect_shape(model, prefix + norm + ".weight", (hidden,))
+            _expect_shape(model, prefix + "attn_qkv.weight", (3 * hidden, hidden))
+            _expect_shape(model, prefix + "attn_out.weight", (hidden, hidden))
+            _expect_shape(model, prefix + "ffn_gate.weight", (intermediate, hidden))
+            _expect_shape(model, prefix + "ffn_up.weight", (intermediate, hidden))
+            _expect_shape(model, prefix + "ffn_down.weight", (hidden, intermediate))
+            if is_glm_ocr:
+                _expect_shape(model, prefix + "attn_qkv.bias", (3 * hidden,))
+                _expect_shape(model, prefix + "attn_out.bias", (hidden,))
+                _expect_shape(
+                    model,
+                    prefix + "attn_q_norm.weight",
+                    (hidden // heads,),
+                )
+                _expect_shape(
+                    model,
+                    prefix + "attn_k_norm.weight",
+                    (hidden // heads,),
+                )
+                _expect_shape(model, prefix + "ffn_gate.bias", (intermediate,))
+                _expect_shape(model, prefix + "ffn_up.bias", (intermediate,))
+                _expect_shape(model, prefix + "ffn_down.bias", (hidden,))
+        return
+
+    if projector_type in {"qwen2a", "qwen3a", "glma"}:
+        hidden = int(metadata["clip.audio.embedding_length"])
+        intermediate = int(metadata["clip.audio.feed_forward_length"])
+        projection = int(metadata["clip.audio.projection_dim"])
+        layers = int(metadata["clip.audio.block_count"])
+        heads = int(metadata["clip.audio.attention.head_count"])
+        mel = int(metadata["clip.audio.num_mel_bins"])
+        if hidden <= 0 or heads <= 0 or hidden % heads:
+            raise ValueError("audio hidden size must be divisible by its head count")
+        position = _shape(model, "a.position_embd.weight")
+        if len(position) != 2 or position[1] != hidden:
+            raise ValueError("audio position embeddings must be [positions, hidden]")
+        for layer in range(layers):
+            prefix = f"a.blk.{layer}."
+            for norm in ("ln1", "ln2"):
+                _expect_shape(model, prefix + norm + ".weight", (hidden,))
+                _expect_shape(model, prefix + norm + ".bias", (hidden,))
+            for stem in ("attn_q", "attn_k", "attn_v", "attn_out"):
+                _expect_shape(model, prefix + stem + ".weight", (hidden, hidden))
+            for stem in ("attn_q", "attn_v", "attn_out"):
+                _expect_shape(model, prefix + stem + ".bias", (hidden,))
+            if projector_type == "qwen3a":
+                _expect_shape(model, prefix + "attn_k.bias", (hidden,))
+            _expect_shape(model, prefix + "ffn_up.weight", (intermediate, hidden))
+            _expect_shape(model, prefix + "ffn_up.bias", (intermediate,))
+            _expect_shape(model, prefix + "ffn_down.weight", (hidden, intermediate))
+            _expect_shape(model, prefix + "ffn_down.bias", (hidden,))
+        _expect_shape(model, "a.post_ln.weight", (hidden,))
+        _expect_shape(model, "a.post_ln.bias", (hidden,))
+
+        if projector_type in {"qwen2a", "glma"}:
+            _expect_shape(model, "a.conv1d.1.weight", (hidden, mel, 3))
+            _expect_shape(model, "a.conv1d.2.weight", (hidden, hidden, 3))
+            for index in (1, 2):
+                bias = _shape(model, f"a.conv1d.{index}.bias")
+                if math.prod(bias) != hidden:
+                    raise ValueError(f"a.conv1d.{index}.bias must contain {hidden} values")
+        if projector_type == "qwen2a":
+            _expect_shape(model, "mm.a.fc.weight", (projection, hidden))
+            _expect_shape(model, "mm.a.fc.bias", (projection,))
+            return
+        if projector_type == "glma":
+            stack = int(metadata["clip.audio.projector.stack_factor"])
+            projector_intermediate = _shape(model, "mm.a.mlp.1.weight")[0]
+            _expect_shape(
+                model,
+                "mm.a.mlp.1.weight",
+                (projector_intermediate, hidden * stack),
+            )
+            _expect_shape(model, "mm.a.mlp.1.bias", (projector_intermediate,))
+            _expect_shape(
+                model,
+                "mm.a.mlp.2.weight",
+                (projection, projector_intermediate),
+            )
+            _expect_shape(model, "mm.a.mlp.2.bias", (projection,))
+            _expect_shape(model, "mm.a.norm_pre.weight", (hidden,))
+            _expect_shape(model, "mm.a.norm_pre.bias", (hidden,))
+            _expect_shape(model, "v.boi", (projection,))
+            _expect_shape(model, "v.eoi", (projection,))
+            return
+
+        downsample = _shape(model, "a.conv2d.1.weight")[0]
+        _expect_shape(model, "a.conv2d.1.weight", (downsample, 1, 3, 3))
+        _expect_shape(model, "a.conv2d.2.weight", (downsample, downsample, 3, 3))
+        _expect_shape(model, "a.conv2d.3.weight", (downsample, downsample, 3, 3))
+        for index in (1, 2, 3):
+            bias = _shape(model, f"a.conv2d.{index}.bias")
+            if math.prod(bias) != downsample:
+                raise ValueError(f"a.conv2d.{index}.bias must contain {downsample} values")
+        mel_after = (mel + 1) // 2
+        mel_after = (mel_after + 1) // 2
+        mel_after = (mel_after + 1) // 2
+        _expect_shape(model, "a.conv_out.weight", (hidden, downsample * mel_after))
+        _expect_shape(model, "mm.a.mlp.1.weight", (hidden, hidden))
+        _expect_shape(model, "mm.a.mlp.1.bias", (hidden,))
+        _expect_shape(model, "mm.a.mlp.2.weight", (projection, hidden))
+        _expect_shape(model, "mm.a.mlp.2.bias", (projection,))
+        return
+
+    if projector_type == "qwen3tts_spkenc":
+        if int(metadata["clip.audio.block_count"]) != 3:
+            raise ValueError("qwen3tts_spkenc requires exactly three SE-Res2Net blocks")
+        stem_shape = _shape(model, "a.conv1d.0.weight")
+        if len(stem_shape) != 3 or stem_shape[2] != 5:
+            raise ValueError("Qwen3-TTS speaker stem must be [channels, mel_bins, 5]")
+        channels = stem_shape[0]
+        _expect_shape(model, "a.conv1d.0.bias", (channels,))
+        for block in range(1, 4):
+            prefix = f"a.blk.{block}."
+            _expect_shape(model, prefix + "conv_pw1.weight", (channels, channels, 1))
+            _expect_shape(model, prefix + "conv_pw1.bias", (channels,))
+            _expect_shape(model, prefix + "conv_pw2.weight", (channels, channels, 1))
+            _expect_shape(model, prefix + "conv_pw2.bias", (channels,))
+            se_channels = _shape(model, prefix + "se_conv1.weight")[0]
+            _expect_shape(
+                model,
+                prefix + "se_conv1.weight",
+                (se_channels, channels, 1),
+            )
+            _expect_shape(model, prefix + "se_conv1.bias", (se_channels,))
+            _expect_shape(
+                model,
+                prefix + "se_conv2.weight",
+                (channels, se_channels, 1),
+            )
+            _expect_shape(model, prefix + "se_conv2.bias", (channels,))
+            for branch in range(7):
+                _expect_shape(
+                    model,
+                    prefix + f"res2.{branch}.weight",
+                    (channels // 8, channels // 8, 3),
+                )
+                _expect_shape(
+                    model,
+                    prefix + f"res2.{branch}.bias",
+                    (channels // 8,),
+                )
+        mfa = _shape(model, "a.conv_out.weight")
+        if len(mfa) != 3 or mfa[1:] != (3 * channels, 1):
+            raise ValueError("Qwen3-TTS MFA weight must consume all three block outputs")
+        _expect_shape(model, "a.conv_out.bias", (mfa[0],))
+        asp_tdnn = _shape(model, "a.asp_tdnn.weight")
+        if len(asp_tdnn) != 3 or asp_tdnn[1:] != (3 * mfa[0], 1):
+            raise ValueError("Qwen3-TTS ASP TDNN must consume hidden/mean/std")
+        _expect_shape(model, "a.asp_tdnn.bias", (asp_tdnn[0],))
+        _expect_shape(model, "a.asp_attn.weight", (mfa[0], asp_tdnn[0], 1))
+        _expect_shape(model, "a.asp_attn.bias", (mfa[0],))
+        final = _shape(model, "mm.a.fc.weight")
+        if len(final) != 3 or final[1:] != (2 * mfa[0], 1):
+            raise ValueError("Qwen3-TTS speaker FC must consume weighted mean and std")
+        _expect_shape(model, "mm.a.fc.bias", (final[0],))
+        return
+
+    raise ValueError(f"No shape validator for projector type {projector_type!r}")
+
+
+def build_qwen_glm_projector_package(
+    model: Any,
+    *,
+    resolved_path: str | Path,
+    projector_type: str,
+    dtype: str | None,
+    execution_provider: str,
+) -> ModelPackage:
+    """Build and load the exact standalone component set for this cohort."""
+    from mobius._builder import build_from_module, resolve_dtype
+    from mobius.tasks import (
+        GGUFAudioProjectorModel,
+        GGUFAudioProjectorTask,
+        GGUFSpeakerProjectorModel,
+        GGUFSpeakerProjectorTask,
+        GGUFVisionProjectorModel,
+        GGUFVisionProjectorTask,
+    )
+
+    resolved_dtype = resolve_dtype(dtype) or ir.DataType.FLOAT
+    if projector_type == "qwen3tts_spkenc" and resolved_dtype != ir.DataType.FLOAT:
+        raise ValueError(
+            "qwen3tts_spkenc executes its TDNN matrix products in float32; "
+            "reduced-precision graph conversion is not exact."
+        )
+
+    if projector_type == "qwen2.5o":
+        vision_config = read_qwen25o_vision_config(model, dtype=resolved_dtype)
+        vision_component = GGUFQwen25OmniVisionProjector(vision_config)
+        vision_package = build_from_module(
+            GGUFVisionProjectorModel(vision_component),
+            vision_config,
+            task=GGUFVisionProjectorTask(),
+            execution_provider=execution_provider,
+        )
+        vision_package.apply_weights(
+            qwen25o_vision_state(model, component_prefix="vision_encoder")
+        )
+
+        audio_config = read_qwen2a_sidecar_config(model, dtype=resolved_dtype)
+        audio_component, _ = create_qwen_glm_projector(
+            "qwen2a",
+            model,
+            dtype=resolved_dtype,
+        )
+        audio_package = build_from_module(
+            GGUFAudioProjectorModel(audio_component),
+            audio_config,
+            task=GGUFAudioProjectorTask(),
+            execution_provider=execution_provider,
+        )
+        audio_package.apply_weights(
+            qwen_glm_projector_state(
+                model,
+                "qwen2a",
+                component_prefix="audio_encoder",
+            )
+        )
+        combined_config = dataclasses.replace(
+            vision_config,
+            audio=audio_config.audio,
+        )
+        package = ModelPackage(
+            {
+                "vision_encoder": vision_package["vision_encoder"],
+                "audio_encoder": audio_package["audio_encoder"],
+            },
+            config=combined_config,
+        )
+    else:
+        component, config = create_qwen_glm_projector(
+            projector_type,
+            model,
+            dtype=resolved_dtype,
+        )
+        if projector_type in {"glm4v", "qwen3vl_merger"}:
+            package = build_from_module(
+                GGUFVisionProjectorModel(component),
+                config,
+                task=GGUFVisionProjectorTask(),
+                execution_provider=execution_provider,
+            )
+            component_prefix = "vision_encoder"
+        elif projector_type == "qwen3tts_spkenc":
+            package = build_from_module(
+                GGUFSpeakerProjectorModel(component),
+                config,
+                task=GGUFSpeakerProjectorTask(),
+                execution_provider=execution_provider,
+            )
+            component_prefix = "speaker_encoder"
+        else:
+            package = build_from_module(
+                GGUFAudioProjectorModel(component),
+                config,
+                task=GGUFAudioProjectorTask(),
+                execution_provider=execution_provider,
+            )
+            component_prefix = "audio_encoder"
+        package.apply_weights(
+            qwen_glm_projector_state(
+                model,
+                projector_type,
+                component_prefix=component_prefix,
+            )
+        )
+
+    package.gguf_source_path = str(Path(resolved_path).resolve())  # type: ignore[attr-defined]
+    package.gguf_projector_type = projector_type  # type: ignore[attr-defined]
+    package.gguf_processor_abi = QWEN_GLM_PROCESSOR_ABIS[  # type: ignore[attr-defined]
+        projector_type
+    ]
+    return package

--- a/src/mobius/integrations/gguf/_qwen_glm_projector.py
+++ b/src/mobius/integrations/gguf/_qwen_glm_projector.py
@@ -62,8 +62,9 @@ QWEN_GLM_PROCESSOR_ABIS: dict[str, dict[str, str | int]] = {
     "qwen3a": {
         "sample_rate": 16_000,
         "input_features": "float32[1,128,frames_multiple_of_100]",
-        "output": "13 * (frames / 100) audio rows",
-        "preprocessing": "Qwen3 Whisper mel; <=800-frame windows padded to 100",
+        "feature_attention_mask": "int64[1,frames], binary and right-padded",
+        "output": "valid audio rows plus int64[1] audio_feature_lengths",
+        "preprocessing": "Qwen3 Whisper mel; 100-frame chunks with right padding",
         "empty_media": "do not invoke the audio graph",
     },
     "glma": {
@@ -169,6 +170,154 @@ def _expect_shape(model: Any, name: str, expected: tuple[int, ...]) -> None:
     actual = _shape(model, name)
     if actual != expected:
         raise ValueError(f"mmproj tensor {name!r} has shape {actual}, expected {expected}.")
+
+
+def _positive_integer(metadata: dict[str, Any], key: str) -> int:
+    value = metadata[key]
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)) or value <= 0:
+        raise ValueError(f"{key} must be a positive integer, got {value!r}.")
+    return int(value)
+
+
+def _positive_finite_number(metadata: dict[str, Any], key: str) -> float:
+    value = metadata[key]
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float, np.integer, np.floating))
+        or not math.isfinite(float(value))
+        or value <= 0
+    ):
+        raise ValueError(f"{key} must be a positive finite number, got {value!r}.")
+    return float(value)
+
+
+def _validate_bool(
+    metadata: dict[str, Any], key: str, *, expected: bool | None = None
+) -> None:
+    value = metadata[key]
+    if not isinstance(value, bool) or (expected is not None and value is not expected):
+        expectation = f" boolean {expected!r}" if expected is not None else " a boolean"
+        raise ValueError(f"{key} must be{expectation}, got {value!r}.")
+
+
+def _validate_float_vector(
+    metadata: dict[str, Any],
+    key: str,
+    *,
+    positive: bool,
+) -> None:
+    value = metadata[key]
+    if not isinstance(value, (list, tuple)) or len(value) != 3:
+        raise ValueError(f"{key} must be a three-element numeric sequence, got {value!r}.")
+    for item in value:
+        if (
+            isinstance(item, bool)
+            or not isinstance(item, (int, float, np.integer, np.floating))
+            or not math.isfinite(float(item))
+            or (positive and item <= 0)
+        ):
+            qualifier = "positive finite" if positive else "finite"
+            raise ValueError(f"{key} values must be {qualifier} numbers, got {value!r}.")
+
+
+def validate_qwen_glm_projector_metadata(model: Any, projector_type: str) -> None:
+    """Reject malformed route metadata before inspecting the tensor closure."""
+    metadata = model.metadata
+    vision_routes = {"glm4v", "qwen2.5o", "qwen3vl_merger"}
+    audio_routes = {"glma", "qwen2.5o", "qwen2a", "qwen3a", "qwen3tts_spkenc"}
+
+    if projector_type in vision_routes:
+        _validate_bool(metadata, "clip.has_vision_encoder", expected=True)
+        vision_keys = (
+            "clip.vision.embedding_length",
+            "clip.vision.feed_forward_length",
+            "clip.vision.block_count",
+            "clip.vision.projection_dim",
+            "clip.vision.attention.head_count",
+            "clip.vision.image_size",
+            "clip.vision.patch_size",
+        )
+        vision_values = {key: _positive_integer(metadata, key) for key in vision_keys}
+        _positive_finite_number(metadata, "clip.vision.attention.layer_norm_epsilon")
+        _validate_float_vector(metadata, "clip.vision.image_mean", positive=False)
+        _validate_float_vector(metadata, "clip.vision.image_std", positive=True)
+        hidden = vision_values["clip.vision.embedding_length"]
+        heads = vision_values["clip.vision.attention.head_count"]
+        image_size = vision_values["clip.vision.image_size"]
+        patch_size = vision_values["clip.vision.patch_size"]
+        if hidden % heads:
+            raise ValueError("clip.vision.embedding_length must divide by head_count")
+        if image_size % patch_size:
+            raise ValueError("clip.vision.image_size must be divisible by patch_size")
+
+    if projector_type in audio_routes:
+        _validate_bool(metadata, "clip.has_audio_encoder", expected=True)
+        audio_keys = (
+            "clip.audio.embedding_length",
+            "clip.audio.feed_forward_length",
+            "clip.audio.block_count",
+            "clip.audio.projection_dim",
+            "clip.audio.attention.head_count",
+            "clip.audio.num_mel_bins",
+        )
+        audio_values = {key: _positive_integer(metadata, key) for key in audio_keys}
+        _positive_finite_number(metadata, "clip.audio.attention.layer_norm_epsilon")
+        if (
+            audio_values["clip.audio.embedding_length"]
+            % audio_values["clip.audio.attention.head_count"]
+        ):
+            raise ValueError("clip.audio.embedding_length must divide by head_count")
+
+    type_key = (
+        "clip.audio.projector_type"
+        if projector_type in {"qwen3a", "qwen3tts_spkenc"}
+        else "clip.projector_type"
+    )
+    actual_type = metadata[type_key]
+    if not isinstance(actual_type, str) or actual_type != projector_type:
+        raise ValueError(f"{type_key} must equal {projector_type!r}, got {actual_type!r}.")
+
+    if "clip.use_silu" in metadata:
+        _validate_bool(metadata, "clip.use_silu")
+    if projector_type in {"glm4v", "qwen3vl_merger"}:
+        merge = metadata.get("clip.vision.spatial_merge_size", 2)
+        if isinstance(merge, bool) or not isinstance(merge, (int, np.integer)) or merge != 2:
+            raise ValueError("clip.vision.spatial_merge_size=2 is required")
+    if (
+        projector_type == "qwen3vl_merger"
+        and (declared := metadata.get("clip.vision.is_deepstack_layers")) is not None
+    ):
+        layers = _positive_integer(metadata, "clip.vision.block_count")
+        if (
+            not isinstance(declared, list)
+            or len(declared) != layers
+            or any(not isinstance(enabled, bool) for enabled in declared)
+        ):
+            raise ValueError(
+                "clip.vision.is_deepstack_layers must contain one boolean per vision block"
+            )
+    if projector_type == "qwen2.5o":
+        pattern = _positive_integer(metadata, "clip.vision.n_wa_pattern")
+        layers = _positive_integer(metadata, "clip.vision.block_count")
+        if pattern > layers:
+            raise ValueError("clip.vision.n_wa_pattern cannot exceed block_count")
+    if projector_type == "qwen3a":
+        window = metadata.get("clip.audio.projector.window_size", 800)
+        if (
+            isinstance(window, bool)
+            or not isinstance(window, (int, np.integer))
+            or window <= 0
+            or window % 100
+        ):
+            raise ValueError(
+                "clip.audio.projector.window_size must be a positive multiple of 100"
+            )
+    if projector_type == "glma":
+        _positive_integer(metadata, "clip.audio.projector.stack_factor")
+    if projector_type == "qwen3tts_spkenc" and (
+        _positive_integer(metadata, "clip.audio.block_count") != 3
+    ):
+        raise ValueError("qwen3tts_spkenc requires exactly three SE-Res2Net blocks")
 
 
 def read_qwen3vl_sidecar_config(model: Any, *, dtype: ir.DataType) -> ArchitectureConfig:
@@ -309,9 +458,10 @@ def read_qwen25o_vision_config(
         window_size=112,
         hidden_act="silu",
     )
+    assert vision.out_hidden_size is not None
     return _base_config(
         model_type="gguf_qwen25o_vision",
-        hidden_size=int(vision.out_hidden_size or 0),
+        hidden_size=int(vision.out_hidden_size),
         dtype=dtype,
         vision=vision,
     )
@@ -334,9 +484,10 @@ def _audio_config(model: Any) -> AudioConfig:
 
 def read_qwen2a_sidecar_config(model: Any, *, dtype: ir.DataType) -> ArchitectureConfig:
     audio = _audio_config(model)
+    assert audio.output_dim is not None
     return _base_config(
         model_type="gguf_qwen2a",
-        hidden_size=int(audio.output_dim or 0),
+        hidden_size=int(audio.output_dim),
         dtype=dtype,
         audio=audio,
     )
@@ -349,9 +500,10 @@ def read_qwen3a_sidecar_config(model: Any, *, dtype: ir.DataType) -> Architectur
         n_window=50,
         n_window_infer=int(model.metadata.get("clip.audio.projector.window_size", 800)),
     )
+    assert audio.output_dim is not None
     return _base_config(
         model_type="gguf_qwen3a",
-        hidden_size=int(audio.output_dim or 0),
+        hidden_size=int(audio.output_dim),
         dtype=dtype,
         audio=audio,
     )
@@ -359,9 +511,10 @@ def read_qwen3a_sidecar_config(model: Any, *, dtype: ir.DataType) -> Architectur
 
 def read_glma_sidecar_config(model: Any, *, dtype: ir.DataType) -> ArchitectureConfig:
     audio = _audio_config(model)
+    assert audio.output_dim is not None
     return _base_config(
         model_type="gguf_glma",
-        hidden_size=int(audio.output_dim or 0),
+        hidden_size=int(audio.output_dim),
         dtype=dtype,
         audio=audio,
     )
@@ -417,15 +570,23 @@ def create_qwen_glm_projector(
         config = read_qwen2a_sidecar_config(model, dtype=dtype)
         audio = config.audio
         assert audio is not None
+        assert audio.num_mel_bins is not None
+        assert audio.d_model is not None
+        assert audio.encoder_ffn_dim is not None
+        assert audio.encoder_layers is not None
+        assert audio.encoder_attention_heads is not None
+        assert audio.max_source_positions is not None
+        assert audio.output_dim is not None
+        assert audio.encoder_layer_norm_eps is not None
         component = GGUFQwen2AudioProjector(
-            num_mel_bins=int(audio.num_mel_bins or 0),
-            hidden_size=int(audio.d_model or 0),
-            intermediate_size=int(audio.encoder_ffn_dim or 0),
-            num_hidden_layers=int(audio.encoder_layers or 0),
-            num_attention_heads=int(audio.encoder_attention_heads or 0),
-            max_source_positions=int(audio.max_source_positions or 0),
-            output_size=int(audio.output_dim or 0),
-            norm_eps=float(audio.encoder_layer_norm_eps or 1e-5),
+            num_mel_bins=int(audio.num_mel_bins),
+            hidden_size=int(audio.d_model),
+            intermediate_size=int(audio.encoder_ffn_dim),
+            num_hidden_layers=int(audio.encoder_layers),
+            num_attention_heads=int(audio.encoder_attention_heads),
+            max_source_positions=int(audio.max_source_positions),
+            output_size=int(audio.output_dim),
+            norm_eps=float(audio.encoder_layer_norm_eps),
         )
         return component, config
     if projector_type == "qwen3a":
@@ -435,18 +596,26 @@ def create_qwen_glm_projector(
         config = read_glma_sidecar_config(model, dtype=dtype)
         audio = config.audio
         assert audio is not None
+        assert audio.num_mel_bins is not None
+        assert audio.d_model is not None
+        assert audio.encoder_ffn_dim is not None
+        assert audio.encoder_layers is not None
+        assert audio.encoder_attention_heads is not None
+        assert audio.max_source_positions is not None
+        assert audio.output_dim is not None
+        assert audio.encoder_layer_norm_eps is not None
         stack_factor = int(model.metadata["clip.audio.projector.stack_factor"])
         component = GGUFLegacyGlmAudioProjector(
-            num_mel_bins=int(audio.num_mel_bins or 0),
-            hidden_size=int(audio.d_model or 0),
-            intermediate_size=int(audio.encoder_ffn_dim or 0),
-            num_hidden_layers=int(audio.encoder_layers or 0),
-            num_attention_heads=int(audio.encoder_attention_heads or 0),
-            max_source_positions=int(audio.max_source_positions or 0),
+            num_mel_bins=int(audio.num_mel_bins),
+            hidden_size=int(audio.d_model),
+            intermediate_size=int(audio.encoder_ffn_dim),
+            num_hidden_layers=int(audio.encoder_layers),
+            num_attention_heads=int(audio.encoder_attention_heads),
+            max_source_positions=int(audio.max_source_positions),
             stack_factor=stack_factor,
             projector_intermediate_size=_shape(model, "mm.a.mlp.1.weight")[0],
-            output_size=int(audio.output_dim or 0),
-            norm_eps=float(audio.encoder_layer_norm_eps or 1e-5),
+            output_size=int(audio.output_dim),
+            norm_eps=float(audio.encoder_layer_norm_eps),
             activation="silu" if bool(model.metadata.get("clip.use_silu")) else "gelu",
         )
         return component, config

--- a/src/mobius/integrations/gguf/_qwen_glm_projector.py
+++ b/src/mobius/integrations/gguf/_qwen_glm_projector.py
@@ -62,7 +62,7 @@ QWEN_GLM_PROCESSOR_ABIS: dict[str, dict[str, str | int]] = {
     "qwen3a": {
         "sample_rate": 16_000,
         "input_features": "float32[1,128,frames_multiple_of_100]",
-        "feature_attention_mask": "int64[1,frames], binary and right-padded",
+        "input_features_mask": "int32[1,frames], binary and right-padded",
         "output": "valid audio rows plus int64[1] audio_feature_lengths",
         "preprocessing": "Qwen3 Whisper mel; 100-frame chunks with right padding",
         "empty_media": "do not invoke the audio graph",
@@ -277,7 +277,7 @@ def validate_qwen_glm_projector_metadata(model: Any, projector_type: str) -> Non
     if not isinstance(actual_type, str) or actual_type != projector_type:
         raise ValueError(f"{type_key} must equal {projector_type!r}, got {actual_type!r}.")
 
-    if "clip.use_silu" in metadata:
+    if projector_type in {"glm4v", "qwen3vl_merger", "glma"} and "clip.use_silu" in metadata:
         _validate_bool(metadata, "clip.use_silu")
     if projector_type in {"glm4v", "qwen3vl_merger"}:
         merge = metadata.get("clip.vision.spatial_merge_size", 2)

--- a/src/mobius/integrations/gguf/_qwen_glm_projector_test.py
+++ b/src/mobius/integrations/gguf/_qwen_glm_projector_test.py
@@ -496,9 +496,13 @@ _ROUTES = {
 }
 
 
-def _build_package(projector_type: str, *, dtype: str | None = None):
-    factory, target, _ = _ROUTES[projector_type]
-    sidecar = factory()
+def _build_package_from_sidecar(
+    projector_type: str,
+    sidecar: _FakeSidecar,
+    *,
+    dtype: str | None = None,
+):
+    _, target, _ = _ROUTES[projector_type]
     with (
         mock.patch(
             "mobius.integrations.gguf._mmproj._resolve_mmproj_companion_path",
@@ -516,6 +520,11 @@ def _build_package(projector_type: str, *, dtype: str | None = None):
     return sidecar, package
 
 
+def _build_package(projector_type: str, *, dtype: str | None = None):
+    factory, _, _ = _ROUTES[projector_type]
+    return _build_package_from_sidecar(projector_type, factory(), dtype=dtype)
+
+
 @pytest.mark.parametrize("projector_type", tuple(_ROUTES))
 def test_every_route_builds_only_its_declared_components(projector_type: str) -> None:
     _, _, expected = _ROUTES[projector_type]
@@ -529,6 +538,96 @@ def test_every_route_builds_only_its_declared_components(projector_type: str) ->
         for graph in package.values()
         for initializer in graph.graph.initializers.values()
     )
+
+
+def test_public_dispatch_preflights_qwen_route_once() -> None:
+    from mobius.integrations.gguf import _mmproj
+
+    sidecar = _qwen2a_sidecar()
+    with (
+        mock.patch(
+            "mobius.integrations.gguf._mmproj._resolve_mmproj_companion_path",
+            return_value="synthetic.gguf",
+        ),
+        mock.patch("mobius.integrations.gguf._builder._validate_gguf_model"),
+        mock.patch(
+            "mobius.integrations.gguf._mmproj._preflight_standalone_mmproj",
+            wraps=_mmproj._preflight_standalone_mmproj,
+        ) as preflight,
+    ):
+        build_mmproj_from_gguf(
+            "synthetic.gguf",
+            projector_type="qwen2a",
+            target_architecture="qwen2",
+            _mmproj_gguf_model=sidecar,
+        )
+
+    preflight.assert_called_once_with(
+        sidecar,
+        projector_type="qwen2a",
+        target_architecture="qwen2",
+    )
+
+
+@pytest.mark.parametrize("projector_type", ("qwen2a", "qwen3a", "qwen2.5o", "qwen3tts_spkenc"))
+def test_unrelated_silu_metadata_does_not_change_nonconsumer_graph(
+    projector_type: str,
+) -> None:
+    factory, _, _ = _ROUTES[projector_type]
+    baseline_sidecar = factory()
+    unrelated_sidecar = factory()
+    unrelated_sidecar.metadata["clip.use_silu"] = {"invalid": "but unrelated"}
+    _, baseline = _build_package_from_sidecar(projector_type, baseline_sidecar)
+    _, unrelated = _build_package_from_sidecar(projector_type, unrelated_sidecar)
+
+    def signature(package) -> dict[str, tuple[object, ...]]:
+        return {
+            role: (
+                tuple((node.domain, node.op_type) for node in model.graph),
+                tuple(
+                    (value.name, str(value.type), str(value.shape))
+                    for value in model.graph.inputs
+                ),
+                tuple(
+                    (value.name, str(value.type), str(value.shape))
+                    for value in model.graph.outputs
+                ),
+                tuple(model.graph.initializers),
+            )
+            for role, model in package.items()
+        }
+
+    assert baseline.config == unrelated.config
+    assert signature(baseline) == signature(unrelated)
+
+
+@pytest.mark.parametrize("projector_type", ("glm4v", "glma", "qwen3vl_merger"))
+@pytest.mark.parametrize("invalid", [0, 1, "true"])
+def test_silu_consumers_require_boolean_metadata(
+    projector_type: str,
+    invalid: object,
+) -> None:
+    factory, _, _ = _ROUTES[projector_type]
+    sidecar = factory()
+    sidecar.metadata["clip.use_silu"] = invalid
+
+    with pytest.raises(ValueError, match="must be a boolean"):
+        validate_qwen_glm_projector_metadata(sidecar, projector_type)
+
+
+def test_qwen3vl_silu_metadata_changes_only_transformer_block_activation() -> None:
+    gelu_sidecar = _qwen3vl_sidecar()
+    silu_sidecar = _qwen3vl_sidecar()
+    silu_sidecar.metadata["clip.use_silu"] = True
+    _, gelu_package = _build_package_from_sidecar("qwen3vl_merger", gelu_sidecar)
+    _, silu_package = _build_package_from_sidecar("qwen3vl_merger", silu_sidecar)
+
+    gelu_ops = [node.op_type for node in gelu_package["vision_encoder"].graph]
+    silu_ops = [node.op_type for node in silu_package["vision_encoder"].graph]
+    assert "Swish" not in gelu_ops
+    assert silu_ops.count("Swish") == 1
+    # Final and DeepStack mergers remain tanh-GELU in both variants.
+    assert silu_ops.count("Gelu") == gelu_ops.count("Gelu") - 1
 
 
 @pytest.mark.parametrize("projector_type", tuple(_ROUTES))
@@ -895,7 +994,7 @@ def test_qwen3a_projector_matches_transformers() -> None:
         "audio_encoder",
         {
             "input_features": features,
-            "feature_attention_mask": np.ones((1, 100), dtype=np.int64),
+            "input_features_mask": np.ones((1, 100), dtype=np.int32),
         },
     )
     np.testing.assert_allclose(actual, expected, rtol=3e-4, atol=3e-4)
@@ -913,7 +1012,7 @@ def test_qwen3a_projector_matches_transformers() -> None:
         padded_outputs = session.run(
             {
                 "input_features": padded,
-                "feature_attention_mask": padded_mask,
+                "input_features_mask": padded_mask.astype(np.int32),
             }
         )
     finally:
@@ -942,20 +1041,64 @@ def test_qwen3a_graph_io_and_processor_metadata_publish_lengths() -> None:
 
     assert [value.name for value in graph.inputs] == [
         "input_features",
-        "feature_attention_mask",
+        "input_features_mask",
     ]
     assert [value.name for value in graph.outputs] == [
         "audio_features",
         "audio_feature_lengths",
     ]
-    assert package.gguf_processor_abi["feature_attention_mask"] == (
-        "int64[1,frames], binary and right-padded"
+    assert package.gguf_processor_abi["input_features_mask"] == (
+        "int32[1,frames], binary and right-padded"
     )
     assert "audio_feature_lengths" in package.gguf_processor_abi["output"]
 
 
+def test_qwen3a_accepts_processor_outputs_without_adapter() -> None:
+    from transformers import WhisperFeatureExtractor
+    from transformers.models.qwen3_asr.processing_qwen3_asr import Qwen3ASRProcessor
+
+    _, package = _build_package("qwen3a")
+    # Construct the pinned processor class with a tiny, network-free feature
+    # extractor. Text is omitted, so only these attributes are consulted.
+    processor = object.__new__(Qwen3ASRProcessor)
+    processor.feature_extractor = WhisperFeatureExtractor(
+        feature_size=8,
+        sampling_rate=16_000,
+        hop_length=160,
+        chunk_length=1,
+        n_fft=400,
+        padding_value=0.0,
+        return_attention_mask=True,
+    )
+    processor.tokenizer = SimpleNamespace(init_kwargs={})
+    processor.chat_template = None
+    processor.timestamp_segment_time = 80
+    processor.audio_token = "<audio>"
+    processed = processor(
+        text=None,
+        audio=[np.zeros(16_000, dtype=np.float32)],
+        sampling_rate=16_000,
+        return_tensors="pt",
+    )
+    input_names = {value.name for value in package["audio_encoder"].graph.inputs}
+    feeds = {name: processed[name].numpy() for name in input_names}
+
+    assert set(feeds) == {"input_features", "input_features_mask"}
+    assert feeds["input_features_mask"].dtype == np.int32
+    session = OnnxModelSession(package["audio_encoder"])
+    try:
+        outputs = session.run(feeds)
+    finally:
+        session.close()
+    assert outputs["audio_features"].shape == (13, 12)
+    np.testing.assert_array_equal(
+        outputs["audio_feature_lengths"],
+        np.array([13], dtype=np.int64),
+    )
+
+
 @pytest.mark.parametrize(
-    "feature_attention_mask",
+    "input_features_mask",
     [
         np.zeros((1, 100), dtype=np.int64),
         np.array([[1] * 49 + [0] + [1] * 50], dtype=np.int64),
@@ -964,7 +1107,7 @@ def test_qwen3a_graph_io_and_processor_metadata_publish_lengths() -> None:
     ids=["empty", "not-right-padded", "non-binary"],
 )
 def test_qwen3a_processor_mask_fails_closed(
-    feature_attention_mask: np.ndarray,
+    input_features_mask: np.ndarray,
 ) -> None:
     _, package = _build_package("qwen3a")
     features = np.zeros((1, 8, 100), dtype=np.float32)
@@ -982,7 +1125,7 @@ def test_qwen3a_processor_mask_fails_closed(
             "audio_encoder",
             {
                 "input_features": features,
-                "feature_attention_mask": feature_attention_mask,
+                "input_features_mask": input_features_mask.astype(np.int32),
             },
         )
 
@@ -1654,7 +1797,7 @@ def test_reduced_precision_audio_casts_float_processor_input(
 
     feeds = {"input_features": features}
     if projector_type == "qwen3a":
-        feeds["feature_attention_mask"] = np.ones((1, frames), dtype=np.int64)
+        feeds["input_features_mask"] = np.ones((1, frames), dtype=np.int32)
     actual = _run_component(package, "audio_encoder", feeds)
 
     assert actual.dtype == np.float16

--- a/src/mobius/integrations/gguf/_qwen_glm_projector_test.py
+++ b/src/mobius/integrations/gguf/_qwen_glm_projector_test.py
@@ -18,6 +18,7 @@ from mobius._testing.ort_inference import OnnxModelSession
 from mobius.integrations.gguf._mmproj import build_mmproj_from_gguf
 from mobius.integrations.gguf._qwen_glm_projector import (
     qwen3vl_decoder_mrope_positions,
+    validate_qwen_glm_projector_metadata,
 )
 
 
@@ -530,6 +531,188 @@ def test_every_route_builds_only_its_declared_components(projector_type: str) ->
     )
 
 
+@pytest.mark.parametrize("projector_type", tuple(_ROUTES))
+@pytest.mark.parametrize(
+    "invalid",
+    [0, -1, float("nan"), float("inf"), "1e-5", True],
+    ids=["zero", "negative", "nan", "inf", "string", "bool"],
+)
+def test_route_metadata_rejects_invalid_epsilon_before_tensors(
+    projector_type: str,
+    invalid: object,
+) -> None:
+    factory, _, _ = _ROUTES[projector_type]
+    sidecar = factory()
+    modality = "vision" if projector_type in {"glm4v", "qwen3vl_merger"} else "audio"
+    if projector_type == "qwen2.5o":
+        modality = "vision"
+    sidecar.metadata[f"clip.{modality}.attention.layer_norm_epsilon"] = invalid
+
+    with pytest.raises(ValueError, match="positive finite number"):
+        validate_qwen_glm_projector_metadata(sidecar, projector_type)
+
+
+@pytest.mark.parametrize("projector_type", tuple(_ROUTES))
+@pytest.mark.parametrize(
+    "invalid",
+    [0, -1, float("nan"), float("inf"), "8", True, 1.5],
+    ids=["zero", "negative", "nan", "inf", "string", "bool", "float"],
+)
+def test_route_metadata_rejects_invalid_dimensions(
+    projector_type: str,
+    invalid: object,
+) -> None:
+    factory, _, _ = _ROUTES[projector_type]
+    sidecar = factory()
+    modality = "vision" if projector_type in {"glm4v", "qwen3vl_merger"} else "audio"
+    if projector_type == "qwen2.5o":
+        modality = "vision"
+    sidecar.metadata[f"clip.{modality}.embedding_length"] = invalid
+
+    with pytest.raises(ValueError, match="positive integer"):
+        validate_qwen_glm_projector_metadata(sidecar, projector_type)
+
+
+@pytest.mark.parametrize("projector_type", tuple(_ROUTES))
+@pytest.mark.parametrize("invalid", [0, 1, "true"], ids=["zero", "one", "string"])
+def test_route_metadata_requires_boolean_presence(
+    projector_type: str,
+    invalid: object,
+) -> None:
+    factory, _, _ = _ROUTES[projector_type]
+    sidecar = factory()
+    modality = "vision" if projector_type in {"glm4v", "qwen3vl_merger"} else "audio"
+    if projector_type == "qwen2.5o":
+        modality = "vision"
+    sidecar.metadata[f"clip.has_{modality}_encoder"] = invalid
+
+    with pytest.raises(ValueError, match="must be boolean True"):
+        validate_qwen_glm_projector_metadata(sidecar, projector_type)
+
+
+@pytest.mark.parametrize("projector_type", tuple(_ROUTES))
+def test_route_metadata_requires_exact_projector_enum(projector_type: str) -> None:
+    factory, _, _ = _ROUTES[projector_type]
+    sidecar = factory()
+    type_key = (
+        "clip.audio.projector_type"
+        if projector_type in {"qwen3a", "qwen3tts_spkenc"}
+        else "clip.projector_type"
+    )
+    sidecar.metadata[type_key] = 7
+
+    with pytest.raises(ValueError, match="must equal"):
+        validate_qwen_glm_projector_metadata(sidecar, projector_type)
+
+
+@pytest.mark.parametrize(
+    ("projector_type", "updates"),
+    [
+        (
+            "glm4v",
+            {
+                "clip.vision.attention.head_count": 8,
+                "clip.vision.image_size": 2,
+                "clip.vision.spatial_merge_size": 2,
+            },
+        ),
+        (
+            "glma",
+            {"clip.audio.attention.head_count": 8, "clip.audio.projector.stack_factor": 1},
+        ),
+        (
+            "qwen2.5o",
+            {
+                "clip.vision.attention.head_count": 8,
+                "clip.vision.image_size": 2,
+                "clip.vision.n_wa_pattern": 1,
+                "clip.audio.attention.head_count": 8,
+            },
+        ),
+        ("qwen2a", {"clip.audio.attention.head_count": 8}),
+        (
+            "qwen3a",
+            {
+                "clip.audio.attention.head_count": 8,
+                "clip.audio.projector.window_size": 100,
+            },
+        ),
+        (
+            "qwen3vl_merger",
+            {
+                "clip.vision.attention.head_count": 8,
+                "clip.vision.image_size": 2,
+                "clip.vision.spatial_merge_size": 2,
+            },
+        ),
+        ("qwen3tts_spkenc", {"clip.audio.attention.head_count": 24}),
+    ],
+)
+def test_route_metadata_accepts_exact_valid_boundaries(
+    projector_type: str,
+    updates: dict[str, object],
+) -> None:
+    factory, _, _ = _ROUTES[projector_type]
+    sidecar = factory()
+    sidecar.metadata.update(updates)
+
+    validate_qwen_glm_projector_metadata(sidecar, projector_type)
+
+
+@pytest.mark.parametrize(
+    ("projector_type", "key", "invalid", "message"),
+    [
+        ("glm4v", "clip.vision.spatial_merge_size", 1, "spatial_merge_size=2"),
+        ("glma", "clip.audio.projector.stack_factor", 0, "positive integer"),
+        ("qwen2.5o", "clip.vision.n_wa_pattern", 2, "cannot exceed"),
+        ("qwen2a", "clip.audio.attention.head_count", 3, "divide by"),
+        ("qwen3a", "clip.audio.projector.window_size", 150, "multiple of 100"),
+        (
+            "qwen3vl_merger",
+            "clip.vision.is_deepstack_layers",
+            [1],
+            "one boolean",
+        ),
+        ("qwen3tts_spkenc", "clip.audio.block_count", 2, "exactly three"),
+    ],
+)
+def test_route_metadata_rejects_route_specific_geometry(
+    projector_type: str,
+    key: str,
+    invalid: object,
+    message: str,
+) -> None:
+    factory, _, _ = _ROUTES[projector_type]
+    sidecar = factory()
+    sidecar.metadata[key] = invalid
+
+    with pytest.raises(ValueError, match=message):
+        validate_qwen_glm_projector_metadata(sidecar, projector_type)
+
+
+def test_standalone_metadata_validation_precedes_tensor_closure() -> None:
+    sidecar = _qwen2a_sidecar()
+    sidecar.metadata["clip.audio.attention.layer_norm_epsilon"] = 0.0
+    with (
+        mock.patch(
+            "mobius.integrations.gguf._mmproj._resolve_mmproj_companion_path",
+            return_value="synthetic.gguf",
+        ),
+        mock.patch("mobius.integrations.gguf._builder._validate_gguf_model"),
+        mock.patch(
+            "mobius.integrations.gguf._mmproj._validate_mmproj_tensor_closure"
+        ) as closure,
+        pytest.raises(ValueError, match="positive finite number"),
+    ):
+        build_mmproj_from_gguf(
+            "synthetic.gguf",
+            projector_type="qwen2a",
+            target_architecture="qwen2",
+            _mmproj_gguf_model=sidecar,
+        )
+    closure.assert_not_called()
+
+
 def _run_component(package, component: str, feeds: dict[str, np.ndarray]) -> np.ndarray:
     session = OnnxModelSession(package[component])
     try:
@@ -710,9 +893,98 @@ def test_qwen3a_projector_matches_transformers() -> None:
     actual = _run_component(
         package,
         "audio_encoder",
-        {"input_features": features},
+        {
+            "input_features": features,
+            "feature_attention_mask": np.ones((1, 100), dtype=np.int64),
+        },
     )
     np.testing.assert_allclose(actual, expected, rtol=3e-4, atol=3e-4)
+
+    padded = np.concatenate(
+        [features, np.linspace(1.0, 2.0, 800, dtype=np.float32).reshape(1, 8, 100)],
+        axis=2,
+    )
+    padded_mask = np.concatenate(
+        [np.ones((1, 100), dtype=np.int64), np.zeros((1, 100), dtype=np.int64)],
+        axis=1,
+    )
+    session = OnnxModelSession(package["audio_encoder"])
+    try:
+        padded_outputs = session.run(
+            {
+                "input_features": padded,
+                "feature_attention_mask": padded_mask,
+            }
+        )
+    finally:
+        session.close()
+    np.testing.assert_allclose(
+        padded_outputs["audio_features"],
+        expected,
+        rtol=3e-4,
+        atol=3e-4,
+    )
+    np.testing.assert_allclose(
+        padded_outputs["audio_features"],
+        actual,
+        rtol=3e-4,
+        atol=3e-4,
+    )
+    np.testing.assert_array_equal(
+        padded_outputs["audio_feature_lengths"],
+        np.array([13], dtype=np.int64),
+    )
+
+
+def test_qwen3a_graph_io_and_processor_metadata_publish_lengths() -> None:
+    _, package = _build_package("qwen3a")
+    graph = package["audio_encoder"].graph
+
+    assert [value.name for value in graph.inputs] == [
+        "input_features",
+        "feature_attention_mask",
+    ]
+    assert [value.name for value in graph.outputs] == [
+        "audio_features",
+        "audio_feature_lengths",
+    ]
+    assert package.gguf_processor_abi["feature_attention_mask"] == (
+        "int64[1,frames], binary and right-padded"
+    )
+    assert "audio_feature_lengths" in package.gguf_processor_abi["output"]
+
+
+@pytest.mark.parametrize(
+    "feature_attention_mask",
+    [
+        np.zeros((1, 100), dtype=np.int64),
+        np.array([[1] * 49 + [0] + [1] * 50], dtype=np.int64),
+        np.array([[1] * 99 + [2]], dtype=np.int64),
+    ],
+    ids=["empty", "not-right-padded", "non-binary"],
+)
+def test_qwen3a_processor_mask_fails_closed(
+    feature_attention_mask: np.ndarray,
+) -> None:
+    _, package = _build_package("qwen3a")
+    features = np.zeros((1, 8, 100), dtype=np.float32)
+
+    with pytest.raises(
+        (
+            ort.capi.onnxruntime_pybind11_state.Fail,
+            ort.capi.onnxruntime_pybind11_state.InvalidArgument,
+            ort.capi.onnxruntime_pybind11_state.RuntimeException,
+        ),
+        match="indices element out of data bounds",
+    ):
+        _run_component(
+            package,
+            "audio_encoder",
+            {
+                "input_features": features,
+                "feature_attention_mask": feature_attention_mask,
+            },
+        )
 
 
 def _qwen3vl_hf_state(sidecar: _FakeSidecar) -> dict[str, torch.Tensor]:
@@ -1380,11 +1652,10 @@ def test_reduced_precision_audio_casts_float_processor_input(
         frames,
     )
 
-    actual = _run_component(
-        package,
-        "audio_encoder",
-        {"input_features": features},
-    )
+    feeds = {"input_features": features}
+    if projector_type == "qwen3a":
+        feeds["feature_attention_mask"] = np.ones((1, frames), dtype=np.int64)
+    actual = _run_component(package, "audio_encoder", feeds)
 
     assert actual.dtype == np.float16
     assert np.isfinite(actual).all()

--- a/src/mobius/integrations/gguf/_qwen_glm_projector_test.py
+++ b/src/mobius/integrations/gguf/_qwen_glm_projector_test.py
@@ -1,0 +1,1390 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Executable coverage for the Qwen/GLM GGUF projector cohort."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import mock
+
+import numpy as np
+import onnxruntime as ort
+import pytest
+import torch
+import torch.nn.functional as functional
+
+from mobius._testing.ort_inference import OnnxModelSession
+from mobius.integrations.gguf._mmproj import build_mmproj_from_gguf
+from mobius.integrations.gguf._qwen_glm_projector import (
+    qwen3vl_decoder_mrope_positions,
+)
+
+
+class _FakeSidecar:
+    architecture = "clip"
+
+    def __init__(
+        self,
+        metadata: dict[str, object],
+        shapes: dict[str, tuple[int, ...]],
+        *,
+        seed: int = 0,
+    ) -> None:
+        self.metadata = {
+            "general.architecture": "clip",
+            "general.type": "mmproj",
+            **metadata,
+        }
+        self.tensor_names = list(shapes)
+        self._shapes = shapes
+        rng = np.random.default_rng(seed)
+        self._values = {
+            name: (
+                rng.standard_normal(shape).astype(np.float32) * 0.03
+                if shape
+                else np.array(0.0, dtype=np.float32)
+            )
+            for name, shape in shapes.items()
+        }
+
+    def get_tensor_shape(self, name: str) -> tuple[int, ...]:
+        return self._shapes[name]
+
+    def get_tensor_type(self, name: str):
+        del name
+        return SimpleNamespace(name="F32")
+
+    def get_tensor(self, name: str) -> np.ndarray:
+        return self._values[name]
+
+
+def _vision_metadata(
+    *,
+    projector_type: str,
+    hidden: int,
+    intermediate: int,
+    output: int,
+    patch: int,
+    layers: int = 1,
+) -> dict[str, object]:
+    return {
+        "clip.has_vision_encoder": True,
+        "clip.projector_type": projector_type,
+        "clip.vision.embedding_length": hidden,
+        "clip.vision.feed_forward_length": intermediate,
+        "clip.vision.block_count": layers,
+        "clip.vision.projection_dim": output,
+        "clip.vision.attention.head_count": 2,
+        "clip.vision.attention.layer_norm_epsilon": 1e-6,
+        "clip.vision.image_size": patch * 2,
+        "clip.vision.patch_size": patch,
+        "clip.vision.image_mean": [0.5, 0.5, 0.5],
+        "clip.vision.image_std": [0.5, 0.5, 0.5],
+    }
+
+
+def _audio_metadata(
+    *,
+    projector_type: str,
+    hidden: int,
+    intermediate: int,
+    output: int,
+    mel: int,
+    layers: int = 1,
+    global_type: bool = False,
+) -> dict[str, object]:
+    metadata: dict[str, object] = {
+        "clip.has_audio_encoder": True,
+        "clip.audio.embedding_length": hidden,
+        "clip.audio.feed_forward_length": intermediate,
+        "clip.audio.block_count": layers,
+        "clip.audio.projection_dim": output,
+        "clip.audio.attention.head_count": 2,
+        "clip.audio.attention.layer_norm_epsilon": 1e-5,
+        "clip.audio.num_mel_bins": mel,
+    }
+    metadata["clip.projector_type" if global_type else "clip.audio.projector_type"] = (
+        projector_type
+    )
+    return metadata
+
+
+def _whisper_block_shapes(
+    *,
+    hidden: int,
+    intermediate: int,
+    key_bias: bool,
+    prefix: str = "a.blk.0.",
+) -> dict[str, tuple[int, ...]]:
+    shapes = {
+        prefix + "ln1.weight": (hidden,),
+        prefix + "ln1.bias": (hidden,),
+        prefix + "ln2.weight": (hidden,),
+        prefix + "ln2.bias": (hidden,),
+        prefix + "attn_q.weight": (hidden, hidden),
+        prefix + "attn_q.bias": (hidden,),
+        prefix + "attn_k.weight": (hidden, hidden),
+        prefix + "attn_v.weight": (hidden, hidden),
+        prefix + "attn_v.bias": (hidden,),
+        prefix + "attn_out.weight": (hidden, hidden),
+        prefix + "attn_out.bias": (hidden,),
+        prefix + "ffn_up.weight": (intermediate, hidden),
+        prefix + "ffn_up.bias": (intermediate,),
+        prefix + "ffn_down.weight": (hidden, intermediate),
+        prefix + "ffn_down.bias": (hidden,),
+    }
+    if key_bias:
+        shapes[prefix + "attn_k.bias"] = (hidden,)
+    return shapes
+
+
+def _qwen2a_sidecar(*, alias: bool = False) -> _FakeSidecar:
+    hidden, intermediate, output, mel = 8, 16, 12, 8
+    metadata = _audio_metadata(
+        projector_type="qwen2.5o" if alias else "qwen2a",
+        hidden=hidden,
+        intermediate=intermediate,
+        output=output,
+        mel=mel,
+        global_type=True,
+    )
+    shapes = {
+        "a.conv1d.1.weight": (hidden, mel, 3),
+        "a.conv1d.1.bias": (hidden, 1),
+        "a.conv1d.2.weight": (hidden, hidden, 3),
+        "a.conv1d.2.bias": (hidden, 1),
+        "a.position_embd.weight": (8, hidden),
+        "a.post_ln.weight": (hidden,),
+        "a.post_ln.bias": (hidden,),
+        "mm.a.fc.weight": (output, hidden),
+        "mm.a.fc.bias": (output,),
+        **_whisper_block_shapes(
+            hidden=hidden,
+            intermediate=intermediate,
+            key_bias=False,
+        ),
+    }
+    return _FakeSidecar(metadata, shapes, seed=2)
+
+
+def _qwen3a_sidecar() -> _FakeSidecar:
+    hidden, intermediate, output, mel, channels = 8, 16, 12, 8, 4
+    metadata = _audio_metadata(
+        projector_type="qwen3a",
+        hidden=hidden,
+        intermediate=intermediate,
+        output=output,
+        mel=mel,
+    )
+    shapes = {
+        "a.conv2d.1.weight": (channels, 1, 3, 3),
+        "a.conv2d.1.bias": (channels, 1, 1),
+        "a.conv2d.2.weight": (channels, channels, 3, 3),
+        "a.conv2d.2.bias": (channels, 1, 1),
+        "a.conv2d.3.weight": (channels, channels, 3, 3),
+        "a.conv2d.3.bias": (channels, 1, 1),
+        "a.conv_out.weight": (hidden, channels),
+        "a.position_embd.weight": (13, hidden),
+        "a.post_ln.weight": (hidden,),
+        "a.post_ln.bias": (hidden,),
+        "mm.a.mlp.1.weight": (hidden, hidden),
+        "mm.a.mlp.1.bias": (hidden,),
+        "mm.a.mlp.2.weight": (output, hidden),
+        "mm.a.mlp.2.bias": (output,),
+        **_whisper_block_shapes(
+            hidden=hidden,
+            intermediate=intermediate,
+            key_bias=True,
+        ),
+    }
+    return _FakeSidecar(metadata, shapes, seed=3)
+
+
+def _qwen3vl_sidecar() -> _FakeSidecar:
+    hidden, intermediate, output, patch = 8, 16, 12, 2
+    metadata = {
+        **_vision_metadata(
+            projector_type="qwen3vl_merger",
+            hidden=hidden,
+            intermediate=intermediate,
+            output=output,
+            patch=patch,
+        ),
+        "clip.vision.spatial_merge_size": 2,
+        "clip.vision.is_deepstack_layers": [True],
+        "clip.use_gelu": True,
+    }
+    merged = hidden * 4
+    shapes = {
+        "v.patch_embd.weight": (hidden, 3, patch, patch),
+        "v.patch_embd.weight.1": (hidden, 3, patch, patch),
+        "v.patch_embd.bias": (hidden,),
+        "v.position_embd.weight": (4, hidden),
+        "v.post_ln.weight": (hidden,),
+        "v.post_ln.bias": (hidden,),
+        "mm.0.weight": (merged, merged),
+        "mm.0.bias": (merged,),
+        "mm.2.weight": (output, merged),
+        "mm.2.bias": (output,),
+    }
+    for stem, shape in {
+        "ln1.weight": (hidden,),
+        "ln1.bias": (hidden,),
+        "ln2.weight": (hidden,),
+        "ln2.bias": (hidden,),
+        "attn_qkv.weight": (3 * hidden, hidden),
+        "attn_qkv.bias": (3 * hidden,),
+        "attn_out.weight": (hidden, hidden),
+        "attn_out.bias": (hidden,),
+        "ffn_up.weight": (intermediate, hidden),
+        "ffn_up.bias": (intermediate,),
+        "ffn_down.weight": (hidden, intermediate),
+        "ffn_down.bias": (hidden,),
+    }.items():
+        shapes["v.blk.0." + stem] = shape
+    for stem, shape in {
+        "norm.weight": (merged,),
+        "norm.bias": (merged,),
+        "fc1.weight": (merged, merged),
+        "fc1.bias": (merged,),
+        "fc2.weight": (output, merged),
+        "fc2.bias": (output,),
+    }.items():
+        shapes["v.deepstack.0." + stem] = shape
+    return _FakeSidecar(metadata, shapes, seed=4)
+
+
+def _glm4v_sidecar() -> _FakeSidecar:
+    hidden, intermediate, output, patch = 8, 16, 12, 2
+    projector_intermediate = output * 3
+    metadata = {
+        **_vision_metadata(
+            projector_type="glm4v",
+            hidden=hidden,
+            intermediate=intermediate,
+            output=output,
+            patch=patch,
+        ),
+        "clip.use_silu": True,
+    }
+    shapes = {
+        "v.patch_embd.weight": (hidden, 3, patch, patch),
+        "v.patch_embd.weight.1": (hidden, 3, patch, patch),
+        "v.patch_embd.bias": (hidden,),
+        "v.post_ln.weight": (hidden,),
+        "mm.patch_merger.weight": (output, hidden, 2, 2),
+        "mm.patch_merger.bias": (output,),
+        "mm.model.fc.weight": (output, output),
+        "mm.post_norm.weight": (output,),
+        "mm.post_norm.bias": (output,),
+        "mm.up.weight": (projector_intermediate, output),
+        "mm.gate.weight": (projector_intermediate, output),
+        "mm.down.weight": (output, projector_intermediate),
+    }
+    for stem, shape in {
+        "ln1.weight": (hidden,),
+        "ln2.weight": (hidden,),
+        "attn_qkv.weight": (3 * hidden, hidden),
+        "attn_qkv.bias": (3 * hidden,),
+        "attn_q_norm.weight": (hidden // 2,),
+        "attn_k_norm.weight": (hidden // 2,),
+        "attn_out.weight": (hidden, hidden),
+        "attn_out.bias": (hidden,),
+        "ffn_gate.weight": (intermediate, hidden),
+        "ffn_gate.bias": (intermediate,),
+        "ffn_up.weight": (intermediate, hidden),
+        "ffn_up.bias": (intermediate,),
+        "ffn_down.weight": (hidden, intermediate),
+        "ffn_down.bias": (hidden,),
+    }.items():
+        shapes["v.blk.0." + stem] = shape
+    return _FakeSidecar(metadata, shapes, seed=5)
+
+
+def _glm4v_learned_position_sidecar() -> _FakeSidecar:
+    hidden, intermediate, output, patch = 8, 16, 12, 2
+    projector_intermediate = 16
+    metadata = {
+        **_vision_metadata(
+            projector_type="glm4v",
+            hidden=hidden,
+            intermediate=intermediate,
+            output=output,
+            patch=patch,
+        ),
+        "clip.vision.spatial_merge_size": 2,
+        "clip.use_silu": True,
+    }
+    shapes = {
+        "v.patch_embd.weight": (hidden, 3, patch, patch),
+        "v.patch_embd.weight.1": (hidden, 3, patch, patch),
+        "v.patch_embd.bias": (hidden,),
+        "v.norm_embd.weight": (hidden,),
+        "v.position_embd.weight": (4, hidden),
+        "v.post_ln.weight": (hidden,),
+        "mm.patch_merger.weight": (output, hidden, 2, 2),
+        "mm.patch_merger.bias": (output,),
+        "mm.model.fc.weight": (output, output),
+        "mm.post_norm.weight": (output,),
+        "mm.post_norm.bias": (output,),
+        "mm.up.weight": (projector_intermediate, output),
+        "mm.gate.weight": (projector_intermediate, output),
+        "mm.down.weight": (output, projector_intermediate),
+    }
+    for stem, shape in {
+        "ln1.weight": (hidden,),
+        "ln2.weight": (hidden,),
+        "attn_qkv.weight": (3 * hidden, hidden),
+        "attn_out.weight": (hidden, hidden),
+        "ffn_gate.weight": (output, hidden),
+        "ffn_up.weight": (output, hidden),
+        "ffn_down.weight": (hidden, output),
+    }.items():
+        shapes["v.blk.0." + stem] = shape
+    return _FakeSidecar(metadata, shapes, seed=15)
+
+
+def _glma_sidecar() -> _FakeSidecar:
+    hidden, intermediate, output, mel, stack = 8, 16, 12, 8, 2
+    metadata = {
+        **_audio_metadata(
+            projector_type="glma",
+            hidden=hidden,
+            intermediate=intermediate,
+            output=output,
+            mel=mel,
+            global_type=True,
+        ),
+        "clip.audio.projector.stack_factor": stack,
+    }
+    shapes = {
+        "a.conv1d.1.weight": (hidden, mel, 3),
+        "a.conv1d.1.bias": (hidden, 1),
+        "a.conv1d.2.weight": (hidden, hidden, 3),
+        "a.conv1d.2.bias": (hidden, 1),
+        "a.position_embd.weight": (8, hidden),
+        "a.post_ln.weight": (hidden,),
+        "a.post_ln.bias": (hidden,),
+        "mm.a.norm_pre.weight": (hidden,),
+        "mm.a.norm_pre.bias": (hidden,),
+        "mm.a.mlp.1.weight": (intermediate, hidden * stack),
+        "mm.a.mlp.1.bias": (intermediate,),
+        "mm.a.mlp.2.weight": (output, intermediate),
+        "mm.a.mlp.2.bias": (output,),
+        "v.boi": (output,),
+        "v.eoi": (output,),
+        **_whisper_block_shapes(
+            hidden=hidden,
+            intermediate=intermediate,
+            key_bias=False,
+        ),
+    }
+    return _FakeSidecar(metadata, shapes, seed=6)
+
+
+def _speaker_sidecar() -> _FakeSidecar:
+    channels, mel, mfa, attention, output = 8, 4, 24, 4, 12
+    metadata = {
+        **_audio_metadata(
+            projector_type="qwen3tts_spkenc",
+            hidden=mfa,
+            intermediate=mfa,
+            output=output,
+            mel=mel,
+            layers=3,
+        ),
+        "clip.has_gen_audio_encoder": True,
+        "clip.gen.audio.projector_type": "qwen3tts_gen",
+    }
+    shapes = {
+        "a.conv1d.0.weight": (channels, mel, 5),
+        "a.conv1d.0.bias": (channels,),
+        "a.conv_out.weight": (mfa, 3 * channels, 1),
+        "a.conv_out.bias": (mfa,),
+        "a.asp_tdnn.weight": (attention, 3 * mfa, 1),
+        "a.asp_tdnn.bias": (attention,),
+        "a.asp_attn.weight": (mfa, attention, 1),
+        "a.asp_attn.bias": (mfa,),
+        "mm.a.fc.weight": (output, 2 * mfa, 1),
+        "mm.a.fc.bias": (output,),
+        "a.gen.code.proj_in.weight": (1,),
+    }
+    for block in range(1, 4):
+        shapes.update(
+            {
+                f"a.blk.{block}.conv_pw1.weight": (channels, channels, 1),
+                f"a.blk.{block}.conv_pw1.bias": (channels,),
+                f"a.blk.{block}.conv_pw2.weight": (channels, channels, 1),
+                f"a.blk.{block}.conv_pw2.bias": (channels,),
+                f"a.blk.{block}.se_conv1.weight": (4, channels, 1),
+                f"a.blk.{block}.se_conv1.bias": (4,),
+                f"a.blk.{block}.se_conv2.weight": (channels, 4, 1),
+                f"a.blk.{block}.se_conv2.bias": (channels,),
+            }
+        )
+        for branch in range(7):
+            shapes[f"a.blk.{block}.res2.{branch}.weight"] = (1, 1, 3)
+            shapes[f"a.blk.{block}.res2.{branch}.bias"] = (1,)
+    return _FakeSidecar(metadata, shapes, seed=7)
+
+
+def _qwen25o_sidecar() -> _FakeSidecar:
+    sidecar = _qwen2a_sidecar(alias=True)
+    hidden, intermediate, output, patch = 8, 12, 12, 2
+    sidecar.metadata.update(
+        _vision_metadata(
+            projector_type="qwen2.5o",
+            hidden=hidden,
+            intermediate=hidden,
+            output=output,
+            patch=patch,
+        )
+    )
+    sidecar.metadata["clip.projector_type"] = "qwen2.5o"
+    sidecar.metadata["clip.vision.n_wa_pattern"] = 1
+    merged = hidden * 4
+    vision_shapes = {
+        "v.patch_embd.weight": (hidden, 3, patch, patch),
+        "v.patch_embd.weight.1": (hidden, 3, patch, patch),
+        "v.post_ln.weight": (hidden,),
+        "mm.0.weight": (merged, merged),
+        "mm.0.bias": (merged,),
+        "mm.2.weight": (output, merged),
+        "mm.2.bias": (output,),
+    }
+    for stem, shape in {
+        "ln1.weight": (hidden,),
+        "ln2.weight": (hidden,),
+        "attn_q.weight": (hidden, hidden),
+        "attn_q.bias": (hidden,),
+        "attn_k.weight": (hidden, hidden),
+        "attn_k.bias": (hidden,),
+        "attn_v.weight": (hidden, hidden),
+        "attn_v.bias": (hidden,),
+        "attn_out.weight": (hidden, hidden),
+        "attn_out.bias": (hidden,),
+        "ffn_gate.weight": (intermediate, hidden),
+        "ffn_gate.bias": (intermediate,),
+        "ffn_up.weight": (intermediate, hidden),
+        "ffn_up.bias": (intermediate,),
+        "ffn_down.weight": (hidden, intermediate),
+        "ffn_down.bias": (hidden,),
+    }.items():
+        vision_shapes["v.blk.0." + stem] = shape
+    rng = np.random.default_rng(8)
+    sidecar._shapes.update(vision_shapes)
+    sidecar.tensor_names.extend(vision_shapes)
+    sidecar._values.update(
+        {
+            name: (rng.standard_normal(shape) * 0.03).astype(np.float32)
+            for name, shape in vision_shapes.items()
+        }
+    )
+    return sidecar
+
+
+_ROUTES = {
+    "glm4v": (_glm4v_sidecar, "glm4", {"vision_encoder"}),
+    "glma": (_glma_sidecar, "llama", {"audio_encoder"}),
+    "qwen2.5o": (_qwen25o_sidecar, "qwen2vl", {"vision_encoder", "audio_encoder"}),
+    "qwen2a": (_qwen2a_sidecar, "qwen2", {"audio_encoder"}),
+    "qwen3a": (_qwen3a_sidecar, "qwen3vl", {"audio_encoder"}),
+    "qwen3vl_merger": (_qwen3vl_sidecar, "qwen3vl", {"vision_encoder"}),
+    "qwen3tts_spkenc": (_speaker_sidecar, "qwen3tts", {"speaker_encoder"}),
+}
+
+
+def _build_package(projector_type: str, *, dtype: str | None = None):
+    factory, target, _ = _ROUTES[projector_type]
+    sidecar = factory()
+    with (
+        mock.patch(
+            "mobius.integrations.gguf._mmproj._resolve_mmproj_companion_path",
+            return_value="synthetic.gguf",
+        ),
+        mock.patch("mobius.integrations.gguf._builder._validate_gguf_model"),
+    ):
+        package = build_mmproj_from_gguf(
+            "synthetic.gguf",
+            projector_type=projector_type,
+            target_architecture=target,
+            dtype=dtype,
+            _mmproj_gguf_model=sidecar,
+        )
+    return sidecar, package
+
+
+@pytest.mark.parametrize("projector_type", tuple(_ROUTES))
+def test_every_route_builds_only_its_declared_components(projector_type: str) -> None:
+    _, _, expected = _ROUTES[projector_type]
+    _, package = _build_package(projector_type)
+
+    assert set(package) == expected
+    assert package.gguf_projector_type == projector_type
+    assert package.gguf_processor_abi
+    assert all(
+        initializer.const_value is not None
+        for graph in package.values()
+        for initializer in graph.graph.initializers.values()
+    )
+
+
+def _run_component(package, component: str, feeds: dict[str, np.ndarray]) -> np.ndarray:
+    session = OnnxModelSession(package[component])
+    try:
+        return next(iter(session.run(feeds).values()))
+    finally:
+        session.close()
+
+
+def _load_qwen2_hf_state(sidecar: _FakeSidecar, encoder, projector) -> None:
+    state = {}
+    direct = {
+        "a.conv1d.1.weight": "conv1.weight",
+        "a.conv1d.1.bias": "conv1.bias",
+        "a.conv1d.2.weight": "conv2.weight",
+        "a.conv1d.2.bias": "conv2.bias",
+        "a.position_embd.weight": "embed_positions.weight",
+        "a.post_ln.weight": "layer_norm.weight",
+        "a.post_ln.bias": "layer_norm.bias",
+    }
+    block = {
+        "ln1": "self_attn_layer_norm",
+        "ln2": "final_layer_norm",
+        "attn_q": "self_attn.q_proj",
+        "attn_k": "self_attn.k_proj",
+        "attn_v": "self_attn.v_proj",
+        "attn_out": "self_attn.out_proj",
+        "ffn_up": "fc1",
+        "ffn_down": "fc2",
+    }
+    for source, target in direct.items():
+        value = sidecar.get_tensor(source)
+        state[target] = torch.from_numpy(
+            value.reshape(-1) if source.endswith(".bias") else value
+        )
+    for source, value in sidecar._values.items():
+        match = __import__("re").match(
+            r"^a\.blk\.0\.([^.]+)\.(weight|bias)$",
+            source,
+        )
+        if match is None:
+            continue
+        stem, kind = match.groups()
+        state[f"layers.0.{block[stem]}.{kind}"] = torch.from_numpy(value)
+    encoder.load_state_dict(state, strict=True)
+    projector.linear.weight.data.copy_(torch.from_numpy(sidecar.get_tensor("mm.a.fc.weight")))
+    projector.linear.bias.data.copy_(torch.from_numpy(sidecar.get_tensor("mm.a.fc.bias")))
+
+
+def test_qwen2a_projector_matches_transformers() -> None:
+    from transformers.models.qwen2_audio.configuration_qwen2_audio import (
+        Qwen2AudioEncoderConfig,
+    )
+    from transformers.models.qwen2_audio.modeling_qwen2_audio import (
+        Qwen2AudioEncoder,
+        Qwen2AudioMultiModalProjector,
+    )
+
+    sidecar, package = _build_package("qwen2a")
+    config = Qwen2AudioEncoderConfig(
+        num_mel_bins=8,
+        encoder_layers=1,
+        encoder_attention_heads=2,
+        encoder_ffn_dim=16,
+        d_model=8,
+        max_source_positions=8,
+    )
+    encoder = Qwen2AudioEncoder(config).eval()
+    projector = Qwen2AudioMultiModalProjector(
+        SimpleNamespace(
+            audio_config=SimpleNamespace(d_model=8),
+            text_config=SimpleNamespace(hidden_size=12),
+        )
+    ).eval()
+    _load_qwen2_hf_state(sidecar, encoder, projector)
+
+    features = np.linspace(-1.0, 1.0, 128, dtype=np.float32).reshape(1, 8, 16)
+    with torch.no_grad():
+        expected = projector(encoder(torch.from_numpy(features)).last_hidden_state).numpy()
+    actual = _run_component(
+        package,
+        "audio_encoder",
+        {"input_features": features},
+    )
+    np.testing.assert_allclose(actual, expected[0], rtol=2e-4, atol=2e-4)
+
+
+def _load_qwen3_audio_hf_state(sidecar: _FakeSidecar, encoder) -> None:
+    state = {}
+    direct = {
+        "a.conv2d.1.weight": "conv2d1.weight",
+        "a.conv2d.1.bias": "conv2d1.bias",
+        "a.conv2d.2.weight": "conv2d2.weight",
+        "a.conv2d.2.bias": "conv2d2.bias",
+        "a.conv2d.3.weight": "conv2d3.weight",
+        "a.conv2d.3.bias": "conv2d3.bias",
+        "a.conv_out.weight": "conv_out.weight",
+        "a.post_ln.weight": "ln_post.weight",
+        "a.post_ln.bias": "ln_post.bias",
+        "mm.a.mlp.1.weight": "proj1.weight",
+        "mm.a.mlp.1.bias": "proj1.bias",
+        "mm.a.mlp.2.weight": "proj2.weight",
+        "mm.a.mlp.2.bias": "proj2.bias",
+    }
+    block = {
+        "ln1": "self_attn_layer_norm",
+        "ln2": "final_layer_norm",
+        "attn_q": "self_attn.q_proj",
+        "attn_k": "self_attn.k_proj",
+        "attn_v": "self_attn.v_proj",
+        "attn_out": "self_attn.out_proj",
+        "ffn_up": "fc1",
+        "ffn_down": "fc2",
+    }
+    for source, target in direct.items():
+        value = sidecar.get_tensor(source)
+        state[target] = torch.from_numpy(
+            value.reshape(-1) if source.endswith(".bias") else value
+        )
+    for source, value in sidecar._values.items():
+        match = __import__("re").match(
+            r"^a\.blk\.0\.([^.]+)\.(weight|bias)$",
+            source,
+        )
+        if match is None:
+            continue
+        stem, kind = match.groups()
+        state[f"layers.0.{block[stem]}.{kind}"] = torch.from_numpy(value)
+    encoder.load_state_dict(state, strict=True)
+
+
+def test_qwen3a_projector_matches_transformers() -> None:
+    from transformers.models.qwen3_omni_moe.configuration_qwen3_omni_moe import (
+        Qwen3OmniMoeAudioEncoderConfig,
+    )
+    from transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe import (
+        Qwen3OmniMoeAudioEncoder,
+    )
+
+    sidecar = _qwen3a_sidecar()
+    config = Qwen3OmniMoeAudioEncoderConfig(
+        num_mel_bins=8,
+        encoder_layers=1,
+        encoder_attention_heads=2,
+        encoder_ffn_dim=16,
+        d_model=8,
+        max_source_positions=13,
+        n_window=50,
+        n_window_infer=800,
+        conv_chunksize=1,
+        output_dim=12,
+        downsample_hidden_size=4,
+    )
+    encoder = Qwen3OmniMoeAudioEncoder(config).eval()
+    positional = encoder.positional_embedding.positional_embedding.detach().numpy()
+    sidecar._values["a.position_embd.weight"] = positional.astype(np.float32)
+    _load_qwen3_audio_hf_state(sidecar, encoder)
+    # Rebuild with the exact generated position table used by the HF reference.
+    with (
+        mock.patch(
+            "mobius.integrations.gguf._mmproj._resolve_mmproj_companion_path",
+            return_value="synthetic.gguf",
+        ),
+        mock.patch("mobius.integrations.gguf._builder._validate_gguf_model"),
+    ):
+        package = build_mmproj_from_gguf(
+            "synthetic.gguf",
+            projector_type="qwen3a",
+            target_architecture="qwen3vl",
+            _mmproj_gguf_model=sidecar,
+        )
+
+    features = np.linspace(-0.4, 0.6, 800, dtype=np.float32).reshape(1, 8, 100)
+    with torch.no_grad():
+        expected = encoder(
+            torch.from_numpy(features[0]),
+            feature_lens=torch.tensor([100]),
+        ).last_hidden_state.numpy()
+    actual = _run_component(
+        package,
+        "audio_encoder",
+        {"input_features": features},
+    )
+    np.testing.assert_allclose(actual, expected, rtol=3e-4, atol=3e-4)
+
+
+def _qwen3vl_hf_state(sidecar: _FakeSidecar) -> dict[str, torch.Tensor]:
+    state: dict[str, torch.Tensor] = {
+        "patch_embed.proj.weight": torch.from_numpy(
+            np.stack(
+                [
+                    sidecar.get_tensor("v.patch_embd.weight"),
+                    sidecar.get_tensor("v.patch_embd.weight.1"),
+                ],
+                axis=2,
+            )
+        ),
+        "patch_embed.proj.bias": torch.from_numpy(sidecar.get_tensor("v.patch_embd.bias")),
+        "pos_embed.weight": torch.from_numpy(sidecar.get_tensor("v.position_embd.weight")),
+        "merger.norm.weight": torch.from_numpy(sidecar.get_tensor("v.post_ln.weight")),
+        "merger.norm.bias": torch.from_numpy(sidecar.get_tensor("v.post_ln.bias")),
+        "merger.linear_fc1.weight": torch.from_numpy(sidecar.get_tensor("mm.0.weight")),
+        "merger.linear_fc1.bias": torch.from_numpy(sidecar.get_tensor("mm.0.bias")),
+        "merger.linear_fc2.weight": torch.from_numpy(sidecar.get_tensor("mm.2.weight")),
+        "merger.linear_fc2.bias": torch.from_numpy(sidecar.get_tensor("mm.2.bias")),
+    }
+    block_map = {
+        "ln1": "norm1",
+        "ln2": "norm2",
+        "attn_qkv": "attn.qkv",
+        "attn_out": "attn.proj",
+        "ffn_up": "mlp.linear_fc1",
+        "ffn_down": "mlp.linear_fc2",
+    }
+    for source, value in sidecar._values.items():
+        match = __import__("re").match(
+            r"^v\.blk\.0\.([^.]+)\.(weight|bias)$",
+            source,
+        )
+        if match is not None:
+            stem, kind = match.groups()
+            state[f"blocks.0.{block_map[stem]}.{kind}"] = torch.from_numpy(value)
+            continue
+        match = __import__("re").match(
+            r"^v\.deepstack\.0\.(norm|fc1|fc2)\.(weight|bias)$",
+            source,
+        )
+        if match is not None:
+            stem, kind = match.groups()
+            target = {
+                "norm": "norm",
+                "fc1": "linear_fc1",
+                "fc2": "linear_fc2",
+            }[stem]
+            state[f"deepstack_merger_list.0.{target}.{kind}"] = torch.from_numpy(value)
+    return state
+
+
+def test_qwen3vl_projector_matches_transformers() -> None:
+    from transformers.models.qwen3_vl.configuration_qwen3_vl import (
+        Qwen3VLVisionConfig,
+    )
+    from transformers.models.qwen3_vl.modeling_qwen3_vl import Qwen3VLVisionModel
+
+    sidecar, package = _build_package("qwen3vl_merger")
+    config = Qwen3VLVisionConfig(
+        depth=1,
+        hidden_size=8,
+        intermediate_size=16,
+        num_heads=2,
+        in_channels=3,
+        patch_size=2,
+        spatial_merge_size=2,
+        temporal_patch_size=2,
+        out_hidden_size=12,
+        num_position_embeddings=4,
+        deepstack_visual_indexes=[0],
+    )
+    reference = Qwen3VLVisionModel(config).eval()
+    reference.load_state_dict(_qwen3vl_hf_state(sidecar), strict=True)
+    # llama.cpp hardcodes its tanh-approximate GELU for both merger families.
+    reference.merger.act_fn = torch.nn.GELU(approximate="tanh")
+    reference.deepstack_merger_list[0].act_fn = torch.nn.GELU(approximate="tanh")
+
+    pixels = np.linspace(-0.5, 0.7, 96, dtype=np.float32).reshape(4, 24)
+    grid = np.array([[1, 2, 2]], dtype=np.int64)
+    with torch.no_grad():
+        output = reference(
+            torch.from_numpy(pixels),
+            torch.from_numpy(grid),
+        )
+        expected = torch.cat(
+            [output.pooler_output, *output.deepstack_features],
+            dim=1,
+        ).numpy()
+    actual = _run_component(
+        package,
+        "vision_encoder",
+        {"pixel_values": pixels, "image_grid_thw": grid},
+    )
+    np.testing.assert_allclose(actual, expected, rtol=4e-4, atol=4e-4)
+
+
+def _glm4v_hf_state(sidecar: _FakeSidecar) -> dict[str, torch.Tensor]:
+    state: dict[str, torch.Tensor] = {
+        "patch_embed.proj.weight": torch.from_numpy(
+            np.stack(
+                [
+                    sidecar.get_tensor("v.patch_embd.weight"),
+                    sidecar.get_tensor("v.patch_embd.weight.1"),
+                ],
+                axis=2,
+            )
+        ),
+        "patch_embed.proj.bias": torch.from_numpy(sidecar.get_tensor("v.patch_embd.bias")),
+        "post_layernorm.weight": torch.from_numpy(sidecar.get_tensor("v.post_ln.weight")),
+        "downsample.weight": torch.from_numpy(sidecar.get_tensor("mm.patch_merger.weight")),
+        "downsample.bias": torch.from_numpy(sidecar.get_tensor("mm.patch_merger.bias")),
+        "merger.proj.weight": torch.from_numpy(sidecar.get_tensor("mm.model.fc.weight")),
+        "merger.post_projection_norm.weight": torch.from_numpy(
+            sidecar.get_tensor("mm.post_norm.weight")
+        ),
+        "merger.post_projection_norm.bias": torch.from_numpy(
+            sidecar.get_tensor("mm.post_norm.bias")
+        ),
+        "merger.up_proj.weight": torch.from_numpy(sidecar.get_tensor("mm.up.weight")),
+        "merger.gate_proj.weight": torch.from_numpy(sidecar.get_tensor("mm.gate.weight")),
+        "merger.down_proj.weight": torch.from_numpy(sidecar.get_tensor("mm.down.weight")),
+    }
+    block_map = {
+        "ln1": "norm1",
+        "ln2": "norm2",
+        "attn_qkv": "attn.qkv",
+        "attn_q_norm": "attn.q_norm",
+        "attn_k_norm": "attn.k_norm",
+        "attn_out": "attn.proj",
+        "ffn_gate": "mlp.gate_proj",
+        "ffn_up": "mlp.up_proj",
+        "ffn_down": "mlp.down_proj",
+    }
+    for source, value in sidecar._values.items():
+        match = __import__("re").match(
+            r"^v\.blk\.0\.([^.]+)\.(weight|bias)$",
+            source,
+        )
+        if match is None:
+            continue
+        stem, kind = match.groups()
+        state[f"blocks.0.{block_map[stem]}.{kind}"] = torch.from_numpy(value)
+    return state
+
+
+def test_glm4v_projector_matches_transformers() -> None:
+    from transformers.models.glm_ocr.configuration_glm_ocr import (
+        GlmOcrVisionConfig,
+    )
+    from transformers.models.glm_ocr.modeling_glm_ocr import GlmOcrVisionModel
+
+    sidecar, package = _build_package("glm4v")
+    config = GlmOcrVisionConfig(
+        depth=1,
+        hidden_size=8,
+        intermediate_size=16,
+        num_heads=2,
+        in_channels=3,
+        image_size=4,
+        patch_size=2,
+        spatial_merge_size=2,
+        temporal_patch_size=2,
+        out_hidden_size=12,
+    )
+    reference = GlmOcrVisionModel(config).eval()
+    reference.load_state_dict(_glm4v_hf_state(sidecar), strict=True)
+    pixels = np.linspace(-0.8, 0.9, 96, dtype=np.float32).reshape(4, 24)
+    grid = np.array([[1, 2, 2]], dtype=np.int64)
+    with torch.no_grad():
+        expected = reference(
+            torch.from_numpy(pixels),
+            torch.from_numpy(grid),
+        ).pooler_output.numpy()
+    actual = _run_component(
+        package,
+        "vision_encoder",
+        {"pixel_values": pixels, "image_grid_thw": grid},
+    )
+    np.testing.assert_allclose(actual, expected, rtol=4e-4, atol=4e-4)
+
+
+def test_glm4v_learned_position_variant_matches_transformers() -> None:
+    from transformers.models.glm4v.configuration_glm4v import Glm4vVisionConfig
+    from transformers.models.glm4v.modeling_glm4v import Glm4vVisionModel
+
+    sidecar = _glm4v_learned_position_sidecar()
+    with (
+        mock.patch(
+            "mobius.integrations.gguf._mmproj._resolve_mmproj_companion_path",
+            return_value="synthetic.gguf",
+        ),
+        mock.patch("mobius.integrations.gguf._builder._validate_gguf_model"),
+    ):
+        package = build_mmproj_from_gguf(
+            "synthetic.gguf",
+            projector_type="glm4v",
+            target_architecture="glm4",
+            _mmproj_gguf_model=sidecar,
+        )
+
+    config = Glm4vVisionConfig(
+        depth=1,
+        hidden_size=8,
+        intermediate_size=16,
+        num_heads=2,
+        in_channels=3,
+        image_size=4,
+        patch_size=2,
+        spatial_merge_size=2,
+        temporal_patch_size=2,
+        out_hidden_size=12,
+    )
+    reference = Glm4vVisionModel(config).eval()
+    state = _glm4v_hf_state(sidecar)
+    state["post_conv_layernorm.weight"] = torch.from_numpy(
+        sidecar.get_tensor("v.norm_embd.weight")
+    )
+    state["embeddings.position_embedding.weight"] = torch.from_numpy(
+        sidecar.get_tensor("v.position_embd.weight")
+    )
+    reference.load_state_dict(state, strict=True)
+    pixels = np.linspace(-0.6, 0.8, 96, dtype=np.float32).reshape(4, 24)
+    grid = np.array([[1, 2, 2]], dtype=np.int64)
+    with torch.no_grad():
+        expected = reference(
+            torch.from_numpy(pixels),
+            torch.from_numpy(grid),
+        ).pooler_output.numpy()
+    actual = _run_component(
+        package,
+        "vision_encoder",
+        {"pixel_values": pixels, "image_grid_thw": grid},
+    )
+    np.testing.assert_allclose(actual, expected, rtol=5e-4, atol=5e-4)
+
+
+def _qwen25o_hf_vision_state(sidecar: _FakeSidecar) -> dict[str, torch.Tensor]:
+    state: dict[str, torch.Tensor] = {
+        "patch_embed.proj.weight": torch.from_numpy(
+            np.stack(
+                [
+                    sidecar.get_tensor("v.patch_embd.weight"),
+                    sidecar.get_tensor("v.patch_embd.weight.1"),
+                ],
+                axis=2,
+            )
+        ),
+        "merger.ln_q.weight": torch.from_numpy(sidecar.get_tensor("v.post_ln.weight")),
+        "merger.mlp.0.weight": torch.from_numpy(sidecar.get_tensor("mm.0.weight")),
+        "merger.mlp.0.bias": torch.from_numpy(sidecar.get_tensor("mm.0.bias")),
+        "merger.mlp.2.weight": torch.from_numpy(sidecar.get_tensor("mm.2.weight")),
+        "merger.mlp.2.bias": torch.from_numpy(sidecar.get_tensor("mm.2.bias")),
+    }
+    block_map = {
+        "ln1": "norm1",
+        "ln2": "norm2",
+        "attn_q": "attn.q",
+        "attn_k": "attn.k",
+        "attn_v": "attn.v",
+        "attn_out": "attn.proj",
+        "ffn_gate": "mlp.gate_proj",
+        "ffn_up": "mlp.up_proj",
+        "ffn_down": "mlp.down_proj",
+    }
+    for source, value in sidecar._values.items():
+        match = __import__("re").match(
+            r"^v\.blk\.0\.([^.]+)\.(weight|bias)$",
+            source,
+        )
+        if match is None:
+            continue
+        stem, kind = match.groups()
+        state[f"blocks.0.{block_map[stem]}.{kind}"] = torch.from_numpy(value)
+    return state
+
+
+def test_qwen25o_alias_vision_matches_transformers() -> None:
+    from transformers.models.qwen2_5_omni.configuration_qwen2_5_omni import (
+        Qwen2_5OmniVisionEncoderConfig,
+    )
+    from transformers.models.qwen2_5_omni.modeling_qwen2_5_omni import (
+        Qwen2_5OmniVisionEncoder,
+    )
+
+    sidecar, package = _build_package("qwen2.5o")
+    config = Qwen2_5OmniVisionEncoderConfig(
+        depth=1,
+        hidden_size=8,
+        intermediate_size=12,
+        num_heads=2,
+        in_channels=3,
+        patch_size=2,
+        spatial_merge_size=2,
+        temporal_patch_size=2,
+        window_size=8,
+        out_hidden_size=12,
+        fullatt_block_indexes=[0],
+    )
+    reference = Qwen2_5OmniVisionEncoder(config).eval()
+    reference.load_state_dict(_qwen25o_hf_vision_state(sidecar), strict=True)
+    pixels = np.linspace(-0.3, 0.6, 96, dtype=np.float32).reshape(4, 24)
+    grid = np.array([[1, 2, 2]], dtype=np.int64)
+    with torch.no_grad():
+        expected = reference(
+            torch.from_numpy(pixels),
+            torch.from_numpy(grid),
+        ).pooler_output.numpy()
+    actual = _run_component(
+        package,
+        "vision_encoder",
+        {"pixel_values": pixels, "image_grid_thw": grid},
+    )
+    np.testing.assert_allclose(actual, expected, rtol=4e-4, atol=4e-4)
+
+
+def _linear(
+    value: torch.Tensor,
+    sidecar: _FakeSidecar,
+    stem: str,
+) -> torch.Tensor:
+    weight = torch.from_numpy(sidecar.get_tensor(stem + ".weight"))
+    bias = (
+        torch.from_numpy(sidecar.get_tensor(stem + ".bias").reshape(-1))
+        if stem + ".bias" in sidecar._values
+        else None
+    )
+    return functional.linear(value, weight, bias)
+
+
+def _layer_norm(
+    value: torch.Tensor,
+    sidecar: _FakeSidecar,
+    stem: str,
+    *,
+    eps: float = 1e-5,
+) -> torch.Tensor:
+    return functional.layer_norm(
+        value,
+        (value.shape[-1],),
+        torch.from_numpy(sidecar.get_tensor(stem + ".weight")),
+        torch.from_numpy(sidecar.get_tensor(stem + ".bias")),
+        eps,
+    )
+
+
+def test_glma_projector_matches_independent_torch_reference() -> None:
+    sidecar, package = _build_package("glma")
+    features = np.linspace(-0.7, 0.8, 128, dtype=np.float32).reshape(1, 8, 16)
+    x = torch.from_numpy(features)
+
+    x = functional.gelu(
+        functional.conv1d(
+            x,
+            torch.from_numpy(sidecar.get_tensor("a.conv1d.1.weight")),
+            torch.from_numpy(sidecar.get_tensor("a.conv1d.1.bias").reshape(-1)),
+            padding=1,
+        )
+    )
+    x = functional.gelu(
+        functional.conv1d(
+            x,
+            torch.from_numpy(sidecar.get_tensor("a.conv1d.2.weight")),
+            torch.from_numpy(sidecar.get_tensor("a.conv1d.2.bias").reshape(-1)),
+            stride=2,
+            padding=1,
+        )
+    ).transpose(1, 2)
+    x = x + torch.from_numpy(sidecar.get_tensor("a.position_embd.weight"))[: x.shape[1]]
+
+    residual = x
+    normed = _layer_norm(x, sidecar, "a.blk.0.ln1")
+    q = _linear(normed, sidecar, "a.blk.0.attn_q")
+    k = _linear(normed, sidecar, "a.blk.0.attn_k")
+    v = _linear(normed, sidecar, "a.blk.0.attn_v")
+    batch, sequence, hidden = q.shape
+    heads, head_dim = 2, hidden // 2
+    q = q.reshape(batch, sequence, heads, head_dim).transpose(1, 2)
+    k = k.reshape(batch, sequence, heads, head_dim).transpose(1, 2)
+    v = v.reshape(batch, sequence, heads, head_dim).transpose(1, 2)
+    attention = torch.softmax((q * (head_dim**-0.5)) @ k.transpose(-1, -2), dim=-1)
+    attention = (attention @ v).transpose(1, 2).reshape(batch, sequence, hidden)
+    x = residual + _linear(attention, sidecar, "a.blk.0.attn_out")
+
+    residual = x
+    x = _layer_norm(x, sidecar, "a.blk.0.ln2")
+    x = _linear(
+        functional.gelu(_linear(x, sidecar, "a.blk.0.ffn_up")),
+        sidecar,
+        "a.blk.0.ffn_down",
+    )
+    x = residual + x
+    x = _layer_norm(x, sidecar, "a.post_ln")
+    x = _layer_norm(x, sidecar, "mm.a.norm_pre")
+    x = x.reshape(1, -1, 16)
+    x = _linear(
+        functional.gelu(_linear(x, sidecar, "mm.a.mlp.1")),
+        sidecar,
+        "mm.a.mlp.2",
+    )
+    expected = torch.cat(
+        [
+            torch.from_numpy(sidecar.get_tensor("v.boi")).reshape(1, 1, -1),
+            x,
+            torch.from_numpy(sidecar.get_tensor("v.eoi")).reshape(1, 1, -1),
+        ],
+        dim=1,
+    )[0].numpy()
+
+    actual = _run_component(
+        package,
+        "audio_encoder",
+        {"input_features": features},
+    )
+    np.testing.assert_allclose(actual, expected, rtol=3e-4, atol=3e-4)
+
+
+def _speaker_conv(
+    value: torch.Tensor,
+    sidecar: _FakeSidecar,
+    stem: str,
+    *,
+    dilation: int = 1,
+) -> torch.Tensor:
+    weight = torch.from_numpy(sidecar.get_tensor(stem + ".weight"))
+    bias = torch.from_numpy(sidecar.get_tensor(stem + ".bias"))
+    padding = (weight.shape[-1] - 1) * dilation // 2
+    if padding:
+        value = functional.pad(value, (padding, padding), mode="reflect")
+    return functional.conv1d(value, weight, bias, dilation=dilation)
+
+
+def _speaker_block_reference(
+    value: torch.Tensor,
+    sidecar: _FakeSidecar,
+    block: int,
+    dilation: int,
+) -> torch.Tensor:
+    prefix = f"a.blk.{block}."
+    residual = value
+    value = functional.relu(_speaker_conv(value, sidecar, prefix + "conv_pw1"))
+    chunks = value.chunk(8, dim=1)
+    outputs = [chunks[0]]
+    previous = None
+    for index in range(1, 8):
+        branch_input = chunks[index] if index == 1 else chunks[index] + previous
+        previous = functional.relu(
+            _speaker_conv(
+                branch_input,
+                sidecar,
+                prefix + f"res2.{index - 1}",
+                dilation=dilation,
+            )
+        )
+        outputs.append(previous)
+    value = torch.cat(outputs, dim=1)
+    value = functional.relu(_speaker_conv(value, sidecar, prefix + "conv_pw2"))
+    gate = value.mean(dim=2, keepdim=True)
+    gate = functional.relu(_speaker_conv(gate, sidecar, prefix + "se_conv1"))
+    gate = torch.sigmoid(_speaker_conv(gate, sidecar, prefix + "se_conv2"))
+    return residual + value * gate
+
+
+def test_qwen3tts_speaker_matches_independent_torch_reference() -> None:
+    sidecar, package = _build_package("qwen3tts_spkenc")
+    mel = np.linspace(-0.5, 0.6, 44, dtype=np.float32).reshape(11, 4)
+    value = torch.from_numpy(mel).T.unsqueeze(0)
+    value = functional.relu(_speaker_conv(value, sidecar, "a.conv1d.0"))
+    block_outputs = []
+    for block, dilation in zip(range(1, 4), (2, 3, 4)):
+        value = _speaker_block_reference(value, sidecar, block, dilation)
+        block_outputs.append(value)
+    value = functional.relu(
+        _speaker_conv(
+            torch.cat(block_outputs, dim=1),
+            sidecar,
+            "a.conv_out",
+        )
+    )
+
+    mean = value.mean(dim=2, keepdim=True)
+    std = torch.sqrt(((value - mean) ** 2).mean(dim=2, keepdim=True) + 1e-12)
+    attention_input = torch.cat(
+        [value, mean.expand_as(value), std.expand_as(value)],
+        dim=1,
+    )
+    attention = functional.relu(_speaker_conv(attention_input, sidecar, "a.asp_tdnn"))
+    attention = torch.tanh(attention)
+    attention = torch.softmax(
+        _speaker_conv(attention, sidecar, "a.asp_attn"),
+        dim=2,
+    )
+    weighted_mean = (attention * value).sum(dim=2)
+    weighted_std = torch.sqrt(
+        (attention * (value - weighted_mean.unsqueeze(2)) ** 2).sum(dim=2) + 1e-12
+    )
+    statistics = torch.cat([weighted_mean, weighted_std], dim=1).unsqueeze(2)
+    expected = _speaker_conv(statistics, sidecar, "mm.a.fc").squeeze(2).numpy()
+
+    actual = _run_component(
+        package,
+        "speaker_encoder",
+        {"mel_features": mel},
+    )
+    np.testing.assert_allclose(actual, expected, rtol=3e-4, atol=3e-4)
+
+
+def test_qwen25o_alias_has_two_distinct_processor_abis() -> None:
+    contract = _ROUTES["qwen2.5o"][0]().metadata
+    assert contract["clip.projector_type"] == "qwen2.5o"
+    assert contract["clip.has_vision_encoder"] is True
+    assert contract["clip.has_audio_encoder"] is True
+
+
+def test_qwen3tts_quarantines_only_generated_audio_namespace() -> None:
+    sidecar = _speaker_sidecar()
+    sidecar._shapes["unexpected.weight"] = (1,)
+    sidecar._values["unexpected.weight"] = np.ones((1,), dtype=np.float32)
+    sidecar.tensor_names.append("unexpected.weight")
+    with (
+        mock.patch(
+            "mobius.integrations.gguf._mmproj._resolve_mmproj_companion_path",
+            return_value="synthetic.gguf",
+        ),
+        mock.patch("mobius.integrations.gguf._builder._validate_gguf_model"),
+        pytest.raises(ValueError, match="outside the pinned suffix-exact"),
+    ):
+        build_mmproj_from_gguf(
+            "synthetic.gguf",
+            projector_type="qwen3tts_spkenc",
+            target_architecture="qwen3tts",
+            _mmproj_gguf_model=sidecar,
+        )
+
+
+def test_qwen3tts_export_warns_that_runtime_prompt_assembly_is_unvalidated(
+    caplog,
+) -> None:
+    _build_package("qwen3tts_spkenc")
+    assert "downstream runtime orchestration is deferred" in caplog.text
+    assert "tts_pad" in caplog.text
+
+
+def test_qwen3vl_rejects_non_two_spatial_merge() -> None:
+    sidecar = _qwen3vl_sidecar()
+    sidecar.metadata["clip.vision.spatial_merge_size"] = 3
+    with (
+        mock.patch(
+            "mobius.integrations.gguf._mmproj._resolve_mmproj_companion_path",
+            return_value="synthetic.gguf",
+        ),
+        mock.patch("mobius.integrations.gguf._builder._validate_gguf_model"),
+        pytest.raises(ValueError, match="spatial_merge_size=2"),
+    ):
+        build_mmproj_from_gguf(
+            "synthetic.gguf",
+            projector_type="qwen3vl_merger",
+            target_architecture="qwen3vl",
+            _mmproj_gguf_model=sidecar,
+        )
+
+
+def test_qwen3vl_multi_media_cardinality_and_deepstack_width() -> None:
+    _, package = _build_package("qwen3vl_merger")
+    pixels = np.arange(12 * 24, dtype=np.float32).reshape(12, 24) / 100
+    grid = np.array([[1, 2, 2], [1, 2, 4]], dtype=np.int64)
+
+    actual = _run_component(
+        package,
+        "vision_encoder",
+        {"pixel_values": pixels, "image_grid_thw": grid},
+    )
+
+    # One 2x2 image contributes one merged row; one 2x4 image contributes two.
+    assert actual.shape == (3, 24)
+    assert np.isfinite(actual).all()
+
+
+@pytest.mark.parametrize(
+    ("pixels", "grid"),
+    [
+        (np.zeros((3, 24), np.float32), np.array([[1, 2, 2]], np.int64)),
+        (np.zeros((6, 24), np.float32), np.array([[1, 2, 3]], np.int64)),
+    ],
+)
+def test_qwen3vl_runtime_grid_contract_fails_closed(pixels, grid) -> None:
+    _, package = _build_package("qwen3vl_merger")
+    with pytest.raises(
+        (
+            ort.capi.onnxruntime_pybind11_state.Fail,
+            ort.capi.onnxruntime_pybind11_state.InvalidArgument,
+            ort.capi.onnxruntime_pybind11_state.RuntimeException,
+        ),
+        match="indices element out of data bounds",
+    ):
+        _run_component(
+            package,
+            "vision_encoder",
+            {"pixel_values": pixels, "image_grid_thw": grid},
+        )
+
+
+def test_qwen3vl_decoder_positions_are_four_section_y_then_x() -> None:
+    positions, next_position = qwen3vl_decoder_mrope_positions(
+        merged_height=2,
+        merged_width=3,
+        start_position=7,
+    )
+
+    np.testing.assert_array_equal(
+        positions,
+        np.array(
+            [
+                [7, 7, 7, 7, 7, 7],
+                [7, 7, 7, 8, 8, 8],
+                [7, 8, 9, 7, 8, 9],
+                [0, 0, 0, 0, 0, 0],
+            ],
+            dtype=np.int64,
+        ),
+    )
+    assert next_position == 10
+
+
+def test_packed_qtype_is_rejected_before_graph_construction() -> None:
+    sidecar = _qwen2a_sidecar()
+    sidecar.get_tensor_type = lambda name: SimpleNamespace(  # type: ignore[method-assign]
+        name="Q8_0" if name == "mm.a.fc.weight" else "F32"
+    )
+    with (
+        mock.patch(
+            "mobius.integrations.gguf._mmproj._resolve_mmproj_companion_path",
+            return_value="synthetic.gguf",
+        ),
+        mock.patch("mobius.integrations.gguf._builder._validate_gguf_model"),
+        pytest.raises(NotImplementedError, match="packed Q8_0"),
+    ):
+        build_mmproj_from_gguf(
+            "synthetic.gguf",
+            projector_type="qwen2a",
+            target_architecture="qwen2",
+            _mmproj_gguf_model=sidecar,
+        )
+
+
+@pytest.mark.parametrize(
+    ("projector_type", "frames"),
+    [
+        ("qwen2a", 16),
+        ("qwen3a", 100),
+        ("glma", 16),
+        ("qwen2.5o", 16),
+    ],
+)
+def test_reduced_precision_audio_casts_float_processor_input(
+    projector_type: str,
+    frames: int,
+) -> None:
+    _, package = _build_package(projector_type, dtype="f16")
+    features = np.linspace(-0.2, 0.3, 8 * frames, dtype=np.float32).reshape(
+        1,
+        8,
+        frames,
+    )
+
+    actual = _run_component(
+        package,
+        "audio_encoder",
+        {"input_features": features},
+    )
+
+    assert actual.dtype == np.float16
+    assert np.isfinite(actual).all()

--- a/src/mobius/integrations/gguf/_route_census_test.py
+++ b/src/mobius/integrations/gguf/_route_census_test.py
@@ -64,8 +64,8 @@ def test_every_route_has_one_actionable_classification() -> None:
     }
     assert Counter(item.category for item in items) == {
         "dependency-or-mobius-abi-blocked": 99,
-        "evidence-only": 117,
-        "immediately-implementable": 38,
+        "evidence-only": 124,
+        "immediately-implementable": 31,
         "intentionally-rejected": 19,
         "artifact-unavailable": 5,
     }
@@ -104,6 +104,16 @@ def test_known_route_boundaries_are_not_collapsed() -> None:
     assert by_id["architecture:plamo2"].category == "evidence-only"
     assert by_id["architecture:jamba"].category == "evidence-only"
     assert by_id["projector:qwen2vl_merger"].category == "evidence-only"
+    for projector_type in (
+        "glm4v",
+        "glma",
+        "qwen2.5o",
+        "qwen2a",
+        "qwen3a",
+        "qwen3vl_merger",
+        "qwen3tts_spkenc",
+    ):
+        assert by_id[f"projector:{projector_type}"].category == "evidence-only"
     assert by_id["projector:lfm2"].category == "immediately-implementable"
     assert by_id["projector:pixtral"].category == "evidence-only"
     for projector_type in (

--- a/src/mobius/models/gguf_qwen_glm_projector.py
+++ b/src/mobius/models/gguf_qwen_glm_projector.py
@@ -241,6 +241,7 @@ class GGUFQwen3VLProjector(nn.Module):
             spatial_merge_size=2,
             num_position_embeddings=int(vision.num_position_embeddings),
             deepstack_visual_indexes=vision.deepstack_visual_indexes or [],
+            block_activation=vision.hidden_act,
             # llama.cpp's FFN_GELU is the tanh approximation for both the
             # final merger and every DeepStack merger.
             merger_gelu_approximate="tanh",
@@ -375,8 +376,8 @@ class GGUFQwen3AudioProjector(nn.Module):
                 ),
             ),
             (
-                "feature_attention_mask",
-                ir.DataType.INT64,
+                "input_features_mask",
+                ir.DataType.INT32,
                 (1, ir.SymbolicDim("audio_frames_multiple_of_100")),
             ),
         )
@@ -385,7 +386,7 @@ class GGUFQwen3AudioProjector(nn.Module):
         self,
         op: OpBuilder,
         input_features: ir.Value,
-        feature_attention_mask: ir.Value,
+        input_features_mask: ir.Value,
     ) -> tuple[ir.Value, ir.Value]:
         input_features = op.CastLike(
             input_features,
@@ -406,11 +407,12 @@ class GGUFQwen3AudioProjector(nn.Module):
         # The encoder derives output cardinality from a binary right-padded
         # processor mask. Reject malformed masks rather than treating holes or
         # non-binary values as valid audio.
-        mask_bool = op.Cast(feature_attention_mask, to=ir.DataType.BOOL)
+        mask_bool = op.Cast(input_features_mask, to=ir.DataType.BOOL)
         binary = op.Equal(
-            feature_attention_mask,
-            op.Cast(mask_bool, to=ir.DataType.INT64),
+            input_features_mask,
+            op.Cast(mask_bool, to=ir.DataType.INT32),
         )
+        feature_attention_mask = op.Cast(input_features_mask, to=ir.DataType.INT64)
         valid_frames = op.ReduceSum(
             feature_attention_mask,
             op.Constant(value_ints=[1]),

--- a/src/mobius/models/gguf_qwen_glm_projector.py
+++ b/src/mobius/models/gguf_qwen_glm_projector.py
@@ -363,6 +363,7 @@ class GGUFQwen3AudioProjector(nn.Module):
         if config.audio is None:
             raise ValueError("Qwen3 audio sidecar requires an audio configuration")
         self.audio_tower = Qwen3ASRAudioEncoder(config)
+        self.output_names = ("audio_features", "audio_feature_lengths")
         self.input_schema = (
             (
                 "input_features",
@@ -373,14 +374,23 @@ class GGUFQwen3AudioProjector(nn.Module):
                     ir.SymbolicDim("audio_frames_multiple_of_100"),
                 ),
             ),
+            (
+                "feature_attention_mask",
+                ir.DataType.INT64,
+                (1, ir.SymbolicDim("audio_frames_multiple_of_100")),
+            ),
         )
 
-    def forward(self, op: OpBuilder, input_features: ir.Value) -> ir.Value:
+    def forward(
+        self,
+        op: OpBuilder,
+        input_features: ir.Value,
+        feature_attention_mask: ir.Value,
+    ) -> tuple[ir.Value, ir.Value]:
         input_features = op.CastLike(
             input_features,
             self.audio_tower.conv2d1.weight,
         )
-        batch = op.Shape(input_features, start=0, end=1)
         frames = op.Shape(input_features, start=2, end=3)
         frame_count = op.Squeeze(frames, [0])
         invalid_frames = op.Cast(
@@ -392,13 +402,63 @@ class GGUFQwen3AudioProjector(nn.Module):
         )
         guard = op.Gather(op.Constant(value_ints=[0]), invalid_frames, axis=0)
         input_features = op.Add(input_features, op.CastLike(guard, input_features))
-        mask_shape = op.Concat(batch, frames, axis=0)
-        feature_mask = op.Expand(
-            op.Constant(value_int=1),
-            mask_shape,
+
+        # The encoder derives output cardinality from a binary right-padded
+        # processor mask. Reject malformed masks rather than treating holes or
+        # non-binary values as valid audio.
+        mask_bool = op.Cast(feature_attention_mask, to=ir.DataType.BOOL)
+        binary = op.Equal(
+            feature_attention_mask,
+            op.Cast(mask_bool, to=ir.DataType.INT64),
         )
-        audio_features, _ = self.audio_tower(op, input_features, feature_mask)
-        return op.Squeeze(audio_features, [0])
+        valid_frames = op.ReduceSum(
+            feature_attention_mask,
+            op.Constant(value_ints=[1]),
+            keepdims=0,
+        )
+        positions = op.Range(
+            op.Constant(value_int=0),
+            frame_count,
+            op.Constant(value_int=1),
+        )
+        expected_mask = op.Less(
+            op.Unsqueeze(positions, [0]),
+            op.Unsqueeze(valid_frames, [1]),
+        )
+        valid_mask = op.And(binary, op.Equal(mask_bool, expected_mask))
+        all_valid = op.ReduceMin(
+            op.Cast(valid_mask, to=ir.DataType.INT64),
+            keepdims=0,
+        )
+        invalid_mask = op.Or(
+            op.Equal(all_valid, op.Constant(value_int=0)),
+            op.LessOrEqual(
+                op.Squeeze(valid_frames, [0]),
+                op.Constant(value_int=0),
+            ),
+        )
+        mask_guard = op.Gather(
+            op.Constant(value_ints=[0]),
+            op.Cast(invalid_mask, to=ir.DataType.INT64),
+            axis=0,
+        )
+        feature_attention_mask = op.Add(feature_attention_mask, mask_guard)
+
+        audio_features, audio_feature_lengths = self.audio_tower(
+            op,
+            input_features,
+            feature_attention_mask,
+        )
+        # The standalone ABI has batch=1. Compact padding-derived tail rows and
+        # still publish the exact valid cardinality for downstream prompt assembly.
+        audio_features = op.Squeeze(audio_features, [0])
+        audio_features = op.Slice(
+            audio_features,
+            op.Constant(value_ints=[0]),
+            audio_feature_lengths,
+            op.Constant(value_ints=[0]),
+        )
+        return audio_features, audio_feature_lengths
 
 
 class GGUFQwen3TTSSpeakerProjector(nn.Module):

--- a/src/mobius/models/gguf_qwen_glm_projector.py
+++ b/src/mobius/models/gguf_qwen_glm_projector.py
@@ -1,0 +1,434 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Standalone Qwen/GLM components for GGUF ``clip`` sidecars."""
+
+from __future__ import annotations
+
+import onnx_ir as ir
+from onnxscript import OpBuilder, nn
+
+from mobius._configs import ArchitectureConfig
+from mobius.components import (
+    Glm4VVisionModel,
+    GlmOcrVisionModel,
+    Qwen3VLVisionModel,
+    Qwen25VLVisionModel,
+    SpeakerEncoder,
+)
+from mobius.models.qwen3_asr import Qwen3ASRAudioEncoder
+
+
+def _guard_merged_grid_contract(
+    op: OpBuilder,
+    pixel_values: ir.Value,
+    image_grid_thw: ir.Value,
+) -> tuple[ir.Value, ir.Value]:
+    temporal = op.Slice(image_grid_thw, [0], [1], [1], [1])
+    height = op.Slice(image_grid_thw, [1], [2], [1], [1])
+    width = op.Slice(image_grid_thw, [2], [3], [1], [1])
+    invalid_grid = op.Or(
+        op.LessOrEqual(image_grid_thw, op.Constant(value_int=0)),
+        op.Concat(
+            op.Equal(temporal, op.Constant(value_int=-1)),
+            op.Not(op.Equal(op.Mod(height, 2), 0)),
+            op.Not(op.Equal(op.Mod(width, 2), 0)),
+            axis=1,
+        ),
+    )
+    invalid_count = op.ReduceSum(
+        op.Cast(invalid_grid, to=ir.DataType.INT64),
+        keepdims=False,
+    )
+    expected_patches = op.ReduceSum(
+        op.Mul(temporal, op.Mul(height, width)),
+        keepdims=False,
+    )
+    actual_patches = op.Squeeze(op.Shape(pixel_values, start=0, end=1), [0])
+    invalid_count = op.Add(
+        invalid_count,
+        op.Cast(
+            op.Not(op.Equal(expected_patches, actual_patches)),
+            to=ir.DataType.INT64,
+        ),
+    )
+    guard = op.Gather(op.Constant(value_ints=[0]), invalid_count, axis=0)
+    return (
+        op.Add(pixel_values, op.CastLike(guard, pixel_values)),
+        op.Add(image_grid_thw, op.CastLike(guard, image_grid_thw)),
+    )
+
+
+class GGUFGlm4VVisionProjector(nn.Module):
+    """GLM4V vision encoder plus its downsampler and gated projector."""
+
+    def __init__(self, config: ArchitectureConfig) -> None:
+        super().__init__()
+        self._dtype = config.dtype
+        vision = config.vision
+        if vision is None:
+            raise ValueError("GLM4V sidecar requires a vision configuration")
+        required = (
+            vision.hidden_size,
+            vision.intermediate_size,
+            vision.num_hidden_layers,
+            vision.num_attention_heads,
+            vision.patch_size,
+            vision.out_hidden_size,
+        )
+        if any(value is None for value in required):
+            raise ValueError("GLM4V sidecar vision dimensions must be complete")
+        assert vision.hidden_size is not None
+        assert vision.intermediate_size is not None
+        assert vision.num_hidden_layers is not None
+        assert vision.num_attention_heads is not None
+        assert vision.patch_size is not None
+        assert vision.out_hidden_size is not None
+        self.visual = Glm4VVisionModel(
+            depth=int(vision.num_hidden_layers),
+            hidden_size=int(vision.hidden_size),
+            intermediate_size=int(vision.intermediate_size),
+            num_heads=int(vision.num_attention_heads),
+            patch_size=int(vision.patch_size),
+            temporal_patch_size=int(vision.temporal_patch_size),
+            in_channels=int(vision.in_channels),
+            out_hidden_size=int(vision.out_hidden_size),
+            spatial_merge_size=int(vision.spatial_merge_size),
+            norm_eps=float(vision.norm_eps),
+            hidden_act=vision.hidden_act or "silu",
+            num_position_embeddings=vision.num_position_embeddings,
+            projector_intermediate_size=vision.projector_intermediate_size,
+        )
+        pixel_width = (
+            int(vision.in_channels)
+            * int(vision.temporal_patch_size)
+            * int(vision.patch_size) ** 2
+        )
+        self.input_schema = (
+            (
+                "pixel_values",
+                ir.DataType.FLOAT,
+                (ir.SymbolicDim("total_patches"), pixel_width),
+            ),
+            (
+                "image_grid_thw",
+                ir.DataType.INT64,
+                (ir.SymbolicDim("num_media"), 3),
+            ),
+        )
+
+    def forward(
+        self,
+        op: OpBuilder,
+        pixel_values: ir.Value,
+        image_grid_thw: ir.Value,
+    ) -> ir.Value:
+        pixel_values, image_grid_thw = _guard_merged_grid_contract(
+            op,
+            pixel_values,
+            image_grid_thw,
+        )
+        pixel_values = op.Cast(pixel_values, to=self._dtype)
+        return self.visual(op, pixel_values, image_grid_thw)
+
+
+class GGUFGlmOcrVisionProjector(nn.Module):
+    """GLM-OCR tensor variant serialized under the glm4v projector route."""
+
+    def __init__(self, config: ArchitectureConfig) -> None:
+        super().__init__()
+        vision = config.vision
+        if vision is None:
+            raise ValueError("GLM-OCR sidecar requires a vision configuration")
+        required = (
+            vision.hidden_size,
+            vision.intermediate_size,
+            vision.num_hidden_layers,
+            vision.num_attention_heads,
+            vision.patch_size,
+            vision.out_hidden_size,
+        )
+        if any(value is None for value in required):
+            raise ValueError("GLM-OCR sidecar vision dimensions must be complete")
+        assert vision.hidden_size is not None
+        assert vision.intermediate_size is not None
+        assert vision.num_hidden_layers is not None
+        assert vision.num_attention_heads is not None
+        assert vision.patch_size is not None
+        assert vision.out_hidden_size is not None
+        self.visual = GlmOcrVisionModel(
+            depth=int(vision.num_hidden_layers),
+            hidden_size=int(vision.hidden_size),
+            intermediate_size=int(vision.intermediate_size),
+            num_heads=int(vision.num_attention_heads),
+            patch_size=int(vision.patch_size),
+            temporal_patch_size=int(vision.temporal_patch_size),
+            in_channels=int(vision.in_channels),
+            out_hidden_size=int(vision.out_hidden_size),
+            spatial_merge_size=int(vision.spatial_merge_size),
+            norm_eps=float(vision.norm_eps),
+        )
+        pixel_width = (
+            int(vision.in_channels)
+            * int(vision.temporal_patch_size)
+            * int(vision.patch_size) ** 2
+        )
+        self.input_schema = (
+            (
+                "pixel_values",
+                ir.DataType.FLOAT,
+                (ir.SymbolicDim("total_patches"), pixel_width),
+            ),
+            (
+                "image_grid_thw",
+                ir.DataType.INT64,
+                (ir.SymbolicDim("num_media"), 3),
+            ),
+        )
+
+    def forward(
+        self,
+        op: OpBuilder,
+        pixel_values: ir.Value,
+        image_grid_thw: ir.Value,
+    ) -> ir.Value:
+        pixel_values, image_grid_thw = _guard_merged_grid_contract(
+            op,
+            pixel_values,
+            image_grid_thw,
+        )
+        pixel_values = op.CastLike(pixel_values, self.visual.patch_embed.weight)
+        return self.visual(op, pixel_values, image_grid_thw)
+
+
+class GGUFQwen3VLProjector(nn.Module):
+    """Qwen3-VL vision tower with final and DeepStack mergers packed by width."""
+
+    def __init__(self, config: ArchitectureConfig) -> None:
+        super().__init__()
+        vision = config.vision
+        if vision is None:
+            raise ValueError("Qwen3-VL sidecar requires a vision configuration")
+        required = (
+            vision.hidden_size,
+            vision.intermediate_size,
+            vision.num_hidden_layers,
+            vision.num_attention_heads,
+            vision.patch_size,
+            vision.out_hidden_size,
+            vision.num_position_embeddings,
+        )
+        if any(value is None for value in required):
+            raise ValueError("Qwen3-VL sidecar vision dimensions must be complete")
+        assert vision.hidden_size is not None
+        assert vision.intermediate_size is not None
+        assert vision.num_hidden_layers is not None
+        assert vision.num_attention_heads is not None
+        assert vision.patch_size is not None
+        assert vision.out_hidden_size is not None
+        assert vision.num_position_embeddings is not None
+        if int(vision.spatial_merge_size) != 2:
+            raise ValueError("Qwen3-VL GGUF merger requires spatial_merge_size=2")
+        self.visual = Qwen3VLVisionModel(
+            depth=int(vision.num_hidden_layers),
+            hidden_size=int(vision.hidden_size),
+            intermediate_size=int(vision.intermediate_size),
+            num_heads=int(vision.num_attention_heads),
+            patch_size=int(vision.patch_size),
+            temporal_patch_size=int(vision.temporal_patch_size),
+            in_channels=int(vision.in_channels),
+            out_hidden_size=int(vision.out_hidden_size),
+            spatial_merge_size=2,
+            num_position_embeddings=int(vision.num_position_embeddings),
+            deepstack_visual_indexes=vision.deepstack_visual_indexes or [],
+            # llama.cpp's FFN_GELU is the tanh approximation for both the
+            # final merger and every DeepStack merger.
+            merger_gelu_approximate="tanh",
+        )
+        pixel_width = (
+            int(vision.in_channels)
+            * int(vision.temporal_patch_size)
+            * int(vision.patch_size) ** 2
+        )
+        self.input_schema = (
+            (
+                "pixel_values",
+                ir.DataType.FLOAT,
+                (ir.SymbolicDim("total_patches"), pixel_width),
+            ),
+            (
+                "image_grid_thw",
+                ir.DataType.INT64,
+                (ir.SymbolicDim("num_media"), 3),
+            ),
+        )
+
+    def forward(
+        self,
+        op: OpBuilder,
+        pixel_values: ir.Value,
+        image_grid_thw: ir.Value,
+    ) -> ir.Value:
+        pixel_values, image_grid_thw = _guard_merged_grid_contract(
+            op,
+            pixel_values,
+            image_grid_thw,
+        )
+        pixel_values = op.CastLike(pixel_values, self.visual.patch_embed.weight)
+        outputs = self.visual(op, pixel_values, image_grid_thw)
+        merged = outputs[0]
+        if len(outputs) == 1:
+            return merged
+        # llama.cpp concatenates DeepStack maps after the final map along the
+        # embedding width: [tokens, text_hidden * (1 + deepstack_layers)].
+        return op.Concat(merged, *outputs[1:], axis=1)
+
+
+class GGUFQwen25OmniVisionProjector(nn.Module):
+    """Qwen2.5-Omni legacy vision context resolved as qwen2.5vl_merger."""
+
+    def __init__(self, config: ArchitectureConfig) -> None:
+        super().__init__()
+        self._dtype = config.dtype
+        vision = config.vision
+        if vision is None:
+            raise ValueError("Qwen2.5-Omni sidecar requires a vision configuration")
+        required = (
+            vision.hidden_size,
+            vision.intermediate_size,
+            vision.num_hidden_layers,
+            vision.num_attention_heads,
+            vision.patch_size,
+            vision.out_hidden_size,
+        )
+        if any(value is None for value in required):
+            raise ValueError("Qwen2.5-Omni vision dimensions must be complete")
+        assert vision.hidden_size is not None
+        assert vision.intermediate_size is not None
+        assert vision.num_hidden_layers is not None
+        assert vision.num_attention_heads is not None
+        assert vision.patch_size is not None
+        assert vision.out_hidden_size is not None
+        self.visual = Qwen25VLVisionModel(
+            depth=int(vision.num_hidden_layers),
+            hidden_size=int(vision.hidden_size),
+            intermediate_size=int(vision.intermediate_size),
+            num_heads=int(vision.num_attention_heads),
+            patch_size=int(vision.patch_size),
+            temporal_patch_size=int(vision.temporal_patch_size),
+            in_channels=int(vision.in_channels),
+            out_hidden_size=int(vision.out_hidden_size),
+            spatial_merge_size=int(vision.spatial_merge_size),
+            fullatt_block_indexes=vision.fullatt_block_indexes,
+            window_size=vision.window_size or 112,
+        )
+        pixel_width = (
+            int(vision.in_channels)
+            * int(vision.temporal_patch_size)
+            * int(vision.patch_size) ** 2
+        )
+        self.input_schema = (
+            (
+                "pixel_values",
+                ir.DataType.FLOAT,
+                (ir.SymbolicDim("total_patches"), pixel_width),
+            ),
+            (
+                "image_grid_thw",
+                ir.DataType.INT64,
+                (ir.SymbolicDim("num_media"), 3),
+            ),
+        )
+
+    def forward(
+        self,
+        op: OpBuilder,
+        pixel_values: ir.Value,
+        image_grid_thw: ir.Value,
+    ) -> ir.Value:
+        pixel_values, image_grid_thw = _guard_merged_grid_contract(
+            op,
+            pixel_values,
+            image_grid_thw,
+        )
+        pixel_values = op.Cast(pixel_values, to=self._dtype)
+        return self.visual(op, pixel_values, image_grid_thw)
+
+
+class GGUFQwen3AudioProjector(nn.Module):
+    """Qwen3 audio encoder for one preprocessor-padded 100-frame window group."""
+
+    def __init__(self, config: ArchitectureConfig) -> None:
+        super().__init__()
+        if config.audio is None:
+            raise ValueError("Qwen3 audio sidecar requires an audio configuration")
+        self.audio_tower = Qwen3ASRAudioEncoder(config)
+        self.input_schema = (
+            (
+                "input_features",
+                ir.DataType.FLOAT,
+                (
+                    1,
+                    config.audio.num_mel_bins or 128,
+                    ir.SymbolicDim("audio_frames_multiple_of_100"),
+                ),
+            ),
+        )
+
+    def forward(self, op: OpBuilder, input_features: ir.Value) -> ir.Value:
+        input_features = op.CastLike(
+            input_features,
+            self.audio_tower.conv2d1.weight,
+        )
+        batch = op.Shape(input_features, start=0, end=1)
+        frames = op.Shape(input_features, start=2, end=3)
+        frame_count = op.Squeeze(frames, [0])
+        invalid_frames = op.Cast(
+            op.Or(
+                op.LessOrEqual(frame_count, op.Constant(value_int=0)),
+                op.Not(op.Equal(op.Mod(frame_count, 100), op.Constant(value_int=0))),
+            ),
+            to=ir.DataType.INT64,
+        )
+        guard = op.Gather(op.Constant(value_ints=[0]), invalid_frames, axis=0)
+        input_features = op.Add(input_features, op.CastLike(guard, input_features))
+        mask_shape = op.Concat(batch, frames, axis=0)
+        feature_mask = op.Expand(
+            op.Constant(value_int=1),
+            mask_shape,
+        )
+        audio_features, _ = self.audio_tower(op, input_features, feature_mask)
+        return op.Squeeze(audio_features, [0])
+
+
+class GGUFQwen3TTSSpeakerProjector(nn.Module):
+    """Qwen3-TTS ECAPA-TDNN speaker embedding sidecar."""
+
+    def __init__(self, config: ArchitectureConfig) -> None:
+        super().__init__()
+        tts = config.tts
+        speaker = tts.speaker_encoder if tts else None
+        if speaker is None:
+            raise ValueError("Qwen3-TTS sidecar requires a speaker encoder configuration")
+        self.encoder = SpeakerEncoder(
+            config,
+            mel_dim=speaker.mel_dim,
+            enc_dim=speaker.enc_dim,
+            enc_channels=speaker.enc_channels,
+            enc_kernel_sizes=speaker.enc_kernel_sizes,
+            enc_dilations=speaker.enc_dilations,
+            enc_attention_channels=speaker.enc_attention_channels,
+            enc_res2net_scale=speaker.enc_res2net_scale,
+            enc_se_channels=speaker.enc_se_channels,
+        )
+        self.input_schema = (
+            (
+                "mel_features",
+                ir.DataType.FLOAT,
+                (ir.SymbolicDim("audio_frames"), speaker.mel_dim),
+            ),
+        )
+
+    def forward(self, op: OpBuilder, mel_features: ir.Value) -> ir.Value:
+        # mtmd preprocessing produces one unbatched [frames, mel_bins] clip.
+        return self.encoder(op, op.Unsqueeze(mel_features, [0]))

--- a/src/mobius/tasks/__init__.py
+++ b/src/mobius/tasks/__init__.py
@@ -40,6 +40,8 @@ __all__ = [
     "DiarizationTask",
     "FeatureExtractionTask",
     "GGUFEncoderFeatureExtractionTask",
+    "GGUFAudioProjectorModel",
+    "GGUFAudioProjectorTask",
     "GGUFEmbeddingFeatureExtractionTask",
     "GGUFProjectorVisionLanguageTask",
     "GGUFSpeakerProjectorModel",
@@ -140,12 +142,6 @@ from mobius.tasks._feature_extraction import (
     GGUFEncoderFeatureExtractionTask,
 )
 from mobius.tasks._fun_asr_speech_language import FunASRSpeechLanguageTask
-from mobius.tasks._gguf_projector import (
-    GGUFSpeakerProjectorModel,
-    GGUFSpeakerProjectorTask,
-    GGUFVisionProjectorModel,
-    GGUFVisionProjectorTask,
-)
 from mobius.tasks._gemma3n import Gemma3nTask
 from mobius.tasks._gemma4 import (
     Gemma4Task,
@@ -154,6 +150,8 @@ from mobius.tasks._gemma4 import (
 )
 from mobius.tasks._gemma4_assistant import Gemma4AssistantTask
 from mobius.tasks._gguf_projector import (
+    GGUFAudioProjectorModel,
+    GGUFAudioProjectorTask,
     GGUFSpeakerProjectorModel,
     GGUFSpeakerProjectorTask,
     GGUFVisionProjectorModel,

--- a/src/mobius/tasks/__init__.py
+++ b/src/mobius/tasks/__init__.py
@@ -140,6 +140,12 @@ from mobius.tasks._feature_extraction import (
     GGUFEncoderFeatureExtractionTask,
 )
 from mobius.tasks._fun_asr_speech_language import FunASRSpeechLanguageTask
+from mobius.tasks._gguf_projector import (
+    GGUFSpeakerProjectorModel,
+    GGUFSpeakerProjectorTask,
+    GGUFVisionProjectorModel,
+    GGUFVisionProjectorTask,
+)
 from mobius.tasks._gemma3n import Gemma3nTask
 from mobius.tasks._gemma4 import (
     Gemma4Task,

--- a/src/mobius/tasks/_gguf_projector.py
+++ b/src/mobius/tasks/_gguf_projector.py
@@ -51,8 +51,15 @@ class GGUFAudioProjectorTask(ModelTask):
             name: builder.input(name, dtype=dtype, shape=list(shape))
             for name, dtype, shape in input_schema
         }
-        audio_features = audio_encoder(builder.op, **inputs)
-        builder.add_output(audio_features, "audio_features")
+        outputs = audio_encoder(builder.op, **inputs)
+        output_names = getattr(audio_encoder, "output_names", ("audio_features",))
+        if not isinstance(output_names, tuple) or not output_names:
+            raise TypeError("GGUF audio encoder output_names must be a non-empty tuple")
+        output_values = outputs if isinstance(outputs, tuple) else (outputs,)
+        if len(output_values) != len(output_names):
+            raise ValueError("GGUF audio encoder output count does not match output_names")
+        for value, name in zip(output_values, output_names):
+            builder.add_output(value, name)
         return ModelPackage({"audio_encoder": _make_model(graph)}, config=config)
 
 

--- a/src/mobius/tasks/_gguf_projector.py
+++ b/src/mobius/tasks/_gguf_projector.py
@@ -15,6 +15,47 @@ from mobius._pipeline_contract import declare_component_presence
 from mobius.tasks._base import ComponentSpec, ModelTask, _make_graph, _make_model
 
 
+class GGUFAudioProjectorModel(nn.Module):
+    """Container exposing one exact sidecar audio encoder/projector."""
+
+    def __init__(self, audio_encoder: nn.Module) -> None:
+        super().__init__()
+        self.audio_encoder = audio_encoder
+
+    def forward(self, op, **kwargs):
+        del op, kwargs
+        raise NotImplementedError("GGUFAudioProjectorTask builds the audio component")
+
+
+class GGUFAudioProjectorTask(ModelTask):
+    """Build one processor-native rank-2 audio feature graph."""
+
+    model_roles: ClassVar[dict[str, str]] = {"audio_encoder": "encoder"}
+    components = ComponentSpec(audio_encoder="audio_encoder")
+
+    def build(
+        self,
+        module: nn.Module,
+        config: ArchitectureConfig,
+    ) -> ModelPackage:
+        self._validate_components(module)
+        if not isinstance(module, GGUFAudioProjectorModel):
+            raise TypeError("GGUFAudioProjectorTask requires GGUFAudioProjectorModel")
+        audio_encoder = module.audio_encoder
+        input_schema = getattr(audio_encoder, "input_schema", None)
+        if not isinstance(input_schema, tuple) or not input_schema:
+            raise TypeError("GGUF audio encoder must declare a non-empty input_schema")
+
+        graph, builder = _make_graph(name="audio_encoder")
+        inputs = {
+            name: builder.input(name, dtype=dtype, shape=list(shape))
+            for name, dtype, shape in input_schema
+        }
+        audio_features = audio_encoder(builder.op, **inputs)
+        builder.add_output(audio_features, "audio_features")
+        return ModelPackage({"audio_encoder": _make_model(graph)}, config=config)
+
+
 class GGUFVisionProjectorModel(nn.Module):
     """Container exposing one exact sidecar vision encoder/projector."""
 
@@ -39,7 +80,9 @@ class GGUFVisionProjectorTask(ModelTask):
         config: ArchitectureConfig,
     ) -> ModelPackage:
         self._validate_components(module)
-        vision_encoder = module.vision_encoder  # type: ignore[attr-defined]
+        if not isinstance(module, GGUFVisionProjectorModel):
+            raise TypeError("GGUFVisionProjectorTask requires GGUFVisionProjectorModel")
+        vision_encoder = module.vision_encoder
         input_schema = getattr(vision_encoder, "input_schema", None)
         if not isinstance(input_schema, tuple) or not input_schema:
             raise TypeError("GGUF vision encoder must declare a non-empty input_schema")
@@ -79,7 +122,9 @@ class GGUFSpeakerProjectorTask(ModelTask):
         config: ArchitectureConfig,
     ) -> ModelPackage:
         self._validate_components(module)
-        speaker_encoder = module.speaker_encoder  # type: ignore[attr-defined]
+        if not isinstance(module, GGUFSpeakerProjectorModel):
+            raise TypeError("GGUFSpeakerProjectorTask requires GGUFSpeakerProjectorModel")
+        speaker_encoder = module.speaker_encoder
         input_schema = getattr(speaker_encoder, "input_schema", None)
         if not isinstance(input_schema, tuple) or not input_schema:
             raise TypeError("GGUF speaker encoder must declare a non-empty input_schema")


### PR DESCRIPTION
## Summary

- add exact standalone GGUF projector routes for `glm4v`, `glma`, `qwen2.5o`, `qwen2a`, `qwen3a`, `qwen3vl_merger`, and `qwen3tts_spkenc`
- enforce metadata, tensor closure, shape, modality pairing, and F32/F16/BF16-only qtype contracts; quarantine `qwen3tts_gen`
- cover Qwen3-VL 2x2 merge cardinality, DeepStack width packing, four-section decoder MRoPE, and route-selected transformer activation semantics
- preserve #688's advisory-only downstream-runtime policy and semantically retain #689's core-VLM builders, roles, evidence, component-presence metadata, census, docs, and tests

## Rebased commit stack

- `171cec98` — small remaining shared standalone-dispatch/export delta after #689 absorbed the reusable projector foundation
- `168414fe` — exactly the seven Qwen/GLM routes, mappings, components, evidence, docs, and tests
- `1de782cf` — strict pre-closure metadata validation and Qwen3 audio padding/length hardening
- `4b03d27e` — processor-native Qwen3 mask ABI, consumer-scoped SiLU semantics, and single-preflight fix

Shared surfaces remain additive with #689: `_MMPROJ_BUILDERS` retains both `core_vlm_projector` and `qwen_glm_projector`; generic vision/audio/speaker tasks retain core component-presence metadata and Qwen multi-output audio support.

## Review hardening

- `qwen3a` accepts the pinned `Qwen3ASRProcessor` output directly as `input_features_mask: int32`, casts internally only for length arithmetic, compacts padding-derived rows, and publishes `audio_feature_lengths`
- all seven routes validate consumed metadata types, positive/finite ranges, boolean presence flags, exact projector enums, and route-specific geometry before tensor closure or graph construction
- `clip.use_silu` is validated and fingerprint-relevant only for `glm4v`, `glma`, and `qwen3vl_merger`; Qwen3-VL transformer FFNs follow it while final and DeepStack mergers remain tanh-GELU
- public standalone dispatch performs the expensive Qwen/GLM preflight once; direct route-wrapper calls still validate when no prevalidated model is injected
- the outstanding duplicate-preflight review thread was answered and resolved

## Validation

- combined focused projector/task suite: 440 passed
- broad non-integration suite: 9,230 passed, 64 skipped, 1 subtest passed
- lintrunner clean
- generated GGUF docs clean
- changed production modules pass mypy with import traversal isolated
- independent medium-effort review and follow-up review: no findings

Immutable selected evidence totals 5,980,273,312 bytes, below the 16 GiB cap.