### PR TITLE
Allow GGUF export with deferred tokenizers

### DIFF
--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -28,10 +28,10 @@ package.save("output")
 ```
 
 `keep_quantized=True` requests quantized target storage where supported; it does
-not guarantee source byte or numerical fidelity. Mobius classifies qtypes before
-payload conversion, emits one aggregate warning for lossy requantization, and
-saves the typed result as `quantization_report.json`. Use
-`keep_quantized=False` for explicit float import.
+not guarantee source fidelity. An authoritative tokenizer blocker does not invalidate
+a proven graph: the API returns the model, emits one structured warning, omits assets,
+and persists the exact component disposition in `export_report.json`. Lossy qtype
+conversion remains in `quantization_report.json`; use `keep_quantized=False` for float.
 
 Packed MatMulNBits storage may use a native op or portable nibble unpack,
 `DequantizeLinear`, and float `MatMul`; neither implies dense storage or a specific kernel.
@@ -59,12 +59,13 @@ build_from_gguf(
 )
 ```
 
-The function returns a `ModelPackage`. Import validates architecture metadata, exact tensor
-closure, shapes, qtypes, and selected graph route before publication. Source reuse requires
-the original immutable GGUF at runtime. Runtime packages additionally require an exact
-artifact, graph, tokenizer, runtime version, parity proof, and deterministic state/generation
-evidence match.
-Processor-owned `image_token_id` overrides are forwarded unchanged for `mmproj=` packages.
+The function returns a `ModelPackage`. Mobius-side graph/semantic inability, corruption,
+identity, I/O, malformed tokenizer, and unexpected errors remain fail-closed. Authoritative
+tokenizer blockers become partial exports with exact reasons and no unverified assets.
+Downstream runtime, version, registry, or executor limitations preserve the accurate model
+package and record distinct `export_status` and `runtime_validation_status` fields instead of
+blocking export. Only exact artifact, graph, tokenizer, version, parity, and state evidence
+marks a complete runtime package validated and end-to-end runnable.
 
 Use `build_mmproj_from_gguf("mmproj.gguf", projector_type=..., target_architecture=...)`
 to export a registry-evidenced standalone `vision_encoder`, `audio_encoder`, or

--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -65,7 +65,9 @@ tokenizer blockers become partial exports with exact reasons and no unverified a
 Downstream runtime, version, registry, or executor limitations preserve the accurate model
 package and record distinct `export_status` and `runtime_validation_status` fields instead of
 blocking export. Only exact artifact, graph, tokenizer, version, parity, and state evidence
-marks a complete runtime package validated and end-to-end runnable.
+covering the final directory bytes (including `export_report.json` and
+`runtime_compatibility.json`) marks a package validated and end-to-end runnable. Existing
+pre-report runtime evidence remains unvalidated until its final-package hashes are regenerated.
 
 Use `build_mmproj_from_gguf("mmproj.gguf", projector_type=..., target_architecture=...)`
 to export a registry-evidenced standalone `vision_encoder`, `audio_encoder`, or

--- a/src/mobius/__init__.py
+++ b/src/mobius/__init__.py
@@ -22,6 +22,8 @@ __all__ = [
     "CausalLMConfig",
     "CausalLMTask",
     "ComponentInfo",
+    "ComponentExportDisposition",
+    "ComponentExportReport",
     "DepthAnythingConfig",
     "EncoderConfig",
     "EpCapabilities",
@@ -108,6 +110,7 @@ from mobius._configs import (
 )
 from mobius._constants import OPSET_VERSION
 from mobius._execution_providers import EpCapabilities, ep_registry, get_ep, register_ep
+from mobius._export_report import ComponentExportDisposition, ComponentExportReport
 from mobius._inspect import ComponentInfo, inspect_components
 from mobius._model_package import ModelPackage
 from mobius._optimizations import optimize_model

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -679,7 +679,6 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
     output_dir = args.output_dir
     target_config = getattr(args, "target_config", None)
     runtime = getattr(args, "runtime", None)
-    tokenizer_component_partial = False
 
     if args.max_seq_len is not None and not args.static_cache:
         raise SystemExit("Error: --max-seq-len can only be used with --static-cache.")
@@ -705,9 +704,6 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
             _resolve_gguf_path,
             _validate_gguf_model,
         )
-        from mobius.integrations.gguf._component_export import (
-            resolve_tokenizer_export_verdict,
-        )
         from mobius.integrations.gguf._shard_set import open_gguf_model
 
         # Resolve and validate the exact selected source before graph construction.
@@ -716,11 +712,6 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
         resolved_gguf_path = _resolve_gguf_path(gguf_path)
         gguf_model = open_gguf_model(resolved_gguf_path)
         _validate_gguf_model(gguf_model, source=str(resolved_gguf_path))
-        tokenizer_verdict = resolve_tokenizer_export_verdict(
-            gguf_model,
-            str(resolved_gguf_path),
-        )
-        tokenizer_component_partial = tokenizer_verdict.blocker_category is not None
         if tokenizer_repository is not None and (
             tokenizer_repository.count("/") != 1 or not all(tokenizer_repository.split("/"))
         ):
@@ -753,15 +744,9 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
         for model in pkg.values():
             strip_debug_metadata(model)
 
-    from mobius.integrations.gguf._component_export import tokenizer_export_is_partial
-
-    partial_tokenizer_export = tokenizer_export_is_partial(pkg)
-    if runtime is not None and tokenizer_component_partial != partial_tokenizer_export:
-        raise RuntimeError(
-            "GGUF tokenizer disposition changed between runtime preflight and graph export."
-        )
     if runtime is None:
-        os.makedirs(output_dir, exist_ok=True)
+        if getattr(pkg, "export_report", None) is None:
+            os.makedirs(output_dir, exist_ok=True)
         pkg.save(
             output_dir,
             external_data=args.external_data,
@@ -785,9 +770,12 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
 
         draft_manifest = getattr(pkg, "draft_manifest", None)
         if draft_manifest is not None:
-            from mobius.integrations.gguf._draft import write_draft_manifest
+            if getattr(pkg, "export_report", None) is None:
+                from mobius.integrations.gguf._draft import write_draft_manifest
 
-            manifest_path = write_draft_manifest(draft_manifest, output_dir)
+                manifest_path = write_draft_manifest(draft_manifest, output_dir)
+            else:
+                manifest_path = os.path.join(output_dir, "draft_manifest.json")
             print(f"Saved draft pairing manifest to {manifest_path}")
 
     if runtime in ("onnx-genai", "ort-genai"):

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -663,12 +663,6 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
     mmproj_path = getattr(args, "mmproj", None)
     keep_quantized = not args.dequantize
     reuse_gguf_weights = args.reuse_gguf_weights
-    if reuse_gguf_weights and args.runtime == "ort-genai":
-        raise SystemExit(
-            "Error: --reuse-gguf-weights cannot be combined with --runtime ort-genai "
-            "because genai_config.json cannot require disabled ORT constant folding. "
-            "Use direct ONNX Runtime with ORT_DISABLE_ALL."
-        )
 
     if keep_quantized:
         print(
@@ -685,6 +679,7 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
     output_dir = args.output_dir
     target_config = getattr(args, "target_config", None)
     runtime = getattr(args, "runtime", None)
+    tokenizer_component_partial = False
 
     if args.max_seq_len is not None and not args.static_cache:
         raise SystemExit("Error: --max-seq-len can only be used with --static-cache.")
@@ -710,12 +705,22 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
             _resolve_gguf_path,
             _validate_gguf_model,
         )
+        from mobius.integrations.gguf._component_export import (
+            resolve_tokenizer_export_verdict,
+        )
         from mobius.integrations.gguf._shard_set import open_gguf_model
 
         # Resolve and validate the exact selected source before graph construction.
+        # Authoritative tokenizer blockers may later produce a clearly reported
+        # partial package; all model and source checks still fail closed here.
         resolved_gguf_path = _resolve_gguf_path(gguf_path)
         gguf_model = open_gguf_model(resolved_gguf_path)
         _validate_gguf_model(gguf_model, source=str(resolved_gguf_path))
+        tokenizer_verdict = resolve_tokenizer_export_verdict(
+            gguf_model,
+            str(resolved_gguf_path),
+        )
+        tokenizer_component_partial = tokenizer_verdict.blocker_category is not None
         if tokenizer_repository is not None and (
             tokenizer_repository.count("/") != 1 or not all(tokenizer_repository.split("/"))
         ):
@@ -748,6 +753,13 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
         for model in pkg.values():
             strip_debug_metadata(model)
 
+    from mobius.integrations.gguf._component_export import tokenizer_export_is_partial
+
+    partial_tokenizer_export = tokenizer_export_is_partial(pkg)
+    if runtime is not None and tokenizer_component_partial != partial_tokenizer_export:
+        raise RuntimeError(
+            "GGUF tokenizer disposition changed between runtime preflight and graph export."
+        )
     if runtime is None:
         os.makedirs(output_dir, exist_ok=True)
         pkg.save(
@@ -759,6 +771,7 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
             max_workers=args.max_workers,
         )
         _print_saved_gguf_models(pkg, output_dir)
+        _print_gguf_export_status(pkg, output_dir, runtime=runtime)
 
         # ModelPackage.save() persisted the MTP sidecar into its manifest-selected
         # collision-safe directory.
@@ -795,11 +808,20 @@ def _cmd_build_gguf(args: argparse.Namespace) -> None:
             ),
             max_workers=args.max_workers,
         )
-        # The writer returns only after atomically publishing the complete graph,
-        # tokenizer, and runtime configuration directory.
+        # The writer atomically publishes either the validated runtime package or
+        # an accurate model package with an explicit unvalidated disposition.
         _print_saved_gguf_models(pkg, output_dir)
         for name, path in artifacts.items():
             print(f"  {name}: {path}")
+        from mobius._export_report import ComponentExportReport
+
+        if isinstance(getattr(pkg, "export_report", None), ComponentExportReport):
+            _print_gguf_export_status(pkg, output_dir, runtime=runtime)
+        else:
+            print(
+                f"Export status: COMPLETE - {runtime} package is end-to-end runnable "
+                "under its pinned evidence contract."
+            )
 
 
 def _print_saved_gguf_models(pkg: Any, output_dir: str) -> None:
@@ -812,6 +834,53 @@ def _print_saved_gguf_models(pkg: Any, output_dir: str) -> None:
             else os.path.join(output_dir, "model.onnx")
         )
         print(f"Saved {name} to {path}")
+
+
+def _print_gguf_export_status(
+    pkg: Any,
+    output_dir: str,
+    *,
+    runtime: str | None,
+) -> None:
+    """Distinguish a durable partial package from a complete runtime package."""
+    from mobius._export_report import ComponentExportReport
+
+    report = getattr(pkg, "export_report", None)
+    if not isinstance(report, ComponentExportReport):
+        print(
+            "Export status: MODEL ONLY - ONNX model files were saved; "
+            "runtime/tokenizer packaging was not requested."
+        )
+        return
+    omitted = ", ".join(
+        component.name for component in report.components if component.output == "omitted"
+    )
+    if report.export_status == "partial":
+        print(
+            "Export status: PARTIAL - proven model files were saved, but one or more "
+            "components were omitted."
+        )
+    else:
+        print("Export status: COMPLETE - the accurate model package was saved.")
+    if report.runtime_validation_status == "unvalidated":
+        print(
+            "Runtime validation: UNVALIDATED - export success is not a runtime "
+            "support or end-to-end execution claim."
+        )
+    elif report.runtime_validation_status == "validated":
+        print("Runtime validation: VALIDATED - the package is end-to-end runnable.")
+    runtime_component = report.component("runtime")
+    if (
+        runtime is not None
+        and runtime_component is not None
+        and runtime_component.output == "omitted"
+    ):
+        print(f"  requested runtime: {runtime} (omitted)")
+    elif runtime is not None and report.runtime_validation_status == "unvalidated":
+        print(f"  requested runtime: {runtime} (unvalidated)")
+    if omitted:
+        print(f"  omitted components: {omitted}")
+    print(f"  export report: {os.path.join(output_dir, 'export_report.json')}")
 
 
 def _cmd_convert_comfyui(args: argparse.Namespace) -> None:
@@ -1353,9 +1422,10 @@ def build_parser() -> argparse.ArgumentParser:
         choices=["ort-genai", "onnx-genai"],
         default=None,
         help=(
-            "Generate runtime-specific config files after building. "
-            "Both routes require an exact tokenizer.huggingface.json embedded in "
-            "the GGUF; opaque tokenizer.ggml.pre metadata is not reconstructed. "
+            "Request runtime-specific packaging after building. Exact evidence emits "
+            "a validated runtime config and tokenizer; downstream runtime/version/"
+            "registry/executor limitations preserve the model with an unvalidated "
+            "export report instead of blocking it. "
             "'onnx-genai' writes inference_metadata.yaml and 'ort-genai' writes "
             "genai_config.json."
         ),
@@ -1364,8 +1434,8 @@ def build_parser() -> argparse.ArgumentParser:
         "--runtime-version",
         default=None,
         help=(
-            "Exact selected runtime version. Required once an architecture has a "
-            "runtime-supported evidence record; it must equal the version validated there."
+            "Selected runtime version. An exact evidence match marks the package "
+            "validated; other versions are exported with runtime status unvalidated."
         ),
     )
     gguf_parser.add_argument(
@@ -1374,7 +1444,8 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="OWNER/REPO",
         help=(
             "Exact Hugging Face repository containing tokenizer assets for runtime "
-            "packaging. Requires --tokenizer-revision and must match runtime evidence."
+            "packaging. Requires --tokenizer-revision. Missing or unmatched evidence "
+            "preserves a model-only runtime-unvalidated package."
         ),
     )
     gguf_parser.add_argument(

--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -844,10 +844,16 @@ def _print_gguf_export_status(
         component.name for component in report.components if component.output == "omitted"
     )
     if report.export_status == "partial":
-        print(
-            "Export status: PARTIAL - proven model files were saved, but one or more "
-            "components were omitted."
-        )
+        if omitted:
+            print(
+                "Export status: PARTIAL - proven model files were saved, but one or more "
+                "components were omitted."
+            )
+        else:
+            print(
+                "Export status: PARTIAL - all requested components were exported, but "
+                "one or more support dispositions remain deferred or blocked."
+            )
     else:
         print("Export status: COMPLETE - the accurate model package was saved.")
     if report.runtime_validation_status == "unvalidated":

--- a/src/mobius/_export_report.py
+++ b/src/mobius/_export_report.py
@@ -1,0 +1,356 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Machine-readable component dispositions for partial model-package exports."""
+
+from __future__ import annotations
+
+__all__ = ["ComponentExportDisposition", "ComponentExportReport"]
+
+import dataclasses
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Literal
+
+ComponentSupport = Literal["supported", "deferred", "blocked"]
+ComponentOutput = Literal["exported", "omitted"]
+ExportStatus = Literal["complete", "partial"]
+RuntimeValidationStatus = Literal["validated", "unvalidated", "not-applicable"]
+
+_FORMAT = "mobius.component-export-report.v1"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ComponentExportDisposition:
+    """Support and output status for one independently exportable component."""
+
+    name: str
+    route: str
+    requested: bool
+    discovered: bool
+    support: ComponentSupport
+    output: ComponentOutput
+    runtime_validation_status: RuntimeValidationStatus = "not-applicable"
+    blocker_category: str | None = None
+    reason: str | None = None
+    evidence_id: str | None = None
+    impact: str | None = None
+    remediation: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.name or not self.route:
+            raise ValueError(
+                "Component export dispositions require non-empty names and routes."
+            )
+        if self.support not in {"supported", "deferred", "blocked"}:
+            raise ValueError(f"Invalid component support status: {self.support!r}.")
+        if self.output not in {"exported", "omitted"}:
+            raise ValueError(f"Invalid component export status: {self.output!r}.")
+        if self.runtime_validation_status not in {
+            "validated",
+            "unvalidated",
+            "not-applicable",
+        }:
+            raise ValueError(
+                "Invalid component runtime validation status: "
+                f"{self.runtime_validation_status!r}."
+            )
+        incomplete = (
+            self.support != "supported"
+            or self.output != "exported"
+            or self.runtime_validation_status == "unvalidated"
+        )
+        diagnostics = (
+            self.blocker_category,
+            self.reason,
+            self.impact,
+            self.remediation,
+        )
+        if incomplete and any(not value for value in diagnostics):
+            raise ValueError(
+                "Deferred, blocked, or omitted components require category, reason, "
+                "impact, and remediation diagnostics."
+            )
+        if not incomplete and any(value is not None for value in diagnostics):
+            raise ValueError("A fully exported component cannot carry blocker diagnostics.")
+        if self.evidence_id is not None and not self.evidence_id:
+            raise ValueError("Component evidence IDs must be non-empty when present.")
+
+    @property
+    def supported(self) -> bool:
+        """Whether this component has a proven support route."""
+        return self.support == "supported"
+
+    @property
+    def exported(self) -> bool:
+        """Whether this component was included in the package output."""
+        return self.output == "exported"
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable JSON-compatible representation."""
+        return {
+            "blocker_category": self.blocker_category,
+            "discovered": self.discovered,
+            "evidence_id": self.evidence_id,
+            "export_status": self.output,
+            "exported": self.exported,
+            "impact": self.impact,
+            "reason": self.reason,
+            "remediation": self.remediation,
+            "requested": self.requested,
+            "route": self.route,
+            "runtime_validation_status": self.runtime_validation_status,
+            "support_status": self.support,
+            "supported": self.supported,
+        }
+
+    @classmethod
+    def from_dict(cls, name: str, payload: Mapping[str, object]) -> ComponentExportDisposition:
+        """Parse and validate one component disposition."""
+
+        def require_string(key: str) -> str:
+            value = payload.get(key)
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"Component {name!r} requires a non-empty {key!r} field.")
+            return value
+
+        def optional_string(key: str) -> str | None:
+            value = payload.get(key)
+            if value is not None and (not isinstance(value, str) or not value):
+                raise ValueError(
+                    f"Component {name!r} field {key!r} must be null or a non-empty string."
+                )
+            return value
+
+        def require_bool(key: str) -> bool:
+            value = payload.get(key)
+            if type(value) is not bool:
+                raise TypeError(f"Component {name!r} field {key!r} must be a boolean.")
+            return value
+
+        requested = require_bool("requested")
+        discovered = require_bool("discovered")
+        supported = payload.get("supported")
+        exported = payload.get("exported")
+        if type(supported) is not bool or type(exported) is not bool:
+            raise TypeError(f"Component {name!r} supported/exported fields must be booleans.")
+        raw_support = require_string("support_status")
+        if raw_support == "supported":
+            support: ComponentSupport = "supported"
+        elif raw_support == "deferred":
+            support = "deferred"
+        elif raw_support == "blocked":
+            support = "blocked"
+        else:
+            raise ValueError(f"Component {name!r} has invalid support status {raw_support!r}.")
+        raw_output = require_string("export_status")
+        if raw_output == "exported":
+            output: ComponentOutput = "exported"
+        elif raw_output == "omitted":
+            output = "omitted"
+        else:
+            raise ValueError(f"Component {name!r} has invalid export status {raw_output!r}.")
+        raw_runtime_validation = require_string("runtime_validation_status")
+        if raw_runtime_validation == "validated":
+            runtime_validation_status: RuntimeValidationStatus = "validated"
+        elif raw_runtime_validation == "unvalidated":
+            runtime_validation_status = "unvalidated"
+        elif raw_runtime_validation == "not-applicable":
+            runtime_validation_status = "not-applicable"
+        else:
+            raise ValueError(
+                f"Component {name!r} has invalid runtime validation status "
+                f"{raw_runtime_validation!r}."
+            )
+        if supported != (support == "supported") or exported != (output == "exported"):
+            raise ValueError(f"Component {name!r} contains contradictory status booleans.")
+        return cls(
+            name=name,
+            route=require_string("route"),
+            requested=requested,
+            discovered=discovered,
+            support=support,
+            output=output,
+            runtime_validation_status=runtime_validation_status,
+            blocker_category=optional_string("blocker_category"),
+            reason=optional_string("reason"),
+            evidence_id=optional_string("evidence_id"),
+            impact=optional_string("impact"),
+            remediation=optional_string("remediation"),
+        )
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ComponentExportReport:
+    """Deterministic package-level summary of independently handled components."""
+
+    export_status: ExportStatus
+    runtime_validation_status: RuntimeValidationStatus
+    end_to_end_runnable: bool
+    components: tuple[ComponentExportDisposition, ...]
+
+    def __post_init__(self) -> None:
+        if not self.components:
+            raise ValueError("Component export reports must contain at least one component.")
+        names = tuple(component.name for component in self.components)
+        if names != tuple(sorted(names)) or len(set(names)) != len(names):
+            raise ValueError("Component export report names must be unique and sorted.")
+        expected_status = (
+            "partial"
+            if any(
+                component.support != "supported" or component.output != "exported"
+                for component in self.components
+                if component.requested or component.discovered
+            )
+            else "complete"
+        )
+        if self.export_status != expected_status:
+            raise ValueError(
+                f"Component export report status must be {expected_status!r}, "
+                f"got {self.export_status!r}."
+            )
+        component_runtime_statuses = {
+            component.runtime_validation_status for component in self.components
+        }
+        expected_runtime_status: RuntimeValidationStatus
+        if "unvalidated" in component_runtime_statuses:
+            expected_runtime_status = "unvalidated"
+        elif "validated" in component_runtime_statuses:
+            expected_runtime_status = "validated"
+        else:
+            expected_runtime_status = "not-applicable"
+        if self.runtime_validation_status != expected_runtime_status:
+            raise ValueError(
+                "Component export report runtime validation status must be "
+                f"{expected_runtime_status!r}, got {self.runtime_validation_status!r}."
+            )
+        if self.end_to_end_runnable and self.export_status != "complete":
+            raise ValueError("A partial component export cannot be end-to-end runnable.")
+        if self.end_to_end_runnable and self.runtime_validation_status != "validated":
+            raise ValueError("An end-to-end runnable export must be runtime validated.")
+
+    @property
+    def status(self) -> ExportStatus:
+        """Backward-compatible alias for the explicit export status."""
+        return self.export_status
+
+    @classmethod
+    def create(
+        cls,
+        components: tuple[ComponentExportDisposition, ...],
+        *,
+        end_to_end_runnable: bool,
+    ) -> ComponentExportReport:
+        """Create a report with a status derived from its component dispositions."""
+        ordered = tuple(sorted(components, key=lambda component: component.name))
+        status: ExportStatus = (
+            "partial"
+            if any(
+                component.support != "supported" or component.output != "exported"
+                for component in ordered
+                if component.requested or component.discovered
+            )
+            else "complete"
+        )
+        runtime_statuses = {component.runtime_validation_status for component in ordered}
+        runtime_validation_status: RuntimeValidationStatus
+        if "unvalidated" in runtime_statuses:
+            runtime_validation_status = "unvalidated"
+        elif "validated" in runtime_statuses:
+            runtime_validation_status = "validated"
+        else:
+            runtime_validation_status = "not-applicable"
+        return cls(
+            export_status=status,
+            runtime_validation_status=runtime_validation_status,
+            end_to_end_runnable=end_to_end_runnable,
+            components=ordered,
+        )
+
+    def component(self, name: str) -> ComponentExportDisposition | None:
+        """Return one named component disposition, if present."""
+        return next(
+            (component for component in self.components if component.name == name),
+            None,
+        )
+
+    def with_component(
+        self, component: ComponentExportDisposition, *, end_to_end_runnable: bool | None = None
+    ) -> ComponentExportReport:
+        """Return a report with one component inserted or replaced."""
+        components_by_name = {existing.name: existing for existing in self.components}
+        components_by_name[component.name] = component
+        return self.create(
+            tuple(components_by_name.values()),
+            end_to_end_runnable=(
+                self.end_to_end_runnable
+                if end_to_end_runnable is None
+                else end_to_end_runnable
+            ),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable JSON-compatible representation."""
+        return {
+            "components": {
+                component.name: component.to_dict() for component in self.components
+            },
+            "end_to_end_runnable": self.end_to_end_runnable,
+            "export_status": self.export_status,
+            "format": _FORMAT,
+            "runtime_validation_status": self.runtime_validation_status,
+        }
+
+    def to_json(self) -> str:
+        """Serialize with deterministic key ordering and a trailing newline."""
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True) + "\n"
+
+    def write_json(self, path: str | Path) -> None:
+        """Write the deterministic report."""
+        Path(path).write_text(self.to_json(), encoding="utf-8")
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> ComponentExportReport:
+        """Parse and validate a component export report."""
+        if payload.get("format") != _FORMAT:
+            raise ValueError("Invalid component export report format.")
+        status = payload.get("export_status")
+        if status not in {"complete", "partial"}:
+            raise ValueError("Invalid component export report status.")
+        raw_runtime_validation = payload.get("runtime_validation_status")
+        if raw_runtime_validation == "validated":
+            runtime_validation_status: RuntimeValidationStatus = "validated"
+        elif raw_runtime_validation == "unvalidated":
+            runtime_validation_status = "unvalidated"
+        elif raw_runtime_validation == "not-applicable":
+            runtime_validation_status = "not-applicable"
+        else:
+            raise ValueError("Invalid component export report runtime validation status.")
+        runnable = payload.get("end_to_end_runnable")
+        if type(runnable) is not bool:
+            raise ValueError("Component export report runnable status must be a boolean.")
+        raw_components = payload.get("components")
+        if not isinstance(raw_components, dict) or not raw_components:
+            raise ValueError("Component export report components must be a non-empty object.")
+        components: list[ComponentExportDisposition] = []
+        for name, component_payload in sorted(raw_components.items()):
+            if not isinstance(name, str) or not name:
+                raise ValueError("Component export report names must be non-empty strings.")
+            if not isinstance(component_payload, dict):
+                raise TypeError(f"Component export report entry {name!r} must be an object.")
+            components.append(ComponentExportDisposition.from_dict(name, component_payload))
+        return cls(
+            export_status=status,
+            runtime_validation_status=runtime_validation_status,
+            end_to_end_runnable=runnable,
+            components=tuple(components),
+        )
+
+    @classmethod
+    def read_json(cls, path: str | Path) -> ComponentExportReport:
+        """Read and validate a component export report."""
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise TypeError("Component export report must contain a JSON object.")
+        return cls.from_dict(payload)

--- a/src/mobius/_model_package.py
+++ b/src/mobius/_model_package.py
@@ -37,6 +37,7 @@ import rfc8785
 import torch
 import tqdm
 
+from mobius._export_report import ComponentExportReport
 from mobius._optimizations import fold_initializers_after_weights
 from mobius.adapters import (
     AdapterArtifact,
@@ -48,6 +49,8 @@ from mobius.integrations._weight_loading import _assign_weight
 
 if TYPE_CHECKING:
     from mobius.integrations.gguf._quantization_report import GGUFQuantizationReport
+    from mobius.integrations.gguf._runtime_evidence import GGUFArtifactIdentity
+    from mobius.integrations.gguf._tokenizer import GGUFTokenizerVerdict
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +58,7 @@ _PACKAGE_MANIFEST = ".mobius-package.json"
 _PACKAGE_MANIFEST_FORMAT = "mobius.model-package.v1"
 _MTP_SIDECAR_BASENAME = ".mobius-mtp"
 _QUANTIZATION_REPORT = "quantization_report.json"
+_EXPORT_REPORT = "export_report.json"
 _WEIGHT_LOADING_REPORT = "weight-loading-report.json"
 _DEFAULT_STREAMING_DENSE_SHARD_BYTES = 1 << 30
 _MAX_STREAMING_DENSE_SHARD_BYTES = 5_000_000_000
@@ -138,6 +142,7 @@ def _validate_mtp_chain(package: ModelPackage) -> None:
             component_keys.add(collision_key)
             if collision_key in {
                 _PACKAGE_MANIFEST.casefold(),
+                _EXPORT_REPORT.casefold(),
                 _QUANTIZATION_REPORT.casefold(),
                 _WEIGHT_LOADING_REPORT.casefold(),
             }:
@@ -176,6 +181,11 @@ def _validate_mtp_save_paths(
 ) -> None:
     """Reject unsafe output paths throughout the package chain before any writes."""
     _validate_output_directory(directory, kind="package", inspect_contents=False)
+    if package.export_report is not None and components is not None:
+        raise ValueError(
+            "Component-filtered saves cannot preserve an attached export report; "
+            "save the complete package or detach and replace the report."
+        )
     report_path = os.path.join(directory, _QUANTIZATION_REPORT)
     if os.path.lexists(report_path) and (
         os.path.islink(report_path) or not os.path.isfile(report_path)
@@ -186,6 +196,31 @@ def _validate_mtp_save_paths(
             "ModelPackage output contains a stale quantization_report.json, but the "
             "package being saved has no GGUF quantization report. Remove or clean the "
             "output directory before saving."
+        )
+    export_report_path = os.path.join(directory, _EXPORT_REPORT)
+    if os.path.lexists(export_report_path) and (
+        os.path.islink(export_report_path) or not os.path.isfile(export_report_path)
+    ):
+        raise ValueError("ModelPackage component export report output must be a real file.")
+    if package.export_report is None and os.path.isfile(export_report_path):
+        raise ValueError(
+            "ModelPackage output contains a stale export_report.json, but the package "
+            "being saved has no component export report. Remove or clean the output "
+            "directory before saving."
+        )
+    if (
+        package.export_report is not None
+        and (
+            package.export_report.status == "partial"
+            or package.export_report.runtime_validation_status == "unvalidated"
+        )
+        and os.path.isdir(directory)
+        and os.listdir(directory)
+    ):
+        raise FileExistsError(
+            "Partial or runtime-unvalidated component exports require an empty output "
+            "directory so omitted or unverified components cannot survive from a "
+            "previous package."
         )
     weight_report_path = os.path.join(directory, _WEIGHT_LOADING_REPORT)
     if os.path.lexists(weight_report_path) and (
@@ -293,6 +328,8 @@ class ModelPackage(UserDict[str, ir.Model]):
             or ``None`` if not available (e.g. after :meth:`load`).
         gguf_quantization_report: Optional persisted report describing GGUF
             source-storage preservation and conversion behavior.
+        export_report: Optional persisted component-level report describing
+            independently supported/exported and deferred/omitted package parts.
         quantization_report: Optional transient, loader-specific metadata describing
             quantization handling. The concrete report type and schema belong to the
             integration that produced it (for example, ``CompressedTensorsLoadReport``);
@@ -315,10 +352,20 @@ class ModelPackage(UserDict[str, ir.Model]):
         super().__init__(models or {})
         self.config = config
         self.gguf_quantization_report: GGUFQuantizationReport | None = None
+        self.gguf_architecture = ""
+        self.gguf_artifact_identity: GGUFArtifactIdentity | None = None
+        self.gguf_execution_provider = ""
+        self.gguf_import_route = ""
+        self.gguf_source_filename = ""
+        self.gguf_source_identity: object | None = None
+        self.gguf_source_path = ""
+        self.gguf_tokenizer_verdict: GGUFTokenizerVerdict | None = None
+        self.export_report: ComponentExportReport | None = None
         self.quantization_report: object | None = None
         self.weight_loading_report: dict[str, object] | None = None
         # Optional persistence policy attached by the GGUF importer.
         self.gguf_reuse_plan: Any = None
+        self.draft_manifest: Any = None
         self.mtp_head: ModelPackage | None = None
         self.policy_components = dict(policy_components or {})
         self.adapter_target_manifest = adapter_target_manifest
@@ -457,6 +504,7 @@ class ModelPackage(UserDict[str, ir.Model]):
         quantization_report_path = os.path.join(directory, _QUANTIZATION_REPORT)
         if self.gguf_quantization_report is not None:
             self.gguf_quantization_report.write_json(quantization_report_path)
+        export_report_path = os.path.join(directory, _EXPORT_REPORT)
         selected = {
             name: model
             for name, model in self.data.items()
@@ -618,6 +666,10 @@ class ModelPackage(UserDict[str, ir.Model]):
                 and not os.path.islink(previous_sidecar)
             ):
                 shutil.rmtree(previous_sidecar)
+        if self.export_report is not None:
+            if os.path.islink(export_report_path):
+                raise ValueError("Component export report must not be a symlink.")
+            self.export_report.write_json(export_report_path)
 
     def add_policy_component(self, name: str, component: PolicyComponent) -> None:
         """Attach a reusable generation-policy graph to this package."""
@@ -987,6 +1039,11 @@ class ModelPackage(UserDict[str, ir.Model]):
             package.gguf_quantization_report = GGUFQuantizationReport.read_json(
                 quantization_report_path
             )
+        export_report_path = os.path.join(directory, _EXPORT_REPORT)
+        if os.path.lexists(export_report_path):
+            if os.path.islink(export_report_path) or not os.path.isfile(export_report_path):
+                raise ValueError("ModelPackage component export report must be a real file.")
+            package.export_report = ComponentExportReport.read_json(export_report_path)
         report_path = os.path.join(directory, _WEIGHT_LOADING_REPORT)
         if os.path.lexists(report_path):
             if os.path.islink(report_path) or not os.path.isfile(report_path):

--- a/src/mobius/_model_package.py
+++ b/src/mobius/_model_package.py
@@ -26,10 +26,12 @@ import logging
 import math
 import os
 import shutil
+import tempfile
 import threading
 from collections import UserDict
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import onnx_ir as ir
@@ -49,8 +51,6 @@ from mobius.integrations._weight_loading import _assign_weight
 
 if TYPE_CHECKING:
     from mobius.integrations.gguf._quantization_report import GGUFQuantizationReport
-    from mobius.integrations.gguf._runtime_evidence import GGUFArtifactIdentity
-    from mobius.integrations.gguf._tokenizer import GGUFTokenizerVerdict
 
 logger = logging.getLogger(__name__)
 
@@ -210,6 +210,7 @@ def _validate_mtp_save_paths(
         )
     if (
         package.export_report is not None
+        and package.gguf_reuse_plan is None
         and (
             package.export_report.status == "partial"
             or package.export_report.runtime_validation_status == "unvalidated"
@@ -353,13 +354,13 @@ class ModelPackage(UserDict[str, ir.Model]):
         self.config = config
         self.gguf_quantization_report: GGUFQuantizationReport | None = None
         self.gguf_architecture = ""
-        self.gguf_artifact_identity: GGUFArtifactIdentity | None = None
+        self.gguf_artifact_identity: Any = None
         self.gguf_execution_provider = ""
         self.gguf_import_route = ""
         self.gguf_source_filename = ""
         self.gguf_source_identity: object | None = None
         self.gguf_source_path = ""
-        self.gguf_tokenizer_verdict: GGUFTokenizerVerdict | None = None
+        self.gguf_tokenizer_verdict: Any = None
         self.export_report: ComponentExportReport | None = None
         self.quantization_report: object | None = None
         self.weight_loading_report: dict[str, object] | None = None
@@ -407,6 +408,7 @@ class ModelPackage(UserDict[str, ir.Model]):
         check_weights: bool = True,
         include_policy_components: bool = True,
         include_adapter_artifacts: bool = True,
+        _atomic_export_report: bool = True,
     ) -> None:
         """Save all component models to a directory.
 
@@ -488,6 +490,46 @@ class ModelPackage(UserDict[str, ir.Model]):
         if max_workers <= 0:
             raise ValueError(f"max_workers must be positive, got {max_workers}.")
         reuse_plan = getattr(self, "gguf_reuse_plan", None)
+        if self.export_report is not None and _atomic_export_report and reuse_plan is None:
+            destination = os.path.abspath(directory)
+            if os.path.lexists(destination):
+                raise FileExistsError(
+                    "Component-report package destination already exists; refusing "
+                    "non-atomic replacement."
+                )
+            parent = os.path.dirname(destination)
+            os.makedirs(parent, exist_ok=True)
+            stage = tempfile.mkdtemp(
+                prefix=f".{os.path.basename(destination)}.",
+                suffix=".tmp",
+                dir=parent,
+            )
+            try:
+                self.save(
+                    stage,
+                    external_data=external_data,
+                    max_shard_size_bytes=max_shard_size_bytes,
+                    max_workers=max_workers,
+                    components=components,
+                    progress_bar=progress_bar,
+                    check_weights=check_weights,
+                    include_policy_components=include_policy_components,
+                    include_adapter_artifacts=include_adapter_artifacts,
+                    _atomic_export_report=False,
+                )
+                if self.draft_manifest is not None:
+                    from mobius.integrations.gguf._draft import write_draft_manifest
+
+                    write_draft_manifest(self.draft_manifest, stage)
+                from mobius.integrations.gguf._runtime_package import (
+                    _publish_directory_no_replace,
+                )
+
+                _publish_directory_no_replace(Path(stage), Path(destination))
+            finally:
+                if os.path.isdir(stage):
+                    shutil.rmtree(stage)
+            return
         if reuse_plan is not None:
             if external_data != "onnx":
                 raise ValueError(
@@ -579,11 +621,21 @@ class ModelPackage(UserDict[str, ir.Model]):
                 if reuse_plan is not None:
                     from mobius.integrations.gguf._reuse import save_reuse_package
 
+                    package_metadata: dict[str, bytes] = {}
+                    if self.export_report is not None:
+                        package_metadata[_EXPORT_REPORT] = (
+                            self.export_report.to_json().encode()
+                        )
+                    if self.draft_manifest is not None:
+                        package_metadata["draft_manifest.json"] = (
+                            json.dumps(self.draft_manifest, indent=2, sort_keys=True) + "\n"
+                        ).encode()
                     save_reuse_package(
                         saved_model,
                         path,
                         reuse_plan,
                         callback=callback,
+                        package_metadata=package_metadata,
                     )
                 elif external_data == "safetensors":
                     ir.save_safetensors(
@@ -666,7 +718,7 @@ class ModelPackage(UserDict[str, ir.Model]):
                 and not os.path.islink(previous_sidecar)
             ):
                 shutil.rmtree(previous_sidecar)
-        if self.export_report is not None:
+        if self.export_report is not None and reuse_plan is None:
             if os.path.islink(export_report_path):
                 raise ValueError("Component export report must not be a symlink.")
             self.export_report.write_json(export_report_path)

--- a/src/mobius/_model_package.py
+++ b/src/mobius/_model_package.py
@@ -191,7 +191,11 @@ def _validate_mtp_save_paths(
         os.path.islink(report_path) or not os.path.isfile(report_path)
     ):
         raise ValueError("ModelPackage quantization report output must be a real file.")
-    if package.gguf_quantization_report is None and os.path.isfile(report_path):
+    if (
+        package.gguf_quantization_report is None
+        and package.gguf_reuse_plan is None
+        and os.path.isfile(report_path)
+    ):
         raise ValueError(
             "ModelPackage output contains a stale quantization_report.json, but the "
             "package being saved has no GGUF quantization report. Remove or clean the "
@@ -202,7 +206,11 @@ def _validate_mtp_save_paths(
         os.path.islink(export_report_path) or not os.path.isfile(export_report_path)
     ):
         raise ValueError("ModelPackage component export report output must be a real file.")
-    if package.export_report is None and os.path.isfile(export_report_path):
+    if (
+        package.export_report is None
+        and package.gguf_reuse_plan is None
+        and os.path.isfile(export_report_path)
+    ):
         raise ValueError(
             "ModelPackage output contains a stale export_report.json, but the package "
             "being saved has no component export report. Remove or clean the output "
@@ -544,7 +552,7 @@ class ModelPackage(UserDict[str, ir.Model]):
         previous_sidecar_name = _read_mtp_sidecar_name(directory)
         os.makedirs(directory, exist_ok=True)
         quantization_report_path = os.path.join(directory, _QUANTIZATION_REPORT)
-        if self.gguf_quantization_report is not None:
+        if self.gguf_quantization_report is not None and reuse_plan is None:
             self.gguf_quantization_report.write_json(quantization_report_path)
         export_report_path = os.path.join(directory, _EXPORT_REPORT)
         selected = {
@@ -622,6 +630,15 @@ class ModelPackage(UserDict[str, ir.Model]):
                     from mobius.integrations.gguf._reuse import save_reuse_package
 
                     package_metadata: dict[str, bytes] = {}
+                    if self.gguf_quantization_report is not None:
+                        package_metadata[_QUANTIZATION_REPORT] = (
+                            json.dumps(
+                                self.gguf_quantization_report.to_dict(),
+                                indent=2,
+                                sort_keys=True,
+                            )
+                            + "\n"
+                        ).encode()
                     if self.export_report is not None:
                         package_metadata[_EXPORT_REPORT] = (
                             self.export_report.to_json().encode()

--- a/src/mobius/_model_package_test.py
+++ b/src/mobius/_model_package_test.py
@@ -251,10 +251,11 @@ class TestComponentExportReport:
     def test_partial_report_roundtrips_deterministically(self, tmp_path):
         pkg = ModelPackage({"model": _make_simple_model()})
         pkg.export_report = _partial_export_report()
+        output = tmp_path / "output"
 
-        pkg.save(str(tmp_path), progress_bar=False)
-        report_bytes = (tmp_path / "export_report.json").read_bytes()
-        loaded = ModelPackage.load(str(tmp_path))
+        pkg.save(str(output), progress_bar=False)
+        report_bytes = (output / "export_report.json").read_bytes()
+        loaded = ModelPackage.load(str(output))
 
         assert loaded.export_report == pkg.export_report
         loaded_report = loaded.export_report
@@ -307,6 +308,96 @@ class TestComponentExportReport:
             pkg.save(str(tmp_path / "output"), progress_bar=False)
 
         assert not (tmp_path / "output" / "export_report.json").exists()
+        assert not list(tmp_path.glob(".output.*.tmp"))
+
+    def test_report_write_failure_publishes_nothing(self, tmp_path, monkeypatch):
+        pkg = ModelPackage({"model": _make_simple_model()})
+        pkg.export_report = _partial_export_report()
+        output = tmp_path / "output"
+
+        def fail_report(*_args, **_kwargs):
+            raise OSError("report disk full")
+
+        monkeypatch.setattr(ComponentExportReport, "write_json", fail_report)
+        with pytest.raises(OSError, match="report disk full"):
+            pkg.save(str(output), progress_bar=False)
+
+        assert not output.exists()
+        assert not list(tmp_path.glob(".output.*.tmp"))
+
+    def test_draft_manifest_failure_publishes_nothing(self, tmp_path, monkeypatch):
+        pkg = ModelPackage({"model": _make_simple_model()})
+        pkg.export_report = _partial_export_report()
+        pkg.draft_manifest = {"architecture": "eagle3"}
+        output = tmp_path / "output"
+
+        def fail_manifest(*_args, **_kwargs):
+            raise OSError("draft manifest disk full")
+
+        monkeypatch.setattr(
+            "mobius.integrations.gguf._draft.write_draft_manifest",
+            fail_manifest,
+        )
+        with pytest.raises(OSError, match="draft manifest disk full"):
+            pkg.save(str(output), progress_bar=False)
+
+        assert not output.exists()
+        assert not list(tmp_path.glob(".output.*.tmp"))
+
+    def test_report_save_refuses_existing_destination_without_mutation(self, tmp_path):
+        pkg = ModelPackage({"model": _make_simple_model()})
+        pkg.export_report = _partial_export_report()
+        output = tmp_path / "output"
+        output.mkdir()
+        sentinel = output / "sentinel.bin"
+        sentinel.write_bytes(b"unchanged")
+
+        with pytest.raises(FileExistsError, match="omitted or unverified components"):
+            pkg.save(str(output), progress_bar=False)
+
+        assert sentinel.read_bytes() == b"unchanged"
+        assert not list(tmp_path.glob(".output.*.tmp"))
+
+    def test_atomic_report_publish_failure_rolls_back_stage(self, tmp_path, monkeypatch):
+        from mobius.integrations.gguf import _runtime_package
+
+        pkg = ModelPackage({"model": _make_simple_model()})
+        pkg.export_report = _partial_export_report()
+        output = tmp_path / "output"
+
+        def fail_publish(*_args, **_kwargs):
+            raise PermissionError("destination permission denied")
+
+        monkeypatch.setattr(_runtime_package, "_publish_directory_no_replace", fail_publish)
+        with pytest.raises(PermissionError, match="permission denied"):
+            pkg.save(str(output), progress_bar=False)
+
+        assert not output.exists()
+        assert not list(tmp_path.glob(".output.*.tmp"))
+
+    def test_atomic_report_publish_refuses_concurrent_destination(self, tmp_path, monkeypatch):
+        from mobius.integrations.gguf import _runtime_package
+
+        pkg = ModelPackage({"model": _make_simple_model()})
+        pkg.export_report = _partial_export_report()
+        output = tmp_path / "output"
+        publish = _runtime_package._publish_directory_no_replace
+
+        def create_concurrent_destination(stage, destination):
+            destination.mkdir()
+            (destination / "sentinel.bin").write_bytes(b"concurrent")
+            publish(stage, destination)
+
+        monkeypatch.setattr(
+            _runtime_package,
+            "_publish_directory_no_replace",
+            create_concurrent_destination,
+        )
+        with pytest.raises(OSError):
+            pkg.save(str(output), progress_bar=False)
+
+        assert (output / "sentinel.bin").read_bytes() == b"concurrent"
+        assert not list(tmp_path.glob(".output.*.tmp"))
 
     def test_report_rejects_component_filtered_save(self, tmp_path):
         pkg = ModelPackage({"model": _make_simple_model()})

--- a/src/mobius/_model_package_test.py
+++ b/src/mobius/_model_package_test.py
@@ -15,6 +15,7 @@ import torch
 
 from mobius._builder import build_from_module
 from mobius._configs import VisionConfig
+from mobius._export_report import ComponentExportDisposition, ComponentExportReport
 from mobius._model_package import (
     ModelPackage,
     _make_progress_callback,
@@ -31,6 +32,36 @@ def _make_simple_model(name: str = "test") -> ir.Model:
     """Create a minimal ir.Model for testing."""
     graph = ir.Graph([], [], nodes=[], name=name)
     return ir.Model(graph, ir_version=10)
+
+
+def _partial_export_report() -> ComponentExportReport:
+    return ComponentExportReport.create(
+        (
+            ComponentExportDisposition(
+                name="model",
+                route="llama",
+                requested=True,
+                discovered=True,
+                support="supported",
+                output="exported",
+            ),
+            ComponentExportDisposition(
+                name="tokenizer",
+                route="blocked-pre",
+                requested=True,
+                discovered=True,
+                support="blocked",
+                output="omitted",
+                runtime_validation_status="unvalidated",
+                blocker_category="semantic-mismatch",
+                reason="the pinned tokenizer differs",
+                evidence_id="tokenizer-evidence",
+                impact="the package is not runnable",
+                remediation="provide and validate a tokenizer",
+            ),
+        ),
+        end_to_end_runnable=False,
+    )
 
 
 class TestModelPackageDict:
@@ -214,6 +245,93 @@ class TestWeightLoadingReport:
 
         assert external.read_text() == "unchanged"
         assert not (tmp_path / "model.onnx").exists()
+
+
+class TestComponentExportReport:
+    def test_partial_report_roundtrips_deterministically(self, tmp_path):
+        pkg = ModelPackage({"model": _make_simple_model()})
+        pkg.export_report = _partial_export_report()
+
+        pkg.save(str(tmp_path), progress_bar=False)
+        report_bytes = (tmp_path / "export_report.json").read_bytes()
+        loaded = ModelPackage.load(str(tmp_path))
+
+        assert loaded.export_report == pkg.export_report
+        loaded_report = loaded.export_report
+        assert loaded_report is not None
+        assert loaded_report.status == "partial"
+        assert loaded_report.runtime_validation_status == "unvalidated"
+        tokenizer = loaded_report.component("tokenizer")
+        assert tokenizer is not None
+        assert tokenizer.exported is False
+        assert report_bytes == pkg.export_report.to_json().encode()
+        payload = pkg.export_report.to_dict()
+        assert payload["export_status"] == "partial"
+        assert payload["runtime_validation_status"] == "unvalidated"
+        components = payload["components"]
+        assert isinstance(components, dict)
+        assert components["tokenizer"]["export_status"] == "omitted"
+        assert components["tokenizer"]["runtime_validation_status"] == "unvalidated"
+
+    def test_save_without_report_rejects_stale_report(self, tmp_path):
+        report_path = tmp_path / "export_report.json"
+        report_path.write_text(_partial_export_report().to_json(), encoding="utf-8")
+        pkg = ModelPackage({"model": _make_simple_model()})
+
+        with pytest.raises(ValueError, match=r"stale export_report.json"):
+            pkg.save(str(tmp_path), progress_bar=False)
+
+        assert not (tmp_path / "model.onnx").exists()
+
+    def test_partial_report_rejects_stale_omitted_component_assets(self, tmp_path):
+        stale_tokenizer = tmp_path / "tokenizer.json"
+        stale_tokenizer.write_text('{"unverified": true}', encoding="utf-8")
+        pkg = ModelPackage({"model": _make_simple_model()})
+        pkg.export_report = _partial_export_report()
+
+        with pytest.raises(FileExistsError, match="unverified components cannot survive"):
+            pkg.save(str(tmp_path), progress_bar=False)
+
+        assert stale_tokenizer.read_text(encoding="utf-8") == '{"unverified": true}'
+        assert not (tmp_path / "model.onnx").exists()
+
+    def test_report_is_written_only_after_model_serialization(self, tmp_path, monkeypatch):
+        pkg = ModelPackage({"model": _make_simple_model()})
+        pkg.export_report = _partial_export_report()
+
+        def fail_save(*_args, **_kwargs):
+            raise OSError("serialization failed")
+
+        monkeypatch.setattr(ir, "save", fail_save)
+        with pytest.raises(OSError, match="serialization failed"):
+            pkg.save(str(tmp_path / "output"), progress_bar=False)
+
+        assert not (tmp_path / "output" / "export_report.json").exists()
+
+    def test_report_rejects_component_filtered_save(self, tmp_path):
+        pkg = ModelPackage({"model": _make_simple_model()})
+        pkg.export_report = _partial_export_report()
+
+        with pytest.raises(ValueError, match="Component-filtered saves"):
+            pkg.save(
+                str(tmp_path),
+                components=lambda _name: False,
+                progress_bar=False,
+            )
+
+        assert not (tmp_path / "model.onnx").exists()
+        assert not (tmp_path / "export_report.json").exists()
+
+    def test_report_rejects_contradictory_status_booleans(self):
+        payload = _partial_export_report().to_dict()
+        components = payload["components"]
+        assert isinstance(components, dict)
+        tokenizer = components["tokenizer"]
+        assert isinstance(tokenizer, dict)
+        tokenizer["exported"] = True
+
+        with pytest.raises(ValueError, match="contradictory status booleans"):
+            ComponentExportReport.from_dict(payload)
 
 
 class TestOnnxShardedSave:

--- a/src/mobius/integrations/gguf/__init__.py
+++ b/src/mobius/integrations/gguf/__init__.py
@@ -22,8 +22,8 @@ Usage::
     # Multimodal (text + companion mmproj vision/audio encoder)
     pkg = build_from_gguf("path/to/model.gguf", mmproj="path/to/mmproj.gguf")
 
-    # Runtime packaging is fail-closed and available only for an exact artifact,
-    # import route, runtime version, and pinned tokenizer evidence record.
+    # Exact evidence emits a validated runtime package. Downstream runtime
+    # limitations preserve an accurate model package marked runtime-unvalidated.
 
 :func:`build_from_gguf` is the single entry point; passing ``mmproj`` delegates
 to the matching architecture-specific multimodal builder.

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -6847,7 +6847,7 @@ def build_from_gguf(
         from mobius.integrations.gguf._mmproj import build_vlm_from_gguf
 
         parsed_source = {"_text_gguf_model": _gguf_model} if _gguf_model is not None else {}
-        return build_vlm_from_gguf(
+        pkg = build_vlm_from_gguf(
             gguf_path,
             mmproj,
             dtype=dtype,
@@ -6856,6 +6856,80 @@ def build_from_gguf(
             keep_quantized=keep_quantized,
             **parsed_source,
         )
+        from mobius.integrations.gguf._arch_registry import get_arch_spec
+        from mobius.integrations.gguf._component_export import (
+            attach_tokenizer_export_report,
+            resolve_tokenizer_export_verdict,
+        )
+        from mobius.integrations.gguf._shard_set import open_gguf_model
+
+        if not pkg.gguf_source_path:
+            raise RuntimeError(
+                "Multimodal GGUF builder did not preserve its canonical text source path."
+            )
+        source_path = Path(pkg.gguf_source_path)
+        text_model = _gguf_model if _gguf_model is not None else open_gguf_model(source_path)
+        source_matches_path = getattr(text_model, "source_matches_path", None)
+        if callable(source_matches_path) and not source_matches_path():
+            raise ValueError(
+                "GGUF source changed after multimodal graph construction; "
+                "refusing to bind stale source metadata."
+            )
+        architecture_spec = get_arch_spec(text_model.architecture)
+        canonical_architecture = architecture_spec.gguf_arch
+        pkg.gguf_architecture = canonical_architecture
+        pkg.gguf_execution_provider = execution_provider
+        source_filename = getattr(pkg, "gguf_source_filename", None)
+        if not isinstance(source_filename, str) or not source_filename:
+            source_filename = source_path.name
+            pkg.gguf_source_filename = source_filename
+        source_identities = getattr(text_model, "source_identities", None)
+        pkg.gguf_source_identity = (
+            tuple(source_identities)
+            if source_identities is not None
+            else getattr(text_model, "source_identity", None)
+        )
+        pkg.gguf_import_route = json.dumps(
+            {
+                "architecture": architecture_spec.gguf_arch,
+                "components": sorted(pkg),
+                "execution_provider": execution_provider,
+                "model_type": getattr(pkg.config, "model_type", None),
+                "multimodal_projector": True,
+                "route_schema": 1,
+                "task": "multimodal",
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        tokenizer_verdict = getattr(pkg, "gguf_tokenizer_verdict", None)
+        if getattr(pkg, "gguf_artifact_identity", None) is None:
+            from mobius.integrations.gguf._runtime_evidence import gguf_artifact_identity
+
+            pkg.gguf_artifact_identity = gguf_artifact_identity(
+                source_path,
+                text_model,
+                architecture=canonical_architecture,
+                filename=source_filename,
+            )
+            if callable(source_matches_path) and not source_matches_path():
+                raise ValueError(
+                    "GGUF source changed while its multimodal package identity was captured."
+                )
+        if tokenizer_verdict is not None:
+            tokenizer_verdict = resolve_tokenizer_export_verdict(
+                text_model,
+                source_path,
+                verdict=tokenizer_verdict,
+                artifact_identity=getattr(pkg, "gguf_artifact_identity", None),
+            )
+            pkg.gguf_tokenizer_verdict = tokenizer_verdict
+            attach_tokenizer_export_report(
+                pkg,
+                tokenizer_verdict,
+                model_route=canonical_architecture,
+            )
+        return pkg
     if image_token_id is not None:
         raise ValueError("image_token_id requires a companion mmproj package.")
 
@@ -7580,6 +7654,18 @@ def build_from_gguf(
     pkg.gguf_source_filename = logical_source_filename
     pkg.gguf_architecture = spec.gguf_arch
     pkg.gguf_execution_provider = execution_provider
+    source_matches_path = getattr(gguf_model, "source_matches_path", None)
+    if callable(source_matches_path) and not source_matches_path():
+        raise ValueError(
+            "GGUF source changed during graph construction; refusing to bind the package "
+            "to stale source metadata."
+        )
+    source_identities = getattr(gguf_model, "source_identities", None)
+    pkg.gguf_source_identity = (
+        tuple(source_identities)
+        if source_identities is not None
+        else getattr(gguf_model, "source_identity", None)
+    )
     if dataclasses.is_dataclass(resolved_task) and not isinstance(resolved_task, type):
         task_state: object = dataclasses.asdict(resolved_task)
     elif isinstance(resolved_task, str):
@@ -7619,7 +7705,7 @@ def build_from_gguf(
         sort_keys=True,
     )
     source_matches_path = getattr(gguf_model, "source_matches_path", None)
-    if source_matches_path is not None:
+    if callable(source_matches_path):
         if not source_matches_path():
             raise ValueError(
                 "GGUF source changed after the reader opened it; refusing to bind the graph "
@@ -7637,7 +7723,19 @@ def build_from_gguf(
             raise ValueError(
                 "GGUF source changed while its graph and artifact identity were being built."
             )
+    from mobius.integrations.gguf._component_export import (
+        attach_tokenizer_export_report,
+        resolve_tokenizer_export_verdict,
+    )
+
+    tokenizer_verdict = resolve_tokenizer_export_verdict(
+        gguf_model,
+        canonical_source_path,
+        verdict=tokenizer_verdict,
+        artifact_identity=getattr(pkg, "gguf_artifact_identity", None),
+    )
     pkg.gguf_tokenizer_verdict = tokenizer_verdict
+    attach_tokenizer_export_report(pkg, tokenizer_verdict, model_route=spec.gguf_arch)
 
     return pkg
 

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -7240,7 +7240,7 @@ class TestKimiLinearGGUFBuild:
 
         output = tmp_path / "roundtrip"
         package.save(output, progress_bar=False)
-        reloaded = ModelPackage.load(output)
+        reloaded = ModelPackage.load(str(output))
         assert set(reloaded) == {"model"}
         assert (
             reloaded["model"].metadata_props["mobius.cache_abi"]
@@ -7699,7 +7699,7 @@ class TestNemotronHMoEGGUFBuild:
         package = build_from_gguf(path)
 
         output = tmp_path / "runtime-package"
-        write_gguf_runtime_package(
+        artifacts = write_gguf_runtime_package(
             package,
             path,
             output,
@@ -7712,6 +7712,44 @@ class TestNemotronHMoEGGUFBuild:
         )
         assert compatibility["runtime_validation_status"] == "unvalidated"
         assert compatibility["gguf_architecture"] == "nemotron_h_moe"
+        assert (output / "model.onnx").is_file()
+        assert Path(artifacts["export_report"]).is_file()
+        report = package.export_report
+        assert report is not None
+        model = report.component("model")
+        runtime = report.component("runtime")
+        assert model is not None
+        assert runtime is not None
+        assert model.output == "exported"
+        assert runtime.output == "exported"
+        assert runtime.runtime_validation_status == "unvalidated"
+        assert runtime.blocker_category == "runtime-route-deferred"
+        assert not (output / "tokenizer.json").exists()
+
+    def test_runtime_unvalidated_fallback_rejects_source_mutation(
+        self, tmp_path: Path
+    ) -> None:
+        from mobius.integrations.gguf import build_from_gguf, write_gguf_runtime_package
+
+        path = tmp_path / "nemotron-h-moe-mutated.gguf"
+        _write_nemotron_h_moe_gguf(path, quantized=False)
+        package = build_from_gguf(path)
+        with path.open("r+b") as stream:
+            stream.seek(-1, os.SEEK_END)
+            value = stream.read(1)
+            stream.seek(-1, os.SEEK_END)
+            stream.write(bytes([value[0] ^ 0xFF]))
+
+        output = tmp_path / "runtime-mutated"
+        with pytest.raises(ValueError, match="exact artifact identity"):
+            write_gguf_runtime_package(
+                package,
+                path,
+                output,
+                runtime_version="0.15.2",
+            )
+        assert not output.exists()
+        assert not output.exists()
 
     def test_latent_projection_imports_and_executes(self, tmp_path: Path) -> None:
         from mobius._testing.ort_inference import OnnxModelSession
@@ -7920,19 +7958,47 @@ class TestMultimodalQuantizationDefault:
         self, keep_quantized: bool
     ):
         from mobius.integrations.gguf import build_from_gguf
+        from mobius.integrations.gguf._tokenizer import GGUFTokenizerVerdict
 
-        expected = mock.sentinel.package
+        expected = mock.MagicMock()
+        expected.__iter__.return_value = iter(("model", "vision"))
+        expected.config = SimpleNamespace(model_type="test-vlm")
+        expected.gguf_source_path = "text.gguf"
+        expected.gguf_source_filename = "text.gguf"
+        expected.gguf_tokenizer_verdict = GGUFTokenizerVerdict(
+            route="copy",
+            model="gpt2",
+            pre="gpt-2",
+            canonical_pre="gpt-2",
+            reason="exact embedded tokenizer",
+            token_count=2,
+        )
+        expected.export_report = None
+        text_model = SimpleNamespace(
+            architecture="llama",
+            metadata={},
+            source_identity=(1, 2, 3),
+            source_matches_path=lambda: True,
+        )
         with mock.patch(
             "mobius.integrations.gguf._mmproj.build_vlm_from_gguf",
             return_value=expected,
         ) as build_multimodal:
-            kwargs = {} if keep_quantized else {"keep_quantized": False}
-            actual = build_from_gguf(
-                "text.gguf",
-                mmproj="mmproj.gguf",
-                image_token_id=-200,
-                **kwargs,
-            )
+            if keep_quantized:
+                actual = build_from_gguf(
+                    "text.gguf",
+                    mmproj="mmproj.gguf",
+                    image_token_id=-200,
+                    _gguf_model=text_model,
+                )
+            else:
+                actual = build_from_gguf(
+                    "text.gguf",
+                    mmproj="mmproj.gguf",
+                    image_token_id=-200,
+                    keep_quantized=False,
+                    _gguf_model=text_model,
+                )
 
         assert actual is expected
         build_multimodal.assert_called_once_with(
@@ -7942,6 +8008,7 @@ class TestMultimodalQuantizationDefault:
             execution_provider="default",
             image_token_id=-200,
             keep_quantized=keep_quantized,
+            _text_gguf_model=text_model,
         )
 
     def test_image_token_id_requires_mmproj(self):

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -5303,6 +5303,7 @@ class TestLanguageDiffusionDispatch:
         class _DreamGGUF:
             architecture = "dream"
             metadata: ClassVar[dict] = {
+                "general.architecture": "dream",
                 "dream.embedding_length": 8,
                 "dream.feed_forward_length": 16,
                 "dream.block_count": 1,

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -2953,8 +2953,9 @@ class TestReuseGgufWeights:
         )
 
         loaded = ModelPackage.load(str(tmp_path))
-        loaded.save(str(tmp_path), progress_bar=False)
-        assert not (tmp_path / "gguf-reuse.json").exists()
+        ordinary_output = tmp_path / "ordinary-resave"
+        loaded.save(str(ordinary_output), progress_bar=False)
+        assert not (ordinary_output / "gguf-reuse.json").exists()
 
     def test_verifier_rejects_unmanifested_external_initializer(self, tmp_path: Path):
         from mobius.integrations.gguf import (

--- a/src/mobius/integrations/gguf/_builder_test.py
+++ b/src/mobius/integrations/gguf/_builder_test.py
@@ -2957,6 +2957,35 @@ class TestReuseGgufWeights:
         loaded.save(str(ordinary_output), progress_bar=False)
         assert not (ordinary_output / "gguf-reuse.json").exists()
 
+    @pytest.mark.parametrize("projection_quantization", ["f32", "q4_0"])
+    def test_reuse_transaction_removes_stale_optional_package_metadata(
+        self,
+        tmp_path: Path,
+        projection_quantization: str,
+    ) -> None:
+        from mobius.integrations.gguf import build_from_gguf
+
+        gguf_path = tmp_path / "source.gguf"
+        _write_quantized_gguf(
+            gguf_path,
+            projection_quantization=projection_quantization,
+        )
+        package = build_from_gguf(gguf_path, reuse_gguf_weights=True)
+        package.draft_manifest = {"architecture": "eagle3"}
+        package.save(str(tmp_path), progress_bar=False)
+        assert (tmp_path / "draft_manifest.json").is_file()
+        assert (tmp_path / "export_report.json").is_file()
+        assert (tmp_path / "quantization_report.json").is_file()
+
+        package.draft_manifest = None
+        package.export_report = None
+        package.gguf_quantization_report = None
+        package.save(str(tmp_path), progress_bar=False)
+
+        assert not (tmp_path / "draft_manifest.json").exists()
+        assert not (tmp_path / "export_report.json").exists()
+        assert not (tmp_path / "quantization_report.json").exists()
+
     def test_verifier_rejects_unmanifested_external_initializer(self, tmp_path: Path):
         from mobius.integrations.gguf import (
             build_from_gguf,
@@ -3162,10 +3191,17 @@ class TestReuseGgufWeights:
 
         gguf_path = tmp_path / "source.gguf"
         _write_quantized_gguf(gguf_path, projection_quantization="f32")
-        build_from_gguf(gguf_path, reuse_gguf_weights=True).save(
-            str(tmp_path), progress_bar=False
+        initial = build_from_gguf(gguf_path, reuse_gguf_weights=True)
+        initial.draft_manifest = {"architecture": "eagle3", "generation": 1}
+        initial.save(str(tmp_path), progress_bar=False)
+        artifact_names = (
+            "model.onnx",
+            "model.onnx.data",
+            "gguf-reuse.json",
+            "quantization_report.json",
+            "export_report.json",
+            "draft_manifest.json",
         )
-        artifact_names = ("model.onnx", "model.onnx.data", "gguf-reuse.json")
         original = {name: (tmp_path / name).read_bytes() for name in artifact_names}
 
         real_replace = _reuse.os.replace
@@ -3186,6 +3222,7 @@ class TestReuseGgufWeights:
 
         monkeypatch.setattr(_reuse.os, "replace", fail_manifest_install)
         rerun = build_from_gguf(gguf_path, reuse_gguf_weights=True)
+        rerun.draft_manifest = {"architecture": "eagle3", "generation": 2}
         with pytest.raises(OSError, match="injected"):
             rerun.save(str(tmp_path), progress_bar=False)
 

--- a/src/mobius/integrations/gguf/_component_export.py
+++ b/src/mobius/integrations/gguf/_component_export.py
@@ -1,0 +1,347 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Component-level GGUF export diagnostics and partial-package policy."""
+
+from __future__ import annotations
+
+__all__ = [
+    "attach_runtime_unvalidated_report",
+    "attach_tokenizer_export_report",
+    "emit_runtime_unvalidated_warning",
+    "resolve_tokenizer_export_verdict",
+    "tokenizer_export_is_partial",
+]
+
+import dataclasses
+import json
+import logging
+from pathlib import Path
+from typing import Any, Literal
+
+from mobius._export_report import ComponentExportDisposition, ComponentExportReport
+from mobius.integrations.gguf._tokenizer import GGUFTokenizerVerdict, inspect_gguf_tokenizer
+
+logger = logging.getLogger(__name__)
+
+_TOKENIZER_IMPACT = (
+    "The proven model graph was exported, but the package is not end-to-end runnable "
+    "because tokenizer assets were omitted."
+)
+_TOKENIZER_REMEDIATION = (
+    "Tokenizer semantics are unverified. Provide and validate a tokenizer against the "
+    "source GGUF before end-to-end use."
+)
+_RUNTIME_OMITTED_IMPACT = (
+    "The accurate model package was exported, but runtime-specific assets were omitted "
+    "because execution with the requested runtime has not been validated."
+)
+_RUNTIME_EXPORTED_IMPACT = (
+    "The runtime configuration was exported faithfully, but execution with the requested "
+    "runtime has not been validated."
+)
+_RUNTIME_REMEDIATION = (
+    "Validate the exported package with the requested runtime and version before production "
+    "use; export success is not a runtime support claim."
+)
+_RUNTIME_NOT_REQUESTED_IMPACT = (
+    "No runtime-specific configuration was requested by this model-only export."
+)
+_RUNTIME_NOT_REQUESTED_REMEDIATION = (
+    "Request runtime packaging separately when an end-to-end runtime package is needed."
+)
+
+
+def resolve_tokenizer_export_verdict(
+    gguf_model: Any,
+    source_path: str | Path,
+    *,
+    verdict: GGUFTokenizerVerdict | None = None,
+    artifact_identity: Any | None = None,
+) -> GGUFTokenizerVerdict:
+    """Add an exact artifact blocker to an otherwise validated tokenizer verdict."""
+    if verdict is None:
+        verdict = inspect_gguf_tokenizer(gguf_model.metadata, source=str(source_path))
+    if verdict.materialized or verdict.metadata_sha256 is None:
+        return verdict
+
+    from mobius.integrations.gguf._tokenizer_evidence import (
+        matching_tokenizer_blocker_evidence,
+    )
+
+    blocker = matching_tokenizer_blocker_evidence(
+        Path(source_path),
+        gguf_model,
+        metadata_sha256=verdict.metadata_sha256,
+        artifact_identity=artifact_identity,
+    )
+    if blocker is None:
+        return verdict
+    return dataclasses.replace(
+        verdict,
+        reason=blocker.disposition,
+        audit_status="deferred-pinned-artifact-mismatch",
+        blocker_category="pinned-candidate-source-semantic-mismatch",
+        evidence_id=blocker.evidence_id,
+    )
+
+
+def attach_tokenizer_export_report(
+    pkg: Any,
+    verdict: GGUFTokenizerVerdict,
+    *,
+    model_route: str,
+) -> None:
+    """Record and warn once when a proven graph must omit a tokenizer component."""
+    if verdict.blocker_category is None:
+        return
+    existing = getattr(pkg, "export_report", None)
+    if (
+        isinstance(existing, ComponentExportReport)
+        and existing.component("tokenizer") is not None
+    ):
+        return
+
+    support: Literal["blocked", "deferred"] = (
+        "blocked"
+        if verdict.audit_status == "deferred-pinned-artifact-mismatch"
+        else "deferred"
+    )
+    tokenizer = ComponentExportDisposition(
+        name="tokenizer",
+        route=verdict.route_identifier,
+        requested=True,
+        discovered=True,
+        support=support,
+        output="omitted",
+        runtime_validation_status="unvalidated",
+        blocker_category=verdict.blocker_category,
+        reason=verdict.reason,
+        evidence_id=verdict.evidence_id,
+        impact=_TOKENIZER_IMPACT,
+        remediation=_TOKENIZER_REMEDIATION,
+    )
+    model = ComponentExportDisposition(
+        name="model",
+        route=model_route,
+        requested=True,
+        discovered=True,
+        support="supported",
+        output="exported",
+    )
+    runtime = ComponentExportDisposition(
+        name="runtime",
+        route="not-requested",
+        requested=False,
+        discovered=False,
+        support="deferred",
+        output="omitted",
+        blocker_category="not-requested",
+        reason="Runtime packaging was not requested during model graph construction.",
+        impact=_RUNTIME_NOT_REQUESTED_IMPACT,
+        remediation=_RUNTIME_NOT_REQUESTED_REMEDIATION,
+    )
+    pkg.export_report = ComponentExportReport.create(
+        (model, runtime, tokenizer),
+        end_to_end_runnable=False,
+    )
+    warning = {
+        "blocker_category": tokenizer.blocker_category,
+        "component": tokenizer.name,
+        "evidence_id": tokenizer.evidence_id,
+        "export_status": tokenizer.output,
+        "impact": tokenizer.impact,
+        "reason": tokenizer.reason,
+        "remediation": tokenizer.remediation,
+        "route": tokenizer.route,
+        "runtime_validation_status": tokenizer.runtime_validation_status,
+        "support_status": tokenizer.support,
+    }
+    logger.warning(
+        "GGUF PARTIAL EXPORT WARNING: %s",
+        json.dumps(warning, ensure_ascii=True, separators=(",", ":"), sort_keys=True),
+        extra={
+            "mobius_warning_code": "gguf_component_partial_export",
+            "mobius_component": tokenizer.name,
+            "mobius_component_route": tokenizer.route,
+            "mobius_blocker_category": tokenizer.blocker_category,
+            "mobius_evidence_id": tokenizer.evidence_id,
+        },
+    )
+
+
+def tokenizer_export_is_partial(pkg: Any) -> bool:
+    """Whether the package carries an omitted/deferred tokenizer disposition."""
+    report = getattr(pkg, "export_report", None)
+    if not isinstance(report, ComponentExportReport):
+        return False
+    tokenizer = report.component("tokenizer")
+    return tokenizer is not None and (
+        tokenizer.support != "supported" or tokenizer.output != "exported"
+    )
+
+
+def attach_runtime_unvalidated_report(
+    pkg: Any,
+    runtime: str,
+    *,
+    blocker_category: str | None,
+    reason: str | None,
+    evidence_id: str | None = None,
+    support_status: Literal["supported", "deferred", "blocked"] = "deferred",
+    runtime_output: Literal["exported", "omitted"] = "exported",
+    runtime_validation_status: Literal["validated", "unvalidated"] = "unvalidated",
+    tokenizer_exported: bool = False,
+    emit_warning: bool = True,
+) -> bool:
+    """Record the exported runtime component and its independent validation status."""
+    existing = getattr(pkg, "export_report", None)
+    if isinstance(existing, ComponentExportReport):
+        runtime_component = existing.component("runtime")
+        if (
+            runtime_component is not None
+            and runtime_component.runtime_validation_status == runtime_validation_status
+            and runtime_component.output == runtime_output
+        ):
+            return False
+
+    model = (
+        existing.component("model") if isinstance(existing, ComponentExportReport) else None
+    )
+    if model is None:
+        model = ComponentExportDisposition(
+            name="model",
+            route=getattr(pkg, "gguf_architecture", "gguf-model"),
+            requested=True,
+            discovered=True,
+            support="supported",
+            output="exported",
+        )
+    tokenizer = (
+        existing.component("tokenizer")
+        if isinstance(existing, ComponentExportReport)
+        else None
+    )
+    tokenizer_verdict = getattr(pkg, "gguf_tokenizer_verdict", None)
+    if tokenizer is None:
+        if tokenizer_verdict is None:
+            raise ValueError(
+                "Runtime-unvalidated packaging requires the tokenizer disposition captured "
+                "during graph construction."
+            )
+        tokenizer_route = getattr(tokenizer_verdict, "route_identifier", None)
+        if not isinstance(tokenizer_route, str) or not tokenizer_route:
+            tokenizer_route = "embedded" if tokenizer_exported else "unresolved"
+        if tokenizer_exported or tokenizer_verdict.materialized:
+            tokenizer = ComponentExportDisposition(
+                name="tokenizer",
+                route=tokenizer_route,
+                requested=True,
+                discovered=True,
+                support="supported",
+                output="exported",
+            )
+        else:
+            tokenizer = ComponentExportDisposition(
+                name="tokenizer",
+                route=tokenizer_route,
+                requested=True,
+                discovered=True,
+                support="deferred",
+                output="omitted",
+                runtime_validation_status="unvalidated",
+                blocker_category=(
+                    getattr(tokenizer_verdict, "blocker_category", None)
+                    or "tokenizer-materialization-unvalidated"
+                ),
+                reason=tokenizer_verdict.reason,
+                evidence_id=getattr(tokenizer_verdict, "evidence_id", None),
+                impact=_TOKENIZER_IMPACT,
+                remediation=_TOKENIZER_REMEDIATION,
+            )
+    runtime_component = ComponentExportDisposition(
+        name="runtime",
+        route=runtime,
+        requested=True,
+        discovered=True,
+        support=support_status,
+        output=runtime_output,
+        runtime_validation_status=runtime_validation_status,
+        blocker_category=blocker_category,
+        reason=reason,
+        evidence_id=evidence_id,
+        impact=(
+            None
+            if runtime_validation_status == "validated"
+            else (
+                _RUNTIME_EXPORTED_IMPACT
+                if runtime_output == "exported"
+                else _RUNTIME_OMITTED_IMPACT
+            )
+        ),
+        remediation=(
+            None if runtime_validation_status == "validated" else _RUNTIME_REMEDIATION
+        ),
+    )
+    components = (model, runtime_component, tokenizer)
+    if isinstance(existing, ComponentExportReport):
+        report = existing
+        for component in components:
+            report = report.with_component(component, end_to_end_runnable=False)
+        pkg.export_report = report
+    else:
+        pkg.export_report = ComponentExportReport.create(
+            components,
+            end_to_end_runnable=False,
+        )
+    end_to_end_runnable = (
+        runtime_validation_status == "validated"
+        and runtime_output == "exported"
+        and tokenizer.output == "exported"
+    )
+    if end_to_end_runnable:
+        pkg.export_report = ComponentExportReport.create(
+            pkg.export_report.components,
+            end_to_end_runnable=True,
+        )
+    if emit_warning and runtime_validation_status == "unvalidated":
+        emit_runtime_unvalidated_warning(pkg, runtime)
+    return True
+
+
+def emit_runtime_unvalidated_warning(pkg: Any, runtime: str) -> None:
+    """Emit the structured warning for a persisted runtime-unvalidated report."""
+    report = getattr(pkg, "export_report", None)
+    if not isinstance(report, ComponentExportReport):
+        raise TypeError("Runtime validation warning requires a component export report.")
+    runtime_component = report.component("runtime")
+    if (
+        runtime_component is None
+        or runtime_component.runtime_validation_status != "unvalidated"
+    ):
+        raise ValueError(
+            "Runtime validation warning requires an unvalidated runtime component."
+        )
+    warning = {
+        "blocker_category": runtime_component.blocker_category,
+        "component": "runtime",
+        "evidence_id": runtime_component.evidence_id,
+        "export_status": runtime_component.output,
+        "impact": runtime_component.impact,
+        "reason": runtime_component.reason,
+        "remediation": runtime_component.remediation,
+        "route": runtime,
+        "runtime_validation_status": "unvalidated",
+        "support_status": runtime_component.support,
+    }
+    logger.warning(
+        "GGUF RUNTIME VALIDATION WARNING: %s",
+        json.dumps(warning, ensure_ascii=True, separators=(",", ":"), sort_keys=True),
+        extra={
+            "mobius_warning_code": "gguf_runtime_unvalidated",
+            "mobius_component": "runtime",
+            "mobius_component_route": runtime,
+            "mobius_blocker_category": runtime_component.blocker_category,
+            "mobius_evidence_id": runtime_component.evidence_id,
+        },
+    )

--- a/src/mobius/integrations/gguf/_component_export.py
+++ b/src/mobius/integrations/gguf/_component_export.py
@@ -200,8 +200,13 @@ def attach_runtime_unvalidated_report(
         runtime_component = existing.component("runtime")
         if (
             runtime_component is not None
+            and runtime_component.route == runtime
+            and runtime_component.support == support_status
             and runtime_component.runtime_validation_status == runtime_validation_status
             and runtime_component.output == runtime_output
+            and runtime_component.blocker_category == blocker_category
+            and runtime_component.reason == reason
+            and runtime_component.evidence_id == evidence_id
         ):
             return False
 

--- a/src/mobius/integrations/gguf/_docs.py
+++ b/src/mobius/integrations/gguf/_docs.py
@@ -732,10 +732,10 @@ package.save("output")
 ```
 
 `keep_quantized=True` requests quantized target storage where supported; it does
-not guarantee source byte or numerical fidelity. Mobius classifies qtypes before
-payload conversion, emits one aggregate warning for lossy requantization, and
-saves the typed result as `quantization_report.json`. Use
-`keep_quantized=False` for explicit float import.
+not guarantee source fidelity. An authoritative tokenizer blocker does not invalidate
+a proven graph: the API returns the model, emits one structured warning, omits assets,
+and persists the exact component disposition in `export_report.json`. Lossy qtype
+conversion remains in `quantization_report.json`; use `keep_quantized=False` for float.
 
 Packed MatMulNBits storage may use a native op or portable nibble unpack,
 `DequantizeLinear`, and float `MatMul`; neither implies dense storage or a specific kernel.
@@ -763,12 +763,13 @@ build_from_gguf(
 )
 ```
 
-The function returns a `ModelPackage`. Import validates architecture metadata, exact tensor
-closure, shapes, qtypes, and selected graph route before publication. Source reuse requires
-the original immutable GGUF at runtime. Runtime packages additionally require an exact
-artifact, graph, tokenizer, runtime version, parity proof, and deterministic state/generation
-evidence match.
-Processor-owned `image_token_id` overrides are forwarded unchanged for `mmproj=` packages.
+The function returns a `ModelPackage`. Mobius-side graph/semantic inability, corruption,
+identity, I/O, malformed tokenizer, and unexpected errors remain fail-closed. Authoritative
+tokenizer blockers become partial exports with exact reasons and no unverified assets.
+Downstream runtime, version, registry, or executor limitations preserve the accurate model
+package and record distinct `export_status` and `runtime_validation_status` fields instead of
+blocking export. Only exact artifact, graph, tokenizer, version, parity, and state evidence
+marks a complete runtime package validated and end-to-end runnable.
 
 Use `build_mmproj_from_gguf("mmproj.gguf", projector_type=..., target_architecture=...)`
 to export a registry-evidenced standalone `vision_encoder`, `audio_encoder`, or

--- a/src/mobius/integrations/gguf/_docs.py
+++ b/src/mobius/integrations/gguf/_docs.py
@@ -769,7 +769,9 @@ tokenizer blockers become partial exports with exact reasons and no unverified a
 Downstream runtime, version, registry, or executor limitations preserve the accurate model
 package and record distinct `export_status` and `runtime_validation_status` fields instead of
 blocking export. Only exact artifact, graph, tokenizer, version, parity, and state evidence
-marks a complete runtime package validated and end-to-end runnable.
+covering the final directory bytes (including `export_report.json` and
+`runtime_compatibility.json`) marks a package validated and end-to-end runnable. Existing
+pre-report runtime evidence remains unvalidated until its final-package hashes are regenerated.
 
 Use `build_mmproj_from_gguf("mmproj.gguf", projector_type=..., target_architecture=...)`
 to export a registry-evidenced standalone `vision_encoder`, `audio_encoder`, or

--- a/src/mobius/integrations/gguf/_mmproj_test.py
+++ b/src/mobius/integrations/gguf/_mmproj_test.py
@@ -1084,7 +1084,10 @@ class TestStandaloneCoreProjectorBuild:
         _write_quantized_gemma4_text_gguf(text_path)
         _write_gemma4_unified_mmproj_gguf(mmproj_path)
         text = GGUFModel(str(text_path))
-        text.metadata["tokenizer.ggml.tokens"] = ["<|audio|>", *(["token"] * 63)]
+        text.metadata["tokenizer.ggml.tokens"] = [
+            "<|audio|>",
+            *(f"token-{index}" for index in range(1, 64)),
+        ]
 
         package = build_gemma4_vlm_from_gguf(
             text_path,
@@ -1495,7 +1498,10 @@ class TestVisionEncoderBuildAndRun:
         _write_quantized_gemma4_text_gguf(text_path)
         _write_clip_mmproj_gguf(mmproj_path, with_audio=True)
         text = GGUFModel(str(text_path))
-        text.metadata["tokenizer.ggml.tokens"] = ["<|audio|>", *(["token"] * 63)]
+        text.metadata["tokenizer.ggml.tokens"] = [
+            "<|audio|>",
+            *(f"token-{index}" for index in range(1, 64)),
+        ]
 
         package = build_gemma4_vlm_from_gguf(
             text_path,

--- a/src/mobius/integrations/gguf/_reuse.py
+++ b/src/mobius/integrations/gguf/_reuse.py
@@ -34,9 +34,17 @@ _MANIFEST_NAME = "gguf-reuse.json"
 _SIDECAR_NAME = "model.onnx.data"
 _TRANSACTION_NAME = ".gguf-reuse.transaction.json"
 _LOCK_NAME = ".gguf-reuse.lock"
+_OPTIONAL_PACKAGE_METADATA = frozenset({"draft_manifest.json", "export_report.json"})
 _EXTERNAL_WEIGHT_THRESHOLD = 256
 _GENERATED_NAMES = frozenset(
-    {"model.onnx", _SIDECAR_NAME, _MANIFEST_NAME, _TRANSACTION_NAME, _LOCK_NAME}
+    {
+        "model.onnx",
+        _SIDECAR_NAME,
+        _MANIFEST_NAME,
+        _TRANSACTION_NAME,
+        _LOCK_NAME,
+        *_OPTIONAL_PACKAGE_METADATA,
+    }
 )
 _FLOAT_QTYPE_DTYPES = {
     "F32": ir.DataType.FLOAT,
@@ -462,6 +470,17 @@ def _write_json_exclusive(path: Path, payload: Mapping[str, object]) -> None:
         os.close(descriptor)
 
 
+def _write_bytes_exclusive(path: Path, payload: bytes) -> None:
+    descriptor = _open_exclusive(path)
+    try:
+        with os.fdopen(descriptor, "wb", closefd=False) as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+    finally:
+        os.close(descriptor)
+
+
 def _require_regular_or_missing(path: Path, *, artifact: str) -> None:
     """Reject links, directories, devices, and sockets at generated paths."""
     try:
@@ -745,14 +764,15 @@ def _validated_transaction_journal(path: Path) -> _TransactionJournal:
     managed = journal.get("managed")
     staged = journal.get("staged")
     phase = journal.get("phase", "replacing")
-    expected_finals = {"model.onnx", _SIDECAR_NAME, _MANIFEST_NAME}
+    required_finals = {"model.onnx", _SIDECAR_NAME, _MANIFEST_NAME}
+    allowed_finals = required_finals | _OPTIONAL_PACKAGE_METADATA
     if (
         phase not in {"replacing", "committed"}
         or not isinstance(managed, list)
         or not isinstance(staged, list)
     ):
         raise TypeError("Invalid GGUF transaction journal.")
-    if len(managed) != len(expected_finals):
+    if not len(required_finals) <= len(managed) <= len(allowed_finals):
         raise ValueError("Invalid GGUF transaction journal managed artifact set.")
 
     validated_managed: list[_TransactionEntry] = []
@@ -765,7 +785,7 @@ def _validated_transaction_journal(path: Path) -> _TransactionJournal:
         had_existing = entry.get("had_existing")
         if (
             not isinstance(final, str)
-            or final not in expected_finals
+            or final not in allowed_finals
             or final in seen_finals
             or not isinstance(backup, str)
             or re.fullmatch(
@@ -780,7 +800,7 @@ def _validated_transaction_journal(path: Path) -> _TransactionJournal:
         validated_managed.append(
             {"final": final, "backup": backup, "had_existing": had_existing}
         )
-    if seen_finals != expected_finals:
+    if not required_finals.issubset(seen_finals) or not seen_finals.issubset(allowed_finals):
         raise ValueError("Invalid GGUF transaction journal managed artifact set.")
 
     validated_staged: list[str] = []
@@ -791,7 +811,7 @@ def _validated_transaction_journal(path: Path) -> _TransactionJournal:
         matched_final = next(
             (
                 final
-                for final in expected_finals
+                for final in allowed_finals
                 if re.fullmatch(
                     rf"\.{re.escape(final)}\.[0-9a-f]{{32}}\.tmp",
                     staged_name,
@@ -814,6 +834,7 @@ def save_reuse_package(
     plan: GGUFReusePlan,
     *,
     callback=None,
+    package_metadata: Mapping[str, bytes] | None = None,
 ) -> tuple[str, ...]:
     """Transactionally save mixed GGUF references plus a converted sidecar."""
     path = Path(path)
@@ -829,7 +850,23 @@ def save_reuse_package(
         staged_manifest = path.with_name(f".{_MANIFEST_NAME}.{token}.tmp")
         final_sidecar = path.parent / _SIDECAR_NAME
         final_manifest = path.parent / _MANIFEST_NAME
-        for staged_path in (staged_model, staged_sidecar, staged_manifest):
+        package_metadata = dict(package_metadata or {})
+        if not set(package_metadata).issubset(_OPTIONAL_PACKAGE_METADATA):
+            raise ValueError("GGUF reuse package metadata contains an unsupported filename.")
+        staged_metadata = {
+            name: (
+                path.parent / f".{name}.{token}.tmp",
+                path.parent / name,
+            )
+            for name in sorted(package_metadata)
+        }
+        all_staged = (
+            staged_model,
+            staged_sidecar,
+            staged_manifest,
+            *(staged for staged, _ in staged_metadata.values()),
+        )
+        for staged_path in all_staged:
             _require_regular_or_missing(staged_path, artifact="staged")
             if staged_path.exists():
                 raise ValueError(f"Unexpected GGUF staged artifact: {staged_path}")
@@ -869,6 +906,8 @@ def save_reuse_package(
             ir.save(model, staged_model)
             _fsync_file(staged_model)
             _write_json_exclusive(staged_manifest, _manifest_payload(plan, converted_names))
+            for name, (staged_path, _) in staged_metadata.items():
+                _write_bytes_exclusive(staged_path, package_metadata[name])
             verify_gguf_reuse_manifest(
                 path.parent,
                 model_path=staged_model,
@@ -882,15 +921,26 @@ def save_reuse_package(
             }
             if memory_initializers:
                 replacements[final_sidecar] = staged_sidecar
+            replacements.update(
+                {
+                    final_path: staged_path
+                    for staged_path, final_path in staged_metadata.values()
+                }
+            )
             _require_source_identity(plan)
             _replace_artifacts_locked(
                 replacements,
-                (path, final_sidecar, final_manifest),
+                (
+                    path,
+                    final_sidecar,
+                    final_manifest,
+                    *(final for _, final in staged_metadata.values()),
+                ),
             )
         finally:
             for value, tensor in zip(memory_initializers, original_tensors, strict=True):
                 value.const_value = tensor
-            for staged_path in (staged_model, staged_sidecar, staged_manifest):
+            for staged_path in all_staged:
                 _require_regular_or_missing(staged_path, artifact="staged")
                 staged_path.unlink(missing_ok=True)
 

--- a/src/mobius/integrations/gguf/_reuse.py
+++ b/src/mobius/integrations/gguf/_reuse.py
@@ -34,7 +34,9 @@ _MANIFEST_NAME = "gguf-reuse.json"
 _SIDECAR_NAME = "model.onnx.data"
 _TRANSACTION_NAME = ".gguf-reuse.transaction.json"
 _LOCK_NAME = ".gguf-reuse.lock"
-_OPTIONAL_PACKAGE_METADATA = frozenset({"draft_manifest.json", "export_report.json"})
+_OPTIONAL_PACKAGE_METADATA = frozenset(
+    {"draft_manifest.json", "export_report.json", "quantization_report.json"}
+)
 _EXTERNAL_WEIGHT_THRESHOLD = 256
 _GENERATED_NAMES = frozenset(
     {
@@ -934,7 +936,7 @@ def save_reuse_package(
                     path,
                     final_sidecar,
                     final_manifest,
-                    *(final for _, final in staged_metadata.values()),
+                    *(path.parent / name for name in sorted(_OPTIONAL_PACKAGE_METADATA)),
                 ),
             )
         finally:

--- a/src/mobius/integrations/gguf/_runtime_evidence.py
+++ b/src/mobius/integrations/gguf/_runtime_evidence.py
@@ -9,6 +9,8 @@ __all__ = [
     "GGUFArtifactIdentity",
     "GGUFGraphPackageIdentity",
     "GGUFRuntimeEvidence",
+    "RuntimeEvidenceUnavailableError",
+    "find_matching_runtime_evidence",
     "gguf_artifact_identity",
     "gguf_graph_package_identity",
     "iter_runtime_evidence",
@@ -29,6 +31,10 @@ from types import MappingProxyType
 from typing import Any
 
 from mobius.integrations.gguf._reader import _descriptor_identity
+
+
+class RuntimeEvidenceUnavailableError(ValueError):
+    """An otherwise-valid package route without exact downstream runtime evidence."""
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -954,7 +960,7 @@ def validate_runtime_evidence_ids(architecture: str, evidence_ids: tuple[str, ..
         )
 
 
-def matching_runtime_evidence(
+def find_matching_runtime_evidence(
     evidence_ids: tuple[str, ...],
     *,
     architecture: str,
@@ -964,11 +970,12 @@ def matching_runtime_evidence(
     built_identity: GGUFArtifactIdentity,
     import_route: str,
     runtime_version: str | None,
-    tokenizer_repository: str,
-    tokenizer_revision: str,
-) -> GGUFRuntimeEvidence:
-    """Return exact evidence for the package source, route, and requested runtime."""
-    validate_runtime_evidence_ids(architecture, evidence_ids)
+    tokenizer_repository: str | None,
+    tokenizer_revision: str | None,
+) -> GGUFRuntimeEvidence | None:
+    """Return exact runtime evidence, while treating an absent match as unvalidated."""
+    if evidence_ids:
+        validate_runtime_evidence_ids(architecture, evidence_ids)
     current_identity = gguf_artifact_identity(
         source_path,
         gguf_model,
@@ -980,10 +987,13 @@ def matching_runtime_evidence(
             "The GGUF source no longer matches the exact artifact identity captured during "
             f"graph construction: built={built_identity!r}, current={current_identity!r}."
         )
-    if runtime_version is None:
-        raise ValueError(
-            "Runtime packaging requires the exact runtime version covered by evidence."
-        )
+    if (
+        not evidence_ids
+        or runtime_version is None
+        or tokenizer_repository is None
+        or tokenizer_revision is None
+    ):
+        return None
     identity = built_identity
     candidates = [
         _RUNTIME_EVIDENCE[evidence_id]
@@ -999,13 +1009,47 @@ def matching_runtime_evidence(
         and _RUNTIME_EVIDENCE[evidence_id].tokenizer_repository == tokenizer_repository
         and _RUNTIME_EVIDENCE[evidence_id].tokenizer_revision == tokenizer_revision
     ]
-    if len(candidates) != 1:
-        raise ValueError(
+    if len(candidates) > 1:
+        raise RuntimeError(
+            "GGUF runtime evidence contains duplicate package identities for "
+            f"architecture={architecture!r}, runtime={runtime!r} {runtime_version!r}."
+        )
+    return candidates[0] if candidates else None
+
+
+def matching_runtime_evidence(
+    evidence_ids: tuple[str, ...],
+    *,
+    architecture: str,
+    runtime: str,
+    source_path: Path,
+    gguf_model: Any,
+    built_identity: GGUFArtifactIdentity,
+    import_route: str,
+    runtime_version: str | None,
+    tokenizer_repository: str | None,
+    tokenizer_revision: str | None,
+) -> GGUFRuntimeEvidence:
+    """Return exact evidence for the package source, route, and requested runtime."""
+    match = find_matching_runtime_evidence(
+        evidence_ids,
+        architecture=architecture,
+        runtime=runtime,
+        source_path=source_path,
+        gguf_model=gguf_model,
+        built_identity=built_identity,
+        import_route=import_route,
+        runtime_version=runtime_version,
+        tokenizer_repository=tokenizer_repository,
+        tokenizer_revision=tokenizer_revision,
+    )
+    if match is None:
+        raise RuntimeEvidenceUnavailableError(
             f"No unique GGUF runtime evidence matches architecture={architecture!r}, "
-            f"runtime={runtime!r} {runtime_version!r}, artifact={identity!r}, "
+            f"runtime={runtime!r} {runtime_version!r}, artifact={built_identity!r}, "
             f"import_route={import_route!r}."
         )
-    return candidates[0]
+    return match
 
 
 def gguf_artifact_identity(

--- a/src/mobius/integrations/gguf/_runtime_evidence.py
+++ b/src/mobius/integrations/gguf/_runtime_evidence.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 __all__ = [
+    "FINAL_RUNTIME_PACKAGE_SCHEMA",
     "GGUFArtifactIdentity",
     "GGUFGraphPackageIdentity",
     "GGUFRuntimeEvidence",
@@ -31,6 +32,9 @@ from types import MappingProxyType
 from typing import Any
 
 from mobius.integrations.gguf._reader import _descriptor_identity
+
+FINAL_RUNTIME_PACKAGE_SCHEMA = "mobius.gguf-runtime-package.v2"
+LEGACY_RUNTIME_PACKAGE_SCHEMA = "legacy-without-component-export-report"
 
 
 class RuntimeEvidenceUnavailableError(ValueError):
@@ -95,6 +99,7 @@ class GGUFRuntimeEvidence:
     runtime_version: str
     result: str = "passed"
     limitations: str | None = None
+    runtime_package_schema: str = LEGACY_RUNTIME_PACKAGE_SCHEMA
 
     def __post_init__(self) -> None:
         text_fields = (
@@ -123,6 +128,7 @@ class GGUFRuntimeEvidence:
             self.runtime,
             self.runtime_version,
             self.result,
+            self.runtime_package_schema,
         )
         if any(not value.strip() for value in text_fields):
             raise ValueError("GGUF runtime evidence fields must be non-empty")
@@ -998,7 +1004,9 @@ def find_matching_runtime_evidence(
     candidates = [
         _RUNTIME_EVIDENCE[evidence_id]
         for evidence_id in evidence_ids
-        if _RUNTIME_EVIDENCE[evidence_id].runtime == runtime
+        if _RUNTIME_EVIDENCE[evidence_id].runtime_package_schema
+        == FINAL_RUNTIME_PACKAGE_SCHEMA
+        and _RUNTIME_EVIDENCE[evidence_id].runtime == runtime
         and _RUNTIME_EVIDENCE[evidence_id].runtime_version == runtime_version
         and _RUNTIME_EVIDENCE[evidence_id].filename == identity.filename
         and _RUNTIME_EVIDENCE[evidence_id].size == identity.size

--- a/src/mobius/integrations/gguf/_runtime_evidence_test.py
+++ b/src/mobius/integrations/gguf/_runtime_evidence_test.py
@@ -26,6 +26,7 @@ from mobius.integrations.gguf._runtime_blocker_evidence import (
     runtime_blocker_evidence,
 )
 from mobius.integrations.gguf._runtime_evidence import (
+    FINAL_RUNTIME_PACKAGE_SCHEMA,
     GGUFRuntimeEvidence,
     gguf_artifact_identity,
     gguf_graph_package_identity,
@@ -118,6 +119,7 @@ def _record(payload: bytes) -> GGUFRuntimeEvidence:
         onnxruntime_version="1.29.0",
         runtime="onnx-genai",
         runtime_version="1.0.0",
+        runtime_package_schema=FINAL_RUNTIME_PACKAGE_SCHEMA,
     )
 
 
@@ -135,6 +137,16 @@ def _model():
 def test_runtime_evidence_rejects_non_hex_tokenizer_metadata_digest() -> None:
     with pytest.raises(ValueError, match="immutable 40-hex revisions and LFS SHA-256"):
         replace(_record(b"pinned-gguf"), tokenizer_metadata_sha256="g" * 64)
+
+
+def test_production_runtime_evidence_requires_final_package_regeneration() -> None:
+    from mobius.integrations.gguf._runtime_evidence import iter_runtime_evidence
+
+    records = iter_runtime_evidence()
+    assert records
+    assert all(
+        record.runtime_package_schema != FINAL_RUNTIME_PACKAGE_SCHEMA for record in records
+    )
 
 
 def test_low_cost_runtime_batch_manifest_is_closed_and_within_budget() -> None:

--- a/src/mobius/integrations/gguf/_runtime_package.py
+++ b/src/mobius/integrations/gguf/_runtime_package.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Emit a runnable package from a GGUF build.
+"""Emit a validated runtime package or an accurate runtime-unvalidated model package.
 
 Saving the ONNX graph is not enough to run a model: the runtime also needs a
 tokenizer and its own configuration contract. Those come from two different
@@ -9,9 +9,10 @@ places — the tokenizer from the GGUF's embedded ggml metadata, the contract
 from the built package — so a caller that saves the graph and stops produces a
 directory that loads nowhere.
 
-This module is the single place that knows the full artifact set, so the CLI
-and the Python API cannot drift apart on what a complete package contains, and
-so both supported runtimes are reachable from one entry point.
+This module is the single place that knows the full artifact set. Exact runtime
+evidence produces a complete package. Downstream runtime, version, registry, or
+executor limitations preserve the model package with explicit unvalidated
+metadata instead of blocking export.
 """
 
 from __future__ import annotations
@@ -31,6 +32,7 @@ from typing import Any, Literal
 
 from mobius.integrations.gguf._arch_registry import get_arch_spec
 from mobius.integrations.gguf._runtime_evidence import (
+    RuntimeEvidenceUnavailableError,
     gguf_artifact_identity,
     gguf_graph_package_identity,
     matching_runtime_evidence,
@@ -335,13 +337,6 @@ def write_gguf_runtime_package(
             "GGUF runtime packaging requires the immutable source identity captured during "
             "graph construction."
         )
-    if runtime == "ort-genai" and getattr(pkg, "gguf_reuse_plan", None) is not None:
-        raise ValueError(
-            "ORT GenAI packaging is not supported with reused GGUF weights because "
-            "genai_config.json has no supported setting that disables ORT constant "
-            "folding. Use direct ONNX Runtime with ORT_DISABLE_ALL, or build without "
-            "reuse_gguf_weights."
-        )
     draft_manifest = getattr(pkg, "draft_manifest", None)
     mtp_head = getattr(pkg, "mtp_head", None)
 
@@ -377,6 +372,7 @@ def write_gguf_runtime_package(
             "refusing runtime publication."
         )
     evidence = None
+    evidence_warning: str | None = None
     if (
         tokenizer_repository is not None
         and tokenizer_revision is not None
@@ -395,14 +391,8 @@ def write_gguf_runtime_package(
                 tokenizer_repository=tokenizer_repository,
                 tokenizer_revision=tokenizer_revision,
             )
-        except ValueError as error:
-            if not (
-                str(error).startswith("No unique GGUF runtime evidence matches")
-                or str(error)
-                == "Runtime packaging requires the exact runtime version covered by evidence."
-            ):
-                raise
-            _LOGGER.warning("%s Export continues without claiming runtime validation.", error)
+        except RuntimeEvidenceUnavailableError as error:
+            evidence_warning = f"{error} Export continues without claiming runtime validation."
     if not source_model.source_matches_path():
         raise ValueError(
             "The GGUF source changed while runtime evidence was being matched; "
@@ -420,11 +410,17 @@ def write_gguf_runtime_package(
             "The GGUF tokenizer metadata no longer matches the identity captured during "
             "graph construction; refusing to pair the graph with a replaced tokenizer source."
         )
+    if getattr(built_verdict, "blocker_category", None) is not None:
+        # Exact runtime evidence cannot override a tokenizer route that the
+        # authoritative tokenizer census has explicitly withheld.
+        evidence = None
 
     output_dir.parent.mkdir(parents=True, exist_ok=True)
     stage = Path(
         tempfile.mkdtemp(prefix=f".{output_dir.name}.", suffix=".tmp", dir=output_dir.parent)
     )
+    previous_export_report = getattr(pkg, "export_report", None)
+    published = False
     try:
         artifacts: dict[str, str] = {}
         pkg.save(str(stage), **save_kwargs)
@@ -435,10 +431,17 @@ def write_gguf_runtime_package(
             )
         graph_identity = gguf_graph_package_identity(stage)
         validation_warnings: list[str] = []
+        if evidence_warning is not None:
+            validation_warnings.append(evidence_warning)
         if architecture_spec.runtime is not Support.SUPPORTED:
             validation_warnings.append(
                 f"No real-artifact runtime validation is recorded for {architecture!r}: "
                 f"{architecture_spec.reason}"
+            )
+        if runtime == "ort-genai" and getattr(pkg, "gguf_reuse_plan", None) is not None:
+            validation_warnings.append(
+                "ORT GenAI cannot disable constant folding for reused GGUF weights; "
+                "the faithful package is exported without claiming runtime validation."
             )
         if evidence is not None and (
             graph_identity.files != evidence.graph_files
@@ -449,6 +452,8 @@ def write_gguf_runtime_package(
             )
             evidence = None
 
+        tokenizer_exported = False
+        tokenizer_warning: str | None = None
         if evidence is not None:
             tokenizer_source = GGUFTokenizerSource(
                 repository=evidence.tokenizer_repository,
@@ -468,6 +473,7 @@ def write_gguf_runtime_package(
                 local_files_only=local_files_only,
             )
             artifacts["tokenizer"] = tokenizer_path
+            tokenizer_exported = True
         elif verdict.materialized:
             artifacts["tokenizer"] = write_gguf_tokenizer_json(
                 source_path,
@@ -476,11 +482,16 @@ def write_gguf_runtime_package(
                 expected_metadata_sha256=verdict.metadata_sha256,
                 source_identity=f"sha256:{built_identity.sha256}/{built_identity.filename}",
             )
+            tokenizer_exported = True
         else:
-            validation_warnings.append(
-                "No faithful tokenizer processor could be materialized from the GGUF source; "
-                "the graph and runtime metadata were still exported."
+            tokenizer_warning = (
+                f"Tokenizer route {verdict.route_identifier!r} was omitted "
+                f"({verdict.blocker_category or 'tokenizer-materialization-unvalidated'}"
+                f"{f'; evidence={verdict.evidence_id}' if verdict.evidence_id else ''}): "
+                f"{verdict.reason} Tokenizer semantics are unverified; provide and validate "
+                "a tokenizer before end-to-end use."
             )
+            validation_warnings.append(tokenizer_warning)
 
         if runtime == "ort-genai":
             from mobius.integrations.ort_genai import write_ort_genai_config
@@ -579,15 +590,64 @@ def write_gguf_runtime_package(
             else {"runtime": runtime}
         )
         existing_status = compatibility.get("runtime_validation_status")
-        if existing_status == "unsupported-by-tested-runtime":
+        if evidence is not None:
+            validation_status = "validated"
+        elif existing_status == "unsupported-by-tested-runtime":
             validation_status = existing_status
         else:
             validation_status = "unvalidated"
+        runtime_support: Literal["supported", "deferred", "blocked"]
+        blocker_category: str | None
+        runtime_reason: str | None
+        report_validation_status: Literal["validated", "unvalidated"]
         if evidence is not None:
-            validation_warnings.append(
-                "Exact graph/tokenizer evidence exists, but the emitted compatibility metadata "
-                "changes the recorded package identity; new end-to-end evidence is required."
+            runtime_support = "supported"
+            blocker_category = None
+            runtime_reason = None
+            report_validation_status = "validated"
+        elif existing_status == "unsupported-by-tested-runtime":
+            runtime_support = "blocked"
+            blocker_category = "runtime-unsupported-by-tested-runtime"
+            runtime_reason = "; ".join(validation_warnings)
+            report_validation_status = "unvalidated"
+        elif architecture_spec.runtime is Support.REJECTED:
+            runtime_support = "blocked"
+            blocker_category = "runtime-route-rejected"
+            runtime_reason = "; ".join(validation_warnings)
+            report_validation_status = "unvalidated"
+        elif architecture_spec.runtime is Support.DEFERRED:
+            runtime_support = "deferred"
+            blocker_category = "runtime-route-deferred"
+            runtime_reason = "; ".join(validation_warnings)
+            report_validation_status = "unvalidated"
+        else:
+            runtime_support = "deferred"
+            blocker_category = "runtime-validation-unavailable"
+            runtime_reason = (
+                "; ".join(validation_warnings)
+                or "No exact end-to-end runtime validation is claimed for the emitted package."
             )
+            report_validation_status = "unvalidated"
+        from mobius.integrations.gguf._component_export import (
+            attach_runtime_unvalidated_report,
+        )
+
+        attach_runtime_unvalidated_report(
+            pkg,
+            runtime,
+            blocker_category=blocker_category,
+            reason=runtime_reason,
+            evidence_id=(evidence.evidence_id if evidence is not None else None),
+            support_status=runtime_support,
+            runtime_output="exported",
+            runtime_validation_status=report_validation_status,
+            tokenizer_exported=tokenizer_exported,
+            emit_warning=False,
+        )
+        assert pkg.export_report is not None
+        export_report_path = stage / "export_report.json"
+        pkg.export_report.write_json(export_report_path)
+        artifacts["export_report"] = str(export_report_path)
         compatibility.update(
             {
                 "runtime_validation_status": validation_status,
@@ -610,8 +670,6 @@ def write_gguf_runtime_package(
             json.dumps(compatibility, indent=2) + "\n", encoding="utf-8"
         )
         artifacts["runtime_compatibility"] = str(compatibility_path)
-        for warning in validation_warnings:
-            _LOGGER.warning("%s", warning)
         if mtp_head is not None:
             runtime_payload_identity = gguf_graph_package_identity(stage)
             status_path = _write_mtp_runtime_status(
@@ -633,6 +691,13 @@ def write_gguf_runtime_package(
                 "refusing package publication."
             )
         _publish_directory_no_replace(stage, output_dir)
+        published = True
+        for warning in validation_warnings:
+            if (
+                warning != tokenizer_warning
+                or getattr(built_verdict, "blocker_category", None) is None
+            ):
+                _LOGGER.warning("%s", warning)
         return {
             name: str(output_dir / Path(path).relative_to(stage))
             for name, path in artifacts.items()
@@ -640,3 +705,5 @@ def write_gguf_runtime_package(
     finally:
         if stage.exists():
             shutil.rmtree(stage)
+        if not published:
+            pkg.export_report = previous_export_report

--- a/src/mobius/integrations/gguf/_runtime_package.py
+++ b/src/mobius/integrations/gguf/_runtime_package.py
@@ -503,9 +503,6 @@ def write_gguf_runtime_package(
 
         if runtime == "ort-genai":
             from mobius.integrations.ort_genai import write_ort_genai_config
-            from mobius.integrations.ort_genai.auto_export import (
-                _copy_tokenizer_files,
-            )
 
             execution_provider = getattr(pkg, "gguf_execution_provider", None)
             if not isinstance(execution_provider, str) or not execution_provider:
@@ -523,15 +520,6 @@ def write_gguf_runtime_package(
                     f"ORT GenAI runtime execution with provider {execution_provider!r} has not "
                     "been validated; the provider identity is preserved in genai_config.json."
                 )
-            if mtp_head is not None and evidence is None and tokenizer_repository is not None:
-                assert tokenizer_revision is not None
-                for filename in _copy_tokenizer_files(
-                    tokenizer_repository,
-                    str(stage),
-                    revision=tokenizer_revision,
-                    local_files_only=local_files_only,
-                ):
-                    artifacts[filename] = str(stage / filename)
             artifacts.update(
                 write_ort_genai_config(
                     pkg,
@@ -548,16 +536,8 @@ def write_gguf_runtime_package(
                     pkg,
                     str(stage),
                     config=getattr(pkg, "config", None),
-                    source=(
-                        tokenizer_repository
-                        if mtp_head is not None and evidence is None
-                        else None
-                    ),
-                    revision=(
-                        tokenizer_revision
-                        if mtp_head is not None and evidence is None
-                        else None
-                    ),
+                    source=None,
+                    revision=None,
                 )
             )
         if draft_manifest is not None:

--- a/src/mobius/integrations/gguf/_runtime_package.py
+++ b/src/mobius/integrations/gguf/_runtime_package.py
@@ -253,6 +253,14 @@ def _write_mtp_runtime_status(
     return str(path)
 
 
+def _runtime_package_matches_evidence(evidence: Any, identity: Any) -> bool:
+    """Whether the complete final package bytes match one runtime evidence record."""
+    return (
+        identity.files == evidence.runtime_package_files
+        and identity.sha256 == evidence.runtime_package_sha256
+    )
+
+
 def write_gguf_runtime_package(
     pkg: Any,
     gguf_path: str | Path,
@@ -423,7 +431,7 @@ def write_gguf_runtime_package(
     published = False
     try:
         artifacts: dict[str, str] = {}
-        pkg.save(str(stage), **save_kwargs)
+        pkg.save(str(stage), _atomic_export_report=False, **save_kwargs)
         if not source_model.source_matches_path():
             raise ValueError(
                 "The GGUF source changed while target/MTP graphs were being serialized; "
@@ -573,106 +581,103 @@ def write_gguf_runtime_package(
             )
             if speculator_path is not None:
                 artifacts["speculator"] = str(speculator_path)
-        runtime_identity = gguf_graph_package_identity(stage)
-        if evidence is not None and (
-            runtime_identity.files != evidence.runtime_package_files
-            or runtime_identity.sha256 != evidence.runtime_package_sha256
-        ):
-            validation_warnings.append(
-                "The completed runtime package does not match the recorded runtime-evidence "
-                "identity."
-            )
-            evidence = None
         compatibility_path = stage / "runtime_compatibility.json"
         compatibility = (
             json.loads(compatibility_path.read_text(encoding="utf-8"))
             if compatibility_path.exists()
             else {"runtime": runtime}
         )
+        compatibility_warnings = list(compatibility.get("warnings", []))
         existing_status = compatibility.get("runtime_validation_status")
-        if evidence is not None:
-            validation_status = "validated"
-        elif existing_status == "unsupported-by-tested-runtime":
-            validation_status = existing_status
-        else:
-            validation_status = "unvalidated"
-        runtime_support: Literal["supported", "deferred", "blocked"]
-        blocker_category: str | None
-        runtime_reason: str | None
-        report_validation_status: Literal["validated", "unvalidated"]
-        if evidence is not None:
-            runtime_support = "supported"
-            blocker_category = None
-            runtime_reason = None
-            report_validation_status = "validated"
-        elif existing_status == "unsupported-by-tested-runtime":
-            runtime_support = "blocked"
-            blocker_category = "runtime-unsupported-by-tested-runtime"
-            runtime_reason = "; ".join(validation_warnings)
-            report_validation_status = "unvalidated"
-        elif architecture_spec.runtime is Support.REJECTED:
-            runtime_support = "blocked"
-            blocker_category = "runtime-route-rejected"
-            runtime_reason = "; ".join(validation_warnings)
-            report_validation_status = "unvalidated"
-        elif architecture_spec.runtime is Support.DEFERRED:
-            runtime_support = "deferred"
-            blocker_category = "runtime-route-deferred"
-            runtime_reason = "; ".join(validation_warnings)
-            report_validation_status = "unvalidated"
-        else:
-            runtime_support = "deferred"
-            blocker_category = "runtime-validation-unavailable"
-            runtime_reason = (
-                "; ".join(validation_warnings)
-                or "No exact end-to-end runtime validation is claimed for the emitted package."
-            )
-            report_validation_status = "unvalidated"
         from mobius.integrations.gguf._component_export import (
             attach_runtime_unvalidated_report,
         )
 
-        attach_runtime_unvalidated_report(
-            pkg,
-            runtime,
-            blocker_category=blocker_category,
-            reason=runtime_reason,
-            evidence_id=(evidence.evidence_id if evidence is not None else None),
-            support_status=runtime_support,
-            runtime_output="exported",
-            runtime_validation_status=report_validation_status,
-            tokenizer_exported=tokenizer_exported,
-            emit_warning=False,
-        )
-        assert pkg.export_report is not None
         export_report_path = stage / "export_report.json"
-        pkg.export_report.write_json(export_report_path)
         artifacts["export_report"] = str(export_report_path)
-        compatibility.update(
-            {
-                "runtime_validation_status": validation_status,
-                "gguf_architecture": architecture,
-                "execution_provider": getattr(pkg, "gguf_execution_provider", None),
-                "gguf_graph_identity": {
-                    "files": list(graph_identity.files),
-                    "sha256": str(graph_identity.sha256),
-                },
-                "runtime_evidence_id": (
-                    evidence.evidence_id if evidence is not None else None
-                ),
-                "warnings": [
-                    *compatibility.get("warnings", []),
-                    *validation_warnings,
-                ],
-            }
-        )
-        compatibility_path.write_text(
-            json.dumps(compatibility, indent=2) + "\n", encoding="utf-8"
-        )
         artifacts["runtime_compatibility"] = str(compatibility_path)
-        if mtp_head is not None:
+
+        def write_final_metadata() -> None:
+            if evidence is not None:
+                validation_status = "validated"
+                runtime_support: Literal["supported", "deferred", "blocked"] = "supported"
+                blocker_category = None
+                runtime_reason = None
+                report_validation_status: Literal["validated", "unvalidated"] = "validated"
+            elif existing_status == "unsupported-by-tested-runtime":
+                validation_status = existing_status
+                runtime_support = "blocked"
+                blocker_category = "runtime-unsupported-by-tested-runtime"
+                runtime_reason = "; ".join(validation_warnings)
+                report_validation_status = "unvalidated"
+            elif architecture_spec.runtime is Support.REJECTED:
+                validation_status = "unvalidated"
+                runtime_support = "blocked"
+                blocker_category = "runtime-route-rejected"
+                runtime_reason = "; ".join(validation_warnings)
+                report_validation_status = "unvalidated"
+            elif architecture_spec.runtime is Support.DEFERRED:
+                validation_status = "unvalidated"
+                runtime_support = "deferred"
+                blocker_category = "runtime-route-deferred"
+                runtime_reason = "; ".join(validation_warnings)
+                report_validation_status = "unvalidated"
+            else:
+                validation_status = "unvalidated"
+                runtime_support = "deferred"
+                blocker_category = "runtime-validation-unavailable"
+                runtime_reason = (
+                    "; ".join(validation_warnings)
+                    or "No exact end-to-end runtime validation is claimed for the "
+                    "emitted package."
+                )
+                report_validation_status = "unvalidated"
+
+            attach_runtime_unvalidated_report(
+                pkg,
+                runtime,
+                blocker_category=blocker_category,
+                reason=runtime_reason,
+                evidence_id=(evidence.evidence_id if evidence is not None else None),
+                support_status=runtime_support,
+                runtime_output="exported",
+                runtime_validation_status=report_validation_status,
+                tokenizer_exported=tokenizer_exported,
+                emit_warning=False,
+            )
+            assert pkg.export_report is not None
+            pkg.export_report.write_json(export_report_path)
+            compatibility.update(
+                {
+                    "runtime_validation_status": validation_status,
+                    "gguf_architecture": architecture,
+                    "execution_provider": getattr(pkg, "gguf_execution_provider", None),
+                    "gguf_graph_identity": {
+                        "files": list(graph_identity.files),
+                        "sha256": str(graph_identity.sha256),
+                    },
+                    "runtime_evidence_id": (
+                        evidence.evidence_id if evidence is not None else None
+                    ),
+                    "warnings": [
+                        *compatibility_warnings,
+                        *validation_warnings,
+                    ],
+                }
+            )
+            compatibility_path.write_text(
+                json.dumps(compatibility, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+        def write_mtp_status() -> None:
+            if mtp_head is None:
+                return
+            status_path = stage / "mtp_runtime_status.json"
+            if status_path.exists():
+                status_path.unlink()
             runtime_payload_identity = gguf_graph_package_identity(stage)
-            status_path = _write_mtp_runtime_status(
+            artifacts["mtp_runtime_status"] = _write_mtp_runtime_status(
                 stage,
                 pkg=pkg,
                 built_identity=built_identity,
@@ -684,7 +689,20 @@ def write_gguf_runtime_package(
                 tokenizer_revision=tokenizer_revision,
                 tokenizer_metadata_sha256=verdict.metadata_sha256,
             )
-            artifacts["mtp_runtime_status"] = status_path
+
+        write_final_metadata()
+        write_mtp_status()
+        final_identity = gguf_graph_package_identity(stage)
+        if evidence is not None and not _runtime_package_matches_evidence(
+            evidence, final_identity
+        ):
+            validation_warnings.append(
+                "The final staged runtime package, including export and compatibility "
+                "metadata, does not match the recorded runtime-evidence identity."
+            )
+            evidence = None
+            write_final_metadata()
+            write_mtp_status()
         if not source_model.source_matches_path():
             raise ValueError(
                 "The GGUF source changed while runtime metadata was being written; "

--- a/src/mobius/integrations/gguf/_runtime_package_test.py
+++ b/src/mobius/integrations/gguf/_runtime_package_test.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Tests for atomic, tokenizer-gated GGUF runtime package emission."""
+"""Tests for atomic, component-aware GGUF runtime package emission."""
 
 from __future__ import annotations
 
@@ -9,12 +9,16 @@ import json
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest import mock
 
 import pytest
 
 from mobius.integrations.gguf import _runtime_package, write_gguf_runtime_package
+from mobius.integrations.gguf._component_export import attach_tokenizer_export_report
+from mobius.integrations.gguf._runtime_evidence import RuntimeEvidenceUnavailableError
 from mobius.integrations.gguf._spec import Support
+from mobius.integrations.gguf._tokenizer import GGUFTokenizerVerdict
 
 _TOKENIZER_REPOSITORY = "owner/tokenizer"
 _TOKENIZER_REVISION = "c" * 40
@@ -33,12 +37,15 @@ class _FakePackage:
         self.gguf_import_route = '{"route_schema":1}'
         self.gguf_artifact_identity = _BUILT_IDENTITY
         self.gguf_tokenizer_verdict = _materialized()
+        self.export_report: Any = None
         self.saved_to: str | None = None
 
     def save(self, path, **kwargs):
         self.saved_to = path
         Path(path).mkdir(parents=True, exist_ok=True)
         (Path(path) / "model.onnx").write_bytes(b"stub")
+        if self.export_report is not None:
+            self.export_report.write_json(Path(path) / "export_report.json")
 
     def __iter__(self):
         return iter(("model",))
@@ -47,6 +54,7 @@ class _FakePackage:
 def _materialized():
     return SimpleNamespace(
         materialized=True,
+        route_identifier="embedded",
         reason="exact embedded tokenizer",
         metadata_sha256="f" * 64,
     )
@@ -109,6 +117,14 @@ def _successful_runtime_dependencies(runtime: str = "onnx-genai"):
         ),
     ):
         yield
+
+
+def _source_model():
+    return SimpleNamespace(
+        metadata={},
+        architecture="llama",
+        source_matches_path=lambda: True,
+    )
 
 
 def _write_runtime(pkg, source, output, **kwargs):
@@ -276,7 +292,7 @@ class TestWriteGgufRuntimePackage:
             ),
             mock.patch(
                 "mobius.integrations.gguf._runtime_package.matching_runtime_evidence",
-                side_effect=ValueError(
+                side_effect=RuntimeEvidenceUnavailableError(
                     "No unique GGUF runtime evidence matches architecture='llama'"
                 ),
             ),
@@ -286,6 +302,11 @@ class TestWriteGgufRuntimePackage:
         compatibility = json.loads((out / "runtime_compatibility.json").read_text())
         assert compatibility["runtime_validation_status"] == "unvalidated"
         assert "independent parity is missing" in compatibility["warnings"][0]
+        assert pkg.export_report is not None
+        runtime_component = pkg.export_report.component("runtime")
+        assert runtime_component is not None
+        assert runtime_component.output == "exported"
+        assert runtime_component.support == "deferred"
 
     def test_atomically_emits_graph_tokenizer_and_runtime_config(self, tmp_path):
         pkg = _FakePackage()
@@ -294,9 +315,7 @@ class TestWriteGgufRuntimePackage:
             mock.patch(
                 "mobius.integrations.gguf._runtime_package.open_gguf_model",
                 return_value=SimpleNamespace(
-                    metadata={},
-                    architecture="llama",
-                    source_matches_path=lambda: True,
+                    **vars(_source_model()),
                 ),
             ),
             mock.patch(
@@ -320,7 +339,60 @@ class TestWriteGgufRuntimePackage:
         compatibility = json.loads((out / "runtime_compatibility.json").read_text())
         assert compatibility["runtime_validation_status"] == "unvalidated"
         assert "completed runtime package" in compatibility["warnings"][-1]
+        assert pkg.export_report is not None
+        assert pkg.export_report.component("runtime").output == "exported"
+        assert pkg.export_report.component("tokenizer").output == "exported"
+        assert (out / "export_report.json").is_file()
         assert not list(tmp_path.glob(".out.*.tmp"))
+
+    def test_exact_runtime_evidence_marks_package_validated(self, tmp_path):
+        pkg = _FakePackage()
+        out = tmp_path / "out"
+        evidence = SimpleNamespace(
+            evidence_id="test-evidence",
+            graph_files=("model.onnx",),
+            graph_sha256="b" * 64,
+            runtime_package_files=(
+                "inference_metadata.yaml",
+                "model.onnx",
+                "tokenizer.json",
+            ),
+            runtime_package_sha256="c" * 64,
+            tokenizer_repository=_TOKENIZER_REPOSITORY,
+            tokenizer_revision=_TOKENIZER_REVISION,
+            tokenizer_metadata_sha256="f" * 64,
+            tokenizer_assets=(("tokenizer.json", 2, "a" * 64),),
+        )
+        with (
+            _successful_runtime_dependencies(),
+            mock.patch(
+                "mobius.integrations.gguf._runtime_package.matching_runtime_evidence",
+                return_value=evidence,
+            ),
+            mock.patch(
+                "mobius.integrations.gguf._runtime_package.gguf_graph_package_identity",
+                side_effect=(
+                    SimpleNamespace(files=evidence.graph_files, sha256=evidence.graph_sha256),
+                    SimpleNamespace(
+                        files=evidence.runtime_package_files,
+                        sha256=evidence.runtime_package_sha256,
+                    ),
+                ),
+            ),
+        ):
+            _write_runtime(pkg, tmp_path / "m.gguf", out, runtime_version="0.15.2")
+
+        assert pkg.export_report is not None
+        assert pkg.export_report.export_status == "complete"
+        assert pkg.export_report.runtime_validation_status == "validated"
+        assert pkg.export_report.end_to_end_runnable is True
+        runtime_component = pkg.export_report.component("runtime")
+        assert runtime_component is not None
+        assert runtime_component.support == "supported"
+        assert runtime_component.runtime_validation_status == "validated"
+        compatibility = json.loads((out / "runtime_compatibility.json").read_text())
+        assert compatibility["runtime_validation_status"] == "validated"
+        assert compatibility["runtime_evidence_id"] == "test-evidence"
 
     def test_missing_evidence_runtime_version_does_not_block_export(self, tmp_path):
         pkg = _FakePackage()
@@ -328,7 +400,7 @@ class TestWriteGgufRuntimePackage:
         with (
             mock.patch(
                 "mobius.integrations.gguf._runtime_package.matching_runtime_evidence",
-                side_effect=ValueError(
+                side_effect=RuntimeEvidenceUnavailableError(
                     "Runtime packaging requires the exact runtime version covered by evidence."
                 ),
             ),
@@ -348,9 +420,7 @@ class TestWriteGgufRuntimePackage:
             mock.patch(
                 "mobius.integrations.gguf._runtime_package.open_gguf_model",
                 return_value=SimpleNamespace(
-                    metadata={},
-                    architecture="llama",
-                    source_matches_path=lambda: True,
+                    **vars(_source_model()),
                 ),
             ),
             mock.patch(
@@ -387,9 +457,7 @@ class TestWriteGgufRuntimePackage:
             mock.patch(
                 "mobius.integrations.gguf._runtime_package.open_gguf_model",
                 return_value=SimpleNamespace(
-                    metadata={},
-                    architecture="llama",
-                    source_matches_path=lambda: True,
+                    **vars(_source_model()),
                 ),
             ),
             mock.patch(
@@ -444,6 +512,43 @@ class TestWriteGgufRuntimePackage:
                 tokenizer_revision="main",
             )
         read_source.assert_not_called()
+
+    def test_tokenizer_blocker_omits_only_tokenizer_assets(self, tmp_path, caplog):
+        pkg = _FakePackage()
+        blocker = GGUFTokenizerVerdict(
+            route="deferred",
+            model="gpt2",
+            pre="blocked-pre",
+            canonical_pre="blocked-pre",
+            token_count=2,
+            metadata_sha256="f" * 64,
+            blocker_category="semantic-mismatch",
+            audit_status="deferred-pinned-artifact-mismatch",
+            reason="recorded tokenizer mismatch",
+            evidence_id="blocker-evidence",
+        )
+        out = tmp_path / "out"
+        with (
+            caplog.at_level("WARNING"),
+            _successful_runtime_dependencies(),
+            mock.patch(
+                "mobius.integrations.gguf._runtime_package.inspect_gguf_tokenizer",
+                return_value=blocker,
+            ),
+        ):
+            pkg.gguf_tokenizer_verdict = blocker
+            attach_tokenizer_export_report(pkg, blocker, model_route="llama")
+            artifacts = _write_runtime(pkg, tmp_path / "m.gguf", out)
+
+        assert (out / "model.onnx").is_file()
+        assert Path(artifacts["export_report"]).is_file()
+        assert pkg.export_report.component("tokenizer").output == "omitted"
+        runtime_component = pkg.export_report.component("runtime")
+        assert runtime_component.output == "exported"
+        assert runtime_component.support == "deferred"
+        assert not (out / "tokenizer.json").exists()
+        assert (out / "inference_metadata.yaml").is_file()
+        assert caplog.text.count("GGUF PARTIAL EXPORT WARNING:") == 1
 
     def test_replaced_source_tokenizer_rejects_before_save_or_output(self, tmp_path):
         pkg = _FakePackage()
@@ -521,17 +626,26 @@ class TestWriteGgufRuntimePackage:
             "sentinel.bin": b"unchanged"
         }
 
-    def test_ort_genai_rejects_reused_gguf_weights(self, tmp_path):
+    def test_ort_genai_exports_reused_weights_as_runtime_unvalidated(self, tmp_path, caplog):
         pkg = _FakePackage()
         pkg.gguf_reuse_plan = object()
-        with pytest.raises(ValueError, match="no supported setting"):
-            _write_runtime(
+        out = tmp_path / "out"
+        with (
+            _successful_runtime_dependencies("ort-genai"),
+            caplog.at_level("WARNING"),
+        ):
+            artifacts = _write_runtime(
                 pkg,
                 tmp_path / "m.gguf",
-                tmp_path / "out",
+                out,
                 runtime="ort-genai",
             )
-        assert not (tmp_path / "out").exists()
+        assert (out / "model.onnx").is_file()
+        assert Path(artifacts["export_report"]).is_file()
+        runtime_component = pkg.export_report.component("runtime")
+        assert runtime_component.output == "exported"
+        assert "cannot disable constant folding" in runtime_component.reason
+        assert "cannot disable constant folding" in caplog.text
 
     def test_unknown_execution_provider_is_preserved_as_advisory(self, tmp_path):
         pkg = _FakePackage()

--- a/src/mobius/integrations/gguf/_runtime_package_test.py
+++ b/src/mobius/integrations/gguf/_runtime_package_test.py
@@ -177,6 +177,59 @@ def _runtime_supported():
 
 
 class TestWriteGgufRuntimePackage:
+    def test_runtime_disposition_is_replaced_when_runtime_changes(self):
+        from mobius.integrations.gguf._component_export import (
+            attach_runtime_unvalidated_report,
+        )
+
+        pkg = _FakePackage()
+        attach_runtime_unvalidated_report(
+            pkg,
+            "onnx-genai",
+            blocker_category="first-category",
+            reason="first reason",
+            tokenizer_exported=True,
+            emit_warning=False,
+        )
+        attach_runtime_unvalidated_report(
+            pkg,
+            "ort-genai",
+            blocker_category="second-category",
+            reason="second reason",
+            tokenizer_exported=True,
+            emit_warning=False,
+        )
+
+        runtime = pkg.export_report.component("runtime")
+        assert runtime.route == "ort-genai"
+        assert runtime.blocker_category == "second-category"
+        assert runtime.reason == "second reason"
+
+    def test_every_runtime_evidence_record_rejects_final_package_mutation(self):
+        from mobius.integrations.gguf._runtime_evidence import iter_runtime_evidence
+
+        for evidence in iter_runtime_evidence():
+            exact = SimpleNamespace(
+                files=evidence.runtime_package_files,
+                sha256=evidence.runtime_package_sha256,
+            )
+            mutated_hash = SimpleNamespace(
+                files=evidence.runtime_package_files,
+                sha256="0" * 64,
+            )
+            mutated_files = SimpleNamespace(
+                files=(*evidence.runtime_package_files, "unexpected.json"),
+                sha256=evidence.runtime_package_sha256,
+            )
+
+            assert _runtime_package._runtime_package_matches_evidence(evidence, exact)
+            assert not _runtime_package._runtime_package_matches_evidence(
+                evidence, mutated_hash
+            )
+            assert not _runtime_package._runtime_package_matches_evidence(
+                evidence, mutated_files
+            )
+
     def test_atomic_publication_refuses_concurrent_destination(self, tmp_path):
         stage = tmp_path / "stage"
         stage.mkdir()
@@ -338,7 +391,7 @@ class TestWriteGgufRuntimePackage:
         assert Path(artifacts["inference_metadata"]) == out / "inference_metadata.yaml"
         compatibility = json.loads((out / "runtime_compatibility.json").read_text())
         assert compatibility["runtime_validation_status"] == "unvalidated"
-        assert "completed runtime package" in compatibility["warnings"][-1]
+        assert "final staged runtime package" in compatibility["warnings"][-1]
         assert pkg.export_report is not None
         assert pkg.export_report.component("runtime").output == "exported"
         assert pkg.export_report.component("tokenizer").output == "exported"

--- a/src/mobius/integrations/gguf/_runtime_package_test.py
+++ b/src/mobius/integrations/gguf/_runtime_package_test.py
@@ -805,6 +805,18 @@ class TestWriteGgufRuntimePackage:
     def test_onnx_runtime_emits_unvalidated_mtp_without_artifact_allowlist(self, tmp_path):
         pkg = _FakePackage()
         pkg.mtp_head = SimpleNamespace(config=object())
+        deferred_tokenizer = GGUFTokenizerVerdict(
+            route="deferred",
+            model="llama",
+            pre=None,
+            canonical_pre=None,
+            reason="tokenizer pipeline is incomplete",
+            token_count=0,
+            metadata_sha256="f" * 64,
+            audit_status="deferred-incomplete-pipeline",
+            blocker_category="serialized-tokenizer-pipeline-incomplete",
+        )
+        pkg.gguf_tokenizer_verdict = deferred_tokenizer
         out = tmp_path / "out"
 
         def write_status(stage, **_kwargs):
@@ -836,19 +848,19 @@ class TestWriteGgufRuntimePackage:
             ),
             mock.patch(
                 "mobius.integrations.gguf._runtime_package.inspect_gguf_tokenizer",
-                return_value=_materialized(),
+                return_value=deferred_tokenizer,
             ),
             mock.patch(
                 "mobius.integrations.gguf._runtime_package.write_gguf_tokenizer_json",
                 side_effect=_write_tokenizer,
-            ),
+            ) as write_tokenizer,
             mock.patch(
                 "mobius.integrations.gguf._runtime_package.matching_runtime_evidence"
             ) as match_evidence,
             mock.patch(
                 "mobius.integrations.onnx_genai.write_onnx_genai_config",
                 side_effect=_write_config,
-            ),
+            ) as write_config,
             mock.patch(
                 "mobius._model_package._read_mtp_sidecar_name",
                 return_value=".mobius-mtp",
@@ -872,7 +884,11 @@ class TestWriteGgufRuntimePackage:
                 runtime_version="1.29.0",
             )
         match_evidence.assert_not_called()
+        write_tokenizer.assert_not_called()
+        assert write_config.call_args.kwargs["source"] is None
+        assert write_config.call_args.kwargs["revision"] is None
         assert out.is_dir()
+        assert not (out / "tokenizer.json").exists()
         assert artifacts["mtp_runtime_status"] == str(out / "mtp_runtime_status.json")
 
     def test_mtp_source_change_during_serialization_publishes_nothing(self, tmp_path):

--- a/src/mobius/integrations/gguf/_tokenizer.py
+++ b/src/mobius/integrations/gguf/_tokenizer.py
@@ -444,6 +444,44 @@ def _incomplete_tokenizer_verdict(
     )
 
 
+def _unsupported_tokenizer_fields(metadata: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return tokenizer fields outside the pinned loader/converter closure."""
+    known = LOADER_CONSUMED_TOKENIZER_FIELDS | CONVERTER_OR_EXTENSION_TOKENIZER_FIELDS
+    return tuple(
+        sorted(
+            key
+            for key in metadata
+            if key.startswith("tokenizer.")
+            and key not in known
+            and not key.startswith("tokenizer.chat_template.")
+        )
+    )
+
+
+def _unsupported_fields_verdict(
+    *,
+    metadata: Mapping[str, Any],
+    model: str | None,
+    pre: str | None,
+    canonical_pre: str | None,
+    token_count: int,
+    unsupported: tuple[str, ...],
+) -> GGUFTokenizerVerdict:
+    """Defer tokenizer publication when serialized semantics are outside closure."""
+    return GGUFTokenizerVerdict(
+        "deferred",
+        model,
+        pre,
+        canonical_pre,
+        f"unsupported tokenizer metadata fields are outside the pinned loader/converter "
+        f"closure: {list(unsupported)}",
+        token_count,
+        metadata_sha256=_tokenizer_metadata_sha256(metadata),
+        audit_status="deferred-unsupported-metadata-fields",
+        blocker_category="unsupported-tokenizer-metadata-fields",
+    )
+
+
 def _validate_incomplete_tokenizer_fields(
     metadata: Mapping[str, Any],
     *,
@@ -573,11 +611,6 @@ def _validate_incomplete_tokenizer_fields(
         type(value) is not int or value < -128 or value > 255 for value in charsmap
     ):
         raise ValueError("tokenizer.ggml.precompiled_charsmap must contain byte values")
-    if "tokenizer.ggml.byte_fallback" in metadata:
-        raise ValueError(
-            "tokenizer.ggml.byte_fallback is not a pinned GGUF key; byte-fallback semantics "
-            "cannot be inferred from it"
-        )
     _validate_chat_templates(metadata)
     return len(tokens)
 
@@ -607,6 +640,16 @@ def inspect_gguf_tokenizer(
                 source=source,
                 model=None,
             )
+            unsupported = _unsupported_tokenizer_fields(metadata)
+            if unsupported:
+                return _unsupported_fields_verdict(
+                    metadata=metadata,
+                    model=None,
+                    pre=metadata.get("tokenizer.ggml.pre"),
+                    canonical_pre=None,
+                    token_count=token_count,
+                    unsupported=unsupported,
+                )
             return _incomplete_tokenizer_verdict(
                 model=None,
                 reason=(
@@ -627,6 +670,18 @@ def inspect_gguf_tokenizer(
                 source=source,
                 model=model,
             )
+            unsupported = _unsupported_tokenizer_fields(metadata)
+            if unsupported:
+                pre = metadata.get("tokenizer.ggml.pre")
+                policy = tokenizer_pre_policies().get(pre) if isinstance(pre, str) else None
+                return _unsupported_fields_verdict(
+                    metadata=metadata,
+                    model=model,
+                    pre=pre,
+                    canonical_pre=policy.canonical if policy else None,
+                    token_count=token_count,
+                    unsupported=unsupported,
+                )
             return _incomplete_tokenizer_verdict(
                 model=model,
                 reason=f"{source} contains no complete tokenizer token table",
@@ -740,18 +795,30 @@ def inspect_gguf_tokenizer(
         type(value) is not int or value < -128 or value > 255 for value in charsmap
     ):
         raise ValueError("tokenizer.ggml.precompiled_charsmap must contain byte values")
-    if "tokenizer.ggml.byte_fallback" in metadata:
-        raise ValueError(
-            "tokenizer.ggml.byte_fallback is not a pinned GGUF key; byte-fallback semantics "
-            "cannot be inferred from it"
-        )
     _validate_chat_templates(metadata)
 
+    rwkv_world = metadata.get("tokenizer.rwkv.world")
+    if rwkv_world is not None and not isinstance(rwkv_world, str):
+        raise ValueError("tokenizer.rwkv.world must be a string")
     embedded = metadata.get("tokenizer.huggingface.json")
+    embedded_digest = None
     if embedded is not None:
         if not isinstance(embedded, str):
             raise ValueError("tokenizer.huggingface.json must be a string")
-        digest = _validate_embedded_tokenizer_json(embedded, tokens)
+        embedded_digest = _validate_embedded_tokenizer_json(embedded, tokens)
+
+    unsupported = _unsupported_tokenizer_fields(metadata)
+    if unsupported:
+        return _unsupported_fields_verdict(
+            metadata=metadata,
+            model=model,
+            pre=pre_value,
+            canonical_pre=policy.canonical if policy else None,
+            token_count=len(tokens),
+            unsupported=unsupported,
+        )
+
+    if embedded_digest is not None:
         return GGUFTokenizerVerdict(
             "copy",
             model,
@@ -760,7 +827,7 @@ def inspect_gguf_tokenizer(
             "embedded tokenizers JSON is copied verbatim and its ordered vocabulary "
             "matches GGUF; pipeline execution is delegated to that artifact",
             len(tokens),
-            digest,
+            embedded_digest,
             _tokenizer_metadata_sha256(metadata),
         )
 

--- a/src/mobius/integrations/gguf/_tokenizer.py
+++ b/src/mobius/integrations/gguf/_tokenizer.py
@@ -444,6 +444,144 @@ def _incomplete_tokenizer_verdict(
     )
 
 
+def _validate_incomplete_tokenizer_fields(
+    metadata: Mapping[str, Any],
+    *,
+    source: str,
+    model: str | None,
+) -> int:
+    """Validate every serialized field before downgrading an incomplete pipeline."""
+    tokens_raw = _require_list(metadata, "tokenizer.ggml.tokens")
+    tokens = list(tokens_raw or ())
+    if any(not isinstance(token, str) for token in tokens):
+        raise ValueError(f"{source} tokenizer.ggml.tokens must contain only UTF-8 strings")
+    if len(set(tokens)) != len(tokens):
+        raise ValueError(f"{source} tokenizer.ggml.tokens contains duplicate token strings")
+
+    pre = metadata.get("tokenizer.ggml.pre")
+    if pre is not None:
+        if not isinstance(pre, str) or not pre:
+            raise ValueError("tokenizer.ggml.pre must be a non-empty string")
+        if pre not in tokenizer_pre_policies():
+            raise ValueError(f"{source} declares unknown tokenizer.ggml.pre {pre!r}")
+        if model is not None and model not in _BPE_MODELS:
+            architecture = metadata.get("general.architecture")
+            legacy_default = pre == "default" and (
+                model == "plamo2"
+                or (
+                    model == "llama"
+                    and isinstance(architecture, str)
+                    and architecture in {"minicpm", "minicpm3"}
+                )
+            )
+            if not legacy_default:
+                raise ValueError(
+                    f"{source} declares tokenizer.ggml.pre for non-BPE model {model!r}; "
+                    "the pinned loader does not consume that combination"
+                )
+
+    rwkv_world = metadata.get("tokenizer.rwkv.world")
+    if rwkv_world is not None and not isinstance(rwkv_world, str):
+        raise ValueError("tokenizer.rwkv.world must be a string")
+
+    embedded = metadata.get("tokenizer.huggingface.json")
+    if embedded is not None:
+        if not isinstance(embedded, str):
+            raise ValueError("tokenizer.huggingface.json must be a string")
+        if tokens:
+            _validate_embedded_tokenizer_json(embedded, tokens)
+        else:
+            try:
+                payload = json.loads(embedded)
+            except json.JSONDecodeError as error:
+                raise ValueError("tokenizer.huggingface.json is not valid JSON") from error
+            if not isinstance(payload, dict):
+                raise TypeError("tokenizer.huggingface.json must contain a JSON object")
+            try:
+                from tokenizers import Tokenizer
+
+                Tokenizer.from_str(embedded)
+            except Exception as error:
+                raise ValueError(
+                    "tokenizer.huggingface.json is not a loadable tokenizers tokenizer"
+                ) from error
+
+    token_types = _require_list(metadata, "tokenizer.ggml.token_type")
+    if token_types is not None:
+        if len(token_types) != len(tokens):
+            raise ValueError(
+                "tokenizer.ggml.token_type length must equal tokenizer token count"
+            )
+        if any(type(value) is not int or value not in range(7) for value in token_types):
+            raise ValueError("tokenizer.ggml.token_type values must be integers in [0, 6]")
+
+    scores = _require_list(metadata, "tokenizer.ggml.scores")
+    if scores is not None:
+        if len(scores) != len(tokens):
+            raise ValueError("tokenizer.ggml.scores length must equal tokenizer token count")
+        if any(
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(float(value))
+            for value in scores
+        ):
+            raise ValueError("tokenizer.ggml.scores must contain finite numeric values")
+
+    merges = _require_list(metadata, "tokenizer.ggml.merges")
+    if merges is not None:
+        pairs: list[tuple[str, str]] = []
+        vocabulary = set(tokens)
+        for index, merge in enumerate(merges):
+            if not isinstance(merge, str):
+                raise TypeError(f"tokenizer.ggml.merges[{index}] must be a string")
+            separator = merge.find(" ", 1)
+            if separator < 0:
+                raise ValueError(f"tokenizer.ggml.merges[{index}] has no valid pair separator")
+            pair = (merge[:separator], merge[separator + 1 :])
+            if not all(pair) or pair[0] not in vocabulary or pair[1] not in vocabulary:
+                raise ValueError(
+                    f"tokenizer.ggml.merges[{index}] references a token outside the vocabulary"
+                )
+            pairs.append(pair)
+        if len(set(pairs)) != len(pairs):
+            raise ValueError("tokenizer.ggml.merges contains duplicate merge pairs")
+
+    for key in _SPECIAL_ID_KEYS:
+        value = metadata.get(key)
+        if value is not None and (
+            type(value) is not int or value < 0 or (tokens and value >= len(tokens))
+        ):
+            upper_bound = str(len(tokens)) if tokens else "the serialized token count"
+            raise ValueError(f"{key} must be an integer in [0, {upper_bound})")
+    for key in _BOOL_KEYS:
+        value = metadata.get(key)
+        if value is not None and type(value) is not bool:
+            raise ValueError(f"{key} must be a boolean")
+
+    type_count = metadata.get("tokenizer.ggml.token_type_count")
+    if type_count is not None and (type(type_count) is not int or type_count <= 0):
+        raise ValueError("tokenizer.ggml.token_type_count must be a positive integer")
+    suppress = _require_list(metadata, "tokenizer.ggml.suppress_tokens")
+    if suppress is not None and any(
+        type(value) is not int or value < 0 or value >= len(tokens) for value in suppress
+    ):
+        raise ValueError("tokenizer.ggml.suppress_tokens contains an out-of-range token id")
+    if suppress is not None and len(set(suppress)) != len(suppress):
+        raise ValueError("tokenizer.ggml.suppress_tokens contains duplicate token ids")
+    charsmap = _require_list(metadata, "tokenizer.ggml.precompiled_charsmap")
+    if charsmap is not None and any(
+        type(value) is not int or value < -128 or value > 255 for value in charsmap
+    ):
+        raise ValueError("tokenizer.ggml.precompiled_charsmap must contain byte values")
+    if "tokenizer.ggml.byte_fallback" in metadata:
+        raise ValueError(
+            "tokenizer.ggml.byte_fallback is not a pinned GGUF key; byte-fallback semantics "
+            "cannot be inferred from it"
+        )
+    _validate_chat_templates(metadata)
+    return len(tokens)
+
+
 def inspect_gguf_tokenizer(
     metadata: Mapping[str, Any],
     *,
@@ -460,15 +598,22 @@ def inspect_gguf_tokenizer(
         )
 
     model = metadata.get("tokenizer.ggml.model")
-    if not isinstance(model, str) or not model:
+    if model is not None and (not isinstance(model, str) or not model):
+        raise ValueError(f"{source} tokenizer.ggml.model must be a non-empty string")
+    if model is None:
         if not require_complete:
+            token_count = _validate_incomplete_tokenizer_fields(
+                metadata,
+                source=source,
+                model=None,
+            )
             return _incomplete_tokenizer_verdict(
                 model=None,
                 reason=(
                     f"{source} contains partial tokenizer metadata without "
                     "tokenizer.ggml.model"
                 ),
-                token_count=len(metadata.get("tokenizer.ggml.tokens", ())),
+                token_count=token_count,
             )
         raise ValueError(f"{source} tokenizer.ggml.model must be a non-empty string")
     if model not in _KNOWN_MODELS:
@@ -477,10 +622,15 @@ def inspect_gguf_tokenizer(
     tokens_raw = _require_list(metadata, "tokenizer.ggml.tokens")
     if not tokens_raw:
         if not require_complete:
+            token_count = _validate_incomplete_tokenizer_fields(
+                metadata,
+                source=source,
+                model=model,
+            )
             return _incomplete_tokenizer_verdict(
                 model=model,
                 reason=f"{source} contains no complete tokenizer token table",
-                token_count=0,
+                token_count=token_count,
             )
         raise ValueError(f"{source} tokenizer.ggml.tokens must be a non-empty string array")
     if any(not isinstance(token, str) for token in tokens_raw):

--- a/src/mobius/integrations/gguf/_tokenizer.py
+++ b/src/mobius/integrations/gguf/_tokenizer.py
@@ -586,9 +586,14 @@ def _validate_incomplete_tokenizer_fields(
 
     for key in _SPECIAL_ID_KEYS:
         value = metadata.get(key)
-        if value is not None and (
-            type(value) is not int or value < 0 or (tokens and value >= len(tokens))
-        ):
+        if value is not None and (type(value) is not int or value < 0):
+            raise ValueError(f"{key} must be a non-negative integer")
+        if value is not None and tokens and value >= len(tokens):
+            raise ValueError(f"{key} must be an integer in [0, {len(tokens)})")
+        tokenless_diffusion_mask = key == "tokenizer.ggml.mask_token_id" and metadata.get(
+            "general.architecture"
+        ) in {"dream", "llada", "llada-moe", "rnd1"}
+        if value is not None and not tokens and not tokenless_diffusion_mask:
             upper_bound = str(len(tokens)) if tokens else "the serialized token count"
             raise ValueError(f"{key} must be an integer in [0, {upper_bound})")
     for key in _BOOL_KEYS:

--- a/src/mobius/integrations/gguf/_tokenizer.py
+++ b/src/mobius/integrations/gguf/_tokenizer.py
@@ -221,10 +221,18 @@ class GGUFTokenizerVerdict:
     token_count: int
     tokenizer_sha256: str | None = None
     metadata_sha256: str | None = None
+    audit_status: str | None = None
+    blocker_category: str | None = None
+    evidence_id: str | None = None
 
     @property
     def materialized(self) -> bool:
         return self.route in {"copy", "pinned-source"}
+
+    @property
+    def route_identifier(self) -> str:
+        """Exact serialized route discriminator used for diagnostics."""
+        return self.pre or self.model or "absent"
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -383,6 +391,38 @@ def _tokenizer_metadata_sha256(metadata: Mapping[str, Any]) -> str:
         sort_keys=True,
     )
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _deferred_route_diagnostics(
+    pre: str | None,
+    *,
+    reason: str,
+) -> tuple[str | None, str | None, str | None, str]:
+    """Resolve stable authoritative diagnostics for a deferred tokenizer route."""
+    if pre is None:
+        return (
+            "deferred-incomplete-pipeline",
+            "serialized-tokenizer-pipeline-incomplete",
+            None,
+            reason,
+        )
+
+    # Imported lazily because the census evidence records depend on the tokenizer
+    # source dataclasses defined in this module.
+    from mobius.integrations.gguf._tokenizer_census import tokenizer_route_census
+
+    audit = next(
+        (record for record in tokenizer_route_census() if record.identifier == pre),
+        None,
+    )
+    if audit is None or audit.current_status == "validated-pinned-source":
+        return None, None, None, reason
+    return (
+        audit.current_status,
+        audit.blocker_category,
+        audit.blocker_evidence_id or audit.evidence_id,
+        audit.candidate_disposition or reason,
+    )
 
 
 def inspect_gguf_tokenizer(
@@ -566,14 +606,22 @@ def inspect_gguf_tokenizer(
         if pre_value is not None
         else f"model {model!r} omits the complete tokenizer pipeline"
     )
+    reason = f"{detail}; exact ORT tokenizer materialization is unavailable"
+    audit_status, blocker_category, evidence_id, reason = _deferred_route_diagnostics(
+        pre_value,
+        reason=reason,
+    )
     return GGUFTokenizerVerdict(
         "deferred",
         model,
         pre_value,
         policy.canonical if policy else None,
-        f"{detail}; exact ORT tokenizer materialization is unavailable",
+        reason,
         len(tokens),
         metadata_sha256=_tokenizer_metadata_sha256(metadata),
+        audit_status=audit_status,
+        blocker_category=blocker_category,
+        evidence_id=evidence_id,
     )
 
 

--- a/src/mobius/integrations/gguf/_tokenizer.py
+++ b/src/mobius/integrations/gguf/_tokenizer.py
@@ -425,6 +425,25 @@ def _deferred_route_diagnostics(
     )
 
 
+def _incomplete_tokenizer_verdict(
+    *,
+    model: str | None,
+    reason: str,
+    token_count: int,
+) -> GGUFTokenizerVerdict:
+    """Return an authoritative deferred verdict for incomplete serialized metadata."""
+    return GGUFTokenizerVerdict(
+        "deferred",
+        model,
+        None,
+        None,
+        reason,
+        token_count,
+        audit_status="deferred-incomplete-pipeline",
+        blocker_category="serialized-tokenizer-pipeline-incomplete",
+    )
+
+
 def inspect_gguf_tokenizer(
     metadata: Mapping[str, Any],
     *,
@@ -434,25 +453,22 @@ def inspect_gguf_tokenizer(
     """Validate embedded tokenizer metadata and return an exact route verdict."""
     tokenizer_keys = [key for key in metadata if key.startswith("tokenizer.")]
     if not tokenizer_keys:
-        return GGUFTokenizerVerdict(
-            "deferred",
-            None,
-            None,
-            None,
-            f"{source} contains no tokenizer metadata",
-            0,
+        return _incomplete_tokenizer_verdict(
+            model=None,
+            reason=f"{source} contains no tokenizer metadata",
+            token_count=0,
         )
 
     model = metadata.get("tokenizer.ggml.model")
     if not isinstance(model, str) or not model:
         if not require_complete:
-            return GGUFTokenizerVerdict(
-                "deferred",
-                None,
-                None,
-                None,
-                f"{source} contains partial tokenizer metadata without tokenizer.ggml.model",
-                len(metadata.get("tokenizer.ggml.tokens", ())),
+            return _incomplete_tokenizer_verdict(
+                model=None,
+                reason=(
+                    f"{source} contains partial tokenizer metadata without "
+                    "tokenizer.ggml.model"
+                ),
+                token_count=len(metadata.get("tokenizer.ggml.tokens", ())),
             )
         raise ValueError(f"{source} tokenizer.ggml.model must be a non-empty string")
     if model not in _KNOWN_MODELS:
@@ -461,13 +477,10 @@ def inspect_gguf_tokenizer(
     tokens_raw = _require_list(metadata, "tokenizer.ggml.tokens")
     if not tokens_raw:
         if not require_complete:
-            return GGUFTokenizerVerdict(
-                "deferred",
-                model,
-                None,
-                None,
-                f"{source} contains no complete tokenizer token table",
-                0,
+            return _incomplete_tokenizer_verdict(
+                model=model,
+                reason=f"{source} contains no complete tokenizer token table",
+                token_count=0,
             )
         raise ValueError(f"{source} tokenizer.ggml.tokens must be a non-empty string array")
     if any(not isinstance(token, str) for token in tokens_raw):

--- a/src/mobius/integrations/gguf/_tokenizer_evidence.py
+++ b/src/mobius/integrations/gguf/_tokenizer_evidence.py
@@ -10,6 +10,7 @@ __all__ = [
     "GGUFTokenizerEvidence",
     "iter_tokenizer_blocker_evidence",
     "iter_tokenizer_evidence",
+    "matching_tokenizer_blocker_evidence",
     "matching_tokenizer_evidence",
     "tokenizer_blocker_evidence",
     "tokenizer_evidence",
@@ -2307,6 +2308,90 @@ def iter_tokenizer_blocker_evidence() -> tuple[GGUFTokenizerBlockerEvidence, ...
     )
 
 
+def _sequence_digest(metadata: dict[str, Any], key: str) -> tuple[int, str]:
+    values = metadata.get(key)
+    if not isinstance(values, list):
+        return 0, ""
+    payload = json.dumps(values, ensure_ascii=False, separators=(",", ":")).encode()
+    return len(values), hashlib.sha256(payload).hexdigest()
+
+
+def _matching_tokenizer_blockers(
+    identity: Any,
+    gguf_model: Any,
+    *,
+    metadata_sha256: str | None,
+) -> list[GGUFTokenizerBlockerEvidence]:
+    metadata = gguf_model.metadata
+    token_count, vocabulary_sha256 = _sequence_digest(metadata, "tokenizer.ggml.tokens")
+    merge_count, merges_sha256 = _sequence_digest(metadata, "tokenizer.ggml.merges")
+    score_count, scores_sha256 = _sequence_digest(metadata, "tokenizer.ggml.scores")
+    token_type_count, token_types_sha256 = _sequence_digest(
+        metadata, "tokenizer.ggml.token_type"
+    )
+    return [
+        evidence
+        for evidence in _TOKENIZER_BLOCKER_EVIDENCE.values()
+        if evidence.architecture == gguf_model.architecture
+        and evidence.pre_identifier == metadata.get("tokenizer.ggml.pre")
+        and evidence.tokenizer_model == metadata.get("tokenizer.ggml.model")
+        and evidence.filename == identity.filename
+        and evidence.size == identity.size
+        and evidence.lfs_sha256 == identity.sha256
+        and evidence.tensor_count == identity.tensor_count
+        and evidence.tensor_qtypes == identity.tensor_qtypes
+        and evidence.tokenizer_metadata_sha256 == metadata_sha256
+        and evidence.token_count == token_count
+        and evidence.ordered_vocabulary_sha256 == vocabulary_sha256
+        and evidence.merge_count == merge_count
+        and evidence.ordered_merges_sha256 == (merges_sha256 or None)
+        and evidence.score_count == score_count
+        and evidence.ordered_scores_sha256 == (scores_sha256 or None)
+        and evidence.token_count == token_type_count
+        and evidence.ordered_token_types_sha256 == token_types_sha256
+        and gguf_model.get_tensor_shape("token_embd.weight")[0]
+        == evidence.embedding_vocabulary_size
+    ]
+
+
+def matching_tokenizer_blocker_evidence(
+    source_path: Path,
+    gguf_model: Any,
+    *,
+    metadata_sha256: str | None,
+    artifact_identity: Any | None = None,
+) -> GGUFTokenizerBlockerEvidence | None:
+    """Return an exact authoritative tokenizer blocker for one artifact, if any."""
+    metadata = gguf_model.metadata
+    candidates = [
+        evidence
+        for evidence in _TOKENIZER_BLOCKER_EVIDENCE.values()
+        if evidence.architecture == gguf_model.architecture
+        and evidence.pre_identifier == metadata.get("tokenizer.ggml.pre")
+        and evidence.tokenizer_model == metadata.get("tokenizer.ggml.model")
+        and evidence.tokenizer_metadata_sha256 == metadata_sha256
+    ]
+    if not candidates:
+        return None
+    identity = artifact_identity
+    if identity is None:
+        identity = gguf_artifact_identity(
+            source_path,
+            gguf_model,
+            architecture=gguf_model.architecture,
+        )
+    blockers = _matching_tokenizer_blockers(
+        identity,
+        gguf_model,
+        metadata_sha256=metadata_sha256,
+    )
+    if len(blockers) == 1:
+        return blockers[0]
+    if blockers:
+        raise RuntimeError("Tokenizer blocker evidence contains duplicate artifact identities")
+    return None
+
+
 def matching_tokenizer_evidence(
     source_path: Path,
     gguf_model: Any,
@@ -2322,17 +2407,12 @@ def matching_tokenizer_evidence(
     )
     metadata = gguf_model.metadata
 
-    def sequence_digest(key: str) -> tuple[int, str]:
-        values = metadata.get(key)
-        if not isinstance(values, list):
-            return 0, ""
-        payload = json.dumps(values, ensure_ascii=False, separators=(",", ":")).encode()
-        return len(values), hashlib.sha256(payload).hexdigest()
-
-    token_count, vocabulary_sha256 = sequence_digest("tokenizer.ggml.tokens")
-    merge_count, merges_sha256 = sequence_digest("tokenizer.ggml.merges")
-    score_count, scores_sha256 = sequence_digest("tokenizer.ggml.scores")
-    token_type_count, token_types_sha256 = sequence_digest("tokenizer.ggml.token_type")
+    token_count, vocabulary_sha256 = _sequence_digest(metadata, "tokenizer.ggml.tokens")
+    merge_count, merges_sha256 = _sequence_digest(metadata, "tokenizer.ggml.merges")
+    score_count, scores_sha256 = _sequence_digest(metadata, "tokenizer.ggml.scores")
+    token_type_count, token_types_sha256 = _sequence_digest(
+        metadata, "tokenizer.ggml.token_type"
+    )
     token_types = metadata.get("tokenizer.ggml.token_type")
     effective_pre = metadata.get("tokenizer.ggml.pre")
     if effective_pre is None and metadata.get("tokenizer.ggml.model") == "gemma4":
@@ -2373,29 +2453,11 @@ def matching_tokenizer_evidence(
             for token, token_id in evidence.user_defined_token_ids
         )
     ]
-    blockers = [
-        evidence
-        for evidence in _TOKENIZER_BLOCKER_EVIDENCE.values()
-        if evidence.architecture == architecture
-        and evidence.pre_identifier == metadata.get("tokenizer.ggml.pre")
-        and evidence.tokenizer_model == metadata.get("tokenizer.ggml.model")
-        and evidence.filename == identity.filename
-        and evidence.size == identity.size
-        and evidence.lfs_sha256 == identity.sha256
-        and evidence.tensor_count == identity.tensor_count
-        and evidence.tensor_qtypes == identity.tensor_qtypes
-        and evidence.tokenizer_metadata_sha256 == metadata_sha256
-        and evidence.token_count == token_count
-        and evidence.ordered_vocabulary_sha256 == vocabulary_sha256
-        and evidence.merge_count == merge_count
-        and evidence.ordered_merges_sha256 == (merges_sha256 or None)
-        and evidence.score_count == score_count
-        and evidence.ordered_scores_sha256 == (scores_sha256 or None)
-        and evidence.token_count == token_type_count
-        and evidence.ordered_token_types_sha256 == token_types_sha256
-        and gguf_model.get_tensor_shape("token_embd.weight")[0]
-        == evidence.embedding_vocabulary_size
-    ]
+    blockers = _matching_tokenizer_blockers(
+        identity,
+        gguf_model,
+        metadata_sha256=metadata_sha256,
+    )
     if len(blockers) == 1:
         blocker = blockers[0]
         raise ValueError(

--- a/src/mobius/integrations/gguf/_tokenizer_evidence_test.py
+++ b/src/mobius/integrations/gguf/_tokenizer_evidence_test.py
@@ -24,6 +24,7 @@ from mobius.integrations.gguf._tokenizer_census import tokenizer_route_census
 from mobius.integrations.gguf._tokenizer_evidence import (
     iter_tokenizer_blocker_evidence,
     iter_tokenizer_evidence,
+    matching_tokenizer_blocker_evidence,
     matching_tokenizer_evidence,
     tokenizer_blocker_evidence,
     tokenizer_evidence,
@@ -798,6 +799,14 @@ def test_matching_plm_blocker_reports_exact_normalizer_mismatch(tmp_path, monkey
         get_tensor_shape=lambda _name: (2, 4),
     )
 
+    assert (
+        matching_tokenizer_blocker_evidence(
+            tmp_path / "tiny.gguf",
+            model,
+            metadata_sha256=tiny.tokenizer_metadata_sha256,
+        )
+        is tiny
+    )
     with pytest.raises(ValueError, match=r"explicitly blocked.*NFC normalization"):
         matching_tokenizer_evidence(
             tmp_path / "tiny.gguf",

--- a/src/mobius/integrations/gguf/_tokenizer_test.py
+++ b/src/mobius/integrations/gguf/_tokenizer_test.py
@@ -184,6 +184,36 @@ class TestTokenizerPreCensus:
 
 
 class TestInspectGgufTokenizer:
+    @pytest.mark.parametrize(
+        ("metadata", "route", "reason"),
+        [
+            ({}, "absent", "contains no tokenizer metadata"),
+            (
+                {"tokenizer.ggml.tokens": ["token"]},
+                "absent",
+                "without tokenizer.ggml.model",
+            ),
+            (
+                {"tokenizer.ggml.model": "llama"},
+                "llama",
+                "no complete tokenizer token table",
+            ),
+        ],
+    )
+    def test_incomplete_metadata_has_authoritative_deferred_diagnostics(
+        self,
+        metadata: dict,
+        route: str,
+        reason: str,
+    ) -> None:
+        verdict = inspect_gguf_tokenizer(metadata)
+
+        assert verdict.route == "deferred"
+        assert verdict.route_identifier == route
+        assert verdict.audit_status == "deferred-incomplete-pipeline"
+        assert verdict.blocker_category == "serialized-tokenizer-pipeline-incomplete"
+        assert reason in verdict.reason
+
     def test_known_pre_without_complete_pipeline_is_deferred(self):
         verdict = inspect_gguf_tokenizer(_metadata(pre="hunyuan-dense"))
         assert verdict.route == "deferred"

--- a/src/mobius/integrations/gguf/_tokenizer_test.py
+++ b/src/mobius/integrations/gguf/_tokenizer_test.py
@@ -16,6 +16,7 @@ import pytest
 
 from mobius.integrations.gguf import _tokenizer
 from mobius.integrations.gguf._tokenizer import (
+    LOADER_CONSUMED_TOKENIZER_FIELDS,
     GGUFTokenizerAsset,
     GGUFTokenizerSource,
     inspect_gguf_tokenizer,
@@ -295,6 +296,90 @@ class TestInspectGgufTokenizer:
         with pytest.raises((TypeError, ValueError), match=message):
             inspect_gguf_tokenizer(metadata)
 
+    @pytest.mark.parametrize(
+        "metadata",
+        [
+            {"tokenizer.ggml.future_semantics": "opaque"},
+            {
+                "tokenizer.ggml.model": "llama",
+                "tokenizer.ggml.future_semantics": "opaque",
+            },
+            {
+                "tokenizer.ggml.model": "llama",
+                "tokenizer.chat_templates.tool": "near-miss",
+            },
+            {
+                "tokenizer.ggml.model": "llama",
+                "tokenizer.ggml.byte_fallback": True,
+            },
+        ],
+    )
+    def test_incomplete_unknown_fields_are_authoritatively_deferred(
+        self, metadata: dict
+    ) -> None:
+        verdict = inspect_gguf_tokenizer(metadata)
+
+        assert verdict.route == "deferred"
+        assert verdict.audit_status == "deferred-unsupported-metadata-fields"
+        assert verdict.blocker_category == "unsupported-tokenizer-metadata-fields"
+        assert "outside the pinned loader/converter closure" in verdict.reason
+        assert next(
+            key for key in metadata if key not in LOADER_CONSUMED_TOKENIZER_FIELDS
+        ) in (verdict.reason)
+
+    def test_complete_unknown_field_prevents_embedded_tokenizer_copy(self) -> None:
+        metadata = _metadata(embedded=True)
+        metadata["tokenizer.ggml.future_semantics"] = "opaque"
+
+        verdict = inspect_gguf_tokenizer(metadata)
+
+        assert verdict.route == "deferred"
+        assert verdict.blocker_category == "unsupported-tokenizer-metadata-fields"
+        assert verdict.tokenizer_sha256 is None
+        assert "tokenizer.ggml.future_semantics" in verdict.reason
+
+    @pytest.mark.parametrize(
+        "field",
+        ["tokenizer.ggml.byte_fallback", "tokenizer.ggml.future_semantics"],
+    )
+    def test_complete_unknown_semantic_field_is_deferred(self, field: str) -> None:
+        metadata = _metadata()
+        metadata[field] = True
+
+        verdict = inspect_gguf_tokenizer(metadata)
+
+        assert verdict.blocker_category == "unsupported-tokenizer-metadata-fields"
+        assert field in verdict.reason
+
+    @pytest.mark.parametrize(
+        ("field", "value", "message"),
+        [
+            ("tokenizer.huggingface.json", 42, "must be a string"),
+            ("tokenizer.rwkv.world", 42, "must be a string"),
+        ],
+    )
+    def test_malformed_known_extension_stays_fatal_with_unknown_field(
+        self, field: str, value: object, message: str
+    ) -> None:
+        metadata = _metadata()
+        metadata["tokenizer.ggml.future_semantics"] = "opaque"
+        metadata[field] = value
+
+        with pytest.raises(ValueError, match=message):
+            inspect_gguf_tokenizer(metadata)
+
+    @pytest.mark.parametrize("complete", [False, True])
+    def test_named_chat_template_namespace_is_inside_field_closure(
+        self, complete: bool
+    ) -> None:
+        metadata = _metadata(embedded=True) if complete else {"tokenizer.ggml.model": "llama"}
+        metadata["tokenizer.chat_template.tool_use"] = "tool-template"
+
+        verdict = inspect_gguf_tokenizer(metadata)
+
+        assert verdict.blocker_category != "unsupported-tokenizer-metadata-fields"
+        assert verdict.route == ("copy" if complete else "deferred")
+
     def test_known_pre_without_complete_pipeline_is_deferred(self):
         verdict = inspect_gguf_tokenizer(_metadata(pre="hunyuan-dense"))
         assert verdict.route == "deferred"
@@ -422,10 +507,6 @@ class TestInspectGgufTokenizer:
                     "tokenizer.ggml.precompiled_charsmap", [0, 256]
                 ),
                 "byte values",
-            ),
-            (
-                lambda value: value.__setitem__("tokenizer.ggml.byte_fallback", True),
-                "not a pinned GGUF key",
             ),
             (
                 lambda value: value.__setitem__("tokenizer.ggml.suppress_tokens", [0, 0]),

--- a/src/mobius/integrations/gguf/_tokenizer_test.py
+++ b/src/mobius/integrations/gguf/_tokenizer_test.py
@@ -214,6 +214,87 @@ class TestInspectGgufTokenizer:
         assert verdict.blocker_category == "serialized-tokenizer-pipeline-incomplete"
         assert reason in verdict.reason
 
+    @pytest.mark.parametrize(
+        ("metadata", "message"),
+        [
+            (
+                {"tokenizer.ggml.tokens": ["duplicate", "duplicate"]},
+                "duplicate token strings",
+            ),
+            (
+                {"tokenizer.ggml.tokens": ["valid", 1]},
+                "contain only UTF-8 strings",
+            ),
+            (
+                {
+                    "tokenizer.ggml.model": "llama",
+                    "tokenizer.ggml.token_type": [7],
+                },
+                "token_type length",
+            ),
+            (
+                {
+                    "tokenizer.ggml.model": "llama",
+                    "tokenizer.chat_templates": ["missing"],
+                },
+                "does not exactly match",
+            ),
+            (
+                {
+                    "tokenizer.ggml.model": 1,
+                    "tokenizer.ggml.tokens": ["valid"],
+                },
+                "must be a non-empty string",
+            ),
+            (
+                {
+                    "tokenizer.ggml.model": "llama",
+                    "tokenizer.ggml.pre": 1,
+                },
+                "pre must be a non-empty string",
+            ),
+            (
+                {
+                    "tokenizer.ggml.tokens": [],
+                    "tokenizer.huggingface.json": 42,
+                },
+                "tokenizer.huggingface.json must be a string",
+            ),
+            (
+                {
+                    "tokenizer.ggml.model": "llama",
+                    "tokenizer.huggingface.json": "{",
+                },
+                "not valid JSON",
+            ),
+            (
+                {
+                    "tokenizer.ggml.model": "llama",
+                    "tokenizer.ggml.eos_token_id": -1,
+                },
+                "eos_token_id must be an integer",
+            ),
+            (
+                {
+                    "tokenizer.ggml.model": "llama",
+                    "tokenizer.ggml.pre": "hunyuan-dense",
+                },
+                "pre for non-BPE model",
+            ),
+            (
+                {"tokenizer.rwkv.world": 42},
+                "tokenizer.rwkv.world must be a string",
+            ),
+        ],
+    )
+    def test_incomplete_pipeline_does_not_downgrade_present_field_corruption(
+        self,
+        metadata: dict,
+        message: str,
+    ) -> None:
+        with pytest.raises((TypeError, ValueError), match=message):
+            inspect_gguf_tokenizer(metadata)
+
     def test_known_pre_without_complete_pipeline_is_deferred(self):
         verdict = inspect_gguf_tokenizer(_metadata(pre="hunyuan-dense"))
         assert verdict.route == "deferred"

--- a/src/mobius/integrations/gguf/_tokenizer_test.py
+++ b/src/mobius/integrations/gguf/_tokenizer_test.py
@@ -21,6 +21,7 @@ from mobius.integrations.gguf._tokenizer import (
     inspect_gguf_tokenizer,
     materialize_gguf_tokenizer,
 )
+from mobius.integrations.gguf._tokenizer_census import tokenizer_route_census
 from mobius.integrations.gguf._tokenizer_registry import tokenizer_pre_policies
 
 _PINNED_PRE_IDENTIFIERS = (
@@ -188,6 +189,40 @@ class TestInspectGgufTokenizer:
         assert verdict.route == "deferred"
         assert verdict.pre == "hunyuan-dense"
         assert "compiled llama.cpp behavior" in verdict.reason
+        assert verdict.audit_status == "deferred-compiled-semantics"
+        assert verdict.blocker_category == "compiled-llama.cpp-semantic-dependency"
+
+    @pytest.mark.parametrize(
+        "identifier",
+        [
+            "bailingmoe",
+            "bailingmoe2",
+            "llada-moe",
+            "chatglm-bpe",
+            "glm4",
+            "cohere2moe",
+            "tiny_aya",
+        ],
+    )
+    def test_known_alias_blocker_uses_exact_authoritative_evidence(
+        self, identifier: str
+    ) -> None:
+        audit = next(
+            record for record in tokenizer_route_census() if record.identifier == identifier
+        )
+        verdict = inspect_gguf_tokenizer(_metadata(pre=identifier))
+
+        assert verdict.audit_status == "deferred-pinned-artifact-mismatch"
+        assert verdict.blocker_category == "pinned-candidate-source-semantic-mismatch"
+        assert verdict.evidence_id == audit.blocker_evidence_id
+        assert verdict.reason == audit.candidate_disposition
+
+    def test_validated_route_is_not_mislabeled_as_supported_tokenizer_output(self) -> None:
+        verdict = inspect_gguf_tokenizer(_metadata(pre="gpt-2"))
+
+        assert verdict.route == "deferred"
+        assert verdict.blocker_category is None
+        assert verdict.evidence_id is None
 
     def test_plamo2_legacy_default_pre_is_validated_but_deferred(self):
         metadata = _metadata(pre="default")

--- a/src/mobius/integrations/gguf/_tokenizer_test.py
+++ b/src/mobius/integrations/gguf/_tokenizer_test.py
@@ -273,7 +273,21 @@ class TestInspectGgufTokenizer:
                     "tokenizer.ggml.model": "llama",
                     "tokenizer.ggml.eos_token_id": -1,
                 },
+                "eos_token_id must be a non-negative integer",
+            ),
+            (
+                {
+                    "tokenizer.ggml.model": "llama",
+                    "tokenizer.ggml.eos_token_id": 999,
+                },
                 "eos_token_id must be an integer",
+            ),
+            (
+                {
+                    "tokenizer.ggml.model": "llama",
+                    "tokenizer.ggml.mask_token_id": 999,
+                },
+                "mask_token_id must be an integer",
             ),
             (
                 {
@@ -326,6 +340,20 @@ class TestInspectGgufTokenizer:
         assert next(
             key for key in metadata if key not in LOADER_CONSUMED_TOKENIZER_FIELDS
         ) in (verdict.reason)
+
+    def test_tokenless_diffusion_mask_id_is_left_to_graph_contract_validation(
+        self,
+    ) -> None:
+        verdict = inspect_gguf_tokenizer(
+            {
+                "general.architecture": "dream",
+                "tokenizer.ggml.model": "llama",
+                "tokenizer.ggml.mask_token_id": 999,
+            }
+        )
+
+        assert verdict.route == "deferred"
+        assert verdict.blocker_category == "serialized-tokenizer-pipeline-incomplete"
 
     def test_complete_unknown_field_prevents_embedded_tokenizer_copy(self) -> None:
         metadata = _metadata(embedded=True)

--- a/tests/gguf_test.py
+++ b/tests/gguf_test.py
@@ -574,6 +574,33 @@ class TestCLIBuildGGUF:
             "gguf_tokenizer_manifest.json",
         }.intersection(path.name for path in first.iterdir())
 
+    def test_missing_tokenizer_metadata_exports_model_with_one_structured_warning(
+        self, tmp_path, caplog
+    ):
+        from mobius.integrations.gguf import build_from_gguf
+
+        path = _create_tiny_gguf(tmp_path / "no-tokenizer.gguf")
+        with caplog.at_level("WARNING", logger="mobius.integrations.gguf._component_export"):
+            package = build_from_gguf(path, keep_quantized=False)
+
+        tokenizer = package.export_report.component("tokenizer")
+        assert tokenizer.route == "absent"
+        assert tokenizer.support == "deferred"
+        assert tokenizer.output == "omitted"
+        assert tokenizer.blocker_category == "serialized-tokenizer-pipeline-incomplete"
+        assert tokenizer.reason.endswith("contains no tokenizer metadata")
+        assert "semantics are unverified" in tokenizer.remediation
+        warnings = [
+            record.getMessage()
+            for record in caplog.records
+            if record.getMessage().startswith("GGUF PARTIAL EXPORT WARNING:")
+        ]
+        assert len(warnings) == 1
+        warning = json.loads(warnings[0].partition(": ")[2])
+        assert warning["route"] == "absent"
+        assert warning["blocker_category"] == ("serialized-tokenizer-pipeline-incomplete")
+        assert warning["reason"].endswith("contains no tokenizer metadata")
+
     def test_unexpected_tokenizer_disposition_error_still_fails(
         self, tmp_path, monkeypatch, caplog
     ):

--- a/tests/gguf_test.py
+++ b/tests/gguf_test.py
@@ -38,6 +38,7 @@ def _create_tiny_gguf(
     ffn_size: int | None = None,
     float_type: str = "f32",
     tokenizer_pre: str | None = None,
+    unknown_tokenizer_field: bool = False,
 ) -> str:
     """Create a minimal GGUF file with fp32 weights for testing.
 
@@ -62,6 +63,8 @@ def _create_tiny_gguf(
         writer.add_string("tokenizer.ggml.pre", tokenizer_pre)
         writer.add_token_list(tokens)
         writer.add_token_merges([f"{tokens[0]} {tokens[1]}"])
+    if unknown_tokenizer_field:
+        writer.add_string("tokenizer.ggml.future_semantics", "opaque")
 
     # Tensors — unquantized random weights
     rng = np.random.default_rng(42)
@@ -656,6 +659,24 @@ class TestCLIBuildGGUF:
         assert warning["route"] == "absent"
         assert warning["blocker_category"] == ("serialized-tokenizer-pipeline-incomplete")
         assert warning["reason"].endswith("contains no tokenizer metadata")
+
+    def test_unknown_tokenizer_field_exports_model_with_explicit_diagnostics(
+        self, tmp_path, caplog
+    ):
+        from mobius.integrations.gguf import build_from_gguf
+
+        path = _create_tiny_gguf(
+            tmp_path / "unknown-tokenizer-field.gguf",
+            unknown_tokenizer_field=True,
+        )
+        with caplog.at_level("WARNING", logger="mobius.integrations.gguf._component_export"):
+            package = build_from_gguf(path, keep_quantized=False)
+
+        tokenizer = package.export_report.component("tokenizer")
+        assert tokenizer.blocker_category == "unsupported-tokenizer-metadata-fields"
+        assert tokenizer.output == "omitted"
+        assert "tokenizer.ggml.future_semantics" in tokenizer.reason
+        assert caplog.text.count("GGUF PARTIAL EXPORT WARNING:") == 1
 
     def test_unexpected_tokenizer_disposition_error_still_fails(
         self, tmp_path, monkeypatch, caplog

--- a/tests/gguf_test.py
+++ b/tests/gguf_test.py
@@ -9,6 +9,9 @@ test the full pipeline without network downloads.
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 import numpy as np
@@ -34,6 +37,7 @@ def _create_tiny_gguf(
     vocab: int = 256,
     ffn_size: int | None = None,
     float_type: str = "f32",
+    tokenizer_pre: str | None = None,
 ) -> str:
     """Create a minimal GGUF file with fp32 weights for testing.
 
@@ -52,6 +56,12 @@ def _create_tiny_gguf(
     writer.add_context_length(128)
     writer.add_feed_forward_length(ffn_size)
     writer.add_vocab_size(vocab)
+    if tokenizer_pre is not None:
+        tokens = [f"token-{index}" for index in range(vocab)]
+        writer.add_tokenizer_model("gpt2")
+        writer.add_string("tokenizer.ggml.pre", tokenizer_pre)
+        writer.add_token_list(tokens)
+        writer.add_token_merges([f"{tokens[0]} {tokens[1]}"])
 
     # Tensors — unquantized random weights
     rng = np.random.default_rng(42)
@@ -503,6 +513,284 @@ class TestCLIBuildGGUF:
         assert "MatMulNBits" not in op_types
         assert "BlockQuantizedMatMul" not in op_types
 
+    def test_authoritative_tokenizer_blocker_exports_partial_model_package(
+        self, tmp_path, caplog
+    ):
+        from mobius._model_package import ModelPackage
+        from mobius.integrations.gguf import build_from_gguf
+        from mobius.integrations.gguf._tokenizer_census import tokenizer_route_census
+
+        path = _create_tiny_gguf(
+            tmp_path / "blocked-tokenizer.gguf",
+            tokenizer_pre="bailingmoe2",
+        )
+        with caplog.at_level("WARNING", logger="mobius.integrations.gguf._component_export"):
+            package = build_from_gguf(path, keep_quantized=False)
+
+        assert "model" in package
+        assert package.export_report is not None
+        assert package.export_report.status == "partial"
+        assert package.export_report.runtime_validation_status == "unvalidated"
+        tokenizer = package.export_report.component("tokenizer")
+        assert tokenizer is not None
+        audit = next(
+            record for record in tokenizer_route_census() if record.identifier == "bailingmoe2"
+        )
+        assert tokenizer.route == "bailingmoe2"
+        assert tokenizer.support == "blocked"
+        assert tokenizer.output == "omitted"
+        assert tokenizer.blocker_category == audit.blocker_category
+        assert tokenizer.evidence_id == audit.blocker_evidence_id
+        assert tokenizer.reason == audit.candidate_disposition
+        assert "semantics are unverified" in tokenizer.remediation
+
+        warnings = [
+            record.getMessage()
+            for record in caplog.records
+            if record.getMessage().startswith("GGUF PARTIAL EXPORT WARNING:")
+        ]
+        assert len(warnings) == 1
+        warning = json.loads(warnings[0].partition(": ")[2])
+        assert warning["route"] == "bailingmoe2"
+        assert warning["blocker_category"] == audit.blocker_category
+        assert warning["evidence_id"] == audit.blocker_evidence_id
+        assert warning["reason"] == audit.candidate_disposition
+        assert "not end-to-end runnable" in warning["impact"]
+        assert "Provide and validate a tokenizer" in warning["remediation"]
+
+        first = tmp_path / "partial-a"
+        second = tmp_path / "partial-b"
+        package.save(first, progress_bar=False)
+        package.save(second, progress_bar=False)
+        assert (first / "model.onnx").is_file()
+        assert (first / "export_report.json").read_bytes() == (
+            second / "export_report.json"
+        ).read_bytes()
+        assert ModelPackage.load(first).export_report == package.export_report
+        assert not {
+            "tokenizer.json",
+            "tokenizer_config.json",
+            "special_tokens_map.json",
+            "gguf_tokenizer_manifest.json",
+        }.intersection(path.name for path in first.iterdir())
+
+    def test_unexpected_tokenizer_disposition_error_still_fails(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        from mobius.integrations.gguf import build_from_gguf
+
+        path = _create_tiny_gguf(
+            tmp_path / "unexpected-tokenizer.gguf",
+            tokenizer_pre="bailingmoe",
+        )
+
+        def unexpected(*_args, **_kwargs):
+            raise RuntimeError("unexpected tokenizer evidence failure")
+
+        monkeypatch.setattr(
+            "mobius.integrations.gguf._tokenizer_evidence.matching_tokenizer_blocker_evidence",
+            unexpected,
+        )
+        with pytest.raises(RuntimeError, match="unexpected tokenizer evidence failure"):
+            build_from_gguf(path, keep_quantized=False)
+        assert "GGUF PARTIAL EXPORT WARNING" not in caplog.text
+
+    def test_model_route_blocker_remains_a_hard_failure(self, tmp_path, caplog):
+        from mobius.integrations.gguf import build_from_gguf
+        from mobius.integrations.gguf._errors import UnsupportedGGUFArchitectureError
+
+        path = _create_tiny_gguf(
+            tmp_path / "unsupported-model.gguf",
+            arch="future-model",
+            tokenizer_pre="bailingmoe",
+        )
+
+        with pytest.raises(UnsupportedGGUFArchitectureError):
+            build_from_gguf(path, keep_quantized=False)
+        assert "GGUF PARTIAL EXPORT WARNING" not in caplog.text
+
+    def test_exact_artifact_blocker_overrides_a_validated_route(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        from mobius.integrations.gguf import build_from_gguf
+        from mobius.integrations.gguf._tokenizer_evidence import tokenizer_blocker_evidence
+
+        blocker = tokenizer_blocker_evidence("plm-1.8b-instruct-q4-k-m-tokenizer-blocker")
+        assert blocker is not None
+        path = _create_tiny_gguf(
+            tmp_path / "exact-artifact-blocker.gguf",
+            tokenizer_pre="qwen2",
+        )
+        monkeypatch.setattr(
+            "mobius.integrations.gguf._tokenizer_evidence.matching_tokenizer_blocker_evidence",
+            lambda *_args, **_kwargs: blocker,
+        )
+
+        with caplog.at_level("WARNING", logger="mobius.integrations.gguf._component_export"):
+            package = build_from_gguf(path, keep_quantized=False)
+
+        tokenizer = package.export_report.component("tokenizer")
+        assert tokenizer.route == "qwen2"
+        assert tokenizer.evidence_id == blocker.evidence_id
+        assert tokenizer.reason == blocker.disposition
+        assert caplog.text.count("GGUF PARTIAL EXPORT WARNING:") == 1
+
+    def test_multimodal_route_records_identity_and_exact_tokenizer_blocker(
+        self, tmp_path, monkeypatch
+    ):
+        from mobius.integrations.gguf import build_from_gguf
+        from mobius.integrations.gguf._tokenizer import GGUFTokenizerVerdict
+        from mobius.integrations.gguf._tokenizer_evidence import tokenizer_blocker_evidence
+
+        blocker = tokenizer_blocker_evidence("plm-1.8b-instruct-q4-k-m-tokenizer-blocker")
+        assert blocker is not None
+        package = mock.MagicMock()
+        package.__iter__.return_value = iter(("model", "vision"))
+        package.config = SimpleNamespace(model_type="test-vlm")
+        package.gguf_source_path = str(tmp_path / "text.gguf")
+        package.gguf_tokenizer_verdict = GGUFTokenizerVerdict(
+            route="deferred",
+            model="gpt2",
+            pre="qwen2",
+            canonical_pre="qwen2",
+            reason="base deferred reason",
+            token_count=2,
+            metadata_sha256="a" * 64,
+        )
+        package.export_report = None
+        text_model = SimpleNamespace(
+            architecture="llama",
+            metadata={},
+            source_identity=(1, 2, 3),
+            source_matches_path=lambda: True,
+        )
+        monkeypatch.setattr(
+            "mobius.integrations.gguf._mmproj.build_vlm_from_gguf",
+            lambda *_args, **_kwargs: package,
+        )
+        monkeypatch.setattr(
+            "mobius.integrations.gguf._tokenizer_evidence.matching_tokenizer_blocker_evidence",
+            lambda *_args, **_kwargs: blocker,
+        )
+
+        result = build_from_gguf(
+            "text.gguf",
+            mmproj="vision.gguf",
+            _gguf_model=text_model,
+        )
+
+        assert result is package
+        assert package.gguf_architecture == "llama"
+        assert package.gguf_execution_provider == "default"
+        assert package.gguf_source_filename == "text.gguf"
+        route = json.loads(package.gguf_import_route)
+        assert route["components"] == ["model", "vision"]
+        assert route["multimodal_projector"] is True
+        tokenizer = package.export_report.component("tokenizer")
+        assert tokenizer.evidence_id == blocker.evidence_id
+        assert tokenizer.reason == blocker.disposition
+
+    def test_validated_tokenizer_route_preserves_existing_graph_package_files(
+        self, tmp_path, caplog
+    ):
+        from mobius.integrations.gguf import build_from_gguf
+
+        path = _create_tiny_gguf(
+            tmp_path / "validated-tokenizer.gguf",
+            tokenizer_pre="gpt-2",
+        )
+        package = build_from_gguf(path, keep_quantized=False)
+        output = tmp_path / "validated-output"
+        package.save(output, progress_bar=False)
+
+        assert package.export_report is None
+        assert not (output / "export_report.json").exists()
+        assert "GGUF PARTIAL EXPORT WARNING" not in caplog.text
+
+    def test_cli_runtime_request_preserves_model_for_tokenizer_blocker(
+        self, tmp_path, caplog, capsys
+    ):
+        from mobius.__main__ import main
+        from mobius._model_package import ModelPackage
+
+        path = _create_tiny_gguf(
+            tmp_path / "runtime-blocked-tokenizer.gguf",
+            tokenizer_pre="cohere2moe",
+        )
+        output = tmp_path / "runtime-partial"
+        with caplog.at_level("WARNING", logger="mobius.integrations.gguf._component_export"):
+            main(
+                [
+                    "build-gguf",
+                    path,
+                    "--output",
+                    str(output),
+                    "--dequantize",
+                    "--runtime",
+                    "ort-genai",
+                ]
+            )
+
+        stdout = capsys.readouterr().out
+        package = ModelPackage.load(output)
+        assert (output / "model.onnx").is_file()
+        assert (output / "export_report.json").is_file()
+        assert package.export_report is not None
+        assert package.export_report.component("runtime").output == "exported"
+        assert "Export status: PARTIAL" in stdout
+        assert "requested runtime: ort-genai (unvalidated)" in stdout
+        assert "omitted components: tokenizer" in stdout
+        assert caplog.text.count("GGUF PARTIAL EXPORT WARNING:") == 1
+        assert (output / "genai_config.json").is_file()
+        assert not (output / "tokenizer.json").exists()
+        assert not list(tmp_path.glob(".runtime-partial.*.tmp"))
+
+    def test_cli_unmatched_runtime_version_exports_unvalidated_model(
+        self, tmp_path, caplog, capsys
+    ):
+        from mobius.__main__ import main
+        from mobius._model_package import ModelPackage
+
+        path = _create_tiny_gguf(
+            tmp_path / "runtime-unvalidated.gguf",
+            tokenizer_pre="gpt-2",
+        )
+        output = tmp_path / "runtime-unvalidated"
+        with caplog.at_level("WARNING", logger="mobius.integrations.gguf._component_export"):
+            main(
+                [
+                    "build-gguf",
+                    path,
+                    "--output",
+                    str(output),
+                    "--dequantize",
+                    "--runtime",
+                    "ort-genai",
+                    "--runtime-version",
+                    "99.0",
+                    "--tokenizer-repository",
+                    "owner/tokenizer",
+                    "--tokenizer-revision",
+                    "a" * 40,
+                ]
+            )
+
+        stdout = capsys.readouterr().out
+        package = ModelPackage.load(output)
+        assert (output / "model.onnx").is_file()
+        assert package.export_report is not None
+        assert package.export_report.export_status == "partial"
+        assert package.export_report.runtime_validation_status == "unvalidated"
+        runtime_component = package.export_report.component("runtime")
+        assert runtime_component.blocker_category == "runtime-validation-unavailable"
+        assert runtime_component.output == "exported"
+        assert "Export status: PARTIAL" in stdout
+        assert "Runtime validation: UNVALIDATED" in stdout
+        assert "requested runtime: ort-genai (unvalidated)" in stdout
+        assert (output / "genai_config.json").is_file()
+        assert (output / "runtime_compatibility.json").is_file()
+        assert not (output / "tokenizer.json").exists()
+
     @pytest.mark.parametrize(
         ("extra_args", "expected"),
         [
@@ -565,21 +853,74 @@ class TestCLIBuildGGUF:
 
         assert build.call_args.kwargs["reuse_gguf_weights"] is True
 
-    def test_reuse_rejects_ort_genai_runtime(self, tmp_path):
+    def test_reuse_with_ort_genai_preserves_runtime_unvalidated_model(self, tmp_path):
         from mobius.__main__ import main
+        from mobius.integrations.gguf._component_export import (
+            attach_runtime_unvalidated_report,
+        )
 
-        with pytest.raises(SystemExit, match="cannot be combined"):
+        package = mock.MagicMock()
+        package.export_report = None
+        package.gguf_architecture = "llama"
+        package.gguf_tokenizer_verdict = mock.Mock(
+            materialized=False,
+            route_identifier="gpt-2",
+            reason="tokenizer materialization was not validated",
+            blocker_category=None,
+            evidence_id=None,
+        )
+        package.__iter__.return_value = iter(("model",))
+        package.__len__.return_value = 1
+        gguf_model = mock.Mock(metadata={}, architecture="llama")
+        output = tmp_path / "output"
+
+        def publish(pkg, _source, destination, **_kwargs):
+            attach_runtime_unvalidated_report(
+                pkg,
+                "ort-genai",
+                blocker_category="runtime-executor-limitation",
+                reason="ORT GenAI cannot disable constant folding.",
+            )
+            destination = Path(destination)
+            destination.mkdir()
+            (destination / "model.onnx").write_bytes(b"model")
+            pkg.export_report.write_json(destination / "export_report.json")
+            return {"export_report": str(destination / "export_report.json")}
+
+        with (
+            mock.patch(
+                "mobius.integrations.gguf._builder._resolve_gguf_path",
+                return_value=str(tmp_path / "model.gguf"),
+            ),
+            mock.patch(
+                "mobius.integrations.gguf._shard_set.open_gguf_model",
+                return_value=gguf_model,
+            ),
+            mock.patch("mobius.integrations.gguf._builder._validate_gguf_model"),
+            mock.patch(
+                "mobius.integrations.gguf.build_from_gguf",
+                return_value=package,
+            ) as build,
+            mock.patch(
+                "mobius.integrations.gguf.write_gguf_runtime_package",
+                side_effect=publish,
+            ),
+        ):
             main(
                 [
                     "build-gguf",
                     str(tmp_path / "model.gguf"),
                     "--output",
-                    str(tmp_path / "output"),
+                    str(output),
                     "--reuse-gguf-weights",
                     "--runtime",
                     "ort-genai",
                 ]
             )
+
+        assert build.call_args.kwargs["reuse_gguf_weights"] is True
+        assert (output / "model.onnx").is_file()
+        assert package.export_report.component("runtime").output == "exported"
 
     def test_ort_genai_runtime_is_forwarded_to_package_writer(self, tmp_path):
         """build-gguf forwards one canonically opened source to build and packaging."""
@@ -650,11 +991,41 @@ class TestCLIBuildGGUF:
             max_workers=8,
         )
 
-    def test_runtime_without_pinned_tokenizer_fails_before_graph_or_output(self, tmp_path):
+    def test_runtime_without_pinned_tokenizer_exports_unvalidated_model(
+        self, tmp_path, capsys
+    ):
         from mobius.__main__ import main
-        from mobius.integrations.gguf._spec import Support
+        from mobius.integrations.gguf._component_export import (
+            attach_runtime_unvalidated_report,
+        )
 
         output = tmp_path / "output"
+        package = mock.MagicMock()
+        package.export_report = None
+        package.gguf_architecture = "llama"
+        package.gguf_tokenizer_verdict = mock.Mock(
+            materialized=False,
+            route_identifier="gpt-2",
+            reason="tokenizer materialization was not validated",
+            blocker_category=None,
+            evidence_id=None,
+        )
+        package.__iter__.return_value = iter(("model",))
+        package.__len__.return_value = 1
+
+        def publish_unvalidated(pkg, _source, destination, **_kwargs):
+            attach_runtime_unvalidated_report(
+                pkg,
+                "ort-genai",
+                blocker_category="runtime-tokenizer-identity-unavailable",
+                reason="No immutable tokenizer identity was supplied.",
+            )
+            destination = Path(destination)
+            destination.mkdir()
+            (destination / "model.onnx").write_bytes(b"model")
+            pkg.export_report.write_json(destination / "export_report.json")
+            return {"export_report": str(destination / "export_report.json")}
+
         with (
             mock.patch(
                 "mobius.integrations.gguf._builder._resolve_gguf_path",
@@ -666,15 +1037,13 @@ class TestCLIBuildGGUF:
             ),
             mock.patch("mobius.integrations.gguf._builder._validate_gguf_model"),
             mock.patch(
-                "mobius.integrations.gguf._arch_registry.get_arch_spec",
-                return_value=mock.Mock(
-                    gguf_arch="llama",
-                    runtime=Support.SUPPORTED,
-                    reason=None,
-                ),
+                "mobius.integrations.gguf.build_from_gguf",
+                return_value=package,
+            ) as build,
+            mock.patch(
+                "mobius.integrations.gguf.write_gguf_runtime_package",
+                side_effect=publish_unvalidated,
             ),
-            mock.patch("mobius.integrations.gguf.build_from_gguf") as build,
-            pytest.raises(SystemExit, match="requires --tokenizer-repository"),
         ):
             main(
                 [
@@ -686,8 +1055,13 @@ class TestCLIBuildGGUF:
                     "ort-genai",
                 ]
             )
-        build.assert_not_called()
-        assert not output.exists()
+
+        assert build.call_count == 1
+        assert (output / "model.onnx").is_file()
+        assert (output / "export_report.json").is_file()
+        assert package.export_report.export_status == "partial"
+        assert package.export_report.runtime_validation_status == "unvalidated"
+        assert "requested runtime: ort-genai (unvalidated)" in capsys.readouterr().out
 
     @pytest.mark.parametrize(
         ("error", "message"),

--- a/tests/gguf_test.py
+++ b/tests/gguf_test.py
@@ -478,6 +478,62 @@ class TestGGUFTensorProcessors:
 class TestCLIBuildGGUF:
     """Test the build-gguf CLI subcommand."""
 
+    def test_partial_cli_status_distinguishes_deferred_support_from_omission(
+        self, tmp_path, capsys
+    ):
+        from types import SimpleNamespace
+
+        from mobius.__main__ import _print_gguf_export_status
+        from mobius._export_report import (
+            ComponentExportDisposition,
+            ComponentExportReport,
+        )
+
+        report = ComponentExportReport.create(
+            (
+                ComponentExportDisposition(
+                    name="model",
+                    route="llama",
+                    requested=True,
+                    discovered=True,
+                    support="supported",
+                    output="exported",
+                ),
+                ComponentExportDisposition(
+                    name="runtime",
+                    route="ort-genai",
+                    requested=True,
+                    discovered=True,
+                    support="deferred",
+                    output="exported",
+                    runtime_validation_status="unvalidated",
+                    blocker_category="runtime-validation-unavailable",
+                    reason="runtime evidence is pending",
+                    impact="execution is unvalidated",
+                    remediation="validate before production use",
+                ),
+                ComponentExportDisposition(
+                    name="tokenizer",
+                    route="embedded",
+                    requested=True,
+                    discovered=True,
+                    support="supported",
+                    output="exported",
+                ),
+            ),
+            end_to_end_runnable=False,
+        )
+
+        _print_gguf_export_status(
+            SimpleNamespace(export_report=report),
+            str(tmp_path),
+            runtime="ort-genai",
+        )
+
+        output = capsys.readouterr().out
+        assert "all requested components were exported" in output
+        assert "components were omitted" not in output
+
     def test_help_text(self, capsys):
         """build-gguf subcommand shows in help."""
         from mobius.__main__ import main


### PR DESCRIPTION
## Summary

- Preserve proven GGUF model and runtime/config components when an authoritative tokenizer route is deferred or blocked.
- Emit exactly one structured tokenizer warning with route, blocker category, evidence ID, exact recorded reason, impact, and remediation; never publish unverified tokenizer assets.
- Persist generic component `support_status`, `export_status`, and `runtime_validation_status` in `export_report.json`.
- Keep architecture, config, tensor closure, graph, qtype, source identity, I/O, malformed known metadata, and unexpected failures fail-closed.

## Final blocker evidence

- **Tokenizer field closure:** Complete and incomplete paths accept only exact consumed/extension allowlists plus `tokenizer.chat_template.*`. Unknown/near-miss fields defer as `unsupported-tokenizer-metadata-fields`; malformed known fields remain fatal even when unknown fields coexist.
- **Incomplete tokenizer safety:** Present model/`pre`, embedded JSON, RWKV, token list, types/scores/merges, special IDs, booleans, suppress/charsmap, and chat templates validate before downgrade. Tokenless special IDs fail; only `mask_token_id` on recognized masked-diffusion architectures is left to the graph contract.
- **MTP tokenizer safety:** Deferred/blocked MTP routes never copy or pass through unevidenced tokenizer repositories. Only runtime evidence or validated embedded materialization writes tokenizer assets; faithful runtime config remains exported.
- **Reuse metadata lifecycle:** The rollback journal always manages/removes stale draft, export, and quantization reports across sidecar variants. Failed reruns restore the complete prior graph/report set.
- **Final-byte runtime identity:** Evidence matching occurs after final export/compatibility/MTP status bytes. Pre-report evidence is explicitly legacy/non-validating until regenerated final-package hashes exist.
- **Atomic publication:** Report-bearing normal saves use sibling staging and atomic no-replace publication; graph/report/draft/permission/concurrent-destination failures leave no stale output. MTP status and reuse remain non-duplicated transactional surfaces.

## Validation

- Final MTP/tokenizer regressions: **116 passed, 15 deselected**.
- #696 audio-projector affected gate: **428 passed, 453 deselected**.
- Final broad serial suite on exact base: **9,471 passed, 64 skipped, 12 deselected, 1 subtest passed**.
- Generated GGUF docs, full initialized `lintrunner`, and diff check: clean.
- New disposition/runtime modules: targeted mypy clean.
- Broad mypy exact-base comparison: branch **3,768** vs base **3,804** existing diagnostics; **0 normalized new errors**.
- Multiple independent medium-effort reviews completed; final MTP/mask review reported no findings.
- GitHub review threads: **1 total, 0 unresolved**.

## Publication preflight

- Clean worktree and matching remote head.
- Session artifacts: **0 bytes retained**. Completed exact-base mypy worktrees/logs were deleted; no downloaded GGUF/ONNX/package payloads or scratch caches remain.
- Lease push completed after conflict-free semantic rebase onto #696.
- All commits contain `Signed-off-by` and required Copilot `Co-authored-by` trailers. GPG signing was unavailable because `gpg` is not installed.
- CI is intentionally not monitored and this PR is not being merged by this session.

## Exact revisions

- Base: `82e31222c9dbc08d2ea825fd6265498f0f594019`
- Head: `960beeddec616d10d83f5bebe0ecd157a64ff199`