### PR TITLE
Promote evidenced GGUF tokenizers independently of runtime evidence

### DIFF
--- a/docs/api/build_from_gguf.md
+++ b/docs/api/build_from_gguf.md
@@ -65,6 +65,8 @@ build_from_gguf(
 The function returns a `ModelPackage`. Mobius-side graph/semantic inability, corruption,
 identity, I/O, malformed tokenizer, and unexpected errors remain fail-closed. Authoritative
 tokenizer blockers become partial exports with exact reasons and no unverified assets.
+Exact tokenizer evidence is matched independently from runtime evidence, so a proven tokenizer
+is exported even when downstream runtime execution remains unvalidated.
 Downstream runtime, version, registry, or executor limitations preserve the accurate model
 package and record distinct `export_status` and `runtime_validation_status` fields instead of
 blocking export. Only exact artifact, graph, tokenizer, version, parity, and state evidence
@@ -157,7 +159,7 @@ from mobius.integrations.gguf import materialize_evidenced_gguf_tokenizer
 materialize_evidenced_gguf_tokenizer("Qwen3.5-0.8B-Q4_0.gguf", "tokenizer")
 ```
 
-Each row is independently artifact-scoped and proves ordered tokenizer semantics, source assets, embedding alignment, and the final materialized hash. Shared rows also require identical pinned llama.cpp dispatch. This does not claim graph or runtime support.
+Each row is independently artifact-scoped and proves ordered tokenizer semantics, source assets, embedding alignment, and the final materialized hash. Shared rows also require identical pinned llama.cpp dispatch. A matching complete immutable GGUF is automatically promoted to the pinned-source route during model and runtime package export; identifier-only inspection remains deferred because an identifier cannot prove artifact identity. This does not claim graph or runtime support.
 
 ### Fail-closed tokenizer evidence
 

--- a/src/mobius/integrations/gguf/_component_export.py
+++ b/src/mobius/integrations/gguf/_component_export.py
@@ -66,6 +66,7 @@ def resolve_tokenizer_export_verdict(
         return verdict
 
     from mobius.integrations.gguf._tokenizer_evidence import (
+        find_matching_tokenizer_evidence,
         matching_tokenizer_blocker_evidence,
     )
 
@@ -76,7 +77,26 @@ def resolve_tokenizer_export_verdict(
         artifact_identity=artifact_identity,
     )
     if blocker is None:
-        return verdict
+        evidence = find_matching_tokenizer_evidence(
+            Path(source_path),
+            gguf_model,
+            metadata_sha256=verdict.metadata_sha256,
+            artifact_identity=artifact_identity,
+        )
+        if evidence is None:
+            return verdict
+        return dataclasses.replace(
+            verdict,
+            route="pinned-source",
+            reason=(
+                "complete immutable GGUF identity matches independently validated tokenizer "
+                f"evidence {evidence.evidence_id!r}"
+            ),
+            tokenizer_sha256=evidence.materialized_tokenizer_sha256,
+            audit_status="validated-pinned-source",
+            blocker_category=None,
+            evidence_id=evidence.evidence_id,
+        )
     return dataclasses.replace(
         verdict,
         reason=blocker.disposition,

--- a/src/mobius/integrations/gguf/_component_export.py
+++ b/src/mobius/integrations/gguf/_component_export.py
@@ -59,7 +59,7 @@ def resolve_tokenizer_export_verdict(
     verdict: GGUFTokenizerVerdict | None = None,
     artifact_identity: Any | None = None,
 ) -> GGUFTokenizerVerdict:
-    """Add an exact artifact blocker to an otherwise validated tokenizer verdict."""
+    """Apply exact artifact evidence to promote or block a tokenizer verdict."""
     if verdict is None:
         verdict = inspect_gguf_tokenizer(gguf_model.metadata, source=str(source_path))
     if verdict.materialized or verdict.metadata_sha256 is None:

--- a/src/mobius/integrations/gguf/_docs.py
+++ b/src/mobius/integrations/gguf/_docs.py
@@ -739,6 +739,9 @@ def render_document() -> str:
             "Each row is independently artifact-scoped and proves ordered tokenizer semantics,",
             "source assets, embedding alignment, and the final materialized hash.",
             "Shared rows also require identical pinned llama.cpp dispatch.",
+            "A matching complete immutable GGUF is automatically promoted to the pinned-source",
+            "route during model and runtime package export; identifier-only inspection remains",
+            "deferred because an identifier cannot prove artifact identity.",
             "This does not claim graph or runtime support.",
         )
     )
@@ -830,6 +833,8 @@ build_from_gguf(
 The function returns a `ModelPackage`. Mobius-side graph/semantic inability, corruption,
 identity, I/O, malformed tokenizer, and unexpected errors remain fail-closed. Authoritative
 tokenizer blockers become partial exports with exact reasons and no unverified assets.
+Exact tokenizer evidence is matched independently from runtime evidence, so a proven tokenizer
+is exported even when downstream runtime execution remains unvalidated.
 Downstream runtime, version, registry, or executor limitations preserve the accurate model
 package and record distinct `export_status` and `runtime_validation_status` fields instead of
 blocking export. Only exact artifact, graph, tokenizer, version, parity, and state evidence

--- a/src/mobius/integrations/gguf/_runtime_package.py
+++ b/src/mobius/integrations/gguf/_runtime_package.py
@@ -427,6 +427,7 @@ def write_gguf_runtime_package(
         or built_verdict.metadata_sha256 != verdict.metadata_sha256
         or built_verdict.route != verdict.route
         or built_verdict.evidence_id != verdict.evidence_id
+        or built_verdict.tokenizer_sha256 != verdict.tokenizer_sha256
     ):
         raise ValueError(
             "The GGUF tokenizer metadata no longer matches the identity captured during "

--- a/src/mobius/integrations/gguf/_runtime_package.py
+++ b/src/mobius/integrations/gguf/_runtime_package.py
@@ -46,6 +46,7 @@ from mobius.integrations.gguf._tokenizer import (
     materialize_gguf_tokenizer,
     write_gguf_tokenizer_json,
 )
+from mobius.integrations.gguf._tokenizer_evidence import tokenizer_evidence
 
 __all__ = ["write_gguf_runtime_package"]
 
@@ -412,8 +413,21 @@ def write_gguf_runtime_package(
         source=str(source_path),
         require_complete=False,
     )
+    from mobius.integrations.gguf._component_export import resolve_tokenizer_export_verdict
+
+    verdict = resolve_tokenizer_export_verdict(
+        source_model,
+        source_path,
+        verdict=verdict,
+        artifact_identity=built_identity,
+    )
     built_verdict = getattr(pkg, "gguf_tokenizer_verdict", None)
-    if built_verdict is None or built_verdict.metadata_sha256 != verdict.metadata_sha256:
+    if (
+        built_verdict is None
+        or built_verdict.metadata_sha256 != verdict.metadata_sha256
+        or built_verdict.route != verdict.route
+        or built_verdict.evidence_id != verdict.evidence_id
+    ):
         raise ValueError(
             "The GGUF tokenizer metadata no longer matches the identity captured during "
             "graph construction; refusing to pair the graph with a replaced tokenizer source."
@@ -462,7 +476,28 @@ def write_gguf_runtime_package(
 
         tokenizer_exported = False
         tokenizer_warning: str | None = None
-        if evidence is not None:
+        tokenizer_route_evidence = (
+            tokenizer_evidence(verdict.evidence_id)
+            if verdict.route == "pinned-source" and verdict.evidence_id is not None
+            else None
+        )
+        if verdict.route == "pinned-source":
+            if tokenizer_route_evidence is None:
+                raise ValueError(
+                    "Pinned-source tokenizer verdict references missing exact evidence "
+                    f"{verdict.evidence_id!r}."
+                )
+            tokenizer_path = materialize_gguf_tokenizer(
+                source_path,
+                stage,
+                source=tokenizer_route_evidence.source,
+                metadata=source_metadata,
+                source_identity=(f"sha256:{built_identity.sha256}/{built_identity.filename}"),
+                local_files_only=local_files_only,
+            )
+            artifacts["tokenizer"] = tokenizer_path
+            tokenizer_exported = True
+        elif evidence is not None:
             tokenizer_source = GGUFTokenizerSource(
                 repository=evidence.tokenizer_repository,
                 revision=evidence.tokenizer_revision,
@@ -482,7 +517,7 @@ def write_gguf_runtime_package(
             )
             artifacts["tokenizer"] = tokenizer_path
             tokenizer_exported = True
-        elif verdict.materialized:
+        elif verdict.route == "copy":
             artifacts["tokenizer"] = write_gguf_tokenizer_json(
                 source_path,
                 stage,

--- a/src/mobius/integrations/gguf/_runtime_package_test.py
+++ b/src/mobius/integrations/gguf/_runtime_package_test.py
@@ -54,9 +54,11 @@ class _FakePackage:
 def _materialized():
     return SimpleNamespace(
         materialized=True,
+        route="copy",
         route_identifier="embedded",
         reason="exact embedded tokenizer",
         metadata_sha256="f" * 64,
+        evidence_id=None,
     )
 
 
@@ -177,6 +179,51 @@ def _runtime_supported():
 
 
 class TestWriteGgufRuntimePackage:
+    def test_exact_tokenizer_evidence_exports_without_runtime_evidence(self, tmp_path):
+        pkg = _FakePackage()
+        pinned = GGUFTokenizerVerdict(
+            route="pinned-source",
+            model="gpt2",
+            pre="qwen2",
+            canonical_pre="qwen2",
+            reason="exact tokenizer evidence",
+            token_count=2,
+            tokenizer_sha256="a" * 64,
+            metadata_sha256="f" * 64,
+            audit_status="validated-pinned-source",
+            evidence_id="tokenizer-only-evidence",
+        )
+        pkg.gguf_tokenizer_verdict = pinned
+        tokenizer_source = object()
+        out = tmp_path / "out"
+        with (
+            _successful_runtime_dependencies(),
+            mock.patch(
+                "mobius.integrations.gguf._runtime_package.matching_runtime_evidence",
+                return_value=None,
+            ),
+            mock.patch(
+                "mobius.integrations.gguf._component_export.resolve_tokenizer_export_verdict",
+                return_value=pinned,
+            ),
+            mock.patch(
+                "mobius.integrations.gguf._runtime_package.tokenizer_evidence",
+                return_value=SimpleNamespace(source=tokenizer_source),
+            ),
+            mock.patch(
+                "mobius.integrations.gguf._runtime_package.materialize_gguf_tokenizer",
+                side_effect=_write_tokenizer,
+            ) as materialize,
+        ):
+            artifacts = _write_runtime(pkg, tmp_path / "m.gguf", out)
+
+        assert Path(artifacts["tokenizer"]).is_file()
+        assert pkg.export_report.component("tokenizer").output == "exported"
+        assert (
+            pkg.export_report.component("runtime").runtime_validation_status == "unvalidated"
+        )
+        assert materialize.call_args.kwargs["source"] is tokenizer_source
+
     def test_runtime_disposition_is_replaced_when_runtime_changes(self):
         from mobius.integrations.gguf._component_export import (
             attach_runtime_unvalidated_report,

--- a/src/mobius/integrations/gguf/_runtime_package_test.py
+++ b/src/mobius/integrations/gguf/_runtime_package_test.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import json
 from contextlib import contextmanager
 from pathlib import Path
@@ -57,6 +58,7 @@ def _materialized():
         route="copy",
         route_identifier="embedded",
         reason="exact embedded tokenizer",
+        tokenizer_sha256="e" * 64,
         metadata_sha256="f" * 64,
         evidence_id=None,
     )
@@ -223,6 +225,35 @@ class TestWriteGgufRuntimePackage:
             pkg.export_report.component("runtime").runtime_validation_status == "unvalidated"
         )
         assert materialize.call_args.kwargs["source"] is tokenizer_source
+
+    def test_changed_pinned_tokenizer_digest_rejects_before_package_save(self, tmp_path):
+        pkg = _FakePackage()
+        built = GGUFTokenizerVerdict(
+            route="pinned-source",
+            model="gpt2",
+            pre="qwen2",
+            canonical_pre="qwen2",
+            reason="exact tokenizer evidence",
+            token_count=2,
+            tokenizer_sha256="a" * 64,
+            metadata_sha256="f" * 64,
+            audit_status="validated-pinned-source",
+            evidence_id="tokenizer-only-evidence",
+        )
+        current = dataclasses.replace(built, tokenizer_sha256="b" * 64)
+        pkg.gguf_tokenizer_verdict = built
+        with (
+            _successful_runtime_dependencies(),
+            mock.patch(
+                "mobius.integrations.gguf._component_export.resolve_tokenizer_export_verdict",
+                return_value=current,
+            ),
+            pytest.raises(ValueError, match="replaced tokenizer source"),
+        ):
+            _write_runtime(pkg, tmp_path / "m.gguf", tmp_path / "out")
+
+        assert pkg.saved_to is None
+        assert not (tmp_path / "out").exists()
 
     def test_runtime_disposition_is_replaced_when_runtime_changes(self):
         from mobius.integrations.gguf._component_export import (

--- a/src/mobius/integrations/gguf/_tokenizer_evidence.py
+++ b/src/mobius/integrations/gguf/_tokenizer_evidence.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 __all__ = [
     "GGUFTokenizerBlockerEvidence",
     "GGUFTokenizerEvidence",
+    "find_matching_tokenizer_evidence",
     "iter_tokenizer_blocker_evidence",
     "iter_tokenizer_evidence",
     "matching_tokenizer_blocker_evidence",
@@ -2392,19 +2393,22 @@ def matching_tokenizer_blocker_evidence(
     return None
 
 
-def matching_tokenizer_evidence(
+def _matching_tokenizer_evidence_records(
     source_path: Path,
     gguf_model: Any,
     *,
     metadata_sha256: str | None,
-) -> GGUFTokenizerEvidence:
-    """Return the unique evidence record matching the complete artifact identity."""
+    artifact_identity: Any | None = None,
+) -> tuple[list[GGUFTokenizerEvidence], list[GGUFTokenizerBlockerEvidence], Any]:
+    """Return exact evidence candidates after complete artifact and tokenizer matching."""
     architecture = gguf_model.architecture
-    identity = gguf_artifact_identity(
-        source_path,
-        gguf_model,
-        architecture=architecture,
-    )
+    identity = artifact_identity
+    if identity is None:
+        identity = gguf_artifact_identity(
+            source_path,
+            gguf_model,
+            architecture=architecture,
+        )
     metadata = gguf_model.metadata
 
     token_count, vocabulary_sha256 = _sequence_digest(metadata, "tokenizer.ggml.tokens")
@@ -2458,6 +2462,50 @@ def matching_tokenizer_evidence(
         gguf_model,
         metadata_sha256=metadata_sha256,
     )
+    return matches, blockers, identity
+
+
+def find_matching_tokenizer_evidence(
+    source_path: Path,
+    gguf_model: Any,
+    *,
+    metadata_sha256: str | None,
+    artifact_identity: Any | None = None,
+) -> GGUFTokenizerEvidence | None:
+    """Return exact tokenizer evidence when this complete artifact is allowlisted."""
+    matches, blockers, _ = _matching_tokenizer_evidence_records(
+        source_path,
+        gguf_model,
+        metadata_sha256=metadata_sha256,
+        artifact_identity=artifact_identity,
+    )
+    if len(blockers) == 1:
+        blocker = blockers[0]
+        raise ValueError(
+            f"Tokenizer materialization is explicitly blocked by {blocker.evidence_id!r}: "
+            f"{blocker.disposition}"
+        )
+    if blockers:
+        raise RuntimeError("Tokenizer blocker evidence contains duplicate artifact identities")
+    if len(matches) > 1:
+        raise RuntimeError("Tokenizer evidence contains duplicate artifact identities")
+    return matches[0] if matches else None
+
+
+def matching_tokenizer_evidence(
+    source_path: Path,
+    gguf_model: Any,
+    *,
+    metadata_sha256: str | None,
+    artifact_identity: Any | None = None,
+) -> GGUFTokenizerEvidence:
+    """Return the unique evidence record matching the complete artifact identity."""
+    matches, blockers, identity = _matching_tokenizer_evidence_records(
+        source_path,
+        gguf_model,
+        metadata_sha256=metadata_sha256,
+        artifact_identity=artifact_identity,
+    )
     if len(blockers) == 1:
         blocker = blockers[0]
         raise ValueError(
@@ -2469,7 +2517,7 @@ def matching_tokenizer_evidence(
     if len(matches) != 1:
         raise ValueError(
             "No unique exact tokenizer evidence matches "
-            f"architecture={architecture!r}, artifact={identity!r}, "
+            f"architecture={gguf_model.architecture!r}, artifact={identity!r}, "
             f"metadata_sha256={metadata_sha256!r}."
         )
     return matches[0]

--- a/src/mobius/integrations/gguf/_tokenizer_test.py
+++ b/src/mobius/integrations/gguf/_tokenizer_test.py
@@ -1396,6 +1396,40 @@ def test_evidenced_materializer_atomically_publishes_complete_directory(
     assert not list(tmp_path.glob(".output.*.tmp"))
 
 
+def test_exact_artifact_evidence_promotes_deferred_identifier_to_pinned_source(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from mobius.integrations.gguf._component_export import resolve_tokenizer_export_verdict
+
+    verdict = inspect_gguf_tokenizer(_metadata(pre="qwen2"))
+    evidence = SimpleNamespace(
+        evidence_id="exact-tokenizer-evidence",
+        materialized_tokenizer_sha256="a" * 64,
+    )
+    monkeypatch.setattr(
+        "mobius.integrations.gguf._tokenizer_evidence.matching_tokenizer_blocker_evidence",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        "mobius.integrations.gguf._tokenizer_evidence.find_matching_tokenizer_evidence",
+        lambda *_a, **_k: evidence,
+    )
+
+    promoted = resolve_tokenizer_export_verdict(
+        SimpleNamespace(metadata=_metadata(pre="qwen2")),
+        tmp_path / "model.gguf",
+        verdict=verdict,
+        artifact_identity=object(),
+    )
+
+    assert promoted.route == "pinned-source"
+    assert promoted.materialized
+    assert promoted.audit_status == "validated-pinned-source"
+    assert promoted.evidence_id == evidence.evidence_id
+    assert promoted.tokenizer_sha256 == evidence.materialized_tokenizer_sha256
+    assert promoted.blocker_category is None
+
+
 @pytest.mark.parametrize(
     ("token", "token_type", "message"),
     [


### PR DESCRIPTION
## Summary

- promote a tokenizer from deferred to `pinned-source` only when the complete immutable GGUF identity matches existing exact tokenizer evidence
- materialize exact tokenizer evidence during runtime package export independently of graph/runtime evidence
- preserve machine-readable deferred/blocked tokenizer warnings without blocking model or component export
- regenerate the synchronized GGUF API documentation

## Authoritative tokenizer census

- 87 exact identifiers across 56 semantic groups
- 31 `validated-pinned-source` identifiers, conditionally promoted only for their evidenced complete artifacts
- 45 `deferred-compiled-semantics` identifiers
- 4 `deferred-pinned-artifact-evidence` identifiers
- 7 `deferred-pinned-artifact-mismatch` identifiers

The 56 remaining tokenizer work items therefore have no currently feasible promotion under the existing immutable-evidence and 16 GiB/session policy. Identifier-only inspection remains deferred because it cannot prove artifact identity.

## Validation

- focused tokenizer/evidence/runtime package tests: 157 passed
- broad serial suite: 9,670 passed, 64 skipped, 12 deselected, 1 subtest passed
- focused mypy: clean
- generated docs: synchronized
- lintrunner formatting/lint: clean
- independent medium review: no findings

Base: `027fd42bb89e970defde0098792df104cd83b541`
Head: `8bebbaa8ae1fad23e776c03f6f2db4eea53ef5c4`

Local pytest/mypy caches were removed; workspace footprint is 81 MiB. No CI monitoring or merge requested.