### PR TITLE
Make export reports byte-deterministic

### DIFF
--- a/src/mobius/_export_report.py
+++ b/src/mobius/_export_report.py
@@ -306,9 +306,13 @@ class ComponentExportReport:
         """Serialize with deterministic key ordering and a trailing newline."""
         return json.dumps(self.to_dict(), indent=2, sort_keys=True) + "\n"
 
+    def to_bytes(self) -> bytes:
+        """Serialize to deterministic UTF-8 bytes with LF line endings."""
+        return self.to_json().encode("utf-8")
+
     def write_json(self, path: str | Path) -> None:
-        """Write the deterministic report."""
-        Path(path).write_text(self.to_json(), encoding="utf-8")
+        """Write the deterministic report without platform newline translation."""
+        Path(path).write_bytes(self.to_bytes())
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, object]) -> ComponentExportReport:

--- a/src/mobius/_model_package.py
+++ b/src/mobius/_model_package.py
@@ -650,9 +650,7 @@ class ModelPackage(UserDict[str, ir.Model]):
                             + "\n"
                         ).encode()
                     if self.export_report is not None:
-                        package_metadata[_EXPORT_REPORT] = (
-                            self.export_report.to_json().encode()
-                        )
+                        package_metadata[_EXPORT_REPORT] = self.export_report.to_bytes()
                     if self.draft_manifest is not None:
                         package_metadata["draft_manifest.json"] = (
                             json.dumps(self.draft_manifest, indent=2, sort_keys=True) + "\n"

--- a/src/mobius/_model_package_test.py
+++ b/src/mobius/_model_package_test.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import logging
 import threading
 import types
+from pathlib import Path
 
 import onnx_ir as ir
 import pytest
@@ -273,6 +274,24 @@ class TestComponentExportReport:
         assert isinstance(components, dict)
         assert components["tokenizer"]["export_status"] == "omitted"
         assert components["tokenizer"]["runtime_validation_status"] == "unvalidated"
+
+    def test_report_write_preserves_lf_when_text_writes_translate_newlines(
+        self, tmp_path, monkeypatch
+    ):
+        report = _partial_export_report()
+        report_path = tmp_path / "export_report.json"
+
+        def write_text_with_windows_newlines(
+            path: Path, data: str, encoding: str | None = None, **_kwargs
+        ) -> int:
+            encoded = data.replace("\n", "\r\n").encode(encoding or "utf-8")
+            return path.write_bytes(encoded)
+
+        monkeypatch.setattr(Path, "write_text", write_text_with_windows_newlines)
+        report.write_json(report_path)
+
+        assert report_path.read_bytes() == report.to_bytes()
+        assert b"\r\n" not in report_path.read_bytes()
 
     def test_save_without_report_rejects_stale_report(self, tmp_path):
         report_path = tmp_path / "export_report.json"


### PR DESCRIPTION
## Summary
- serialize component export reports as explicit UTF-8 bytes with LF endings
- reuse the byte serializer for GGUF reuse package metadata
- simulate Windows text newline translation in a platform-independent regression

## Root cause
`ComponentExportReport.write_json()` used `Path.write_text()`. Windows text mode translated the serializer's LF characters to CRLF, so persisted `export_report.json` bytes differed from the deterministic serializer and package hashes varied by platform.

## Tests
- `python -m pytest src/mobius/_model_package_test.py -q --tb=short` (90 passed)
- `lintrunner f --output oneline src/mobius/_export_report.py src/mobius/_model_package.py src/mobius/_model_package_test.py`
- `git diff --check`