### PR TITLE
Privatize transformer config helpers

### DIFF
--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -27,10 +27,10 @@ from mobius._builder import (
 )
 from mobius._optimizations import strip_debug_metadata
 from mobius._registry import registry
-from mobius.integrations.transformers import (
+from mobius.integrations.transformers import build
+from mobius.integrations.transformers._config_resolver import (
     _config_from_hf,
     _default_task_for_model,
-    build,
 )
 
 logger = logging.getLogger(__name__)

--- a/src/mobius/_exporter_test.py
+++ b/src/mobius/_exporter_test.py
@@ -33,6 +33,24 @@ from mobius.models.base import CausalLMModel
 from mobius.tasks import CausalLMTask, ModelTask
 
 
+def test_transformers_package_exposes_only_public_builders():
+    import mobius.integrations.transformers as transformers_integration
+
+    assert transformers_integration.__all__ == ["build", "build_transformers_model"]
+    assert transformers_integration.build is build
+    assert transformers_integration.build_transformers_model is build
+
+    for helper in (
+        "_config_from_hf",
+        "_default_task_for_model",
+        "_dict_to_pretrained_config",
+        "_try_load_config_json",
+    ):
+        assert helper not in vars(transformers_integration)
+        with pytest.raises(AttributeError):
+            getattr(transformers_integration, helper)
+
+
 class TestBuildFromModule:
     def test_default_task(self):
         config = make_config()

--- a/src/mobius/integrations/gguf/_builder.py
+++ b/src/mobius/integrations/gguf/_builder.py
@@ -6951,7 +6951,7 @@ def build_from_gguf(
     from mobius.integrations.gguf._tensor_processors import (
         process_tensors,
     )
-    from mobius.integrations.transformers import (
+    from mobius.integrations.transformers._config_resolver import (
         _default_task_for_model,
     )
 

--- a/src/mobius/integrations/nemo/_builder.py
+++ b/src/mobius/integrations/nemo/_builder.py
@@ -61,7 +61,7 @@ def build_from_nemo(
     from mobius._registry import registry
     from mobius.integrations.nemo._config_mapping import nemo_to_config
     from mobius.integrations.nemo._reader import NeMoArchive
-    from mobius.integrations.transformers import _default_task_for_model
+    from mobius.integrations.transformers._config_resolver import _default_task_for_model
 
     archive = NeMoArchive(nemo_path, revision=revision)
     logger.info("Loaded NeMo archive: %s (target=%s)", archive.path, archive.target)

--- a/src/mobius/integrations/nemo/_builder_test.py
+++ b/src/mobius/integrations/nemo/_builder_test.py
@@ -1,0 +1,50 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for the NeMo model builder."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import mock
+
+
+def test_build_uses_transformers_config_resolver_for_default_task(monkeypatch) -> None:
+    import mobius._builder as core_builder
+    import mobius.integrations.nemo._config_mapping as config_mapping
+    import mobius.integrations.nemo._reader as nemo_reader
+    import mobius.integrations.transformers._config_resolver as config_resolver
+    from mobius._registry import registry
+    from mobius.integrations.nemo._builder import build_from_nemo
+
+    config = SimpleNamespace(model_type="llama")
+    weights = {"model.weight": object()}
+    archive = SimpleNamespace(
+        path="model.nemo",
+        target="example.Model",
+        config={},
+        state_dict=lambda: weights,
+    )
+    module = object()
+    module_class = mock.Mock(return_value=module)
+    package = mock.MagicMock()
+    resolve_task = mock.Mock(return_value="text-generation")
+    build_module = mock.Mock(return_value=package)
+
+    monkeypatch.setattr(nemo_reader, "NeMoArchive", mock.Mock(return_value=archive))
+    monkeypatch.setattr(config_mapping, "nemo_to_config", mock.Mock(return_value=config))
+    monkeypatch.setattr(registry, "get", mock.Mock(return_value=module_class))
+    monkeypatch.setattr(config_resolver, "_default_task_for_model", resolve_task)
+    monkeypatch.setattr(core_builder, "build_from_module", build_module)
+
+    result = build_from_nemo("model.nemo", revision="immutable-revision")
+
+    assert result is package
+    resolve_task.assert_called_once_with("llama")
+    build_module.assert_called_once_with(
+        module,
+        config,
+        "text-generation",
+        execution_provider="default",
+    )
+    package.apply_weights.assert_called_once_with(weights, prefix_map=None)

--- a/src/mobius/integrations/transformers/__init__.py
+++ b/src/mobius/integrations/transformers/__init__.py
@@ -7,20 +7,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mobius.integrations.transformers._config_resolver import (
-    _config_from_hf,
-    _default_task_for_model,
-    _dict_to_pretrained_config,
-    _try_load_config_json,
-)
-
 __all__ = [
     "build",
     "build_transformers_model",
-    "_config_from_hf",
-    "_default_task_for_model",
-    "_dict_to_pretrained_config",
-    "_try_load_config_json",
 ]
 
 if TYPE_CHECKING:

--- a/src/mobius/models/glm_ocr_test.py
+++ b/src/mobius/models/glm_ocr_test.py
@@ -11,7 +11,7 @@ import torch
 
 from mobius._builder import _cast_module_dtype
 from mobius._testing.ort_inference import OnnxModelSession
-from mobius.integrations.transformers import _config_from_hf
+from mobius.integrations.transformers._config_resolver import _config_from_hf
 from mobius.models.glm_ocr import GlmOcrForConditionalGeneration
 from mobius.tasks import GlmOcrVLTask
 


### PR DESCRIPTION
## Summary
- remove private config resolver helpers from the `mobius.integrations.transformers` package surface
- import resolver internals directly from their owning `_config_resolver` module in CLI, GGUF, NeMo, and tests
- add package-surface and NeMo default-task routing regressions while preserving `build` and `build_transformers_model`

## Rebase
Originally stacked on #702. After #702 was squash-merged, rebased the single #706 commit onto `main` at `421fca26dbf681679f0d1d05834ac2307ba2bbfa`. `git range-diff` reports an exact patch match (`a0d5077d = 7de0cdc3`), with current native-audio behavior and split test layouts inherited unchanged from `main`.

## Validation
- package surface / Transformers / private-owner import paths: 70 passed
- CLI and native-audio tests: 214 passed
- build-graph suite: 1,583 passed, 52 skipped
- representative split integration selection: 11 passed, 1 skipped
- full applicable non-integration suite: 11,897 passed, 450 skipped, 61 xfailed
- repository-wide AST audit: zero facade imports of the four private helpers
- fresh-process package import smoke test
- `lintrunner f --output oneline --all-files`
- `git diff --check`
- exact-head GPT-5.6 Sol read-only review: no findings
