### PR TITLE
Decouple ONNX-GenAI metadata contracts

### DIFF
--- a/src/mobius/__main__.py
+++ b/src/mobius/__main__.py
@@ -659,6 +659,8 @@ def _save_package(
         from mobius.integrations.onnx_genai import write_onnx_genai_config
         from mobius.integrations.onnx_genai.inference_metadata import (
             is_native_vlm_package,
+        )
+        from mobius.integrations.onnx_genai.workflow_metadata import (
             write_native_vlm_package_metadata,
         )
 

--- a/src/mobius/integrations/onnx_genai/__init__.py
+++ b/src/mobius/integrations/onnx_genai/__init__.py
@@ -34,6 +34,9 @@ The core model/task/component layers remain runtime-agnostic; all onnx-genai
 specific code lives here.
 """
 
+from mobius.integrations.onnx_genai._workflow_contract import (
+    add_policy_components_to_workflow,
+)
 from mobius.integrations.onnx_genai.auto_export import write_onnx_genai_config
 from mobius.integrations.onnx_genai.comfyui import (
     ComfyUIWorkflow,
@@ -55,7 +58,6 @@ from mobius.integrations.onnx_genai.decoder_metadata import (
 )
 from mobius.integrations.onnx_genai.inference_metadata import (
     SchedulerConfig,
-    add_policy_components_to_workflow,
     build_diffusion_pipeline_metadata,
     build_multimodal_pipeline_metadata,
     build_speech_to_text_pipeline_metadata,

--- a/src/mobius/integrations/onnx_genai/_metadata_io.py
+++ b/src/mobius/integrations/onnx_genai/_metadata_io.py
@@ -1,0 +1,19 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Deterministic serialization helpers for ONNX-GenAI metadata."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import yaml
+
+
+class _NoAliasSafeDumper(yaml.SafeDumper):
+    def ignore_aliases(self, data: Any) -> bool:
+        return True
+
+
+def _dump_yaml(metadata: dict[str, Any], handle: Any) -> None:
+    yaml.dump(metadata, handle, Dumper=_NoAliasSafeDumper, sort_keys=False)

--- a/src/mobius/integrations/onnx_genai/_workflow_contract.py
+++ b/src/mobius/integrations/onnx_genai/_workflow_contract.py
@@ -1,0 +1,696 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Dependency-neutral primitives for published ONNX-GenAI workflow contracts."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import onnx_ir as ir
+
+
+@dataclasses.dataclass(frozen=True)
+class _Port:
+    """Structural description of one ONNX graph port."""
+
+    value: Any
+    name: str
+    dtype: str
+    rank: int | None
+    dims: tuple[Any, ...]
+
+
+_DTYPE_TAGS = {
+    "FLOAT": "fp32",
+    "FLOAT16": "fp16",
+    "BFLOAT16": "bf16",
+    "FLOAT8E4M3FN": "float8_e4m3fn",
+    "FLOAT8E5M2": "float8_e5m2",
+    "INT64": "int64",
+    "INT32": "int32",
+    "INT8": "int8",
+    "UINT8": "uint8",
+    "BOOL": "bool",
+    "STRING": "string",
+}
+
+
+def _port(value: Any) -> _Port:
+    shape = getattr(value, "shape", None)
+    dims = tuple(shape) if shape is not None else ()
+    dtype = getattr(getattr(value, "dtype", None), "name", "")
+    return _Port(
+        value=value,
+        name=str(value.name),
+        dtype=_DTYPE_TAGS.get(str(dtype).upper(), str(dtype).lower() or "fp32"),
+        rank=len(dims) if shape is not None else None,
+        dims=dims,
+    )
+
+
+def _shape_metadata(port: _Port) -> list[int | str]:
+    """Return a YAML-safe graph shape without losing symbolic dimensions."""
+    shape: list[int | str] = []
+    for axis, dim in enumerate(port.dims):
+        if isinstance(dim, int):
+            shape.append(dim)
+            continue
+        value = getattr(dim, "value", None)
+        # Metadata dimensions cannot be null. Preserve named graph dimensions;
+        # give anonymous dynamic dimensions a stable, port-local name instead
+        # of pretending they are static or serializing an invalid null.
+        shape.append(str(value) if value is not None else f"{port.name}_dim_{axis}")
+    return shape
+
+
+#: Symbolic dimension Mobius emits for every request-aligned ONNX port.
+REQUEST_AXIS_SYMBOL = "batch"
+_BATCH_DIMENSION_NAMES = frozenset({"batch", "batch_size", "batch_dim", "b"})
+
+
+def request_batch_layout(shape: list[Any] | None) -> dict[str, Any] | None:
+    """Return the request-aligned batch layout implied by a port's shape."""
+    axes = [
+        axis
+        for axis, dimension in enumerate(shape or [])
+        if str(dimension) in _BATCH_DIMENSION_NAMES
+    ]
+    if len(axes) == 1:
+        return {"kind": "request_aligned", "axis": axes[0]}
+    return None
+
+
+def declare_request_alignment(workflow: dict[str, Any]) -> None:
+    """Stamp the request axis named by exactly one batch symbol.
+
+    The runtime compacts finished rows out of a batch by applying one row
+    permutation to every request-aligned tensor. A contract whose batch axis
+    does not say so is unpermutable, so state,
+    component ports, and outputs would silently drift apart after the first
+    eviction. Deriving the declaration from the admitted graph's own batch
+    symbol keeps alignment a property of the model interface rather than an
+    annotation every workflow builder has to remember.
+    """
+
+    def stamp(contract: Any) -> None:
+        if not isinstance(contract, dict) or "batch_layout" in contract:
+            return
+        shape = contract.get("shape") or []
+        if layout := request_batch_layout(shape):
+            contract["batch_layout"] = layout
+
+    for section in ("inputs", "outputs", "state"):
+        for declaration in (workflow.get(section) or {}).values():
+            if isinstance(declaration, dict):
+                stamp(declaration.get("contract"))
+    for component in (workflow.get("components") or {}).values():
+        ports = component.get("ports", {}) if isinstance(component, dict) else {}
+        for side in ("inputs", "outputs"):
+            for contract in (ports.get(side) or {}).values():
+                stamp(contract)
+    # A cell backed by a state-service group is stored by the runtime, not by
+    # the workflow: the group owns the buffer and the eviction policy, so the
+    # cell also needs an explicit boundary at which the runtime may free it.
+    for declaration in (workflow.get("state") or {}).values():
+        if isinstance(declaration, dict) and declaration.get("service_group"):
+            declaration.setdefault("management", "runtime")
+            declaration.setdefault("release_boundary", declaration.get("scope", "invocation"))
+
+
+def published_value_references(workflow: dict[str, Any]) -> set[str]:
+    """Every value name the published program reads, on any path.
+
+    Reachability here is deliberately path-insensitive: it answers "does this
+    workflow ever look at this value", which is what an admission decision
+    needs. Whether a particular request reaches the branch that reads it is a
+    runtime fact, and a package that guessed at it would be describing one
+    caller rather than its own contract.
+    """
+    references: set[str] = set()
+
+    def note(value: Any) -> None:
+        if isinstance(value, str):
+            references.add(value)
+        elif isinstance(value, dict):
+            for item in value.values():
+                note(item)
+        elif isinstance(value, list):
+            for item in value:
+                note(item)
+
+    def visit(step: Any) -> None:
+        if isinstance(step, list):
+            for item in step:
+                visit(item)
+            return
+        if not isinstance(step, dict):
+            return
+        kind = step.get("kind")
+        if kind == "invoke":
+            note(step.get("inputs"))
+        elif kind == "emit":
+            note(step.get("value"))
+            note(step.get("valid_length"))
+            note(step.get("when"))
+        elif kind == "branch":
+            note(step.get("predicate"))
+            note(step.get("outputs"))
+            for case in (step.get("cases") or {}).values():
+                visit(case)
+            visit(step.get("default"))
+        elif kind == "loop":
+            note(step.get("continue_when"))
+            note(step.get("max_iterations"))
+            for carry in step.get("carried") or []:
+                note(carry.get("next"))
+                note(carry.get("initial"))
+        for key in ("steps", "setup", "nodes"):
+            visit(step.get(key))
+
+    visit(workflow.get("steps") or [])
+    for declaration in (workflow.get("state") or {}).values():
+        if isinstance(declaration, dict):
+            note(declaration.get("initializer"))
+            # A bounded or growing cell reads its own extent every step, so the
+            # bound and the step size are read positions like any other. The
+            # sibling ``kind``/``axis`` keys describe the recurrence rather than
+            # naming values, so they are not references.
+            recurrence = declaration.get("recurrence") or {}
+            note(recurrence.get("max"))
+            note(recurrence.get("increment"))
+    # The serving block names the workflow values a runtime reads to drive
+    # batching -- the active/done row masks and the accepted length.
+    serving = workflow.get("serving") or {}
+    for key, value in serving.items():
+        if key != "state_service":
+            note(value)
+    # ``state_service`` is mostly port and cell names rather than values, with
+    # one exception: a group's fixed update extent is itself a workflow value.
+    for group in ((serving.get("state_service") or {}).get("groups") or {}).values():
+        if isinstance(group, dict):
+            note((group.get("update") or {}).get("capacity"))
+    return references
+
+
+def declare_input_admission(workflow: dict[str, Any]) -> None:
+    """Publish every package input's admission requirement instead of implying it.
+
+    ``required`` is what a runtime admits a request against: an input it holds
+    required and the caller did not attach is a rejected request, on every path,
+    before a single component runs. A consumer cannot see what an *absent*
+    ``required`` key was meant to say, so it has to choose a default, and the
+    choice it makes is the opposite of what omission means to a producer -- a
+    value the workflow computes for itself, defaults for itself, or explicitly
+    branches on the absence of, silently becomes a mandatory caller attachment.
+
+    So the flag is derived from the published program rather than left to a
+    reader, and stamped on every declaration:
+
+    * a declaration the package can satisfy on its own -- it carries a
+      ``default``, which is also the only thing a package-owned ``literal``
+      source is ever bound from -- is not something a caller can be required to
+      send;
+    * a declaration whose absence the program *observes*, through a
+      ``present_as`` symbol the steps actually branch on, is one the workflow
+      has been written to run without;
+    * anything else is genuinely externally required, and says so out loud.
+
+    A builder that declares both an escape and ``required: True`` has written
+    two contradictory contracts, and there is no reading of the package that
+    satisfies both, so this fails closed rather than picking one. The mirror
+    case fails closed for the same reason: an input marked optional that the
+    package has no way to proceed without is not optional, it is a request that
+    is admitted and then fails part-way through on an unbound value, which is
+    strictly worse than the rejection it replaced.
+    """
+    inputs = workflow.get("inputs") or {}
+    if not inputs:
+        return
+    references = published_value_references(workflow)
+    for name, declaration in inputs.items():
+        if not isinstance(declaration, dict):
+            continue
+        escapes = []
+        literal = (declaration.get("source") or {}).get("kind") == "literal"
+        if "default" in declaration:
+            escapes.append("a package-supplied default" if literal else "a default")
+        elif literal:
+            # A literal source is resolved from the declaration's own default
+            # and from nothing else, so one without a default names a value the
+            # package neither holds nor can ask a caller for.
+            raise ValueError(
+                f"workflow input {name!r} is sourced from a package literal but "
+                "carries no default, so nothing ever binds it"
+            )
+        present_as = declaration.get("present_as")
+        if present_as is not None:
+            if present_as not in references:
+                raise ValueError(
+                    f"workflow input {name!r} declares the presence symbol "
+                    f"{present_as!r} that no step reads, so the workflow never "
+                    "handles the input being absent"
+                )
+            escapes.append(f"the presence gate {present_as!r}")
+        if not escapes:
+            if declaration.get("required", True) is False:
+                raise ValueError(
+                    f"workflow input {name!r} is declared optional but the workflow "
+                    "carries no default and no presence gate for it, so a request "
+                    "that omits it has no defined behaviour"
+                )
+            declaration["required"] = True
+            continue
+        if declaration.get("required", False):
+            raise ValueError(
+                f"workflow input {name!r} is declared required but the workflow "
+                f"already proceeds without it through {', '.join(escapes)}"
+            )
+        declaration["required"] = False
+
+
+def add_policy_components_to_workflow(
+    metadata: dict[str, Any],
+    pkg: Any,
+) -> dict[str, Any]:
+    """Reference attached ONNX policy artifacts from an existing workflow.
+
+    This helper intentionally does not synthesize a workflow or guess bindings.
+    It only adds schema-defined component declarations when a producer has
+    already emitted the exact workflow contract.
+    """
+    policy_components = getattr(pkg, "policy_components", {})
+    if not policy_components:
+        return metadata
+    workflow = metadata.get("pipeline", {}).get("workflow")
+    if not isinstance(workflow, dict):
+        return metadata
+    components = workflow.setdefault("components", {})
+
+    def semantic_contract(component: Any) -> dict[str, Any]:
+        contract = component.contract
+        contract_name, version = component.contract_id.rsplit("@", 1)
+        bindings = {
+            key: value
+            for key, value in contract.items()
+            if key
+            not in {
+                "role",
+                "mode",
+                "effect",
+                "rng",
+                "state_class",
+                "batching",
+                "inactive_rows",
+            }
+            and isinstance(value, str)
+        }
+        rng = contract.get("rng")
+        if isinstance(rng, dict):
+            bindings.update(
+                {key: value for key, value in rng.items() if isinstance(value, str)}
+            )
+        declaration: dict[str, Any] = {
+            "id": contract_name,
+            "version": version,
+            "bindings": bindings,
+        }
+        parameters = {
+            key: contract[key]
+            for key in ("mode", "batching", "inactive_rows")
+            if key in contract
+        }
+        if parameters:
+            declaration["parameters"] = parameters
+        return declaration
+
+    def tensor_contract(value: Any) -> dict[str, Any]:
+        port = _port(value)
+        dtype = {
+            "fp32": "float32",
+            "fp16": "float16",
+            "bf16": "bfloat16",
+        }.get(port.dtype, port.dtype)
+        shape = _shape_metadata(port)
+        contract: dict[str, Any] = {
+            "dtype": dtype,
+            "rank": port.rank,
+            "shape": shape,
+        }
+        layout = request_batch_layout(shape)
+        if layout is not None:
+            contract["batch_layout"] = layout
+        return contract
+
+    for name, component in policy_components.items():
+        # A policy graph is synthesized by this producer to realize the
+        # workflow's own control flow, so its port contracts are not a
+        # transcription of an external interface: they are the type annotations
+        # of the workflow's dataflow. A workflow value acquires its dtype, rank
+        # and request axis from the port that produces it, and the validator
+        # reads metadata without the artifacts, so a policy output that states
+        # no contract leaves every value derived from it untyped.
+        declaration = {
+            "implementation": {
+                "kind": "onnx",
+                "artifact": f"policies/{name}.onnx",
+            },
+            "ports": {
+                "inputs": {
+                    value.name: tensor_contract(value)
+                    for value in component.model.graph.inputs
+                },
+                "outputs": {
+                    value.name: tensor_contract(value)
+                    for value in component.model.graph.outputs
+                },
+            },
+        }
+        if component.contract:
+            declaration["contract"] = semantic_contract(component)
+            if component.contract.get("role") == "token_sampler":
+                declaration["application_overridable"] = True
+        components[name] = declaration
+    declare_request_alignment(workflow)
+    declare_input_admission(workflow)
+    return metadata
+
+
+def _contract(value: ir.Value) -> dict[str, Any]:
+    port = _port(value)
+    dtype = {"fp16": "float16", "bf16": "bfloat16", "fp32": "float32"}.get(
+        port.dtype, port.dtype
+    )
+    shape = _shape_metadata(port)
+    contract: dict[str, Any] = {
+        "dtype": dtype,
+        "rank": port.rank,
+        "shape": shape,
+    }
+    layout = request_batch_layout(shape)
+    if layout is not None:
+        contract["batch_layout"] = layout
+    return contract
+
+
+def _request_aligned(contract: dict[str, Any], axis: int = 0) -> dict[str, Any]:
+    """Mark a contract as carrying exactly one entry per in-flight request.
+
+    This is a structural batching fact, not a row identity: it tells the runtime
+    which axis to permute when it compacts the batch, while scheduler slots and
+    sequence handles stay runtime-private.
+    """
+    return {**contract, "batch_layout": {"kind": "request_aligned", "axis": axis}}
+
+
+# Translation between the port vocabulary this producer *mints* when it builds
+# a graph and the runtime's architecture-neutral role vocabulary. Both sides are
+# fixed vocabularies and Mobius owns one of them: the task builders in
+# ``mobius.tasks`` choose these exact names, so reading them back here is a
+# lookup, not an inference about a graph of unknown provenance. A port outside
+# this vocabulary carries no role, because a workflow that guesses is worse than
+# one that stays silent.
+_PORT_ROLES: dict[str, str] = {
+    "input_ids": "token_ids",
+    "inputs_embeds": "inputs_embeds",
+    "attention_mask": "attention_mask",
+    "position_ids": "position_ids",
+    "logits": "logits",
+    "last_hidden_state": "hidden_states",
+    "encoder_hidden_states": "encoder_hidden_states",
+    "audio_features": "audio_features",
+}
+
+
+def _component(
+    model: ir.Model,
+    artifact: str,
+    *,
+    effects: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    """Declare one ONNX-backed workflow component: its artifact and port roles.
+
+    A component declares only what its artifact cannot say about itself. The
+    ``.onnx`` file is shipped inside the package and is authoritative for which
+    ports exist and what dtype, rank and shape each one has, so transcribing
+    that into YAML would create a second copy of a fact the package already
+    carries — one that can drift from the graph and that nothing cross-checks
+    at rest. The runtime resolves ports against the live session instead, which
+    catches a name the graph does not expose rather than agreeing with a stale
+    echo of it.
+
+    What no graph carries is what a port *means*. ``input_ids`` and
+    ``position_ids`` are both rank-2 ``int64``; nothing in the file says which
+    one is the autoregressive sequence. An invocation binds an SSA value to a
+    port, which records which value arrives but not whether it is tokens, a mask
+    or logits — and that second fact is what a runtime needs before it can
+    specialize a decode step. So ``roles`` is the whole declaration here.
+
+    Only ports in this producer's own vocabulary get a role, and state ports
+    never need one: the group that carries them already names its pairs, which
+    is also where the fixed-capacity scatter ABI is stated.
+
+    ``batch_capacity`` is intentionally absent. A request-aligned or dynamic
+    batch axis is structural shape information, not proof that co-batching
+    preserves each request's result. Builders may add that semantic permission
+    only after the complete grouped contract has been authored and validated.
+    """
+    del effects
+    named = [str(value.name) for value in (*model.graph.inputs, *model.graph.outputs)]
+    roles = {name: _PORT_ROLES[name] for name in named if name in _PORT_ROLES}
+    declaration: dict[str, Any] = {"implementation": {"kind": "onnx", "artifact": artifact}}
+    if roles:
+        declaration["ports"] = {"roles": roles}
+    return declaration
+
+
+def _effect(consumes: str, produces: str) -> dict[str, str]:
+    return {"consumes": consumes, "produces": produces}
+
+
+def _publish_workflow_v1(workflow: dict[str, Any]) -> dict[str, Any]:
+    """Publish structured steps and logical carries without compiler bookkeeping."""
+    graph = workflow.pop("graph")
+    workflow.pop("initial_effects", None)
+    for declaration in workflow.get("inputs", {}).values():
+        source = declaration.get("source")
+        if isinstance(source, dict) and source.get("kind") == "request":
+            source.pop("field", None)
+
+    # Every workflow value whose leading dimension is the batch symbol holds one
+    # entry per in-flight request, so declare that structurally instead of leaving
+    # a runtime to infer it. Graph-derived contracts already carry the layout;
+    # this covers the hand-written declarations the runtime compares them against
+    # when it validates a carry, a binding, or an emit.
+    def _declare_row_alignment(contract: Any) -> Any:
+        if (
+            isinstance(contract, dict)
+            and "batch_layout" not in contract
+            and request_batch_layout(contract.get("shape")) is not None
+        ):
+            return _request_aligned(contract)
+        return contract
+
+    for section in ("inputs", "outputs", "state"):
+        for declaration in workflow.get(section, {}).values():
+            declaration["contract"] = _declare_row_alignment(declaration.get("contract"))
+    for component in workflow.get("components", {}).values():
+        for side in ("inputs", "outputs"):
+            ports = component.get("ports", {}).get(side)
+            if not ports:
+                continue
+            for port, contract in ports.items():
+                ports[port] = _declare_row_alignment(contract)
+    substitutions: dict[str, str] = {}
+    loop_index = 0
+    cell_aliases = {
+        cell: f"{cell}_state" if cell in workflow.get("outputs", {}) else cell
+        for cell in workflow.get("state", {})
+    }
+    if any(cell != alias for cell, alias in cell_aliases.items()):
+        workflow["state"] = {
+            cell_aliases[cell]: declaration for cell, declaration in workflow["state"].items()
+        }
+
+    def collect_carried(node: dict[str, Any]) -> None:
+        if node["kind"] == "loop":
+            for carry in node.get("carried", []):
+                alias = cell_aliases.get(carry["cell"], carry["cell"])
+                substitutions[carry["body_input"]] = alias
+                substitutions[carry["next"]] = alias
+            collect_carried(node["setup"])
+            collect_carried(node["body"])
+        elif node["kind"] == "sequence":
+            for child in node["nodes"]:
+                collect_carried(child)
+        elif node["kind"] == "branch":
+            for case in node["cases"].values():
+                collect_carried(case)
+            if "default" in node:
+                collect_carried(node["default"])
+
+    def rewrite(value: Any) -> Any:
+        if isinstance(value, str):
+            return substitutions.get(value, value)
+        if isinstance(value, list):
+            return [rewrite(item) for item in value]
+        if isinstance(value, dict):
+            return {key: rewrite(item) for key, item in value.items()}
+        return value
+
+    def convert(node: dict[str, Any]) -> dict[str, Any]:
+        nonlocal loop_index
+        kind = node["kind"]
+        if kind == "sequence":
+            return {
+                "kind": "sequence",
+                "steps": [convert(child) for child in node["nodes"]],
+            }
+        if kind == "invoke":
+            return {
+                "kind": "invoke",
+                "component": node["component"],
+                "inputs": rewrite(node.get("inputs", {})),
+                "outputs": rewrite(node.get("outputs", {})),
+            }
+        if kind == "emit":
+            result = {
+                "kind": "emit",
+                "value": rewrite(node["value"]),
+                "output": node["output"],
+                "mode": node["mode"],
+            }
+            if "axis" in node:
+                result["axis"] = node["axis"]
+            if "valid_length" in node:
+                result["valid_length"] = rewrite(node["valid_length"])
+            if "when" in node:
+                result["when"] = rewrite(node["when"])
+            return result
+        if kind == "branch":
+            result = {
+                "kind": "branch",
+                "predicate": rewrite(node["predicate"]),
+                "cases": {name: convert(case) for name, case in node["cases"].items()},
+                "outputs": rewrite(node.get("outputs", {})),
+            }
+            if "default" in node:
+                result["default"] = convert(node["default"])
+            return result
+        if kind == "loop":
+            current_loop = loop_index
+            loop_index += 1
+            setup = node["setup"]
+            body = node["body"]
+            setup_steps = (
+                [convert(child) for child in setup["nodes"]]
+                if setup["kind"] == "sequence"
+                else [convert(setup)]
+            )
+            body_steps = (
+                [convert(child) for child in body["nodes"]]
+                if body["kind"] == "sequence"
+                else [convert(body)]
+            )
+            carried = []
+            for carry in node.get("carried", []):
+                cell = cell_aliases.get(carry["cell"], carry["cell"])
+                published_carry = {
+                    "cell": cell,
+                    "next": rewrite(carry["body_output"]),
+                }
+                initial = rewrite(carry["current"])
+                if workflow["state"][cell]["initializer"] != initial:
+                    published_carry["initial"] = initial
+                carried.append(published_carry)
+            active_cell = node.get("active_cell")
+            if active_cell is None:
+                active_cell = f"loop_{current_loop}_active"
+                active_initializer = f"package.{active_cell}"
+                workflow["inputs"][active_initializer] = {
+                    "contract": {"dtype": "bool", "rank": 1, "shape": [1]},
+                    "role": {"kind": "opaque"},
+                    "source": {"kind": "literal"},
+                    "required": False,
+                    "default": True,
+                }
+                workflow["state"][active_cell] = {
+                    "contract": {"dtype": "bool", "rank": 1, "shape": [1]},
+                    "scope": "invocation",
+                    "initializer": active_initializer,
+                    "recurrence": {"kind": "invariant"},
+                }
+                carried.append(
+                    {
+                        "cell": active_cell,
+                        "next": rewrite(node["condition"]),
+                    }
+                )
+            result = {
+                "kind": "loop",
+                "setup": setup_steps,
+                "steps": body_steps,
+                "continue_when": active_cell,
+                "max_iterations": rewrite(node["max_iterations"]),
+                "carried": carried,
+            }
+            if "termination" in node:
+                result["termination"] = node["termination"]
+            if "iteration" in node:
+                result["iteration"] = node["iteration"]
+            return result
+        raise ValueError(f"unsupported workflow node kind {kind!r}")
+
+    collect_carried(graph)
+    published = convert(graph)
+    workflow["steps"] = published["steps"] if published["kind"] == "sequence" else [published]
+    declare_request_alignment(workflow)
+    declare_input_admission(workflow)
+    return workflow
+
+
+def _invoke(
+    component: str,
+    inputs: dict[str, str],
+    outputs: dict[str, str],
+    _effects: dict[str, dict[str, str]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "kind": "invoke",
+        "component": component,
+        "inputs": inputs,
+        "outputs": outputs,
+    }
+
+
+def _model_cache_pairs(model: ir.Model) -> list[tuple[ir.Value, ir.Value]]:
+    outputs = {value.name: value for value in model.graph.outputs}
+    pairs = []
+    for past in model.graph.inputs:
+        present = next(
+            (
+                outputs.get(name)
+                for name in _cache_output_candidates(past.name or "")
+                if name in outputs
+            ),
+            None,
+        )
+        if present is not None:
+            pairs.append((past, present))
+    return pairs
+
+
+def _cache_output_candidates(past_name: str) -> tuple[str, ...]:
+    """Names an exporter may give the output that continues a cache input.
+
+    An appending cache renames ``past`` to ``present``; a static, indexed cache
+    keeps the buffer's name and prefixes the written result instead, because the
+    output is the same buffer rather than a longer one.
+    """
+    return (
+        past_name.replace("past_key_values", "present"),
+        past_name.replace("past.", "present."),
+        past_name.replace("past_", "present_"),
+        f"updated_{past_name}",
+    )

--- a/src/mobius/integrations/onnx_genai/genai_config_import.py
+++ b/src/mobius/integrations/onnx_genai/genai_config_import.py
@@ -27,8 +27,8 @@ from typing import Any
 import onnx_ir as ir
 
 from mobius._model_package import ModelPackage
+from mobius.integrations.onnx_genai._metadata_io import _dump_yaml
 from mobius.integrations.onnx_genai.workflow_metadata import (
-    _dump_yaml,
     build_speech_to_text_workflow_metadata,
 )
 

--- a/src/mobius/integrations/onnx_genai/inference_metadata.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata.py
@@ -48,6 +48,17 @@ from mobius._constants import (
     STATIC_CACHE_WRITE_INDICES,
 )
 from mobius._pipeline_contract import component_presence, optional_input_contract
+from mobius.integrations.onnx_genai._workflow_contract import (
+    _invoke,
+    _Port,
+    _port,
+    _publish_workflow_v1,
+    _request_aligned,
+    _shape_metadata,
+    add_policy_components_to_workflow,
+    declare_input_admission,
+    declare_request_alignment,
+)
 from mobius.upstream_patches import apply_asset_patches
 
 _LOGGER = logging.getLogger(__name__)
@@ -81,17 +92,6 @@ _TEXT_RUNTIME_ASSET_NAMES = tuple(
 
 
 @dataclasses.dataclass(frozen=True)
-class _Port:
-    """Structural description of one ONNX graph port."""
-
-    value: Any
-    name: str
-    dtype: str
-    rank: int | None
-    dims: tuple[Any, ...]
-
-
-@dataclasses.dataclass(frozen=True)
 class _ImageProgram:
     """Registry result for one declared image processor contract."""
 
@@ -101,53 +101,6 @@ class _ImageProgram:
     token_count_source: str
     summary_contents: tuple[str, ...] = ()
     vision_properties: Callable[[dict[str, Any]], dict[str, Any]] | None = None
-
-
-_DTYPE_TAGS = {
-    "FLOAT": "fp32",
-    "FLOAT16": "fp16",
-    "BFLOAT16": "bf16",
-    "FLOAT8E4M3FN": "float8_e4m3fn",
-    "FLOAT8E5M2": "float8_e5m2",
-    "INT64": "int64",
-    "INT32": "int32",
-    "INT8": "int8",
-    "UINT8": "uint8",
-    "BOOL": "bool",
-    "STRING": "string",
-}
-
-
-def _port(value: Any) -> _Port:
-    shape = getattr(value, "shape", None)
-    dims = tuple(shape) if shape is not None else ()
-    dtype = getattr(getattr(value, "dtype", None), "name", "")
-    return _Port(
-        value=value,
-        name=str(value.name),
-        dtype=_DTYPE_TAGS.get(str(dtype).upper(), str(dtype).lower() or "fp32"),
-        rank=len(dims) if shape is not None else None,
-        dims=dims,
-    )
-
-
-_BATCH_DIMENSION = "batch"
-"""Symbolic leading dimension mobius uses for per-request batching."""
-
-
-def _shape_metadata(port: _Port) -> list[int | str]:
-    """Return a YAML-safe graph shape without losing symbolic dimensions."""
-    shape: list[int | str] = []
-    for axis, dim in enumerate(port.dims):
-        if isinstance(dim, int):
-            shape.append(dim)
-            continue
-        value = getattr(dim, "value", None)
-        # Metadata dimensions cannot be null. Preserve named graph dimensions;
-        # give anonymous dynamic dimensions a stable, port-local name instead
-        # of pretending they are static or serializing an invalid null.
-        shape.append(str(value) if value is not None else f"{port.name}_dim_{axis}")
-    return shape
 
 
 def _name_image_preprocessing_program(image: dict[str, Any]) -> None:
@@ -1435,320 +1388,6 @@ def validate_executable_closure(pkg: Any, metadata: dict[str, Any]) -> None:
                 )
 
 
-#: Symbolic dimension Mobius emits for every request-aligned ONNX port.
-REQUEST_AXIS_SYMBOL = "batch"
-
-
-def request_batch_layout(shape: list[Any] | None) -> dict[str, Any] | None:
-    """Return the request-aligned batch layout implied by a port's shape."""
-    axes = [
-        axis
-        for axis, dimension in enumerate(shape or [])
-        if str(dimension) in _BATCH_DIMENSION_NAMES
-    ]
-    if len(axes) == 1:
-        return {"kind": "request_aligned", "axis": axes[0]}
-    return None
-
-
-def add_policy_components_to_workflow(
-    metadata: dict[str, Any],
-    pkg: Any,
-) -> dict[str, Any]:
-    """Reference attached ONNX policy artifacts from an existing workflow.
-
-    This helper intentionally does not synthesize a workflow or guess bindings.
-    It only adds schema-defined component declarations when a producer has
-    already emitted the exact workflow contract.
-    """
-    policy_components = getattr(pkg, "policy_components", {})
-    if not policy_components:
-        return metadata
-    workflow = metadata.get("pipeline", {}).get("workflow")
-    if not isinstance(workflow, dict):
-        return metadata
-    components = workflow.setdefault("components", {})
-
-    def semantic_contract(component: Any) -> dict[str, Any]:
-        contract = component.contract
-        contract_name, version = component.contract_id.rsplit("@", 1)
-        bindings = {
-            key: value
-            for key, value in contract.items()
-            if key
-            not in {
-                "role",
-                "mode",
-                "effect",
-                "rng",
-                "state_class",
-                "batching",
-                "inactive_rows",
-            }
-            and isinstance(value, str)
-        }
-        rng = contract.get("rng")
-        if isinstance(rng, dict):
-            bindings.update(
-                {key: value for key, value in rng.items() if isinstance(value, str)}
-            )
-        declaration: dict[str, Any] = {
-            "id": contract_name,
-            "version": version,
-            "bindings": bindings,
-        }
-        parameters = {
-            key: contract[key]
-            for key in ("mode", "batching", "inactive_rows")
-            if key in contract
-        }
-        if parameters:
-            declaration["parameters"] = parameters
-        return declaration
-
-    def tensor_contract(value: Any) -> dict[str, Any]:
-        port = _port(value)
-        dtype = {
-            "fp32": "float32",
-            "fp16": "float16",
-            "bf16": "bfloat16",
-        }.get(port.dtype, port.dtype)
-        shape = _shape_metadata(port)
-        contract: dict[str, Any] = {
-            "dtype": dtype,
-            "rank": port.rank,
-            "shape": shape,
-        }
-        layout = request_batch_layout(shape)
-        if layout is not None:
-            contract["batch_layout"] = layout
-        return contract
-
-    for name, component in policy_components.items():
-        # A policy graph is synthesized by this producer to realize the
-        # workflow's own control flow, so its port contracts are not a
-        # transcription of an external interface: they are the type annotations
-        # of the workflow's dataflow. A workflow value acquires its dtype, rank
-        # and request axis from the port that produces it, and the validator
-        # reads metadata without the artifacts, so a policy output that states
-        # no contract leaves every value derived from it untyped.
-        declaration = {
-            "implementation": {
-                "kind": "onnx",
-                "artifact": f"policies/{name}.onnx",
-            },
-            "ports": {
-                "inputs": {
-                    value.name: tensor_contract(value)
-                    for value in component.model.graph.inputs
-                },
-                "outputs": {
-                    value.name: tensor_contract(value)
-                    for value in component.model.graph.outputs
-                },
-            },
-        }
-        if component.contract:
-            declaration["contract"] = semantic_contract(component)
-            if component.contract.get("role") == "token_sampler":
-                declaration["application_overridable"] = True
-        components[name] = declaration
-    declare_request_alignment(workflow)
-    declare_input_admission(workflow)
-    return metadata
-
-
-_BATCH_DIMENSION_NAMES = frozenset({"batch", "batch_size", "batch_dim", "b"})
-
-
-def declare_request_alignment(workflow: dict[str, Any]) -> None:
-    """Stamp the request axis named by exactly one batch symbol.
-
-    The runtime compacts finished rows out of a batch by applying one row
-    permutation to every request-aligned tensor. A contract whose batch axis
-    does not say so is unpermutable, so state,
-    component ports, and outputs would silently drift apart after the first
-    eviction. Deriving the declaration from the admitted graph's own batch
-    symbol keeps alignment a property of the model interface rather than an
-    annotation every workflow builder has to remember.
-    """
-
-    def stamp(contract: Any) -> None:
-        if not isinstance(contract, dict) or "batch_layout" in contract:
-            return
-        shape = contract.get("shape") or []
-        if layout := request_batch_layout(shape):
-            contract["batch_layout"] = layout
-
-    for section in ("inputs", "outputs", "state"):
-        for declaration in (workflow.get(section) or {}).values():
-            if isinstance(declaration, dict):
-                stamp(declaration.get("contract"))
-    for component in (workflow.get("components") or {}).values():
-        ports = component.get("ports", {}) if isinstance(component, dict) else {}
-        for side in ("inputs", "outputs"):
-            for contract in (ports.get(side) or {}).values():
-                stamp(contract)
-    # A cell backed by a state-service group is stored by the runtime, not by
-    # the workflow: the group owns the buffer and the eviction policy, so the
-    # cell also needs an explicit boundary at which the runtime may free it.
-    for declaration in (workflow.get("state") or {}).values():
-        if isinstance(declaration, dict) and declaration.get("service_group"):
-            declaration.setdefault("management", "runtime")
-            declaration.setdefault("release_boundary", declaration.get("scope", "invocation"))
-
-
-def published_value_references(workflow: dict[str, Any]) -> set[str]:
-    """Every value name the published program reads, on any path.
-
-    Reachability here is deliberately path-insensitive: it answers "does this
-    workflow ever look at this value", which is what an admission decision
-    needs. Whether a particular request reaches the branch that reads it is a
-    runtime fact, and a package that guessed at it would be describing one
-    caller rather than its own contract.
-    """
-    references: set[str] = set()
-
-    def note(value: Any) -> None:
-        if isinstance(value, str):
-            references.add(value)
-        elif isinstance(value, dict):
-            for item in value.values():
-                note(item)
-        elif isinstance(value, list):
-            for item in value:
-                note(item)
-
-    def visit(step: Any) -> None:
-        if isinstance(step, list):
-            for item in step:
-                visit(item)
-            return
-        if not isinstance(step, dict):
-            return
-        kind = step.get("kind")
-        if kind == "invoke":
-            note(step.get("inputs"))
-        elif kind == "emit":
-            note(step.get("value"))
-            note(step.get("valid_length"))
-            note(step.get("when"))
-        elif kind == "branch":
-            note(step.get("predicate"))
-            note(step.get("outputs"))
-            for case in (step.get("cases") or {}).values():
-                visit(case)
-            visit(step.get("default"))
-        elif kind == "loop":
-            note(step.get("continue_when"))
-            note(step.get("max_iterations"))
-            for carry in step.get("carried") or []:
-                note(carry.get("next"))
-                note(carry.get("initial"))
-        for key in ("steps", "setup", "nodes"):
-            visit(step.get(key))
-
-    visit(workflow.get("steps") or [])
-    for declaration in (workflow.get("state") or {}).values():
-        if isinstance(declaration, dict):
-            note(declaration.get("initializer"))
-            # A bounded or growing cell reads its own extent every step, so the
-            # bound and the step size are read positions like any other. The
-            # sibling ``kind``/``axis`` keys describe the recurrence rather than
-            # naming values, so they are not references.
-            recurrence = declaration.get("recurrence") or {}
-            note(recurrence.get("max"))
-            note(recurrence.get("increment"))
-    # The serving block names the workflow values a runtime reads to drive
-    # batching -- the active/done row masks and the accepted length.
-    serving = workflow.get("serving") or {}
-    for key, value in serving.items():
-        if key != "state_service":
-            note(value)
-    # ``state_service`` is mostly port and cell names rather than values, with
-    # one exception: a group's fixed update extent is itself a workflow value.
-    for group in ((serving.get("state_service") or {}).get("groups") or {}).values():
-        if isinstance(group, dict):
-            note((group.get("update") or {}).get("capacity"))
-    return references
-
-
-def declare_input_admission(workflow: dict[str, Any]) -> None:
-    """Publish every package input's admission requirement instead of implying it.
-
-    ``required`` is what a runtime admits a request against: an input it holds
-    required and the caller did not attach is a rejected request, on every path,
-    before a single component runs. A consumer cannot see what an *absent*
-    ``required`` key was meant to say, so it has to choose a default, and the
-    choice it makes is the opposite of what omission means to a producer -- a
-    value the workflow computes for itself, defaults for itself, or explicitly
-    branches on the absence of, silently becomes a mandatory caller attachment.
-
-    So the flag is derived from the published program rather than left to a
-    reader, and stamped on every declaration:
-
-    * a declaration the package can satisfy on its own -- it carries a
-      ``default``, which is also the only thing a package-owned ``literal``
-      source is ever bound from -- is not something a caller can be required to
-      send;
-    * a declaration whose absence the program *observes*, through a
-      ``present_as`` symbol the steps actually branch on, is one the workflow
-      has been written to run without;
-    * anything else is genuinely externally required, and says so out loud.
-
-    A builder that declares both an escape and ``required: True`` has written
-    two contradictory contracts, and there is no reading of the package that
-    satisfies both, so this fails closed rather than picking one. The mirror
-    case fails closed for the same reason: an input marked optional that the
-    package has no way to proceed without is not optional, it is a request that
-    is admitted and then fails part-way through on an unbound value, which is
-    strictly worse than the rejection it replaced.
-    """
-    inputs = workflow.get("inputs") or {}
-    if not inputs:
-        return
-    references = published_value_references(workflow)
-    for name, declaration in inputs.items():
-        if not isinstance(declaration, dict):
-            continue
-        escapes = []
-        literal = (declaration.get("source") or {}).get("kind") == "literal"
-        if "default" in declaration:
-            escapes.append("a package-supplied default" if literal else "a default")
-        elif literal:
-            # A literal source is resolved from the declaration's own default
-            # and from nothing else, so one without a default names a value the
-            # package neither holds nor can ask a caller for.
-            raise ValueError(
-                f"workflow input {name!r} is sourced from a package literal but "
-                "carries no default, so nothing ever binds it"
-            )
-        present_as = declaration.get("present_as")
-        if present_as is not None:
-            if present_as not in references:
-                raise ValueError(
-                    f"workflow input {name!r} declares the presence symbol "
-                    f"{present_as!r} that no step reads, so the workflow never "
-                    "handles the input being absent"
-                )
-            escapes.append(f"the presence gate {present_as!r}")
-        if not escapes:
-            if declaration.get("required", True) is False:
-                raise ValueError(
-                    f"workflow input {name!r} is declared optional but the workflow "
-                    "carries no default and no presence gate for it, so a request "
-                    "that omits it has no defined behaviour"
-                )
-            declaration["required"] = True
-            continue
-        if declaration.get("required", False):
-            raise ValueError(
-                f"workflow input {name!r} is declared required but the workflow "
-                f"already proceeds without it through {', '.join(escapes)}"
-            )
-        declaration["required"] = False
-
-
 def add_adapter_service_to_metadata(
     metadata: dict[str, Any],
     pkg: Any,
@@ -1948,7 +1587,8 @@ def build_native_vlm_package_metadata(
     closure. It is consumed by
     :func:`~mobius.integrations.onnx_genai.workflow_metadata.build_vlm_workflow_metadata`,
     which publishes the workflow and the ``preprocessing`` program. Use
-    :func:`write_native_vlm_package_metadata` to emit the package contract.
+    :func:`~mobius.integrations.onnx_genai.workflow_metadata.write_native_vlm_package_metadata`
+    to emit the package contract.
 
     Processor selection is registry-driven from graph rank/dtype/shape
     signatures. No model type, architecture name, or model-name branch
@@ -2228,35 +1868,6 @@ def _copy_runtime_assets(
         for filename in names
         if os.path.isfile(os.path.join(output_dir, filename))
     }
-
-
-def write_native_vlm_package_metadata(
-    pkg: Any,
-    directory: str,
-    *,
-    config: Any,
-    source: str | None = None,
-    revision: str | None = None,
-) -> dict[str, str]:
-    """Write the published VLM package contract and its tokenizer/processor assets.
-
-    What lands in ``inference_metadata.yaml`` is the typed SSA workflow built by
-    :func:`~mobius.integrations.onnx_genai.workflow_metadata.build_vlm_workflow_metadata`,
-    not the structural descriptor :func:`build_native_vlm_package_metadata`
-    returns.
-    """
-    from mobius.integrations.onnx_genai.workflow_metadata import (
-        write_vlm_workflow_metadata,
-    )
-
-    # Assets first: the workflow document declares their package-relative
-    # locations under ``package.tokenizer.artifacts``, so they have to be in the
-    # package before the document that names them is written.
-    artifacts = _copy_runtime_assets(directory, source, revision=revision)
-    artifacts["inference_metadata"] = write_vlm_workflow_metadata(
-        pkg, directory, config, source=source
-    )
-    return artifacts
 
 
 @dataclasses.dataclass(frozen=True)
@@ -2685,11 +2296,6 @@ def build_diffusion_pipeline_metadata(
         build_tensor_clamp,
         build_tensor_scale,
         build_zeros_like,
-    )
-    from mobius.integrations.onnx_genai.workflow_metadata import (
-        _invoke,
-        _publish_workflow_v1,
-        _request_aligned,
     )
 
     if num_inference_steps < 1:

--- a/src/mobius/integrations/onnx_genai/inference_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata_test.py
@@ -23,30 +23,32 @@ from mobius._pipeline_contract import (
     declare_optional_input,
 )
 from mobius.generation import build_greedy_sampler
+from mobius.integrations.onnx_genai._workflow_contract import (
+    _port,
+    add_policy_components_to_workflow,
+    declare_input_admission,
+    published_value_references,
+    request_batch_layout,
+)
 from mobius.integrations.onnx_genai.inference_metadata import (
     SchedulerConfig,
     _decoder_io,
     _input_source_map,
     _match_max_token_grid,
-    _port,
     _processor_values,
-    add_policy_components_to_workflow,
     build_diffusion_pipeline_metadata,
     build_multimodal_pipeline_metadata,
     build_native_vlm_package_metadata,
-    declare_input_admission,
     is_native_vlm_package,
     load_diffusers_scheduler_config,
     load_diffusers_vae_scaling_factor,
-    published_value_references,
-    request_batch_layout,
     validate_executable_closure,
     write_diffusion_pipeline_metadata,
     write_mtp_speculator_metadata,
-    write_native_vlm_package_metadata,
 )
 from mobius.integrations.onnx_genai.workflow_metadata import (
     build_vlm_workflow_metadata,
+    write_native_vlm_package_metadata,
 )
 
 

--- a/src/mobius/integrations/onnx_genai/metadata_dependency_test.py
+++ b/src/mobius/integrations/onnx_genai/metadata_dependency_test.py
@@ -20,6 +20,35 @@ _PACKAGE = "mobius.integrations.onnx_genai"
 _SOURCE_ROOT = Path(__file__).resolve().parents[3]
 
 
+def _import_edges(source: str, package: str) -> set[str]:
+    """Return normalized module edges for imports written inside *package*."""
+    edges: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            edges.update(alias.name for alias in node.names)
+            continue
+        if not isinstance(node, ast.ImportFrom):
+            continue
+
+        if node.level:
+            package_parts = package.split(".")
+            base_length = len(package_parts) - node.level + 1
+            if base_length < 0:
+                continue
+            module_parts = package_parts[:base_length]
+            if node.module:
+                module_parts.extend(node.module.split("."))
+            module = ".".join(module_parts)
+        else:
+            module = node.module
+        if not module:
+            continue
+
+        edges.add(module)
+        edges.update(f"{module}.{alias.name}" for alias in node.names if alias.name != "*")
+    return edges
+
+
 @pytest.mark.parametrize(
     "module",
     [
@@ -37,24 +66,39 @@ def test_metadata_modules_import_in_fresh_process(module: str) -> None:
     )
 
 
-def test_inference_metadata_has_no_workflow_metadata_dependency() -> None:
-    inference_path = Path(__file__).with_name("inference_metadata.py")
-    contract_path = Path(__file__).with_name("_workflow_contract.py")
+@pytest.mark.parametrize(
+    ("source", "prohibited"),
+    [
+        (f"from {_PACKAGE} import workflow_metadata", True),
+        (f"import {_PACKAGE}.workflow_metadata", True),
+        ("from . import workflow_metadata", True),
+        ("from ._workflow_contract import _port", False),
+    ],
+)
+def test_import_edges_cover_metadata_dependency_syntax(source: str, prohibited: bool) -> None:
+    target = f"{_PACKAGE}.workflow_metadata"
+    assert (target in _import_edges(source, _PACKAGE)) is prohibited
 
-    inference_imports = {
-        node.module
-        for node in ast.walk(ast.parse(inference_path.read_text(encoding="utf-8")))
-        if isinstance(node, ast.ImportFrom)
-    }
-    contract_imports = {
-        node.module
-        for node in ast.walk(ast.parse(contract_path.read_text(encoding="utf-8")))
-        if isinstance(node, ast.ImportFrom)
-    }
 
-    assert f"{_PACKAGE}.workflow_metadata" not in inference_imports
-    assert f"{_PACKAGE}.workflow_metadata" not in contract_imports
-    assert f"{_PACKAGE}.inference_metadata" not in contract_imports
+@pytest.mark.parametrize(
+    ("filename", "forbidden"),
+    [
+        ("inference_metadata.py", {f"{_PACKAGE}.workflow_metadata"}),
+        (
+            "_workflow_contract.py",
+            {
+                f"{_PACKAGE}.inference_metadata",
+                f"{_PACKAGE}.workflow_metadata",
+            },
+        ),
+    ],
+)
+def test_metadata_modules_keep_one_way_dependencies(
+    filename: str, forbidden: set[str]
+) -> None:
+    path = Path(__file__).with_name(filename)
+    imports = _import_edges(path.read_text(encoding="utf-8"), _PACKAGE)
+    assert imports.isdisjoint(forbidden)
 
 
 def test_metadata_yaml_is_deterministic_and_suppresses_aliases() -> None:
@@ -63,11 +107,4 @@ def test_metadata_yaml_is_deterministic_and_suppresses_aliases() -> None:
 
     _dump_yaml({"first": shared, "second": shared}, output)
 
-    assert output.getvalue().encode() == (
-        b"first:\n"
-        b"- 1\n"
-        b"- 2\n"
-        b"second:\n"
-        b"- 1\n"
-        b"- 2\n"
-    )
+    assert output.getvalue().encode() == (b"first:\n- 1\n- 2\nsecond:\n- 1\n- 2\n")

--- a/src/mobius/integrations/onnx_genai/metadata_dependency_test.py
+++ b/src/mobius/integrations/onnx_genai/metadata_dependency_test.py
@@ -1,0 +1,73 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Dependency and serialization boundaries for ONNX-GenAI metadata."""
+
+from __future__ import annotations
+
+import ast
+import io
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from mobius.integrations.onnx_genai._metadata_io import _dump_yaml
+
+_PACKAGE = "mobius.integrations.onnx_genai"
+_SOURCE_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        f"{_PACKAGE}.workflow_metadata",
+        f"{_PACKAGE}.inference_metadata",
+    ],
+)
+def test_metadata_modules_import_in_fresh_process(module: str) -> None:
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = str(_SOURCE_ROOT)
+    subprocess.run(
+        [sys.executable, "-c", f"import {module}"],
+        check=True,
+        env=environment,
+    )
+
+
+def test_inference_metadata_has_no_workflow_metadata_dependency() -> None:
+    inference_path = Path(__file__).with_name("inference_metadata.py")
+    contract_path = Path(__file__).with_name("_workflow_contract.py")
+
+    inference_imports = {
+        node.module
+        for node in ast.walk(ast.parse(inference_path.read_text(encoding="utf-8")))
+        if isinstance(node, ast.ImportFrom)
+    }
+    contract_imports = {
+        node.module
+        for node in ast.walk(ast.parse(contract_path.read_text(encoding="utf-8")))
+        if isinstance(node, ast.ImportFrom)
+    }
+
+    assert f"{_PACKAGE}.workflow_metadata" not in inference_imports
+    assert f"{_PACKAGE}.workflow_metadata" not in contract_imports
+    assert f"{_PACKAGE}.inference_metadata" not in contract_imports
+
+
+def test_metadata_yaml_is_deterministic_and_suppresses_aliases() -> None:
+    shared = [1, 2]
+    output = io.StringIO()
+
+    _dump_yaml({"first": shared, "second": shared}, output)
+
+    assert output.getvalue().encode() == (
+        b"first:\n"
+        b"- 1\n"
+        b"- 2\n"
+        b"second:\n"
+        b"- 1\n"
+        b"- 2\n"
+    )

--- a/src/mobius/integrations/onnx_genai/shared_state_flow_metadata.py
+++ b/src/mobius/integrations/onnx_genai/shared_state_flow_metadata.py
@@ -9,7 +9,6 @@ import os
 from typing import Any
 
 import onnx_ir as ir
-import yaml
 
 from mobius.generation import (
     PolicyCapabilities,
@@ -30,17 +29,15 @@ from mobius.generation import (
     build_tensor_scale,
     build_x0_flow_velocity,
 )
-from mobius.integrations.onnx_genai.inference_metadata import (
-    add_policy_components_to_workflow,
-)
-from mobius.integrations.onnx_genai.workflow_metadata import (
+from mobius.integrations.onnx_genai._metadata_io import _dump_yaml
+from mobius.integrations.onnx_genai._workflow_contract import (
     _component,
     _contract,
     _effect,
     _invoke,
     _model_cache_pairs,
-    _NoAliasSafeDumper,
     _publish_workflow_v1,
+    add_policy_components_to_workflow,
 )
 
 
@@ -937,5 +934,5 @@ def write_shared_state_pixel_flow_workflow_metadata(
     pkg.save_policy_components(output_dir)
     path = os.path.join(output_dir, "inference_metadata.yaml")
     with open(path, "w", encoding="utf-8") as handle:
-        yaml.dump(metadata, handle, Dumper=_NoAliasSafeDumper, sort_keys=False)
+        _dump_yaml(metadata, handle)
     return path

--- a/src/mobius/integrations/onnx_genai/workflow_metadata.py
+++ b/src/mobius/integrations/onnx_genai/workflow_metadata.py
@@ -15,7 +15,6 @@ from collections.abc import Mapping, Sequence
 from typing import Any, ClassVar
 
 import onnx_ir as ir
-import yaml
 
 from mobius._constants import (
     STATIC_CACHE_KV_SEQUENCE_LENGTH,
@@ -109,17 +108,26 @@ from mobius.generation import (
     build_zeros_like,
     rotary_axis_count,
 )
-from mobius.integrations.onnx_genai.inference_metadata import (
-    _name_image_preprocessing_program,
+from mobius.integrations.onnx_genai._metadata_io import _dump_yaml
+from mobius.integrations.onnx_genai._workflow_contract import (
+    _cache_output_candidates,
+    _component,
+    _contract,
+    _effect,
+    _invoke,
+    _model_cache_pairs,
     _port,
+    _publish_workflow_v1,
+    _request_aligned,
     _shape_metadata,
+    add_policy_components_to_workflow,
+)
+from mobius.integrations.onnx_genai.inference_metadata import (
+    _copy_runtime_assets,
+    _name_image_preprocessing_program,
     _source_asset_path,
     add_adapter_service_to_metadata,
-    add_policy_components_to_workflow,
     build_native_vlm_package_metadata,
-    declare_input_admission,
-    declare_request_alignment,
-    request_batch_layout,
 )
 from mobius.integrations.onnx_genai.package_facts import (
     MEDIA_TOKEN_ROLES,
@@ -128,110 +136,12 @@ from mobius.integrations.onnx_genai.package_facts import (
     source_declared_value,
 )
 
-
-class _NoAliasSafeDumper(yaml.SafeDumper):
-    def ignore_aliases(self, data: Any) -> bool:
-        return True
-
-
 _CTC_TOKEN_ROLES = tuple(role for role in TEXT_TOKEN_ROLES if role.name == "pad_token_id")
-
-
-def _dump_yaml(metadata: dict[str, Any], handle: Any) -> None:
-    yaml.dump(metadata, handle, Dumper=_NoAliasSafeDumper, sort_keys=False)
 
 
 def _source_model_value(source: str | None, name: str, fallback: Any) -> Any:
     """Resolve a value from packaged runtime metadata when available."""
     return source_declared_value(source, name, fallback)
-
-
-def _contract(value: ir.Value) -> dict[str, Any]:
-    port = _port(value)
-    dtype = {"fp16": "float16", "bf16": "bfloat16", "fp32": "float32"}.get(
-        port.dtype, port.dtype
-    )
-    shape = _shape_metadata(port)
-    contract: dict[str, Any] = {
-        "dtype": dtype,
-        "rank": port.rank,
-        "shape": shape,
-    }
-    layout = request_batch_layout(shape)
-    if layout is not None:
-        contract["batch_layout"] = layout
-    return contract
-
-
-def _request_aligned(contract: dict[str, Any], axis: int = 0) -> dict[str, Any]:
-    """Mark a contract as carrying exactly one entry per in-flight request.
-
-    This is a structural batching fact, not a row identity: it tells the runtime
-    which axis to permute when it compacts the batch, while scheduler slots and
-    sequence handles stay runtime-private.
-    """
-    return {**contract, "batch_layout": {"kind": "request_aligned", "axis": axis}}
-
-
-# Translation between the port vocabulary this producer *mints* when it builds
-# a graph and the runtime's architecture-neutral role vocabulary. Both sides are
-# fixed vocabularies and Mobius owns one of them: the task builders in
-# ``mobius.tasks`` choose these exact names, so reading them back here is a
-# lookup, not an inference about a graph of unknown provenance. A port outside
-# this vocabulary carries no role, because a workflow that guesses is worse than
-# one that stays silent.
-_PORT_ROLES: dict[str, str] = {
-    "input_ids": "token_ids",
-    "inputs_embeds": "inputs_embeds",
-    "attention_mask": "attention_mask",
-    "position_ids": "position_ids",
-    "logits": "logits",
-    "last_hidden_state": "hidden_states",
-    "encoder_hidden_states": "encoder_hidden_states",
-    "audio_features": "audio_features",
-}
-
-
-def _component(
-    model: ir.Model,
-    artifact: str,
-    *,
-    effects: tuple[str, ...] = (),
-) -> dict[str, Any]:
-    """Declare one ONNX-backed workflow component: its artifact and port roles.
-
-    A component declares only what its artifact cannot say about itself. The
-    ``.onnx`` file is shipped inside the package and is authoritative for which
-    ports exist and what dtype, rank and shape each one has, so transcribing
-    that into YAML would create a second copy of a fact the package already
-    carries — one that can drift from the graph and that nothing cross-checks
-    at rest. The runtime resolves ports against the live session instead, which
-    catches a name the graph does not expose rather than agreeing with a stale
-    echo of it.
-
-    What no graph carries is what a port *means*. ``input_ids`` and
-    ``position_ids`` are both rank-2 ``int64``; nothing in the file says which
-    one is the autoregressive sequence. An invocation binds an SSA value to a
-    port, which records which value arrives but not whether it is tokens, a mask
-    or logits — and that second fact is what a runtime needs before it can
-    specialize a decode step. So ``roles`` is the whole declaration here.
-
-    Only ports in this producer's own vocabulary get a role, and state ports
-    never need one: the group that carries them already names its pairs, which
-    is also where the fixed-capacity scatter ABI is stated.
-
-    ``batch_capacity`` is intentionally absent. A request-aligned or dynamic
-    batch axis is structural shape information, not proof that co-batching
-    preserves each request's result. Builders may add that semantic permission
-    only after the complete grouped contract has been authored and validated.
-    """
-    del effects
-    named = [str(value.name) for value in (*model.graph.inputs, *model.graph.outputs)]
-    roles = {name: _PORT_ROLES[name] for name in named if name in _PORT_ROLES}
-    declaration: dict[str, Any] = {"implementation": {"kind": "onnx", "artifact": artifact}}
-    if roles:
-        declaration["ports"] = {"roles": roles}
-    return declaration
 
 
 def _declare_batch_capacities(
@@ -435,205 +345,6 @@ def _grammar_adapter_component(action: str) -> dict[str, Any]:
         # ABI when the batch changes; without it the FSM rows would drift out
         # of correspondence with the sequences they guide.
         "row_scope": {"axis": 0, "stateful": True},
-    }
-
-
-def _effect(consumes: str, produces: str) -> dict[str, str]:
-    return {"consumes": consumes, "produces": produces}
-
-
-def _publish_workflow_v1(workflow: dict[str, Any]) -> dict[str, Any]:
-    """Publish structured steps and logical carries without compiler bookkeeping."""
-    graph = workflow.pop("graph")
-    workflow.pop("initial_effects", None)
-    for declaration in workflow.get("inputs", {}).values():
-        source = declaration.get("source")
-        if isinstance(source, dict) and source.get("kind") == "request":
-            source.pop("field", None)
-
-    # Every workflow value whose leading dimension is the batch symbol holds one
-    # entry per in-flight request, so declare that structurally instead of leaving
-    # a runtime to infer it. Graph-derived contracts already carry the layout;
-    # this covers the hand-written declarations the runtime compares them against
-    # when it validates a carry, a binding, or an emit.
-    def _declare_row_alignment(contract: Any) -> Any:
-        if (
-            isinstance(contract, dict)
-            and "batch_layout" not in contract
-            and request_batch_layout(contract.get("shape")) is not None
-        ):
-            return _request_aligned(contract)
-        return contract
-
-    for section in ("inputs", "outputs", "state"):
-        for declaration in workflow.get(section, {}).values():
-            declaration["contract"] = _declare_row_alignment(declaration.get("contract"))
-    for component in workflow.get("components", {}).values():
-        for side in ("inputs", "outputs"):
-            ports = component.get("ports", {}).get(side)
-            if not ports:
-                continue
-            for port, contract in ports.items():
-                ports[port] = _declare_row_alignment(contract)
-    substitutions: dict[str, str] = {}
-    loop_index = 0
-    cell_aliases = {
-        cell: f"{cell}_state" if cell in workflow.get("outputs", {}) else cell
-        for cell in workflow.get("state", {})
-    }
-    if any(cell != alias for cell, alias in cell_aliases.items()):
-        workflow["state"] = {
-            cell_aliases[cell]: declaration for cell, declaration in workflow["state"].items()
-        }
-
-    def collect_carried(node: dict[str, Any]) -> None:
-        if node["kind"] == "loop":
-            for carry in node.get("carried", []):
-                alias = cell_aliases.get(carry["cell"], carry["cell"])
-                substitutions[carry["body_input"]] = alias
-                substitutions[carry["next"]] = alias
-            collect_carried(node["setup"])
-            collect_carried(node["body"])
-        elif node["kind"] == "sequence":
-            for child in node["nodes"]:
-                collect_carried(child)
-        elif node["kind"] == "branch":
-            for case in node["cases"].values():
-                collect_carried(case)
-            if "default" in node:
-                collect_carried(node["default"])
-
-    def rewrite(value: Any) -> Any:
-        if isinstance(value, str):
-            return substitutions.get(value, value)
-        if isinstance(value, list):
-            return [rewrite(item) for item in value]
-        if isinstance(value, dict):
-            return {key: rewrite(item) for key, item in value.items()}
-        return value
-
-    def convert(node: dict[str, Any]) -> dict[str, Any]:
-        nonlocal loop_index
-        kind = node["kind"]
-        if kind == "sequence":
-            return {
-                "kind": "sequence",
-                "steps": [convert(child) for child in node["nodes"]],
-            }
-        if kind == "invoke":
-            return {
-                "kind": "invoke",
-                "component": node["component"],
-                "inputs": rewrite(node.get("inputs", {})),
-                "outputs": rewrite(node.get("outputs", {})),
-            }
-        if kind == "emit":
-            result = {
-                "kind": "emit",
-                "value": rewrite(node["value"]),
-                "output": node["output"],
-                "mode": node["mode"],
-            }
-            if "axis" in node:
-                result["axis"] = node["axis"]
-            if "valid_length" in node:
-                result["valid_length"] = rewrite(node["valid_length"])
-            if "when" in node:
-                result["when"] = rewrite(node["when"])
-            return result
-        if kind == "branch":
-            result = {
-                "kind": "branch",
-                "predicate": rewrite(node["predicate"]),
-                "cases": {name: convert(case) for name, case in node["cases"].items()},
-                "outputs": rewrite(node.get("outputs", {})),
-            }
-            if "default" in node:
-                result["default"] = convert(node["default"])
-            return result
-        if kind == "loop":
-            current_loop = loop_index
-            loop_index += 1
-            setup = node["setup"]
-            body = node["body"]
-            setup_steps = (
-                [convert(child) for child in setup["nodes"]]
-                if setup["kind"] == "sequence"
-                else [convert(setup)]
-            )
-            body_steps = (
-                [convert(child) for child in body["nodes"]]
-                if body["kind"] == "sequence"
-                else [convert(body)]
-            )
-            carried = []
-            for carry in node.get("carried", []):
-                cell = cell_aliases.get(carry["cell"], carry["cell"])
-                published_carry = {
-                    "cell": cell,
-                    "next": rewrite(carry["body_output"]),
-                }
-                initial = rewrite(carry["current"])
-                if workflow["state"][cell]["initializer"] != initial:
-                    published_carry["initial"] = initial
-                carried.append(published_carry)
-            active_cell = node.get("active_cell")
-            if active_cell is None:
-                active_cell = f"loop_{current_loop}_active"
-                active_initializer = f"package.{active_cell}"
-                workflow["inputs"][active_initializer] = {
-                    "contract": {"dtype": "bool", "rank": 1, "shape": [1]},
-                    "role": {"kind": "opaque"},
-                    "source": {"kind": "literal"},
-                    "required": False,
-                    "default": True,
-                }
-                workflow["state"][active_cell] = {
-                    "contract": {"dtype": "bool", "rank": 1, "shape": [1]},
-                    "scope": "invocation",
-                    "initializer": active_initializer,
-                    "recurrence": {"kind": "invariant"},
-                }
-                carried.append(
-                    {
-                        "cell": active_cell,
-                        "next": rewrite(node["condition"]),
-                    }
-                )
-            result = {
-                "kind": "loop",
-                "setup": setup_steps,
-                "steps": body_steps,
-                "continue_when": active_cell,
-                "max_iterations": rewrite(node["max_iterations"]),
-                "carried": carried,
-            }
-            if "termination" in node:
-                result["termination"] = node["termination"]
-            if "iteration" in node:
-                result["iteration"] = node["iteration"]
-            return result
-        raise ValueError(f"unsupported workflow node kind {kind!r}")
-
-    collect_carried(graph)
-    published = convert(graph)
-    workflow["steps"] = published["steps"] if published["kind"] == "sequence" else [published]
-    declare_request_alignment(workflow)
-    declare_input_admission(workflow)
-    return workflow
-
-
-def _invoke(
-    component: str,
-    inputs: dict[str, str],
-    outputs: dict[str, str],
-    _effects: dict[str, dict[str, str]] | None = None,
-) -> dict[str, Any]:
-    return {
-        "kind": "invoke",
-        "component": component,
-        "inputs": inputs,
-        "outputs": outputs,
     }
 
 
@@ -2309,38 +2020,6 @@ def write_audio_codec_workflow_metadata(pkg: Any, output_dir: str) -> str:
     with open(path, "w", encoding="utf-8") as handle:
         _dump_yaml(metadata, handle)
     return path
-
-
-def _model_cache_pairs(model: ir.Model) -> list[tuple[ir.Value, ir.Value]]:
-    outputs = {value.name: value for value in model.graph.outputs}
-    pairs = []
-    for past in model.graph.inputs:
-        present = next(
-            (
-                outputs.get(name)
-                for name in _cache_output_candidates(past.name or "")
-                if name in outputs
-            ),
-            None,
-        )
-        if present is not None:
-            pairs.append((past, present))
-    return pairs
-
-
-def _cache_output_candidates(past_name: str) -> tuple[str, ...]:
-    """Names an exporter may give the output that continues a cache input.
-
-    An appending cache renames ``past`` to ``present``; a static, indexed cache
-    keeps the buffer's name and prefixes the written result instead, because the
-    output is the same buffer rather than a longer one.
-    """
-    return (
-        past_name.replace("past_key_values", "present"),
-        past_name.replace("past.", "present."),
-        past_name.replace("past_", "present_"),
-        f"updated_{past_name}",
-    )
 
 
 def _constant_extent(dimension: Any) -> int | None:
@@ -7359,6 +7038,31 @@ def write_vlm_workflow_metadata(
     with open(path, "w", encoding="utf-8") as handle:
         _dump_yaml(metadata, handle)
     return path
+
+
+def write_native_vlm_package_metadata(
+    pkg: Any,
+    directory: str,
+    *,
+    config: Any,
+    source: str | None = None,
+    revision: str | None = None,
+) -> dict[str, str]:
+    """Write the published VLM package contract and its tokenizer/processor assets.
+
+    What lands in ``inference_metadata.yaml`` is the typed SSA workflow built by
+    :func:`build_vlm_workflow_metadata`, not the structural descriptor
+    :func:`~mobius.integrations.onnx_genai.inference_metadata.build_native_vlm_package_metadata`
+    returns.
+    """
+    # Assets first: the workflow document declares their package-relative
+    # locations under ``package.tokenizer.artifacts``, so they have to be in the
+    # package before the document that names them is written.
+    artifacts = _copy_runtime_assets(directory, source, revision=revision)
+    artifacts["inference_metadata"] = write_vlm_workflow_metadata(
+        pkg, directory, config, source=source
+    )
+    return artifacts
 
 
 def build_speculative_workflow_metadata(

--- a/src/mobius/models/sensenova_u1_test.py
+++ b/src/mobius/models/sensenova_u1_test.py
@@ -635,7 +635,7 @@ class TestInferenceMetadataStatus:
         none, and a caller-supplied value is an override of that derivation, not
         a precondition for it.
         """
-        from mobius.integrations.onnx_genai.inference_metadata import (
+        from mobius.integrations.onnx_genai._workflow_contract import (
             published_value_references,
         )
         from mobius.integrations.onnx_genai.shared_state_flow_metadata import (

--- a/tests/canonical_workflow_contract_test.py
+++ b/tests/canonical_workflow_contract_test.py
@@ -39,7 +39,7 @@ import yaml
 from mobius import registry
 from mobius._configs import ArchitectureConfig
 from mobius._optimizations import optimize_model
-from mobius.integrations.onnx_genai.inference_metadata import (
+from mobius.integrations.onnx_genai._workflow_contract import (
     published_value_references,
 )
 from mobius.integrations.onnx_genai.workflow_metadata import (

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1066,7 +1066,7 @@ class TestCLIBuildRuntime:
         """A VLM package emits the workflow IR, not a legacy composite pipeline."""
         pkg = mock.MagicMock()
         pkg.items.return_value = []
-        pkg.__iter__.return_value = iter(("vision_encoder", "embedding", "decoder"))
+        pkg.__iter__.side_effect = lambda: iter(("vision_encoder", "embedding", "decoder"))
         pkg.config = object()
         args = SimpleNamespace(
             max_shard_size=None,
@@ -1084,18 +1084,23 @@ class TestCLIBuildRuntime:
             mock.patch(
                 "mobius.integrations.onnx_genai.write_onnx_genai_config",
                 return_value={},
-            ) as writer,
+            ) as generic_writer,
+            mock.patch(
+                "mobius.integrations.onnx_genai.workflow_metadata."
+                "write_native_vlm_package_metadata",
+                return_value={},
+            ) as vlm_writer,
         ):
             _save_package(pkg, tmpdir, args, None, None)
 
-        writer.assert_called_once_with(
+        vlm_writer.assert_called_once_with(
             pkg,
             tmpdir,
             config=pkg.config,
             source="/models/vlm",
             revision="pinned-revision",
-            guidance_scale=None,
         )
+        generic_writer.assert_not_called()
 
     def test_runtime_onnx_genai_forwards_guidance_scale(self):
         pkg = mock.MagicMock()
@@ -1129,7 +1134,7 @@ class TestCLIBuildRuntime:
     def test_runtime_onnx_genai_does_not_fallback_for_unsupported_vlm(self):
         pkg = mock.MagicMock()
         pkg.items.return_value = []
-        pkg.__iter__.return_value = iter(("vision_encoder", "embedding", "decoder"))
+        pkg.__iter__.side_effect = lambda: iter(("vision_encoder", "embedding", "decoder"))
         pkg.config = object()
         args = SimpleNamespace(
             max_shard_size=None,
@@ -1145,15 +1150,27 @@ class TestCLIBuildRuntime:
             tempfile.TemporaryDirectory() as tmpdir,
             mock.patch(
                 "mobius.integrations.onnx_genai.write_onnx_genai_config",
+                return_value={},
+            ) as generic_writer,
+            mock.patch(
+                "mobius.integrations.onnx_genai.workflow_metadata."
+                "write_native_vlm_package_metadata",
                 side_effect=ValueError(
                     "unsupported VLM signature; regenerate processor assets or register it"
                 ),
-            ) as writer,
+            ) as vlm_writer,
             pytest.raises(SystemExit, match=r"regenerate.*register"),
         ):
             _save_package(pkg, tmpdir, args, None, None)
 
-        writer.assert_called_once()
+        vlm_writer.assert_called_once_with(
+            pkg,
+            tmpdir,
+            config=pkg.config,
+            source="/models/unsupported-vlm",
+            revision=None,
+        )
+        generic_writer.assert_not_called()
 
     def test_no_runtime_does_not_call_write_ort_genai_config(self):
         """Omitting --runtime does NOT call write_ort_genai_config()."""


### PR DESCRIPTION
## Summary

- extract dependency-neutral workflow contract primitives into `_workflow_contract.py`
- extract deterministic no-alias YAML serialization into `_metadata_io.py`
- remove every `inference_metadata -> workflow_metadata` import and migrate sibling callers to direct owners
- co-locate native-VLM package publication with the VLM workflow writer while preserving package exports

## Dependency change

Before: `workflow_metadata <-> inference_metadata`, with shared-state and GenAI import modules reaching into the workflow builder for private helpers.

After: `_workflow_contract` and `_metadata_io` are dependency-neutral leaves; `inference_metadata -> _workflow_contract`; `workflow_metadata -> _workflow_contract + _metadata_io + inference_metadata`; no reverse inference-to-workflow edge.

## Behavior equivalence

- 88 baseline/post-refactor `inference_metadata.yaml` outputs are dictionary-deep-equal and byte-identical
- all 15 deterministic conformance fixture families are byte-identical to `main`
- filenames, writer return values, no-alias behavior, and domain workflow builders are unchanged

## Validation

- `407 passed, 2 skipped` — full `src/mobius/integrations/onnx_genai` suite
- `471 passed, 2 skipped` — final ONNX-GenAI + CLI suite
- `396 passed` — canonical workflow, CLI, and affected model tests
- `9838 passed, 64 skipped` — full non-integration suite
- extracted modules pass mypy
- lintrunner and `git diff --check` pass
- independent GPT-5.6 Sol review found no remaining significant issues