### PR TITLE
Decouple ONNX-GenAI test support

### DIFF
--- a/src/mobius/integrations/onnx_genai/_test_support.py
+++ b/src/mobius/integrations/onnx_genai/_test_support.py
@@ -1,0 +1,373 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Private builders shared by ONNX-GenAI tests and validation fixtures."""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+
+import onnx_ir as ir
+
+from mobius._model_package import ModelPackage
+from mobius._pipeline_contract import declare_optional_input
+
+
+def _onnx_genai_schema_path() -> str:
+    """Locate onnx-genai's published pipeline JSON schema.
+
+    The vendored copy under ``_schema/`` is the default so conformance never
+    skips. A developer checkout is deliberately not consulted implicitly: one
+    that is ahead of or behind ``main`` makes the result machine-dependent. Set
+    ``ONNX_GENAI_SCHEMA`` to validate against a specific revision.
+    """
+    override = os.environ.get("ONNX_GENAI_SCHEMA")
+    if override:
+        return override
+    return os.path.join(os.path.dirname(__file__), "_schema", "inference_metadata.schema.json")
+
+
+def _value(
+    name: str,
+    dtype: ir.DataType,
+    shape: list[int | str],
+) -> ir.Value:
+    return ir.Value(
+        name=name,
+        type=ir.TensorType(dtype),
+        shape=ir.Shape(shape),
+    )
+
+
+def _model(
+    name: str,
+    inputs: list[ir.Value],
+    output_specs: list[tuple[str, ir.DataType, list[int | str]]],
+) -> ir.Model:
+    outputs = [_value(*spec) for spec in output_specs]
+    nodes = [
+        ir.Node("", "Identity", [inputs[0]], outputs=[output], name=f"emit_{output.name}")
+        for output in outputs
+    ]
+    graph = ir.Graph(
+        inputs=inputs,
+        outputs=outputs,
+        nodes=nodes,
+        name=name,
+        opset_imports={"": 21},
+    )
+    model = ir.Model(graph, ir_version=10)
+    assert ir.to_proto(model).graph.name == name
+    return model
+
+
+@dataclasses.dataclass
+class _VisionConfig:
+    image_size: int = 448
+    patch_size: int = 14
+    temporal_patch_size: int = 2
+    spatial_merge_size: int = 2
+    mm_tokens_per_image: int | None = None
+    image_token_id: int = 200010
+
+
+@dataclasses.dataclass
+class _VlmConfig:
+    num_hidden_layers: int = 4
+    num_attention_heads: int = 8
+    num_key_value_heads: int = 2
+    head_dim: int = 8
+    hidden_size: int = 64
+    vocab_size: int = 128
+    max_position_embeddings: int = 4096
+    image_token_id: int = 200010
+    mm_tokens_per_image: int | None = None
+    mrope_section: list[int] | None = None
+    mrope_interleaved: bool = False
+    layer_types: list[str] | None = None
+    vision: _VisionConfig = dataclasses.field(default_factory=_VisionConfig)
+
+
+def _embedding_model(
+    outputs: list[tuple[str, ir.DataType, list[int | str]]],
+    *,
+    optional_image: bool = False,
+    include_audio: bool = False,
+    optional_audio: bool = False,
+) -> ir.Model:
+    image_features = _value("image_features", ir.DataType.FLOAT, ["image_tokens", 64])
+    if optional_image:
+        declare_optional_input(
+            image_features,
+            presence="image",
+            absent_shape=[0, 64],
+        )
+    inputs = [
+        _value("input_ids", ir.DataType.INT64, ["batch", "sequence"]),
+        image_features,
+    ]
+    if include_audio:
+        audio_features = _value("audio_features", ir.DataType.FLOAT, ["audio_tokens", 64])
+        if optional_audio:
+            declare_optional_input(
+                audio_features,
+                presence="audio",
+                absent_shape=[0, 64],
+            )
+        inputs.append(audio_features)
+    return _model("embedding", inputs, outputs)
+
+
+def _decoder_model(
+    routed_inputs: list[tuple[str, ir.DataType, list[int | str]]],
+    *,
+    position_shape: list[int | str],
+    raw_token_input: bool = False,
+    fixed_state: bool = False,
+    equal_kv_shape: bool = False,
+    kv_head_dims: list[int] | None = None,
+) -> ir.Model:
+    inputs = [_value(name, dtype, shape) for name, dtype, shape in routed_inputs]
+    inputs.extend(
+        [
+            _value(
+                "attention_mask",
+                ir.DataType.INT64,
+                ["batch", "past_sequence + sequence"],
+            ),
+            _value("position_ids", ir.DataType.INT64, position_shape),
+        ]
+    )
+    if raw_token_input:
+        inputs.append(_value("input_ids", ir.DataType.INT64, ["batch", "sequence"]))
+    kv_head_dims = kv_head_dims or [8]
+    for layer, head_dim in enumerate(kv_head_dims):
+        inputs.extend(
+            [
+                _value(
+                    f"past_key_values.{layer}.key",
+                    ir.DataType.FLOAT,
+                    ["batch", 2, "past_sequence", head_dim],
+                ),
+                _value(
+                    f"past_key_values.{layer}.value",
+                    ir.DataType.FLOAT,
+                    ["batch", 2, "past_sequence", head_dim],
+                ),
+            ]
+        )
+    output_specs = [("logits", ir.DataType.FLOAT, ["batch", "sequence", 128])]
+    for layer, head_dim in enumerate(kv_head_dims):
+        output_shape = (
+            ["batch", 2, "past_sequence", head_dim]
+            if equal_kv_shape
+            else ["batch", 2, "total_sequence", head_dim]
+        )
+        output_specs.extend(
+            [
+                (f"present.{layer}.key", ir.DataType.FLOAT, output_shape),
+                (f"present.{layer}.value", ir.DataType.FLOAT, output_shape),
+            ]
+        )
+    if fixed_state:
+        inputs.extend(
+            [
+                _value(
+                    "past_key_values.3.conv_state",
+                    ir.DataType.FLOAT,
+                    ["batch", 16, 3],
+                ),
+                _value(
+                    "past_key_values.3.recurrent_state",
+                    ir.DataType.FLOAT,
+                    ["batch", 2, 4, 8],
+                ),
+            ]
+        )
+        output_specs.extend(
+            [
+                (
+                    "present.3.conv_state",
+                    ir.DataType.FLOAT,
+                    ["batch", 16, 3],
+                ),
+                (
+                    "present.3.recurrent_state",
+                    ir.DataType.FLOAT,
+                    ["batch", 2, 4, 8],
+                ),
+            ]
+        )
+    return _model("decoder", inputs, output_specs)
+
+
+def _native_package(
+    vision_encoder: ir.Model,
+    config: _VlmConfig,
+    *,
+    position_shape: list[int | str] | None = None,
+    equal_kv_shape: bool = False,
+) -> ModelPackage:
+    return ModelPackage(
+        {
+            "decoder": _decoder_model(
+                [
+                    (
+                        "inputs_embeds",
+                        ir.DataType.FLOAT,
+                        ["batch", "sequence", 64],
+                    )
+                ],
+                position_shape=position_shape or ["batch", "sequence"],
+                equal_kv_shape=equal_kv_shape,
+            ),
+            "vision_encoder": vision_encoder,
+            "embedding": _embedding_model(
+                [
+                    (
+                        "inputs_embeds",
+                        ir.DataType.FLOAT,
+                        ["batch", "sequence", 64],
+                    )
+                ]
+            ),
+        },
+        config=config,
+    )
+
+
+@dataclasses.dataclass
+class _Cfg:
+    num_attention_heads: int = 16
+    num_key_value_heads: int = 4
+    head_dim: int = 64
+    hidden_size: int = 1024
+    max_position_embeddings: int = 8192
+    sliding_window: int | None = None
+    model_type: str = "qwen"
+
+
+@dataclasses.dataclass
+class _VisionCfg:
+    patch_size: int = 14
+    temporal_patch_size: int = 2
+    merge_size: int = 1
+    spatial_merge_size: int = 1
+    size: dict[str, int] = dataclasses.field(
+        default_factory=lambda: {"shortest_edge": 224, "longest_edge": 224}
+    )
+
+
+@dataclasses.dataclass
+class _VlmCfg(_Cfg):
+    vision: _VisionCfg = dataclasses.field(default_factory=_VisionCfg)
+    image_token_id: int = 32000
+    eos_token_id: int = 2
+
+
+def _vlm_package(*, audio: bool = False):
+    vision = _model(
+        "vision_encoder",
+        [
+            _value("pixel_values", ir.DataType.FLOAT, ["patches", 1176]),
+            _value("grid_thw", ir.DataType.INT64, ["images", 3]),
+        ],
+        [("image_features", ir.DataType.FLOAT, ["batch", 256, 32])],
+    )
+    embedding_inputs = [
+        _value("input_ids", ir.DataType.INT64, ["batch", "sequence"]),
+        _value("image_features", ir.DataType.FLOAT, ["batch", 256, 32]),
+    ]
+    components = {"vision_encoder": vision}
+    if audio:
+        components["audio_encoder"] = _model(
+            "audio_encoder",
+            [_value("input_features", ir.DataType.FLOAT, ["batch", 80, "frames"])],
+            [("audio_features", ir.DataType.FLOAT, ["batch", 64, 32])],
+        )
+        embedding_inputs.append(_value("audio_features", ir.DataType.FLOAT, ["batch", 64, 32]))
+    embedding = _model(
+        "embedding",
+        embedding_inputs,
+        [("inputs_embeds", ir.DataType.FLOAT, ["batch", "sequence", 32])],
+    )
+    decoder = _decoder_model(
+        [("inputs_embeds", ir.DataType.FLOAT, ["batch", "sequence", 32])],
+        position_shape=["batch", "sequence"],
+    )
+    components.update({"embedding": embedding, "decoder": decoder})
+    return ModelPackage(components, config=_VlmCfg())
+
+
+def _decoder_package(config=None):
+    model = _decoder_model(
+        [],
+        position_shape=["batch", "sequence"],
+        raw_token_input=True,
+    )
+    return ModelPackage({"model": model}, config=config or _Cfg())
+
+
+def _graph_model(
+    name: str,
+    inputs: list[ir.Value],
+    outputs: list[ir.Value],
+) -> ir.Model:
+    return ir.Model(
+        ir.Graph(
+            inputs=inputs,
+            outputs=outputs,
+            nodes=[],
+            name=name,
+            opset_imports={"": 24},
+        ),
+        ir_version=11,
+    )
+
+
+def _speculative_package(
+    *,
+    adaptive: bool = False,
+    budget_dtype: ir.DataType = ir.DataType.INT64,
+) -> ModelPackage:
+    proposer_inputs = [_value("tokens", ir.DataType.INT64, ["batch", 4])]
+    if adaptive:
+        proposer_inputs.append(_value("proposal_budget", budget_dtype, ["batch"]))
+    proposer = _graph_model(
+        "proposer",
+        proposer_inputs,
+        [
+            _value("proposed_tokens", ir.DataType.INT64, ["batch", 4]),
+            _value("proposal_scores", ir.DataType.FLOAT, ["batch", 4, 32]),
+        ],
+    )
+    verifier = _graph_model(
+        "verifier",
+        [
+            _value("proposed_tokens", ir.DataType.INT64, ["batch", 4]),
+            _value(
+                "past_key_values.0.key",
+                ir.DataType.FLOAT,
+                ["batch", 2, "past_sequence", 8],
+            ),
+            _value(
+                "past_key_values.0.value",
+                ir.DataType.FLOAT,
+                ["batch", 4, "past_sequence", 4],
+            ),
+        ],
+        [
+            _value("target_scores", ir.DataType.FLOAT, ["batch", 4, 32]),
+            _value(
+                "present.0.key",
+                ir.DataType.FLOAT,
+                ["batch", 2, "past_sequence + 4", 8],
+            ),
+            _value(
+                "present.0.value",
+                ir.DataType.FLOAT,
+                ["batch", 4, "past_sequence + 4", 4],
+            ),
+        ],
+    )
+    return ModelPackage({"proposer": proposer, "verifier": verifier})

--- a/src/mobius/integrations/onnx_genai/auto_export_test.py
+++ b/src/mobius/integrations/onnx_genai/auto_export_test.py
@@ -17,6 +17,13 @@ import yaml
 from mobius._configs import QuantizationConfig
 from mobius._model_package import ModelPackage
 from mobius.integrations.onnx_genai import write_onnx_genai_config
+from mobius.integrations.onnx_genai._test_support import (
+    _Cfg,
+    _decoder_package,
+    _model,
+    _value,
+    _vlm_package,
+)
 from mobius.integrations.onnx_genai.auto_export import (
     _ddim_alpha_schedule,
     _flow_match_euler_schedule,
@@ -24,27 +31,11 @@ from mobius.integrations.onnx_genai.auto_export import (
     _looks_like_video_diffusion,
 )
 from mobius.integrations.onnx_genai.inference_metadata import SchedulerConfig
-from mobius.integrations.onnx_genai.inference_metadata_test import (
-    _decoder_model,
-    _model,
-    _value,
-)
 from mobius.integrations.onnx_genai.workflow_metadata import (
     HierarchicalAudioWorkflowConfig,
     build_decoder_workflow_metadata,
     build_hierarchical_audio_workflow_metadata,
 )
-
-
-@dataclasses.dataclass
-class _Cfg:
-    num_attention_heads: int = 16
-    num_key_value_heads: int = 4
-    head_dim: int = 64
-    hidden_size: int = 1024
-    max_position_embeddings: int = 8192
-    sliding_window: int | None = None
-    model_type: str = "qwen"
 
 
 @dataclasses.dataclass
@@ -160,67 +151,6 @@ def _video_diffusion_package() -> ModelPackage:
 
 class _MultimodalPkg(dict):
     config = _Cfg()
-
-
-@dataclasses.dataclass
-class _VisionCfg:
-    patch_size: int = 14
-    temporal_patch_size: int = 2
-    merge_size: int = 1
-    spatial_merge_size: int = 1
-    size: dict[str, int] = dataclasses.field(
-        default_factory=lambda: {"shortest_edge": 224, "longest_edge": 224}
-    )
-
-
-@dataclasses.dataclass
-class _VlmCfg(_Cfg):
-    vision: _VisionCfg = dataclasses.field(default_factory=_VisionCfg)
-    image_token_id: int = 32000
-    eos_token_id: int = 2
-
-
-def _vlm_package(*, audio: bool = False):
-    vision = _model(
-        "vision_encoder",
-        [
-            _value("pixel_values", ir.DataType.FLOAT, ["patches", 1176]),
-            _value("grid_thw", ir.DataType.INT64, ["images", 3]),
-        ],
-        [("image_features", ir.DataType.FLOAT, ["batch", 256, 32])],
-    )
-    embedding_inputs = [
-        _value("input_ids", ir.DataType.INT64, ["batch", "sequence"]),
-        _value("image_features", ir.DataType.FLOAT, ["batch", 256, 32]),
-    ]
-    components = {"vision_encoder": vision}
-    if audio:
-        components["audio_encoder"] = _model(
-            "audio_encoder",
-            [_value("input_features", ir.DataType.FLOAT, ["batch", 80, "frames"])],
-            [("audio_features", ir.DataType.FLOAT, ["batch", 64, 32])],
-        )
-        embedding_inputs.append(_value("audio_features", ir.DataType.FLOAT, ["batch", 64, 32]))
-    embedding = _model(
-        "embedding",
-        embedding_inputs,
-        [("inputs_embeds", ir.DataType.FLOAT, ["batch", "sequence", 32])],
-    )
-    decoder = _decoder_model(
-        [("inputs_embeds", ir.DataType.FLOAT, ["batch", "sequence", 32])],
-        position_shape=["batch", "sequence"],
-    )
-    components.update({"embedding": embedding, "decoder": decoder})
-    return ModelPackage(components, config=_VlmCfg())
-
-
-def _decoder_package(config=None):
-    model = _decoder_model(
-        [],
-        position_shape=["batch", "sequence"],
-        raw_token_input=True,
-    )
-    return ModelPackage({"model": model}, config=config or _Cfg())
 
 
 def test_dispatch_decoder(tmp_path):

--- a/src/mobius/integrations/onnx_genai/codec_workflow_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/codec_workflow_metadata_test.py
@@ -12,7 +12,7 @@ import pytest
 import yaml
 
 from mobius._model_package import ModelPackage
-from mobius.integrations.onnx_genai.inference_metadata_test import (
+from mobius.integrations.onnx_genai._test_support import (
     _model,
     _onnx_genai_schema_path,
     _value,

--- a/src/mobius/integrations/onnx_genai/comfyui_test.py
+++ b/src/mobius/integrations/onnx_genai/comfyui_test.py
@@ -10,6 +10,9 @@ import json
 import pytest
 import yaml
 
+from mobius.integrations.onnx_genai._test_support import (
+    _onnx_genai_schema_path,
+)
 from mobius.integrations.onnx_genai.comfyui import (
     ComfyUIWorkflow,
     parse_comfyui_workflow,
@@ -18,9 +21,6 @@ from mobius.integrations.onnx_genai.comfyui import (
 )
 from mobius.integrations.onnx_genai.convert import convert_comfyui_workflow
 from mobius.integrations.onnx_genai.inference_metadata import SchedulerConfig
-from mobius.integrations.onnx_genai.inference_metadata_test import (
-    _onnx_genai_schema_path,
-)
 
 # ComfyUI's canonical "default" text-to-image API-format workflow (trimmed).
 _DEFAULT_TXT2IMG = {

--- a/src/mobius/integrations/onnx_genai/decoder_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/decoder_metadata_test.py
@@ -12,14 +12,14 @@ import pytest
 import yaml
 
 from mobius._configs import QuantizationConfig
+from mobius.integrations.onnx_genai._test_support import (
+    _onnx_genai_schema_path,
+)
 from mobius.integrations.onnx_genai.decoder_metadata import (
     build_decoder_metadata,
     decoder_metadata_from_config,
     moe_metadata_from_config,
     write_decoder_metadata,
-)
-from mobius.integrations.onnx_genai.inference_metadata_test import (
-    _onnx_genai_schema_path,
 )
 
 

--- a/src/mobius/integrations/onnx_genai/duplex_workflow_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/duplex_workflow_metadata_test.py
@@ -20,7 +20,7 @@ import pytest
 import yaml
 
 from mobius._model_package import ModelPackage
-from mobius.integrations.onnx_genai.inference_metadata_test import (
+from mobius.integrations.onnx_genai._test_support import (
     _model,
     _onnx_genai_schema_path,
     _value,

--- a/src/mobius/integrations/onnx_genai/inference_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata_test.py
@@ -18,11 +18,18 @@ import pytest
 import yaml
 
 from mobius._model_package import ModelPackage
-from mobius._pipeline_contract import (
-    declare_component_presence,
-    declare_optional_input,
-)
+from mobius._pipeline_contract import declare_component_presence
 from mobius.generation import build_greedy_sampler
+from mobius.integrations.onnx_genai._test_support import (
+    _decoder_model,
+    _embedding_model,
+    _model,
+    _native_package,
+    _onnx_genai_schema_path,
+    _value,
+    _VisionConfig,
+    _VlmConfig,
+)
 from mobius.integrations.onnx_genai._workflow_contract import (
     _port,
     add_policy_components_to_workflow,
@@ -201,54 +208,6 @@ def test_workflow_policy_components_reference_saved_onnx_artifacts(tmp_path):
     assert (tmp_path / component["implementation"]["artifact"]).is_file()
 
 
-def _onnx_genai_schema_path() -> str:
-    """Locate onnx-genai's published pipeline JSON schema.
-
-    The vendored copy under ``_schema/`` is the default so conformance never
-    skips. A developer checkout is deliberately not consulted implicitly: one
-    that is ahead of or behind ``main`` makes the result machine-dependent. Set
-    ``ONNX_GENAI_SCHEMA`` to validate against a specific revision.
-    """
-    override = os.environ.get("ONNX_GENAI_SCHEMA")
-    if override:
-        return override
-    return os.path.join(os.path.dirname(__file__), "_schema", "inference_metadata.schema.json")
-
-
-def _value(
-    name: str,
-    dtype: ir.DataType,
-    shape: list[int | str],
-) -> ir.Value:
-    return ir.Value(
-        name=name,
-        type=ir.TensorType(dtype),
-        shape=ir.Shape(shape),
-    )
-
-
-def _model(
-    name: str,
-    inputs: list[ir.Value],
-    output_specs: list[tuple[str, ir.DataType, list[int | str]]],
-) -> ir.Model:
-    outputs = [_value(*spec) for spec in output_specs]
-    nodes = [
-        ir.Node("", "Identity", [inputs[0]], outputs=[output], name=f"emit_{output.name}")
-        for output in outputs
-    ]
-    graph = ir.Graph(
-        inputs=inputs,
-        outputs=outputs,
-        nodes=nodes,
-        name=name,
-        opset_imports={"": 21},
-    )
-    model = ir.Model(graph, ir_version=10)
-    assert ir.to_proto(model).graph.name == name
-    return model
-
-
 def test_qwen4_decoder_metadata_preserves_qsa_kv_index_and_four_axis_positions():
     decoder = _model(
         "decoder",
@@ -333,146 +292,6 @@ def test_qwen4_decoder_metadata_preserves_qsa_kv_index_and_four_axis_positions()
         "axes": ["text", "temporal", "height", "width"],
         "sections": [1, 1, 0],
     }
-
-
-@dataclasses.dataclass
-class _VisionConfig:
-    image_size: int = 448
-    patch_size: int = 14
-    temporal_patch_size: int = 2
-    spatial_merge_size: int = 2
-    mm_tokens_per_image: int | None = None
-    image_token_id: int = 200010
-
-
-@dataclasses.dataclass
-class _VlmConfig:
-    num_hidden_layers: int = 4
-    num_attention_heads: int = 8
-    num_key_value_heads: int = 2
-    head_dim: int = 8
-    hidden_size: int = 64
-    vocab_size: int = 128
-    max_position_embeddings: int = 4096
-    image_token_id: int = 200010
-    mm_tokens_per_image: int | None = None
-    mrope_section: list[int] | None = None
-    mrope_interleaved: bool = False
-    layer_types: list[str] | None = None
-    vision: _VisionConfig = dataclasses.field(default_factory=_VisionConfig)
-
-
-def _embedding_model(
-    outputs: list[tuple[str, ir.DataType, list[int | str]]],
-    *,
-    optional_image: bool = False,
-    include_audio: bool = False,
-    optional_audio: bool = False,
-) -> ir.Model:
-    image_features = _value("image_features", ir.DataType.FLOAT, ["image_tokens", 64])
-    if optional_image:
-        declare_optional_input(
-            image_features,
-            presence="image",
-            absent_shape=[0, 64],
-        )
-    inputs = [
-        _value("input_ids", ir.DataType.INT64, ["batch", "sequence"]),
-        image_features,
-    ]
-    if include_audio:
-        audio_features = _value("audio_features", ir.DataType.FLOAT, ["audio_tokens", 64])
-        if optional_audio:
-            declare_optional_input(
-                audio_features,
-                presence="audio",
-                absent_shape=[0, 64],
-            )
-        inputs.append(audio_features)
-    return _model("embedding", inputs, outputs)
-
-
-def _decoder_model(
-    routed_inputs: list[tuple[str, ir.DataType, list[int | str]]],
-    *,
-    position_shape: list[int | str],
-    raw_token_input: bool = False,
-    fixed_state: bool = False,
-    equal_kv_shape: bool = False,
-    kv_head_dims: list[int] | None = None,
-) -> ir.Model:
-    inputs = [_value(name, dtype, shape) for name, dtype, shape in routed_inputs]
-    inputs.extend(
-        [
-            _value(
-                "attention_mask",
-                ir.DataType.INT64,
-                ["batch", "past_sequence + sequence"],
-            ),
-            _value("position_ids", ir.DataType.INT64, position_shape),
-        ]
-    )
-    if raw_token_input:
-        inputs.append(_value("input_ids", ir.DataType.INT64, ["batch", "sequence"]))
-    kv_head_dims = kv_head_dims or [8]
-    for layer, head_dim in enumerate(kv_head_dims):
-        inputs.extend(
-            [
-                _value(
-                    f"past_key_values.{layer}.key",
-                    ir.DataType.FLOAT,
-                    ["batch", 2, "past_sequence", head_dim],
-                ),
-                _value(
-                    f"past_key_values.{layer}.value",
-                    ir.DataType.FLOAT,
-                    ["batch", 2, "past_sequence", head_dim],
-                ),
-            ]
-        )
-    output_specs = [("logits", ir.DataType.FLOAT, ["batch", "sequence", 128])]
-    for layer, head_dim in enumerate(kv_head_dims):
-        output_shape = (
-            ["batch", 2, "past_sequence", head_dim]
-            if equal_kv_shape
-            else ["batch", 2, "total_sequence", head_dim]
-        )
-        output_specs.extend(
-            [
-                (f"present.{layer}.key", ir.DataType.FLOAT, output_shape),
-                (f"present.{layer}.value", ir.DataType.FLOAT, output_shape),
-            ]
-        )
-    if fixed_state:
-        inputs.extend(
-            [
-                _value(
-                    "past_key_values.3.conv_state",
-                    ir.DataType.FLOAT,
-                    ["batch", 16, 3],
-                ),
-                _value(
-                    "past_key_values.3.recurrent_state",
-                    ir.DataType.FLOAT,
-                    ["batch", 2, 4, 8],
-                ),
-            ]
-        )
-        output_specs.extend(
-            [
-                (
-                    "present.3.conv_state",
-                    ir.DataType.FLOAT,
-                    ["batch", 16, 3],
-                ),
-                (
-                    "present.3.recurrent_state",
-                    ir.DataType.FLOAT,
-                    ["batch", 2, 4, 8],
-                ),
-            ]
-        )
-    return _model("decoder", inputs, output_specs)
 
 
 def _static_cache_decoder_model() -> ir.Model:
@@ -610,41 +429,6 @@ class TestCrossAttentionCacheSources:
                 "strategy": strategy,
             }
         }
-
-
-def _native_package(
-    vision_encoder: ir.Model,
-    config: _VlmConfig,
-    *,
-    position_shape: list[int | str] | None = None,
-    equal_kv_shape: bool = False,
-) -> ModelPackage:
-    return ModelPackage(
-        {
-            "decoder": _decoder_model(
-                [
-                    (
-                        "inputs_embeds",
-                        ir.DataType.FLOAT,
-                        ["batch", "sequence", 64],
-                    )
-                ],
-                position_shape=position_shape or ["batch", "sequence"],
-                equal_kv_shape=equal_kv_shape,
-            ),
-            "vision_encoder": vision_encoder,
-            "embedding": _embedding_model(
-                [
-                    (
-                        "inputs_embeds",
-                        ir.DataType.FLOAT,
-                        ["batch", "sequence", 64],
-                    )
-                ]
-            ),
-        },
-        config=config,
-    )
 
 
 def _assert_all_graph_ports_declared(
@@ -2492,7 +2276,7 @@ class TestMtpSpeculatorMetadata:
         of which is an ONNX component, so the verifier can only be identified by
         its declared ``logits`` role.
         """
-        from mobius.integrations.onnx_genai.auto_export_test import _decoder_package
+        from mobius.integrations.onnx_genai._test_support import _decoder_package
         from mobius.integrations.onnx_genai.workflow_metadata import (
             write_decoder_workflow_metadata,
         )

--- a/src/mobius/integrations/onnx_genai/metadata_dependency_test.py
+++ b/src/mobius/integrations/onnx_genai/metadata_dependency_test.py
@@ -108,7 +108,17 @@ def test_metadata_modules_keep_one_way_dependencies(
     test_paths = set(package_path.glob("*_test.py"))
     test_modules = {f"{_PACKAGE}.{path.stem}" for path in test_paths}
     cross_test_imports = []
-    for python_path in repository_root.rglob("*.py"):
+    tracked_files = subprocess.run(
+        ["git", "ls-files", "-z", "--", "src", "tests", "scripts"],
+        check=True,
+        cwd=repository_root,
+        stdout=subprocess.PIPE,
+        text=True,
+    ).stdout
+    tracked_python_paths = sorted(
+        repository_root / path for path in tracked_files.split("\0") if path.endswith(".py")
+    )
+    for python_path in tracked_python_paths:
         relative_path = python_path.relative_to(repository_root).with_suffix("")
         module_parts = list(relative_path.parts)
         if module_parts[0] == "src":

--- a/src/mobius/integrations/onnx_genai/metadata_dependency_test.py
+++ b/src/mobius/integrations/onnx_genai/metadata_dependency_test.py
@@ -129,9 +129,9 @@ def test_metadata_modules_keep_one_way_dependencies(
         else:
             package_parts = module_parts[:-1]
         package = ".".join(package_parts)
-        imported_tests = _import_edges(
-            python_path.read_text(encoding="utf-8"), package
-        ) & test_modules
+        imported_tests = (
+            _import_edges(python_path.read_text(encoding="utf-8"), package) & test_modules
+        )
         cross_test_imports.extend(
             (str(relative_path.with_suffix(".py")), imported_test)
             for imported_test in imported_tests

--- a/src/mobius/integrations/onnx_genai/metadata_dependency_test.py
+++ b/src/mobius/integrations/onnx_genai/metadata_dependency_test.py
@@ -100,6 +100,45 @@ def test_metadata_modules_keep_one_way_dependencies(
     imports = _import_edges(path.read_text(encoding="utf-8"), _PACKAGE)
     assert imports.isdisjoint(forbidden)
 
+    if filename != "inference_metadata.py":
+        return
+
+    repository_root = Path(__file__).resolve().parents[4]
+    package_path = Path(__file__).parent
+    test_paths = set(package_path.glob("*_test.py"))
+    test_modules = {f"{_PACKAGE}.{path.stem}" for path in test_paths}
+    cross_test_imports = []
+    for python_path in repository_root.rglob("*.py"):
+        relative_path = python_path.relative_to(repository_root).with_suffix("")
+        module_parts = list(relative_path.parts)
+        if module_parts[0] == "src":
+            module_parts.pop(0)
+        if module_parts[-1] == "__init__":
+            module_parts.pop()
+            package_parts = module_parts
+        else:
+            package_parts = module_parts[:-1]
+        package = ".".join(package_parts)
+        imported_tests = _import_edges(
+            python_path.read_text(encoding="utf-8"), package
+        ) & test_modules
+        cross_test_imports.extend(
+            (str(relative_path.with_suffix(".py")), imported_test)
+            for imported_test in imported_tests
+        )
+    assert not cross_test_imports
+
+    support_path = package_path / "_test_support.py"
+    assert support_path not in test_paths
+    support_tree = ast.parse(support_path.read_text(encoding="utf-8"))
+    collected_definitions = {
+        node.name
+        for node in ast.walk(support_tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+        and (node.name.startswith("test_") or node.name.startswith("Test"))
+    }
+    assert not collected_definitions
+
 
 def test_metadata_yaml_is_deterministic_and_suppresses_aliases() -> None:
     shared = [1, 2]

--- a/src/mobius/integrations/onnx_genai/package_facts_test.py
+++ b/src/mobius/integrations/onnx_genai/package_facts_test.py
@@ -24,12 +24,14 @@ import yaml
 from mobius._configs import MMSConfig
 from mobius._model_package import ModelPackage
 from mobius.integrations.onnx_genai import SpecialTokenFact
-from mobius.integrations.onnx_genai.auto_export import write_onnx_genai_config
-from mobius.integrations.onnx_genai.auto_export_test import _vlm_package, _VlmCfg
-from mobius.integrations.onnx_genai.inference_metadata_test import (
+from mobius.integrations.onnx_genai._test_support import (
     _decoder_model,
     _onnx_genai_schema_path,
+    _speculative_package,
+    _vlm_package,
+    _VlmCfg,
 )
+from mobius.integrations.onnx_genai.auto_export import write_onnx_genai_config
 from mobius.integrations.onnx_genai.package_facts import (
     IMAGE_PLACEHOLDER_ROLE,
     _byte_level_alphabet,
@@ -43,7 +45,6 @@ from mobius.integrations.onnx_genai.workflow_metadata import (
     write_ctc_asr_workflow_metadata,
     write_decoder_workflow_metadata,
 )
-from mobius.integrations.onnx_genai.workflow_metadata_test import _speculative_package
 from mobius.models.wav2vec2_ctc import Wav2Vec2ForCTCModel
 from mobius.tasks._ctc_asr import CTCAsrTask
 

--- a/src/mobius/integrations/onnx_genai/speech_enhancement_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/speech_enhancement_metadata_test.py
@@ -18,10 +18,10 @@ from mobius.integrations.onnx_genai import (
     write_onnx_genai_config,
     write_speech_enhancement_workflow_metadata,
 )
-from mobius.integrations.onnx_genai.auto_export import _looks_like_speech_enhancement
-from mobius.integrations.onnx_genai.inference_metadata_test import (
+from mobius.integrations.onnx_genai._test_support import (
     _onnx_genai_schema_path,
 )
+from mobius.integrations.onnx_genai.auto_export import _looks_like_speech_enhancement
 from mobius.models.reuse import ReUseConfig, SEMambaSpeechEnhancementModel
 
 _TINY = {

--- a/src/mobius/integrations/onnx_genai/speech_to_text_workflow_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/speech_to_text_workflow_metadata_test.py
@@ -14,12 +14,12 @@ import pytest
 import yaml
 
 from mobius._model_package import ModelPackage
-from mobius.integrations.onnx_genai.auto_export import _audio_preprocessing_program
-from mobius.integrations.onnx_genai.inference_metadata_test import (
+from mobius.integrations.onnx_genai._test_support import (
     _model,
     _onnx_genai_schema_path,
     _value,
 )
+from mobius.integrations.onnx_genai.auto_export import _audio_preprocessing_program
 from mobius.integrations.onnx_genai.workflow_metadata import (
     build_speech_to_text_workflow_metadata,
     write_speech_to_text_workflow_metadata,

--- a/src/mobius/integrations/onnx_genai/workflow_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/workflow_metadata_test.py
@@ -11,9 +11,12 @@ import pytest
 import yaml
 
 from mobius._model_package import ModelPackage
-from mobius.integrations.onnx_genai.inference_metadata_test import (
+from mobius.integrations.onnx_genai._test_support import (
+    _graph_model,
     _model,
     _native_package,
+    _speculative_package,
+    _value,
     _VlmConfig,
 )
 from mobius.integrations.onnx_genai.workflow_metadata import (
@@ -68,10 +71,6 @@ def test_speculative_emit_uses_accepted_prefix_length():
     assert workflow["state"]["cache_0"]["service_group"] == "verifier_cache"
     assert workflow["serving"]["accepted_len"] == "accepted_len"
     assert workflow["inputs"]["package.max_context"]["default"] == 4096
-
-
-def _value(name: str, dtype: ir.DataType, shape: list[int | str]) -> ir.Value:
-    return ir.Value(name=name, type=ir.TensorType(dtype), shape=ir.Shape(shape))
 
 
 def test_vlm_preprocessing_is_explicit_typed_ssa(tmp_path):
@@ -764,71 +763,6 @@ def test_language_diffusion_rejects_zero_steps():
             _masked_denoiser_package(),
             num_inference_steps=0,
         )
-
-
-def _graph_model(
-    name: str,
-    inputs: list[ir.Value],
-    outputs: list[ir.Value],
-) -> ir.Model:
-    return ir.Model(
-        ir.Graph(
-            inputs=inputs,
-            outputs=outputs,
-            nodes=[],
-            name=name,
-            opset_imports={"": 24},
-        ),
-        ir_version=11,
-    )
-
-
-def _speculative_package(
-    *,
-    adaptive: bool = False,
-    budget_dtype: ir.DataType = ir.DataType.INT64,
-) -> ModelPackage:
-    proposer_inputs = [_value("tokens", ir.DataType.INT64, ["batch", 4])]
-    if adaptive:
-        proposer_inputs.append(_value("proposal_budget", budget_dtype, ["batch"]))
-    proposer = _graph_model(
-        "proposer",
-        proposer_inputs,
-        [
-            _value("proposed_tokens", ir.DataType.INT64, ["batch", 4]),
-            _value("proposal_scores", ir.DataType.FLOAT, ["batch", 4, 32]),
-        ],
-    )
-    verifier = _graph_model(
-        "verifier",
-        [
-            _value("proposed_tokens", ir.DataType.INT64, ["batch", 4]),
-            _value(
-                "past_key_values.0.key",
-                ir.DataType.FLOAT,
-                ["batch", 2, "past_sequence", 8],
-            ),
-            _value(
-                "past_key_values.0.value",
-                ir.DataType.FLOAT,
-                ["batch", 4, "past_sequence", 4],
-            ),
-        ],
-        [
-            _value("target_scores", ir.DataType.FLOAT, ["batch", 4, 32]),
-            _value(
-                "present.0.key",
-                ir.DataType.FLOAT,
-                ["batch", 2, "past_sequence + 4", 8],
-            ),
-            _value(
-                "present.0.value",
-                ir.DataType.FLOAT,
-                ["batch", 4, "past_sequence + 4", 4],
-            ),
-        ],
-    )
-    return ModelPackage({"proposer": proposer, "verifier": verifier})
 
 
 def test_adaptive_speculative_requires_int64_budget_port():

--- a/tests/generate_onnx_genai_validation_packages.py
+++ b/tests/generate_onnx_genai_validation_packages.py
@@ -34,7 +34,7 @@ from mobius.integrations.diffusers._configs import (
     MiniMaxMusic3WorkflowConfig,
 )
 from mobius.integrations.onnx_genai import write_onnx_genai_config
-from mobius.integrations.onnx_genai.auto_export_test import (
+from mobius.integrations.onnx_genai._test_support import (
     _Cfg,
     _VlmCfg,
 )


### PR DESCRIPTION
## Summary

Move reusable ONNX-GenAI test infrastructure into the private, non-collected `src/mobius/integrations/onnx_genai/_test_support.py` module and rewire every repository consumer away from collected `*_test.py` modules.

This is a behavior-preserving refactor. It does not change production code, test assertions, or test ownership, and it does not split `inference_metadata_test.py` or `auto_export_test.py`.

## Final base

- Base branch: `main`
- Exact base: `236baa0b80ec7d922e1c775bac07fec522278a83`
- Exact head: `251421a97f6a1e89c5aaec25068268af2f3a948a`
- Includes merged #708 metadata dependency ownership and merged #717 Windows cross-drive fixture fix

## Moved support inventory

- Schema/value/model builders: `_onnx_genai_schema_path`, `_value`, `_model`
- Native VLM fixtures: `_VisionConfig`, `_VlmConfig`, `_embedding_model`, `_decoder_model`, `_native_package`
- Auto-export fixtures: `_Cfg`, `_VisionCfg`, `_VlmCfg`, `_vlm_package`, `_decoder_package`
- Speculative fixtures: `_graph_model`, `_speculative_package`

All 15 moved definitions are AST-equivalent to their definitions at final main.

## Import boundary

- Removed all repository imports of collected ONNX-GenAI test modules, including the validation-package generator and the prior `inference_metadata_test.py` -> `auto_export_test.py` cycle.
- Preserves merged #708's owner-specific `_import_edges` dependency tests and uses that helper to reject imports of collected ONNX-GenAI test modules.
- Scans only a sorted `git ls-files -z -- src tests scripts` inventory, so ignored/untracked environments and generated artifacts cannot affect the boundary.
- Verifies `_test_support.py` has no test definitions and remains outside the collection pattern.

## Collection evidence

Against exact main `236baa0b`, normalized collection inventories are identical, including parametrized node IDs and markers:

- Base: 414
- Head: 414

## Fresh-process evidence

Each formerly coupled consumer passes in its own pytest process:

- `auto_export_test.py`: 49 passed
- `codec_workflow_metadata_test.py`: 6 passed
- `comfyui_test.py`: 28 passed
- `decoder_metadata_test.py`: 23 passed
- `duplex_workflow_metadata_test.py`: 13 passed
- `inference_metadata_test.py`: 72 passed, 2 skipped
- `package_facts_test.py`: 37 passed
- `speech_enhancement_metadata_test.py`: 76 passed
- `speech_to_text_workflow_metadata_test.py`: 9 passed
- `workflow_metadata_test.py`: 29 passed

## Validation

- ONNX-GenAI tests together: 412 passed, 2 skipped
- Dependency/import boundary: 9 passed
- Current non-integration suite (`tests/build_graph`, `tests/cli_test.py`, `src/`): 9,864 passed, 64 skipped, 1 subtest passed
- `lintrunner f --output oneline --all-files`
- `git diff --check`
- Range-diff: all three commits replayed identically onto final main
- Independent exact-head GPT-5.6 Sol review: no findings
