### PR TITLE
Fix PersonaPlex review findings from #702

### DIFF
--- a/src/mobius/integrations/_moshi.py
+++ b/src/mobius/integrations/_moshi.py
@@ -43,10 +43,16 @@ class _PersonaPlexWorkflowConfig:
 
 def _is_personaplex_checkpoint(checkpoint: str | Path) -> bool:
     """Recognize the canonical Hub ID or a strongly identified local checkpoint."""
-    path = Path(os.path.expanduser(str(checkpoint)))
-    if path.is_dir():
+    path = _local_checkpoint_path(checkpoint)
+    if path is not None:
         return _is_local_personaplex_checkpoint(path)
     return str(checkpoint).casefold() == _PERSONAPLEX_MODEL_ID.casefold()
+
+
+def _local_checkpoint_path(checkpoint: str | Path) -> Path | None:
+    """Resolve an existing local checkpoint directory before interpreting Hub IDs."""
+    path = Path(os.path.expanduser(str(checkpoint)))
+    return path if path.is_dir() else None
 
 
 def _is_local_personaplex_checkpoint(path: Path) -> bool:
@@ -93,7 +99,7 @@ def _is_local_personaplex_checkpoint(path: Path) -> bool:
 
 
 def _personaplex_revision(checkpoint: str | Path, revision: str | None) -> str | None:
-    if Path(os.path.expanduser(str(checkpoint))).is_dir():
+    if _local_checkpoint_path(checkpoint) is not None:
         return None
     if revision is not None:
         return revision

--- a/src/mobius/integrations/_moshi_test.py
+++ b/src/mobius/integrations/_moshi_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 from unittest import mock
 
 import onnx_ir as ir
@@ -130,7 +131,9 @@ def test_public_build_dispatches_before_transformers_detection():
     )
 
 
-def test_local_checkpoint_dispatches_and_records_local_revision(tmp_path, monkeypatch):
+def test_canonical_looking_local_checkpoint_dispatches_and_records_local_revision(
+    tmp_path, monkeypatch
+):
     checkpoint = _local_personaplex_checkpoint(tmp_path / "nvidia" / "personaplex-7b-v1")
     monkeypatch.chdir(tmp_path)
     mimi = ModelPackage({"encoder": _component("encoder"), "decoder": _component("decoder")})
@@ -165,6 +168,30 @@ def test_local_checkpoint_dispatches_and_records_local_revision(tmp_path, monkey
     assert {model.metadata_props["mobius.source_revision"] for model in package.values()} == {
         "local"
     }
+
+
+def test_personaplex_hub_id_uses_pinned_revision(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    assert (
+        _builder._personaplex_revision(_builder._PERSONAPLEX_MODEL_ID, None)
+        == _builder._PERSONAPLEX_REVISION
+    )
+
+
+def test_other_existing_local_directory_forms_do_not_use_hub_revision(tmp_path, monkeypatch):
+    checkpoint = tmp_path / "checkpoints" / "personaplex"
+    checkpoint.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    local_forms = [
+        checkpoint,
+        str(checkpoint),
+        os.path.relpath(checkpoint),
+        "~/checkpoints/personaplex",
+    ]
+    for local_form in local_forms:
+        assert _builder._personaplex_revision(local_form, "ignored") is None
 
 
 def test_local_detection_fails_closed_for_ambiguous_checkpoint(tmp_path):

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -18,6 +18,7 @@ from unittest import mock
 
 import numpy as np
 import onnx
+import onnx_ir as ir
 import pytest
 
 from mobius.__main__ import _save_package, build_parser, main
@@ -147,6 +148,8 @@ class TestCLIBuild:
                     "nvidia/personaplex-7b-v1",
                     tmpdir,
                     "--no-weights",
+                    "--dtype",
+                    "f16",
                     "--execution-provider",
                     "cuda",
                 ]
@@ -156,7 +159,7 @@ class TestCLIBuild:
         assert build_model.call_args.kwargs["revision"] == _PERSONAPLEX_REVISION
         assert build_model.call_args.kwargs["load_weights"] is False
         assert build_model.call_args.kwargs["execution_provider"] == "cuda"
-        assert build_model.call_args.kwargs["dtype"] is None
+        assert build_model.call_args.kwargs["dtype"] == ir.DataType.FLOAT16
         save_package.assert_called_once()
 
     def test_local_personaplex_config_bypasses_transformers(self):


### PR DESCRIPTION
## Summary

Follow up on two valid Copilot review findings left on the already-merged #702:

- assert the PersonaPlex CLI dtype with the repository-native `onnx_ir.DataType.FLOAT16` instead of a protobuf enum
- resolve existing local PersonaPlex checkpoint directories before interpreting canonical-looking strings as Hub IDs, while retaining the pinned revision for the actual Hub source
- add focused regression coverage for canonical-looking relative directories, absolute/string/`Path`/home-relative local forms, and the canonical Hub ID

The existing unrelated `onnx.load` calls in `tests/cli_test.py` remain untouched; the PersonaPlex assertion no longer introduces or uses `onnx.TensorProto`.

## Tests

- `python -m pytest tests/cli_test.py::TestCLIBuild::test_standard_build_dispatches_personaplex_through_public_build src/mobius/integrations/_moshi_test.py -q --tb=short`
- `lintrunner f --output oneline -- tests/cli_test.py src/mobius/integrations/_moshi.py src/mobius/integrations/_moshi_test.py`
- `lintrunner --output oneline -- tests/cli_test.py src/mobius/integrations/_moshi.py src/mobius/integrations/_moshi_test.py`
- `git diff --check`

## Review

Independent exact-head review with GPT-5.6 Sol reported no high-confidence findings.