### PR TITLE
Fix late PersonaPlex review findings from #715

### DIFF
--- a/src/mobius/integrations/_moshi_test.py
+++ b/src/mobius/integrations/_moshi_test.py
@@ -183,6 +183,7 @@ def test_other_existing_local_directory_forms_do_not_use_hub_revision(tmp_path, 
     checkpoint = tmp_path / "checkpoints" / "personaplex"
     checkpoint.mkdir(parents=True)
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
     local_forms = [
         checkpoint,

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -149,7 +149,7 @@ class TestCLIBuild:
                     tmpdir,
                     "--no-weights",
                     "--dtype",
-                    "f16",
+                    "f32",
                     "--execution-provider",
                     "cuda",
                 ]
@@ -159,7 +159,7 @@ class TestCLIBuild:
         assert build_model.call_args.kwargs["revision"] == _PERSONAPLEX_REVISION
         assert build_model.call_args.kwargs["load_weights"] is False
         assert build_model.call_args.kwargs["execution_provider"] == "cuda"
-        assert build_model.call_args.kwargs["dtype"] == ir.DataType.FLOAT16
+        assert build_model.call_args.kwargs["dtype"] == ir.DataType.FLOAT
         save_package.assert_called_once()
 
     def test_local_personaplex_config_bypasses_transformers(self):


### PR DESCRIPTION
## Summary

Follow up on valid Copilot review comments that arrived after #715 was merged:

- keep the PersonaPlex CLI regression on its supported `f32` dtype and assert the direct `onnx_ir.DataType.FLOAT` enum
- make the home-relative local checkpoint test portable by isolating both `HOME` and `USERPROFILE` while preserving `~` expansion coverage

## Validation

- `python -m pytest tests/cli_test.py::TestCLIBuild::test_standard_build_dispatches_personaplex_through_public_build src/mobius/integrations/_moshi_test.py -q --tb=short`
- `lintrunner f --output oneline -- tests/cli_test.py src/mobius/integrations/_moshi_test.py`
- `lintrunner --output oneline -- tests/cli_test.py src/mobius/integrations/_moshi_test.py`
- direct `ntpath.expanduser` check with isolated `USERPROFILE`
- `git diff --check`

Independent exact-head GPT-5.6 Sol review reported no high-confidence findings.

Follow-up to merged #715.