### PR TITLE
Fix Windows local checkpoint path test

### DIFF
--- a/src/mobius/integrations/_moshi_test.py
+++ b/src/mobius/integrations/_moshi_test.py
@@ -3,7 +3,8 @@
 
 from __future__ import annotations
 
-import os
+import ntpath
+from pathlib import Path
 from unittest import mock
 
 import onnx_ir as ir
@@ -180,15 +181,21 @@ def test_personaplex_hub_id_uses_pinned_revision(tmp_path, monkeypatch):
 
 
 def test_other_existing_local_directory_forms_do_not_use_hub_revision(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     checkpoint = tmp_path / "checkpoints" / "personaplex"
     checkpoint.mkdir(parents=True)
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
+    # Keep the relative form anchored to the temporary cwd, not the repository checkout.
+    relative_checkpoint = checkpoint.relative_to(Path.cwd())
+    assert relative_checkpoint == Path("checkpoints/personaplex")
+    assert ntpath.normpath(relative_checkpoint.as_posix()) == r"checkpoints\personaplex"
+
     local_forms = [
         checkpoint,
         str(checkpoint),
-        os.path.relpath(checkpoint),
+        relative_checkpoint,
         "~/checkpoints/personaplex",
     ]
     for local_form in local_forms:


### PR DESCRIPTION
## Summary

- anchor the PersonaPlex relative checkpoint fixture to the pytest temporary working directory
- preserve absolute `Path`, absolute string, canonical relative local `Path`, and home-relative `~` coverage
- validate the relative fixture with Windows `ntpath` semantics without changing production behavior

## Root cause

The Windows CI failure in `src/mobius/integrations/_moshi_test.py::test_other_existing_local_directory_forms_do_not_use_hub_revision` occurred after merged #708/#716 because the test called `os.path.relpath(checkpoint)` while the checkout was on `C:` and `tmp_path` was on `D:`. Python raised `ValueError: path is on mount 'D:', start on mount 'C:'` before `_personaplex_revision` ran. This is a fixture bug, not a local checkpoint resolution bug.

## Validation

- focused failing test: 1 passed
- full `src/mobius/integrations/_moshi_test.py`: 11 passed
- PersonaPlex CLI tests: 3 passed
- `lintrunner f --output oneline --all-files`
- `git diff --check`
- independent exact-head GPT-5.6 Sol review: no findings