### PR TITLE
Remove GenAI capability warnings

### DIFF
--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -162,9 +162,7 @@ tokenizer files to the output directory:
   directory.
 
 For a graph-representable, single-model decoder-only text graph, Mobius emits the
-architecture-neutral `model.type: "decoder"` contract. Validation currently targets
-onnxruntime-genai 0.15.2, but the tested runtime version and registry are evidence,
-not export admission checks.
+architecture-neutral `model.type: "decoder"` contract.
 The graph determines the exact semantic input names, output names, cache templates,
 and global cache indices, so dense, MoE, tied-weight, quantized, and unknown
 architecture names do not need a runtime registry entry.
@@ -186,21 +184,6 @@ which selects `Gpt_Model`, `LFM2_Model`, `WhisperModel`, `MarianModel`,
 its [dedicated runtime model](https://github.com/microsoft/onnxruntime-genai/blob/v0.15.2/src/models/qwen_vl_model.cpp).
 The Phi-3 LongRoPE threshold dispatch is in the released
 [`Generator`](https://github.com/microsoft/onnxruntime-genai/blob/v0.15.2/src/generators.cpp).
-
-Mobius preserves graph-derived recurrent and heterogeneous state names even when the
-tested runtime cannot orchestrate them. The generated compatibility sidecar records
-the complete component input/output contract and marks such packages
-`unsupported-by-tested-runtime`; the state-manifest work is tracked by
-[#605](https://github.com/onnxruntime/mobius/issues/605).
-
-Each export also writes `runtime_compatibility.json` with
-`runtime_validation_status`, warnings, the requested and tested versions, and the
-graph-derived component contract. `validated` means the exact requested runtime was
-exercised; `unvalidated` means no matching evidence exists; and
-`unsupported-by-tested-runtime` records a known downstream limitation without
-blocking export. GGUF runtime evidence remains an independent exact-artifact matrix.
-Source identity and tokenizer semantic mismatches still fail because they would make
-the package metadata incorrect.
 
 #### Example
 

--- a/src/mobius/integrations/gguf/_mtp_test.py
+++ b/src/mobius/integrations/gguf/_mtp_test.py
@@ -664,14 +664,11 @@ class TestBuildMtpHead:
             qwen35_mtp_gguf,
             output,
             runtime="ort-genai",
-            runtime_version="0.15.2",
             progress_bar=False,
         )
 
         with open(artifacts["mtp_config"], encoding="utf-8") as handle:
             mtp_config = json.load(handle)
-        with open(artifacts["runtime_compatibility"], encoding="utf-8") as handle:
-            compatibility = json.load(handle)
         with open(artifacts["mtp_runtime_status"], encoding="utf-8") as handle:
             status = json.load(handle)
         assert (output / ".mobius-mtp" / "model.onnx").is_file()
@@ -682,8 +679,6 @@ class TestBuildMtpHead:
             mtp_config["cache_namespaces"]["target"]["namespace"]
             != mtp_config["cache_namespaces"]["mtp"]["namespace"]
         )
-        assert compatibility["runtime_validation_status"] == "unvalidated"
-        assert compatibility["tested_versions"] == ["0.15.2"]
         assert status["status"] == "runtime_unvalidated"
         assert status["artifact"]["sha256"] == package.gguf_artifact_identity.sha256
         assert status["graph_package"]["sha256"]

--- a/src/mobius/integrations/gguf/_runtime_package.py
+++ b/src/mobius/integrations/gguf/_runtime_package.py
@@ -581,7 +581,6 @@ def write_gguf_runtime_package(
                     pkg,
                     str(stage),
                     ep=runtime_execution_provider,
-                    runtime_version=runtime_version,
                 )
             )
         else:

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -164,8 +164,6 @@ _UNWRAPPED_VLM_MODEL_TYPES = {
     "qwen3_5_moe_text": "qwen3_5_moe",
 }
 _LONGROPE_TEXT_TYPES = frozenset({"phi3", "phi3small", "phimoe"})
-_GENERIC_DECODER_MIN_VERSION = (0, 14, 0)
-_GENERIC_DECODER_TESTED_VERSIONS = ("0.15.2",)
 _DECODER_SEMANTIC_INPUTS = frozenset(
     {
         "input_ids",
@@ -436,8 +434,8 @@ def _inspect_decoder_abi(model: ir.Model, *, model_type: str) -> _DecoderAbi:
             _name_template(output_cache["conv_state"], label="present-convolution"),
             _name_template(output_cache["recurrent_state"], label="present-recurrent"),
         }
-        # Preserve graph-derived names in the compatibility sidecar even when a
-        # tested runtime derives different names from the key-cache templates.
+        # Preserve graph-derived names even when a runtime derives different
+        # names from the key-cache templates.
         del (
             expected_input_prefix,
             expected_output_prefix,
@@ -451,58 +449,6 @@ def _inspect_decoder_abi(model: ir.Model, *, model_type: str) -> _DecoderAbi:
         cache_slots=max(all_indices) + 1,
         has_recurrent_state=has_recurrent_state,
     )
-
-
-def _write_runtime_compatibility(
-    output_dir: str,
-    *,
-    model_type: str,
-    runtime_version: str | None,
-    pkg: ModelPackage | None = None,
-) -> str:
-    minimum_versions = {
-        "decoder": _GENERIC_DECODER_MIN_VERSION,
-        "lfm2": (0, 15, 2),
-    }
-    minimum_version = minimum_versions.get(model_type)
-    tested_versions = {
-        "decoder": list(_GENERIC_DECODER_TESTED_VERSIONS),
-        "lfm2": ["0.15.2"],
-    }
-    graph_contract = None
-    if pkg is not None:
-        graph_contract = {
-            name: {
-                "inputs": [
-                    value.name for value in model.graph.inputs if value.name is not None
-                ],
-                "outputs": [
-                    value.name for value in model.graph.outputs if value.name is not None
-                ],
-            }
-            for name, model in pkg.items()
-        }
-    metadata = {
-        "runtime": "onnxruntime-genai",
-        "model_type": model_type,
-        "requested_version": runtime_version,
-        # Export metadata describes the package's graph contract, not what a
-        # particular downstream runtime version can execute.
-        "runtime_validation_status": "unvalidated",
-        "warnings": [],
-        "minimum_version": (
-            ".".join(map(str, minimum_version)) if minimum_version is not None else None
-        ),
-        "tested_versions": tested_versions.get(model_type, []),
-        "uses_main_only_state_groups": False,
-        "heterogeneous_state_manifest": "deferred: https://github.com/onnxruntime/mobius/issues/605",
-        "graph_contract": graph_contract,
-    }
-    path = os.path.join(output_dir, "runtime_compatibility.json")
-    with open(path, "w", encoding="utf-8") as handle:
-        json.dump(metadata, handle, indent=2)
-        handle.write("\n")
-    return path
 
 
 def _load_generation_config(model_id: str):
@@ -1983,7 +1929,6 @@ def write_ort_genai_config(
     context_length: int = 4096,
     local_config_dir: str | None = None,
     trust_remote_code: bool = False,
-    runtime_version: str | None = None,
 ) -> dict[str, str]:
     """Generate ORT-GenAI config artifacts for an already-built ModelPackage.
 
@@ -2020,8 +1965,6 @@ def write_ort_genai_config(
             directory rather than a HuggingFace model ID.
         trust_remote_code: Allow custom HuggingFace configuration code when
             resolving token IDs and model type.
-        runtime_version: Optional onnxruntime-genai version recorded in
-            ``runtime_compatibility.json``.
 
     Returns:
         Dict mapping artifact name to file path, e.g.::
@@ -2044,18 +1987,6 @@ def write_ort_genai_config(
             "Diffusion models (which have no config) are not supported."
         )
     os.makedirs(directory, exist_ok=True)
-    component_names = set(pkg)
-    if component_names in ({"audio_encoder"}, {"speaker_encoder"}) and getattr(
-        pkg, "gguf_projector_type", None
-    ):
-        compatibility_path = _write_runtime_compatibility(
-            directory,
-            model_type=str(getattr(config, "model_type", "unknown")),
-            runtime_version=runtime_version,
-            pkg=pkg,
-        )
-        return {"runtime_compatibility": compatibility_path}
-
     # Normalize EP: 'default' and 'onnx-standard' are portable-ONNX modes
     # that carry no EP-specific session options → treat as CPU.
     if ep in ("default", "onnx-standard"):
@@ -2199,13 +2130,6 @@ def write_ort_genai_config(
         has_speech=has_speech,
     )
     result["genai_config"] = genai_path
-    compatibility_path = _write_runtime_compatibility(
-        directory,
-        model_type=ort_model_type,
-        runtime_version=runtime_version,
-        pkg=pkg,
-    )
-    result["runtime_compatibility"] = compatibility_path
 
     # Write processor config for VLMs
     processor_path = _write_vision_processor_config(
@@ -2251,7 +2175,6 @@ def export_package(
     context_length: int = 4096,
     local_config_dir: str | None = None,
     trust_remote_code: bool = False,
-    runtime_version: str | None = None,
     external_data: str = "onnx",
     progress_bar: bool = True,
 ) -> dict[str, str]:
@@ -2295,8 +2218,6 @@ def export_package(
             resolving token IDs and model type.
         revision: Optional immutable HuggingFace revision used for remote
             configuration, tokenizer, and processor requests.
-        runtime_version: Optional onnxruntime-genai version that will consume
-            the package.
         external_data: External-data format passed to :meth:`ModelPackage.save`
             (``"onnx"`` or ``"safetensors"``).
         progress_bar: Whether to show the save progress bar.
@@ -2353,7 +2274,6 @@ def export_package(
         context_length=context_length,
         local_config_dir=local_config_dir,
         trust_remote_code=trust_remote_code,
-        runtime_version=runtime_version,
     )
 
     # 3. Add ONNX paths to the manifest

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -453,21 +453,12 @@ def _inspect_decoder_abi(model: ir.Model, *, model_type: str) -> _DecoderAbi:
     )
 
 
-def _runtime_version_tuple(version: str) -> tuple[int, int, int] | None:
-    match = re.match(r"^([0-9]+)\.([0-9]+)\.([0-9]+)", version)
-    if match is None:
-        return None
-    major, minor, patch = match.groups()
-    return int(major), int(minor), int(patch)
-
-
 def _write_runtime_compatibility(
     output_dir: str,
     *,
     model_type: str,
     runtime_version: str | None,
     pkg: ModelPackage | None = None,
-    capability_warnings: tuple[str, ...] = (),
 ) -> str:
     minimum_versions = {
         "decoder": _GENERIC_DECODER_MIN_VERSION,
@@ -478,32 +469,6 @@ def _write_runtime_compatibility(
         "decoder": list(_GENERIC_DECODER_TESTED_VERSIONS),
         "lfm2": ["0.15.2"],
     }
-    warnings = list(capability_warnings)
-    parsed_version = _runtime_version_tuple(runtime_version) if runtime_version else None
-    if runtime_version is not None and parsed_version is None:
-        warnings.append(
-            f"Requested onnxruntime-genai version {runtime_version!r} is not a recognized "
-            "MAJOR.MINOR.PATCH version; runtime compatibility is unvalidated."
-        )
-    if (
-        minimum_version is not None
-        and parsed_version is not None
-        and parsed_version < minimum_version
-    ):
-        warnings.append(
-            f"Tested runtime support for model type {model_type!r} starts at "
-            f"{'.'.join(map(str, minimum_version))}; requested {runtime_version}."
-        )
-    if capability_warnings or (
-        minimum_version is not None
-        and parsed_version is not None
-        and parsed_version < minimum_version
-    ):
-        validation_status = "unsupported-by-tested-runtime"
-    else:
-        # This writer has runtime-version coverage, not exact package evidence.
-        # A caller with artifact-bound evidence may promote the completed package.
-        validation_status = "unvalidated"
     graph_contract = None
     if pkg is not None:
         graph_contract = {
@@ -521,8 +486,10 @@ def _write_runtime_compatibility(
         "runtime": "onnxruntime-genai",
         "model_type": model_type,
         "requested_version": runtime_version,
-        "runtime_validation_status": validation_status,
-        "warnings": warnings,
+        # Export metadata describes the package's graph contract, not what a
+        # particular downstream runtime version can execute.
+        "runtime_validation_status": "unvalidated",
+        "warnings": [],
         "minimum_version": (
             ".".join(map(str, minimum_version)) if minimum_version is not None else None
         ),
@@ -535,8 +502,6 @@ def _write_runtime_compatibility(
     with open(path, "w", encoding="utf-8") as handle:
         json.dump(metadata, handle, indent=2)
         handle.write("\n")
-    for warning in warnings:
-        logger.warning("%s Export continues with faithful graph metadata.", warning)
     return path
 
 
@@ -1884,85 +1849,6 @@ def _write_genai_config(
     return generator.write(output_dir)
 
 
-def _runtime_capability_warnings(pkg: ModelPackage) -> tuple[str, ...]:
-    """Describe tested-runtime limitations without making them export gates."""
-    config = getattr(pkg, "config", None)
-    warnings: list[str] = []
-    if getattr(config, "model_type", None) in _QWEN4_EXP_MODEL_TYPES:
-        warnings.append(
-            "onnxruntime-genai 0.15.2 cannot represent Qwen4-Exp's explicit "
-            "four-axis position state or heterogeneous per-layer PLE/QSA state "
-            "membership; use the graph's mobius.state_manifest metadata."
-        )
-    if getattr(config, "model_type", None) == "parakeet_ctc":
-        warnings.append(
-            "onnxruntime-genai 0.15.2 does not define a feature-input CTC ASR pipeline."
-        )
-    if getattr(config, "model_type", None) in _GLMASR_MODEL_TYPES:
-        warnings.append(
-            "onnxruntime-genai 0.15.2 does not register a GLM-ASR multimodal model type."
-        )
-    if {"vision_encoder", "decoder"}.issubset(pkg) and "embedding" not in pkg:
-        model_type = getattr(config, "model_type", "unknown")
-        warnings.append(
-            "onnxruntime-genai 0.15.2 does not support generic vision encoder-decoder "
-            f"packages such as {model_type!r}."
-        )
-    if getattr(config, "model_type", None) == "mage_vl":
-        warnings.append(
-            "onnxruntime-genai 0.15.2 does not support Mage-VL's patch_positions "
-            "vision input and 1D decoder position_ids contract."
-        )
-    decoder_key = "decoder" if "decoder" in pkg else "model"
-    decoder_model = pkg.get(decoder_key)
-    if decoder_model is not None:
-        input_names = [
-            value.name for value in decoder_model.graph.inputs if value.name is not None
-        ]
-        output_names = [
-            value.name for value in decoder_model.graph.outputs if value.name is not None
-        ]
-        input_cache = _cache_names(input_names)
-        output_cache = _cache_names(output_names)
-        unsupported_state_kinds = (set(input_cache) | set(output_cache)) - {
-            "key",
-            "value",
-            "conv_state",
-            "recurrent_state",
-        }
-        if unsupported_state_kinds:
-            warnings.append(
-                "onnxruntime-genai 0.15.2 cannot orchestrate decoder state kinds "
-                f"{sorted(unsupported_state_kinds)}; exact names remain in graph_contract."
-            )
-        if _is_single_model_decoder_package(pkg):
-            cache_input_names = {
-                name
-                for indexed_names in input_cache.values()
-                for name in indexed_names.values()
-            }
-            additional_inputs = set(input_names) - cache_input_names - _DECODER_SEMANTIC_INPUTS
-            if additional_inputs:
-                warnings.append(
-                    "onnxruntime-genai 0.15.2 cannot automatically supply decoder inputs "
-                    f"{sorted(additional_inputs)}; exact names remain in graph_contract."
-                )
-        has_recurrent_state = any(
-            node.op_type == "LinearAttention" and node.domain == "com.microsoft"
-            for node in decoder_model.graph
-        )
-        has_standard_attention = any(
-            node.op_type == "Attention" and node.domain in ("", "ai.onnx")
-            for node in decoder_model.graph
-        )
-        if has_recurrent_state and has_standard_attention:
-            warnings.append(
-                "onnxruntime-genai 0.15.2 cannot orchestrate a shared cache for mixed "
-                "LinearAttention and standard Attention nodes."
-            )
-    return tuple(warnings)
-
-
 def _mtp_state_ports(model: Any) -> list[dict[str, str]]:
     """Return exact local cache port pairs from one target or MTP graph."""
     output_names = {value.name for value in model.graph.outputs if value.name is not None}
@@ -2134,8 +2020,8 @@ def write_ort_genai_config(
             directory rather than a HuggingFace model ID.
         trust_remote_code: Allow custom HuggingFace configuration code when
             resolving token IDs and model type.
-        runtime_version: Optional onnxruntime-genai version that will consume the
-            package. Generic decoder packages reject versions older than 0.14.0.
+        runtime_version: Optional onnxruntime-genai version recorded in
+            ``runtime_compatibility.json``.
 
     Returns:
         Dict mapping artifact name to file path, e.g.::
@@ -2157,23 +2043,16 @@ def write_ort_genai_config(
             "This is set automatically when building with mobius.build(). "
             "Diffusion models (which have no config) are not supported."
         )
-    capability_warnings = _runtime_capability_warnings(pkg)
-
     os.makedirs(directory, exist_ok=True)
     component_names = set(pkg)
     if component_names in ({"audio_encoder"}, {"speaker_encoder"}) and getattr(
         pkg, "gguf_projector_type", None
     ):
-        warning = (
-            "The tested onnxruntime-genai runtime cannot orchestrate a standalone GGUF "
-            "audio/speaker sidecar; no genai_config.json was emitted."
-        )
         compatibility_path = _write_runtime_compatibility(
             directory,
             model_type=str(getattr(config, "model_type", "unknown")),
             runtime_version=runtime_version,
             pkg=pkg,
-            capability_warnings=(warning,),
         )
         return {"runtime_compatibility": compatibility_path}
 
@@ -2243,14 +2122,6 @@ def write_ort_genai_config(
                 is_decoder_only=is_decoder_only,
                 rope_type=getattr(config, "rope_type", None),
             )
-        if ort_model_type == "unknown":
-            logger.warning(
-                "Could not determine ORT-GenAI model type: pkg.config.model_type "
-                "is missing, None, or not mapped to an ORT-GenAI type (got %r). "
-                "Pass hf_model_id to resolve it from the HuggingFace config, or "
-                "the generated genai_config.json may not load correctly.",
-                raw_type,
-            )
         # Read token IDs from ArchitectureConfig (populated by from_transformers()
         # when --config is used with a local directory).
         bos_token_id = getattr(config, "bos_token_id", None)
@@ -2284,10 +2155,6 @@ def write_ort_genai_config(
     mtp_path = _write_mtp_config(pkg, directory)
     if mtp_path is not None:
         result["mtp_config"] = mtp_path
-        logger.warning(
-            "Wrote external MTP coordination metadata. The ONNX target and MTP graphs are "
-            "exported, but onnxruntime-genai orchestration remains runtime_unvalidated."
-        )
 
     # Copy tokenizer files. A local hf_model_id is a local model directory, not a
     # Hub repo id; copy directly instead of calling hf_hub_download.
@@ -2337,7 +2204,6 @@ def write_ort_genai_config(
         model_type=ort_model_type,
         runtime_version=runtime_version,
         pkg=pkg,
-        capability_warnings=capability_warnings,
     )
     result["runtime_compatibility"] = compatibility_path
 

--- a/src/mobius/integrations/ort_genai/auto_export.py
+++ b/src/mobius/integrations/ort_genai/auto_export.py
@@ -1987,6 +1987,11 @@ def write_ort_genai_config(
             "Diffusion models (which have no config) are not supported."
         )
     os.makedirs(directory, exist_ok=True)
+    if set(pkg) in ({"audio_encoder"}, {"speaker_encoder"}) and getattr(
+        pkg, "gguf_projector_type", None
+    ):
+        return {}
+
     # Normalize EP: 'default' and 'onnx-standard' are portable-ONNX modes
     # that carry no EP-specific session options → treat as CPU.
     if ep in ("default", "onnx-standard"):

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -1386,7 +1386,7 @@ class TestExportForOrtGenai:
         assert data["model"]["decoder"]["inputs"]["position_ids"] == "position_ids"
         assert (tmp_path / "runtime_compatibility.json").is_file()
 
-    def test_generic_vision_encoder_decoder_exports_with_warning(self, tmp_path):
+    def test_generic_vision_encoder_decoder_exports_graph_contract(self, tmp_path):
         import dataclasses
 
         from mobius._model_package import ModelPackage
@@ -1412,8 +1412,9 @@ class TestExportForOrtGenai:
         )
         result = write_ort_genai_config(pkg, str(tmp_path))
         compatibility = json.loads(Path(result["runtime_compatibility"]).read_text())
-        assert compatibility["runtime_validation_status"] == "unsupported-by-tested-runtime"
-        assert "generic vision encoder-decoder" in compatibility["warnings"][0]
+        assert compatibility["runtime_validation_status"] == "unvalidated"
+        assert compatibility["warnings"] == []
+        assert set(compatibility["graph_contract"]) == {"vision_encoder", "decoder"}
 
     def test_processor_config_written_with_vision(self, tmp_path):
         """image_processor.json is written when pkg.config.vision is set."""
@@ -1841,7 +1842,7 @@ class TestExportForOrtGenai:
         assert data["model"]["type"] == "qwen3_5_moe"
         assert data["model"]["vision"]["patch_size"] == 16
 
-    def test_mage_vl_exports_with_runtime_warning(self, tmp_path):
+    def test_mage_vl_exports_graph_contract(self, tmp_path):
         import dataclasses
 
         from mobius._model_package import ModelPackage
@@ -1878,7 +1879,8 @@ class TestExportForOrtGenai:
         output_dir = tmp_path / "ort-genai"
         result = write_ort_genai_config(pkg, str(output_dir))
         compatibility = json.loads(Path(result["runtime_compatibility"]).read_text())
-        assert compatibility["runtime_validation_status"] == "unsupported-by-tested-runtime"
+        assert compatibility["runtime_validation_status"] == "unvalidated"
+        assert compatibility["warnings"] == []
         assert "vision_encoder" in compatibility["graph_contract"]
 
     def test_processor_config_not_written_without_vision(self, tmp_path):
@@ -2087,7 +2089,7 @@ class TestExportForOrtGenai:
         assert speech["inputs"]["audio_embeds"] == "input_features"
         assert speech["inputs"]["attention_mask"] == "input_features_mask"
 
-    def test_glmasr_registry_gap_does_not_block_export(self, tmp_path):
+    def test_glmasr_exports_without_runtime_capability_warning(self, tmp_path):
         import dataclasses
 
         from mobius._model_package import ModelPackage
@@ -2129,8 +2131,8 @@ class TestExportForOrtGenai:
         result = write_ort_genai_config(pkg, str(tmp_path))
         compatibility = json.loads(Path(result["runtime_compatibility"]).read_text())
         assert compatibility["model_type"] == "glmasr"
-        assert compatibility["runtime_validation_status"] == "unsupported-by-tested-runtime"
-        assert "does not register" in compatibility["warnings"][0]
+        assert compatibility["runtime_validation_status"] == "unvalidated"
+        assert compatibility["warnings"] == []
 
     def test_tokenizer_not_copied_without_model_id(self, tmp_path):
         """No tokenizer files copied when hf_model_id=None."""
@@ -3034,7 +3036,7 @@ class TestExportPackage:
         # ONNX path is in the manifest (single-component package)
         assert result["model"] == os.path.join(str(tmp_path), "model.onnx")
 
-    def test_mage_vl_runtime_gap_does_not_block_saving_onnx(self, tmp_path):
+    def test_mage_vl_exports_without_runtime_capability_warning(self, tmp_path):
         pkg = self._make_pkg()
         pkg.config.model_type = "mage_vl"
 
@@ -3043,7 +3045,8 @@ class TestExportPackage:
 
         save.assert_called_once()
         compatibility = json.loads(Path(result["runtime_compatibility"]).read_text())
-        assert compatibility["runtime_validation_status"] == "unsupported-by-tested-runtime"
+        assert compatibility["runtime_validation_status"] == "unvalidated"
+        assert compatibility["warnings"] == []
 
     def test_propagates_save_kwargs(self, tmp_path, monkeypatch):
         """external_data and progress_bar are forwarded to pkg.save."""
@@ -3774,7 +3777,7 @@ def test_generic_decoder_runtime_compatibility_metadata(tmp_path):
     }
 
 
-def test_heterogeneous_decoder_state_exports_with_specific_runtime_warning(tmp_path):
+def test_heterogeneous_decoder_state_preserves_graph_contract(tmp_path):
     pkg = _make_fake_llm_pkg("unknown_architecture")
     pkg["model"] = _mock_model(
         inputs=[
@@ -3795,13 +3798,12 @@ def test_heterogeneous_decoder_state_exports_with_specific_runtime_warning(tmp_p
     result = write_ort_genai_config(pkg, str(tmp_path))
     compatibility = json.loads(Path(result["runtime_compatibility"]).read_text())
 
-    assert compatibility["runtime_validation_status"] == "unsupported-by-tested-runtime"
-    assert any("ssm_state" in warning for warning in compatibility["warnings"])
-    assert any("cache_position" in warning for warning in compatibility["warnings"])
+    assert compatibility["runtime_validation_status"] == "unvalidated"
+    assert compatibility["warnings"] == []
     assert "past_key_values.1.ssm_state" in compatibility["graph_contract"]["model"]["inputs"]
 
 
-def test_lfm2_runtime_compatibility_is_pinned_to_released_probe(tmp_path):
+def test_lfm2_runtime_compatibility_records_requested_version(tmp_path):
     path = _write_runtime_compatibility(
         str(tmp_path), model_type="lfm2", runtime_version="0.15.2"
     )
@@ -3814,7 +3816,8 @@ def test_lfm2_runtime_compatibility_is_pinned_to_released_probe(tmp_path):
         str(tmp_path), model_type="lfm2", runtime_version="0.15.1"
     )
     old_metadata = json.loads(Path(old_path).read_text())
-    assert old_metadata["runtime_validation_status"] == "unsupported-by-tested-runtime"
+    assert old_metadata["requested_version"] == "0.15.1"
+    assert old_metadata["runtime_validation_status"] == "unvalidated"
 
 
 def test_decoder_sidecar_preserves_type_and_matching_compatibility_metadata(tmp_path):
@@ -4104,7 +4107,7 @@ def test_generic_decoder_schema_is_architecture_and_weight_agnostic(
 
 
 @pytest.mark.parametrize("runtime_version", ["0.13.0", "unknown-development-build"])
-def test_generic_decoder_old_or_unknown_runtime_does_not_block_export(
+def test_generic_decoder_runtime_version_does_not_change_export_metadata(
     tmp_path, runtime_version
 ):
     result = write_ort_genai_config(
@@ -4116,10 +4119,8 @@ def test_generic_decoder_old_or_unknown_runtime_does_not_block_export(
     compatibility = json.loads(Path(result["runtime_compatibility"]).read_text())
     assert config["model"]["type"] == "decoder"
     assert config["model"]["decoder"]["inputs"]["past_key_names"] == ("past_key_values.%d.key")
-    assert compatibility["runtime_validation_status"] in {
-        "unvalidated",
-        "unsupported-by-tested-runtime",
-    }
+    assert compatibility["runtime_validation_status"] == "unvalidated"
+    assert compatibility["warnings"] == []
 
 
 def test_gpt2_separate_cache_graph_uses_generic_decoder(tmp_path):
@@ -4429,7 +4430,7 @@ class TestGemma4RealModel:
             revision=revision,
         )
 
-    def test_auto_export_keeps_mage_vl_runtime_gap_advisory(self, tmp_path):
+    def test_auto_export_omits_mage_vl_runtime_capability_warning(self, tmp_path):
         pkg = _make_fake_llm_pkg("mage_vl")
 
         with (
@@ -4457,7 +4458,8 @@ class TestGemma4RealModel:
 
         save.assert_called_once()
         compatibility = json.loads(Path(result["runtime_compatibility"]).read_text())
-        assert compatibility["runtime_validation_status"] == "unsupported-by-tested-runtime"
+        assert compatibility["runtime_validation_status"] == "unvalidated"
+        assert compatibility["warnings"] == []
 
     def test_auto_export_produces_genai_config(self, tmp_path):
         """Mock build() to return a tiny package, verify genai_config."""

--- a/src/mobius/integrations/ort_genai/auto_export_test.py
+++ b/src/mobius/integrations/ort_genai/auto_export_test.py
@@ -33,10 +33,8 @@ from mobius.integrations.ort_genai.auto_export import (
     _uses_compact_sliding_kv_cache,
     _write_audio_processor_config,
     _write_genai_config,
-    _write_runtime_compatibility,
     _write_vision_processor_config,
     auto_export,
-    export_package,
     write_ort_genai_config,
 )
 
@@ -1384,37 +1382,6 @@ class TestExportForOrtGenai:
         assert "model" in data
         assert data["model"]["type"] == "decoder"
         assert data["model"]["decoder"]["inputs"]["position_ids"] == "position_ids"
-        assert (tmp_path / "runtime_compatibility.json").is_file()
-
-    def test_generic_vision_encoder_decoder_exports_graph_contract(self, tmp_path):
-        import dataclasses
-
-        from mobius._model_package import ModelPackage
-
-        @dataclasses.dataclass
-        class FakeConfig:
-            model_type: str = "nemotron_parse"
-            vocab_size: int = 256
-            hidden_size: int = 64
-            num_hidden_layers: int = 2
-            num_attention_heads: int = 4
-            num_key_value_heads: int = 2
-            head_dim: int = 16
-            max_position_embeddings: int = 4096
-            pad_token_id: int = 0
-
-        pkg = ModelPackage(
-            {
-                "vision_encoder": _mock_model(),
-                "decoder": _mock_model(),
-            },
-            config=FakeConfig(),
-        )
-        result = write_ort_genai_config(pkg, str(tmp_path))
-        compatibility = json.loads(Path(result["runtime_compatibility"]).read_text())
-        assert compatibility["runtime_validation_status"] == "unvalidated"
-        assert compatibility["warnings"] == []
-        assert set(compatibility["graph_contract"]) == {"vision_encoder", "decoder"}
 
     def test_processor_config_written_with_vision(self, tmp_path):
         """image_processor.json is written when pkg.config.vision is set."""
@@ -1842,47 +1809,6 @@ class TestExportForOrtGenai:
         assert data["model"]["type"] == "qwen3_5_moe"
         assert data["model"]["vision"]["patch_size"] == 16
 
-    def test_mage_vl_exports_graph_contract(self, tmp_path):
-        import dataclasses
-
-        from mobius._model_package import ModelPackage
-        from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
-
-        @dataclasses.dataclass
-        class FakeVision:
-            image_size: int = 448
-            patch_size: int = 16
-            spatial_merge_size: int = 2
-
-        @dataclasses.dataclass
-        class FakeConfig:
-            model_type: str = "mage_vl"
-            vocab_size: int = 151936
-            hidden_size: int = 2560
-            num_hidden_layers: int = 1
-            num_attention_heads: int = 32
-            num_key_value_heads: int = 8
-            head_dim: int = 128
-            image_token_id: int = 151655
-            temporal_patch_size: int = 1
-            vision: FakeVision = dataclasses.field(default_factory=FakeVision)
-
-        pkg = ModelPackage(
-            {
-                "decoder": _mock_model(),
-                "vision_encoder": _mock_model(),
-                "embedding": _mock_model(),
-            },
-            config=FakeConfig(),
-        )
-
-        output_dir = tmp_path / "ort-genai"
-        result = write_ort_genai_config(pkg, str(output_dir))
-        compatibility = json.loads(Path(result["runtime_compatibility"]).read_text())
-        assert compatibility["runtime_validation_status"] == "unvalidated"
-        assert compatibility["warnings"] == []
-        assert "vision_encoder" in compatibility["graph_contract"]
-
     def test_processor_config_not_written_without_vision(self, tmp_path):
         """image_processor.json is NOT written when pkg.config has no vision attr."""
         from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
@@ -2088,51 +2014,6 @@ class TestExportForOrtGenai:
         # input_names mapping: genai internal name -> ONNX model input name
         assert speech["inputs"]["audio_embeds"] == "input_features"
         assert speech["inputs"]["attention_mask"] == "input_features_mask"
-
-    def test_glmasr_exports_without_runtime_capability_warning(self, tmp_path):
-        import dataclasses
-
-        from mobius._model_package import ModelPackage
-        from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
-
-        @dataclasses.dataclass
-        class FakeAudio:
-            audio_token_id: int = 59260
-
-        @dataclasses.dataclass
-        class FakeConfig:
-            model_type: str = "glmasr"
-            vocab_size: int = 59264
-            hidden_size: int = 2048
-            num_hidden_layers: int = 28
-            num_attention_heads: int = 16
-            num_key_value_heads: int = 4
-            head_dim: int = 128
-            audio_token_id: int = 59260
-            audio: FakeAudio = dataclasses.field(default_factory=FakeAudio)
-
-        pkg = ModelPackage(
-            {
-                "decoder": _mock_model_with_inputs(
-                    ["inputs_embeds", "attention_mask", "position_ids"]
-                ),
-                "audio_encoder": _mock_model(
-                    inputs=["input_features", "input_features_mask"],
-                    outputs=["audio_features", "audio_feature_lengths"],
-                ),
-                "embedding": _mock_model(
-                    inputs=["input_ids", "audio_features"],
-                    outputs=["inputs_embeds"],
-                ),
-            },
-            config=FakeConfig(),
-        )
-
-        result = write_ort_genai_config(pkg, str(tmp_path))
-        compatibility = json.loads(Path(result["runtime_compatibility"]).read_text())
-        assert compatibility["model_type"] == "glmasr"
-        assert compatibility["runtime_validation_status"] == "unvalidated"
-        assert compatibility["warnings"] == []
 
     def test_tokenizer_not_copied_without_model_id(self, tmp_path):
         """No tokenizer files copied when hf_model_id=None."""
@@ -3036,18 +2917,6 @@ class TestExportPackage:
         # ONNX path is in the manifest (single-component package)
         assert result["model"] == os.path.join(str(tmp_path), "model.onnx")
 
-    def test_mage_vl_exports_without_runtime_capability_warning(self, tmp_path):
-        pkg = self._make_pkg()
-        pkg.config.model_type = "mage_vl"
-
-        with mock.patch.object(pkg, "save") as save:
-            result = export_package(pkg, str(tmp_path))
-
-        save.assert_called_once()
-        compatibility = json.loads(Path(result["runtime_compatibility"]).read_text())
-        assert compatibility["runtime_validation_status"] == "unvalidated"
-        assert compatibility["warnings"] == []
-
     def test_propagates_save_kwargs(self, tmp_path, monkeypatch):
         """external_data and progress_bar are forwarded to pkg.save."""
         from mobius.integrations.ort_genai.auto_export import export_package
@@ -3734,52 +3603,8 @@ class TestGenericDecoderAbi:
         assert abi.cache_slots == 2
 
 
-def test_generic_decoder_runtime_compatibility_metadata(tmp_path):
-    result = write_ort_genai_config(
-        _make_fake_llm_pkg("unknown_architecture"),
-        str(tmp_path),
-        runtime_version="0.15.2",
-    )
-    with open(result["runtime_compatibility"], encoding="utf-8") as handle:
-        metadata = json.load(handle)
-    assert metadata == {
-        "runtime": "onnxruntime-genai",
-        "model_type": "decoder",
-        "requested_version": "0.15.2",
-        "runtime_validation_status": "unvalidated",
-        "warnings": [],
-        "minimum_version": "0.14.0",
-        "tested_versions": ["0.15.2"],
-        "uses_main_only_state_groups": False,
-        "heterogeneous_state_manifest": (
-            "deferred: https://github.com/onnxruntime/mobius/issues/605"
-        ),
-        "graph_contract": {
-            "model": {
-                "inputs": [
-                    "input_ids",
-                    "attention_mask",
-                    "position_ids",
-                    "past_key_values.0.key",
-                    "past_key_values.0.value",
-                    "past_key_values.1.key",
-                    "past_key_values.1.value",
-                ],
-                "outputs": [
-                    "logits",
-                    "present.0.key",
-                    "present.0.value",
-                    "present.1.key",
-                    "present.1.value",
-                ],
-            }
-        },
-    }
-
-
-def test_heterogeneous_decoder_state_preserves_graph_contract(tmp_path):
-    pkg = _make_fake_llm_pkg("unknown_architecture")
-    pkg["model"] = _mock_model(
+def test_heterogeneous_decoder_state_preserves_graph_contract():
+    decoder = _mock_model(
         inputs=[
             "input_ids",
             "cache_position",
@@ -3795,32 +3620,12 @@ def test_heterogeneous_decoder_state_preserves_graph_contract(tmp_path):
         ],
     )
 
-    result = write_ort_genai_config(pkg, str(tmp_path))
-    compatibility = json.loads(Path(result["runtime_compatibility"]).read_text())
-
-    assert compatibility["runtime_validation_status"] == "unvalidated"
-    assert compatibility["warnings"] == []
-    assert "past_key_values.1.ssm_state" in compatibility["graph_contract"]["model"]["inputs"]
+    abi = _inspect_decoder_abi(decoder, model_type="decoder")
+    assert abi.cache_slots == 2
+    assert abi.inputs["cache_position"] == "cache_position"
 
 
-def test_lfm2_runtime_compatibility_records_requested_version(tmp_path):
-    path = _write_runtime_compatibility(
-        str(tmp_path), model_type="lfm2", runtime_version="0.15.2"
-    )
-    with open(path, encoding="utf-8") as handle:
-        metadata = json.load(handle)
-
-    assert metadata["minimum_version"] == "0.15.2"
-    assert metadata["tested_versions"] == ["0.15.2"]
-    old_path = _write_runtime_compatibility(
-        str(tmp_path), model_type="lfm2", runtime_version="0.15.1"
-    )
-    old_metadata = json.loads(Path(old_path).read_text())
-    assert old_metadata["requested_version"] == "0.15.1"
-    assert old_metadata["runtime_validation_status"] == "unvalidated"
-
-
-def test_decoder_sidecar_preserves_type_and_matching_compatibility_metadata(tmp_path):
+def test_decoder_sidecar_preserves_model_type(tmp_path):
     pkg = _make_fake_llm_pkg("qwen2")
     pkg.config.num_nextn_predict_layers = 1
     pkg["mtp"] = _mock_model(inputs=["hidden_states"], outputs=["draft_logits"])
@@ -3828,12 +3633,7 @@ def test_decoder_sidecar_preserves_type_and_matching_compatibility_metadata(tmp_
     result = write_ort_genai_config(pkg, str(tmp_path))
     with open(result["genai_config"], encoding="utf-8") as handle:
         config = json.load(handle)
-    with open(result["runtime_compatibility"], encoding="utf-8") as handle:
-        compatibility = json.load(handle)
-
     assert config["model"]["type"] == "qwen2"
-    assert compatibility["model_type"] == config["model"]["type"]
-    assert compatibility["runtime_validation_status"] == "unvalidated"
     assert result["mtp_config"].endswith("mtp_config.json")
 
 
@@ -3862,15 +3662,9 @@ def test_attached_mtp_sidecar_emits_component_qualified_cache_contract(tmp_path)
         ),
     )
 
-    result = write_ort_genai_config(
-        pkg,
-        str(tmp_path),
-        runtime_version="0.15.2",
-    )
+    result = write_ort_genai_config(pkg, str(tmp_path))
     with open(result["mtp_config"], encoding="utf-8") as handle:
         mtp = json.load(handle)
-    with open(result["runtime_compatibility"], encoding="utf-8") as handle:
-        compatibility = json.load(handle)
 
     assert mtp["status"] == "runtime_unvalidated"
     assert mtp["model"]["filename"] == ".mobius-mtp/model.onnx"
@@ -3908,9 +3702,6 @@ def test_attached_mtp_sidecar_emits_component_qualified_cache_contract(tmp_path)
             ],
         },
     }
-    assert compatibility["runtime_validation_status"] == "unvalidated"
-    assert compatibility["tested_versions"] == ["0.15.2"]
-    assert compatibility["graph_contract"] is not None
 
 
 def test_gguf_mtp_count_overrides_architecture_config_default_zero(tmp_path):
@@ -4104,23 +3895,6 @@ def test_generic_decoder_schema_is_architecture_and_weight_agnostic(
         "present_value_names": "present.%d.value",
     }
     assert config["search"]["past_present_share_buffer"] is False
-
-
-@pytest.mark.parametrize("runtime_version", ["0.13.0", "unknown-development-build"])
-def test_generic_decoder_runtime_version_does_not_change_export_metadata(
-    tmp_path, runtime_version
-):
-    result = write_ort_genai_config(
-        _make_fake_llm_pkg("unknown_architecture"),
-        str(tmp_path),
-        runtime_version=runtime_version,
-    )
-    config = json.loads(Path(result["genai_config"]).read_text())
-    compatibility = json.loads(Path(result["runtime_compatibility"]).read_text())
-    assert config["model"]["type"] == "decoder"
-    assert config["model"]["decoder"]["inputs"]["past_key_names"] == ("past_key_values.%d.key")
-    assert compatibility["runtime_validation_status"] == "unvalidated"
-    assert compatibility["warnings"] == []
 
 
 def test_gpt2_separate_cache_graph_uses_generic_decoder(tmp_path):
@@ -4429,37 +4203,6 @@ class TestGemma4RealModel:
             str(tmp_path),
             revision=revision,
         )
-
-    def test_auto_export_omits_mage_vl_runtime_capability_warning(self, tmp_path):
-        pkg = _make_fake_llm_pkg("mage_vl")
-
-        with (
-            mock.patch("mobius.integrations.transformers.build", return_value=pkg),
-            mock.patch.object(pkg, "save") as save,
-            mock.patch(
-                "mobius.integrations.ort_genai.auto_export._copy_tokenizer_files",
-                return_value=[],
-            ),
-            mock.patch(
-                "transformers.AutoConfig.from_pretrained",
-                return_value=types.SimpleNamespace(
-                    model_type="mage_vl",
-                    bos_token_id=1,
-                    eos_token_id=2,
-                    pad_token_id=0,
-                ),
-            ),
-            mock.patch(
-                "mobius.integrations.ort_genai.auto_export._load_generation_config",
-                return_value=None,
-            ),
-        ):
-            result = auto_export("microsoft/Mage-VL", str(tmp_path))
-
-        save.assert_called_once()
-        compatibility = json.loads(Path(result["runtime_compatibility"]).read_text())
-        assert compatibility["runtime_validation_status"] == "unvalidated"
-        assert compatibility["warnings"] == []
 
     def test_auto_export_produces_genai_config(self, tmp_path):
         """Mock build() to return a tiny package, verify genai_config."""

--- a/src/mobius/models/gguf_audio_projector_test.py
+++ b/src/mobius/models/gguf_audio_projector_test.py
@@ -591,13 +591,8 @@ def test_standalone_runtime_exports_are_advisory(
     assert "mobius.processor_abi" in onnx_metadata["components"][component]["metadata"]
 
     ort_paths = write_ort_genai_config(package, str(tmp_path / "ort-genai"))
-    ort_metadata = json.loads(
-        (tmp_path / "ort-genai" / "runtime_compatibility.json").read_text()
-    )
-    assert set(ort_paths) == {"runtime_compatibility"}
+    assert ort_paths == {}
     assert not (tmp_path / "ort-genai" / "genai_config.json").exists()
-    assert ort_metadata["runtime_validation_status"] == "unsupported-by-tested-runtime"
-    assert set(ort_metadata["graph_contract"]) == {component}
 
 
 def test_granite_feature_capture_precedes_midpoint_ctc_injection():

--- a/src/mobius/models/parakeet_ctc_test.py
+++ b/src/mobius/models/parakeet_ctc_test.py
@@ -4,8 +4,6 @@
 from __future__ import annotations
 
 import dataclasses
-import json
-from pathlib import Path
 
 import numpy as np
 import onnx_ir as ir
@@ -25,7 +23,6 @@ from mobius import build_from_module
 from mobius._configs import ParakeetCTCConfig
 from mobius._testing.ort_inference import OnnxModelSession
 from mobius.integrations._weight_loading import apply_weights
-from mobius.integrations.ort_genai import write_ort_genai_config
 from mobius.models import ParakeetForCTCModel
 from mobius.tasks import FeatureCTCAsrTask
 
@@ -168,14 +165,3 @@ def test_parakeet_synthetic_parity_with_padding():
         session.close()
 
     np.testing.assert_allclose(actual, expected, atol=1e-5, rtol=1e-5)
-
-
-def test_parakeet_exports_with_unsupported_runtime_status(tmp_path):
-    _, _, _, package = _build_tiny()
-
-    result = write_ort_genai_config(package, str(tmp_path))
-    compatibility = json.loads(
-        Path(result["runtime_compatibility"]).read_text(encoding="utf-8")
-    )
-    assert compatibility["runtime_validation_status"] == "unsupported-by-tested-runtime"
-    assert "feature-input CTC ASR pipeline" in compatibility["warnings"][0]

--- a/src/mobius/models/qwen4_exp_test.py
+++ b/src/mobius/models/qwen4_exp_test.py
@@ -531,13 +531,12 @@ def test_multimodal_embedding_preserves_global_image_order():
     np.testing.assert_array_equal(actual[0, 0], weight[input_ids[0, 0]].numpy())
 
 
-def test_state_manifest_preserves_layers_and_runtime_workflows_fail_closed(tmp_path):
+def test_state_manifest_preserves_layers_and_workflows_fail_closed(tmp_path):
     from mobius._model_package import ModelPackage
     from mobius.integrations.onnx_genai.auto_export import write_onnx_genai_config
     from mobius.integrations.onnx_genai.workflow_metadata import (
         build_vlm_workflow_metadata,
     )
-    from mobius.integrations.ort_genai.auto_export import write_ort_genai_config
 
     config = _vl_config()
     package = Qwen4ExpVisionLanguageTask().build(
@@ -575,14 +574,6 @@ def test_state_manifest_preserves_layers_and_runtime_workflows_fail_closed(tmp_p
             "update": {"key": "append", "value": "append", "index_key": "replace"},
         },
     ]
-    ort_output = tmp_path / "ort"
-    ort_artifacts = write_ort_genai_config(package, str(ort_output))
-    ort_compatibility = json.loads(
-        Path(ort_artifacts["runtime_compatibility"]).read_text(encoding="utf-8")
-    )
-    assert ort_compatibility["runtime_validation_status"] == ("unsupported-by-tested-runtime")
-    assert "past_position_ids" in ort_compatibility["graph_contract"]["decoder"]["inputs"]
-
     with pytest.raises(ValueError, match="cannot bind Qwen4-Exp"):
         build_vlm_workflow_metadata(package, config)
     onnx_genai_output = tmp_path / "onnx-genai"
@@ -631,25 +622,6 @@ def test_state_manifest_preserves_layers_and_runtime_workflows_fail_closed(tmp_p
         )["runtime_validation_status"]
         == "unsupported-by-tested-runtime"
     )
-
-
-def test_ort_genai_text_export_writes_advisory_runtime_metadata(tmp_path):
-    from mobius.integrations.ort_genai.auto_export import export_package
-
-    config = _config()
-    package = build_from_module(
-        Qwen4ExpCausalLMModel(config),
-        config,
-        task="qwen4-exp-text-generation",
-    )
-    output_dir = tmp_path / "output"
-    with mock.patch.object(package, "save") as save:
-        result = export_package(package, str(output_dir))
-    save.assert_called_once()
-    compatibility = json.loads(
-        Path(result["runtime_compatibility"]).read_text(encoding="utf-8")
-    )
-    assert compatibility["runtime_validation_status"] == "unsupported-by-tested-runtime"
 
 
 def test_processor_config_matches_qwen4exp_graph_contract(tmp_path):

--- a/tests/gguf_test.py
+++ b/tests/gguf_test.py
@@ -892,7 +892,6 @@ class TestCLIBuildGGUF:
         assert "Runtime validation: UNVALIDATED" in stdout
         assert "requested runtime: ort-genai (unvalidated)" in stdout
         assert (output / "genai_config.json").is_file()
-        assert (output / "runtime_compatibility.json").is_file()
         assert not (output / "tokenizer.json").exists()
 
     @pytest.mark.parametrize(

--- a/tests/ort_genai_e2e_test.py
+++ b/tests/ort_genai_e2e_test.py
@@ -218,7 +218,6 @@ def test_generic_decoder_end_to_end_and_reload(
     write_ort_genai_config(
         package,
         str(package_dir),
-        runtime_version=installed_version,
     )
 
     config = json.loads((package_dir / "genai_config.json").read_text(encoding="utf-8"))
@@ -261,7 +260,6 @@ def test_malformed_genai_config_is_rejected(
     write_ort_genai_config(
         package,
         str(package_dir),
-        runtime_version=version("onnxruntime-genai"),
     )
     config_path = package_dir / "genai_config.json"
     config = json.loads(config_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
Remove downstream ORT GenAI capability warnings and runtime_compatibility.json emission. Retains intrinsic GenAI configuration, decoder ABI, cache, and MTP contract validation.