### PR TITLE
Validate Moonshine Streaming FP16 CUDA

### DIFF
--- a/docs/_generate_models.py
+++ b/docs/_generate_models.py
@@ -80,16 +80,11 @@ def _source_file(cls: type) -> str:
 
 
 def _class_description(cls: type) -> str:
-    """Extract the first paragraph of the class docstring."""
+    """Extract the full class docstring for the generated model page."""
     doc = inspect.getdoc(cls)
     if not doc:
         return ""
-    lines = []
-    for line in doc.split("\n"):
-        if not line.strip() and lines:
-            break
-        lines.append(line.strip())
-    return " ".join(lines)
+    return doc
 
 
 def _generate_model_page(model_type: str, cls: type) -> str:

--- a/docs/model-catalog.md
+++ b/docs/model-catalog.md
@@ -190,49 +190,6 @@ Also registered with `T5ForConditionalGeneration` (task: `seq2seq`):
 | `qwen3_asr` | `Qwen3ASRForConditionalGeneration` | `speech-language` | — |
 | `qwen3_forced_aligner` | `Qwen3ASRForConditionalGeneration` | `speech-language` | — |
 
-#### Moonshine Streaming caller contract
-
-The `moonshine_streaming` export contains an `encoder` and a cached `decoder`.
-It is compatible with FP16 CUDA builds (`execution_provider="cuda"`) as well
-as CPU builds.
-
-The encoder consumes a rolling **raw-audio window**, not precomputed features:
-
-| Tensor | Type | Shape | Meaning |
-|---|---|---|---|
-| `input_values` | graph dtype (`float32` or `float16`) | `(batch, audio_samples)` | Raw 16 kHz waveform. The sample dimension must be a multiple of 80: the model frames 80 samples (5 ms) at a time. |
-| `attention_mask` | `int64` | `(batch, audio_samples)` | `1` for real samples and `0` for right padding. It must match `input_values`. |
-| `encoder_hidden_states` | graph dtype | `(batch, encoder_frames, hidden_size)` | Encoder output for the decoder. |
-| `encoder_attention_mask` | `int64` | `(batch, encoder_frames)` | Downsampled validity mask for encoder frames. |
-
-The causal convolution front end downsamples four 5-ms input frames into each
-encoder frame. Encoder attention has bounded right lookahead, so frames near a
-window's right edge can change after more audio arrives. The pinned tiny
-checkpoint has four layers with a right window of four encoder frames, for a
-maximum 16-frame (320-ms) composed lookahead. The export does not expose a
-stable-frame count; retain that tail when displaying a provisional result.
-
-This is a streaming *architecture*, not a stateful streaming inference API.
-Neither the export nor Hugging Face's `MoonshineStreamingForConditionalGeneration`
-provides encoder cache, encoder offset, `predict`, `commit`, or `finalize`
-inputs/outputs. Each encoder invocation is independent, so callers cannot
-faithfully commit newly stable tokens by chaining ONNX encoder state. The
-supported protocol is to retain the raw waveform, periodically re-run the
-encoder and normal seq2seq decoder for an uncommitted hypothesis, and publish
-the final transcript only after end-of-stream. At end-of-stream, pad the final
-raw window to an 80-sample boundary, set its padding mask entries to zero,
-re-run on the complete buffered waveform, and decode normally; there is no
-separate flush operation or finalization token.
-
-To decode, pass `decoder_input_ids`, the current encoder outputs, and
-`position_ids`, with zero-length `past_key_values.*.{key,value}` tensors for
-the first token. Feed every `present.*.{key,value}` output back as the
-corresponding `past_key_values.*.{key,value}` input for each later token while
-keeping the encoder outputs and mask for that decode fixed. If an application
-chooses to display partial hypotheses, it must compare and de-duplicate those
-ordinary decoded token sequences at the application layer; they are not model
-commit events.
-
 ### Text-to-Speech
 
 | Model Type | Module Class | Task | Example HuggingFace Model |

--- a/docs/model-catalog.md
+++ b/docs/model-catalog.md
@@ -185,8 +185,53 @@ Also registered with `T5ForConditionalGeneration` (task: `seq2seq`):
 | Model Type | Module Class | Task | Example HuggingFace Model |
 |---|---|---|---|
 | `whisper` | `WhisperForConditionalGeneration` | `speech-to-text` | `openai/whisper-tiny` |
+| `moonshine` | `MoonshineForConditionalGeneration` | `speech-to-text` | `UsefulSensors/moonshine-tiny` |
+| `moonshine_streaming` | `MoonshineStreamingForConditionalGeneration` | `speech-to-text` | `moonshine-ai/moonshine-streaming-tiny` |
 | `qwen3_asr` | `Qwen3ASRForConditionalGeneration` | `speech-language` | — |
 | `qwen3_forced_aligner` | `Qwen3ASRForConditionalGeneration` | `speech-language` | — |
+
+#### Moonshine Streaming caller contract
+
+The `moonshine_streaming` export contains an `encoder` and a cached `decoder`.
+It is compatible with FP16 CUDA builds (`execution_provider="cuda"`) as well
+as CPU builds.
+
+The encoder consumes a rolling **raw-audio window**, not precomputed features:
+
+| Tensor | Type | Shape | Meaning |
+|---|---|---|---|
+| `input_values` | graph dtype (`float32` or `float16`) | `(batch, audio_samples)` | Raw 16 kHz waveform. The sample dimension must be a multiple of 80: the model frames 80 samples (5 ms) at a time. |
+| `attention_mask` | `int64` | `(batch, audio_samples)` | `1` for real samples and `0` for right padding. It must match `input_values`. |
+| `encoder_hidden_states` | graph dtype | `(batch, encoder_frames, hidden_size)` | Encoder output for the decoder. |
+| `encoder_attention_mask` | `int64` | `(batch, encoder_frames)` | Downsampled validity mask for encoder frames. |
+
+The causal convolution front end downsamples four 5-ms input frames into each
+encoder frame. Encoder attention has bounded right lookahead, so frames near a
+window's right edge can change after more audio arrives. The pinned tiny
+checkpoint has four layers with a right window of four encoder frames, for a
+maximum 16-frame (320-ms) composed lookahead. The export does not expose a
+stable-frame count; retain that tail when displaying a provisional result.
+
+This is a streaming *architecture*, not a stateful streaming inference API.
+Neither the export nor Hugging Face's `MoonshineStreamingForConditionalGeneration`
+provides encoder cache, encoder offset, `predict`, `commit`, or `finalize`
+inputs/outputs. Each encoder invocation is independent, so callers cannot
+faithfully commit newly stable tokens by chaining ONNX encoder state. The
+supported protocol is to retain the raw waveform, periodically re-run the
+encoder and normal seq2seq decoder for an uncommitted hypothesis, and publish
+the final transcript only after end-of-stream. At end-of-stream, pad the final
+raw window to an 80-sample boundary, set its padding mask entries to zero,
+re-run on the complete buffered waveform, and decode normally; there is no
+separate flush operation or finalization token.
+
+To decode, pass `decoder_input_ids`, the current encoder outputs, and
+`position_ids`, with zero-length `past_key_values.*.{key,value}` tensors for
+the first token. Feed every `present.*.{key,value}` output back as the
+corresponding `past_key_values.*.{key,value}` input for each later token while
+keeping the encoder outputs and mask for that decode fixed. If an application
+chooses to display partial hypotheses, it must compare and de-duplicate those
+ordinary decoded token sequences at the application layer; they are not model
+commit events.
 
 ### Text-to-Speech
 

--- a/src/mobius/_testing/ort_inference.py
+++ b/src/mobius/_testing/ort_inference.py
@@ -189,6 +189,11 @@ class OnnxModelSession:
     def input_names(self) -> list[str]:
         return self._input_names
 
+    @property
+    def providers(self) -> list[str]:
+        """Execution providers in their runtime priority order."""
+        return self._session.get_providers()
+
     def get_input_shape(self, name: str) -> list[int | str] | None:
         """Return the declared shape of an input, or ``None`` if not found.
 

--- a/src/mobius/_testing/ort_inference_test.py
+++ b/src/mobius/_testing/ort_inference_test.py
@@ -120,3 +120,16 @@ def test_close_releases_session_reference() -> None:
     session.close()
 
     assert not hasattr(session, "_session")
+
+
+def test_providers_returns_runtime_priority_order() -> None:
+    class _Session:
+        def get_providers(self) -> list[str]:
+            return ["CUDAExecutionProvider", "CPUExecutionProvider"]
+
+    session = OnnxModelSession.__new__(OnnxModelSession)
+    session._session = _Session()  # type: ignore[attr-defined]
+    session._tmpdir = tempfile.TemporaryDirectory()  # type: ignore[attr-defined]
+
+    assert session.providers == ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    session.close()

--- a/src/mobius/models/moonshine_streaming.py
+++ b/src/mobius/models/moonshine_streaming.py
@@ -409,6 +409,49 @@ class MoonshineStreamingForConditionalGeneration(MoonshineForConditionalGenerati
     causal framing/convolution front end feeding a windowed (bounded-lookahead)
     transformer encoder, and a cached Moonshine decoder that cross-attends to the
     position-adapted encoder context.
+
+    ## Caller contract
+
+    The export contains an ``encoder`` and a cached ``decoder``. It supports
+    FP16 CUDA builds (``execution_provider="cuda"``) and CPU builds.
+
+    The encoder consumes a rolling raw-audio window, not precomputed features:
+
+    | Tensor | Type | Shape | Meaning |
+    |---|---|---|---|
+    | ``input_values`` | graph dtype (``float32`` or ``float16``) | ``(batch, audio_samples)`` | Raw 16 kHz waveform. The sample dimension must be a multiple of 80: the model frames 80 samples (5 ms) at a time. |
+    | ``attention_mask`` | ``int64`` | ``(batch, audio_samples)`` | ``1`` for real samples and ``0`` for right padding. It must match ``input_values``. |
+    | ``encoder_hidden_states`` | graph dtype | ``(batch, encoder_frames, hidden_size)`` | Encoder output for the decoder. |
+    | ``encoder_attention_mask`` | ``int64`` | ``(batch, encoder_frames)`` | Downsampled validity mask for encoder frames. |
+
+    The causal convolution front end downsamples four 5-ms input frames into each
+    encoder frame. Per-layer ``sliding_windows`` gives encoder attention bounded
+    right lookahead, so frames near a window's right edge can change after more
+    audio arrives. The pinned tiny checkpoint has four layers with four
+    right-lookahead encoder frames, giving a maximum composed 16-frame (320-ms)
+    lookahead. The export has no stable-frame-count output; callers must retain
+    that tail when displaying a provisional result.
+
+    This is a streaming *architecture*, not a stateful streaming inference API.
+    Neither this export nor Hugging Face's
+    ``MoonshineStreamingForConditionalGeneration`` provides encoder cache,
+    encoder offset, ``predict``, ``commit``, or ``finalize`` inputs/outputs.
+    Each encoder invocation is independent, so callers cannot faithfully commit
+    newly stable tokens by chaining ONNX encoder state. The supported protocol is
+    to retain the raw waveform, periodically re-run the encoder and regular
+    seq2seq decoder for an uncommitted hypothesis, and publish the final
+    transcript after end-of-stream. At end-of-stream, pad the final raw window to
+    an 80-sample boundary, set its padding-mask entries to zero, re-run on the
+    complete buffered waveform, and decode normally; there is no separate flush
+    operation or finalization token.
+
+    To decode, pass ``decoder_input_ids``, the current encoder outputs, and
+    ``position_ids``, with zero-length ``past_key_values.*.{key,value}`` tensors
+    for the first token. Feed each ``present.*.{key,value}`` output back as its
+    corresponding ``past_key_values.*.{key,value}`` input for later tokens while
+    keeping the encoder outputs and mask fixed. If an application displays
+    partial hypotheses, it must compare and de-duplicate those ordinary decoded
+    token sequences at the application layer; they are not model commit events.
     """
 
     default_task: str = "speech-to-text"

--- a/tests/integration/moonshine_streaming_test.py
+++ b/tests/integration/moonshine_streaming_test.py
@@ -14,12 +14,10 @@ than a HuggingFace intermediate.
 
 from __future__ import annotations
 
-import tempfile
 from pathlib import Path
 
 import librosa
 import numpy as np
-import onnx_ir as ir
 import pytest
 import torch
 import transformers
@@ -38,7 +36,7 @@ from mobius.tasks import SpeechToTextTask
 
 _MODEL_ID = "moonshine-ai/moonshine-streaming-tiny"
 _REVISION = "f8e9dfd8c562c257c151a907b7b7f2fe8ff8511a"
-_AUDIO_PATH = Path(__file__).parent.parent / "testdata" / "652-129742-0006.flac"
+_AUDIO_PATH = Path(__file__).parent.parent.parent / "testdata" / "652-129742-0006.flac"
 _EOS_TOKEN_ID = 2
 
 pytestmark = pytest.mark.skipif(
@@ -875,30 +873,20 @@ class TestMoonshineStreamingRealWeightParity:
                 ),
             )
 
-        with tempfile.TemporaryDirectory() as directory:
-            path = str(Path(directory) / "encoder.onnx")
-            ir.save(package["encoder"], path)
-            session = ort.InferenceSession(path, providers=["CUDAExecutionProvider"])
-            if session.get_providers()[0] != "CUDAExecutionProvider":
+        session = OnnxModelSession(package["encoder"], device="cuda")
+        try:
+            if session.providers[0] != "CUDAExecutionProvider":
                 pytest.skip("CUDAExecutionProvider could not initialize on this host")
-            outputs = dict(
-                zip(
-                    [output.name for output in session.get_outputs()],
-                    session.run(
-                        None,
-                        {
-                            "input_values": real_audio_inputs["input_values"].astype(
-                                np.float16
-                            ),
-                            "attention_mask": real_audio_inputs["attention_mask"].astype(
-                                np.int64
-                            ),
-                        },
-                    ),
-                )
+            outputs = session.run(
+                {
+                    "input_values": real_audio_inputs["input_values"].astype(np.float16),
+                    "attention_mask": real_audio_inputs["attention_mask"].astype(np.int64),
+                }
             )
             actual_hidden = outputs["encoder_hidden_states"]
             actual_mask = outputs["encoder_attention_mask"]
+        finally:
+            session.close()
 
         np.testing.assert_array_equal(
             actual_mask.astype(bool), expected.attention_mask.numpy()

--- a/tests/moonshine_streaming_integration_test.py
+++ b/tests/moonshine_streaming_integration_test.py
@@ -14,10 +14,12 @@ than a HuggingFace intermediate.
 
 from __future__ import annotations
 
+import tempfile
 from pathlib import Path
 
 import librosa
 import numpy as np
+import onnx_ir as ir
 import pytest
 import torch
 import transformers
@@ -798,14 +800,7 @@ class TestMoonshineStreamingRealWeightParity:
         assert processor.decode(content, skip_special_tokens=True)
 
     def test_float16_cpu_parity_and_transcript(self, real_audio_inputs, real_models):
-        """fp16 keeps full-logit parity and an identical transcript on ORT CPU.
-
-        fp16 on CUDA is semantically exact too, but ORT's CUDA fp16 fused
-        attention kernel zeroes the first encoder frame — the sparsest masked
-        query row, which sees only 4 of 456 keys under the ``(16, 4)`` window.
-        That is an execution-provider defect, not a graph defect: the identical
-        graph is accurate here on CPU, and fp32/bf16 are accurate on CUDA.
-        """
+        """fp16 keeps full-logit parity and an identical transcript on ORT CPU."""
         hf_model, processor, _package, _config = real_models
         package = build(_MODEL_ID, dtype="f16", load_weights=True, revision=_REVISION)
         config = package.config
@@ -854,6 +849,67 @@ class TestMoonshineStreamingRealWeightParity:
         assert len(content) == len(golden)
         assert content == golden
         assert processor.decode(content, skip_special_tokens=True)
+
+    def test_float16_cuda_encoder_first_frame_matches_torch(
+        self, real_audio_inputs, real_models
+    ):
+        """CUDA fp16 preserves the sparse-window first encoder frame."""
+        ort = pytest.importorskip("onnxruntime")
+        if "CUDAExecutionProvider" not in ort.get_available_providers():
+            pytest.skip("CUDAExecutionProvider is not available")
+        ort.preload_dlls()
+
+        hf_model, _processor, _package, _config = real_models
+        package = build(
+            _MODEL_ID,
+            dtype="f16",
+            load_weights=True,
+            revision=_REVISION,
+            execution_provider="cuda",
+        )
+        with torch.no_grad():
+            expected = hf_model.get_encoder()(
+                input_values=torch.from_numpy(real_audio_inputs["input_values"]),
+                attention_mask=torch.from_numpy(
+                    real_audio_inputs["attention_mask"].astype(np.int64)
+                ),
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = str(Path(directory) / "encoder.onnx")
+            ir.save(package["encoder"], path)
+            session = ort.InferenceSession(path, providers=["CUDAExecutionProvider"])
+            if session.get_providers()[0] != "CUDAExecutionProvider":
+                pytest.skip("CUDAExecutionProvider could not initialize on this host")
+            outputs = dict(
+                zip(
+                    [output.name for output in session.get_outputs()],
+                    session.run(
+                        None,
+                        {
+                            "input_values": real_audio_inputs["input_values"].astype(
+                                np.float16
+                            ),
+                            "attention_mask": real_audio_inputs["attention_mask"].astype(
+                                np.int64
+                            ),
+                        },
+                    ),
+                )
+            )
+            actual_hidden = outputs["encoder_hidden_states"]
+            actual_mask = outputs["encoder_attention_mask"]
+
+        np.testing.assert_array_equal(
+            actual_mask.astype(bool), expected.attention_mask.numpy()
+        )
+        # The first (16, 4)-window query sees only its four lookahead keys.
+        np.testing.assert_allclose(
+            actual_hidden[:, 0].astype(np.float32),
+            expected.last_hidden_state.numpy()[:, 0],
+            rtol=1e-2,
+            atol=1e-1,
+        )
 
     def test_real_generation_matches_huggingface(self, real_models, real_audio_inputs):
         """Full ONNX pipeline transcribes identically to HuggingFace generate()."""


### PR DESCRIPTION
## Summary

- Remove the obsolete claim that CUDA fp16 attention zeroes the first Moonshine Streaming encoder frame.
- Add a CUDAExecutionProvider regression that builds f16 with the CUDA target and compares the sparse-window first frame with the CPU Torch reference.
- Document the raw-audio, bounded-lookahead, decoder-cache, and buffered-finalization caller contract.

## Validation

- `python -m pytest tests/moonshine_streaming_integration_test.py -k "float16_cpu_parity_and_transcript or float16_cuda_encoder_first_frame_matches_torch" -q --tb=short`
- `python -m ruff check tests/moonshine_streaming_integration_test.py`
- `python -m ruff format --check tests/moonshine_streaming_integration_test.py`
