### PR TITLE
Add Microsoft-managed machine package skill

### DIFF
--- a/.agents/skills/microsoft-managed-machine/SKILL.md
+++ b/.agents/skills/microsoft-managed-machine/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: microsoft-managed-machine
+description: Applies on Microsoft-managed machines when installing Python/PyPI packages.
+---
+
+# Microsoft-managed machine
+
+Install Python packages through the Microsoft package feed proxy:
+
+```bash
+pip install <package> --index-url https://packagefeedproxy.microsoft.io/pypi/simple
+```


### PR DESCRIPTION
Adds a concise skill documenting the Microsoft PyPI feed proxy required on Microsoft-managed machines.