### PR TITLE
Emit current shape-only ONNX GenAI tensor contracts

### DIFF
--- a/src/mobius/integrations/onnx_genai/_metadata_io.py
+++ b/src/mobius/integrations/onnx_genai/_metadata_io.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import copy
 from typing import Any
 
 import yaml
@@ -15,5 +16,39 @@ class _NoAliasSafeDumper(yaml.SafeDumper):
         return True
 
 
+def _published_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Return metadata with tensor contracts in the current serialized form."""
+    published = copy.deepcopy(metadata)
+
+    def normalize(value: Any, path: str) -> None:
+        if isinstance(value, dict):
+            if path == "pipeline.workflow.manifest":
+                value.pop("capabilities", None)
+            if "dtype" in value and "shape" in value and "rank" in value:
+                shape = value["shape"]
+                rank = value["rank"]
+                if not isinstance(shape, list):
+                    raise ValueError(f"tensor contract at {path} has non-list shape {shape!r}")
+                if rank != len(shape):
+                    raise ValueError(
+                        f"tensor contract at {path} declares rank {rank!r} but "
+                        f"shape {shape!r} has rank {len(shape)}"
+                    )
+                del value["rank"]
+            for key, nested in value.items():
+                normalize(nested, f"{path}.{key}" if path else str(key))
+        elif isinstance(value, list):
+            for index, nested in enumerate(value):
+                normalize(nested, f"{path}[{index}]")
+
+    normalize(published, "")
+    return published
+
+
 def _dump_yaml(metadata: dict[str, Any], handle: Any) -> None:
-    yaml.dump(metadata, handle, Dumper=_NoAliasSafeDumper, sort_keys=False)
+    yaml.dump(
+        _published_metadata(metadata),
+        handle,
+        Dumper=_NoAliasSafeDumper,
+        sort_keys=False,
+    )

--- a/src/mobius/integrations/onnx_genai/_metadata_io_test.py
+++ b/src/mobius/integrations/onnx_genai/_metadata_io_test.py
@@ -1,0 +1,74 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from __future__ import annotations
+
+import io
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from mobius.integrations.onnx_genai._metadata_io import _dump_yaml, _published_metadata
+from mobius.integrations.onnx_genai._workflow_contract import _Port, _shape_metadata
+
+
+def test_published_metadata_retires_tensor_rank_without_touching_adapter_rank():
+    metadata = {
+        "pipeline": {
+            "workflow": {
+                "manifest": {"capabilities": ["workflow_ssa"]},
+            }
+        },
+        "scalar": {"dtype": "float32", "rank": 0, "shape": []},
+        "dynamic": {"dtype": "float32", "rank": 2, "shape": ["batch", "Any"]},
+        "adapter": {"dtype": "float32", "rank": 8, "alpha": 16.0},
+    }
+
+    published = _published_metadata(metadata)
+
+    assert published["scalar"] == {"dtype": "float32", "shape": []}
+    assert published["dynamic"] == {
+        "dtype": "float32",
+        "shape": ["batch", "Any"],
+    }
+    assert published["adapter"]["rank"] == 8
+    assert published["pipeline"]["workflow"]["manifest"] == {}
+    assert metadata["scalar"]["rank"] == 0
+
+
+def test_published_metadata_rejects_rank_shape_disagreement():
+    with pytest.raises(ValueError, match="declares rank 2.*has rank 1"):
+        _published_metadata(
+            {"contract": {"dtype": "int64", "rank": 2, "shape": ["batch"]}}
+        )
+
+
+def test_dump_yaml_uses_published_tensor_contract():
+    output = io.StringIO()
+    _dump_yaml(
+        {"contract": {"dtype": "float32", "rank": 1, "shape": ["Any"]}},
+        output,
+    )
+
+    assert yaml.safe_load(output.getvalue()) == {
+        "contract": {"dtype": "float32", "shape": ["Any"]}
+    }
+
+
+def test_shape_metadata_preserves_scalar_symbolic_and_independent_dynamic_semantics():
+    assert _shape_metadata(_Port(None, "scalar", "fp32", 0, ())) == []
+    assert _shape_metadata(
+        _Port(
+            None,
+            "dynamic",
+            "fp32",
+            3,
+            (SimpleNamespace(value="batch"), object(), object()),
+        )
+    ) == ["batch", "Any", "Any"]
+
+
+def test_shape_metadata_rejects_unknown_rank_instead_of_inventing_a_scalar():
+    with pytest.raises(ValueError, match="unknown rank"):
+        _shape_metadata(_Port(None, "unknown", "fp32", None, ()))

--- a/src/mobius/integrations/onnx_genai/_schema/inference_metadata.schema.json
+++ b/src/mobius/integrations/onnx_genai/_schema/inference_metadata.schema.json
@@ -592,7 +592,7 @@
       "type": "object"
     },
     "AudioTransform": {
-      "description": "One generic audio transform operation.\n\n`op` selects the operation from a generic vocabulary; the remaining fields\nare the parameters that operation reads (only the relevant ones are set).\nEvery parameter is model DATA — concrete sample rates, channel counts, mel\nbin counts, and so on live in a model's fixture, never as constants baked\ninto this schema.",
+      "description": "One generic audio transform operation.\n\n`op` selects the operation from a generic vocabulary; the remaining fields\nare the parameters that operation reads (only the relevant ones are set).\nEvery parameter is model DATA \u2014 concrete sample rates, channel counts, mel\nbin counts, and so on live in a model's fixture, never as constants baked\ninto this schema.",
       "properties": {
         "channels": {
           "description": "Target channel count for a `downmix` operation.",
@@ -633,7 +633,7 @@
           ]
         },
         "mel_scale": {
-          "description": "Mel scale convention — generic string data (e.g. `slaney`, `htk`).",
+          "description": "Mel scale convention \u2014 generic string data (e.g. `slaney`, `htk`).",
           "minLength": 1,
           "type": [
             "string",
@@ -641,7 +641,7 @@
           ]
         },
         "mode": {
-          "description": "Padding side / normalization mode selector — generic string data\n(e.g. `right`, `left`, `fixed_window`).",
+          "description": "Padding side / normalization mode selector \u2014 generic string data\n(e.g. `right`, `left`, `fixed_window`).",
           "minLength": 1,
           "type": [
             "string",
@@ -726,7 +726,7 @@
           ]
         },
         "window": {
-          "description": "Analysis window function — generic string data (e.g. `hann`).",
+          "description": "Analysis window function \u2014 generic string data (e.g. `hann`).",
           "minLength": 1,
           "type": [
             "string",
@@ -854,7 +854,7 @@
         },
         {
           "additionalProperties": false,
-          "description": "Items belonging to many requests concatenated along one axis.\n\nThere is exactly one packed axis. Structure above the item — frames\ninside clips inside request rows — is ownership, not a second axis: the\ntensor stays a flat run of items and `levels` says how to fold that run\nback into requests.",
+          "description": "Items belonging to many requests concatenated along one axis.\n\nThere is exactly one packed axis. Structure above the item \u2014 frames\ninside clips inside request rows \u2014 is ownership, not a second axis: the\ntensor stays a flat run of items and `levels` says how to fold that run\nback into requests.",
           "properties": {
             "axis": {
               "description": "Packed axis of this value.\n\nValidation requires axis zero. A run of items is only splittable\ninto per-request pieces without copying when the items are the\noutermost, contiguous stride of the tensor, and a packed axis\nanywhere else would silently turn every split into a gather.",
@@ -867,7 +867,7 @@
               "type": "string"
             },
             "levels": {
-              "description": "Ownership chain of the packed axis, innermost level first.\n\nLevel zero owns the physically packed positions; the last level owns\ninto request rows. One level is the ordinary flat case — items in\nrows — and two states one grouping in between, as frames in clips in\nrows. Validation rejects a third: a runtime walks the whole chain on\nevery split, and each level multiplies the states that have to be\nchecked and tested.",
+              "description": "Ownership chain of the packed axis, innermost level first.\n\nLevel zero owns the physically packed positions; the last level owns\ninto request rows. One level is the ordinary flat case \u2014 items in\nrows \u2014 and two states one grouping in between, as frames in clips in\nrows. Validation rejects a third: a runtime walks the whole chain on\nevery split, and each level multiplies the states that have to be\nchecked and tested.",
               "items": {
                 "$ref": "#/$defs/OwnershipLevel"
               },
@@ -903,7 +903,7 @@
       "description": "One materialized-footprint bound of an assembled invocation.\n\nA budget bounds what the invocation materializes, not what is nominally\nvalid. A packed dimension's footprint is the sum of the items' valid extents,\nwhich is exactly the packed extent because packing stores no padding; a\npadded dimension's footprint is the enclosing count times the padded extent,\nwhich is the rectangle the runtime allocates and the kernel reads. Budgeting\nthe valid sum instead would let one long and fifteen short items pass a bound\nthe group then blows through.",
       "properties": {
         "dimensions": {
-          "description": "Shape symbols whose materialized extents multiply to the bounded\nquantity, in order.\n\nOne symbol bounds that dimension directly — items at an ownership level,\npositions on a packed axis. Several bound an activation-shaped quantity,\nsuch as total padded patch slots, without the package ever naming bytes.",
+          "description": "Shape symbols whose materialized extents multiply to the bounded\nquantity, in order.\n\nOne symbol bounds that dimension directly \u2014 items at an ownership level,\npositions on a packed axis. Several bound an activation-shaped quantity,\nsuch as total padded patch slots, without the package ever naming bytes.",
           "items": {
             "minLength": 1,
             "type": "string"
@@ -941,17 +941,17 @@
     },
     "ComponentBatchCapacity": {
       "additionalProperties": false,
-      "description": "Batching capacity of one invocation of a component.\n\nThis describes the shape of an invocation, never a scheduling policy: which\ndimensions must already agree before two contributions can share a call, and\nhow much the assembled call may materialize. A runtime decides whether to\ngroup at all, and may always group fewer; the package only says what its\nartifact tolerates.\n\nEverything here is keyed by shape symbol rather than by axis index. Ports of\none component routinely differ in rank — a rank-3 payload, a rank-1\ncompanion, a rank-2 pooled output — so an axis index is only meaningful\nrelative to one port, while a symbol names the same quantity on every port\nthat mentions it.",
+      "description": "Batching capacity of one invocation of a component.\n\nThis describes the shape of an invocation, never a scheduling policy: which\ndimensions must already agree before two contributions can share a call, and\nhow much the assembled call may materialize. A runtime decides whether to\ngroup at all, and may always group fewer; the package only says what its\nartifact tolerates.\n\nEverything here is keyed by shape symbol rather than by axis index. Ports of\none component routinely differ in rank \u2014 a rank-3 payload, a rank-1\ncompanion, a rank-2 pooled output \u2014 so an axis index is only meaningful\nrelative to one port, while a symbol names the same quantity on every port\nthat mentions it.",
       "properties": {
         "budgets": {
-          "description": "Upper bounds on what one assembled invocation materializes, keyed by\nshape symbol.\n\nThese are static geometry — a fixed position table, an exported\nconstant, a kernel bound — never a measured throughput sweet spot, which\nwould be a cost model and belongs to the runtime. Every entry is an\nupper bound and never an obligation: a runtime may group fewer,\nincluding one. An empty list bounds nothing beyond what the runtime's\nown row budget already bounds.",
+          "description": "Upper bounds on what one assembled invocation materializes, keyed by\nshape symbol.\n\nThese are static geometry \u2014 a fixed position table, an exported\nconstant, a kernel bound \u2014 never a measured throughput sweet spot, which\nwould be a cost model and belongs to the runtime. Every entry is an\nupper bound and never an obligation: a runtime may group fewer,\nincluding one. An empty list bounds nothing beyond what the runtime's\nown row budget already bounds.",
           "items": {
             "$ref": "#/$defs/CapacityBudget"
           },
           "type": "array"
         },
         "uniform_dimensions": {
-          "description": "Shape symbols whose extents every item in a group must agree on.\n\nA symbol here names a property of one item — a patch width, a mel bin, a\nframe count of a fixed-length clip — that the artifact cannot vary\nwithin a single call. Items that disagree on it cannot share an\ninvocation, so a scheduler splits them into separate groups.\n\nIt may not name a count: not the extent of a packed axis, and not the\nunit or run count of an ownership level. Those are the numbers a packed\nlayout exists to let vary per request, and pinning one would describe a\nfixed-shape batch the package did not declare. A video whose frame count\nreally is fixed is expressed by pinning the frame dimension of an\nordinary request-aligned tensor and declaring no frame ownership level\nat all.",
+          "description": "Shape symbols whose extents every item in a group must agree on.\n\nA symbol here names a property of one item \u2014 a patch width, a mel bin, a\nframe count of a fixed-length clip \u2014 that the artifact cannot vary\nwithin a single call. Items that disagree on it cannot share an\ninvocation, so a scheduler splits them into separate groups.\n\nIt may not name a count: not the extent of a packed axis, and not the\nunit or run count of an ownership level. Those are the numbers a packed\nlayout exists to let vary per request, and pinning one would describe a\nfixed-shape batch the package did not declare. A video whose frame count\nreally is fixed is expressed by pinning the frame dimension of an\nordinary request-aligned tensor and declaring no frame ownership level\nat all.",
           "items": {
             "type": "string"
           },
@@ -1081,7 +1081,7 @@
           "additionalProperties": {
             "$ref": "#/$defs/PortRole"
           },
-          "description": "Semantic role of the ports whose meaning the workflow's own structure\ncannot recover, keyed by port name.\n\nState ports never need an entry: a state group already names its\nper-component `(input, output)` pair, and the fixed-capacity control\nports are named by [`StateUpdate::IndexedScatter`]. What is left is the\nper-step dataflow a workflow binds by SSA value, where the binding\nrecords WHICH value reaches a port but not WHAT the component does with\nit. A runtime that specializes a decode step — packing tokens, reusing a\nlogits buffer, skipping a mask it can prove is causal — needs that\nsecond fact, and inferring it from a port's spelling is exactly the\nname-guessing this schema refuses everywhere else.\n\nRoles are architecture-neutral and describe the port, never the model\nfamily that happens to expose it.",
+          "description": "Semantic role of the ports whose meaning the workflow's own structure\ncannot recover, keyed by port name.\n\nState ports never need an entry: a state group already names its\nper-component `(input, output)` pair, and the fixed-capacity control\nports are named by [`StateUpdate::IndexedScatter`]. What is left is the\nper-step dataflow a workflow binds by SSA value, where the binding\nrecords WHICH value reaches a port but not WHAT the component does with\nit. A runtime that specializes a decode step \u2014 packing tokens, reusing a\nlogits buffer, skipping a mask it can prove is causal \u2014 needs that\nsecond fact, and inferring it from a port's spelling is exactly the\nname-guessing this schema refuses everywhere else.\n\nRoles are architecture-neutral and describe the port, never the model\nfamily that happens to expose it.",
           "type": "object"
         }
       },
@@ -2184,7 +2184,7 @@
     },
     "OwnershipLevel": {
       "additionalProperties": false,
-      "description": "One level of a packed value's ownership chain.\n\nA level is a pair, never a tensor axis: `offsets` gives the exclusive prefix\noffset of each parent's run and `owner` gives the owning position of each\nentry at this level. The two together are what a runtime walks to answer\n\"which request does this item belong to\".\n\nBoth are `shared`, never `request_aligned`. An exclusive prefix sum is not\npermutation-followable — permuting rows does not permute a prefix-offset\nvector, it invalidates it — so a runtime that compacts rebuilds the chain\nrather than gathering it.",
+      "description": "One level of a packed value's ownership chain.\n\nA level is a pair, never a tensor axis: `offsets` gives the exclusive prefix\noffset of each parent's run and `owner` gives the owning position of each\nentry at this level. The two together are what a runtime walks to answer\n\"which request does this item belong to\".\n\nBoth are `shared`, never `request_aligned`. An exclusive prefix sum is not\npermutation-followable \u2014 permuting rows does not permute a prefix-offset\nvector, it invalidates it \u2014 so a runtime that compacts rebuilds the chain\nrather than gathering it.",
       "properties": {
         "extent": {
           "anyOf": [
@@ -2256,7 +2256,7 @@
     },
     "PaddedDimension": {
       "additionalProperties": false,
-      "description": "One padded dimension of a value and the companion that bounds it.\n\nThe dimension is named by its shape symbol rather than by an axis index. The\nsame extent sits at different positions in different values — `patches` is\naxis 1 of the pixel tensor and axis 0 of a pooled one — and an index would\nname whichever the author happened to be looking at.\n\nPadding is always appended: the real entries of a padded dimension form a\nprefix. That is what lets one integer per enclosing entry say everything a\nfull boolean mask would say, and it is a rule rather than a convention\nbecause left padding would shift every position-dependent computation and an\ninterior hole cannot be expressed by a length at all.",
+      "description": "One padded dimension of a value and the companion that bounds it.\n\nThe dimension is named by its shape symbol rather than by an axis index. The\nsame extent sits at different positions in different values \u2014 `patches` is\naxis 1 of the pixel tensor and axis 0 of a pooled one \u2014 and an index would\nname whichever the author happened to be looking at.\n\nPadding is always appended: the real entries of a padded dimension form a\nprefix. That is what lets one integer per enclosing entry say everything a\nfull boolean mask would say, and it is a rule rather than a convention\nbecause left padding would shift every position-dependent computation and an\ninterior hole cannot be expressed by a length at all.",
       "properties": {
         "dimension": {
           "description": "Shape symbol of the padded dimension of the owning value.",
@@ -2264,7 +2264,7 @@
           "type": "string"
         },
         "valid_lengths": {
-          "description": "Value giving how many leading entries of `dimension` are real, one entry\nper position of the axes outer to it.\n\nIt resolves in the namespace of the contract's owner: a sibling port for\na component port, a workflow value for a workflow input, output, or\nstate cell.",
+          "description": "Value giving how many leading entries of `dimension` are real, one entry\nper position of the axes outer to it.\n\nWhen those outer axes include the owning value's request axis, this\ncompanion declares the same request-aligned/request-expanded layout and\nfollows the same positional row plan. When the padded dimension is\noutside the request axis, the companion is genuinely broadcast and\ndeclares `shared`.\n\nIt resolves in the namespace of the contract's owner: a sibling port for\na component port, a workflow value for a workflow input, output, or\nstate cell.",
           "minLength": 1,
           "type": "string"
         }
@@ -2717,7 +2717,7 @@
     },
     "SequenceDecodingSpec": {
       "additionalProperties": false,
-      "description": "Frame-synchronous decoding contract for non-autoregressive sequence models.\n\nA CTC acoustic model emits one class distribution per encoder frame. The\ntranscript is recovered by taking the per-frame argmax, collapsing runs of\nrepeated ids, and dropping the blank id — no generation loop and no\nautoregressive state are involved.",
+      "description": "Frame-synchronous decoding contract for non-autoregressive sequence models.\n\nA CTC acoustic model emits one class distribution per encoder frame. The\ntranscript is recovered by taking the per-frame argmax, collapsing runs of\nrepeated ids, and dropping the blank id \u2014 no generation loop and no\nautoregressive state are involved.",
       "properties": {
         "blank_id": {
           "description": "Class id reserved for the CTC blank symbol.",
@@ -2853,7 +2853,7 @@
               "type": "null"
             }
           ],
-          "description": "How this cell continues one invocation's work into the next.\n\nAbsent means the lease is opaque: the runtime keeps the cell's value for\nthe session and hands it back as the cell's value, which is all a cell\nconsumed by the workflow's own steps needs. A cell the workflow never\nreads — a conversation the *request binding* has to carry — has no such\nreader, so it states which binding continues it here rather than leaving\na runtime to guess."
+          "description": "How this cell continues one invocation's work into the next.\n\nAbsent means the lease is opaque: the runtime keeps the cell's value for\nthe session and hands it back as the cell's value, which is all a cell\nconsumed by the workflow's own steps needs. A cell the workflow never\nreads \u2014 a conversation the *request binding* has to carry \u2014 has no such\nreader, so it states which binding continues it here rather than leaving\na runtime to guess."
         },
         "optimistic_metadata_version": {
           "default": false,
@@ -3175,7 +3175,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Where a runtime obtains `embed(last_token)` for the LEADING half of\nthe fused `token_embedding_input`. A folded-carry proposer graph\nconsumes only the fused input, so it reads no embedding initializer of\nits own and `speculative.shared_weights` stays empty; this names the\nmodel-agnostic embedding table the runtime gathers the leading half\nfrom (never extracted heuristically from a graph). Its `component`\nmust be the speculative target — an ONNX model that owns the named\n`table` initializer — so the table resolves to a real initializer in\nthe target model/artifact. Required whenever `folded_carry_output` is\npresent."
+              "description": "Where a runtime obtains `embed(last_token)` for the LEADING half of\nthe fused `token_embedding_input`. A folded-carry proposer graph\nconsumes only the fused input, so it reads no embedding initializer of\nits own and `speculative.shared_weights` stays empty; this names the\nmodel-agnostic embedding table the runtime gathers the leading half\nfrom (never extracted heuristically from a graph). Its `component`\nmust be the speculative target \u2014 an ONNX model that owns the named\n`table` initializer \u2014 so the table resolves to a real initializer in\nthe target model/artifact. Required whenever `folded_carry_output` is\npresent."
             },
             "token_embedding_input": {
               "description": "Proposer input port receiving the previous selected token embedding.",
@@ -3557,7 +3557,7 @@
           ]
         },
         "output": {
-          "description": "Graph output port carrying this pair's next-step value.\n\nRequired for a read-write transition. A `read_only` binding MAY omit it:\na pure borrowed-state reader — e.g. a shared-KV drafter that consumes\nanother decoder's cache and advances nothing — exposes no present output\nat all, so there is nothing to name. A read-only reader whose artifact\nstill emits a discarded present output for kernel-ABI reasons may name it\nhere, but that value is never a state transition.",
+          "description": "Graph output port carrying this pair's next-step value.\n\nRequired for a read-write transition. A `read_only` binding MAY omit it:\na pure borrowed-state reader \u2014 e.g. a shared-KV drafter that consumes\nanother decoder's cache and advances nothing \u2014 exposes no present output\nat all, so there is nothing to name. A read-only reader whose artifact\nstill emits a discarded present output for kernel-ABI reasons may name it\nhere, but that value is never a state transition.",
           "type": [
             "string",
             "null"
@@ -3807,24 +3807,17 @@
           },
           "type": "array"
         },
-        "rank": {
-          "format": "uint",
-          "minimum": 0,
-          "type": "integer"
-        },
         "shape": {
+          "description": "Complete tensor shape. Its length is the tensor rank.",
           "items": {
             "$ref": "#/$defs/TensorDimension"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": "array"
         }
       },
       "required": [
         "dtype",
-        "rank"
+        "shape"
       ],
       "type": "object"
     },
@@ -3884,12 +3877,12 @@
           "type": "integer"
         },
         {
-          "description": "A runtime shape symbol.",
+          "description": "A non-empty runtime shape symbol. `Any` means one independently\nunconstrained occurrence.",
           "minLength": 1,
           "type": "string"
         }
       ],
-      "description": "One fixed or runtime-resolved tensor-shape dimension."
+      "description": "One fixed, symbolic, or unconstrained tensor-shape dimension."
     },
     "TensorShardFacts": {
       "additionalProperties": false,
@@ -3957,7 +3950,7 @@
           "type": "string"
         },
         "scale": {
-          "description": "Normalizer the target applies to a looked-up row before its backbone\nreads it.\n\nA gathered row is not always the tensor a graph feeds its first block:\nseveral architectures scale the embedding by a constant folded into the\ngraph (`sqrt(hidden_size)` is the common one), so the initializer alone\nis not what a proposer's fused input needs. The proposer stands in for\nthe target's own embedding step, so it must see the *scaled* row — and\nthe factor has to be declared rather than guessed: nothing in a\n`[vocab, hidden]` initializer says whether one was applied, and a\nproposer fed the unscaled row drafts fluent, plausible, uniformly\nrejected tokens. It is the acceptance rate that collapses, not the\noutput, so the failure is invisible to a token-parity check.\n\nAbsent means 1.0: a package whose graph gathers and feeds directly.\n\nSingle precision because that is the precision it is *used* in: the\nfactor multiplies a float16 or float32 table, so declaring more would\npromise an accuracy the application of it discards.",
+          "description": "Normalizer the target applies to a looked-up row before its backbone\nreads it.\n\nA gathered row is not always the tensor a graph feeds its first block:\nseveral architectures scale the embedding by a constant folded into the\ngraph (`sqrt(hidden_size)` is the common one), so the initializer alone\nis not what a proposer's fused input needs. The proposer stands in for\nthe target's own embedding step, so it must see the *scaled* row \u2014 and\nthe factor has to be declared rather than guessed: nothing in a\n`[vocab, hidden]` initializer says whether one was applied, and a\nproposer fed the unscaled row drafts fluent, plausible, uniformly\nrejected tokens. It is the acceptance rate that collapses, not the\noutput, so the failure is invisible to a token-parity check.\n\nAbsent means 1.0: a package whose graph gathers and feeds directly.\n\nSingle precision because that is the precision it is *used* in: the\nfactor multiplies a float16 or float32 table, so declaring more would\npromise an accuracy the application of it discards.",
           "format": "float",
           "type": [
             "number",
@@ -4132,7 +4125,7 @@
       "properties": {
         "content": {
           "$ref": "#/$defs/VisionOutputContent",
-          "description": "Generic content role this tensor carries (pixels, coordinates, grid,\noriginal size, validity mask, or the offsets/owner map of a packed batch\nat item, frame, or clip granularity) — never a model-family label."
+          "description": "Generic content role this tensor carries (pixels, coordinates, grid,\noriginal size, validity mask, or the offsets/owner map of a packed batch\nat item, frame, or clip granularity) \u2014 never a model-family label."
         },
         "contract": {
           "anyOf": [
@@ -4187,7 +4180,7 @@
       "type": "object"
     },
     "VisionOutputContent": {
-      "description": "Generic pixel-output content-role vocabulary.\n\nA program that packs the media of several requests into one batch\nemits the values that map packed entries back to request rows,\nalongside the pixels themselves. Two roles cover every level:\n`pack_offsets` and `pack_owner`. Which level a value serves is\nstated by the ownership chain that references it, not by its role,\nso a frames-to-clips pair and a clips-to-rows pair carry the same\ntwo roles and a runtime resolves both the same way whatever the\nmedium calls its levels. `valid_lengths` says how much of a padded\ndimension is real, and is shared with the audio vocabulary rather\nthan duplicated.\n\nThey are content roles like any other: the runtime reads what a\ntensor means from here, never from the name a producer chose. What\neach value must structurally satisfy is stated by its tensor\ncontract — `batch_layout` and `padding` — which is what the\nvalidator enforces.",
+      "description": "Generic pixel-output content-role vocabulary.\n\nA program that packs the media of several requests into one batch\nemits the values that map packed entries back to request rows,\nalongside the pixels themselves. Two roles cover every level:\n`pack_offsets` and `pack_owner`. Which level a value serves is\nstated by the ownership chain that references it, not by its role,\nso a frames-to-clips pair and a clips-to-rows pair carry the same\ntwo roles and a runtime resolves both the same way whatever the\nmedium calls its levels. `valid_lengths` says how much of a padded\ndimension is real, and is shared with the audio vocabulary rather\nthan duplicated.\n\nThey are content roles like any other: the runtime reads what a\ntensor means from here, never from the name a producer chose. What\neach value must structurally satisfy is stated by its tensor\ncontract \u2014 `batch_layout` and `padding` \u2014 which is what the\nvalidator enforces.",
       "oneOf": [
         {
           "enum": [
@@ -4281,7 +4274,7 @@
       "description": "A square size or an explicit width/height for a pixel transform."
     },
     "VisionTransform": {
-      "description": "One generic pixel transform operation.\n\n`op` selects the operation from a generic vocabulary; the remaining fields\nare the parameters that operation reads (only the relevant ones are set).\nEvery parameter is model DATA — concrete sizes, patch sizes, means, and so on\nlive in a model's fixture, never as constants baked into this schema.",
+      "description": "One generic pixel transform operation.\n\n`op` selects the operation from a generic vocabulary; the remaining fields\nare the parameters that operation reads (only the relevant ones are set).\nEvery parameter is model DATA \u2014 concrete sizes, patch sizes, means, and so on\nlive in a model's fixture, never as constants baked into this schema.",
       "properties": {
         "canvas_pad_value": {
           "description": "RGB canvas fill value applied before dynamic tiling.",
@@ -4351,7 +4344,7 @@
           ]
         },
         "interpolation": {
-          "description": "Interpolation filter for a `resize` operation — generic string data.",
+          "description": "Interpolation filter for a `resize` operation \u2014 generic string data.",
           "minLength": 1,
           "type": [
             "string",
@@ -4424,7 +4417,7 @@
           ]
         },
         "mode": {
-          "description": "Resize/crop mode (e.g. `pad`, `crop`, `stretch`) — generic string data.",
+          "description": "Resize/crop mode (e.g. `pad`, `crop`, `stretch`) \u2014 generic string data.",
           "minLength": 1,
           "type": [
             "string",
@@ -5415,7 +5408,7 @@
           "type": "null"
         }
       ],
-      "description": "Declared, architecture-neutral input preprocessing programs.\n\nCarries the typed multimodal preprocessing contracts: the still-image,\nvideo, and audio transform programs and their named tensor outputs.\nEvery operation and output is generic, parameterized data — never a\nmodel family, vendor string, or baked-in shape. Absent means the model\ndeclares no native preprocessing program and a runtime must obtain it\nelsewhere or fail."
+      "description": "Declared, architecture-neutral input preprocessing programs.\n\nCarries the typed multimodal preprocessing contracts: the still-image,\nvideo, and audio transform programs and their named tensor outputs.\nEvery operation and output is generic, parameterized data \u2014 never a\nmodel family, vendor string, or baked-in shape. Absent means the model\ndeclares no native preprocessing program and a runtime must obtain it\nelsewhere or fail."
     },
     "profiles": {
       "additionalProperties": {
@@ -5451,7 +5444,7 @@
       "type": "array"
     },
     "schema_version": {
-      "description": "Schema version of this inference-metadata document, e.g. `\"v1.1\"`.\n\nCanonically `\"v<major>.<minor>\"`, matching the `v1` that every writer in\nthis repository already stamps. Absence means the initial `v1.0`\ncontract, as do the spellings `\"v1\"`, `\"1\"`, `\"1.0\"` and `\"v1.0\"` that\npredate a canonical form; readers normalize before comparing, so all of\nthem keep loading and `\"1.1\"` is an accepted synonym for `\"v1.1\"`. A\ndocument that uses nothing new keeps stamping what it already stamped —\nrewriting an existing spelling would change the package's semantic\nidentity to say something no reader distinguishes. Bump the major only\nfor breaking schema changes, and the minor whenever a document may carry\na field an older reader would not know.\n\nAn additive field keeps the same major version, but note what that does\nand does not buy: the v1 surface is closed — every structure here denies\nunknown fields — so a reader built before a field was added rejects a\ndocument that uses it rather than ignoring it. Compatibility with older\nreaders therefore comes from a new field being *absent by default*, not\nfrom tolerance of unknown keys. A producer that emits one is declaring\nthat the package needs a reader which understands it, and a package that\ndoes not emit it keeps loading everywhere it loaded before.\n\nThat is a statement about *additive* fields, and it is not a promise that\nthis schema never reshapes one it already had. It does, while it is\npre-release: `token_packed` moved its `offsets` and `owner` into a\n`levels` chain in v1.1, and a document written against the flat spelling\ndoes not load at any version. A version says which fields a reader must\nunderstand; it is not a compatibility guarantee spanning a reshape, and\nnothing here silently reads an old spelling as a new one. See\n`reject_flat_token_packed`.",
+      "description": "Schema version of this inference-metadata document, e.g. `\"v1.1\"`.\n\nCanonically `\"v<major>.<minor>\"`, matching the `v1` that every writer in\nthis repository already stamps. Absence means the initial `v1.0`\ncontract, as do the spellings `\"v1\"`, `\"1\"`, `\"1.0\"` and `\"v1.0\"` that\npredate a canonical form; readers normalize before comparing, so all of\nthem keep loading and `\"1.1\"` is an accepted synonym for `\"v1.1\"`. A\ndocument that uses nothing new keeps stamping what it already stamped \u2014\nrewriting an existing spelling would change the package's semantic\nidentity to say something no reader distinguishes. Bump the major only\nfor breaking schema changes, and the minor whenever a document may carry\na field an older reader would not know.\n\nAn additive field keeps the same major version, but note what that does\nand does not buy: the v1 surface is closed \u2014 every structure here denies\nunknown fields \u2014 so a reader built before a field was added rejects a\ndocument that uses it rather than ignoring it. Compatibility with older\nreaders therefore comes from a new field being *absent by default*, not\nfrom tolerance of unknown keys. A producer that emits one is declaring\nthat the package needs a reader which understands it, and a package that\ndoes not emit it keeps loading everywhere it loaded before.\n\nThat is a statement about *additive* fields, and it is not a promise that\nthis schema never reshapes one it already had. It does, while it is\npre-release: `token_packed` moved its `offsets` and `owner` into a\n`levels` chain in v1.1, and a document written against the flat spelling\ndoes not load at any version. A version says which fields a reader must\nunderstand; it is not a compatibility guarantee spanning a reshape, and\nnothing here silently reads an old spelling as a new one. See\n`reject_flat_token_packed`.",
       "type": [
         "string",
         "null"

--- a/src/mobius/integrations/onnx_genai/_workflow_contract.py
+++ b/src/mobius/integrations/onnx_genai/_workflow_contract.py
@@ -10,6 +10,8 @@ from typing import Any
 
 import onnx_ir as ir
 
+from mobius.integrations.onnx_genai._metadata_io import _published_metadata
+
 
 @dataclasses.dataclass(frozen=True)
 class _Port:
@@ -52,16 +54,21 @@ def _port(value: Any) -> _Port:
 
 def _shape_metadata(port: _Port) -> list[int | str]:
     """Return a YAML-safe graph shape without losing symbolic dimensions."""
+    if port.rank is None:
+        raise ValueError(
+            f"graph port {port.name!r} has unknown rank; ONNX-GenAI tensor "
+            "contracts require an explicit shape"
+        )
     shape: list[int | str] = []
-    for axis, dim in enumerate(port.dims):
+    for dim in port.dims:
         if isinstance(dim, int):
             shape.append(dim)
             continue
         value = getattr(dim, "value", None)
-        # Metadata dimensions cannot be null. Preserve named graph dimensions;
-        # give anonymous dynamic dimensions a stable, port-local name instead
-        # of pretending they are static or serializing an invalid null.
-        shape.append(str(value) if value is not None else f"{port.name}_dim_{axis}")
+        # Preserve named graph dimensions. Each anonymous dynamic dimension is
+        # independently unconstrained; "Any" states that without inventing a
+        # false equality between axes or a fixed extent.
+        shape.append(str(value) if value is not None else "Any")
     return shape
 
 
@@ -335,7 +342,6 @@ def add_policy_components_to_workflow(
         shape = _shape_metadata(port)
         contract: dict[str, Any] = {
             "dtype": dtype,
-            "rank": port.rank,
             "shape": shape,
         }
         layout = request_batch_layout(shape)
@@ -385,7 +391,6 @@ def _contract(value: ir.Value) -> dict[str, Any]:
     shape = _shape_metadata(port)
     contract: dict[str, Any] = {
         "dtype": dtype,
-        "rank": port.rank,
         "shape": shape,
     }
     layout = request_batch_layout(shape)
@@ -609,14 +614,14 @@ def _publish_workflow_v1(workflow: dict[str, Any]) -> dict[str, Any]:
                 active_cell = f"loop_{current_loop}_active"
                 active_initializer = f"package.{active_cell}"
                 workflow["inputs"][active_initializer] = {
-                    "contract": {"dtype": "bool", "rank": 1, "shape": [1]},
+                    "contract": {"dtype": "bool", "shape": [1]},
                     "role": {"kind": "opaque"},
                     "source": {"kind": "literal"},
                     "required": False,
                     "default": True,
                 }
                 workflow["state"][active_cell] = {
-                    "contract": {"dtype": "bool", "rank": 1, "shape": [1]},
+                    "contract": {"dtype": "bool", "shape": [1]},
                     "scope": "invocation",
                     "initializer": active_initializer,
                     "recurrence": {"kind": "invariant"},
@@ -647,7 +652,7 @@ def _publish_workflow_v1(workflow: dict[str, Any]) -> dict[str, Any]:
     workflow["steps"] = published["steps"] if published["kind"] == "sequence" else [published]
     declare_request_alignment(workflow)
     declare_input_admission(workflow)
-    return workflow
+    return _published_metadata({"pipeline": {"workflow": workflow}})["pipeline"]["workflow"]
 
 
 def _invoke(

--- a/src/mobius/integrations/onnx_genai/auto_export_test.py
+++ b/src/mobius/integrations/onnx_genai/auto_export_test.py
@@ -196,7 +196,7 @@ def test_dispatch_decoder(tmp_path):
     ]
     assert workflow["steps"][0]["iteration"] == {
         "value": "loop.iteration",
-        "contract": {"dtype": "int64", "rank": 1, "shape": [1]},
+        "contract": {"dtype": "int64", "shape": [1]},
     }
     assert "iteration" not in workflow["state"]
     serialized = yaml.safe_dump(workflow)
@@ -209,7 +209,6 @@ def test_dispatch_decoder(tmp_path):
     assert workflow["state"]["logits"] == {
         "contract": {
             "dtype": "float32",
-            "rank": 2,
             "shape": ["batch", 128],
             "batch_layout": {"kind": "request_aligned", "axis": 0},
         },
@@ -247,13 +246,11 @@ def test_seeded_decoder_sampler_uses_request_controls_and_direct_kv_carry():
     }
     assert sampler["ports"]["inputs"]["logits"] == {
         "dtype": "float32",
-        "rank": 2,
         "shape": ["batch", "vocabulary"],
         "batch_layout": {"kind": "request_aligned", "axis": 0},
     }
     assert sampler["ports"]["outputs"]["token"] == {
         "dtype": "int64",
-        "rank": 1,
         "shape": ["batch"],
         "batch_layout": {"kind": "request_aligned", "axis": 0},
     }
@@ -285,7 +282,7 @@ def test_seeded_decoder_sampler_uses_request_controls_and_direct_kv_carry():
     assert workflow["state"]["rng_counter"]["initializer"] == "request.rng_counter"
     emit = next(node for node in workflow["steps"][0]["steps"] if node["kind"] == "emit")
     assert "row_ids" not in emit
-    assert "emit_row_identity" not in workflow["manifest"]["capabilities"]
+    assert "capabilities" not in workflow["manifest"]
     assert set(
         workflow["serving"]["state_service"]["groups"]["decoder_cache"]["ports"]["model"]
     ) == {"cache_0", "cache_1"}
@@ -307,7 +304,6 @@ def test_seeded_decoder_sampler_uses_request_controls_and_direct_kv_carry():
     }
     assert workflow["components"]["termination"]["ports"]["inputs"]["iteration"] == {
         "dtype": "int64",
-        "rank": 1,
         "shape": [1],
     }
     assert workflow["components"]["token_state_update"]["contract"] == {
@@ -397,7 +393,7 @@ def test_dispatch_video_diffusion_uses_typed_ddim(tmp_path, monkeypatch):
     with open(artifacts["inference_metadata"]) as handle:
         metadata = yaml.safe_load(handle)
     workflow = metadata["pipeline"]["workflow"]
-    assert workflow["outputs"]["video"]["contract"]["rank"] == 5
+    assert len(workflow["outputs"]["video"]["contract"]["shape"]) == 5
     loop = next(step for step in workflow["steps"] if step["kind"] == "loop")
     assert [node["component"] for node in loop["steps"]].count("transformer") == 2
     _, schedule = _ddim_alpha_schedule(scheduler, 2)
@@ -817,7 +813,6 @@ def test_dispatch_diffusion_auto_reads_scheduler_from_source(tmp_path):
     components = meta["pipeline"]["workflow"]["components"]
     assert components["diffusion_schedule"]["ports"]["outputs"]["schedule"] == {
         "dtype": "float32",
-        "rank": 1,
         "shape": [16],
     }
     schedule = ir.load(out / "policies" / "diffusion_schedule.onnx")
@@ -875,7 +870,6 @@ def test_dispatch_vision_multimodal_pipeline(tmp_path):
     assert workflow["steps"][0]["iteration"]["value"] == "loop.iteration"
     assert workflow["state"]["logits"]["contract"] == {
         "dtype": "float32",
-        "rank": 2,
         "shape": ["batch", 128],
         "batch_layout": {"kind": "request_aligned", "axis": 0},
     }

--- a/src/mobius/integrations/onnx_genai/codec_workflow_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/codec_workflow_metadata_test.py
@@ -49,7 +49,6 @@ def test_codec_workflow_has_typed_ssa_and_audio_emit():
     workflow = pipeline["workflow"]
     assert workflow["inputs"]["request.waveform"]["contract"] == {
         "dtype": "float32",
-        "rank": 3,
         "shape": ["batch", 1, "audio_samples"],
         "batch_layout": {"kind": "request_aligned", "axis": 0},
     }

--- a/src/mobius/integrations/onnx_genai/convert.py
+++ b/src/mobius/integrations/onnx_genai/convert.py
@@ -28,8 +28,7 @@ import math
 import os
 from typing import Any
 
-import yaml
-
+from mobius.integrations.onnx_genai._metadata_io import _dump_yaml
 from mobius.integrations.onnx_genai.comfyui import (
     ComfyUIWorkflow,
     parse_comfyui_workflow,
@@ -261,7 +260,7 @@ def convert_comfyui_workflow(
     package.save_policy_components(output_dir)
     metadata_path = os.path.join(output_dir, "inference_metadata.yaml")
     with open(metadata_path, "w", encoding="utf-8") as handle:
-        yaml.safe_dump(metadata, handle, sort_keys=False)
+        _dump_yaml(metadata, handle)
 
     run_params = {
         "prompt": parsed_workflow.prompt,

--- a/src/mobius/integrations/onnx_genai/decoder_metadata.py
+++ b/src/mobius/integrations/onnx_genai/decoder_metadata.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import os
 from typing import Any
 
-import yaml
+from mobius.integrations.onnx_genai._metadata_io import _dump_yaml
 
 # Mobius' unset-int sentinel.
 _UNSET = -42
@@ -290,5 +290,5 @@ def write_decoder_metadata(
     os.makedirs(directory, exist_ok=True)
     path = os.path.join(directory, filename)
     with open(path, "w", encoding="utf-8") as handle:
-        yaml.safe_dump(metadata, handle, sort_keys=False)
+        _dump_yaml(metadata, handle)
     return path

--- a/src/mobius/integrations/onnx_genai/inference_metadata.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata.py
@@ -48,6 +48,7 @@ from mobius._constants import (
     STATIC_CACHE_WRITE_INDICES,
 )
 from mobius._pipeline_contract import component_presence, optional_input_contract
+from mobius.integrations.onnx_genai._metadata_io import _dump_yaml
 from mobius.integrations.onnx_genai._workflow_contract import (
     _invoke,
     _Port,
@@ -1419,7 +1420,6 @@ def add_adapter_service_to_metadata(
         semantic_role = declaration.get("role", {})
         return (
             contract.get("dtype") == dtype
-            and contract.get("rank") == len(shape)
             and contract.get("shape") == shape
             # A selection tensor the service reads for every batch it plans has
             # no package-side escape, so admission derivation stamps it required
@@ -1442,7 +1442,7 @@ def add_adapter_service_to_metadata(
     ) -> None:
         if name not in inputs:
             inputs[name] = {
-                "contract": {"dtype": dtype, "rank": len(shape), "shape": shape},
+                "contract": {"dtype": dtype, "shape": shape},
                 "role": (
                     {"kind": "runtime", "version": "1.0", "role": role}
                     if role is not None
@@ -2375,18 +2375,16 @@ def build_diffusion_pipeline_metadata(
         )
 
     workflow_dtype = _WORKFLOW_DTYPES[activation_dtype]
-    latent_contract = _request_aligned(
-        {"dtype": workflow_dtype, "rank": 4, "shape": list(_LATENT_DIMS)}
-    )
-    row_float = _request_aligned({"dtype": "float32", "rank": 1, "shape": ["batch"]})
-    batch_bool = _request_aligned({"dtype": "bool", "rank": 1, "shape": ["batch"]})
+    latent_contract = _request_aligned({"dtype": workflow_dtype, "shape": list(_LATENT_DIMS)})
+    row_float = _request_aligned({"dtype": "float32", "shape": ["batch"]})
+    batch_bool = _request_aligned({"dtype": "bool", "shape": ["batch"]})
     prompt_contract = _request_aligned(
-        {"dtype": "int64", "rank": 2, "shape": ["batch", "prompt_sequence"]}
+        {"dtype": "int64", "shape": ["batch", "prompt_sequence"]}
     )
 
     inputs: dict[str, Any] = {
         "request.max_iterations": {
-            "contract": {"dtype": "int64", "rank": 1, "shape": [1]},
+            "contract": {"dtype": "int64", "shape": [1]},
             "role": {"kind": "runtime", "version": "1.0", "role": "max_iterations"},
             "source": {"kind": "request", "field": "max_iterations"},
             "required": False,
@@ -2664,7 +2662,7 @@ def build_diffusion_pipeline_metadata(
                     "max_iterations": "request.max_iterations",
                     "iteration": {
                         "value": "loop.iteration",
-                        "contract": {"dtype": "int64", "rank": 1, "shape": ["batch"]},
+                        "contract": {"dtype": "int64", "shape": ["batch"]},
                     },
                     "carried": carried,
                 },
@@ -2817,7 +2815,7 @@ def write_multimodal_pipeline_metadata(
     os.makedirs(directory, exist_ok=True)
     path = os.path.join(directory, filename)
     with open(path, "w", encoding="utf-8") as handle:
-        yaml.safe_dump(metadata, handle, sort_keys=False)
+        _dump_yaml(metadata, handle)
     return path
 
 
@@ -2908,7 +2906,7 @@ def write_speech_to_text_pipeline_metadata(
     os.makedirs(directory, exist_ok=True)
     path = os.path.join(directory, filename)
     with open(path, "w", encoding="utf-8") as handle:
-        yaml.safe_dump(metadata, handle, sort_keys=False)
+        _dump_yaml(metadata, handle)
     return path
 
 
@@ -2935,7 +2933,7 @@ def write_diffusion_pipeline_metadata(
     package.save_policy_components(directory)
     path = os.path.join(directory, filename)
     with open(path, "w", encoding="utf-8") as handle:
-        yaml.safe_dump(metadata, handle, sort_keys=False)
+        _dump_yaml(metadata, handle)
     return path
 
 
@@ -3126,7 +3124,7 @@ def write_mtp_speculator_metadata(
         **({"rollback_state": rollback_cells} if rollback_cells else {}),
     }
     with open(path, "w", encoding="utf-8") as handle:
-        yaml.safe_dump(metadata, handle, sort_keys=False)
+        _dump_yaml(metadata, handle)
     return path
 
 

--- a/src/mobius/integrations/onnx_genai/inference_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/inference_metadata_test.py
@@ -184,7 +184,6 @@ def test_workflow_policy_components_reference_saved_onnx_artifacts(tmp_path):
         "inputs": {
             "logits": {
                 "dtype": "float32",
-                "rank": 2,
                 "shape": ["batch", "vocabulary"],
                 "batch_layout": {"kind": "request_aligned", "axis": 0},
             }
@@ -192,7 +191,6 @@ def test_workflow_policy_components_reference_saved_onnx_artifacts(tmp_path):
         "outputs": {
             "token": {
                 "dtype": "int64",
-                "rank": 1,
                 "shape": ["batch"],
                 "batch_layout": {"kind": "request_aligned", "axis": 0},
             }
@@ -1948,7 +1946,6 @@ def _seed_backbone_metadata(directory: Path) -> str:
     """
     kv_contract = {
         "dtype": "float16",
-        "rank": 4,
         "shape": ["batch", "kv_heads", "sequence", "head_dim"],
         "batch_layout": {"kind": "request_aligned", "axis": 0},
     }
@@ -1961,7 +1958,6 @@ def _seed_backbone_metadata(directory: Path) -> str:
                     "request.input_ids": {
                         "contract": {
                             "dtype": "int64",
-                            "rank": 2,
                             "shape": ["batch", "sequence"],
                             "batch_layout": {"kind": "request_aligned", "axis": 0},
                         },
@@ -1978,7 +1974,6 @@ def _seed_backbone_metadata(directory: Path) -> str:
                     "request.active": {
                         "contract": {
                             "dtype": "bool",
-                            "rank": 1,
                             "shape": ["batch"],
                             "batch_layout": {"kind": "request_aligned", "axis": 0},
                         },
@@ -1989,7 +1984,6 @@ def _seed_backbone_metadata(directory: Path) -> str:
                     "request.done": {
                         "contract": {
                             "dtype": "bool",
-                            "rank": 1,
                             "shape": ["batch"],
                             "batch_layout": {"kind": "request_aligned", "axis": 0},
                         },

--- a/src/mobius/integrations/onnx_genai/package_facts_test.py
+++ b/src/mobius/integrations/onnx_genai/package_facts_test.py
@@ -378,7 +378,7 @@ class TestMultimodalPackageFacts:
         media = workflow["inputs"]["request.image"]
         assert media["role"] == {"kind": "runtime", "version": "1.0", "role": "media"}
         assert media["contract"]["dtype"] == "uint8"
-        assert media["contract"]["rank"] == 1
+        assert media["contract"]["shape"] == ["encoded_bytes"]
         preprocess = next(
             step
             for step in workflow["steps"][0]["setup"]

--- a/src/mobius/integrations/onnx_genai/shared_state_flow_metadata.py
+++ b/src/mobius/integrations/onnx_genai/shared_state_flow_metadata.py
@@ -289,7 +289,7 @@ def build_shared_state_pixel_flow_workflow_metadata(
             "version": "1",
         },
         "ports": {
-            "inputs": {"encoded": {"dtype": "uint8", "rank": 1, "shape": ["encoded_bytes"]}},
+            "inputs": {"encoded": {"dtype": "uint8", "shape": ["encoded_bytes"]}},
             "outputs": {
                 "pixel_values": {
                     **_contract(vision_input),
@@ -306,7 +306,6 @@ def build_shared_state_pixel_flow_workflow_metadata(
 
     batch_bool = {
         "dtype": "bool",
-        "rank": 1,
         "shape": ["batch"],
         "batch_layout": {"kind": "request_aligned", "axis": 0},
     }
@@ -330,7 +329,7 @@ def build_shared_state_pixel_flow_workflow_metadata(
             "source": {"kind": "request"},
         },
         "request.image": {
-            "contract": {"dtype": "uint8", "rank": 1, "shape": ["encoded_bytes"]},
+            "contract": {"dtype": "uint8", "shape": ["encoded_bytes"]},
             "role": {"kind": "runtime", "version": "1.0", "role": "media"},
             "source": {"kind": "request"},
             "required": False,
@@ -361,7 +360,6 @@ def build_shared_state_pixel_flow_workflow_metadata(
         "request.seed": {
             "contract": {
                 "dtype": "int64",
-                "rank": 1,
                 "shape": ["batch"],
                 "batch_layout": {"kind": "request_aligned", "axis": 0},
             },
@@ -371,14 +369,14 @@ def build_shared_state_pixel_flow_workflow_metadata(
             "default": 0,
         },
         "request.width": {
-            "contract": {"dtype": "int64", "rank": 1, "shape": [1]},
+            "contract": {"dtype": "int64", "shape": [1]},
             "role": {"kind": "runtime", "version": "1.0", "role": "width"},
             "source": {"kind": "request"},
             "required": False,
             "default": 512,
         },
         "request.height": {
-            "contract": {"dtype": "int64", "rank": 1, "shape": [1]},
+            "contract": {"dtype": "int64", "shape": [1]},
             "role": {"kind": "runtime", "version": "1.0", "role": "height"},
             "source": {"kind": "request"},
             "required": False,
@@ -387,7 +385,6 @@ def build_shared_state_pixel_flow_workflow_metadata(
         "request.guidance_scale": {
             "contract": {
                 "dtype": "float32",
-                "rank": 1,
                 "shape": ["batch"],
                 "batch_layout": {"kind": "request_aligned", "axis": 0},
             },
@@ -401,14 +398,14 @@ def build_shared_state_pixel_flow_workflow_metadata(
             "default": float(guidance_scale),
         },
         "request.max_iterations": {
-            "contract": {"dtype": "int64", "rank": 1, "shape": [1]},
+            "contract": {"dtype": "int64", "shape": [1]},
             "role": {"kind": "runtime", "version": "1.0", "role": "max_iterations"},
             "source": {"kind": "request"},
             "required": False,
             "default": num_inference_steps,
         },
         "request.text_only": {
-            "contract": {"dtype": "bool", "rank": 1, "shape": [1]},
+            "contract": {"dtype": "bool", "shape": [1]},
             "role": {"kind": "opaque"},
             "source": {"kind": "application", "name": "text_only"},
             "required": False,
@@ -431,7 +428,6 @@ def build_shared_state_pixel_flow_workflow_metadata(
         "package.accepted_len": {
             "contract": {
                 "dtype": "int64",
-                "rank": 1,
                 "shape": ["batch"],
                 "batch_layout": {"kind": "request_aligned", "axis": 0},
             },
@@ -443,7 +439,6 @@ def build_shared_state_pixel_flow_workflow_metadata(
         "package.rng_offset": {
             "contract": {
                 "dtype": "int64",
-                "rank": 1,
                 "shape": ["batch"],
                 "batch_layout": {"kind": "request_aligned", "axis": 0},
             },
@@ -453,7 +448,7 @@ def build_shared_state_pixel_flow_workflow_metadata(
             "default": 0,
         },
         "package.one": {
-            "contract": {"dtype": "float32", "rank": 1, "shape": [1]},
+            "contract": {"dtype": "float32", "shape": [1]},
             "role": {"kind": "opaque"},
             "source": {"kind": "literal"},
             "required": False,
@@ -467,7 +462,6 @@ def build_shared_state_pixel_flow_workflow_metadata(
                 if decoder_outputs["logits"].shape is not None
                 else {
                     "dtype": _contract(decoder_outputs["logits"])["dtype"],
-                    "rank": 3,
                     "shape": ["batch", "sequence_len", int(config.vocab_size)],
                     "batch_layout": {"kind": "request_aligned", "axis": 0},
                 }
@@ -870,7 +864,6 @@ def build_shared_state_pixel_flow_workflow_metadata(
                                         "value": "loop.iteration",
                                         "contract": {
                                             "dtype": "int64",
-                                            "rank": 1,
                                             "shape": [1],
                                         },
                                     },

--- a/src/mobius/integrations/onnx_genai/speech_enhancement_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/speech_enhancement_metadata_test.py
@@ -230,9 +230,9 @@ class TestMetadata:
             "sample_lengths",
         }
         # The complex spectrogram carries a trailing (real, imag) pair.
-        assert outputs["denoised_com"]["contract"]["rank"] == 4
+        assert len(outputs["denoised_com"]["contract"]["shape"]) == 4
         assert outputs["denoised_com"]["contract"]["shape"][-1] == 2
-        assert outputs["denoised_mag"]["contract"]["rank"] == 3
+        assert len(outputs["denoised_mag"]["contract"]["shape"]) == 3
         profile = metadata["profiles"]["speech_enhancement"]
         assert set(profile["outputs"]) == set(outputs)
 
@@ -274,8 +274,8 @@ class TestMetadata:
         assert bindings["reference_audio"]["source"] == "samples"
         assert bindings["sample_rate"]["source"] == "sample_rate"
         assert bindings["sample_lengths"]["source"] == "sample_lengths"
-        assert bindings["noisy_mag"]["contract"]["rank"] == 3
-        assert bindings["reference_audio"]["contract"]["rank"] == 2
+        assert len(bindings["noisy_mag"]["contract"]["shape"]) == 3
+        assert len(bindings["reference_audio"]["contract"]["shape"]) == 2
 
     def test_declares_the_adapter_abi_when_the_front_end_ships(self):
         """A runtime must be able to version-check the STFT adapter it has to supply.

--- a/src/mobius/integrations/onnx_genai/speech_to_text_workflow_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/speech_to_text_workflow_metadata_test.py
@@ -175,7 +175,7 @@ def test_audio_program_is_declared_and_bound_to_the_encoder_input(tmp_path):
 
     workflow = _workflow(metadata)
     assert workflow["manifest"]["adapter_abis"] == {"onnx-genai.audio-preprocess": "1"}
-    assert "audio_preprocessing_program" in workflow["manifest"]["capabilities"]
+    assert "capabilities" not in workflow["manifest"]
     adapter = workflow["components"]["audio_preprocess"]
     assert adapter["implementation"] == {
         "kind": "adapter",

--- a/src/mobius/integrations/onnx_genai/workflow_metadata.py
+++ b/src/mobius/integrations/onnx_genai/workflow_metadata.py
@@ -299,7 +299,7 @@ def _grammar_adapter_component(action: str) -> dict[str, Any]:
     """Declare one action of the versioned grammar-guidance adapter ABI."""
 
     def port(dtype: str, shape: list[int | str]) -> dict[str, Any]:
-        return {"dtype": dtype, "rank": len(shape), "shape": shape}
+        return {"dtype": dtype, "shape": shape}
 
     return {
         "implementation": {
@@ -792,11 +792,11 @@ def build_hierarchical_audio_workflow_metadata(pkg: Any) -> dict[str, Any]:
         ),
     )
 
-    batch_int = _request_aligned({"dtype": "int64", "rank": 1, "shape": ["batch"]})
-    batch_float = _request_aligned({"dtype": "float32", "rank": 1, "shape": ["batch"]})
-    batch_bool = _request_aligned({"dtype": "bool", "rank": 1, "shape": ["batch"]})
-    scalar_int = {"dtype": "int64", "rank": 0, "shape": []}
-    control_int = {"dtype": "int64", "rank": 1, "shape": [1]}
+    batch_int = _request_aligned({"dtype": "int64", "shape": ["batch"]})
+    batch_float = _request_aligned({"dtype": "float32", "shape": ["batch"]})
+    batch_bool = _request_aligned({"dtype": "bool", "shape": ["batch"]})
+    scalar_int = {"dtype": "int64", "shape": []}
+    control_int = {"dtype": "int64", "shape": [1]}
     prompt_contract = _contract(pkg[roles["global_embedding"]].graph.inputs[0])
     prompt_contract["batch_layout"] = {
         "kind": "request_expanded",
@@ -1619,7 +1619,6 @@ def build_hierarchical_audio_workflow_metadata(pkg: Any) -> dict[str, Any]:
         "frame_history": {
             "contract": {
                 "dtype": dtype_name,
-                "rank": 3,
                 "shape": [1, "frames", fused_hidden_size],
             },
             "scope": "invocation",
@@ -1659,7 +1658,7 @@ def build_hierarchical_audio_workflow_metadata(pkg: Any) -> dict[str, Any]:
             "recurrence": {"kind": "invariant"},
         },
         "local_sequence": {
-            "contract": {"dtype": dtype_name, "rank": 3, "shape": [2, "steps", hidden_size]},
+            "contract": {"dtype": dtype_name, "shape": [2, "steps", hidden_size]},
             "scope": "invocation",
             "initializer": "local.initial_sequence",
             "recurrence": {
@@ -1670,7 +1669,7 @@ def build_hierarchical_audio_workflow_metadata(pkg: Any) -> dict[str, Any]:
             },
         },
         "local_codes": {
-            "contract": {"dtype": "int64", "rank": 2, "shape": [2, "codes"]},
+            "contract": {"dtype": "int64", "shape": [2, "codes"]},
             "scope": "invocation",
             "initializer": "local.initial_codes",
             "recurrence": {
@@ -1681,7 +1680,7 @@ def build_hierarchical_audio_workflow_metadata(pkg: Any) -> dict[str, Any]:
             },
         },
         "local_hidden": {
-            "contract": {"dtype": dtype_name, "rank": 3, "shape": [1, "parts", hidden_size]},
+            "contract": {"dtype": dtype_name, "shape": [1, "parts", hidden_size]},
             "scope": "invocation",
             "initializer": "local.initial_hidden",
             "recurrence": {
@@ -1700,7 +1699,6 @@ def build_hierarchical_audio_workflow_metadata(pkg: Any) -> dict[str, Any]:
         "flow_latents": {
             "contract": {
                 "dtype": dtype_name,
-                "rank": 3,
                 "shape": [1, latent_channels, "latent_length"],
             },
             "scope": "invocation",
@@ -1710,7 +1708,6 @@ def build_hierarchical_audio_workflow_metadata(pkg: Any) -> dict[str, Any]:
         "previous_latent": {
             "contract": {
                 "dtype": dtype_name,
-                "rank": 3,
                 "shape": [1, latent_channels, "carry_length"],
             },
             "scope": "invocation",
@@ -1720,7 +1717,6 @@ def build_hierarchical_audio_workflow_metadata(pkg: Any) -> dict[str, Any]:
         "previous_condition": {
             "contract": {
                 "dtype": dtype_name,
-                "rank": 3,
                 "shape": [1, "carry_length", condition_size],
             },
             "scope": "invocation",
@@ -1731,7 +1727,6 @@ def build_hierarchical_audio_workflow_metadata(pkg: Any) -> dict[str, Any]:
             "contract": _request_aligned(
                 {
                     "dtype": _contract(waveform_output)["dtype"],
-                    "rank": 3,
                     "shape": ["batch", output_channels, "samples"],
                 }
             ),
@@ -1799,7 +1794,6 @@ def build_hierarchical_audio_workflow_metadata(pkg: Any) -> dict[str, Any]:
                 "contract": _request_aligned(
                     {
                         "dtype": _contract(waveform_output)["dtype"],
-                        "rank": 3,
                         "shape": ["batch", output_channels, "samples"],
                     }
                 ),
@@ -2596,9 +2590,9 @@ def _build_real_tts_workflow_metadata(pkg: Any, config: Any) -> dict[str, Any]:
         pkg.add_policy_component("codec_layout", build_codec_layout_transpose(num_groups))
 
     batch = _contract(prompt)["shape"][0]
-    batch_int = _request_aligned({"dtype": "int64", "rank": 1, "shape": [batch]})
-    batch_bool = _request_aligned({"dtype": "bool", "rank": 1, "shape": [batch]})
-    control_int = {"dtype": "int64", "rank": 1, "shape": [1]}
+    batch_int = _request_aligned({"dtype": "int64", "shape": [batch]})
+    batch_bool = _request_aligned({"dtype": "bool", "shape": [batch]})
+    control_int = {"dtype": "int64", "shape": [1]}
     inputs = {
         "request.prompt_tokens": {
             "contract": _contract(prompt),
@@ -2620,14 +2614,14 @@ def _build_real_tts_workflow_metadata(pkg: Any, config: Any) -> dict[str, Any]:
             "default": False,
         },
         "package.zero_scalar": {
-            "contract": {"dtype": "int64", "rank": 0, "shape": []},
+            "contract": {"dtype": "int64", "shape": []},
             "role": {"kind": "opaque"},
             "source": {"kind": "literal"},
             "required": False,
             "default": 0,
         },
         "package.one_scalar": {
-            "contract": {"dtype": "int64", "rank": 0, "shape": []},
+            "contract": {"dtype": "int64", "shape": []},
             "role": {"kind": "opaque"},
             "source": {"kind": "literal"},
             "required": False,
@@ -2692,7 +2686,7 @@ def _build_real_tts_workflow_metadata(pkg: Any, config: Any) -> dict[str, Any]:
     }
     for iteration in range(num_groups - 2):
         inputs[f"package.setup_predictor_iteration_{iteration}"] = {
-            "contract": {"dtype": "int64", "rank": 0, "shape": []},
+            "contract": {"dtype": "int64", "shape": []},
             "role": {"kind": "opaque"},
             "source": {"kind": "literal"},
             "required": False,
@@ -3224,7 +3218,7 @@ def _build_real_tts_workflow_metadata(pkg: Any, config: Any) -> dict[str, Any]:
 
     state = {
         "last_frame": {
-            "contract": {"dtype": "int64", "rank": 2, "shape": [batch, num_groups]},
+            "contract": {"dtype": "int64", "shape": [batch, num_groups]},
             "scope": "invocation",
             "initializer": setup_frame,
             "recurrence": {"kind": "invariant"},
@@ -3232,7 +3226,6 @@ def _build_real_tts_workflow_metadata(pkg: Any, config: Any) -> dict[str, Any]:
         "history": {
             "contract": {
                 "dtype": "int64",
-                "rank": 3,
                 "shape": [batch, "frames", num_groups],
             },
             "scope": "invocation",
@@ -3247,7 +3240,6 @@ def _build_real_tts_workflow_metadata(pkg: Any, config: Any) -> dict[str, Any]:
         "talker_mask": {
             "contract": {
                 "dtype": _contract(talker_mask)["dtype"],
-                "rank": 2,
                 "shape": [batch, "talker_context"],
             },
             "scope": "invocation",
@@ -3274,7 +3266,7 @@ def _build_real_tts_workflow_metadata(pkg: Any, config: Any) -> dict[str, Any]:
             "recurrence": {"kind": "invariant"},
         },
         "frame": {
-            "contract": {"dtype": "int64", "rank": 2, "shape": [batch, num_groups]},
+            "contract": {"dtype": "int64", "shape": [batch, num_groups]},
             "scope": "invocation",
             "initializer": "frame.frame_prefill",
             "recurrence": {"kind": "invariant"},
@@ -3288,7 +3280,6 @@ def _build_real_tts_workflow_metadata(pkg: Any, config: Any) -> dict[str, Any]:
         "predictor_mask": {
             "contract": {
                 "dtype": _contract(predictor_mask)["dtype"],
-                "rank": 2,
                 "shape": [batch, "predictor_context"],
             },
             "scope": "invocation",
@@ -3686,11 +3677,9 @@ def build_tts_workflow_metadata(pkg: Any, config: Any) -> dict[str, Any]:
     if predictor_logits.shape is None or len(predictor_logits.shape) != 2:
         raise ValueError("TTS code predictor logits must be rank 2")
     predictor_step_contract = _contract(predictor_step_input)
-    scalar_code_index = predictor_step_contract["rank"] == 0
-    if predictor_step_contract["dtype"] != "int64" or predictor_step_contract["rank"] not in {
-        0,
-        1,
-    }:
+    predictor_step_rank = len(predictor_step_contract["shape"])
+    scalar_code_index = predictor_step_rank == 0
+    if predictor_step_contract["dtype"] != "int64" or predictor_step_rank not in {0, 1}:
         raise ValueError("TTS code predictor step index must be scalar or batch int64")
 
     codec_name = next(
@@ -3721,9 +3710,9 @@ def build_tts_workflow_metadata(pkg: Any, config: Any) -> dict[str, Any]:
         pkg.add_policy_component("codec_layout", build_codec_layout_transpose(num_groups))
 
     batch = _contract(prompt_input)["shape"][0]
-    batch_int = _request_aligned({"dtype": "int64", "rank": 1, "shape": [batch]})
-    batch_bool = _request_aligned({"dtype": "bool", "rank": 1, "shape": [batch]})
-    control_int = {"dtype": "int64", "rank": 1, "shape": [1]}
+    batch_int = _request_aligned({"dtype": "int64", "shape": [batch]})
+    batch_bool = _request_aligned({"dtype": "bool", "shape": [batch]})
+    control_int = {"dtype": "int64", "shape": [1]}
     inputs: dict[str, Any] = {
         "request.prompt_tokens": {
             "contract": _contract(prompt_input),
@@ -3820,12 +3809,10 @@ def build_tts_workflow_metadata(pkg: Any, config: Any) -> dict[str, Any]:
 
     frame_contract = {
         "dtype": "int64",
-        "rank": 2,
         "shape": [batch, num_groups],
     }
     history_contract = {
         "dtype": "int64",
-        "rank": 3,
         "shape": [batch, "frames", num_groups],
     }
     initial_effects = {
@@ -4343,11 +4330,11 @@ def build_diffusion_workflow_metadata(
 
     batch = _contract(sample_input)["shape"][0]
     latent_contract = _request_aligned(_contract(sample_input))
-    row_int = _request_aligned({"dtype": "int64", "rank": 1, "shape": [batch]})
-    row_float = _request_aligned({"dtype": "float32", "rank": 1, "shape": [batch]})
-    batch_int = _request_aligned({"dtype": "int64", "rank": 1, "shape": [batch]})
-    batch_bool = _request_aligned({"dtype": "bool", "rank": 1, "shape": [batch]})
-    control_int = {"dtype": "int64", "rank": 1, "shape": [1]}
+    row_int = _request_aligned({"dtype": "int64", "shape": [batch]})
+    row_float = _request_aligned({"dtype": "float32", "shape": [batch]})
+    batch_int = _request_aligned({"dtype": "int64", "shape": [batch]})
+    batch_bool = _request_aligned({"dtype": "bool", "shape": [batch]})
+    control_int = {"dtype": "int64", "shape": [1]}
     inputs: dict[str, Any] = {
         "request.max_iterations": {
             "contract": control_int,
@@ -4895,7 +4882,6 @@ def build_image_edit_workflow_metadata(
     # carries the source tokens, so the two contracts differ in sequence length.
     latent_contract = {
         "dtype": _contract(sample_input)["dtype"],
-        "rank": 3,
         "shape": [
             "batch",
             "target_sequence_length",
@@ -4931,9 +4917,9 @@ def build_image_edit_workflow_metadata(
     clamp_output = pkg.policy_components["image_output_clamp"].model.graph.outputs[0]
 
     batch = latent_contract["shape"][0]
-    batch_int = {"dtype": "int64", "rank": 1, "shape": [batch]}
-    batch_bool = {"dtype": "bool", "rank": 1, "shape": [batch]}
-    control_int = {"dtype": "int64", "rank": 1, "shape": [1]}
+    batch_int = {"dtype": "int64", "shape": [batch]}
+    batch_bool = {"dtype": "bool", "shape": [batch]}
+    control_int = {"dtype": "int64", "shape": [1]}
 
     conditioning_ports = ("encoder_hidden_states", "encoder_hidden_states_mask")
     rotary_ports = ("image_rotary_cos", "image_rotary_sin")
@@ -5412,14 +5398,13 @@ def build_video_diffusion_workflow_metadata(
 
     latent_contract = _request_aligned(_contract(sample_input))
     batch = latent_contract["shape"][0]
-    batch_int = {"dtype": "int64", "rank": 1, "shape": [batch]}
-    batch_bool = {"dtype": "bool", "rank": 1, "shape": [batch]}
-    row_float = {"dtype": "float32", "rank": 1, "shape": [batch]}
-    control_int = {"dtype": "int64", "rank": 1, "shape": [1]}
+    batch_int = {"dtype": "int64", "shape": [batch]}
+    batch_bool = {"dtype": "bool", "shape": [batch]}
+    row_float = {"dtype": "float32", "shape": [batch]}
+    control_int = {"dtype": "int64", "shape": [1]}
     history_contract = _request_aligned(
         {
             "dtype": _contract(timestep_input)["dtype"],
-            "rank": 2,
             "shape": [batch, "scheduler_history"],
         }
     )
@@ -6113,9 +6098,9 @@ def build_vlm_workflow_metadata(
         pkg.add_policy_component("cache_length_update", build_selective_integer_add())
 
     batch = _contract(token_input)["shape"][0]
-    batch_int = _request_aligned({"dtype": "int64", "rank": 1, "shape": [batch]})
-    batch_bool = _request_aligned({"dtype": "bool", "rank": 1, "shape": [batch]})
-    control_int = {"dtype": "int64", "rank": 1, "shape": [1]}
+    batch_int = _request_aligned({"dtype": "int64", "shape": [batch]})
+    batch_bool = _request_aligned({"dtype": "bool", "shape": [batch]})
+    control_int = {"dtype": "int64", "shape": [1]}
     inputs: dict[str, Any] = {
         "request.prompt_tokens": {
             "contract": _contract(token_input),
@@ -6124,7 +6109,7 @@ def build_vlm_workflow_metadata(
             "required": True,
         },
         "request.image": {
-            "contract": {"dtype": "uint8", "rank": 1, "shape": ["encoded_bytes"]},
+            "contract": {"dtype": "uint8", "shape": ["encoded_bytes"]},
             "role": {"kind": "runtime", "version": "1.0", "role": "media"},
             "source": {"kind": "request", "field": "media"},
             "required": text_only_vision is None,
@@ -6151,9 +6136,9 @@ def build_vlm_workflow_metadata(
         },
         "request.eos_ids": {
             "contract": (
-                {"dtype": "int64", "rank": 2, "shape": [batch, "num_eos"]}
+                {"dtype": "int64", "shape": [batch, "num_eos"]}
                 if cache_pairs
-                else {"dtype": "int64", "rank": 1, "shape": ["num_eos"]}
+                else {"dtype": "int64", "shape": ["num_eos"]}
             ),
             "role": {"kind": "runtime", "version": "1.0", "role": "eos_token_ids"},
             "source": {"kind": "request"},
@@ -6252,7 +6237,7 @@ def build_vlm_workflow_metadata(
     inputs.update(
         {
             "request.temperature": {
-                "contract": {"dtype": "float32", "rank": 1, "shape": [batch]},
+                "contract": {"dtype": "float32", "shape": [batch]},
                 "role": {
                     "kind": "runtime",
                     "version": "1.0",
@@ -6274,7 +6259,7 @@ def build_vlm_workflow_metadata(
                 "default": 1,
             },
             "request.top_p": {
-                "contract": {"dtype": "float32", "rank": 1, "shape": [batch]},
+                "contract": {"dtype": "float32", "shape": [batch]},
                 "role": {
                     "kind": "runtime",
                     "version": "1.0",
@@ -6285,7 +6270,7 @@ def build_vlm_workflow_metadata(
                 "default": 1.0,
             },
             "request.min_p": {
-                "contract": {"dtype": "float32", "rank": 1, "shape": [batch]},
+                "contract": {"dtype": "float32", "shape": [batch]},
                 "role": {
                     "kind": "runtime",
                     "version": "1.0",
@@ -6387,12 +6372,11 @@ def build_vlm_workflow_metadata(
     logits_contract = _contract(logits_output)
     last_logits_contract = {
         "dtype": "float32",
-        "rank": 2,
         "shape": [logits_contract["shape"][0], logits_contract["shape"][-1]],
     }
     state: dict[str, Any] = {
         "token": {
-            "contract": {"dtype": "int64", "rank": 2, "shape": [batch, 1]},
+            "contract": {"dtype": "int64", "shape": [batch, 1]},
             "scope": "invocation",
             "initializer": "initializer.token_slot",
             "recurrence": {"kind": "invariant"},
@@ -6413,7 +6397,6 @@ def build_vlm_workflow_metadata(
         "attention_mask": {
             "contract": {
                 "dtype": _contract(attention_input)["dtype"],
-                "rank": 2,
                 "shape": [batch, "context"],
             },
             "scope": "invocation",
@@ -6538,7 +6521,6 @@ def build_vlm_workflow_metadata(
         state["position_ids"] = {
             "contract": {
                 "dtype": _contract(position_input)["dtype"],
-                "rank": 2,
                 "shape": [batch, 1],
             },
             "scope": "invocation",
@@ -6929,7 +6911,6 @@ def build_vlm_workflow_metadata(
             "inputs": {
                 "encoded": {
                     "dtype": "uint8",
-                    "rank": 1,
                     "shape": ["encoded_bytes"],
                 }
             },
@@ -6960,7 +6941,6 @@ def build_vlm_workflow_metadata(
                 "contract": _request_aligned(
                     {
                         "dtype": "int64",
-                        "rank": 2,
                         "shape": [batch, "generated_sequence"],
                     }
                 ),
@@ -6992,7 +6972,7 @@ def build_vlm_workflow_metadata(
             "max_iterations": "request.max_iterations",
             "iteration": {
                 "value": "loop.iteration",
-                "contract": {"dtype": "int64", "rank": 1, "shape": [1]},
+                "contract": {"dtype": "int64", "shape": [1]},
             },
             "carried": carried,
         },
@@ -7145,9 +7125,9 @@ def build_speculative_workflow_metadata(
         pkg.add_policy_component("proposal_metrics", build_proposal_metrics())
     pkg.add_policy_component("cache_length_update", build_integer_add())
     batch = _contract(proposer_input)["shape"][0]
-    batch_int = _request_aligned({"dtype": "int64", "rank": 1, "shape": [batch]})
-    batch_bool = _request_aligned({"dtype": "bool", "rank": 1, "shape": [batch]})
-    control_int = {"dtype": "int64", "rank": 1, "shape": [1]}
+    batch_int = _request_aligned({"dtype": "int64", "shape": [batch]})
+    batch_bool = _request_aligned({"dtype": "bool", "shape": [batch]})
+    control_int = {"dtype": "int64", "shape": [1]}
     inputs: dict[str, Any] = {
         "request.tokens": {
             "contract": _contract(proposer_input),
@@ -7230,7 +7210,6 @@ def build_speculative_workflow_metadata(
                 "request.grammar_transition_table": {
                     "contract": {
                         "dtype": "int64",
-                        "rank": 2,
                         "shape": ["grammar_states", "vocabulary"],
                     },
                     "role": {"kind": "opaque"},
@@ -7256,7 +7235,6 @@ def build_speculative_workflow_metadata(
                 "request.adaptive_estimates": {
                     "contract": {
                         "dtype": "float32",
-                        "rank": 2,
                         "shape": [batch, estimate_slots],
                     },
                     "role": {"kind": "opaque"},
@@ -7270,7 +7248,6 @@ def build_speculative_workflow_metadata(
                 "request.draft_ms": {
                     "contract": {
                         "dtype": "float32",
-                        "rank": 1,
                         "shape": [batch],
                     },
                     "role": {"kind": "opaque"},
@@ -7280,7 +7257,6 @@ def build_speculative_workflow_metadata(
                 "request.target_ms": {
                     "contract": {
                         "dtype": "float32",
-                        "rank": 1,
                         "shape": [batch],
                     },
                     "role": {"kind": "opaque"},
@@ -8232,15 +8208,15 @@ def _build_autoregressive_workflow_metadata(
         # Raw encoded audio is the request-level input; the adapter decodes and
         # turns it into the encoder feature tensor declared by the program.
         workflow_inputs["request.audio"] = {
-            "contract": {"dtype": "uint8", "rank": 1, "shape": ["encoded_bytes"]},
+            "contract": {"dtype": "uint8", "shape": ["encoded_bytes"]},
             "role": {"kind": "runtime", "version": "1.0", "role": "media"},
             "source": {"kind": "request", "field": "media"},
             "required": True,
         }
     batch_dimension = _shape_metadata(_port(token_input))[0]
-    batch_int = _request_aligned({"dtype": "int64", "rank": 1, "shape": [batch_dimension]})
-    batch_bool = _request_aligned({"dtype": "bool", "rank": 1, "shape": [batch_dimension]})
-    control_int = {"dtype": "int64", "rank": 1, "shape": [1]}
+    batch_int = _request_aligned({"dtype": "int64", "shape": [batch_dimension]})
+    batch_bool = _request_aligned({"dtype": "bool", "shape": [batch_dimension]})
+    control_int = {"dtype": "int64", "shape": [1]}
     workflow_inputs.update(
         {
             "request.max_iterations": {
@@ -8302,7 +8278,6 @@ def _build_autoregressive_workflow_metadata(
                 "request.eos_ids": {
                     "contract": {
                         "dtype": "int64",
-                        "rank": 2,
                         "shape": [batch_dimension, "num_eos"],
                     },
                     "role": {
@@ -8337,7 +8312,7 @@ def _build_autoregressive_workflow_metadata(
         )
     else:
         workflow_inputs["request.eos_ids"] = {
-            "contract": {"dtype": "int64", "rank": 1, "shape": ["num_eos"]},
+            "contract": {"dtype": "int64", "shape": ["num_eos"]},
             "role": {
                 "kind": "runtime",
                 "version": "1.0",
@@ -8354,7 +8329,6 @@ def _build_autoregressive_workflow_metadata(
                 "request.temperature": {
                     "contract": {
                         "dtype": "float32",
-                        "rank": 1,
                         "shape": [batch_dimension],
                     },
                     "role": {
@@ -8383,7 +8357,6 @@ def _build_autoregressive_workflow_metadata(
                 "request.top_p": {
                     "contract": {
                         "dtype": "float32",
-                        "rank": 1,
                         "shape": [batch_dimension],
                     },
                     "role": {
@@ -8398,7 +8371,6 @@ def _build_autoregressive_workflow_metadata(
                 "request.min_p": {
                     "contract": {
                         "dtype": "float32",
-                        "rank": 1,
                         "shape": [batch_dimension],
                     },
                     "role": {
@@ -8526,14 +8498,12 @@ def _build_autoregressive_workflow_metadata(
     logits_contract = _contract(logits_output)
     last_logits_contract = {
         "dtype": "float32",
-        "rank": 2,
         "shape": [logits_contract["shape"][0], logits_contract["shape"][-1]],
     }
     state: dict[str, Any] = {
         "token": {
             "contract": {
                 "dtype": "int64",
-                "rank": 2,
                 "shape": [batch_dimension, 1],
             },
             "scope": "invocation",
@@ -8692,7 +8662,6 @@ def _build_autoregressive_workflow_metadata(
         decoder_state_specs["attention_mask"] = (
             {
                 "dtype": _contract(attention_input)["dtype"],
-                "rank": 2,
                 "shape": [batch_dimension, "context"],
             },
             (
@@ -8716,7 +8685,6 @@ def _build_autoregressive_workflow_metadata(
         decoder_state_specs["position_ids"] = (
             {
                 "dtype": _contract(position_input)["dtype"],
-                "rank": 2,
                 "shape": [batch_dimension, 1],
             },
             "initializer.body_position_ids",
@@ -9191,7 +9159,6 @@ def _build_autoregressive_workflow_metadata(
                 "contract": _request_aligned(
                     {
                         "dtype": "int64",
-                        "rank": 2,
                         "shape": [batch_dimension, "generated_sequence"],
                     }
                 ),
@@ -9223,7 +9190,6 @@ def _build_autoregressive_workflow_metadata(
                             "inputs": {
                                 "encoded": {
                                     "dtype": "uint8",
-                                    "rank": 1,
                                     "shape": ["encoded_bytes"],
                                 }
                             },
@@ -9259,7 +9225,7 @@ def _build_autoregressive_workflow_metadata(
             "max_iterations": "request.max_iterations",
             "iteration": {
                 "value": "loop.iteration",
-                "contract": {"dtype": "int64", "rank": 1, "shape": [1]},
+                "contract": {"dtype": "int64", "shape": [1]},
             },
             "carried": carried,
         },
@@ -9320,12 +9286,11 @@ def build_language_diffusion_pipeline_metadata(
     token_contract = _contract(token_input)
     mask_contract = {
         "dtype": "bool",
-        "rank": 2,
         "shape": token_contract["shape"],
     }
     batch_dimension = token_contract["shape"][0]
-    batch_int = _request_aligned({"dtype": "int64", "rank": 1, "shape": [batch_dimension]})
-    control_int = {"dtype": "int64", "rank": 1, "shape": [1]}
+    batch_int = _request_aligned({"dtype": "int64", "shape": [batch_dimension]})
+    control_int = {"dtype": "int64", "shape": [1]}
     inputs = {
         "request.input_ids": {
             "contract": token_contract,
@@ -9523,7 +9488,7 @@ def build_language_diffusion_pipeline_metadata(
             "max_iterations": "request.max_iterations",
             "iteration": {
                 "value": "loop.iteration",
-                "contract": {"dtype": "int64", "rank": 1, "shape": [1]},
+                "contract": {"dtype": "int64", "shape": [1]},
             },
             "carried": carried,
         },
@@ -9628,7 +9593,7 @@ def _audio_preprocess_component(
         },
         "ports": {
             "inputs": {
-                "encoded": {"dtype": "uint8", "rank": 1, "shape": ["bytes"]},
+                "encoded": {"dtype": "uint8", "shape": ["bytes"]},
             },
             "outputs": {
                 "input_values": values_contract,
@@ -9726,13 +9691,12 @@ def build_ctc_asr_workflow_metadata(
 
     values_contract = _contract(graph_inputs["input_values"])
     mask_contract = _contract(graph_inputs["attention_mask"])
-    logits_contract = _contract(graph_outputs["logits"])
-
     sample_rate = int(getattr(getattr(config, "audio", None), "sampling_rate", 0) or 16_000)
     # Shape inference may leave the class axis unknown (or the whole shape
     # absent), so fall back to the config rather than emitting a vocabulary
     # whose declared size silently disagrees with the graph.
-    logits_shape = logits_contract.get("shape") or []
+    logits_port = _port(graph_outputs["logits"])
+    logits_shape = _shape_metadata(logits_port) if logits_port.rank is not None else []
     inferred_classes = logits_shape[-1] if logits_shape else None
     vocab_size = int(inferred_classes or getattr(config, "vocab_size", 0) or 0)
     if vocab_size <= 0:
@@ -9740,6 +9704,19 @@ def build_ctc_asr_workflow_metadata(
             "CTC ASR metadata requires a vocabulary size; the 'logits' output "
             "declares no static class axis and the config has no vocab_size"
         )
+    if logits_shape:
+        logits_contract = _contract(graph_outputs["logits"])
+    else:
+        dtype = {
+            "fp16": "float16",
+            "bf16": "bfloat16",
+            "fp32": "float32",
+        }.get(logits_port.dtype, logits_port.dtype)
+        logits_contract = {
+            "dtype": dtype,
+            "shape": [values_contract["shape"][0], "Any", vocab_size],
+            "batch_layout": {"kind": "request_aligned", "axis": 0},
+        }
     blank_id = int(getattr(config, "pad_token_id", 0) or 0)
 
     workflow_outputs = {
@@ -9793,7 +9770,7 @@ def build_ctc_asr_workflow_metadata(
         },
         "inputs": {
             "request.audio": {
-                "contract": {"dtype": "uint8", "rank": 1, "shape": ["bytes"]},
+                "contract": {"dtype": "uint8", "shape": ["bytes"]},
                 "role": {"kind": "runtime", "version": "1.0", "role": "media"},
                 "source": {"kind": "request", "field": "media"},
                 "required": True,
@@ -9877,14 +9854,12 @@ def build_ctc_asr_workflow_metadata(
                         "source": "values",
                         "content": "waveform",
                         "dtype": values_contract["dtype"],
-                        "rank": values_contract["rank"],
                     },
                     {
                         "name": "attention_mask",
                         "source": "sample_mask",
                         "content": "validity_mask",
                         "dtype": mask_contract["dtype"],
-                        "rank": mask_contract["rank"],
                     },
                 ],
             }
@@ -10102,7 +10077,7 @@ def _stft_preprocess_component(
         },
         "ports": {
             "inputs": {
-                "encoded": {"dtype": "uint8", "rank": 1, "shape": ["bytes"]},
+                "encoded": {"dtype": "uint8", "shape": ["bytes"]},
             },
             "outputs": {
                 "noisy_mag": mag_contract,
@@ -10377,11 +10352,10 @@ def build_speech_enhancement_workflow_metadata(
     transforms = _stft_transforms(config)
     waveform_contract = {
         "dtype": "float32",
-        "rank": 2,
         "shape": ["batch", "audio_samples"],
     }
-    sample_rate_contract = {"dtype": "int64", "rank": 0, "shape": []}
-    lengths_contract = {"dtype": "int64", "rank": 1, "shape": ["batch"]}
+    sample_rate_contract = {"dtype": "int64", "shape": []}
+    lengths_contract = {"dtype": "int64", "shape": ["batch"]}
     geometry = _reuse_stft_geometry(config)
     if geometry is not None and geometry["mode"] != "native_scaled":
         expected_bins = geometry["n_fft"] // 2 + 1
@@ -10452,7 +10426,7 @@ def build_speech_enhancement_workflow_metadata(
         initial_effects["audio_postprocess"] = "audio_postprocess.0"
         workflow_inputs = {
             "request.audio": {
-                "contract": {"dtype": "uint8", "rank": 1, "shape": ["bytes"]},
+                "contract": {"dtype": "uint8", "shape": ["bytes"]},
                 "role": {"kind": "runtime", "version": "1.0", "role": "media"},
                 "source": {"kind": "request", "field": "media"},
                 "required": True,
@@ -10577,7 +10551,6 @@ def build_speech_enhancement_workflow_metadata(
                         "source": "magnitude",
                         "content": "features",
                         "dtype": mag_contract["dtype"],
-                        "rank": mag_contract["rank"],
                         "contract": mag_contract,
                     },
                     {
@@ -10585,7 +10558,6 @@ def build_speech_enhancement_workflow_metadata(
                         "source": "phase",
                         "content": "features",
                         "dtype": pha_contract["dtype"],
-                        "rank": pha_contract["rank"],
                         "contract": pha_contract,
                     },
                     {
@@ -10593,7 +10565,6 @@ def build_speech_enhancement_workflow_metadata(
                         "source": "samples",
                         "content": "waveform",
                         "dtype": waveform_contract["dtype"],
-                        "rank": waveform_contract["rank"],
                         "contract": waveform_contract,
                     },
                     {
@@ -10601,7 +10572,6 @@ def build_speech_enhancement_workflow_metadata(
                         "source": "sample_rate",
                         "content": "sample_rate",
                         "dtype": sample_rate_contract["dtype"],
-                        "rank": sample_rate_contract["rank"],
                         "contract": sample_rate_contract,
                     },
                     {
@@ -10609,7 +10579,6 @@ def build_speech_enhancement_workflow_metadata(
                         "source": "sample_lengths",
                         "content": "sample_lengths",
                         "dtype": lengths_contract["dtype"],
-                        "rank": lengths_contract["rank"],
                         "contract": lengths_contract,
                     },
                 ],
@@ -10746,7 +10715,6 @@ def build_full_duplex_workflow_metadata(pkg: Any, config: Any) -> dict[str, Any]
         if temporal_position is not None
         else {
             "dtype": "int64",
-            "rank": 2,
             "shape": [_contract(input_frame)["shape"][0], 1],
         }
     )
@@ -10784,28 +10752,25 @@ def build_full_duplex_workflow_metadata(pkg: Any, config: Any) -> dict[str, Any]
 
     batch = _contract(input_frame)["shape"][0]
     request_aligned = {"kind": "request_aligned", "axis": 0}
-    control_int = {"dtype": "int64", "rank": 0, "shape": []}
-    scalar_bool = {"dtype": "bool", "rank": 0, "shape": []}
+    control_int = {"dtype": "int64", "shape": []}
+    scalar_bool = {"dtype": "bool", "shape": []}
     batch_bool = {
         "dtype": "bool",
-        "rank": 1,
         "shape": [batch],
         "batch_layout": request_aligned,
     }
     batch_int = {
         "dtype": "int64",
-        "rank": 1,
         "shape": [batch],
         "batch_layout": request_aligned,
     }
-    loop_flag = {"dtype": "bool", "rank": 1, "shape": [1]}
-    frame_contract = {"dtype": "int64", "rank": 2, "shape": [batch, channels]}
+    loop_flag = {"dtype": "bool", "shape": [1]}
+    frame_contract = {"dtype": "int64", "shape": [batch, channels]}
     ring_contract = {
         "dtype": "int64",
-        "rank": 3,
         "shape": [batch, channels, cache_length],
     }
-    ring_flags = {"dtype": "bool", "rank": 3, "shape": [batch, channels, cache_length]}
+    ring_flags = {"dtype": "bool", "shape": [batch, channels, cache_length]}
 
     inputs: dict[str, Any] = {
         "request.audio_chunk": {
@@ -10815,7 +10780,7 @@ def build_full_duplex_workflow_metadata(pkg: Any, config: Any) -> dict[str, Any]
             "required": True,
         },
         "request.session_id": {
-            "contract": {"dtype": "int64", "rank": 1, "shape": [batch]},
+            "contract": {"dtype": "int64", "shape": [batch]},
             "role": {"kind": "runtime", "version": "1.0", "role": "session_id"},
             "source": {"kind": "request", "field": "session_id"},
             "required": True,
@@ -10867,14 +10832,14 @@ def build_full_duplex_workflow_metadata(pkg: Any, config: Any) -> dict[str, Any]
             "default": 1,
         },
         "package.delays": {
-            "contract": {"dtype": "int64", "rank": 1, "shape": [channels]},
+            "contract": {"dtype": "int64", "shape": [channels]},
             "role": {"kind": "opaque"},
             "source": {"kind": "literal"},
             "required": False,
             "default": delays,
         },
         "package.initial_tokens": {
-            "contract": {"dtype": "int64", "rank": 1, "shape": [channels]},
+            "contract": {"dtype": "int64", "shape": [channels]},
             "role": {"kind": "opaque"},
             "source": {"kind": "literal"},
             "required": False,
@@ -10937,7 +10902,6 @@ def build_full_duplex_workflow_metadata(pkg: Any, config: Any) -> dict[str, Any]
         "attention_mask": session_cell(
             {
                 "dtype": _contract(temporal_mask)["dtype"],
-                "rank": 2,
                 "shape": [batch, "context"],
             },
             "package.attention_mask_init",
@@ -10954,7 +10918,6 @@ def build_full_duplex_workflow_metadata(pkg: Any, config: Any) -> dict[str, Any]
         "user_waveform": session_cell(
             {
                 "dtype": _contract(waveform_input)["dtype"],
-                "rank": 3,
                 "shape": [batch, 1, "user_samples"],
             },
             "package.user_waveform_init",
@@ -10969,7 +10932,6 @@ def build_full_duplex_workflow_metadata(pkg: Any, config: Any) -> dict[str, Any]
         "agent_codes": session_cell(
             {
                 "dtype": _contract(codes_input)["dtype"],
-                "rank": 3,
                 "shape": [batch, audio_streams, "agent_frames"],
             },
             "package.agent_codes_init",
@@ -11110,7 +11072,7 @@ def build_full_duplex_workflow_metadata(pkg: Any, config: Any) -> dict[str, Any]
         "recurrence": invariant,
     }
     state["prev_token"] = {
-        "contract": {"dtype": "int64", "rank": 1, "shape": [batch]},
+        "contract": {"dtype": "int64", "shape": [batch]},
         "scope": "invocation",
         "initializer": "duplex.text_token",
         "recurrence": invariant,

--- a/src/mobius/integrations/onnx_genai/workflow_metadata_test.py
+++ b/src/mobius/integrations/onnx_genai/workflow_metadata_test.py
@@ -59,8 +59,7 @@ def test_speculative_emit_uses_accepted_prefix_length():
     assert emit["valid_length"] == "acceptance.length"
     # Row identity is runtime-private: the published emit step must not name it.
     assert "row_ids" not in emit
-    assert "emit_valid_length" in workflow["manifest"]["capabilities"]
-    assert "emit_row_identity" not in workflow["manifest"]["capabilities"]
+    assert "capabilities" not in workflow["manifest"]
     assert not any("slot_ids" in name for name in workflow["inputs"])
     assert workflow["outputs"]["tokens"]["contract"]["shape"][-1] == "accepted_sequence"
     assert workflow["state"]["cache_0"]["recurrence"] == {
@@ -289,13 +288,11 @@ def test_vlm_writer_derives_real_decoder_contract_from_artifact(tmp_path):
     assert metadata["package"]["tokenizer"]["special_tokens"]["eos_token_id"] == [200001]
     assert workflow["state"]["cache_103"]["contract"] == {
         "dtype": "bfloat16",
-        "rank": 4,
         "shape": ["batch", 2, "past_sequence", 128],
         "batch_layout": {"kind": "request_aligned", "axis": 0},
     }
     assert workflow["state"]["logits"]["contract"] == {
         "dtype": "float32",
-        "rank": 2,
         "shape": ["batch", 202048],
         "batch_layout": {"kind": "request_aligned", "axis": 0},
     }
@@ -316,7 +313,6 @@ def test_vlm_writer_derives_real_decoder_contract_from_artifact(tmp_path):
     assert workflow["inputs"]["request.max_iterations"]["contract"]["shape"] == [1]
     assert workflow["steps"][0]["iteration"]["contract"] == {
         "dtype": "int64",
-        "rank": 1,
         "shape": [1],
     }
     assert workflow["inputs"]["package.one"]["contract"]["shape"] == ["batch"]
@@ -351,7 +347,7 @@ def test_vlm_writer_derives_real_decoder_contract_from_artifact(tmp_path):
     assert emit["when"] == "active"
     assert emit["valid_length"] == "token.emitted_length"
     assert "row_ids" not in emit
-    assert "emit_row_identity" not in workflow["manifest"]["capabilities"]
+    assert "capabilities" not in workflow["manifest"]
     assert policy_invokes["decoder_step_update"]["inputs"]["logical_length"] == "cache_lengths"
     assert workflow["state"]["attention_mask"]["initializer"] == ("initializer.attention_mask")
     assert any(
@@ -361,7 +357,7 @@ def test_vlm_writer_derives_real_decoder_contract_from_artifact(tmp_path):
     assert workflow["inputs"]["request.image"]["required"] is False
     assert workflow["inputs"]["request.image"]["present_as"] == "request.image_present"
     assert "request.has_media" not in workflow["inputs"]
-    assert "input_presence" in workflow["manifest"]["capabilities"]
+    assert "capabilities" not in workflow["manifest"]
     assert workflow["steps"][0]["termination"] == "generation_eos"
     media_branch = workflow["steps"][0]["setup"][0]
     assert media_branch["kind"] == "branch"
@@ -569,10 +565,10 @@ def test_video_diffusion_keeps_the_temporal_axis_through_every_stage():
 
     published = workflow["outputs"]["video"]
     assert published["role"] == "video"
-    assert published["contract"]["rank"] == 5
+    assert len(published["contract"]["shape"]) == 5
 
     latent = workflow["state"]["latent"]
-    assert latent["contract"]["rank"] == 5
+    assert len(latent["contract"]["shape"]) == 5
     assert latent["contract"]["shape"][1] == "num_frames"
 
     # The scheduler trajectory is state, not telemetry: a multistep video solver
@@ -601,7 +597,7 @@ def test_video_diffusion_keeps_the_temporal_axis_through_every_stage():
     assert emit["mode"] == "append"
     assert emit["axis"] == 2
 
-    assert "bounded_state_recurrence" in workflow["manifest"]["capabilities"]
+    assert "capabilities" not in workflow["manifest"]
 
 
 def test_video_diffusion_rejects_an_image_latent():

--- a/src/mobius/models/sensenova_u1_test.py
+++ b/src/mobius/models/sensenova_u1_test.py
@@ -513,7 +513,7 @@ class TestInferenceMetadataStatus:
             package, config, num_inference_steps=2
         )
         workflow = metadata["pipeline"]["workflow"]
-        assert "linear_effects" in workflow["manifest"]["capabilities"]
+        assert "capabilities" not in workflow["manifest"]
         assert set(workflow["components"]) >= {
             "embedding",
             "vision_encoder",

--- a/tests/canonical_workflow_contract_test.py
+++ b/tests/canonical_workflow_contract_test.py
@@ -299,7 +299,8 @@ class TestOneSerializedContract:
             ports = component["ports"]
             assert ports["inputs"] or ports["outputs"]
             for contract in (*ports["inputs"].values(), *ports["outputs"].values()):
-                assert contract["rank"] == len(contract["shape"])
+                assert "rank" not in contract
+                assert isinstance(contract["shape"], list)
 
     def test_every_declared_role_names_a_port_the_graph_exposes(self, package):
         """A role is only meaningful if it resolves in the artifact.

--- a/tests/compare_onnx_genai_validation_packages.py
+++ b/tests/compare_onnx_genai_validation_packages.py
@@ -102,6 +102,8 @@ def _metadata_invariant_errors(root: Path) -> list[str]:
 
     def retired_fields(value: Any, path: str) -> None:
         if isinstance(value, dict):
+            if "dtype" in value and "shape" in value and "rank" in value:
+                errors.append(f"{path}.rank: retired tensor-contract field")
             for key, nested in value.items():
                 field_path = f"{path}.{key}" if path else str(key)
                 if key in _RETIRED_INFERENCE_METADATA_FIELDS:

--- a/tests/fixtures/onnx_genai_workflows/adapter/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/adapter/inference_metadata.yaml
@@ -4,16 +4,10 @@ pipeline:
     manifest:
       adapter_abis:
         onnx-genai.parameter-overlay: '1'
-      capabilities:
-      - workflow_ssa
-      - typed_emit
-      - parameter_adapters
-      - heterogeneous_adapter_batching
     inputs:
       request.active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -29,7 +23,6 @@ pipeline:
       activations:
         contract:
           dtype: float32
-          rank: 2
           shape:
           - batch
           - 2
@@ -45,7 +38,6 @@ pipeline:
       request.adapter_segments:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - 2
@@ -62,7 +54,6 @@ pipeline:
       request.adapter_counts:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -78,7 +69,6 @@ pipeline:
       request.adapter_scales:
         contract:
           dtype: float32
-          rank: 2
           shape:
           - batch
           - 2
@@ -96,7 +86,6 @@ pipeline:
       result:
         contract:
           dtype: float32
-          rank: 2
           shape:
           - batch
           - 2
@@ -120,7 +109,6 @@ pipeline:
           inputs:
             input:
               dtype: float32
-              rank: 2
               shape:
               - batch
               - 2
@@ -130,7 +118,6 @@ pipeline:
           outputs:
             output:
               dtype: float32
-              rank: 2
               shape:
               - batch
               - 2

--- a/tests/fixtures/onnx_genai_workflows/codec/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/codec/inference_metadata.yaml
@@ -1,16 +1,11 @@
 schema_version: v1
 pipeline:
   workflow:
-    manifest:
-      capabilities:
-      - workflow_ssa
-      - linear_effects
-      - typed_emit
+    manifest: {}
     inputs:
       request.waveform:
         contract:
           dtype: float32
-          rank: 3
           shape:
           - batch
           - 1
@@ -29,7 +24,6 @@ pipeline:
       waveform:
         contract:
           dtype: float32
-          rank: 3
           shape:
           - batch
           - 1

--- a/tests/fixtures/onnx_genai_workflows/decoder/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/decoder/inference_metadata.yaml
@@ -1,21 +1,11 @@
 schema_version: v1.2
 pipeline:
   workflow:
-    manifest:
-      capabilities:
-      - workflow_ssa
-      - linear_effects
-      - nested_control_flow
-      - typed_emit
-      - emit_valid_length
-      - loop_induction_values
-      - serving_service_contract
-      - bounded_state_recurrence
+    manifest: {}
     inputs:
       request.input_ids:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - sequence
@@ -32,7 +22,6 @@ pipeline:
       request.max_iterations:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -45,7 +34,6 @@ pipeline:
       package.one_token:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -60,7 +48,6 @@ pipeline:
       package.one_step:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -72,7 +59,6 @@ pipeline:
       package.max_context:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -84,7 +70,6 @@ pipeline:
       request.prompt_lengths:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -100,7 +85,6 @@ pipeline:
       request.eos_ids:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - num_eos
@@ -117,7 +101,6 @@ pipeline:
       request.eos_lengths:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -133,7 +116,6 @@ pipeline:
       request.row_max_iterations:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -149,7 +131,6 @@ pipeline:
       request.temperature:
         contract:
           dtype: float32
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -166,7 +147,6 @@ pipeline:
       request.top_k:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -183,7 +163,6 @@ pipeline:
       request.top_p:
         contract:
           dtype: float32
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -200,7 +179,6 @@ pipeline:
       request.min_p:
         contract:
           dtype: float32
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -217,7 +195,6 @@ pipeline:
       request.seed:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -234,7 +211,6 @@ pipeline:
       request.rng_counter:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -250,7 +226,6 @@ pipeline:
       package.active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -265,7 +240,6 @@ pipeline:
       package.not_done:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -280,7 +254,6 @@ pipeline:
       package.cache_lengths:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -295,7 +268,6 @@ pipeline:
       package.zero_batch:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -311,7 +283,6 @@ pipeline:
       tokens:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - generated_sequence
@@ -340,7 +311,6 @@ pipeline:
           inputs:
             logits:
               dtype: float32
-              rank: 2
               shape:
               - batch
               - vocabulary
@@ -349,7 +319,6 @@ pipeline:
                 axis: 0
             temperature:
               dtype: float32
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -357,7 +326,6 @@ pipeline:
                 axis: 0
             top_k:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -365,7 +333,6 @@ pipeline:
                 axis: 0
             top_p:
               dtype: float32
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -373,7 +340,6 @@ pipeline:
                 axis: 0
             min_p:
               dtype: float32
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -381,7 +347,6 @@ pipeline:
                 axis: 0
             seed:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -389,7 +354,6 @@ pipeline:
                 axis: 0
             counter:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -397,7 +361,6 @@ pipeline:
                 axis: 0
             active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -405,7 +368,6 @@ pipeline:
                 axis: 0
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -414,7 +376,6 @@ pipeline:
           outputs:
             token:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -422,7 +383,6 @@ pipeline:
                 axis: 0
             next_counter:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -459,7 +419,6 @@ pipeline:
           inputs:
             tokens:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -467,7 +426,6 @@ pipeline:
                 axis: 0
             eos_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - num_eos
@@ -476,7 +434,6 @@ pipeline:
                 axis: 0
             eos_lengths:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -484,12 +441,10 @@ pipeline:
                 axis: 0
             iteration:
               dtype: int64
-              rank: 1
               shape:
               - 1
             max_iterations:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -497,7 +452,6 @@ pipeline:
                 axis: 0
             active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -506,7 +460,6 @@ pipeline:
           outputs:
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -514,7 +467,6 @@ pipeline:
                 axis: 0
             next_active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -522,7 +474,6 @@ pipeline:
                 axis: 0
             continue:
               dtype: bool
-              rank: 1
               shape:
               - 1
         contract:
@@ -552,7 +503,6 @@ pipeline:
           inputs:
             current:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -561,7 +511,6 @@ pipeline:
                 axis: 0
             update:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -570,7 +519,6 @@ pipeline:
                 axis: 0
             active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -578,7 +526,6 @@ pipeline:
                 axis: 0
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -587,7 +534,6 @@ pipeline:
           outputs:
             next:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -615,7 +561,6 @@ pipeline:
           inputs:
             logits:
               dtype: float32
-              rank: 3
               shape:
               - batch
               - sequence
@@ -626,7 +571,6 @@ pipeline:
           outputs:
             last_logits:
               dtype: float32
-              rank: 2
               shape:
               - batch
               - vocabulary
@@ -645,7 +589,6 @@ pipeline:
           inputs:
             prompt_tokens:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - prompt_sequence
@@ -654,7 +597,6 @@ pipeline:
                 axis: 0
             prompt_lengths:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -663,7 +605,6 @@ pipeline:
           outputs:
             attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - total_sequence
@@ -672,7 +613,6 @@ pipeline:
                 axis: 0
             position_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - prompt_sequence
@@ -681,7 +621,6 @@ pipeline:
                 axis: 0
             body_attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - prompt_sequence + 1
@@ -690,7 +629,6 @@ pipeline:
                 axis: 0
             body_position_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -699,7 +637,6 @@ pipeline:
                 axis: 0
             token_slot:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -708,7 +645,6 @@ pipeline:
                 axis: 0
             generated_lengths:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -716,7 +652,6 @@ pipeline:
                 axis: 0
             past_key_values.0.key:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - 2
@@ -727,7 +662,6 @@ pipeline:
                 axis: 0
             past_key_values.0.value:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - 4
@@ -747,7 +681,6 @@ pipeline:
           inputs:
             attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - context
@@ -756,7 +689,6 @@ pipeline:
                 axis: 0
             position_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -766,7 +698,6 @@ pipeline:
           outputs:
             next_attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - context + 1
@@ -775,7 +706,6 @@ pipeline:
                 axis: 0
             next_position_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -793,7 +723,6 @@ pipeline:
           inputs:
             left:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -801,7 +730,6 @@ pipeline:
                 axis: 0
             right:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -809,7 +737,6 @@ pipeline:
                 axis: 0
             active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -817,7 +744,6 @@ pipeline:
                 axis: 0
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -826,7 +752,6 @@ pipeline:
           outputs:
             total:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -841,7 +766,6 @@ pipeline:
           inputs:
             input_eos_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - num_eos
@@ -850,7 +774,6 @@ pipeline:
                 axis: 0
             input_eos_lengths:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -858,7 +781,6 @@ pipeline:
                 axis: 0
             input_max_iterations:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -866,12 +788,10 @@ pipeline:
                 axis: 0
             fallback_max_iterations:
               dtype: int64
-              rank: 1
               shape:
               - 1
             active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -880,7 +800,6 @@ pipeline:
           outputs:
             row_eos_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - num_eos
@@ -889,7 +808,6 @@ pipeline:
                 axis: 0
             eos_lengths:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -897,7 +815,6 @@ pipeline:
                 axis: 0
             max_iterations:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -914,7 +831,6 @@ pipeline:
           inputs:
             token:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -923,7 +839,6 @@ pipeline:
           outputs:
             slot:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -939,7 +854,6 @@ pipeline:
           inputs:
             left:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -947,7 +861,6 @@ pipeline:
                 axis: 0
             right:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -955,7 +868,6 @@ pipeline:
                 axis: 0
             active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -963,7 +875,6 @@ pipeline:
                 axis: 0
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -972,7 +883,6 @@ pipeline:
           outputs:
             total:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -983,7 +893,6 @@ pipeline:
       token:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - 1
@@ -997,7 +906,6 @@ pipeline:
       logits:
         contract:
           dtype: float32
-          rank: 2
           shape:
           - batch
           - 128
@@ -1011,7 +919,6 @@ pipeline:
       generated_lengths:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1025,7 +932,6 @@ pipeline:
       active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1039,7 +945,6 @@ pipeline:
       done:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1053,7 +958,6 @@ pipeline:
       accepted_len:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1067,7 +971,6 @@ pipeline:
       cache_lengths:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1081,7 +984,6 @@ pipeline:
       rng_counter:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1095,7 +997,6 @@ pipeline:
       attention_mask:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - context
@@ -1112,7 +1013,6 @@ pipeline:
       position_ids:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - 1
@@ -1126,7 +1026,6 @@ pipeline:
       cache_0:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 2
@@ -1147,7 +1046,6 @@ pipeline:
       cache_1:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 4
@@ -1382,7 +1280,6 @@ pipeline:
         value: loop.iteration
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
 package:

--- a/tests/fixtures/onnx_genai_workflows/diffusion/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/diffusion/inference_metadata.yaml
@@ -1,18 +1,11 @@
 schema_version: v1.1
 pipeline:
   workflow:
-    manifest:
-      capabilities:
-      - workflow_ssa
-      - linear_effects
-      - nested_control_flow
-      - loop_induction_values
-      - typed_emit
+    manifest: {}
     inputs:
       request.max_iterations:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -26,7 +19,6 @@ pipeline:
       package.false:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -41,7 +33,6 @@ pipeline:
       request.noise:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 4
@@ -60,7 +51,6 @@ pipeline:
       request.input_ids:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - prompt_sequence
@@ -78,7 +68,6 @@ pipeline:
       package.loop_0_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         role:
@@ -91,7 +80,6 @@ pipeline:
       image:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 3
@@ -106,7 +94,6 @@ pipeline:
       latent:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 4
@@ -120,7 +107,6 @@ pipeline:
       noise_estimate:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 4
@@ -134,7 +120,6 @@ pipeline:
       latent_trajectory:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 4
@@ -176,7 +161,6 @@ pipeline:
           inputs:
             sample:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -187,7 +171,6 @@ pipeline:
                 axis: 0
             derivative:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -198,7 +181,6 @@ pipeline:
                 axis: 0
             step:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -206,13 +188,11 @@ pipeline:
                 axis: 0
             schedule:
               dtype: float32
-              rank: 1
               shape:
               - schedule_length
           outputs:
             next_state:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -244,7 +224,6 @@ pipeline:
           inputs:
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -253,7 +232,6 @@ pipeline:
           outputs:
             continue:
               dtype: bool
-              rank: 1
               shape:
               - 1
         batch_capacity: {}
@@ -265,7 +243,6 @@ pipeline:
           inputs:
             sample:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -276,7 +253,6 @@ pipeline:
                 axis: 0
             step:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -284,13 +260,11 @@ pipeline:
                 axis: 0
             schedule:
               dtype: float32
-              rank: 1
               shape:
               - schedule_length
           outputs:
             model_input:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -314,7 +288,6 @@ pipeline:
           outputs:
             schedule:
               dtype: float32
-              rank: 1
               shape:
               - 31
         batch_capacity: {}
@@ -327,7 +300,6 @@ pipeline:
           outputs:
             schedule:
               dtype: float32
-              rank: 1
               shape:
               - 30
         batch_capacity: {}
@@ -339,12 +311,10 @@ pipeline:
           inputs:
             schedule:
               dtype: float32
-              rank: 1
               shape:
               - schedule_length
             step:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -353,7 +323,6 @@ pipeline:
           outputs:
             timestep:
               dtype: float32
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -370,7 +339,6 @@ pipeline:
           inputs:
             tensor:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -381,13 +349,11 @@ pipeline:
                 axis: 0
             scale:
               dtype: float32
-              rank: 1
               shape:
               - 1
           outputs:
             scaled:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -410,7 +376,6 @@ pipeline:
           outputs:
             value:
               dtype: float32
-              rank: 1
               shape:
               - 1
         batch_capacity: {}
@@ -422,7 +387,6 @@ pipeline:
           inputs:
             tensor:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - axis_1
@@ -434,7 +398,6 @@ pipeline:
           outputs:
             clamped:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - axis_1
@@ -452,7 +415,6 @@ pipeline:
       latent_state:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 4
@@ -468,7 +430,6 @@ pipeline:
       loop_0_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         scope: invocation
@@ -572,7 +533,6 @@ pipeline:
         value: loop.iteration
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:

--- a/tests/fixtures/onnx_genai_workflows/diffusion_guided/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/diffusion_guided/inference_metadata.yaml
@@ -1,18 +1,11 @@
 schema_version: v1.1
 pipeline:
   workflow:
-    manifest:
-      capabilities:
-      - workflow_ssa
-      - linear_effects
-      - nested_control_flow
-      - loop_induction_values
-      - typed_emit
+    manifest: {}
     inputs:
       request.max_iterations:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -26,7 +19,6 @@ pipeline:
       package.false:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -41,7 +33,6 @@ pipeline:
       request.seed:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -59,7 +50,6 @@ pipeline:
       package.rng_offset:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -74,7 +64,6 @@ pipeline:
       request.input_ids:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - prompt_sequence
@@ -92,7 +81,6 @@ pipeline:
       request.negative_input_ids:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - prompt_sequence
@@ -110,7 +98,6 @@ pipeline:
       request.guidance_scale:
         contract:
           dtype: float32
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -127,7 +114,6 @@ pipeline:
       package.loop_0_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         role:
@@ -140,7 +126,6 @@ pipeline:
       image:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 3
@@ -155,7 +140,6 @@ pipeline:
       latent:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 4
@@ -169,7 +153,6 @@ pipeline:
       noise_estimate:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 4
@@ -183,7 +166,6 @@ pipeline:
       latent_trajectory:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 4
@@ -197,7 +179,6 @@ pipeline:
       rng_offset:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -236,7 +217,6 @@ pipeline:
           inputs:
             sample:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -247,7 +227,6 @@ pipeline:
                 axis: 0
             estimate:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -258,7 +237,6 @@ pipeline:
                 axis: 0
             history:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -269,7 +247,6 @@ pipeline:
                 axis: 0
             step:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -277,13 +254,11 @@ pipeline:
                 axis: 0
             schedule:
               dtype: float32
-              rank: 1
               shape:
               - schedule_length
           outputs:
             next_state:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -294,7 +269,6 @@ pipeline:
                 axis: 0
             next_history:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -328,7 +302,6 @@ pipeline:
           inputs:
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -337,7 +310,6 @@ pipeline:
           outputs:
             continue:
               dtype: bool
-              rank: 1
               shape:
               - 1
         batch_capacity: {}
@@ -350,7 +322,6 @@ pipeline:
           outputs:
             schedule:
               dtype: float32
-              rank: 1
               shape:
               - 4
         batch_capacity: {}
@@ -363,7 +334,6 @@ pipeline:
           outputs:
             schedule:
               dtype: float32
-              rank: 1
               shape:
               - 3
         batch_capacity: {}
@@ -375,12 +345,10 @@ pipeline:
           inputs:
             schedule:
               dtype: float32
-              rank: 1
               shape:
               - schedule_length
             step:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -389,7 +357,6 @@ pipeline:
           outputs:
             timestep:
               dtype: float32
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -406,7 +373,6 @@ pipeline:
           inputs:
             tensor:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -417,13 +383,11 @@ pipeline:
                 axis: 0
             scale:
               dtype: float32
-              rank: 1
               shape:
               - 1
           outputs:
             scaled:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -446,7 +410,6 @@ pipeline:
           outputs:
             value:
               dtype: float32
-              rank: 1
               shape:
               - 1
         batch_capacity: {}
@@ -458,7 +421,6 @@ pipeline:
           inputs:
             reference:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -470,7 +432,6 @@ pipeline:
           outputs:
             zeros:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -492,7 +453,6 @@ pipeline:
           inputs:
             unconditional:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -503,7 +463,6 @@ pipeline:
                 axis: 0
             conditional:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -514,7 +473,6 @@ pipeline:
                 axis: 0
             scale:
               dtype: float32
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -523,7 +481,6 @@ pipeline:
           outputs:
             estimate:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -553,7 +510,6 @@ pipeline:
           inputs:
             tensor:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - axis_1
@@ -565,7 +521,6 @@ pipeline:
           outputs:
             clamped:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - axis_1
@@ -588,7 +543,6 @@ pipeline:
           outputs:
             shape:
               dtype: int64
-              rank: 1
               shape:
               - 3
         batch_capacity: {}
@@ -600,7 +554,6 @@ pipeline:
           inputs:
             seed:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -608,7 +561,6 @@ pipeline:
                 axis: 0
             offset:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -616,13 +568,11 @@ pipeline:
                 axis: 0
             row_shape:
               dtype: int64
-              rank: 1
               shape:
               - 3
           outputs:
             noise:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -633,7 +583,6 @@ pipeline:
                 axis: 0
             next_offset:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -653,7 +602,6 @@ pipeline:
       latent_state:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 4
@@ -669,7 +617,6 @@ pipeline:
       history:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 4
@@ -685,7 +632,6 @@ pipeline:
       loop_0_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         scope: invocation
@@ -820,7 +766,6 @@ pipeline:
         value: loop.iteration
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:

--- a/tests/fixtures/onnx_genai_workflows/esm2_protein_embeddings/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/esm2_protein_embeddings/inference_metadata.yaml
@@ -12,11 +12,7 @@ profiles:
       normalize: false
 pipeline:
   workflow:
-    manifest:
-      capabilities:
-      - workflow_ssa
-      - linear_effects
-      - typed_emit
+    manifest: {}
     effects:
       encode:
         retry: pure
@@ -26,7 +22,6 @@ pipeline:
       request.input_ids:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - sequence_len
@@ -43,7 +38,6 @@ pipeline:
       request.attention_mask:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - sequence_len
@@ -60,7 +54,6 @@ pipeline:
       last_hidden_state:
         contract:
           dtype: float32
-          rank: 3
           shape:
           - batch
           - sequence_len

--- a/tests/fixtures/onnx_genai_workflows/hierarchical_audio/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/hierarchical_audio/inference_metadata.yaml
@@ -4,19 +4,10 @@ pipeline:
     manifest:
       adapter_abis:
         onnx-genai.text-assembly: '1'
-      capabilities:
-      - workflow_ssa
-      - nested_control_flow
-      - loop_induction_values
-      - loop_carried_state
-      - typed_emit
-      - serving_service_contract
-      - bounded_state_recurrence
     inputs:
       request.prompt_tokens:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - sequence_length
@@ -34,7 +25,6 @@ pipeline:
       request.max_frames_with_warmup:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -47,7 +37,6 @@ pipeline:
       request.seed:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -64,7 +53,6 @@ pipeline:
       package.temperature:
         contract:
           dtype: float32
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -79,7 +67,6 @@ pipeline:
       package.top_k:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -94,7 +81,6 @@ pipeline:
       package.top_p:
         contract:
           dtype: float32
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -109,7 +95,6 @@ pipeline:
       package.min_p:
         contract:
           dtype: float32
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -124,7 +109,6 @@ pipeline:
       package.one:
         contract:
           dtype: int64
-          rank: 0
           shape: []
         role:
           kind: opaque
@@ -135,7 +119,6 @@ pipeline:
       package.one_batch:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -150,7 +133,6 @@ pipeline:
       package.local_steps:
         contract:
           dtype: int64
-          rank: 0
           shape: []
         role:
           kind: opaque
@@ -161,7 +143,6 @@ pipeline:
       package.local_context:
         contract:
           dtype: int64
-          rank: 0
           shape: []
         role:
           kind: opaque
@@ -172,7 +153,6 @@ pipeline:
       package.global_context:
         contract:
           dtype: int64
-          rank: 0
           shape: []
         role:
           kind: opaque
@@ -183,7 +163,6 @@ pipeline:
       package.carry_length:
         contract:
           dtype: int64
-          rank: 0
           shape: []
         role:
           kind: opaque
@@ -194,7 +173,6 @@ pipeline:
       package.max_waveform_samples:
         contract:
           dtype: int64
-          rank: 0
           shape: []
         role:
           kind: opaque
@@ -205,7 +183,6 @@ pipeline:
       package.flow_steps:
         contract:
           dtype: int64
-          rank: 0
           shape: []
         role:
           kind: opaque
@@ -216,7 +193,6 @@ pipeline:
       package.flow_rng_offset:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -231,7 +207,6 @@ pipeline:
       package.loop_1_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         role:
@@ -243,7 +218,6 @@ pipeline:
       package.loop_0_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         role:
@@ -255,7 +229,6 @@ pipeline:
       package.loop_3_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         role:
@@ -267,7 +240,6 @@ pipeline:
       package.loop_2_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         role:
@@ -280,7 +252,6 @@ pipeline:
       audio:
         contract:
           dtype: float32
-          rank: 3
           shape:
           - batch
           - 2
@@ -379,7 +350,6 @@ pipeline:
           inputs:
             prompt_tokens:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - prompt_sequence
@@ -390,7 +360,6 @@ pipeline:
           outputs:
             attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - past_sequence_length + sequence_length
@@ -400,7 +369,6 @@ pipeline:
                 factor: 2
             position_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - prompt_sequence
@@ -410,7 +378,6 @@ pipeline:
                 factor: 2
             body_attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - prompt_sequence + 1
@@ -420,7 +387,6 @@ pipeline:
                 factor: 2
             body_position_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -430,7 +396,6 @@ pipeline:
                 factor: 2
             token_slot:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -440,7 +405,6 @@ pipeline:
                 factor: 2
             past_key_values.0.key:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - 1
@@ -452,7 +416,6 @@ pipeline:
                 factor: 2
             past_key_values.0.value:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - 1
@@ -470,7 +433,6 @@ pipeline:
           inputs:
             attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - context
@@ -480,7 +442,6 @@ pipeline:
                 factor: 2
             position_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -491,7 +452,6 @@ pipeline:
           outputs:
             next_attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - context + 1
@@ -501,7 +461,6 @@ pipeline:
                 factor: 2
             next_position_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -518,14 +477,12 @@ pipeline:
           outputs:
             frame_history:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - 0
               - 64
             rng_counter:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -533,7 +490,6 @@ pipeline:
                 axis: 0
             active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -541,7 +497,6 @@ pipeline:
                 axis: 0
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -555,7 +510,6 @@ pipeline:
           inputs:
             left:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -563,7 +517,6 @@ pipeline:
                 axis: 0
             right:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -572,7 +525,6 @@ pipeline:
           outputs:
             total:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -586,7 +538,6 @@ pipeline:
           inputs:
             logits:
               dtype: float32
-              rank: 3
               shape:
               - 2
               - sequence
@@ -594,7 +545,6 @@ pipeline:
           outputs:
             candidate_logits:
               dtype: float32
-              rank: 2
               shape:
               - 1
               - 16385
@@ -606,7 +556,6 @@ pipeline:
           inputs:
             logits:
               dtype: float32
-              rank: 2
               shape:
               - batch
               - vocabulary
@@ -615,7 +564,6 @@ pipeline:
                 axis: 0
             temperature:
               dtype: float32
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -623,7 +571,6 @@ pipeline:
                 axis: 0
             top_k:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -631,7 +578,6 @@ pipeline:
                 axis: 0
             top_p:
               dtype: float32
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -639,7 +585,6 @@ pipeline:
                 axis: 0
             min_p:
               dtype: float32
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -647,7 +592,6 @@ pipeline:
                 axis: 0
             seed:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -655,7 +599,6 @@ pipeline:
                 axis: 0
             counter:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -663,7 +606,6 @@ pipeline:
                 axis: 0
             active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -671,7 +613,6 @@ pipeline:
                 axis: 0
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -680,7 +621,6 @@ pipeline:
           outputs:
             token:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -688,7 +628,6 @@ pipeline:
                 axis: 0
             next_counter:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -722,30 +661,25 @@ pipeline:
           inputs:
             candidate:
               dtype: int64
-              rank: 1
               shape:
               - 1
           outputs:
             token:
               dtype: int64
-              rank: 1
               shape:
               - 1
             semantic_code:
               dtype: int64
-              rank: 2
               shape:
               - 2
               - 1
             semantic_token:
               dtype: int64
-              rank: 2
               shape:
               - 2
               - 1
             is_stop:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -759,7 +693,6 @@ pipeline:
           inputs:
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -768,7 +701,6 @@ pipeline:
           outputs:
             continue:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -782,7 +714,6 @@ pipeline:
           inputs:
             value:
               dtype: float32
-              rank: 3
               shape:
               - 2
               - sequence
@@ -790,7 +721,6 @@ pipeline:
           outputs:
             last:
               dtype: float32
-              rank: 3
               shape:
               - 2
               - 1
@@ -803,14 +733,12 @@ pipeline:
           inputs:
             global_hidden:
               dtype: float32
-              rank: 3
               shape:
               - 2
               - 1
               - 8
             semantic_embedding:
               dtype: float32
-              rank: 3
               shape:
               - 2
               - 1
@@ -818,20 +746,17 @@ pipeline:
           outputs:
             sequence:
               dtype: float32
-              rank: 3
               shape:
               - 2
               - sequence
               - 8
             acoustic_codes:
               dtype: int64
-              rank: 2
               shape:
               - 2
               - codes
             local_hidden_parts:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - parts
@@ -844,16 +769,13 @@ pipeline:
           inputs:
             left:
               dtype: int64
-              rank: 0
               shape: []
             right:
               dtype: int64
-              rank: 0
               shape: []
           outputs:
             total:
               dtype: int64
-              rank: 0
               shape: []
       local_logits:
         implementation:
@@ -863,7 +785,6 @@ pipeline:
           inputs:
             all_codebook_logits:
               dtype: float32
-              rank: 4
               shape:
               - codebooks
               - 2
@@ -871,12 +792,10 @@ pipeline:
               - vocabulary
             codebook_index:
               dtype: int64
-              rank: 0
               shape: []
           outputs:
             logits:
               dtype: float32
-              rank: 2
               shape:
               - 1
               - vocabulary
@@ -888,17 +807,14 @@ pipeline:
           inputs:
             token:
               dtype: int64
-              rank: 1
               shape:
               - 1
             codebook_index:
               dtype: int64
-              rank: 0
               shape: []
           outputs:
             embedding_ids:
               dtype: int64
-              rank: 2
               shape:
               - 2
               - 1
@@ -910,39 +826,33 @@ pipeline:
           inputs:
             sequence:
               dtype: float32
-              rank: 3
               shape:
               - 2
               - sequence
               - 8
             projected_embedding:
               dtype: float32
-              rank: 3
               shape:
               - 2
               - 1
               - 8
             acoustic_codes:
               dtype: int64
-              rank: 2
               shape:
               - 2
               - codes
             token:
               dtype: int64
-              rank: 1
               shape:
               - 1
             hidden_states:
               dtype: float32
-              rank: 3
               shape:
               - 2
               - sequence
               - 8
             local_hidden_parts:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - parts
@@ -950,23 +860,20 @@ pipeline:
           outputs:
             next_sequence:
               dtype: float32
-              rank: 3
               shape:
               - 2
-              - next_sequence_dim_1
+              - Any
               - 8
             next_acoustic_codes:
               dtype: int64
-              rank: 2
               shape:
               - 2
-              - next_acoustic_codes_dim_1
+              - Any
             next_local_hidden_parts:
               dtype: float32
-              rank: 3
               shape:
               - 1
-              - next_local_hidden_parts_dim_1
+              - Any
               - 8
       frame_append:
         implementation:
@@ -976,21 +883,18 @@ pipeline:
           inputs:
             history:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - frames
               - 64
             global_hidden:
               dtype: float32
-              rank: 3
               shape:
               - 2
               - 1
               - 8
             local_hidden_parts:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - 7
@@ -998,10 +902,9 @@ pipeline:
           outputs:
             next_history:
               dtype: float32
-              rank: 3
               shape:
               - 1
-              - next_history_dim_1
+              - Any
               - 64
       acoustic_frame:
         implementation:
@@ -1011,14 +914,12 @@ pipeline:
           inputs:
             acoustic_codes:
               dtype: int64
-              rank: 2
               shape:
               - 2
               - 7
           outputs:
             framed_acoustic_codes:
               dtype: int64
-              rank: 3
               shape:
               - 2
               - 1
@@ -1031,14 +932,12 @@ pipeline:
           inputs:
             semantic:
               dtype: float32
-              rank: 3
               shape:
               - 2
               - 1
               - 8
             acoustic:
               dtype: float32
-              rank: 3
               shape:
               - 2
               - 1
@@ -1046,7 +945,6 @@ pipeline:
           outputs:
             feedback:
               dtype: float32
-              rank: 3
               shape:
               - 2
               - 1
@@ -1059,20 +957,17 @@ pipeline:
           inputs:
             history:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - frames_with_warmup
               - 64
             stopped:
               dtype: bool
-              rank: 1
               shape:
               - 1
           outputs:
             frame_hiddens:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - frames
@@ -1085,7 +980,6 @@ pipeline:
           inputs:
             frame_hiddens:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - frames
@@ -1093,11 +987,9 @@ pipeline:
           outputs:
             chunk_count:
               dtype: int64
-              rank: 0
               shape: []
             waveform:
               dtype: float32
-              rank: 3
               shape:
               - batch
               - 2
@@ -1107,14 +999,12 @@ pipeline:
                 axis: 0
             previous_latent:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - 128
               - 0
             previous_condition:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - 0
@@ -1131,19 +1021,16 @@ pipeline:
           inputs:
             frame_hiddens:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - frames
               - 64
             chunk_index:
               dtype: int64
-              rank: 0
               shape: []
           outputs:
             frame_chunk:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - chunk_frames
@@ -1160,21 +1047,18 @@ pipeline:
           inputs:
             condition:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - latent_length
               - 2048
             previous_condition:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - carry_length
               - 2048
             previous_latent:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - 128
@@ -1182,25 +1066,21 @@ pipeline:
           outputs:
             guided_condition:
               dtype: float32
-              rank: 3
               shape:
-              - guided_condition_dim_0
-              - guided_condition_dim_1
-              - guided_condition_dim_2
+              - Any
+              - Any
+              - Any
             spliced_condition:
               dtype: float32
-              rank: 3
               shape:
-              - spliced_condition_dim_0
-              - spliced_condition_dim_1
-              - spliced_condition_dim_2
+              - Any
+              - Any
+              - Any
             overlap:
               dtype: int64
-              rank: 0
               shape: []
             noise_row_shape:
               dtype: int64
-              rank: 1
               shape:
               - 2
       latent_noise:
@@ -1211,7 +1091,6 @@ pipeline:
           inputs:
             seed:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -1219,7 +1098,6 @@ pipeline:
                 axis: 0
             offset:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -1227,13 +1105,11 @@ pipeline:
                 axis: 0
             row_shape:
               dtype: int64
-              rank: 1
               shape:
               - 2
           outputs:
             noise:
               dtype: float32
-              rank: 3
               shape:
               - batch
               - channels
@@ -1243,7 +1119,6 @@ pipeline:
                 axis: 0
             next_offset:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -1267,7 +1142,6 @@ pipeline:
           outputs:
             schedule:
               dtype: float32
-              rank: 1
               shape:
               - 31
       flow_timestep:
@@ -1278,12 +1152,10 @@ pipeline:
           inputs:
             schedule:
               dtype: float32
-              rank: 1
               shape:
               - schedule_length
             step:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -1292,7 +1164,6 @@ pipeline:
           outputs:
             timestep:
               dtype: float32
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -1306,42 +1177,36 @@ pipeline:
           inputs:
             latents:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - 128
               - latent_length
             initial_noise:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - 128
               - latent_length
             previous_latent:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - 128
               - carry_length
             overlap:
               dtype: int64
-              rank: 0
               shape: []
             timestep:
               dtype: float32
-              rank: 1
               shape:
               - 1
           outputs:
             blended_latents:
               dtype: float32
-              rank: 3
               shape:
-              - blended_latents_dim_0
-              - blended_latents_dim_1
-              - blended_latents_dim_2
+              - Any
+              - Any
+              - Any
       flow_inputs:
         implementation:
           kind: onnx
@@ -1350,27 +1215,23 @@ pipeline:
           inputs:
             latents:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - 128
               - latent_length
             timestep:
               dtype: float32
-              rank: 1
               shape:
               - 1
           outputs:
             guided_latents:
               dtype: float32
-              rank: 3
               shape:
               - 2
               - 128
               - latent_length
             guided_timestep:
               dtype: float32
-              rank: 1
               shape:
               - 2
       flow_guidance:
@@ -1381,7 +1242,6 @@ pipeline:
           inputs:
             sample:
               dtype: float32
-              rank: 3
               shape:
               - 2
               - 128
@@ -1389,7 +1249,6 @@ pipeline:
           outputs:
             velocity:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - 128
@@ -1402,7 +1261,6 @@ pipeline:
           inputs:
             sample:
               dtype: float32
-              rank: 3
               shape:
               - batch
               - sequence
@@ -1412,7 +1270,6 @@ pipeline:
                 axis: 0
             derivative:
               dtype: float32
-              rank: 3
               shape:
               - batch
               - sequence
@@ -1422,7 +1279,6 @@ pipeline:
                 axis: 0
             step:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -1430,13 +1286,11 @@ pipeline:
                 axis: 0
             schedule:
               dtype: float32
-              rank: 1
               shape:
               - schedule_length
           outputs:
             next_state:
               dtype: float32
-              rank: 3
               shape:
               - batch
               - sequence
@@ -1461,51 +1315,44 @@ pipeline:
           inputs:
             latents:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - 128
               - latent_length
             previous_latent:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - 128
               - carry_length
             condition:
               dtype: float32
-              rank: 3
               shape:
               - 1
               - latent_length
               - 2048
             overlap:
               dtype: int64
-              rank: 0
               shape: []
           outputs:
             restored_latents:
               dtype: float32
-              rank: 3
               shape:
-              - restored_latents_dim_0
-              - restored_latents_dim_1
-              - restored_latents_dim_2
+              - Any
+              - Any
+              - Any
             next_previous_latent:
               dtype: float32
-              rank: 3
               shape:
-              - next_previous_latent_dim_0
-              - next_previous_latent_dim_1
-              - next_previous_latent_dim_2
+              - Any
+              - Any
+              - Any
             next_previous_condition:
               dtype: float32
-              rank: 3
               shape:
-              - next_previous_condition_dim_0
-              - next_previous_condition_dim_1
-              - next_previous_condition_dim_2
+              - Any
+              - Any
+              - Any
       waveform_stitch:
         implementation:
           kind: onnx
@@ -1514,7 +1361,6 @@ pipeline:
           inputs:
             waveform:
               dtype: float32
-              rank: 3
               shape:
               - batch
               - 2
@@ -1524,7 +1370,6 @@ pipeline:
                 axis: 0
             history:
               dtype: float32
-              rank: 3
               shape:
               - batch
               - 2
@@ -1534,16 +1379,13 @@ pipeline:
                 axis: 0
             chunk_index:
               dtype: int64
-              rank: 0
               shape: []
             chunk_count:
               dtype: int64
-              rank: 0
               shape: []
           outputs:
             next_history:
               dtype: float32
-              rank: 3
               shape:
               - batch
               - 2
@@ -1555,7 +1397,6 @@ pipeline:
       global_logits:
         contract:
           dtype: float32
-          rank: 3
           shape:
           - batch
           - sequence_length
@@ -1573,7 +1414,6 @@ pipeline:
       global_hidden:
         contract:
           dtype: float32
-          rank: 3
           shape:
           - batch
           - sequence_length
@@ -1591,7 +1431,6 @@ pipeline:
       global_mask:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - past_sequence_length + sequence_length
@@ -1609,7 +1448,6 @@ pipeline:
       global_position:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - 1
@@ -1624,7 +1462,6 @@ pipeline:
       frame_history:
         contract:
           dtype: float32
-          rank: 3
           shape:
           - 1
           - frames
@@ -1639,7 +1476,6 @@ pipeline:
       rng:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1652,7 +1488,6 @@ pipeline:
       active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1666,7 +1501,6 @@ pipeline:
       done:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1680,7 +1514,6 @@ pipeline:
       global_length:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1694,7 +1527,6 @@ pipeline:
       local_sequence:
         contract:
           dtype: float32
-          rank: 3
           shape:
           - 2
           - steps
@@ -1709,7 +1541,6 @@ pipeline:
       local_codes:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - 2
           - codes
@@ -1723,7 +1554,6 @@ pipeline:
       local_hidden:
         contract:
           dtype: float32
-          rank: 3
           shape:
           - 1
           - parts
@@ -1738,7 +1568,6 @@ pipeline:
       local_rng:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1751,7 +1580,6 @@ pipeline:
       flow_latents:
         contract:
           dtype: float32
-          rank: 3
           shape:
           - 1
           - 128
@@ -1763,7 +1591,6 @@ pipeline:
       previous_latent:
         contract:
           dtype: float32
-          rank: 3
           shape:
           - 1
           - 128
@@ -1777,7 +1604,6 @@ pipeline:
       previous_condition:
         contract:
           dtype: float32
-          rank: 3
           shape:
           - 1
           - carry_length
@@ -1791,7 +1617,6 @@ pipeline:
       waveform:
         contract:
           dtype: float32
-          rank: 3
           shape:
           - batch
           - 2
@@ -1808,7 +1633,6 @@ pipeline:
       flow_rng:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1821,7 +1645,6 @@ pipeline:
       global_cache_0:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 1
@@ -1844,7 +1667,6 @@ pipeline:
       global_cache_1:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 1
@@ -1867,7 +1689,6 @@ pipeline:
       loop_1_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         scope: invocation
@@ -1877,7 +1698,6 @@ pipeline:
       loop_0_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         scope: invocation
@@ -1887,7 +1707,6 @@ pipeline:
       loop_3_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         scope: invocation
@@ -1897,7 +1716,6 @@ pipeline:
       loop_2_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         scope: invocation
@@ -2135,7 +1953,6 @@ pipeline:
           value: local.iteration
           contract:
             dtype: int64
-            rank: 0
             shape: []
       - kind: invoke
         component: frame_append
@@ -2229,7 +2046,6 @@ pipeline:
         value: frame.iteration
         contract:
           dtype: int64
-          rank: 0
           shape: []
     - kind: loop
       setup:
@@ -2350,7 +2166,6 @@ pipeline:
           value: flow.iteration
           contract:
             dtype: int64
-            rank: 1
             shape:
             - batch
             batch_layout:
@@ -2399,7 +2214,6 @@ pipeline:
         value: chunk.iteration
         contract:
           dtype: int64
-          rank: 0
           shape: []
     - kind: emit
       value: waveform

--- a/tests/fixtures/onnx_genai_workflows/masked/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/masked/inference_metadata.yaml
@@ -1,19 +1,11 @@
 schema_version: '1.0'
 pipeline:
   workflow:
-    manifest:
-      capabilities:
-      - workflow_ssa
-      - linear_effects
-      - nested_control_flow
-      - typed_emit
-      - emit_valid_length
-      - loop_induction_values
+    manifest: {}
     inputs:
       request.input_ids:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - sequence
@@ -30,7 +22,6 @@ pipeline:
       request.mask:
         contract:
           dtype: bool
-          rank: 2
           shape:
           - batch
           - sequence
@@ -46,7 +37,6 @@ pipeline:
       request.seed:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -63,7 +53,6 @@ pipeline:
       request.rng_offset:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -79,7 +68,6 @@ pipeline:
       request.max_iterations:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -93,7 +81,6 @@ pipeline:
       package.num_steps:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -108,7 +95,6 @@ pipeline:
       package.loop_0_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         role:
@@ -121,7 +107,6 @@ pipeline:
       tokens:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - sequence
@@ -147,7 +132,6 @@ pipeline:
           inputs:
             current_tokens:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - sequence
@@ -156,7 +140,6 @@ pipeline:
                 axis: 0
             proposed_tokens:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - sequence
@@ -165,7 +148,6 @@ pipeline:
                 axis: 0
             logits:
               dtype: float32
-              rank: 3
               shape:
               - batch
               - sequence
@@ -175,7 +157,6 @@ pipeline:
                 axis: 0
             masked:
               dtype: bool
-              rank: 2
               shape:
               - batch
               - sequence
@@ -184,7 +165,6 @@ pipeline:
                 axis: 0
             step:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -192,7 +172,6 @@ pipeline:
                 axis: 0
             total_steps:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -200,7 +179,6 @@ pipeline:
                 axis: 0
             seed:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -208,7 +186,6 @@ pipeline:
                 axis: 0
             offset:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -217,7 +194,6 @@ pipeline:
           outputs:
             next_state:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - sequence
@@ -226,7 +202,6 @@ pipeline:
                 axis: 0
             next_mask:
               dtype: bool
-              rank: 2
               shape:
               - batch
               - sequence
@@ -235,7 +210,6 @@ pipeline:
                 axis: 0
             next_offset:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -243,7 +217,6 @@ pipeline:
                 axis: 0
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -251,7 +224,6 @@ pipeline:
                 axis: 0
             continue:
               dtype: bool
-              rank: 1
               shape:
               - 1
         contract:
@@ -272,7 +244,6 @@ pipeline:
       tokens_state:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - sequence
@@ -286,7 +257,6 @@ pipeline:
       mask:
         contract:
           dtype: bool
-          rank: 2
           shape:
           - batch
           - sequence
@@ -300,7 +270,6 @@ pipeline:
       rng_offset:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -313,7 +282,6 @@ pipeline:
       logits:
         contract:
           dtype: float32
-          rank: 3
           shape:
           - batch
           - sequence
@@ -328,7 +296,6 @@ pipeline:
       proposal:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - sequence
@@ -342,7 +309,6 @@ pipeline:
       loop_0_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         scope: invocation
@@ -407,6 +373,5 @@ pipeline:
         value: loop.iteration
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1

--- a/tests/fixtures/onnx_genai_workflows/protbert_protein_embeddings/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/protbert_protein_embeddings/inference_metadata.yaml
@@ -12,11 +12,7 @@ profiles:
       normalize: false
 pipeline:
   workflow:
-    manifest:
-      capabilities:
-      - workflow_ssa
-      - linear_effects
-      - typed_emit
+    manifest: {}
     effects:
       encode:
         retry: pure
@@ -26,7 +22,6 @@ pipeline:
       request.input_ids:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - sequence_len
@@ -43,7 +38,6 @@ pipeline:
       request.attention_mask:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - sequence_len
@@ -59,7 +53,6 @@ pipeline:
       request.token_type_ids:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - sequence_len
@@ -76,10 +69,9 @@ pipeline:
       last_hidden_state:
         contract:
           dtype: float32
-          rank: 3
           shape:
           - batch
-          - last_hidden_state_dim_1
+          - Any
           - 64
           batch_layout:
             kind: request_aligned

--- a/tests/fixtures/onnx_genai_workflows/shared_state_pixel_flow/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/shared_state_pixel_flow/inference_metadata.yaml
@@ -41,7 +41,6 @@ preprocessing:
       dtype: float16
       contract:
         dtype: float16
-        rank: 4
         shape:
         - 1
         - 3
@@ -52,19 +51,10 @@ pipeline:
     manifest:
       adapter_abis:
         onnx-genai.image-preprocess: '1'
-      capabilities:
-      - workflow_ssa
-      - linear_effects
-      - typed_emit
-      - nested_control_flow
-      - loop_induction_values
-      - serving_service_contract
-      - input_presence
     inputs:
       request.prompt_tokens:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - sequence_len
@@ -81,7 +71,6 @@ pipeline:
       request.negative_prompt_tokens:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - negative_sequence_len
@@ -98,7 +87,6 @@ pipeline:
       request.image:
         contract:
           dtype: uint8
-          rank: 1
           shape:
           - encoded_bytes
         role:
@@ -112,7 +100,6 @@ pipeline:
       request.image_mask:
         contract:
           dtype: bool
-          rank: 2
           shape:
           - batch
           - sequence_len
@@ -129,7 +116,6 @@ pipeline:
       request.negative_image_mask:
         contract:
           dtype: bool
-          rank: 2
           shape:
           - batch
           - negative_sequence_len
@@ -146,7 +132,6 @@ pipeline:
       request.latent:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 3
@@ -166,7 +151,6 @@ pipeline:
       request.seed:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -183,7 +167,6 @@ pipeline:
       request.width:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -197,7 +180,6 @@ pipeline:
       request.height:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -211,7 +193,6 @@ pipeline:
       request.guidance_scale:
         contract:
           dtype: float32
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -228,7 +209,6 @@ pipeline:
       request.max_iterations:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -242,7 +222,6 @@ pipeline:
       request.text_only:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         role:
@@ -255,7 +234,6 @@ pipeline:
       package.active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -270,7 +248,6 @@ pipeline:
       package.false:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -285,7 +262,6 @@ pipeline:
       package.accepted_len:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -300,7 +276,6 @@ pipeline:
       package.rng_offset:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -315,7 +290,6 @@ pipeline:
       package.one:
         contract:
           dtype: float32
-          rank: 1
           shape:
           - 1
         role:
@@ -327,7 +301,6 @@ pipeline:
       package.loop_0_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         role:
@@ -340,7 +313,6 @@ pipeline:
       logits:
         contract:
           dtype: float32
-          rank: 3
           shape:
           - batch
           - sequence_len
@@ -353,7 +325,6 @@ pipeline:
       image:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 3
@@ -408,13 +379,11 @@ pipeline:
           inputs:
             encoded:
               dtype: uint8
-              rank: 1
               shape:
               - encoded_bytes
           outputs:
             pixel_values:
               dtype: float16
-              rank: 4
               shape:
               - 1
               - 3
@@ -434,7 +403,6 @@ pipeline:
           inputs:
             prompt_tokens:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - prompt_sequence
@@ -444,7 +412,6 @@ pipeline:
           outputs:
             attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - total_sequence_len
@@ -453,7 +420,6 @@ pipeline:
                 axis: 0
             position_ids:
               dtype: int64
-              rank: 3
               shape:
               - 3
               - batch
@@ -463,7 +429,6 @@ pipeline:
                 axis: 1
             body_attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - prompt_sequence + 1
@@ -472,7 +437,6 @@ pipeline:
                 axis: 0
             body_position_ids:
               dtype: int64
-              rank: 3
               shape:
               - 3
               - batch
@@ -482,7 +446,6 @@ pipeline:
                 axis: 1
             token_slot:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -491,7 +454,6 @@ pipeline:
                 axis: 0
             past_key_values.0.key:
               dtype: float16
-              rank: 4
               shape:
               - batch
               - 2
@@ -502,7 +464,6 @@ pipeline:
                 axis: 0
             past_key_values.0.value:
               dtype: float16
-              rank: 4
               shape:
               - batch
               - 2
@@ -520,7 +481,6 @@ pipeline:
           outputs:
             features:
               dtype: float16
-              rank: 3
               shape:
               - 1
               - 0
@@ -533,7 +493,6 @@ pipeline:
           inputs:
             latent:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -544,7 +503,6 @@ pipeline:
                 axis: 0
             prompt_tokens:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - prompt_sequence
@@ -554,7 +512,6 @@ pipeline:
           outputs:
             position_ids:
               dtype: int64
-              rank: 3
               shape:
               - 3
               - batch
@@ -564,7 +521,6 @@ pipeline:
                 axis: 1
             token_grid:
               dtype: int64
-              rank: 1
               shape:
               - 2
       image_dimensions:
@@ -575,7 +531,6 @@ pipeline:
           inputs:
             tensor:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -587,12 +542,10 @@ pipeline:
           outputs:
             height:
               dtype: int64
-              rank: 1
               shape:
               - 1
             width:
               dtype: int64
-              rank: 1
               shape:
               - 1
       image_noise_geometry:
@@ -603,33 +556,27 @@ pipeline:
           inputs:
             height:
               dtype: int64
-              rank: 1
               shape:
               - 1
             width:
               dtype: int64
-              rank: 1
               shape:
               - 1
           outputs:
             row_shape:
               dtype: int64
-              rank: 1
               shape:
               - 3
             token_height:
               dtype: int64
-              rank: 1
               shape:
               - 1
             token_width:
               dtype: int64
-              rank: 1
               shape:
               - 1
             noise_scale:
               dtype: float32
-              rank: 1
               shape:
               - 1
       image_noise:
@@ -640,7 +587,6 @@ pipeline:
           inputs:
             seed:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -648,7 +594,6 @@ pipeline:
                 axis: 0
             offset:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -656,13 +601,11 @@ pipeline:
                 axis: 0
             row_shape:
               dtype: int64
-              rank: 1
               shape:
               - 3
           outputs:
             noise:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -673,7 +616,6 @@ pipeline:
                 axis: 0
             next_offset:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -696,7 +638,6 @@ pipeline:
           inputs:
             tensor:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -707,13 +648,11 @@ pipeline:
                 axis: 0
             scale:
               dtype: float32
-              rank: 1
               shape:
               - 1
           outputs:
             scaled:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -730,7 +669,6 @@ pipeline:
           inputs:
             tensor:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -742,7 +680,6 @@ pipeline:
           outputs:
             clamped:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -760,7 +697,6 @@ pipeline:
           outputs:
             schedule:
               dtype: float32
-              rank: 1
               shape:
               - 3
       schedule_lookup:
@@ -771,12 +707,10 @@ pipeline:
           inputs:
             schedule:
               dtype: float32
-              rank: 1
               shape:
               - schedule_length
             step:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -785,7 +719,6 @@ pipeline:
           outputs:
             timestep:
               dtype: float32
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -799,7 +732,6 @@ pipeline:
           inputs:
             unconditional:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -810,7 +742,6 @@ pipeline:
                 axis: 0
             conditional:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -821,7 +752,6 @@ pipeline:
                 axis: 0
             scale:
               dtype: float32
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -830,7 +760,6 @@ pipeline:
           outputs:
             estimate:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -855,7 +784,6 @@ pipeline:
           inputs:
             sample:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -866,7 +794,6 @@ pipeline:
                 axis: 0
             x0:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -877,7 +804,6 @@ pipeline:
                 axis: 0
             timestep:
               dtype: float32
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -886,7 +812,6 @@ pipeline:
           outputs:
             velocity:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -903,7 +828,6 @@ pipeline:
           inputs:
             sample:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -914,7 +838,6 @@ pipeline:
                 axis: 0
             derivative:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -925,7 +848,6 @@ pipeline:
                 axis: 0
             step:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -933,13 +855,11 @@ pipeline:
                 axis: 0
             schedule:
               dtype: float32
-              rank: 1
               shape:
               - schedule_length
           outputs:
             next_state:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - channels
@@ -965,7 +885,6 @@ pipeline:
           inputs:
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -974,7 +893,6 @@ pipeline:
           outputs:
             continue:
               dtype: bool
-              rank: 1
               shape:
               - 1
       cache_cast_0:
@@ -985,7 +903,6 @@ pipeline:
           inputs:
             value:
               dtype: float16
-              rank: 4
               shape:
               - batch
               - heads
@@ -997,7 +914,6 @@ pipeline:
           outputs:
             cast:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - heads
@@ -1014,7 +930,6 @@ pipeline:
           inputs:
             value:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - heads
@@ -1026,7 +941,6 @@ pipeline:
           outputs:
             cast:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - heads
@@ -1043,7 +957,6 @@ pipeline:
           inputs:
             value:
               dtype: float16
-              rank: 4
               shape:
               - batch
               - heads
@@ -1055,7 +968,6 @@ pipeline:
           outputs:
             cast:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - heads
@@ -1072,7 +984,6 @@ pipeline:
           inputs:
             value:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - heads
@@ -1084,7 +995,6 @@ pipeline:
           outputs:
             cast:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - heads
@@ -1097,7 +1007,6 @@ pipeline:
       conditional_cache_0:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 2
@@ -1116,7 +1025,6 @@ pipeline:
       conditional_cache_1:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 2
@@ -1135,7 +1043,6 @@ pipeline:
       unconditional_cache_0:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 2
@@ -1154,7 +1061,6 @@ pipeline:
       unconditional_cache_1:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 2
@@ -1173,7 +1079,6 @@ pipeline:
       latent:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 3
@@ -1189,7 +1094,6 @@ pipeline:
       loop_0_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         scope: invocation
@@ -1591,7 +1495,6 @@ pipeline:
               value: loop.iteration
               contract:
                 dtype: int64
-                rank: 1
                 shape:
                 - 1
           - kind: invoke

--- a/tests/fixtures/onnx_genai_workflows/speculative/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/speculative/inference_metadata.yaml
@@ -2,25 +2,12 @@ schema_version: v1
 pipeline:
   workflow:
     manifest:
-      capabilities:
-      - workflow_ssa
-      - linear_effects
-      - nested_control_flow
-      - loop_induction_values
-      - typed_emit
-      - emit_valid_length
-      - bounded_state_recurrence
-      - serving_service_contract
-      - grammar_guidance_adapter
-      - adaptive_proposal_budget
-      - advisory_state
       adapter_abis:
         onnx-genai.grammar-guidance: '1'
     inputs:
       request.tokens:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - 4
@@ -37,7 +24,6 @@ pipeline:
       request.seed:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -54,7 +40,6 @@ pipeline:
       request.max_iterations:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -67,7 +52,6 @@ pipeline:
       package.zero:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -82,7 +66,6 @@ pipeline:
       package.one:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -97,7 +80,6 @@ pipeline:
       package.max_context:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -109,7 +91,6 @@ pipeline:
       package.false:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -124,7 +105,6 @@ pipeline:
       package.active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -139,7 +119,6 @@ pipeline:
       request.cache_lengths:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -155,7 +134,6 @@ pipeline:
       request.grammar_state:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -170,7 +148,6 @@ pipeline:
       request.grammar_transition_table:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - grammar_states
           - vocabulary
@@ -183,7 +160,6 @@ pipeline:
       request.adaptive_k:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -199,7 +175,6 @@ pipeline:
       request.adaptive_estimates:
         contract:
           dtype: float32
-          rank: 2
           shape:
           - batch
           - 24
@@ -216,7 +191,6 @@ pipeline:
       request.draft_ms:
         contract:
           dtype: float32
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -231,7 +205,6 @@ pipeline:
       request.target_ms:
         contract:
           dtype: float32
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -246,7 +219,6 @@ pipeline:
       request.verifier.past_key_values.0.key:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 2
@@ -264,7 +236,6 @@ pipeline:
       request.verifier.past_key_values.0.value:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 4
@@ -283,7 +254,6 @@ pipeline:
       tokens:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - accepted_sequence
@@ -310,7 +280,6 @@ pipeline:
           inputs:
             state:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -318,7 +287,6 @@ pipeline:
                 axis: 0
             tokens:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - proposal
@@ -327,7 +295,6 @@ pipeline:
                 axis: 0
             valid_length:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -335,14 +302,12 @@ pipeline:
                 axis: 0
             transition_table:
               dtype: int64
-              rank: 2
               shape:
               - grammar_states
               - vocabulary
           outputs:
             next_state:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -350,7 +315,6 @@ pipeline:
                 axis: 0
             consumed_length:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -358,7 +322,6 @@ pipeline:
                 axis: 0
             logits_mask:
               dtype: bool
-              rank: 2
               shape:
               - batch
               - vocabulary
@@ -367,7 +330,6 @@ pipeline:
                 axis: 0
             forced_tokens:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -376,7 +338,6 @@ pipeline:
                 axis: 0
             forced_length:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -411,7 +372,6 @@ pipeline:
           inputs:
             state:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -419,7 +379,6 @@ pipeline:
                 axis: 0
             tokens:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - proposal
@@ -428,7 +387,6 @@ pipeline:
                 axis: 0
             valid_length:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -436,14 +394,12 @@ pipeline:
                 axis: 0
             transition_table:
               dtype: int64
-              rank: 2
               shape:
               - grammar_states
               - vocabulary
           outputs:
             next_state:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -451,7 +407,6 @@ pipeline:
                 axis: 0
             consumed_length:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -459,7 +414,6 @@ pipeline:
                 axis: 0
             logits_mask:
               dtype: bool
-              rank: 2
               shape:
               - batch
               - vocabulary
@@ -468,7 +422,6 @@ pipeline:
                 axis: 0
             forced_tokens:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -477,7 +430,6 @@ pipeline:
                 axis: 0
             forced_length:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -512,7 +464,6 @@ pipeline:
           inputs:
             state:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -520,7 +471,6 @@ pipeline:
                 axis: 0
             tokens:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - proposal
@@ -529,7 +479,6 @@ pipeline:
                 axis: 0
             valid_length:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -537,14 +486,12 @@ pipeline:
                 axis: 0
             transition_table:
               dtype: int64
-              rank: 2
               shape:
               - grammar_states
               - vocabulary
           outputs:
             next_state:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -552,7 +499,6 @@ pipeline:
                 axis: 0
             consumed_length:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -560,7 +506,6 @@ pipeline:
                 axis: 0
             logits_mask:
               dtype: bool
-              rank: 2
               shape:
               - batch
               - vocabulary
@@ -569,7 +514,6 @@ pipeline:
                 axis: 0
             forced_tokens:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -578,7 +522,6 @@ pipeline:
                 axis: 0
             forced_length:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -612,7 +555,6 @@ pipeline:
           inputs:
             target_scores:
               dtype: float32
-              rank: 3
               shape:
               - batch
               - draft_sequence
@@ -622,7 +564,6 @@ pipeline:
                 axis: 0
             proposed_tokens:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - draft_sequence
@@ -631,7 +572,6 @@ pipeline:
                 axis: 0
             seed:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -639,7 +579,6 @@ pipeline:
                 axis: 0
             offset:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -648,7 +587,6 @@ pipeline:
           outputs:
             accepted_tokens:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - draft_sequence
@@ -657,7 +595,6 @@ pipeline:
                 axis: 0
             accepted_len:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -665,7 +602,6 @@ pipeline:
                 axis: 0
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -673,7 +609,6 @@ pipeline:
                 axis: 0
             next_offset:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -681,7 +616,6 @@ pipeline:
                 axis: 0
             rollback_len:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -689,7 +623,6 @@ pipeline:
                 axis: 0
             continue:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -716,7 +649,6 @@ pipeline:
           inputs:
             logits:
               dtype: float32
-              rank: 2
               shape:
               - batch
               - vocabulary
@@ -725,7 +657,6 @@ pipeline:
                 axis: 0
             logits_mask:
               dtype: bool
-              rank: 2
               shape:
               - batch
               - vocabulary
@@ -734,7 +665,6 @@ pipeline:
                 axis: 0
             forced_tokens:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -743,7 +673,6 @@ pipeline:
                 axis: 0
             forced_length:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -752,7 +681,6 @@ pipeline:
           outputs:
             token:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -767,7 +695,6 @@ pipeline:
           inputs:
             current_k:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -775,7 +702,6 @@ pipeline:
                 axis: 0
             accepted:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -783,7 +709,6 @@ pipeline:
                 axis: 0
             evaluated:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -791,7 +716,6 @@ pipeline:
                 axis: 0
             committed_tokens:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -799,7 +723,6 @@ pipeline:
                 axis: 0
             filled_proposal_budget:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -807,7 +730,6 @@ pipeline:
                 axis: 0
             draft_ms:
               dtype: float32
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -815,7 +737,6 @@ pipeline:
                 axis: 0
             target_ms:
               dtype: float32
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -823,7 +744,6 @@ pipeline:
                 axis: 0
             estimates:
               dtype: float32
-              rank: 2
               shape:
               - batch
               - 24
@@ -833,7 +753,6 @@ pipeline:
           outputs:
             next_k:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -841,7 +760,6 @@ pipeline:
                 axis: 0
             next_estimates:
               dtype: float32
-              rank: 2
               shape:
               - batch
               - 24
@@ -870,7 +788,6 @@ pipeline:
           inputs:
             left:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -878,7 +795,6 @@ pipeline:
                 axis: 0
             right:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -887,7 +803,6 @@ pipeline:
           outputs:
             minimum:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -901,7 +816,6 @@ pipeline:
           inputs:
             logits:
               dtype: float32
-              rank: 3
               shape:
               - batch
               - sequence
@@ -912,7 +826,6 @@ pipeline:
           outputs:
             last_logits:
               dtype: float32
-              rank: 2
               shape:
               - batch
               - vocabulary
@@ -927,7 +840,6 @@ pipeline:
           inputs:
             proposed_tokens:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - proposal
@@ -936,7 +848,6 @@ pipeline:
                 axis: 0
             requested_k:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -945,7 +856,6 @@ pipeline:
           outputs:
             evaluated:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -953,7 +863,6 @@ pipeline:
                 axis: 0
             filled_proposal_budget:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -967,7 +876,6 @@ pipeline:
           inputs:
             left:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -975,7 +883,6 @@ pipeline:
                 axis: 0
             right:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -984,7 +891,6 @@ pipeline:
           outputs:
             total:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -994,7 +900,6 @@ pipeline:
       tokens_state:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - 4
@@ -1009,7 +914,6 @@ pipeline:
       rng_offset:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1023,7 +927,6 @@ pipeline:
       active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1037,7 +940,6 @@ pipeline:
       done:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1051,7 +953,6 @@ pipeline:
       accepted_len:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1065,7 +966,6 @@ pipeline:
       cache_lengths:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1079,7 +979,6 @@ pipeline:
       grammar:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1093,7 +992,6 @@ pipeline:
       proposal_k:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1107,7 +1005,6 @@ pipeline:
       adaptive_estimates:
         contract:
           dtype: float32
-          rank: 2
           shape:
           - batch
           - 24
@@ -1122,7 +1019,6 @@ pipeline:
       cache_0:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 2
@@ -1144,7 +1040,6 @@ pipeline:
       cache_1:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 4
@@ -1363,7 +1258,6 @@ pipeline:
         value: speculative.iteration
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:

--- a/tests/fixtures/onnx_genai_workflows/static_cache/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/static_cache/inference_metadata.yaml
@@ -1,21 +1,11 @@
 schema_version: v1.2
 pipeline:
   workflow:
-    manifest:
-      capabilities:
-      - workflow_ssa
-      - linear_effects
-      - nested_control_flow
-      - typed_emit
-      - emit_valid_length
-      - loop_induction_values
-      - serving_service_contract
-      - bounded_state_recurrence
+    manifest: {}
     inputs:
       request.input_ids:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - sequence
@@ -32,7 +22,6 @@ pipeline:
       request.max_iterations:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -45,7 +34,6 @@ pipeline:
       package.one_token:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -60,7 +48,6 @@ pipeline:
       package.one_step:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -72,7 +59,6 @@ pipeline:
       package.max_context:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -84,7 +70,6 @@ pipeline:
       package.cache_capacity:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -96,7 +81,6 @@ pipeline:
       request.prompt_lengths:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -112,7 +96,6 @@ pipeline:
       request.eos_ids:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - num_eos
@@ -129,7 +112,6 @@ pipeline:
       request.eos_lengths:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -145,7 +127,6 @@ pipeline:
       request.row_max_iterations:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -161,7 +142,6 @@ pipeline:
       request.temperature:
         contract:
           dtype: float32
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -178,7 +158,6 @@ pipeline:
       request.top_k:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -195,7 +174,6 @@ pipeline:
       request.top_p:
         contract:
           dtype: float32
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -212,7 +190,6 @@ pipeline:
       request.min_p:
         contract:
           dtype: float32
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -229,7 +206,6 @@ pipeline:
       request.seed:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -246,7 +222,6 @@ pipeline:
       request.rng_counter:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -262,7 +237,6 @@ pipeline:
       package.active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -277,7 +251,6 @@ pipeline:
       package.not_done:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -292,7 +265,6 @@ pipeline:
       package.cache_lengths:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -307,7 +279,6 @@ pipeline:
       package.zero_batch:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -323,7 +294,6 @@ pipeline:
       tokens:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - generated_sequence
@@ -351,7 +321,6 @@ pipeline:
           inputs:
             logits:
               dtype: float32
-              rank: 2
               shape:
               - batch
               - vocabulary
@@ -360,7 +329,6 @@ pipeline:
                 axis: 0
             temperature:
               dtype: float32
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -368,7 +336,6 @@ pipeline:
                 axis: 0
             top_k:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -376,7 +343,6 @@ pipeline:
                 axis: 0
             top_p:
               dtype: float32
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -384,7 +350,6 @@ pipeline:
                 axis: 0
             min_p:
               dtype: float32
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -392,7 +357,6 @@ pipeline:
                 axis: 0
             seed:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -400,7 +364,6 @@ pipeline:
                 axis: 0
             counter:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -408,7 +371,6 @@ pipeline:
                 axis: 0
             active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -416,7 +378,6 @@ pipeline:
                 axis: 0
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -425,7 +386,6 @@ pipeline:
           outputs:
             token:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -433,7 +393,6 @@ pipeline:
                 axis: 0
             next_counter:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -470,7 +429,6 @@ pipeline:
           inputs:
             tokens:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -478,7 +436,6 @@ pipeline:
                 axis: 0
             eos_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - num_eos
@@ -487,7 +444,6 @@ pipeline:
                 axis: 0
             eos_lengths:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -495,12 +451,10 @@ pipeline:
                 axis: 0
             iteration:
               dtype: int64
-              rank: 1
               shape:
               - 1
             max_iterations:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -508,7 +462,6 @@ pipeline:
                 axis: 0
             active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -517,7 +470,6 @@ pipeline:
           outputs:
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -525,7 +477,6 @@ pipeline:
                 axis: 0
             next_active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -533,7 +484,6 @@ pipeline:
                 axis: 0
             continue:
               dtype: bool
-              rank: 1
               shape:
               - 1
         contract:
@@ -563,7 +513,6 @@ pipeline:
           inputs:
             current:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -572,7 +521,6 @@ pipeline:
                 axis: 0
             update:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -581,7 +529,6 @@ pipeline:
                 axis: 0
             active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -589,7 +536,6 @@ pipeline:
                 axis: 0
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -598,7 +544,6 @@ pipeline:
           outputs:
             next:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -626,7 +571,6 @@ pipeline:
           inputs:
             logits:
               dtype: float32
-              rank: 3
               shape:
               - batch
               - sequence
@@ -637,7 +581,6 @@ pipeline:
           outputs:
             last_logits:
               dtype: float32
-              rank: 2
               shape:
               - batch
               - vocabulary
@@ -656,7 +599,6 @@ pipeline:
           inputs:
             prompt_tokens:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - prompt_sequence
@@ -665,7 +607,6 @@ pipeline:
                 axis: 0
             prompt_lengths:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -674,7 +615,6 @@ pipeline:
           outputs:
             position_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - prompt_sequence
@@ -683,7 +623,6 @@ pipeline:
                 axis: 0
             body_position_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -692,7 +631,6 @@ pipeline:
                 axis: 0
             token_slot:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -701,7 +639,6 @@ pipeline:
                 axis: 0
             generated_lengths:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -709,7 +646,6 @@ pipeline:
                 axis: 0
             cache_lengths:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -717,7 +653,6 @@ pipeline:
                 axis: 0
             write_indices:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -725,7 +660,6 @@ pipeline:
                 axis: 0
             key_cache.0:
               dtype: float32
-              rank: 3
               shape:
               - batch
               - 16
@@ -735,7 +669,6 @@ pipeline:
                 axis: 0
             value_cache.0:
               dtype: float32
-              rank: 3
               shape:
               - batch
               - 16
@@ -754,7 +687,6 @@ pipeline:
           inputs:
             position_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -764,7 +696,6 @@ pipeline:
           outputs:
             next_position_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -780,7 +711,6 @@ pipeline:
           inputs:
             left:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -788,7 +718,6 @@ pipeline:
                 axis: 0
             right:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -796,7 +725,6 @@ pipeline:
                 axis: 0
             active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -804,7 +732,6 @@ pipeline:
                 axis: 0
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -813,7 +740,6 @@ pipeline:
           outputs:
             total:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -828,7 +754,6 @@ pipeline:
           inputs:
             input_eos_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - num_eos
@@ -837,7 +762,6 @@ pipeline:
                 axis: 0
             input_eos_lengths:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -845,7 +769,6 @@ pipeline:
                 axis: 0
             input_max_iterations:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -853,12 +776,10 @@ pipeline:
                 axis: 0
             fallback_max_iterations:
               dtype: int64
-              rank: 1
               shape:
               - 1
             active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -867,7 +788,6 @@ pipeline:
           outputs:
             row_eos_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - num_eos
@@ -876,7 +796,6 @@ pipeline:
                 axis: 0
             eos_lengths:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -884,7 +803,6 @@ pipeline:
                 axis: 0
             max_iterations:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -901,7 +819,6 @@ pipeline:
           inputs:
             token:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -910,7 +827,6 @@ pipeline:
           outputs:
             slot:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -926,7 +842,6 @@ pipeline:
           inputs:
             left:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -934,7 +849,6 @@ pipeline:
                 axis: 0
             right:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -942,7 +856,6 @@ pipeline:
                 axis: 0
             active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -950,7 +863,6 @@ pipeline:
                 axis: 0
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -959,7 +871,6 @@ pipeline:
           outputs:
             total:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -970,7 +881,6 @@ pipeline:
       token:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - 1
@@ -984,7 +894,6 @@ pipeline:
       logits:
         contract:
           dtype: float32
-          rank: 2
           shape:
           - batch
           - 128
@@ -998,7 +907,6 @@ pipeline:
       generated_lengths:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1012,7 +920,6 @@ pipeline:
       active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1026,7 +933,6 @@ pipeline:
       done:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1040,7 +946,6 @@ pipeline:
       accepted_len:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1054,7 +959,6 @@ pipeline:
       cache_lengths:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1068,7 +972,6 @@ pipeline:
       rng_counter:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1082,7 +985,6 @@ pipeline:
       position_ids:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - 1
@@ -1096,7 +998,6 @@ pipeline:
       cache_0:
         contract:
           dtype: float32
-          rank: 3
           shape:
           - batch
           - 16
@@ -1114,7 +1015,6 @@ pipeline:
       cache_1:
         contract:
           dtype: float32
-          rank: 3
           shape:
           - batch
           - 16
@@ -1353,7 +1253,6 @@ pipeline:
         value: loop.iteration
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
 package:

--- a/tests/fixtures/onnx_genai_workflows/tts/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/tts/inference_metadata.yaml
@@ -1,20 +1,11 @@
 schema_version: v1.1
 pipeline:
   workflow:
-    manifest:
-      capabilities:
-      - workflow_ssa
-      - linear_effects
-      - nested_control_flow
-      - loop_induction_values
-      - typed_emit
-      - serving_service_contract
-      - bounded_state_recurrence
+    manifest: {}
     inputs:
       request.prompt_tokens:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - text_sequence_len
@@ -31,7 +22,6 @@ pipeline:
       request.max_iterations:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -44,7 +34,6 @@ pipeline:
       package.false:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -59,7 +48,6 @@ pipeline:
       package.zero_scalar:
         contract:
           dtype: int64
-          rank: 0
           shape: []
         role:
           kind: opaque
@@ -70,7 +58,6 @@ pipeline:
       package.one_scalar:
         contract:
           dtype: int64
-          rank: 0
           shape: []
         role:
           kind: opaque
@@ -81,7 +68,6 @@ pipeline:
       package.remaining_groups:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -93,7 +79,6 @@ pipeline:
       package.predictor_context_limit:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -105,7 +90,6 @@ pipeline:
       package.predictor_mask_limit:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -117,7 +101,6 @@ pipeline:
       package.talker_context_limit:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -129,7 +112,6 @@ pipeline:
       package.one_control:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -141,7 +123,6 @@ pipeline:
       package.zero_batch:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -156,7 +137,6 @@ pipeline:
       package.one_batch:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -171,7 +151,6 @@ pipeline:
       package.true:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -186,7 +165,6 @@ pipeline:
       package.setup_predictor_iteration_0:
         contract:
           dtype: int64
-          rank: 0
           shape: []
         role:
           kind: opaque
@@ -197,7 +175,6 @@ pipeline:
       package.setup_predictor_iteration_1:
         contract:
           dtype: int64
-          rank: 0
           shape: []
         role:
           kind: opaque
@@ -208,7 +185,6 @@ pipeline:
       package.loop_1_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         role:
@@ -220,7 +196,6 @@ pipeline:
       package.loop_0_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         role:
@@ -233,7 +208,6 @@ pipeline:
       waveform:
         contract:
           dtype: float32
-          rank: 3
           shape:
           - batch
           - 1
@@ -324,7 +298,6 @@ pipeline:
           inputs:
             logits:
               dtype: float32
-              rank: 3
               shape:
               - batch
               - sequence
@@ -335,7 +308,6 @@ pipeline:
           outputs:
             last_logits:
               dtype: float32
-              rank: 2
               shape:
               - batch
               - vocabulary
@@ -354,7 +326,6 @@ pipeline:
           inputs:
             logits:
               dtype: float32
-              rank: 2
               shape:
               - batch
               - vocabulary
@@ -364,7 +335,6 @@ pipeline:
           outputs:
             token:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -390,7 +360,6 @@ pipeline:
           inputs:
             logits:
               dtype: float32
-              rank: 2
               shape:
               - batch
               - vocabulary
@@ -400,7 +369,6 @@ pipeline:
           outputs:
             token:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -426,7 +394,6 @@ pipeline:
           inputs:
             logits:
               dtype: float32
-              rank: 2
               shape:
               - batch
               - vocabulary
@@ -436,7 +403,6 @@ pipeline:
           outputs:
             token:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -462,7 +428,6 @@ pipeline:
           inputs:
             logits:
               dtype: float32
-              rank: 2
               shape:
               - batch
               - vocabulary
@@ -472,7 +437,6 @@ pipeline:
           outputs:
             token:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -498,7 +462,6 @@ pipeline:
           inputs:
             logits:
               dtype: float32
-              rank: 2
               shape:
               - batch
               - vocabulary
@@ -508,7 +471,6 @@ pipeline:
           outputs:
             token:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -534,7 +496,6 @@ pipeline:
           inputs:
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -543,7 +504,6 @@ pipeline:
           outputs:
             continue:
               dtype: bool
-              rank: 1
               shape:
               - 1
         batch_capacity: {}
@@ -555,7 +515,6 @@ pipeline:
           inputs:
             prompt_tokens:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - sequence
@@ -565,7 +524,6 @@ pipeline:
           outputs:
             frame_codes:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 4
@@ -574,7 +532,6 @@ pipeline:
                 axis: 0
             token_slot:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -583,7 +540,6 @@ pipeline:
                 axis: 0
             code_history:
               dtype: int64
-              rank: 3
               shape:
               - batch
               - 0
@@ -602,7 +558,6 @@ pipeline:
           inputs:
             token:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -611,7 +566,6 @@ pipeline:
           outputs:
             slot:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -627,7 +581,6 @@ pipeline:
           inputs:
             frame_codes:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 4
@@ -636,7 +589,6 @@ pipeline:
                 axis: 0
             token:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -644,12 +596,10 @@ pipeline:
                 axis: 0
             index:
               dtype: int64
-              rank: 0
               shape: []
           outputs:
             next_frame:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 4
@@ -665,7 +615,6 @@ pipeline:
           inputs:
             history:
               dtype: int64
-              rank: 3
               shape:
               - batch
               - frames
@@ -675,7 +624,6 @@ pipeline:
                 axis: 0
             frame:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 4
@@ -685,7 +633,6 @@ pipeline:
           outputs:
             next_history:
               dtype: int64
-              rank: 3
               shape:
               - batch
               - frames + 1
@@ -704,7 +651,6 @@ pipeline:
           inputs:
             left:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -712,7 +658,6 @@ pipeline:
                 axis: 0
             right:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -721,7 +666,6 @@ pipeline:
           outputs:
             total:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -736,7 +680,6 @@ pipeline:
           inputs:
             prefill_embeds:
               dtype: float32
-              rank: 3
               shape:
               - batch
               - prefill_sequence
@@ -747,7 +690,6 @@ pipeline:
           outputs:
             attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - past_seq_len + seq_len
@@ -756,7 +698,6 @@ pipeline:
                 axis: 0
             position_ids:
               dtype: int64
-              rank: 3
               shape:
               - 3
               - batch
@@ -766,7 +707,6 @@ pipeline:
                 axis: 1
             body_attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - prefill_sequence + 1
@@ -775,7 +715,6 @@ pipeline:
                 axis: 0
             body_position_ids:
               dtype: int64
-              rank: 3
               shape:
               - 3
               - batch
@@ -785,7 +724,6 @@ pipeline:
                 axis: 1
             past_key_values.0.key:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - 1
@@ -796,7 +734,6 @@ pipeline:
                 axis: 0
             past_key_values.0.value:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - 1
@@ -816,7 +753,6 @@ pipeline:
           inputs:
             prefill_embeds:
               dtype: float32
-              rank: 3
               shape:
               - batch
               - prefill_sequence
@@ -827,7 +763,6 @@ pipeline:
           outputs:
             attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - past_seq_len + seq_len
@@ -836,7 +771,6 @@ pipeline:
                 axis: 0
             position_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - sequence_len
@@ -845,7 +779,6 @@ pipeline:
                 axis: 0
             body_attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - prefill_sequence + 1
@@ -854,7 +787,6 @@ pipeline:
                 axis: 0
             body_position_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -863,7 +795,6 @@ pipeline:
                 axis: 0
             past_key_values.0.key:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - 8
@@ -874,7 +805,6 @@ pipeline:
                 axis: 0
             past_key_values.0.value:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - 8
@@ -885,7 +815,6 @@ pipeline:
                 axis: 0
             past_key_values.1.key:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - 8
@@ -896,7 +825,6 @@ pipeline:
                 axis: 0
             past_key_values.1.value:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - 8
@@ -907,7 +835,6 @@ pipeline:
                 axis: 0
             past_key_values.2.key:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - 8
@@ -918,7 +845,6 @@ pipeline:
                 axis: 0
             past_key_values.2.value:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - 8
@@ -929,7 +855,6 @@ pipeline:
                 axis: 0
             past_key_values.3.key:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - 8
@@ -940,7 +865,6 @@ pipeline:
                 axis: 0
             past_key_values.3.value:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - 8
@@ -951,7 +875,6 @@ pipeline:
                 axis: 0
             past_key_values.4.key:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - 8
@@ -962,7 +885,6 @@ pipeline:
                 axis: 0
             past_key_values.4.value:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - 8
@@ -982,7 +904,6 @@ pipeline:
           inputs:
             attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - context
@@ -991,7 +912,6 @@ pipeline:
                 axis: 0
             position_ids:
               dtype: int64
-              rank: 3
               shape:
               - 3
               - batch
@@ -1002,7 +922,6 @@ pipeline:
           outputs:
             next_attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - context + 1
@@ -1011,7 +930,6 @@ pipeline:
                 axis: 0
             next_position_ids:
               dtype: int64
-              rank: 3
               shape:
               - 3
               - batch
@@ -1030,7 +948,6 @@ pipeline:
           inputs:
             attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - context
@@ -1039,7 +956,6 @@ pipeline:
                 axis: 0
             position_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -1049,7 +965,6 @@ pipeline:
           outputs:
             next_attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - context + 1
@@ -1058,7 +973,6 @@ pipeline:
                 axis: 0
             next_position_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -1076,7 +990,6 @@ pipeline:
           inputs:
             history:
               dtype: int64
-              rank: 3
               shape:
               - batch
               - frames
@@ -1087,7 +1000,6 @@ pipeline:
           outputs:
             codes:
               dtype: int64
-              rank: 3
               shape:
               - batch
               - 4
@@ -1102,7 +1014,6 @@ pipeline:
       last_frame:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - 4
@@ -1116,7 +1027,6 @@ pipeline:
       history:
         contract:
           dtype: int64
-          rank: 3
           shape:
           - batch
           - frames
@@ -1134,7 +1044,6 @@ pipeline:
       talker_mask:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - talker_context
@@ -1151,7 +1060,6 @@ pipeline:
       talker_position:
         contract:
           dtype: int64
-          rank: 3
           shape:
           - 3
           - batch
@@ -1166,7 +1074,6 @@ pipeline:
       frame:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - 4
@@ -1180,7 +1087,6 @@ pipeline:
       code_token:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1193,7 +1099,6 @@ pipeline:
       predictor_mask:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - predictor_context
@@ -1210,7 +1115,6 @@ pipeline:
       predictor_position:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - 1
@@ -1224,7 +1128,6 @@ pipeline:
       active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1238,7 +1141,6 @@ pipeline:
       done:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1252,7 +1154,6 @@ pipeline:
       accepted_len:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1266,7 +1167,6 @@ pipeline:
       talker_cache_lengths:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1280,7 +1180,6 @@ pipeline:
       predictor_cache_lengths:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1294,7 +1193,6 @@ pipeline:
       talker_cache_0:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 1
@@ -1316,7 +1214,6 @@ pipeline:
       talker_cache_1:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 1
@@ -1338,7 +1235,6 @@ pipeline:
       predictor_cache_0:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 8
@@ -1360,7 +1256,6 @@ pipeline:
       predictor_cache_1:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 8
@@ -1382,7 +1277,6 @@ pipeline:
       predictor_cache_2:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 8
@@ -1404,7 +1298,6 @@ pipeline:
       predictor_cache_3:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 8
@@ -1426,7 +1319,6 @@ pipeline:
       predictor_cache_4:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 8
@@ -1448,7 +1340,6 @@ pipeline:
       predictor_cache_5:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 8
@@ -1470,7 +1361,6 @@ pipeline:
       predictor_cache_6:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 8
@@ -1492,7 +1382,6 @@ pipeline:
       predictor_cache_7:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 8
@@ -1514,7 +1403,6 @@ pipeline:
       predictor_cache_8:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 8
@@ -1536,7 +1424,6 @@ pipeline:
       predictor_cache_9:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 8
@@ -1558,7 +1445,6 @@ pipeline:
       loop_1_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         scope: invocation
@@ -1568,7 +1454,6 @@ pipeline:
       loop_0_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         scope: invocation
@@ -2255,7 +2140,6 @@ pipeline:
           value: code.iteration
           contract:
             dtype: int64
-            rank: 0
             shape: []
       - kind: invoke
         component: code_history_append
@@ -2322,7 +2206,6 @@ pipeline:
         value: talker.iteration
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:

--- a/tests/fixtures/onnx_genai_workflows/video/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/video/inference_metadata.yaml
@@ -1,19 +1,11 @@
 schema_version: v1.1
 pipeline:
   workflow:
-    manifest:
-      capabilities:
-      - workflow_ssa
-      - linear_effects
-      - nested_control_flow
-      - loop_induction_values
-      - typed_emit
-      - bounded_state_recurrence
+    manifest: {}
     inputs:
       request.noise:
         contract:
           dtype: float32
-          rank: 5
           shape:
           - batch
           - num_frames
@@ -32,7 +24,6 @@ pipeline:
       request.max_iterations:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -46,7 +37,6 @@ pipeline:
       package.false:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -61,7 +51,6 @@ pipeline:
       package.one_control:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -73,7 +62,6 @@ pipeline:
       package.history_limit:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -85,7 +73,6 @@ pipeline:
       package.cache_frames:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -97,7 +84,6 @@ pipeline:
       request.encoder_hidden_states:
         contract:
           dtype: float32
-          rank: 3
           shape:
           - batch
           - prompt_sequence
@@ -114,7 +100,6 @@ pipeline:
       package.loop_0_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         role:
@@ -126,7 +111,6 @@ pipeline:
       package.loop_1_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         role:
@@ -139,7 +123,6 @@ pipeline:
       video:
         contract:
           dtype: float32
-          rank: 5
           shape:
           - batch
           - 3
@@ -173,7 +156,6 @@ pipeline:
           inputs:
             sample:
               dtype: float32
-              rank: 5
               shape:
               - batch
               - frames
@@ -185,7 +167,6 @@ pipeline:
                 axis: 0
             step:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -193,13 +174,11 @@ pipeline:
                 axis: 0
             schedule:
               dtype: float32
-              rank: 1
               shape:
               - schedule_length
           outputs:
             model_input:
               dtype: float32
-              rank: 5
               shape:
               - batch
               - frames
@@ -224,7 +203,6 @@ pipeline:
           inputs:
             sample:
               dtype: float32
-              rank: 5
               shape:
               - batch
               - frames
@@ -236,7 +214,6 @@ pipeline:
                 axis: 0
             derivative:
               dtype: float32
-              rank: 5
               shape:
               - batch
               - frames
@@ -248,7 +225,6 @@ pipeline:
                 axis: 0
             step:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -256,13 +232,11 @@ pipeline:
                 axis: 0
             schedule:
               dtype: float32
-              rank: 1
               shape:
               - schedule_length
           outputs:
             next_state:
               dtype: float32
-              rank: 5
               shape:
               - batch
               - frames
@@ -296,7 +270,6 @@ pipeline:
           inputs:
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -305,7 +278,6 @@ pipeline:
           outputs:
             continue:
               dtype: bool
-              rank: 1
               shape:
               - 1
         batch_capacity: {}
@@ -317,7 +289,6 @@ pipeline:
           inputs:
             noise:
               dtype: float32
-              rank: 5
               shape:
               - batch
               - frames
@@ -330,7 +301,6 @@ pipeline:
           outputs:
             latent:
               dtype: float32
-              rank: 5
               shape:
               - batch
               - frames
@@ -342,7 +312,6 @@ pipeline:
                 axis: 0
             history:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 0
@@ -363,7 +332,6 @@ pipeline:
           inputs:
             history:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - history
@@ -372,7 +340,6 @@ pipeline:
                 axis: 0
             timestep:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -381,7 +348,6 @@ pipeline:
           outputs:
             next:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - next_history
@@ -399,7 +365,6 @@ pipeline:
           inputs:
             latent:
               dtype: float32
-              rank: 5
               shape:
               - batch
               - frames
@@ -412,7 +377,6 @@ pipeline:
           outputs:
             permuted:
               dtype: float32
-              rank: 5
               shape:
               - batch
               - channels
@@ -436,7 +400,6 @@ pipeline:
           inputs:
             latent:
               dtype: float32
-              rank: 5
               shape:
               - batch
               - channels
@@ -449,7 +412,6 @@ pipeline:
           outputs:
             unscaled:
               dtype: float32
-              rank: 5
               shape:
               - batch
               - channels
@@ -473,7 +435,6 @@ pipeline:
           inputs:
             latent:
               dtype: float32
-              rank: 5
               shape:
               - batch
               - channels
@@ -486,7 +447,6 @@ pipeline:
           outputs:
             count:
               dtype: int64
-              rank: 1
               shape:
               - 1
         batch_capacity:
@@ -503,7 +463,6 @@ pipeline:
           inputs:
             latent:
               dtype: float32
-              rank: 5
               shape:
               - batch
               - channels
@@ -515,7 +474,6 @@ pipeline:
                 axis: 0
             step:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -524,7 +482,6 @@ pipeline:
           outputs:
             chunk:
               dtype: float32
-              rank: 5
               shape:
               - batch
               - channels
@@ -548,7 +505,6 @@ pipeline:
           inputs:
             latent:
               dtype: float32
-              rank: 5
               shape:
               - batch
               - channels
@@ -561,7 +517,6 @@ pipeline:
           outputs:
             conv_cache.conv_in:
               dtype: float32
-              rank: 5
               shape:
               - batch
               - 4
@@ -573,7 +528,6 @@ pipeline:
                 axis: 0
             conv_cache.conv_out:
               dtype: float32
-              rank: 5
               shape:
               - batch
               - 3
@@ -598,7 +552,6 @@ pipeline:
           outputs:
             schedule:
               dtype: float32
-              rank: 1
               shape:
               - 4
         batch_capacity: {}
@@ -611,7 +564,6 @@ pipeline:
           outputs:
             schedule:
               dtype: float32
-              rank: 1
               shape:
               - 3
         batch_capacity: {}
@@ -623,12 +575,10 @@ pipeline:
           inputs:
             schedule:
               dtype: float32
-              rank: 1
               shape:
               - schedule_length
             step:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -637,7 +587,6 @@ pipeline:
           outputs:
             timestep:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -650,7 +599,6 @@ pipeline:
       latent:
         contract:
           dtype: float32
-          rank: 5
           shape:
           - batch
           - num_frames
@@ -667,7 +615,6 @@ pipeline:
       scheduler_history:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - scheduler_history
@@ -684,7 +631,6 @@ pipeline:
       conv_cache_conv_in:
         contract:
           dtype: float32
-          rank: 5
           shape:
           - batch
           - 4
@@ -705,7 +651,6 @@ pipeline:
       conv_cache_conv_out:
         contract:
           dtype: float32
-          rank: 5
           shape:
           - batch
           - 3
@@ -726,7 +671,6 @@ pipeline:
       loop_0_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         scope: invocation
@@ -736,7 +680,6 @@ pipeline:
       loop_1_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         scope: invocation
@@ -828,7 +771,6 @@ pipeline:
         value: loop.iteration
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
     - kind: invoke
@@ -906,6 +848,5 @@ pipeline:
         value: decode.iteration
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch

--- a/tests/fixtures/onnx_genai_workflows/vlm/inference_metadata.yaml
+++ b/tests/fixtures/onnx_genai_workflows/vlm/inference_metadata.yaml
@@ -56,7 +56,6 @@ preprocessing:
       source: image.transform_4
       contract:
         dtype: float32
-        rank: 2
         shape:
         - 4
         - 1176
@@ -66,7 +65,6 @@ preprocessing:
       source: image.output_grid_dimensions
       contract:
         dtype: int64
-        rank: 2
         shape:
         - 1
         - 3
@@ -75,20 +73,10 @@ pipeline:
     manifest:
       adapter_abis:
         onnx-genai.image-preprocess: '1'
-      capabilities:
-      - workflow_ssa
-      - linear_effects
-      - nested_control_flow
-      - loop_induction_values
-      - typed_emit
-      - emit_valid_length
-      - serving_service_contract
-      - bounded_state_recurrence
     inputs:
       request.prompt_tokens:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - sequence
@@ -105,7 +93,6 @@ pipeline:
       request.image:
         contract:
           dtype: uint8
-          rank: 1
           shape:
           - encoded_bytes
         role:
@@ -118,7 +105,6 @@ pipeline:
       request.max_iterations:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -131,7 +117,6 @@ pipeline:
       request.prompt_lengths:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -147,7 +132,6 @@ pipeline:
       request.eos_ids:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - num_eos
@@ -164,7 +148,6 @@ pipeline:
       request.row_max_iterations:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -180,7 +163,6 @@ pipeline:
       request.eos_lengths:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -196,7 +178,6 @@ pipeline:
       package.max_context:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -208,7 +189,6 @@ pipeline:
       package.one:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -223,7 +203,6 @@ pipeline:
       package.one_step:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
         role:
@@ -235,7 +214,6 @@ pipeline:
       package.active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -250,7 +228,6 @@ pipeline:
       package.false:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -265,7 +242,6 @@ pipeline:
       package.zero_batch:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -280,7 +256,6 @@ pipeline:
       request.temperature:
         contract:
           dtype: float32
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -297,7 +272,6 @@ pipeline:
       request.top_k:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -314,7 +288,6 @@ pipeline:
       request.top_p:
         contract:
           dtype: float32
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -331,7 +304,6 @@ pipeline:
       request.min_p:
         contract:
           dtype: float32
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -348,7 +320,6 @@ pipeline:
       request.seed:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -365,7 +336,6 @@ pipeline:
       request.rng_counter:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -381,7 +351,6 @@ pipeline:
       package.loop_0_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         role:
@@ -394,7 +363,6 @@ pipeline:
       tokens:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - generated_sequence
@@ -435,19 +403,16 @@ pipeline:
           inputs:
             encoded:
               dtype: uint8
-              rank: 1
               shape:
               - encoded_bytes
           outputs:
             pixel_values:
               dtype: float32
-              rank: 2
               shape:
               - 4
               - 1176
             grid_thw:
               dtype: int64
-              rank: 2
               shape:
               - 1
               - 3
@@ -459,7 +424,6 @@ pipeline:
           inputs:
             logits:
               dtype: float32
-              rank: 2
               shape:
               - batch
               - vocabulary
@@ -468,7 +432,6 @@ pipeline:
                 axis: 0
             temperature:
               dtype: float32
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -476,7 +439,6 @@ pipeline:
                 axis: 0
             top_k:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -484,7 +446,6 @@ pipeline:
                 axis: 0
             top_p:
               dtype: float32
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -492,7 +453,6 @@ pipeline:
                 axis: 0
             min_p:
               dtype: float32
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -500,7 +460,6 @@ pipeline:
                 axis: 0
             seed:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -508,7 +467,6 @@ pipeline:
                 axis: 0
             counter:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -516,7 +474,6 @@ pipeline:
                 axis: 0
             active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -524,7 +481,6 @@ pipeline:
                 axis: 0
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -533,7 +489,6 @@ pipeline:
           outputs:
             token:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -541,7 +496,6 @@ pipeline:
                 axis: 0
             next_counter:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -575,7 +529,6 @@ pipeline:
           inputs:
             tokens:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -583,7 +536,6 @@ pipeline:
                 axis: 0
             eos_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - num_eos
@@ -592,7 +544,6 @@ pipeline:
                 axis: 0
             eos_lengths:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -600,12 +551,10 @@ pipeline:
                 axis: 0
             iteration:
               dtype: int64
-              rank: 1
               shape:
               - 1
             max_iterations:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -613,7 +562,6 @@ pipeline:
                 axis: 0
             active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -622,7 +570,6 @@ pipeline:
           outputs:
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -630,7 +577,6 @@ pipeline:
                 axis: 0
             next_active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -638,7 +584,6 @@ pipeline:
                 axis: 0
             continue:
               dtype: bool
-              rank: 1
               shape:
               - 1
         contract:
@@ -665,7 +610,6 @@ pipeline:
           inputs:
             current:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -674,7 +618,6 @@ pipeline:
                 axis: 0
             update:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -683,7 +626,6 @@ pipeline:
                 axis: 0
             active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -691,7 +633,6 @@ pipeline:
                 axis: 0
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -700,7 +641,6 @@ pipeline:
           outputs:
             next:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -727,7 +667,6 @@ pipeline:
           inputs:
             logits:
               dtype: float32
-              rank: 3
               shape:
               - batch
               - sequence
@@ -738,7 +677,6 @@ pipeline:
           outputs:
             last_logits:
               dtype: float32
-              rank: 2
               shape:
               - batch
               - vocabulary
@@ -753,7 +691,6 @@ pipeline:
           inputs:
             prompt_tokens:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - prompt_sequence
@@ -762,7 +699,6 @@ pipeline:
                 axis: 0
             prompt_lengths:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -771,7 +707,6 @@ pipeline:
           outputs:
             attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - past_sequence + sequence
@@ -780,7 +715,6 @@ pipeline:
                 axis: 0
             position_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - prompt_sequence
@@ -789,7 +723,6 @@ pipeline:
                 axis: 0
             body_attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - prompt_sequence + 1
@@ -798,7 +731,6 @@ pipeline:
                 axis: 0
             body_position_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -807,7 +739,6 @@ pipeline:
                 axis: 0
             token_slot:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -816,7 +747,6 @@ pipeline:
                 axis: 0
             generated_lengths:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -824,7 +754,6 @@ pipeline:
                 axis: 0
             past_key_values.0.key:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - 2
@@ -835,7 +764,6 @@ pipeline:
                 axis: 0
             past_key_values.0.value:
               dtype: float32
-              rank: 4
               shape:
               - batch
               - 2
@@ -852,7 +780,6 @@ pipeline:
           inputs:
             attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - context
@@ -861,7 +788,6 @@ pipeline:
                 axis: 0
             position_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -871,7 +797,6 @@ pipeline:
           outputs:
             next_attention_mask:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - context + 1
@@ -880,7 +805,6 @@ pipeline:
                 axis: 0
             next_position_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -895,7 +819,6 @@ pipeline:
           inputs:
             input_eos_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - num_eos
@@ -904,7 +827,6 @@ pipeline:
                 axis: 0
             input_eos_lengths:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -912,7 +834,6 @@ pipeline:
                 axis: 0
             input_max_iterations:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -920,12 +841,10 @@ pipeline:
                 axis: 0
             fallback_max_iterations:
               dtype: int64
-              rank: 1
               shape:
               - 1
             active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -934,7 +853,6 @@ pipeline:
           outputs:
             row_eos_ids:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - num_eos
@@ -943,7 +861,6 @@ pipeline:
                 axis: 0
             eos_lengths:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -951,7 +868,6 @@ pipeline:
                 axis: 0
             max_iterations:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -965,7 +881,6 @@ pipeline:
           inputs:
             token:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -974,7 +889,6 @@ pipeline:
           outputs:
             slot:
               dtype: int64
-              rank: 2
               shape:
               - batch
               - 1
@@ -989,7 +903,6 @@ pipeline:
           inputs:
             left:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -997,7 +910,6 @@ pipeline:
                 axis: 0
             right:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -1005,7 +917,6 @@ pipeline:
                 axis: 0
             active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -1013,7 +924,6 @@ pipeline:
                 axis: 0
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -1022,7 +932,6 @@ pipeline:
           outputs:
             total:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -1036,7 +945,6 @@ pipeline:
           inputs:
             left:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -1044,7 +952,6 @@ pipeline:
                 axis: 0
             right:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -1052,7 +959,6 @@ pipeline:
                 axis: 0
             active:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -1060,7 +966,6 @@ pipeline:
                 axis: 0
             done:
               dtype: bool
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -1069,7 +974,6 @@ pipeline:
           outputs:
             total:
               dtype: int64
-              rank: 1
               shape:
               - batch
               batch_layout:
@@ -1079,7 +983,6 @@ pipeline:
       token:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - 1
@@ -1093,7 +996,6 @@ pipeline:
       logits:
         contract:
           dtype: float32
-          rank: 2
           shape:
           - batch
           - 128
@@ -1107,7 +1009,6 @@ pipeline:
       generated_lengths:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1121,7 +1022,6 @@ pipeline:
       attention_mask:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - context
@@ -1138,7 +1038,6 @@ pipeline:
       active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1152,7 +1051,6 @@ pipeline:
       done:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1166,7 +1064,6 @@ pipeline:
       accepted_len:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1180,7 +1077,6 @@ pipeline:
       cache_lengths:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1194,7 +1090,6 @@ pipeline:
       rng_counter:
         contract:
           dtype: int64
-          rank: 1
           shape:
           - batch
           batch_layout:
@@ -1208,7 +1103,6 @@ pipeline:
       position_ids:
         contract:
           dtype: int64
-          rank: 2
           shape:
           - batch
           - 1
@@ -1222,7 +1116,6 @@ pipeline:
       cache_0:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 2
@@ -1243,7 +1136,6 @@ pipeline:
       cache_1:
         contract:
           dtype: float32
-          rank: 4
           shape:
           - batch
           - 2
@@ -1264,7 +1156,6 @@ pipeline:
       loop_0_active:
         contract:
           dtype: bool
-          rank: 1
           shape:
           - 1
         scope: invocation
@@ -1519,7 +1410,6 @@ pipeline:
         value: loop.iteration
         contract:
           dtype: int64
-          rank: 1
           shape:
           - 1
 package:

--- a/tests/generate_onnx_genai_validation_packages.py
+++ b/tests/generate_onnx_genai_validation_packages.py
@@ -8,7 +8,6 @@ from types import SimpleNamespace
 
 import numpy as np
 import onnx_ir as ir
-import yaml
 from onnxscript import GraphBuilder
 from safetensors.numpy import save_file
 
@@ -34,6 +33,7 @@ from mobius.integrations.diffusers._configs import (
     MiniMaxMusic3WorkflowConfig,
 )
 from mobius.integrations.onnx_genai import write_onnx_genai_config
+from mobius.integrations.onnx_genai._metadata_io import _dump_yaml
 from mobius.integrations.onnx_genai._test_support import (
     _Cfg,
     _VlmCfg,
@@ -1441,7 +1441,7 @@ def _write_adapter_metadata(package: ModelPackage, directory: Path) -> None:
     }
     add_adapter_service_to_metadata(metadata, package, str(directory))
     with open(directory / "inference_metadata.yaml", "w", encoding="utf-8") as handle:
-        yaml.safe_dump(metadata, handle, sort_keys=False)
+        _dump_yaml(metadata, handle)
 
 
 def generate_packages(output: Path) -> Path:

--- a/tests/onnx_genai_current_schema_test.py
+++ b/tests/onnx_genai_current_schema_test.py
@@ -1,0 +1,47 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Validate every generated signal package against the current tensor contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import yaml
+
+_SCHEMA = (
+    Path(__file__).parents[1]
+    / "src/mobius/integrations/onnx_genai/_schema/inference_metadata.schema.json"
+)
+_EXPECTED_PACKAGES = {
+    "adapter",
+    "codec",
+    "decoder",
+    "diffusion",
+    "diffusion_guided",
+    "esm2_protein_embeddings",
+    "hierarchical_audio",
+    "masked",
+    "protbert_protein_embeddings",
+    "shared_state_pixel_flow",
+    "speculative",
+    "static_cache",
+    "tts",
+    "video",
+    "vlm",
+}
+
+
+def test_all_signal_packages_match_current_onnx_genai_schema(
+    materialized_workflow_packages: str,
+) -> None:
+    root = Path(materialized_workflow_packages)
+    metadata_paths = sorted(root.glob("*/inference_metadata.yaml"))
+    assert {path.parent.name for path in metadata_paths} == _EXPECTED_PACKAGES
+    schema = json.loads(_SCHEMA.read_text(encoding="utf-8"))
+
+    for path in metadata_paths:
+        metadata = yaml.safe_load(path.read_text(encoding="utf-8"))
+        jsonschema.validate(metadata, schema)

--- a/tests/static_cache_metadata_test.py
+++ b/tests/static_cache_metadata_test.py
@@ -211,7 +211,7 @@ class TestStaticCacheWorkflow:
         assert capacity["default"] == CAPACITY
         assert capacity["required"] is False
         assert capacity["contract"]["dtype"] == "int64"
-        assert capacity["contract"]["rank"] == 1
+        assert capacity["contract"]["shape"] == [1]
 
     def test_cache_cells_are_invariant_not_growing(self, static_workflow):
         workflow = static_workflow["pipeline"]["workflow"]
@@ -292,7 +292,7 @@ class TestStaticCachePortDerivation:
         # has to allocate.
         workflow = static_workflow["pipeline"]["workflow"]
         contract = workflow["state"][_cache_cells(workflow)[0]]["contract"]
-        assert contract["rank"] == 3
+        assert len(contract["shape"]) == 3
         # 2 kv heads x 16 head_dim
         assert contract["shape"] == ["batch", CAPACITY, 32]
 


### PR DESCRIPTION
## Summary
- remove retired tensor-contract `rank` emission from the shared ONNX GenAI metadata builders and serializer
- retain exact scalar `shape: []`, named symbolic dimensions, and independent `Any` dynamic dimensions without inventing fixed extents
- retire the obsolete workflow capability list required by the current consumer
- refresh all 15 producer-conformance package snapshots
- add current TensorContract schema coverage across every signal package and stale-fixture guards

Fixes the producer failure reported by onnx-genai signal run https://github.com/justinchuby/onnx-genai/actions/runs/33886695719.

## Validation
- generated and snapshot-compared all 15 packages
- current onnx-genai Rust validator: 15/15 valid
- ONNX GenAI metadata suite: 722 passed, 3 skipped
- Sensenova/static-cache related suite: 50 passed
- Ruff 0.16.2 lint and format checks passed
- `git diff --check`

A broader local non-integration run also reproduced three unrelated failures unchanged on Mobius `origin/main` (GGUF evidence expectation, Qwen Image diffusers API drift, and ModernBERT synthetic tolerance).